### PR TITLE
super-slicer: 2.3.57.12 -> 2.5.59.13

### DIFF
--- a/pkgs/applications/misc/prusa-slicer/super-slicer-use-boost186.patch
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer-use-boost186.patch
@@ -1,0 +1,60 @@
+diff --git a/src/hints/HintsToPot.cpp b/src/hints/HintsToPot.cpp
+index 7c8029cdeb..4791f0612f 100644
+--- a/src/hints/HintsToPot.cpp
++++ b/src/hints/HintsToPot.cpp
+@@ -9,7 +9,7 @@
+ 
+ bool write_to_pot(boost::filesystem::path path, const std::vector<std::pair<std::string, std::string>>& data)
+ {
+-	boost::filesystem::ofstream file(std::move(path), std::ios_base::app);
++	boost::nowide::ofstream file(path.string(), std::ios_base::app);
+ 	for (const auto& element : data)
+ 	{
+ 		//Example of .pot element 
+diff --git a/src/slic3r/GUI/RemovableDriveManager.cpp b/src/slic3r/GUI/RemovableDriveManager.cpp
+index 2f8ac96a1a..f0f95c9459 100644
+--- a/src/slic3r/GUI/RemovableDriveManager.cpp
++++ b/src/slic3r/GUI/RemovableDriveManager.cpp
+@@ -22,7 +22,8 @@
+ #include <pwd.h>
+ #include <boost/filesystem.hpp>
+ #include <boost/system/error_code.hpp>
+-#include <boost/filesystem/convenience.hpp>
++#include <boost/filesystem/path.hpp>
++#include <boost/filesystem/operations.hpp>
+ #include <boost/process.hpp>
+ #endif
+ 
+diff --git a/src/slic3r/GUI/ScriptExecutor.cpp b/src/slic3r/GUI/ScriptExecutor.cpp
+index 3e10680e46..374915ee34 100644
+--- a/src/slic3r/GUI/ScriptExecutor.cpp
++++ b/src/slic3r/GUI/ScriptExecutor.cpp
+@@ -825,6 +825,19 @@ void as_back_custom_initial_value(int preset_type, std::string& key) {
+     set_custom_option(preset_type, serialized_vars);
+ }
+ 
++inline void load_string_file(boost::filesystem::path const& p, std::string& str)
++{
++    boost::filesystem::ifstream file;
++    file.exceptions(std::ios_base::failbit | std::ios_base::badbit);
++    file.open(p, std::ios_base::binary);
++    const boost::uintmax_t sz = boost::filesystem::file_size(p);
++    if (BOOST_UNLIKELY(sz > static_cast< boost::uintmax_t >((std::numeric_limits< std::streamsize >::max)())))
++        BOOST_FILESYSTEM_THROW(std::length_error("File size exceeds max read size"));
++    str.resize(static_cast< std::size_t >(sz), '\0');
++    if (sz > 0u)
++        file.read(&str[0], static_cast< std::streamsize >(sz));
++}
++
+ /////// main script fucntions //////
+ 
+ //TODO: add "unset" function, that revert to last value (befoer a scripted set) if a set has been made since last not-scripted change.
+@@ -960,7 +973,7 @@ void ScriptContainer::init(const std::string& tab_key, Tab* tab)
+         //res = builder.AddSectionFromFile(ui_script_file.string().c_str()); //seems to be problematic on cyrillic locale
+         {
+             std::string all_file;
+-            boost::filesystem::load_string_file(ui_script_file, all_file);
++            load_string_file(ui_script_file, all_file);
+             res = builder.AddSectionFromMemory(ui_script_file.string().c_str(), all_file.c_str(), (unsigned int)(all_file.length()), 0);
+         }
+         if (res < 0) throw CompileErrorException("Error, can't build the script for tab " + tab_key);

--- a/pkgs/applications/misc/prusa-slicer/super-slicer.nix
+++ b/pkgs/applications/misc/prusa-slicer/super-slicer.nix
@@ -13,38 +13,28 @@ let
   description = "PrusaSlicer fork with more features and faster development cycle";
 
   patches = [
-    # Fix compile error with boost 1.79. See https://github.com/supermerill/SuperSlicer/issues/2823
-    (fetchpatch {
-      url = "https://raw.githubusercontent.com/gentoo/gentoo/81e3ca3b7c131e8345aede89e3bbcd700e1ad567/media-gfx/superslicer/files/superslicer-2.4.58.3-boost-1.79-port-v2.patch";
-      # Excludes Linux-only patches
-      excludes = [
-        "src/slic3r/GUI/FreeCADDialog.cpp"
-        "src/slic3r/GUI/Tab.cpp"
-        "src/slic3r/Utils/Http.cpp"
-      ];
-      hash = "sha256-v0q2MhySayij7+qBTE5q01IOq/DyUcWnjpbzB/AV34c=";
-    })
     # Drop if this fix gets merged upstream
     (fetchpatch {
       url = "https://github.com/supermerill/SuperSlicer/commit/fa7c545efa5d1880cf24af32083094fc872d3692.patch";
       hash = "sha256-fh31qrqjQiRQL03pQl4KJAEtbKMwG8/nJroqIDOIePw=";
     })
+    ./super-slicer-use-boost186.patch
   ];
 
   versions = {
     stable = {
-      version = "2.3.57.12";
-      hash = "sha256-lePhDRHI++9zs54bTt2/Lu6ZQ7egjJCWb752aI0s7Mw==";
-      patches = null;
+      version = "2.5.59.13";
+      hash = "sha256-FkoGcgVoBeHSZC3W5y30TBPmPrWnZSlO66TgwskgqAU=";
+      inherit patches;
     };
     latest = {
-      version = "2.4.58.5";
-      hash = "sha256-UywxEGedXaBUTKojEkbkuejI6SdPSkPxTJMwUDNW6W0=";
+      version = "2.5.59.13";
+      hash = "sha256-FkoGcgVoBeHSZC3W5y30TBPmPrWnZSlO66TgwskgqAU=";
       inherit patches;
     };
     beta = {
-      version = "2.5.59.6";
-      hash = "sha256-4ivhkcvVw5NlPsDz3J840aWc0qnp/XzCnTTCICwi3/c=";
+      version = "2.5.60.0";
+      hash = "sha256-dDRK07SatLLhuoc2fJKbHUwAofRRvBUoXWO61W2blFM=";
       inherit patches;
     };
   };


### PR DESCRIPTION
**super-slicer-latest**: _2.4.58.5 -> 2.5.59.13_
**super-slicer-beta**: _2.5.59.6 -> 2.5.60.0_

* Update all super-slicer packages to latest stable verison or pre-release where applicable (changelog [here](https://github.com/supermerill/SuperSlicer/releases))
* Add patches for boost 1.86 support
* Remove patches for boost 1.79

@cab404 This fixes the build error currently present on master.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

/cc @cab404 @hesiod 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
