### PR TITLE
nixos/networkmanager: match upstream units Install sections 

### DIFF
--- a/nixos/modules/services/networking/networkmanager.nix
+++ b/nixos/modules/services/networking/networkmanager.nix
@@ -598,7 +598,7 @@ in
     ];
 
     systemd.services.NetworkManager = {
-      wantedBy = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
       restartTriggers = [ configFile ];
 
       aliases = [ "dbus-org.freedesktop.NetworkManager.service" ];
@@ -614,7 +614,7 @@ in
     };
 
     systemd.services.NetworkManager-dispatcher = {
-      wantedBy = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
       restartTriggers = [
         configFile
         overrideNameserversScript

--- a/nixos/tests/networking/networkmanager.nix
+++ b/nixos/tests/networking/networkmanager.nix
@@ -33,6 +33,17 @@ let
     };
   } extraConfig;
   testCases = {
+    startup = {
+      name = "startup";
+      nodes.client = {
+        networking.useDHCP = false;
+        networking.networkmanager.enable = true;
+      };
+      testScript = ''
+        with subtest("NetworkManager is started automatically at boot"):
+          client.wait_for_unit("NetworkManager.service")
+      '';
+    };
     static = {
       name = "static";
       nodes = {


### PR DESCRIPTION
Match how upstream starts NetworkManager.server at boot. See issue #368262

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested via `nixosTests.networking.networkmanager`
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
