### PR TITLE
cargoCheckHook: proof of concept of fix for the test-threads issue

### DIFF
--- a/pkgs/build-support/rust/hooks/cargo-check-hook.sh
+++ b/pkgs/build-support/rust/hooks/cargo-check-hook.sh
@@ -11,10 +11,9 @@ cargoCheckHook() {
 
     local flagsArray=("-j" "$NIX_BUILD_CORES")
 
-    if [[ -z ${dontUseCargoParallelTests-} ]]; then
-        prependToVar checkFlags "--test-threads=$NIX_BUILD_CORES"
-    else
-        prependToVar checkFlags "--test-threads=1"
+    export RUST_TEST_THREADS=$NIX_BUILD_CORES
+    if [[ ! -z ${dontUseCargoParallelTests-} ]]; then
+        RUST_TEST_THREADS=1
     fi
 
     if [ "${cargoCheckType}" != "debug" ]; then

--- a/pkgs/by-name/ca/carl/package.nix
+++ b/pkgs/by-name/ca/carl/package.nix
@@ -15,7 +15,7 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-+l11eP+1qKrWbZhyUJgQ8FgQ+2rncx778F5RPzCfvV4=";
   };
 
-  doCheck = false;
+  dontUseCargoParallelTests = true;
 
   cargoHash = "sha256-nBl34szwEQX26MibfT10E55czYXN3/9W3y2z936KqTc=";
 

--- a/pkgs/by-name/gl/glitter/package.nix
+++ b/pkgs/by-name/gl/glitter/package.nix
@@ -27,12 +27,6 @@ rustPlatform.buildRustPackage rec {
     git init
   '';
 
-  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  checkFlags = [
-    "--skip"
-    "runs_correctly"
-  ];
-
   meta = with lib; {
     description = "Git wrapper that allows you to compress multiple commands into one";
     homepage = "https://github.com/milo123459/glitter";

--- a/pkgs/by-name/ls/lsd/package.nix
+++ b/pkgs/by-name/ls/lsd/package.nix
@@ -23,6 +23,10 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-yyXFtMyiMq6TaN9/7+BaBERHgubeA8SJGOr08Mn3RnY=";
 
+  checkFlags = [
+    "--skip=git::tests::test_git_workflow"
+  ];
+
   nativeBuildInputs = [
     installShellFiles
     pandoc
@@ -39,9 +43,6 @@ rustPlatform.buildRustPackage rec {
       --fish $releaseDir/build/lsd-*/out/lsd.fish \
       --zsh $releaseDir/build/lsd-*/out/_lsd
   '';
-
-  # Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  doCheck = false;
 
   passthru.tests.version = testers.testVersion { package = lsd; };
 

--- a/pkgs/by-name/na/navi/package.nix
+++ b/pkgs/by-name/na/navi/package.nix
@@ -33,11 +33,6 @@ rustPlatform.buildRustPackage rec {
       --prefix PATH : ${lib.makeBinPath ([ wget ] ++ lib.optionals withFzf [ fzf ])}
   '';
 
-  checkFlags = [
-    # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-    "--skip=test_parse_variable_line"
-  ];
-
   meta = with lib; {
     description = "Interactive cheatsheet tool for the command-line and application launchers";
     homepage = "https://github.com/denisidoro/navi";

--- a/pkgs/by-name/sf/sfz/package.nix
+++ b/pkgs/by-name/sf/sfz/package.nix
@@ -17,9 +17,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-MgbK39xAr8g9F+1MXZiw5rE/PsgQPcLZ2ZV6LiQbA24=";
 
-  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  doCheck = false;
-
   meta = with lib; {
     description = "Simple static file serving command-line tool written in Rust";
     homepage = "https://github.com/weihanglo/sfz";

--- a/pkgs/by-name/ti/tidy-viewer/package.nix
+++ b/pkgs/by-name/ti/tidy-viewer/package.nix
@@ -17,12 +17,6 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-pIGuBP0a4jWFzkQfqvxQUrBmqYjhERVyEbZvL7g5hRM=";
 
-  # this test parses command line arguments
-  # error: Found argument '--test-threads' which wasn't expected, or isn't valid in this context
-  checkFlags = [
-    "--skip=build_reader_can_create_reader_without_file_specified"
-  ];
-
   meta = with lib; {
     description = "Cross-platform CLI csv pretty printer that uses column styling to maximize viewer enjoyment";
     mainProgram = "tidy-viewer";

--- a/pkgs/by-name/ty/typst/package.nix
+++ b/pkgs/by-name/ty/typst/package.nix
@@ -41,12 +41,6 @@ rustPlatform.buildRustPackage rec {
     OPENSSL_NO_VENDOR = true;
   };
 
-  postPatch = ''
-    # Fix for "Found argument '--test-threads' which wasn't expected, or isn't valid in this context"
-    substituteInPlace tests/src/tests.rs --replace-fail 'ARGS.num_threads' 'ARGS.test_threads'
-    substituteInPlace tests/src/args.rs --replace-fail 'num_threads' 'test_threads'
-  '';
-
   postInstall = ''
     installManPage crates/typst-cli/artifacts/*.1
     installShellCompletion \

--- a/pkgs/by-name/wa/wasm-tools/package.nix
+++ b/pkgs/by-name/wa/wasm-tools/package.nix
@@ -23,14 +23,9 @@ rustPlatform.buildRustPackage rec {
     "--package"
     "wasm-tools"
   ];
-  cargoTestFlags =
-    [ "--all" ]
-    ++
-    # Due to https://github.com/bytecodealliance/wasm-tools/issues/1820
-    [
-      "--"
-      "--test-threads=1"
-    ];
+
+  # Due to https://github.com/bytecodealliance/wasm-tools/issues/1820
+  dontUseCargoParallelTests = true;
 
   meta = with lib; {
     description = "Low level tooling for WebAssembly in Rust";


### PR DESCRIPTION
Some tests are failing because an extra arg is being passed to set the amount of threads for cargo test.

This is a proof of concept with the assumption that the arguments passed somehow are stepping on toes of
other argument parsers. Assuming that this amount of threads can also be passed via RUST_TEST_THREADS,
we could achieve the same behaviour and avoid causing this problem.

- **cargoCheckHook: pass test-threads using an environment variable**
- **treewide: reenable tests of packages affected with the test-threads issue**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
