### PR TITLE
godini: init at 1.0.0, treegen: init at 1.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -254,6 +254,14 @@
     githubId = 3417013;
     name = "Eske Nielsen";
   };
+  _4r7if3x = {
+    email = "the.artifex@proton.me";
+    matrix = "@4r7if3x:matrix.org";
+    github = "4r7if3x";
+    githubId = 8606282;
+    name = "4r7if3x";
+    keys = [ { fingerprint = "013C ED4B E769 745A CFC3  0F3C F23C 2613 2266 7A12"; } ];
+  };
   _6543 = {
     email = "6543@obermui.de";
     github = "6543";

--- a/pkgs/by-name/go/godini/package.nix
+++ b/pkgs/by-name/go/godini/package.nix
@@ -1,0 +1,49 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  godini,
+  lib,
+  nix-update-script,
+  testers,
+}:
+
+buildGoModule rec {
+  pname = "godini";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "bilbilak";
+    repo = "godini";
+    tag = "v${version}";
+    hash = "sha256-83OAddIoJzAUXPZKGnAx8XPKrdSmtc1EIJUDmRHTU/U=";
+  };
+
+  vendorHash = "sha256-hocnLCzWN8srQcO3BMNkd2lt0m54Qe7sqAhUxVZlz1k=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/bilbilak/godini/config.Version=${version}"
+  ];
+
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = godini;
+        command = "godini --version";
+      };
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    changelog = "https://github.com/bilbilak/godini/blob/main/CHANGELOG.md";
+    description = "INI Configuration Management Tool";
+    homepage = "https://github.com/bilbilak/godini";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "godini";
+    maintainers = with lib.maintainers; [ _4r7if3x ];
+    platforms = with lib.platforms; unix ++ windows;
+  };
+}

--- a/pkgs/by-name/tr/treegen/package.nix
+++ b/pkgs/by-name/tr/treegen/package.nix
@@ -1,0 +1,49 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+  nix-update-script,
+  testers,
+  treegen,
+}:
+
+buildGoModule rec {
+  pname = "treegen";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "bilbilak";
+    repo = "treegen";
+    tag = "v${version}";
+    hash = "sha256-PPWUEfX7OXKZnghiVXU+eCjveA1VszA3uS8C3uI3pFM=";
+  };
+
+  vendorHash = "sha256-hocnLCzWN8srQcO3BMNkd2lt0m54Qe7sqAhUxVZlz1k=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X github.com/bilbilak/treegen/config.Version=${version}"
+  ];
+
+  passthru = {
+    tests = {
+      version = testers.testVersion {
+        package = treegen;
+        command = "treegen --version";
+      };
+    };
+
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    changelog = "https://github.com/bilbilak/treegen/blob/main/CHANGELOG.md";
+    description = "ASCII Tree Directory and File Structure Generator";
+    homepage = "https://github.com/bilbilak/treegen";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "treegen";
+    maintainers = with lib.maintainers; [ _4r7if3x ];
+    platforms = with lib.platforms; unix ++ windows;
+  };
+}


### PR DESCRIPTION
## Reviewed points

- [x] package path fits guidelines
- [x] package name fits guidelines
- [x] package version fits guidelines
- [x] package builds on x86_64-linux
- [x] executables tested on x86_64-linux
- [x] `meta.description` is set and fits guidelines
- [x] `meta.license` fits upstream license
- [x] `meta.platforms` is set
- [x] `meta.maintainers` is set
- [x] `meta.mainProgram` is set, if applicable.
- [x] source is fetched using the appropriate function
- [x] the list of `phases` is not overridden

### Comments

This is my first contribution to NixOS Packages, so I’ve added myself to the maintainers list and packaged a couple of command-line tools I developed. They both can be cross-compiled for various CPU Architectures and Operating Systems.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
