### PR TITLE
workflows/build: init

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: Build
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+
+jobs:
+  parse-commits:
+    name: Parse commits
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      attributes: ${{ steps.attributes.outputs.attributes }}
+
+    steps:
+      - name: Get attribute names from commits
+        id: attributes
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "attributes=$(gh api \
+            "/repos/{owner}/{repo}/pulls/$PR_NUMBER/commits" \
+            --jq '[ .[] | .commit.message | split("\n") | .[0] | split(":") | .[0] ]')" \
+            >> "$GITHUB_OUTPUT"
+
+  get-merge-commit:
+    uses: ./.github/workflows/get-merge-commit.yml
+
+  build:
+    name: Build ${{ matrix.attribute }} (${{ matrix.platform.system }})
+    needs: [ get-merge-commit, parse-commits ]
+
+    if: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+    runs-on: ${{ matrix.platform.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: ubuntu-latest
+            system: x86_64-linux
+          - os: macos-13
+            system: x86_64-darwin
+          - os: macos-latest
+            system: aarch64-darwin
+        attribute: ${{ fromJSON(needs.parse-commits.outputs.attributes) }}
+
+    steps:
+      - name: Check out the PR at the test merge commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.get-merge-commit.outputs.mergedSha }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+
+      - name: Evaluate attribute
+        id: evaluate
+        # Some of our detected attributes may not exist or have failures for other reasons. Let's not assume anything
+        continue-on-error: true
+        env:
+          attribute: ${{ matrix.attribute }}
+        run: |
+          drv_path=$(nix-instantiate -A "$attribute")
+          echo "drv_path=$drv_path" >> "$GITHUB_ENV"
+
+      - name: Build attribute
+        if: ${{ steps.evaluate.outcome == 'success' }}
+        run: |
+          nix-build "$drv_path"


### PR DESCRIPTION
Part of https://github.com/NixOS/nixpkgs/issues/355847

With the end of OfBorg nigh, it's important to keep at least some automated builds going. So, this is meant to replace OfBorg's [automatic building of attributes](https://github.com/NixOS/ofborg/blob/f91dd4cdd8679c6d12b1cb40a59e51f85bc088b8/README.md#automatic-building) based on the prefix of commit messages

You can find a PR with this in action at https://github.com/getchoo-contrib/nixpkgs/pull/15

Some things to still do now and in the future:

- Run passthru.tests
- Set a neutral check for failed `nix-instantiate' invocations (I can't find a nice way to do this outside of the Node API :/)
  - Currently they are marked as a success, which implies a build 👎 
- Support comment invocations? (i.e., `@ofborg build/test`)
  - Might be better for a different workflow, as that would have to look for the invocation, parse, escape, handle multiple lines of it, etc etc.
- Re-use the evaluation workflow artifacts?
  - Running this after the evaluation workflow would be ideal, as there's not much point in building when eval is broken (at least IMO)
  - We currently re-evaluate (what we assume are) the top-level packages changed, which is a bit wasteful
  - Main problem here is that we have no way of differentiating the packages directly changed by the PR from their dependents...and I don't think we want to be basically running `nixpkgs-review` for *every* PR 😆 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
