### PR TITLE
zsh-powerlevel10k: 1.20.0 -> 1.20.14

### DIFF
--- a/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
+++ b/pkgs/by-name/zs/zsh-powerlevel10k/package.nix
@@ -3,44 +3,20 @@
   stdenv,
   fetchFromGitHub,
   replaceVars,
-  fetchpatch,
   gitstatus,
   bash,
 }:
 
-let
-  # match gitstatus version with given `gitstatus_version`:
-  # https://github.com/romkatv/powerlevel10k/blob/master/gitstatus/build.info
-  gitstatus' = gitstatus.overrideAttrs (oldAtttrs: rec {
-    version = "1.5.4";
-
-    src = fetchFromGitHub {
-      owner = "romkatv";
-      repo = "gitstatus";
-      rev = "refs/tags/v${version}";
-      hash = "sha256-mVfB3HWjvk4X8bmLEC/U8SKBRytTh/gjjuReqzN5qTk=";
-    };
-
-    patches = (oldAtttrs.patches or [ ]) ++ [
-      # remove when bumped to 1.5.5
-      (fetchpatch {
-        url = "https://github.com/romkatv/gitstatus/commit/62177e89b2b04baf242cd1526cc2661041dda0fb.patch";
-        sha256 = "sha256-DSRYRV89MLR/Eh4MFsXpDKH1xJiAWyJgSqmfjDTXhtU=";
-        name = "drop-Werror.patch";
-      })
-    ];
-
-  });
-in
 stdenv.mkDerivation rec {
   pname = "powerlevel10k";
-  version = "1.20.0";
+  version = "1.20.14";
 
   src = fetchFromGitHub {
     owner = "romkatv";
     repo = "powerlevel10k";
-    rev = "refs/tags/v${version}";
-    hash = "sha256-ES5vJXHjAKw/VHjWs8Au/3R+/aotSbY7PWnWAMzCR8E=";
+    # upstream doesn't seem to use tags anymore
+    rev = "5e26473457d819fe148f7fff32db1082dae72012";
+    hash = "sha256-/+FEkgBR6EOTaCAc15vYGWNih2QZkN27ae6LMXlXZU4=";
   };
 
   strictDeps = true;
@@ -48,7 +24,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (replaceVars ./gitstatusd.patch {
-      gitstatusdPath = "${gitstatus'}/bin/gitstatusd";
+      gitstatusdPath = "${gitstatus}/bin/gitstatusd";
     })
   ];
 


### PR DESCRIPTION
Upstream doesn't use tags anymore but does increase the version in the sources. Let's update to get some fixes and use gitstatus 1.5.5 like upstream.

See https://github.com/romkatv/powerlevel10k/commit/5e26473457d819fe148f7fff32db1082dae72012.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
