### PR TITLE
temurin-bin: add version 25 (early access)

### DIFF
--- a/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin.nix
@@ -24,4 +24,7 @@ in
 
   jdk-24 = common { sourcePerArch = sources.jdk.openjdk24; };
   jre-24 = common { sourcePerArch = sources.jre.openjdk24; };
+
+  jdk-25ea = common { sourcePerArch = sources.jdk.openjdk25; };
+  jre-25ea = common { sourcePerArch = sources.jre.openjdk25; };
 }

--- a/pkgs/development/compilers/temurin-bin/jdk-linux.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-linux.nix
@@ -29,4 +29,7 @@ in
 
   jdk-24 = common { sourcePerArch = sources.jdk.openjdk24; };
   jre-24 = common { sourcePerArch = sources.jre.openjdk24; };
+
+  jdk-25ea = common { sourcePerArch = sources.jdk.openjdk25; };
+  jre-25ea = common { sourcePerArch = sources.jre.openjdk25; };
 }

--- a/pkgs/development/compilers/temurin-bin/sources.json
+++ b/pkgs/development/compilers/temurin-bin/sources.json
@@ -70,6 +70,22 @@
             "version": "24.0.0"
           }
         },
+        "openjdk25": {
+          "aarch64": {
+            "build": "23",
+            "sha256": "2eb760bf0f861cb5e25a90827ef47e8ed29cc378bb0f9131d5749913f9c51f85",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_aarch64_alpine-linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "23",
+            "sha256": "03e24b6b0a939580af56e4433c08784dd7f4b97a8f196508d917c24774809ce5",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_x64_alpine-linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -148,6 +164,22 @@
             "sha256": "0f738719d0483d6fe7f08a1371d1c696d68dcfe39f073b4241673f35ffc8d655",
             "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_x64_alpine-linux_hotspot_24_36.tar.gz",
             "version": "24.0.0"
+          }
+        },
+        "openjdk25": {
+          "aarch64": {
+            "build": "23",
+            "sha256": "979933b674631250b063ba7840cbb7b87db441082fc7106926e4bdc5cac0a4d4",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_aarch64_alpine-linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "23",
+            "sha256": "003eddb7dd91ab5bb8c9ea8e18647d8dda701c664736f073c10ee7a03c1d6713",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_x64_alpine-linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
           }
         },
         "openjdk8": {
@@ -320,6 +352,34 @@
             "sha256": "c340dee97b6aa215d248bc196dcac5b56e7be9b5c5d45e691344d40d5d0b171d",
             "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jdk_x64_linux_hotspot_24_36.tar.gz",
             "version": "24.0.0"
+          }
+        },
+        "openjdk25": {
+          "aarch64": {
+            "build": "23",
+            "sha256": "45744f87f31141622686931721a69ec6e1c3374cd32113ad1e2891c5b7b1c71b",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_aarch64_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "packageType": "jdk",
+          "powerpc64le": {
+            "build": "23",
+            "sha256": "f708de073e41aef606704b64b2ad4cc36f5ab54f53405f1b9b65fd56ecdf6998",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_ppc64le_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "riscv64": {
+            "build": "23",
+            "sha256": "dceed795b59b56fbfc812803438fe5b547dcbd5a3b791cb8c0a11140722448e3",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_riscv64_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "23",
+            "sha256": "7050b3b22b4d1282e8bea887e9a2f7456ffbf9306b2b9abf5571aa71ee707295",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_x64_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
           }
         },
         "openjdk8": {
@@ -516,6 +576,34 @@
             "version": "24.0.0"
           }
         },
+        "openjdk25": {
+          "aarch64": {
+            "build": "23",
+            "sha256": "ef3ec6ce53c3bf05fd83bf4856a44e7d758e5d053e6ac7c72001017c6d7dd2f7",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_aarch64_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "packageType": "jre",
+          "powerpc64le": {
+            "build": "23",
+            "sha256": "2a16b52ac01c18d9a48a5775526403c7ba8ed15c0e6bab4c144636669c969584",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_ppc64le_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "riscv64": {
+            "build": "23",
+            "sha256": "7268370006e472c98e07d370137538b882a5e0804c21f323e091e2028fb0fa9c",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_riscv64_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "23",
+            "sha256": "16970617333f7a91c53c34589f84d20b3291edf8b42694c3b2cedd1cb4961612",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_x64_linux_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          }
+        },
         "openjdk8": {
           "aarch64": {
             "build": "6",
@@ -634,6 +722,22 @@
             "version": "24.0.0"
           }
         },
+        "openjdk25": {
+          "aarch64": {
+            "build": "23",
+            "sha256": "40f87d0aba79c7976ca778f1415a07747c15863633c2163c3cd33c322e305824",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_aarch64_mac_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "packageType": "jdk",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "23",
+            "sha256": "998d4f40f64c2891666a9898e01ce65cf64e0a7adedef2cafe257967dfb7cf2d",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jdk_x64_mac_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          }
+        },
         "openjdk8": {
           "packageType": "jdk",
           "vmType": "hotspot",
@@ -724,6 +828,22 @@
             "sha256": "10b2a32a5544c03a4bf36f12efc3a770bb789be20ff3c9edf85102c5879479de",
             "url": "https://github.com/adoptium/temurin24-binaries/releases/download/jdk-24%2B36/OpenJDK24U-jre_x64_mac_hotspot_24_36.tar.gz",
             "version": "24.0.0"
+          }
+        },
+        "openjdk25": {
+          "aarch64": {
+            "build": "23",
+            "sha256": "91ec9b72e288bc9d7227dc82be6e1a45cb65f34d04f20a13cb7a2754c1a00a46",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_aarch64_mac_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
+          },
+          "packageType": "jre",
+          "vmType": "hotspot",
+          "x86_64": {
+            "build": "23",
+            "sha256": "0ab9d3f5056a68573ffe4e5b9ce6be1a724a33bfbcd82c6bcebbc59d3b9e2845",
+            "url": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B23-ea-beta/OpenJDK-jre_x64_mac_hotspot_25_23-ea.tar.gz",
+            "version": "25.0.0"
           }
         },
         "openjdk8": {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4908,6 +4908,9 @@ with pkgs;
 
   ### DEVELOPMENT / COMPILERS
 
+  temurin-bin-25ea = javaPackages.compiler.temurin-bin.jdk-25ea;
+  temurin-jre-bin-25ea = javaPackages.compiler.temurin-bin.jre-25ea;
+
   temurin-bin-24 = javaPackages.compiler.temurin-bin.jdk-24;
   temurin-jre-bin-24 = javaPackages.compiler.temurin-bin.jre-24;
 


### PR DESCRIPTION
## Things done

To be able to test with this version, and as preparation for when it becomes GA (which is expected to be before the next Nix release, https://www.oracle.com/java/technologies/java-se-support-roadmap.html)

I think I would *ideally* prefer this to live outside of nixpkgs until it becomes stable, but I don't think this is currently easy to do, and it's anyway a good stepping stone towards more fully packaging OpenJDK 25 later anyway, so I think on balance it makes sense to have it in nixpkgs.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
