### PR TITLE
qtcreator: pin llvmPackages 18

### DIFF
--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -8365,7 +8365,8 @@ with pkgs;
 
   qtcreator = qt6Packages.callPackage ../development/tools/qtcreator {
     inherit (linuxPackages) perf;
-    stdenv = llvmPackages.stdenv;
+    llvmPackages = llvmPackages_18;
+    stdenv = llvmPackages_18.stdenv;
   };
 
   qxmledit = libsForQt5.callPackage ../applications/editors/qxmledit {} ;


### PR DESCRIPTION
Build failure with llvm 19

```
[161/4146] Building CXX object src/libs/3rdparty/cplusplus/CMakeFiles/3rd_cplusplus.dir/Symbol.cpp.o
[162/4146] Building CXX object src/libs/3rdparty/cplusplus/CMakeFiles/3rd_cplusplus.dir/Symbols.cpp.o
[163/4146] Building C object src/libs/sqlite/CMakeFiles/SqliteInternal.dir/__/3rdparty/sqlite/carray.c.o
[164/4146] Automatic MOC for target QmlPuppetCommunication
[165/4146] Running AUTOMOC file extraction for target QmlPuppetCommunication
[166/4146] Building CXX object src/libs/3rdparty/cplusplus/CMakeFiles/3rd_cplusplus.dir/TranslationUnit.cpp.o
[167/4146] Building CXX object src/libs/languageutils/CMakeFiles/LanguageUtils.dir/fakemetaobject.cpp.o
[168/4146] Building CXX object src/libs/3rdparty/cplusplus/CMakeFiles/3rd_cplusplus.dir/Parser.cpp.o
[169/4146] Building CXX object src/libs/sqlite/CMakeFiles/Sqlite.dir/sqliteglobal.cpp.o
[170/4146] Linking CXX shared library nix/store/zx1wd8m2ndx2fdzb4is3vm6xah094242-qtcreator-15.0.0/lib/qtcreator/libLanguageUtils.so.15.0.0
[171/4146] Creating library symlink nix/store/zx1wd8m2ndx2fdzb4is3vm6xah094242-qtcreator-15.0.0/lib/qtcreator/libLanguageUtils.so.15 nix/store/zx1wd8m2ndx2fdzb4is3vm6xah094242-qtcreator-15.0.0/lib/qtcreator/libLanguageUtils.so
[172/4146] Building CXX object src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitebasestatement.cpp.o
FAILED: src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitebasestatement.cpp.o 
/nix/store/xl0vlc2wdchfbq8536zs19pj2r3xdmma-clang-wrapper-19.1.5/bin/clang++ -DNANOTRACE_ENABLED -DQT_CORE_LIB -DQT_CREATOR -DQT_DISABLE_DEPRECATED_BEFORE=0x050900 -DQT_DISABLE_DEPRECATED_UP_TO=0x050900 -DQT_GUI_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_JAVA_STYLE_ITERATORS -DQT_RESTRICTED_CAST_FROM_ASCII -DQT_USE_QSTRINGBUILDER -DQT_WARN_DEPRECATED_BEFORE=0x060400 -DQT_WARN_DEPRECATED_UP_TO=0x060400 -DRELATIVE_DATA_PATH=\"../share/qtcreator\" -DRELATIVE_DOC_PATH=\"../share/doc/qtcreator\" -DRELATIVE_LIBEXEC_PATH=\"../libexec/qtcreator\" -DRELATIVE_PLUGIN_PATH=\"../lib/qtcreator/plugins\" -DSQLITEINTERNAL_LIBRARY -DSQLITE_CUSTOM_INCLUDE=config.h -DSQLITE_LIBRARY -DSqlite_EXPORTS -I/build/qt-creator-opensource-src-15.0.0/build/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/../3rdparty/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtCore -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/mkspecs/linux-g++ -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtGui -O3 -DNDEBUG -std=c++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -fPIC -Winvalid-pch -Xclang -include-pch -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx -MD -MT src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitebasestatement.cpp.o -MF src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitebasestatement.cpp.o.d -o src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitebasestatement.cpp.o -c /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.cpp
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.cpp:4:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:11:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqliteids.h:150:36: error: reference to non-static member function must be called
  150 |         convertToString(string, id.contextId);
      |                                 ~~~^~~~~~~~~
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.cpp:4:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:416:43: error: no member named 'resetter' in 'BaseSqliteResultRange<ResultType>'
  416 |             : m_statement{std::move(other.resetter)}
      |                                     ~~~~~ ^
2 errors generated.
[173/4146] Building CXX object src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabase.cpp.o
FAILED: src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabase.cpp.o 
/nix/store/xl0vlc2wdchfbq8536zs19pj2r3xdmma-clang-wrapper-19.1.5/bin/clang++ -DNANOTRACE_ENABLED -DQT_CORE_LIB -DQT_CREATOR -DQT_DISABLE_DEPRECATED_BEFORE=0x050900 -DQT_DISABLE_DEPRECATED_UP_TO=0x050900 -DQT_GUI_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_JAVA_STYLE_ITERATORS -DQT_RESTRICTED_CAST_FROM_ASCII -DQT_USE_QSTRINGBUILDER -DQT_WARN_DEPRECATED_BEFORE=0x060400 -DQT_WARN_DEPRECATED_UP_TO=0x060400 -DRELATIVE_DATA_PATH=\"../share/qtcreator\" -DRELATIVE_DOC_PATH=\"../share/doc/qtcreator\" -DRELATIVE_LIBEXEC_PATH=\"../libexec/qtcreator\" -DRELATIVE_PLUGIN_PATH=\"../lib/qtcreator/plugins\" -DSQLITEINTERNAL_LIBRARY -DSQLITE_CUSTOM_INCLUDE=config.h -DSQLITE_LIBRARY -DSqlite_EXPORTS -I/build/qt-creator-opensource-src-15.0.0/build/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/../3rdparty/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtCore -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/mkspecs/linux-g++ -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtGui -O3 -DNDEBUG -std=c++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -fPIC -Winvalid-pch -Xclang -include-pch -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx -MD -MT src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabase.cpp.o -MF src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabase.cpp.o.d -o src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabase.cpp.o -c /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.cpp
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.cpp:4:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.h:9:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitereadstatement.h:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:11:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqliteids.h:150:36: error: reference to non-static member function must be called
  150 |         convertToString(string, id.contextId);
      |                                 ~~~^~~~~~~~~
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.cpp:4:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.h:9:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitereadstatement.h:6:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:416:43: error: no member named 'resetter' in 'BaseSqliteResultRange<ResultType>'
  416 |             : m_statement{std::move(other.resetter)}
      |                                     ~~~~~ ^
2 errors generated.
[174/4146] Building CXX object src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabasebackend.cpp.o
FAILED: src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabasebackend.cpp.o 
/nix/store/xl0vlc2wdchfbq8536zs19pj2r3xdmma-clang-wrapper-19.1.5/bin/clang++ -DNANOTRACE_ENABLED -DQT_CORE_LIB -DQT_CREATOR -DQT_DISABLE_DEPRECATED_BEFORE=0x050900 -DQT_DISABLE_DEPRECATED_UP_TO=0x050900 -DQT_GUI_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_JAVA_STYLE_ITERATORS -DQT_RESTRICTED_CAST_FROM_ASCII -DQT_USE_QSTRINGBUILDER -DQT_WARN_DEPRECATED_BEFORE=0x060400 -DQT_WARN_DEPRECATED_UP_TO=0x060400 -DRELATIVE_DATA_PATH=\"../share/qtcreator\" -DRELATIVE_DOC_PATH=\"../share/doc/qtcreator\" -DRELATIVE_LIBEXEC_PATH=\"../libexec/qtcreator\" -DRELATIVE_PLUGIN_PATH=\"../lib/qtcreator/plugins\" -DSQLITEINTERNAL_LIBRARY -DSQLITE_CUSTOM_INCLUDE=config.h -DSQLITE_LIBRARY -DSqlite_EXPORTS -I/build/qt-creator-opensource-src-15.0.0/build/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/../3rdparty/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtCore -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/mkspecs/linux-g++ -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtGui -O3 -DNDEBUG -std=c++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -fPIC -Winvalid-pch -Xclang -include-pch -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx -MD -MT src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabasebackend.cpp.o -MF src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabasebackend.cpp.o.d -o src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitedatabasebackend.cpp.o -c /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabasebackend.cpp
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabasebackend.cpp:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:11:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqliteids.h:150:36: error: reference to non-static member function must be called
  150 |         convertToString(string, id.contextId);
      |                                 ~~~^~~~~~~~~
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabasebackend.cpp:6:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:416:43: error: no member named 'resetter' in 'BaseSqliteResultRange<ResultType>'
  416 |             : m_statement{std::move(other.resetter)}
      |                                     ~~~~~ ^
2 errors generated.
[175/4146] Building CXX object src/libs/sqlite/CMakeFiles/Sqlite.dir/sqliteexception.cpp.o
[176/4146] Building CXX object src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitesessionchangeset.cpp.o
FAILED: src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitesessionchangeset.cpp.o 
/nix/store/xl0vlc2wdchfbq8536zs19pj2r3xdmma-clang-wrapper-19.1.5/bin/clang++ -DNANOTRACE_ENABLED -DQT_CORE_LIB -DQT_CREATOR -DQT_DISABLE_DEPRECATED_BEFORE=0x050900 -DQT_DISABLE_DEPRECATED_UP_TO=0x050900 -DQT_GUI_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_JAVA_STYLE_ITERATORS -DQT_RESTRICTED_CAST_FROM_ASCII -DQT_USE_QSTRINGBUILDER -DQT_WARN_DEPRECATED_BEFORE=0x060400 -DQT_WARN_DEPRECATED_UP_TO=0x060400 -DRELATIVE_DATA_PATH=\"../share/qtcreator\" -DRELATIVE_DOC_PATH=\"../share/doc/qtcreator\" -DRELATIVE_LIBEXEC_PATH=\"../libexec/qtcreator\" -DRELATIVE_PLUGIN_PATH=\"../lib/qtcreator/plugins\" -DSQLITEINTERNAL_LIBRARY -DSQLITE_CUSTOM_INCLUDE=config.h -DSQLITE_LIBRARY -DSqlite_EXPORTS -I/build/qt-creator-opensource-src-15.0.0/build/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/../3rdparty/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtCore -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/mkspecs/linux-g++ -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtGui -O3 -DNDEBUG -std=c++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -fPIC -Winvalid-pch -Xclang -include-pch -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx -MD -MT src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitesessionchangeset.cpp.o -MF src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitesessionchangeset.cpp.o.d -o src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitesessionchangeset.cpp.o -c /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitesessionchangeset.cpp
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitesessionchangeset.cpp:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitesessions.h:7:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.h:9:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitereadstatement.h:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:11:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqliteids.h:150:36: error: reference to non-static member function must be called
  150 |         convertToString(string, id.contextId);
      |                                 ~~~^~~~~~~~~
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitesessionchangeset.cpp:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitesessions.h:7:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.h:9:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitereadstatement.h:6:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:416:43: error: no member named 'resetter' in 'BaseSqliteResultRange<ResultType>'
  416 |             : m_statement{std::move(other.resetter)}
      |                                     ~~~~~ ^
2 errors generated.
[177/4146] Building CXX object src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitefunctionregistry.cpp.o
FAILED: src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitefunctionregistry.cpp.o 
/nix/store/xl0vlc2wdchfbq8536zs19pj2r3xdmma-clang-wrapper-19.1.5/bin/clang++ -DNANOTRACE_ENABLED -DQT_CORE_LIB -DQT_CREATOR -DQT_DISABLE_DEPRECATED_BEFORE=0x050900 -DQT_DISABLE_DEPRECATED_UP_TO=0x050900 -DQT_GUI_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_JAVA_STYLE_ITERATORS -DQT_RESTRICTED_CAST_FROM_ASCII -DQT_USE_QSTRINGBUILDER -DQT_WARN_DEPRECATED_BEFORE=0x060400 -DQT_WARN_DEPRECATED_UP_TO=0x060400 -DRELATIVE_DATA_PATH=\"../share/qtcreator\" -DRELATIVE_DOC_PATH=\"../share/doc/qtcreator\" -DRELATIVE_LIBEXEC_PATH=\"../libexec/qtcreator\" -DRELATIVE_PLUGIN_PATH=\"../lib/qtcreator/plugins\" -DSQLITEINTERNAL_LIBRARY -DSQLITE_CUSTOM_INCLUDE=config.h -DSQLITE_LIBRARY -DSqlite_EXPORTS -I/build/qt-creator-opensource-src-15.0.0/build/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/../3rdparty/sqlite -I/build/qt-creator-opensource-src-15.0.0/src/libs -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtCore -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/mkspecs/linux-g++ -isystem /nix/store/dh5kclrfrvk7aknvk22n2bnz4x8kj1q6-qtbase-6.8.1/include/QtGui -O3 -DNDEBUG -std=c++20 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wextra -fPIC -Winvalid-pch -Xclang -include-pch -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx.pch -Xclang -include -Xclang /build/qt-creator-opensource-src-15.0.0/build/src/libs/3rdparty/syntax-highlighting/CMakeFiles/QtCreatorPchConsole.dir/cmake_pch.hxx -MD -MT src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitefunctionregistry.cpp.o -MF src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitefunctionregistry.cpp.o.d -o src/libs/sqlite/CMakeFiles/Sqlite.dir/sqlitefunctionregistry.cpp.o -c /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitefunctionregistry.cpp
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitefunctionregistry.cpp:4:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitefunctionregistry.h:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.h:9:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitereadstatement.h:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:11:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqliteids.h:150:36: error: reference to non-static member function must be called
  150 |         convertToString(string, id.contextId);
      |                                 ~~~^~~~~~~~~
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitefunctionregistry.cpp:4:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitefunctionregistry.h:6:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitedatabase.h:9:
In file included from /build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitereadstatement.h:6:
/build/qt-creator-opensource-src-15.0.0/src/libs/sqlite/sqlitebasestatement.h:416:43: error: no member named 'resetter' in 'BaseSqliteResultRange<ResultType>'
  416 |             : m_statement{std::move(other.resetter)}
      |                                     ~~~~~ ^
2 errors generated.
[178/4146] Automatic MOC and UIC for target Utils
[179/4146] Building C object src/libs/sqlite/CMakeFiles/SqliteInternal.dir/__/3rdparty/sqlite/sqlite3.c.o

```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
