### PR TITLE
cargo-semver-checks: 0.34.0 -> 0.38.0 and refactor

### DIFF
--- a/pkgs/by-name/ca/cargo-semver-checks/package.nix
+++ b/pkgs/by-name/ca/cargo-semver-checks/package.nix
@@ -6,7 +6,9 @@
   zlib,
   stdenv,
   darwin,
-  git,
+  testers,
+  cargo-semver-checks,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -16,7 +18,7 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "obi1kenobi";
     repo = pname;
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-IcKjiKFvkFvu8+LFCAmm39AGUaUdK8zhtNzzSb8VPE0=";
   };
 
@@ -53,16 +55,21 @@ rustPlatform.buildRustPackage rec {
         'cargo-semver-checks ${version}'
   '';
 
-  meta = with lib; {
+  passthru = {
+    tests.version = testers.testVersion { package = cargo-semver-checks; };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
     description = "Tool to scan your Rust crate for semver violations";
     mainProgram = "cargo-semver-checks";
     homepage = "https://github.com/obi1kenobi/cargo-semver-checks";
     changelog = "https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       mit # or
       asl20
     ];
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       figsoda
       matthiasbeyer
     ];

--- a/pkgs/by-name/ca/cargo-semver-checks/package.nix
+++ b/pkgs/by-name/ca/cargo-semver-checks/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-semver-checks";
-  version = "0.34.0";
+  version = "0.38.0";
 
   src = fetchFromGitHub {
     owner = "obi1kenobi";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-U7ykTLEuREe2GTVswcAw3R3h4zbkWxuI2dt/2689xSA=";
+    hash = "sha256-IcKjiKFvkFvu8+LFCAmm39AGUaUdK8zhtNzzSb8VPE0=";
   };
 
-  cargoHash = "sha256-NoxYHwY5XpRiqrOjQsaSWQCXFalNAS9SchaKwHbB2uU=";
+  cargoHash = "sha256-QfJ7QnGKmbrGDwYtVyAJNNGoAukD97/tmCwAROvWBIg=";
 
   nativeBuildInputs = [
     cmake
@@ -37,15 +37,20 @@ rustPlatform.buildRustPackage rec {
   checkFlags = [
     # requires internet access
     "--skip=detects_target_dependencies"
+    "--skip=query::tests_lints::feature_missing"
   ];
 
   preCheck = ''
+    # requires internet access
+    rm -r test_crates/feature_missing
+
     patchShebangs scripts/regenerate_test_rustdocs.sh
-    substituteInPlace scripts/regenerate_test_rustdocs.sh \
-      --replace-fail \
-        'TOPLEVEL="$(git rev-parse --show-toplevel)"' \
-        "TOPLEVEL=$PWD"
     scripts/regenerate_test_rustdocs.sh
+
+    substituteInPlace test_outputs/integration_snapshots__bugreport.snap \
+      --replace-fail \
+        'cargo-semver-checks [VERSION] ([HASH])' \
+        'cargo-semver-checks ${version}'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Closes #368662

Changelogs:
- https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.35.0
- https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.36.0
- https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.37.0
- https://github.com/obi1kenobi/cargo-semver-checks/releases/tag/v0.38.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
