### PR TITLE
dmraid: fix build with gcc 14

### DIFF
--- a/pkgs/os-specific/linux/dmraid/default.nix
+++ b/pkgs/os-specific/linux/dmraid/default.nix
@@ -44,6 +44,12 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ lvm2 ];
 
+  # Fix build with gcc 14
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=implicit-int"
+    "-Wno-error=return-mismatch"
+  ];
+
   # Hand-written Makefile does not have full dependencies to survive
   # parallel build:
   #   tools/dmraid.c:12:10: fatal error: dmraid/dmraid.h: No such file


### PR DESCRIPTION
```
error: builder for '/nix/store/6gq1rkbzsdbdrdqp2i3w0ylx0x98znah-dmraid-1.0.0.rc16.drv' failed with exit code 2;
       last 25 log lines:
       > make -C tools
       > make[1]: Entering directory '/build/dmraid/1.0.0.rc16/tools'
       > gcc -MM -MF dmraid.d -I  -I. -I../include -I../lib -O2 -DDMRAID_NATIVE_LOG -DHAVE_GETOPTLONG -fPIC -Wall -Wundef -Wcast-align -Wwrite-strings -Winline -DDMRAID_TEST -DDMRAID_AUTOREGISTER -O2 -D_LARGEFILE64_SOURCE dmraid.c; \
       > gcc -c -I  -I. -I../include -I../lib -O2 -DDMRAID_NATIVE_LOG -DHAVE_GETOPTLONG -fPIC -Wall -Wundef -Wcast-align -Wwrite-strings -Winline -DDMRAID_TEST -DDMRAID_AUTOREGISTER -O2 -D_LARGEFILE64_SOURCE dmraid.c -o dmraid.o
       > gcc -MM -MF commands.d -I  -I. -I../include -I../lib -O2 -DDMRAID_NATIVE_LOG -DHAVE_GETOPTLONG -fPIC -Wall -Wundef -Wcast-align -Wwrite-strings -Winline -DDMRAID_TEST -DDMRAID_AUTOREGISTER -O2 -D_LARGEFILE64_SOURCE commands.c; \
       > gcc -c -I  -I. -I../include -I../lib -O2 -DDMRAID_NATIVE_LOG -DHAVE_GETOPTLONG -fPIC -Wall -Wundef -Wcast-align -Wwrite-strings -Winline -DDMRAID_TEST -DDMRAID_AUTOREGISTER -O2 -D_LARGEFILE64_SOURCE commands.c -o commands.o
       > gcc -MM -MF toollib.d -I  -I. -I../include -I../lib -O2 -DDMRAID_NATIVE_LOG -DHAVE_GETOPTLONG -fPIC -Wall -Wundef -Wcast-align -Wwrite-strings -Winline -DDMRAID_TEST -DDMRAID_AUTOREGISTER -O2 -D_LARGEFILE64_SOURCE toollib.c; \
       > gcc -c -I  -I. -I../include -I../lib -O2 -DDMRAID_NATIVE_LOG -DHAVE_GETOPTLONG -fPIC -Wall -Wundef -Wcast-align -Wwrite-strings -Winline -DDMRAID_TEST -DDMRAID_AUTOREGISTER -O2 -D_LARGEFILE64_SOURCE toollib.c -o toollib.o
       > gcc -o dmraid dmraid.o commands.o toollib.o -rdynamic -L../lib \
       >       -L/nix/store/75k5rywwbb24z7g463cixdh4qnxisjc0-dmraid-1.0.0.rc16/lib -ldmraid -ldevmapper -ldevmapper-event -ldmraid -ldevmapper -ldl
       > gcc -o dmevent_tool dmevent_tool.c -I  -I. -I../include -I../lib -rdynamic -L../lib \
       >       -L/nix/store/75k5rywwbb24z7g463cixdh4qnxisjc0-dmraid-1.0.0.rc16/lib -ldmraid -ldevmapper -ldevmapper-event -ldmraid -ldevmapper -ldl
       > dmevent_tool.c:126:8: error: return type defaults to 'int' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-int-Wimplicit-int8;;]
       >   126 | static _process_opt(int opt, const char *cmd)
       >       |        ^~~~~~~~~~~~
       > dmevent_tool.c: In function '_process_opt':
       > dmevent_tool.c:151:25: error: 'return' with no value, in function returning non-void [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wno-return-mismatch-Wreturn-mismatch8;;]
       >   151 |                         return;
       >       |                         ^~~~~~
       > dmevent_tool.c:126:8: note: declared here
       >   126 | static _process_opt(int opt, const char *cmd)
       >       |        ^~~~~~~~~~~~
       > make[1]: *** [Makefile:78: dmevent_tool] Error 1
       > make[1]: Leaving directory '/build/dmraid/1.0.0.rc16/tools'
       > make: *** [make.tmpl:115: tools] Error 2
       For full logs, run 'nix log /nix/store/6gq1rkbzsdbdrdqp2i3w0ylx0x98znah-dmraid-1.0.0.rc16.drv'.

```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
