### PR TITLE
libdbiDrivers: fix compile errors in tests, backport patches

### DIFF
--- a/pkgs/by-name/li/libdbiDrivers/libdbi-drivers-0.9.0-470b58e15-wait-include.patch
+++ b/pkgs/by-name/li/libdbiDrivers/libdbi-drivers-0.9.0-470b58e15-wait-include.patch
@@ -1,0 +1,23 @@
+commit 470b58e15dc6f406899b1695aec7fc98986b8f14
+Author: Jan Engelhardt <jengelh@inai.de>
+Date:   Fri Jan 27 09:56:44 2017 +0100
+
+    build: resolve compiler warning for wait(2)
+    
+    src/unit.c: In function "wait_for_child_process":
+    src/unit.c:229:5: warning: implicit declaration of function "wait" [-Wimplicit-function-declaration]
+         wait(&status);
+
+diff --git a/tests/cgreen/src/unit.c b/tests/cgreen/src/unit.c
+index 7753ff1..bdd236f 100644
+--- a/tests/cgreen/src/unit.c
++++ b/tests/cgreen/src/unit.c
+@@ -9,6 +9,7 @@
+ #include <stdarg.h>
+ #include <unistd.h>
+ #include <signal.h>
++#include <sys/wait.h>
+ 
+ enum {test_function, test_suite};
+ 
+

--- a/pkgs/by-name/li/libdbiDrivers/libdbi-drivers-0.9.0-9f378826-compare-type.patch
+++ b/pkgs/by-name/li/libdbiDrivers/libdbi-drivers-0.9.0-9f378826-compare-type.patch
@@ -1,0 +1,22 @@
+commit 9f3788269befd2e4290eef1df4b014bc2385d801
+Author: Jan Engelhardt <jengelh@inai.de>
+Date:   Sat Sep 7 22:51:05 2013 +0200
+
+    build: resolve rpmlint aborting due to bad code
+
+diff --git a/tests/cgreen/src/constraint.c b/tests/cgreen/src/constraint.c
+index c19c0dd..b0fbfb8 100644
+--- a/tests/cgreen/src/constraint.c
++++ b/tests/cgreen/src/constraint.c
+@@ -164,8 +164,8 @@ static void test_want_double(Constraint *constraint, const char *function, intpt
+ }
+ 
+ static int compare_using_matcher(Constraint *constraint, intptr_t actual) {
+-	int (*matches)(const void*) = constraint->expected;
+-    return matches(actual);
++	int (*matches)(const void*) = (void *)(intptr_t)constraint->expected;
++    return matches((void *)actual);
+ }
+ 
+ static void test_with_matcher(Constraint *constraint, const char *function, const char* matcher_name, intptr_t matcher_function, const char *test_file, int test_line, TestReporter *reporter) {
+

--- a/pkgs/by-name/li/libdbiDrivers/libdbi-drivers-0.9.0-function-types.patch
+++ b/pkgs/by-name/li/libdbiDrivers/libdbi-drivers-0.9.0-function-types.patch
@@ -1,0 +1,32 @@
+diff --git a/tests/cgreen/src/constraint.c b/tests/cgreen/src/constraint.c
+index 56c3625..d8972bb 100644
+--- a/tests/cgreen/src/constraint.c
++++ b/tests/cgreen/src/constraint.c
+@@ -22,7 +22,7 @@ static double unbox_double(intptr_t box);
+ static double as_double(intptr_t box);
+ 
+ static int compare_using_matcher(Constraint *constraint, intptr_t actual);
+-static void test_with_matcher(Constraint *constraint, const char *function, const char* matcher_name, intptr_t actual, const char *test_file, int test_line, TestReporter *reporter);
++static void test_with_matcher(Constraint *constraint, const char *function, intptr_t actual, const char *test_file, int test_line, TestReporter *reporter);
+ 
+ 
+ void destroy_constraint(void *abstract) {
+@@ -168,15 +168,14 @@ static int compare_using_matcher(Constraint *constraint, intptr_t actual) {
+     return matches((void *)actual);
+ }
+ 
+-static void test_with_matcher(Constraint *constraint, const char *function, const char* matcher_name, intptr_t matcher_function, const char *test_file, int test_line, TestReporter *reporter) {
++static void test_with_matcher(Constraint *constraint, const char *function, intptr_t matcher_function, const char *test_file, int test_line, TestReporter *reporter) {
+     (*reporter->assert_true)(
+             reporter,
+             test_file,
+             test_line,
+             (*constraint->compare)(constraint, matcher_function),
+-            "Wanted parameter [%s] to match [%s] in function [%s]",
++            "Wanted parameter [%s] to match [nil] in function [%s]",
+             constraint->parameter,
+-            matcher_name,
+             function);
+ }
+ 
+

--- a/pkgs/by-name/li/libdbiDrivers/package.nix
+++ b/pkgs/by-name/li/libdbiDrivers/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://sourceforge/libdbi-drivers/libdbi-drivers-${version}.tar.gz";
-    sha256 = "0m680h8cc4428xin4p733azysamzgzcmv4psjvraykrsaz6ymlj3";
+    hash = "sha256-Q9LqzVc6T6/ylvqSXdl/vyrtvxrjXGJjR4IQxhAEyFQ=";
   };
 
   buildInputs = [
@@ -27,6 +27,12 @@ stdenv.mkDerivation rec {
   patches = [
     # https://sourceforge.net/p/libdbi-drivers/libdbi-drivers/ci/24f48b86c8988ee3aaebc5f303d71e9d789f77b6
     ./libdbi-drivers-0.9.0-buffer_overflow.patch
+    # https://sourceforge.net/p/libdbi-drivers/libdbi-drivers/ci/470b58e15dc6f406899b1695aec7fc98986b8f14
+    ./libdbi-drivers-0.9.0-470b58e15-wait-include.patch
+    # https://sourceforge.net/p/libdbi-drivers/libdbi-drivers/ci/9f3788269befd2e4290eef1df4b014bc2385d801
+    ./libdbi-drivers-0.9.0-9f378826-compare-type.patch
+    # fix function pointer type mismatches in tests
+    ./libdbi-drivers-0.9.0-function-types.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
- Fixes #368679
- Presumably caused by the gcc14 bump
- Fetched upstream patches where available, created one patch manually (`libdbi-drivers-0.9.0-function-types.patch`)
- Patches only affect tests.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>gnucash</li>
    <li>libdbiDrivers</li>
    <li>libdbiDriversBase</li>
  </ul>
</details>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
