### PR TITLE
greetd-mini-wl-greeter: init at 0-unstable-2024-12-27

### DIFF
--- a/pkgs/by-name/gr/greetd-mini-wl-greeter/package.nix
+++ b/pkgs/by-name/gr/greetd-mini-wl-greeter/package.nix
@@ -1,0 +1,67 @@
+{
+  fetchFromGitHub,
+  lib,
+  stdenv,
+  unstableGitUpdater,
+  cairo,
+  glib,
+  json_c,
+  libGL,
+  libepoxy,
+  libpng,
+  libxkbcommon,
+  meson,
+  ninja,
+  pango,
+  pkg-config,
+  scdoc,
+  wayland,
+  wayland-protocols,
+  wayland-scanner,
+}:
+stdenv.mkDerivation {
+  pname = "greetd-mini-wl-greeter";
+  version = "0-unstable-2024-12-27";
+
+  src = fetchFromGitHub {
+    owner = "philj56";
+    repo = "greetd-mini-wl-greeter";
+    rev = "61f25ed34a1a35a061c2f3605fc3d4b37a7d0d8e";
+    hash = "sha256-ifeQbzMA9O+yhLveTXpEmgG2BsSp4lxbd3yo8o69fxA=";
+  };
+
+  nativeBuildInputs = [
+    libGL
+    cairo
+    glib
+    json_c
+    libepoxy
+    libpng
+    libxkbcommon
+    pango
+    wayland
+    wayland-protocols
+    wayland-scanner
+  ];
+
+  # https://github.com/philj56/greetd-mini-wl-greeter/issues/2
+  mesonBuildType = "release";
+
+  buildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+  ];
+
+  passthru.updateScript = unstableGitUpdater { };
+
+  meta = {
+    description = "Extremely minimal raw Wayland greeter for greetd";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/philj56/greetd-mini-wl-greeter";
+    mainProgram = "greetd-mini-wl-greeter";
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ _0x5a4 ];
+  };
+}


### PR DESCRIPTION
[greetd-mini-wl-greeter](https://github.com/philj56/greetd-mini-wl-greeter) is a really simple greeter for greetd, inspired by lightdms mini-greeter. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
