### PR TITLE
ranger: 1.9.3-unstable-2023-08-23 -> 1.9.4, update script, tag in src, rm with lib

### DIFF
--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -12,17 +12,18 @@
   neoVimSupport ? true,
   improvedEncodingDetection ? true,
   rightToLeftTextSupport ? false,
+  gitUpdater,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "ranger";
-  version = "1.9.3-unstable-2023-08-23";
+  version = "1.9.3";
 
   src = fetchFromGitHub {
     owner = "ranger";
     repo = "ranger";
-    rev = "38bb8901004b75a407ffee4b9e176bc0a436cb15";
-    hash = "sha256-NpsrABk95xHNvhlRjKFh326IW83mYj1cmK3aE9JQSRo=";
+    tag = "v${version}";
+    hash = "sha256-iNMOKGsPFzjqojCttZf9eGkC9Ju00kFsx9uqz3x2z+c=";
   };
 
   LC_ALL = "en_US.UTF-8";
@@ -67,12 +68,14 @@ python3Packages.buildPythonApplication rec {
         --replace "set preview_images false" "set preview_images true"
     '';
 
-  meta = with lib; {
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
     description = "File manager with minimalistic curses interface";
     homepage = "https://ranger.github.io/";
-    license = licenses.gpl3Only;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
       toonn
       magnetophon
     ];

--- a/pkgs/by-name/ra/ranger/package.nix
+++ b/pkgs/by-name/ra/ranger/package.nix
@@ -17,13 +17,13 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "ranger";
-  version = "1.9.3";
+  version = "1.9.4";
 
   src = fetchFromGitHub {
     owner = "ranger";
     repo = "ranger";
     tag = "v${version}";
-    hash = "sha256-iNMOKGsPFzjqojCttZf9eGkC9Ju00kFsx9uqz3x2z+c=";
+    hash = "sha256-9ehxMXwQj7oVhlotTc3mzCKCkoMSbB9cliPg/NMEoWM=";
   };
 
   LC_ALL = "en_US.UTF-8";


### PR DESCRIPTION
Closes: https://github.com/NixOS/nixpkgs/pull/367654
- **ranger: pin to a version, remove with lib, add update script**
- **ranger: 1.9.3-unstable-2023-08-23 -> 1.9.4**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
