### PR TITLE
{libsForQt5,kdePackages}.{partitionmanager,kpmcore}: drop ReiserFS support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -290,6 +290,11 @@
 
   To get the necessary hash of the vendored dependencies, omit `hash`. The build will fail and tell you the correct value.
 
+- KDE Partition Manager `partitionmanager`'s support for ReiserFS is removed.
+  ReiserFS has not been actively maintained for many years. It has been marked as obsolete since Linux 6.6, and
+  [is removed](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=c01f664e4ca210823b7594b50669bbd9b0a3c3b0)
+  in Linux 6.13.
+
 - `programs.fzf.keybindings` now supports the fish shell.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/pkgs/applications/kde/partitionmanager/default.nix
+++ b/pkgs/applications/kde/partitionmanager/default.nix
@@ -24,8 +24,6 @@
   jfsutils,
   nilfs-utils,
   ntfs3g,
-  reiser4progs,
-  reiserfsprogs,
   udftools,
   xfsprogs,
   zfs,
@@ -54,8 +52,7 @@ let
     jfsutils
     nilfs-utils
     ntfs3g
-    reiser4progs
-    reiserfsprogs
+    # reiser{4,fs}progs intentionally omitted due to filesystem removal from Linux.
     udftools
     xfsprogs
     zfs
@@ -98,7 +95,7 @@ mkDerivation {
     longDescription = ''
       KDE Partition Manager is a utility to help you manage the disks, partitions, and file systems on your computer.
       It allows you to easily create, copy, move, delete, back up, restore, and resize them without losing data.
-      It supports a large number of file systems, including ext2/3/4, btrfs, reiserfs, NTFS, FAT16/32, JFS, XFS and more.
+      It supports a large number of file systems, including ext2/3/4, btrfs, NTFS, FAT16/32, JFS, XFS and more.
 
       To install on NixOS, use the option `programs.partition-manager.enable = true`.
     '';

--- a/pkgs/by-name/re/reiser4progs/package.nix
+++ b/pkgs/by-name/re/reiser4progs/package.nix
@@ -38,5 +38,11 @@ stdenv.mkDerivation rec {
     description = "Reiser4 utilities";
     license = licenses.gpl2Plus;
     platforms = platforms.linux;
+
+    # error: initialization of
+    # 'int (*)(uint64_t *, uint64_t,  uint32_t,  int,  int)' {aka 'int (*)(long unsigned int *, long unsigned int,  unsigned int,  int,  int)'}
+    # from incompatible pointer type
+    # 'int (*)(uint64_t *, uint32_t,  uint64_t,  int,  int)' {aka 'int (*)(long unsigned int *, unsigned int,  long unsigned int,  int,  int)'}
+    broken = true;
   };
 }

--- a/pkgs/kde/gear/kpmcore/default.nix
+++ b/pkgs/kde/gear/kpmcore/default.nix
@@ -18,8 +18,6 @@
   jfsutils,
   nilfs-utils,
   ntfs3g,
-  reiser4progs,
-  reiserfsprogs,
   udftools,
   xfsprogs,
   zfs,
@@ -44,8 +42,7 @@ let
     jfsutils
     nilfs-utils
     ntfs3g
-    reiser4progs
-    reiserfsprogs
+    # reiser{4,fs}progs intentionally omitted due to filesystem removal from Linux.
     udftools
     xfsprogs
     zfs


### PR DESCRIPTION
## Things done

As discussed in https://github.com/NixOS/nixpkgs/issues/367696#issuecomment-2561938696.
Fixes #367696

I also marked `reiser4progs` as broken unless someone wanna fix it later. It produces a non-trivial type error, where the function parameter order is incorrect. I don't want to fix it since it's unmaintained anyway.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
