### PR TITLE
nixos/wireguard-networkd: fix loading pre shared keys for peers without a custom name

### DIFF
--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -22,14 +22,16 @@ let
     ;
   inherit (lib.modules) mkIf;
   inherit (lib.options) literalExpression mkOption;
-  inherit (lib.strings) hasInfix;
+  inherit (lib.strings) hasInfix replaceStrings;
   inherit (lib.trivial) flip pipe;
 
   removeNulls = filterAttrs (_: v: v != null);
 
-  privateKeyCredential = interfaceName: "wireguard-${interfaceName}-private-key";
+  escapeCredentialName = input: replaceStrings [ "\\" ] [ "_" ] input;
+
+  privateKeyCredential = interfaceName: escapeCredentialName "wireguard-${interfaceName}-private-key";
   presharedKeyCredential =
-    interfaceName: peer: "wireguard-${interfaceName}-${peer.name}-preshared-key";
+    interfaceName: peer: escapeCredentialName "wireguard-${interfaceName}-${peer.name}-preshared-key";
 
   interfaceCredentials =
     interfaceName: interface:

--- a/nixos/modules/services/networking/wireguard-networkd.nix
+++ b/nixos/modules/services/networking/wireguard-networkd.nix
@@ -61,7 +61,8 @@ let
     interfaceName: peer:
     removeNulls {
       PublicKey = peer.publicKey;
-      PresharedKey = "@${presharedKeyCredential interfaceName peer}";
+      PresharedKey =
+        if peer.presharedKeyFile == null then null else "@${presharedKeyCredential interfaceName peer}";
       AllowedIPs = peer.allowedIPs;
       Endpoint = peer.endpoint;
       PersistentKeepalive = peer.persistentKeepalive;

--- a/nixos/tests/wireguard/dynamic-refresh.nix
+++ b/nixos/tests/wireguard/dynamic-refresh.nix
@@ -84,7 +84,10 @@ import ../make-test-python.nix (
       ''
         start_all()
 
+        server.systemctl("start network-online.target")
         server.wait_for_unit("network-online.target")
+
+        client.systemctl("start network-online.target")
         client.wait_for_unit("network-online.target")
 
         client.succeed("ping -n -w 1 -c 1 10.23.42.1")

--- a/nixos/tests/wireguard/networkd.nix
+++ b/nixos/tests/wireguard/networkd.nix
@@ -79,8 +79,11 @@ import ../make-test-python.nix (
     testScript = ''
       start_all()
 
-      peer0.wait_for_unit("systemd-networkd-wait-online.service")
-      peer1.wait_for_unit("systemd-networkd-wait-online.service")
+      peer0.systemctl("start network-online.target")
+      peer0.wait_for_unit("network-online.target")
+
+      peer1.systemctl("start network-online.target")
+      peer1.wait_for_unit("network-online.target")
 
       peer1.succeed("ping -c5 fc00::1")
       peer1.succeed("ping -c5 10.23.42.1")

--- a/nixos/tests/wireguard/networkd.nix
+++ b/nixos/tests/wireguard/networkd.nix
@@ -39,6 +39,9 @@ import ../make-test-python.nix (
                 "fc00::2/128"
               ];
 
+              # !!! Don't do this with real keys. The /nix store is world-readable!
+              presharedKeyFile = toString (pkgs.writeText "presharedKey" wg-snakeoil-keys.presharedKey);
+
               inherit (wg-snakeoil-keys.peer1) publicKey;
             };
           };
@@ -69,6 +72,9 @@ import ../make-test-python.nix (
               endpoint = "192.168.0.1:23542";
               persistentKeepalive = 25;
 
+              # !!! Don't do this with real keys. The /nix store is world-readable!
+              presharedKeyFile = toString (pkgs.writeText "presharedKey" wg-snakeoil-keys.presharedKey);
+
               inherit (wg-snakeoil-keys.peer0) publicKey;
             };
           };
@@ -87,6 +93,10 @@ import ../make-test-python.nix (
 
       peer1.succeed("ping -c5 fc00::1")
       peer1.succeed("ping -c5 10.23.42.1")
+
+      with subtest("Has PSK set"):
+        peer0.succeed("wg | grep 'preshared key'")
+        peer1.succeed("wg | grep 'preshared key'")
     '';
   }
 )

--- a/nixos/tests/wireguard/snakeoil-keys.nix
+++ b/nixos/tests/wireguard/snakeoil-keys.nix
@@ -1,4 +1,6 @@
 {
+  presharedKey = "7myEJlGAWLTg83y7Py29pp7REQBVmZfI4xcawjcZpjg=";
+
   peer0 = {
     privateKey = "OPuVRS2T0/AtHDp3PXkNuLQYDiqJaBEEnYe42BSnJnQ=";
     publicKey = "IujkG119YPr2cVQzJkSLYCdjpHIDjvr/qH1w1tdKswY=";


### PR DESCRIPTION
This pull request fixes some wireguard tests not working after #365809 and fixes systemd credential loading for pre shared keys on peers without a custom name.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
