### PR TITLE
pam_ssh_agent_auth: fix build with gcc14

### DIFF
--- a/pkgs/by-name/pa/pam_ssh_agent_auth/package.nix
+++ b/pkgs/by-name/pa/pam_ssh_agent_auth/package.nix
@@ -3,9 +3,11 @@
   stdenv,
   nixosTests,
   fetchFromGitHub,
+  fetchDebianPatch,
   pam,
   openssl,
   perl,
+  autoreconfHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -26,18 +28,50 @@ stdenv.mkDerivation rec {
     sha256 = "ETFpIaWQnlYG8ZuDG2dNjUJddlvibB4ukHquTFn3NZM=";
   };
 
+  # Required because of fix-configure.patch
+  nativeBuildInputs = [
+    autoreconfHook
+  ];
+
   buildInputs = [
     pam
     openssl
     perl
   ];
 
-  patches = [
-    # Allow multiple colon-separated authorized keys files to be
-    # specified in the file= option.
-    ./multiple-key-files.patch
-    ./edcsa-crash-fix.patch
-  ];
+  patches =
+    let
+      fetchDebianPatch' =
+        args:
+        fetchDebianPatch (
+          {
+            pname = "pam-ssh-agent-auth";
+            version = "0.10.3";
+            debianRevision = "11";
+          }
+          // args
+        );
+    in
+    [
+      # Allow multiple colon-separated authorized keys files to be
+      # specified in the file= option.
+      ./multiple-key-files.patch
+      ./edcsa-crash-fix.patch
+
+      # Patch configure to remove implicit function declaration errors under gcc14
+      # Requires autoreconfHook
+      (fetchDebianPatch' {
+        patch = "fix-configure.patch";
+        hash = "sha256-ymXv2o/NpFeVQ6r0hvJEeMpvs5Ht9jq4RSw8ssv43FY=";
+      })
+
+      # Avoided incompatible pointer passing to fix GCC 14 build errors. Add missing 'const', cast to expected pointer type (DSA_SIG) and avoid
+      # pointer to pointer when pointer is required.
+      (fetchDebianPatch' {
+        patch = "1000-gcc-14.patch";
+        hash = "sha256-EvdaIhrfKZ1mB7qvNiGx/hYdthStgnhK7xvJEhhAFDQ=";
+      })
+    ];
 
   configureFlags = [
     # It's not clear to me why this is necessary, but without it, you see:


### PR DESCRIPTION
Fixes #368603

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc