### PR TITLE
lxqt-panel-profiles: init at 1.1

### DIFF
--- a/pkgs/by-name/lx/lxqt-panel-profiles/package.nix
+++ b/pkgs/by-name/lx/lxqt-panel-profiles/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  python3Packages,
+  qt6,
+  bash,
+}:
+let
+  pythonWithPyqt6 = python3Packages.python.withPackages (ps: [
+    ps.pyqt6
+  ]);
+in
+stdenv.mkDerivation rec {
+  pname = "lxqt-panel-profiles";
+  version = "1.1";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "MrReplikant";
+    repo = "lxqt-panel-profiles";
+    rev = version;
+    hash = "sha256-YGjgTLodVTtDzP/SOEg+Ehf1LYggTnG1H1rN5m1jaNM=";
+  };
+
+  postPatch = ''
+    # after copying the layouts folder from the nix store
+    # add write permissions to the folder, so saving profiles works
+    substituteInPlace usr/bin/lxqt-panel-profiles \
+    --replace-fail 'cp -r /usr/share/lxqt-panel-profiles/layouts $XDG_DATA_HOME/lxqt-panel-profiles' 'cp -r /usr/share/lxqt-panel-profiles/layouts $XDG_DATA_HOME/lxqt-panel-profiles; chmod -R u+w,g+w $XDG_DATA_HOME/lxqt-panel-profiles;'
+
+    substituteInPlace usr/bin/lxqt-panel-profiles \
+    --replace-fail "/bin/bash" "${bash}/bin/bash" \
+    --replace-fail "/usr/share/" "$out/usr/share/" \
+    --replace-fail "python3" "${pythonWithPyqt6}/bin/python"
+
+    substituteInPlace usr/share/lxqt-panel-profiles/lxqt-panel-profiles.py \
+    --replace-fail "qdbus" "${qt6.qttools}/bin/qdbus"
+  '';
+
+  installPhase = ''
+    mkdir $out
+    mv usr $out/usr
+  '';
+
+  meta = {
+    description = "";
+    homepage = "https://codeberg.org/MrReplikant/lxqt-panel-profiles/";
+    changelog = "https://codeberg.org/MrReplikant/lxqt-panel-profiles/releases/tag/${version}";
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [ linuxissuper ];
+    mainProgram = "lxqt-panel-profiles";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
LXQt Panel Profiles allows to backup, switch, export and import panel configurations. It is equivalent to XFCE's panel profiles program and behaves very similarly.
from https://codeberg.org/MrReplikant/lxqt-panel-profiles/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
