### PR TITLE
home-assistant: Add support for Yoto custom component

### DIFF
--- a/pkgs/development/python-modules/yoto-api/default.nix
+++ b/pkgs/development/python-modules/yoto-api/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pytz,
+  requests,
+  paho-mqtt,
+}:
+
+buildPythonPackage rec {
+  pname = "yoto-api";
+  version = "1.24.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "cdnninja";
+    repo = "yoto_api";
+    tag = "v${version}";
+    hash = "sha256-wbqeRTYHDpxKqOwTRkkYGtgYOmnyNQY50dnvI0WprwA=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pytz
+    requests
+    paho-mqtt
+  ];
+
+  # All tests require access to and authentication with the Yoto API (api.yotoplay.com).
+  doCheck = false;
+
+  pythonImportsCheck = [ "yoto_api" ];
+
+  meta = with lib; {
+    changelog = "https://github.com/cdnninja/yoto_api/releases/tag/${src.tag}";
+    homepage = "https://github.com/cdnninja/yoto_api";
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ seberm ];
+    license = licenses.mit;
+    description = "A python package that makes it a bit easier to work with the yoto play API.";
+  };
+}

--- a/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/yoto_ha/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  yoto-api,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "cdnninja";
+  domain = "yoto";
+  version = "1.22.0";
+
+  src = fetchFromGitHub {
+    owner = "cdnninja";
+    repo = "yoto_ha";
+    tag = "v${version}";
+    hash = "sha256-uaakUxuPxYqLnE2UK6ept91Lycvvhr0r9vZw44y1W4g=";
+  };
+
+  dependencies = [
+    yoto-api
+  ];
+
+  meta = with lib; {
+    changelog = "https://github.com/cdnninja/yoto_ha/releases/tag/${src.tag}";
+    description = "Home Assistant Integration for Yoto.";
+    homepage = "https://github.com/cdnninja/yoto_ha";
+    maintainers = with maintainers; [ seberm ];
+    license = licenses.mit;
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -18313,6 +18313,8 @@ self: super: with self; {
     python3 = python;
   });
 
+  yoto-api = callPackage ../development/python-modules/yoto-api { };
+
   youless-api = callPackage ../development/python-modules/youless-api { };
 
   youseedee = callPackage ../development/python-modules/youseedee { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds support for Yoto Home-Assistant custom component:
- yoto_ha: https://github.com/cdnninja/yoto_ha
- yoto_api: https://github.com/cdnninja/yoto_api


## Things done
- Added python3 package `yoto-api` which is needed for `yoto-ha` custom component.
- Added and tested the custom Yoto component in my local HA instance.

Tested in my local HA configuration in the following way:

```
customComponents = with pkgs-unstable; [
  (callPackage ../hass/custom-components/yoto_ha/package.nix {
    yoto-api = (python3Packages.callPackage ../hass/pkgs/yoto-api.nix {});
  })
];
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
