### PR TITLE
ghostty: add nixos tests, add build options, fix x11 backend

### DIFF
--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -44,6 +44,8 @@ let
 
     germinal.pkg = p: p.germinal;
 
+    ghostty.pkg = p: p.ghostty;
+
     gnome-terminal.pkg = p: p.gnome-terminal;
 
     guake.pkg = p: p.guake;

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -21,15 +21,17 @@
   versionCheckHook,
   wrapGAppsHook4,
   zig_0_13,
+  # Usually you would override `zig.hook` with this, but we do that internally
+  # since upstream recommends a non-default level
+  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/PACKAGING.md#build-options
+  optimizeLevel ? "ReleaseFast",
   # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/build.zig#L106
   withAdwaita ? true,
 }:
 
 let
-  # Ghostty needs to be built with --release=fast, --release=debug and
-  # --release=safe enable too many runtime safety checks.
   zig_hook = zig_0_13.hook.overrideAttrs {
-    zig_default_flags = "-Dcpu=baseline -Doptimize=ReleaseFast --color off";
+    zig_default_flags = "-Dcpu=baseline -Doptimize=${optimizeLevel} --color off";
   };
 
   # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/apprt.zig#L72-L76

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -61,6 +61,12 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-AHI1Z4mfgXkNwQA8xYq4tS0/BARbHL7gQUT41vCxQTM=";
   };
 
+  # Avoid using runtime hacks to help find X11
+  postPatch = lib.optionalString (appRuntime == "gtk") ''
+    substituteInPlace src/apprt/gtk/x11.zig \
+      --replace-warn 'std.DynLib.open("libX11.so");' 'std.DynLib.open("${lib.getLib libX11}/lib/libX11.so");'
+  '';
+
   deps = callPackage ./deps.nix {
     name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
   };
@@ -154,8 +160,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     remove-references-to -t ${finalAttrs.deps} $out/bin/ghostty
   '';
-
-  NIX_LDFLAGS = lib.optional (appRuntime == "gtk") "-lX11";
 
   nativeInstallCheckInputs = [
     versionCheckHook

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -131,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   passthru = {
     tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      inherit (nixosTests) allTerminfo;
       nixos = nixosTests.terminal-emulators.ghostty;
     };
   };

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -177,7 +177,6 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   meta = {
-    homepage = "https://ghostty.org/";
     description = "Fast, native, feature-rich terminal emulator pushing modern features";
     longDescription = ''
       Ghostty is a terminal emulator that differentiates itself by being
@@ -185,21 +184,24 @@ stdenv.mkDerivation (finalAttrs: {
       emulators available, they all force you to choose between speed,
       features, or native UIs. Ghostty provides all three.
     '';
+    homepage = "https://ghostty.org/";
     downloadPage = "https://ghostty.org/download";
 
     license = lib.licenses.mit;
-    platforms = lib.platforms.linux;
     mainProgram = "ghostty";
+    maintainers = with lib.maintainers; [
+      jcollie
+      pluiedev
+      getchoo
+    ];
     outputsToInstall = [
       "out"
       "man"
       "shell_integration"
       "terminfo"
     ];
-    maintainers = with lib.maintainers; [
-      jcollie
-      pluiedev
-      getchoo
-    ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    # Issues finding the SDK in the sandbox
+    broken = stdenv.hostPlatform.isDarwin;
   };
 })

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -129,6 +129,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   versionCheckProgramArg = [ "--version" ];
 
+  passthru = {
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      nixos = nixosTests.terminal-emulators.ghostty;
+    };
+  };
+
   meta = {
     homepage = "https://ghostty.org/";
     description = "Fast, native, feature-rich terminal emulator pushing modern features";

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -46,11 +46,23 @@ stdenv.mkDerivation (finalAttrs: {
   pname = "ghostty";
   version = "1.0.0";
 
+  outputs = [
+    "out"
+    "man"
+    "shell_integration"
+    "terminfo"
+    "vim"
+  ];
+
   src = fetchFromGitHub {
     owner = "ghostty-org";
     repo = "ghostty";
     tag = "v${finalAttrs.version}";
     hash = "sha256-AHI1Z4mfgXkNwQA8xYq4tS0/BARbHL7gQUT41vCxQTM=";
+  };
+
+  deps = callPackage ./deps.nix {
+    name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
   };
 
   strictDeps = true;
@@ -83,15 +95,6 @@ stdenv.mkDerivation (finalAttrs: {
       harfbuzz
     ];
 
-  dontConfigure = true;
-  # doCheck is set to false because unit tests currently fail inside the Nix sandbox.
-  doCheck = false;
-  doInstallCheck = true;
-
-  deps = callPackage ./deps.nix {
-    name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
-  };
-
   zigBuildFlags =
     [
       "--system"
@@ -109,27 +112,46 @@ stdenv.mkDerivation (finalAttrs: {
 
   zigCheckFlags = finalAttrs.zigBuildFlags;
 
-  outputs = [
-    "out"
-    "terminfo"
-    "shell_integration"
-    "vim"
-  ];
+  # Unit tests currently fail inside the sandbox
+  doCheck = false;
 
-  postInstall = ''
-    mkdir -p "$terminfo/share"
-    mv "$out/share/terminfo" "$terminfo/share/terminfo"
-    ln -sf "$terminfo/share/terminfo" "$out/share/terminfo"
+  /**
+    Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
 
-    mkdir -p "$shell_integration"
-    mv "$out/share/ghostty/shell-integration" "$shell_integration/shell-integration"
-    ln -sf "$shell_integration/shell-integration" "$out/share/ghostty/shell-integration"
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
 
-    mv "$out/share/vim/vimfiles" "$vim"
-    ln -sf "$vim" "$out/share/vim/vimfiles"
-  '';
+    terminfo and shell integration should also be installable on remote machines
 
-  preFixup = ''
+    ```nix
+    { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.ghostty.terminfo ];
+
+      programs.bash = {
+        interactiveShellInit = ''
+          if [[ "$TERM" == "xterm-ghostty" ]]; then
+            builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
+          fi
+        '';
+      };
+    }
+    ```
+  */
+  postFixup = ''
+    ln -s $man/share/man $out/share/man
+
+    moveToOutput share/terminfo $terminfo
+    ln -s $terminfo/share/terminfo $out/share/terminfo
+
+    mv $out/share/ghostty/shell-integration $shell_integration
+    ln -s $shell_integration $out/share/ghostty/shell-integration
+
+    mv $out/share/vim/vimfiles $vim
+    rmdir $out/share/vim
+    ln -s $vim $out/share/vim-plugins
+
+
     remove-references-to -t ${finalAttrs.deps} $out/bin/ghostty
   '';
 
@@ -138,6 +160,8 @@ stdenv.mkDerivation (finalAttrs: {
   nativeInstallCheckInputs = [
     versionCheckHook
   ];
+
+  doInstallCheck = true;
 
   versionCheckProgramArg = [ "--version" ];
 
@@ -162,7 +186,12 @@ stdenv.mkDerivation (finalAttrs: {
     license = lib.licenses.mit;
     platforms = lib.platforms.linux;
     mainProgram = "ghostty";
-    outputsToInstall = finalAttrs.outputs;
+    outputsToInstall = [
+      "out"
+      "man"
+      "shell_integration"
+      "terminfo"
+    ];
     maintainers = with lib.maintainers; [
       jcollie
       pluiedev


### PR DESCRIPTION
Follow up on https://github.com/NixOS/nixpkgs/pull/368404

Big changes here include:

- ~~Exposing all major build configuration options~~ Seems this isn't something wanted
- Removing some un-needed dependencies
- Adding more automated testing
- Fixing start up on X11

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
