### PR TITLE
nixos/oci-containers: support rootless containers & healthchecks

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -470,6 +470,9 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `virtualisation.containers` with backend "podman" now supports rootless containers and `sd_notify(3)`-integration
+  based on container healthchecks.
+
 - Cinnamon has been updated to 6.4, please check the [upstream announcement](https://www.linuxmint.com/rel_xia_whatsnew.php) for more details.
   - Following [changes in Mint 22](https://github.com/linuxmint/mintupgrade/commit/f239cde908288b8c250f938e7311c7ffbc16bd59) we are no longer overriding Qt application styles. You can still restore the previous default with `qt.style = "gtk2"` and `qt.platformTheme = "gtk2"`.
   - Following [changes in Mint 20](https://github.com/linuxmint/mintupgrade-legacy/commit/ce15d946ed9a8cb8444abd25088edd824bfb18f6) we are replacing xplayer with celluloid since xplayer is no longer maintained.

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -17,6 +17,10 @@ let
     { name, ... }:
     {
 
+      config = {
+        podman = mkIf (cfg.backend == "podman") { };
+      };
+
       options = {
 
         image = mkOption {
@@ -287,6 +291,43 @@ let
           '';
         };
 
+        podman = mkOption {
+          type = types.nullOr (
+            types.submodule {
+              options = {
+                sdnotify = mkOption {
+                  default = "conmon";
+                  type = types.enum [
+                    "conmon"
+                    "healthy"
+                    "container"
+                  ];
+                  description = ''
+                    Determines how `podman` should notify systemd that the unit is ready. There are
+                    [three options](https://docs.podman.io/en/latest/markdown/podman-run.1.html#sdnotify-container-conmon-healthy-ignore):
+
+                    * `conmon`: marks the unit as ready when the container has started.
+                    * `healthy`: marks the unit as ready when the [container's healthcheck](https://docs.podman.io/en/stable/markdown/podman-healthcheck-run.1.html) passes.
+                    * `container`: `NOTIFY_SOCKET` is passed into the container and the process inside the container needs to indicate on its own that it's ready.
+                  '';
+                };
+                user = mkOption {
+                  default = "root";
+                  type = types.str;
+                  description = ''
+                    The user under which the container should run.
+                  '';
+                };
+              };
+            }
+          );
+          default = null;
+          description = ''
+            Podman-specific settings in OCI containers. These must be null when using
+            the `docker` backend.
+          '';
+        };
+
         pull = mkOption {
           type =
             with types;
@@ -379,16 +420,20 @@ let
             ${container.imageStream} | ${cfg.backend} load
           ''}
           ${optionalString (cfg.backend == "podman") ''
-            rm -f /run/podman-${escapedName}.ctr-id
+            rm -f /run/${escapedName}/ctr-id
           ''}
         '';
       };
+
+      effectiveUser = container.podman.user or "root";
+      dependOnLingerService =
+        cfg.backend == "podman" && effectiveUser != "root" && config.users.users.${effectiveUser}.linger;
     in
     {
       wantedBy = [ ] ++ optional (container.autoStart) "multi-user.target";
-      wants = lib.optional (
-        container.imageFile == null && container.imageStream == null
-      ) "network-online.target";
+      wants =
+        lib.optional (container.imageFile == null && container.imageStream == null) "network-online.target"
+        ++ lib.optional dependOnLingerService "linger-users.service";
       after =
         lib.optionals (cfg.backend == "docker") [
           "docker.service"
@@ -398,9 +443,15 @@ let
         ++ lib.optionals (container.imageFile == null && container.imageStream == null) [
           "network-online.target"
         ]
-        ++ dependsOn;
+        ++ dependsOn
+        ++ lib.optional dependOnLingerService "linger-users.service";
       requires = dependsOn;
-      environment = proxy_env;
+      environment = lib.mkMerge [
+        proxy_env
+        (mkIf (cfg.backend == "podman" && container.podman.user != "root") {
+          HOME = config.users.users.${container.podman.user}.home;
+        })
+      ];
 
       path =
         if cfg.backend == "docker" then
@@ -424,9 +475,9 @@ let
         ++ optional (container.entrypoint != null) "--entrypoint=${escapeShellArg container.entrypoint}"
         ++ optional (container.hostname != null) "--hostname=${escapeShellArg container.hostname}"
         ++ lib.optionals (cfg.backend == "podman") [
-          "--cidfile=/run/podman-${escapedName}.ctr-id"
-          "--cgroups=no-conmon"
-          "--sdnotify=conmon"
+          "--cidfile=/run/${escapedName}/ctr-id"
+          "--cgroups=enabled"
+          "--sdnotify=${container.podman.sdnotify}"
           "-d"
           "--replace"
         ]
@@ -454,13 +505,13 @@ let
 
       preStop =
         if cfg.backend == "podman" then
-          "podman stop --ignore --cidfile=/run/podman-${escapedName}.ctr-id"
+          "podman stop --ignore --cidfile=/run/${escapedName}/ctr-id"
         else
           "${cfg.backend} stop ${name} || true";
 
       postStop =
         if cfg.backend == "podman" then
-          "podman rm -f --ignore --cidfile=/run/podman-${escapedName}.ctr-id"
+          "podman rm -f --ignore --cidfile=/run/${escapedName}/ctr-id"
         else
           "${cfg.backend} rm -f ${name} || true";
 
@@ -490,6 +541,9 @@ let
           Environment = "PODMAN_SYSTEMD_UNIT=podman-${name}.service";
           Type = "notify";
           NotifyAccess = "all";
+          Delegate = mkIf (container.podman.sdnotify == "healthy") true;
+          User = effectiveUser;
+          RuntimeDirectory = escapedName;
         };
     };
 
@@ -536,17 +590,46 @@ in
 
         assertions =
           let
-            toAssertion =
-              _:
-              { imageFile, imageStream, ... }:
+            toAssertions =
+              name:
               {
-                assertion = imageFile == null || imageStream == null;
+                imageFile,
+                imageStream,
+                podman,
+                ...
+              }:
+              [
+                {
+                  assertion = imageFile == null || imageStream == null;
 
-                message = "You can only define one of imageFile and imageStream";
-              };
-
+                  message = "virtualisation.oci-containers.containers.${name}: You can only define one of imageFile and imageStream";
+                }
+                {
+                  assertion = cfg.backend == "docker" -> podman == null;
+                  message = "virtualisation.oci-containers.containers.${name}: Cannot set `podman` option if backend is `docker`.";
+                }
+              ];
           in
-          lib.mapAttrsToList toAssertion cfg.containers;
+          concatMap (name: toAssertions name cfg.containers.${name}) (lib.attrNames cfg.containers);
+
+        warnings = mkIf (cfg.backend == "podman") (
+          lib.foldlAttrs (
+            warnings: name:
+            { podman, ... }:
+            let
+              inherit (config.users.users.${podman.user}) linger;
+            in
+            warnings
+            ++ lib.optional (podman.user != "root" && linger && podman.sdnotify == "conmon") ''
+              Podman container ${name} is configured as rootless (user ${podman.user})
+              with `--sdnotify=conmon`, but lingering for this user is turned on.
+            ''
+            ++ lib.optional (podman.user != "root" && !linger && podman.sdnotify == "healthy") ''
+              Podman container ${name} is configured as rootless (user ${podman.user})
+              with `--sdnotify=healthy`, but lingering for this user is turned off.
+            ''
+          ) [ ] cfg.containers
+        );
       }
       (lib.mkIf (cfg.backend == "podman") {
         virtualisation.podman.enable = true;
@@ -556,5 +639,4 @@ in
       })
     ]
   );
-
 }

--- a/nixos/tests/oci-containers.nix
+++ b/nixos/tests/oci-containers.nix
@@ -63,8 +63,65 @@ let
       '';
     };
 
+  podmanRootlessTests = lib.genAttrs [ "conmon" "healthy" ] (
+    type:
+    makeTest {
+      name = "oci-containers-podman-rootless-${type}";
+      meta.maintainers = lib.teams.flyingcircus.members;
+      nodes = {
+        podman =
+          { pkgs, ... }:
+          {
+            environment.systemPackages = [ pkgs.redis ];
+            users.groups.redis = { };
+            users.users.redis = {
+              isSystemUser = true;
+              group = "redis";
+              home = "/var/lib/redis";
+              linger = type == "healthy";
+              createHome = true;
+              subUidRanges = [
+                {
+                  count = 65536;
+                  startUid = 2147483646;
+                }
+              ];
+              subGidRanges = [
+                {
+                  count = 65536;
+                  startGid = 2147483647;
+                }
+              ];
+            };
+            virtualisation.oci-containers = {
+              backend = "podman";
+              containers.redis = {
+                image = "redis:latest";
+                imageFile = pkgs.dockerTools.examples.redis;
+                ports = [ "6379:6379" ];
+                podman = {
+                  user = "redis";
+                  sdnotify = type;
+                };
+              };
+            };
+          };
+      };
+
+      testScript = ''
+        start_all()
+        podman.wait_for_unit("podman-redis.service")
+        ${lib.optionalString (type != "healthy") ''
+          podman.wait_for_open_port(6379)
+        ''}
+        podman.wait_until_succeeds("set -eo pipefail; echo 'keys *' | redis-cli")
+      '';
+    }
+  );
 in
-lib.foldl' (attrs: backend: attrs // { ${backend} = mkOCITest backend; }) { } [
-  "docker"
-  "podman"
-]
+{
+  docker = mkOCITest "docker";
+  podman = mkOCITest "podman";
+  podman-rootless-conmon = podmanRootlessTests.conmon;
+  podman-rootless-healthy = podmanRootlessTests.healthy;
+}

--- a/pkgs/build-support/docker/examples.nix
+++ b/pkgs/build-support/docker/examples.nix
@@ -110,6 +110,16 @@ rec {
 
     runAsRoot = ''
       mkdir -p /data
+      cat >/bin/healthcheck <<-'EOF'
+      set -x
+      probe="$(/bin/redis-cli ping)"
+      echo "$probe"
+      if [ "$probe" = 'PONG' ]; then
+        exit 0
+      fi
+      exit 1
+      EOF
+      chmod +x /bin/healthcheck
     '';
 
     config = {
@@ -117,6 +127,15 @@ rec {
       WorkingDir = "/data";
       Volumes = {
         "/data" = { };
+      };
+      Healthcheck = {
+        Test = [
+          "CMD-SHELL"
+          "/bin/healthcheck"
+        ];
+        Interval = 30000000000;
+        Timeout = 10000000000;
+        Retries = 3;
       };
     };
   };


### PR DESCRIPTION
Closes #259770
Closes #207050

The motivation for the former is to not execute the container as root, so you don't have to `sudo -i` to perform podman management tasks.

The idea behind healthchecks is to be able to keep the unit in the activating state until the container is healthy, only then then unit is marked as active.

The following changes were necessary:

* Move the ctr-id into `/run/${containerName}` to make podman can actually write to it since it's now in its RuntimeDirectory.

* Make `sdnotify` option configurable (`healthy` for healthchecks that must pass, default remains `conmon`).

* Set Delegate=yes for `sdnotify=healthy` to make sure a rootless container can actually talk to sd_notify[1].

* Add a warning that lingering must be enabled to have a `systemd --user` instance running which is required for the cgroup support to work properly.

* Added a testcase for rootless containers with both conmon and healthchecks.

[1] https://github.com/containers/podman/discussions/20573#discussioncomment-7612481


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
