### PR TITLE
nixos/swapspace: add installWrapper option

### DIFF
--- a/nixos/tests/swapspace.nix
+++ b/nixos/tests/swapspace.nix
@@ -1,10 +1,10 @@
 import ./make-test-python.nix (
-  { pkgs, lib, ... }:
+  { lib, ... }:
 
   {
     name = "swapspace";
 
-    meta = with pkgs.lib.maintainers; {
+    meta = with lib.maintainers; {
       maintainers = [
         Luflosi
         phanirithvij
@@ -37,6 +37,9 @@ import ./make-test-python.nix (
       machine.wait_for_unit("multi-user.target")
       machine.wait_for_unit("swapspace.service")
       machine.wait_for_unit("root-swapfile.swap")
+
+      # ensure swapspace wrapper command runs
+      machine.succeed("swapspace --inspect")
 
       swamp = False
       with subtest("swapspace works"):

--- a/pkgs/by-name/sw/swapspace/package.nix
+++ b/pkgs/by-name/sw/swapspace/package.nix
@@ -10,14 +10,14 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "swapspace";
   version = "1.18.1";
 
   src = fetchFromGitHub {
     owner = "Tookmund";
     repo = "Swapspace";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     sha256 = "sha256-KrPdmF1H7WFI78ZJlLqDyfxbs7fymSUQpXL+7XjN9bI=";
   };
 
@@ -45,21 +45,24 @@ stdenv.mkDerivation rec {
     install --mode=444 -D 'swapspace.service' "$out/etc/systemd/system/swapspace.service"
   '';
 
-  # Nothing in swapspace --help or swapspace’s man page mentions
-  # anything about swapspace executing its arguments.
-  passthru.binlore.out = binlore.synthesize swapspace ''
-    execer cannot bin/swapspace
-  '';
-  passthru.tests = {
-    inherit (nixosTests) swapspace;
+  passthru = {
+    # Nothing in swapspace --help or swapspace’s man page mentions
+    # anything about swapspace executing its arguments.
+    binlore.out = binlore.synthesize swapspace ''
+      execer cannot bin/swapspace
+    '';
+    tests = {
+      inherit (nixosTests) swapspace;
+    };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Dynamic swap manager for Linux";
     homepage = "https://github.com/Tookmund/Swapspace";
-    license = licenses.gpl2Only;
-    platforms = platforms.linux;
-    maintainers = with maintainers; [ Luflosi ];
+    changelog = "https://github.com/Tookmund/Swapspace/releases/tag/v${finalAttrs.version}";
     mainProgram = "swapspace";
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ Luflosi ];
   };
-}
+})


### PR DESCRIPTION
fixes #368492

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
