### PR TITLE
gpt4all: add passthru.updateScript

### DIFF
--- a/pkgs/by-name/gp/gpt4all/package.nix
+++ b/pkgs/by-name/gp/gpt4all/package.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   fetchurl,
   fetchpatch,
+  nix-update-script,
   cmake,
   qt6,
   fmt,
@@ -100,6 +101,8 @@ stdenv.mkDerivation (finalAttrs: {
     substituteInPlace $out/share/applications/io.gpt4all.gpt4all.desktop \
       --replace-fail 'Exec=chat' 'Exec=${finalAttrs.meta.mainProgram}'
   '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/nomic-ai/gpt4all/releases/tag/v${finalAttrs.version}";


### PR DESCRIPTION
Add `passthru.updateScript` to semi-automatically update this package. However, updating this package with the following patch to `v3.6.1` causes build errors:

```patch
From 7d98a184e74a81c8041c684b86dd70bb674a3e0f Mon Sep 17 00:00:00 2001
From: NAHO <90870942+trueNAHO@users.noreply.github.com>
Date: Fri, 27 Dec 2024 20:32:43 +0100
Subject: [PATCH] gpt4all: 3.4.2 -> 3.6.1

---
 pkgs/by-name/gp/gpt4all/package.nix | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

diff --git a/pkgs/by-name/gp/gpt4all/package.nix b/pkgs/by-name/gp/gpt4all/package.nix
index 4175113edc02..c0dcd3a6e48d 100644
--- a/pkgs/by-name/gp/gpt4all/package.nix
+++ b/pkgs/by-name/gp/gpt4all/package.nix
@@ -19,11 +19,11 @@

 stdenv.mkDerivation (finalAttrs: {
   pname = "gpt4all";
-  version = "3.4.2";
+  version = "3.6.1";

   src = fetchFromGitHub {
     fetchSubmodules = true;
-    hash = "sha256-QzU22y6tt3UhazVSPcFuKejH4AV+mw7JExH61NtAKoM=";
+    hash = "sha256-eJVwLHER3Ch9dnxubSUJFvE1MHt0ywvcYr5s2p2W7X8=";
     owner = "nomic-ai";
     repo = "gpt4all";
     rev = "v${finalAttrs.version}";
--
2.47.0
```

Could the maintainers of this package investigate this and update this package in a follow-up PR?

Cc: @polygon, @titaniumtown

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
