### PR TITLE
Use database port for psql immich.nix

### DIFF
--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -253,7 +253,7 @@ in
       in
       [
         ''
-          ${lib.getExe' config.services.postgresql.package "psql"} -p "${cfg.database.port}" -d "${cfg.database.name}" -f "${sqlFile}"
+          ${lib.getExe' config.services.postgresql.package "psql"} -p "${toString cfg.database.port}" -d "${cfg.database.name}" -f "${sqlFile}"
         ''
       ];
 

--- a/nixos/modules/services/web-apps/immich.nix
+++ b/nixos/modules/services/web-apps/immich.nix
@@ -253,7 +253,7 @@ in
       in
       [
         ''
-          ${lib.getExe' config.services.postgresql.package "psql"} -d "${cfg.database.name}" -f "${sqlFile}"
+          ${lib.getExe' config.services.postgresql.package "psql"} -p "${cfg.database.port}" -d "${cfg.database.name}" -f "${sqlFile}"
         ''
       ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Summary of changes

This change ensures that the PostgreSQL `psql` command respects the database port specified in the configuration when initializing the database. Previously, the port was not considered, leading to potential failures during database initialization when a non-default port was used.

### Problem addressed

Prior to this change, the following issue occurred during the database initialization step when using a non-default port:

```shell
warning: the following units failed: postgresql.service
× postgresql.service - PostgreSQL Server
     Loaded: loaded (/etc/systemd/system/postgresql.service; enabled; preset: ignored)
     Active: failed (Result: exit-code) since Fri ...
     
  Invocation: a467605c84f64d47b244f8e59381273a
    Process: 71128 ExecStartPre=/nix/store/haq0x40s98pha1df8hiwmwid5k3f8wcw-unit-script-postgresql-pre-start/bin/postgresql-pre-start (code=exited, status=0/SUCCESS)
    Process: 71141 ExecStart=/nix/store/nqspp5rwcnx24pwxz7vr075xb94hym5c-postgresql-and-plugins-16.5/bin/postgres (code=exited, status=0/SUCCESS)
    Process: 71211 ExecStartPost=/nix/store/h8a2p4slp8yis80ndlrcx6hc8ckvjhjr-unit-script-postgresql-post-start/bin/postgresql-post-start (code=exited, status=0/SUCCESS)
    Process: 71225 ExecStartPost=/nix/store/0z5iwcvalafm3j2c5pfhllsfbxrbyzf4-postgresql-16.5/bin/psql -d immich -f /nix/store/5b2hymzcdhzvzmv1x08zd8cwrniaap38-immich-pgvectors-setup.sql (code=exited, status=2)
```

The failure was due to `psql` attempting to connect to the default port instead of the configured port.

## Additional Considerations

This change addresses the issue for users who specify a non-default database port in the configuration. However, there is a potential concern: if the non-default port implies the use of an external database setup, disabling the database initialization step entirely might be more appropriate. I am uncertain about the correct approach in this scenario and welcome feedback or guidance.


## My use case

As a developer, I frequently work with a computer running various services, including Docker. To avoid conflicts with standard ports, such as those used by PostgreSQL, I make it a practice to run all background services on non-standard ports. This approach ensures that standard ports remain available for development tools and temporary setups when needed.