### PR TITLE
python312Packages.cwl-upgrader: 1.2.11 -> 1.2.12, cwltool: 3.1.20241024121129 -> 3.1.20241217163858 

### DIFF
--- a/pkgs/by-name/cw/cwltool/package.nix
+++ b/pkgs/by-name/cw/cwltool/package.nix
@@ -6,39 +6,50 @@
   python3,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+let
+  py = python3.override {
+    packageOverrides = final: prev: {
+      # Requires "pydot >= 1.4.1, <3",
+      pydot = prev.pydot.overridePythonAttrs (old: rec {
+        version = "2.0.0";
+        src = old.src.override {
+          inherit version;
+          hash = "sha256-YCRq8hUSP6Bi8hzXkb5n3aI6bygN8J9okZ5jeh5PMjU=";
+        };
+        doCheck = false;
+      });
+    };
+  };
+in
+with py.pkgs;
+
+py.pkgs.buildPythonApplication rec {
   pname = "cwltool";
-  version = "3.1.20241024121129";
+  version = "3.1.20241217163858";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "common-workflow-language";
     repo = "cwltool";
     rev = "refs/tags/${version}";
-    hash = "sha256-MocgfELgis9b+byeDU7mDQcXnLhaWBtvGbqm7MtRdf8=";
+    hash = "sha256-46x/7ewnt1eTu+1GdmPUExpiFfYE3mN8N8VFMM4r1Vk=";
   };
 
   postPatch = ''
     substituteInPlace setup.py \
-      --replace-fail "ruamel.yaml >= 0.16, < 0.19" "ruamel.yaml" \
       --replace-fail "prov == 1.5.1" "prov" \
       --replace-fail '"schema-salad >= 8.7, < 9",' '"schema-salad",' \
       --replace-fail "PYTEST_RUNNER + " ""
-    substituteInPlace pyproject.toml \
-      --replace-fail "ruamel.yaml>=0.16.0,<0.18" "ruamel.yaml" \
-      --replace-fail "mypy==1.13.0" "mypy"
   '';
 
-  nativeBuildInputs =
-    [
-      git
-    ]
-    ++ (with python3.pkgs; [
-      setuptools
-      setuptools-scm
-    ]);
+  build-system = with py.pkgs; [
+    setuptools
+    setuptools-scm
+  ];
 
-  dependencies = with python3.pkgs; [
+  nativeBuildInputs = [ git ];
+
+  dependencies = with py.pkgs; [
     argcomplete
     bagit
     coloredlogs
@@ -50,6 +61,7 @@ python3.pkgs.buildPythonApplication rec {
     pydot
     rdflib
     requests
+    rich-argparse
     ruamel-yaml
     schema-salad
     shellescape
@@ -60,7 +72,7 @@ python3.pkgs.buildPythonApplication rec {
     typing-extensions
   ];
 
-  nativeCheckInputs = with python3.pkgs; [
+  nativeCheckInputs = with py.pkgs; [
     mock
     nodejs
     pytest-mock
@@ -89,7 +101,7 @@ python3.pkgs.buildPythonApplication rec {
     description = "Common Workflow Language reference implementation";
     homepage = "https://www.commonwl.org";
     changelog = "https://github.com/common-workflow-language/cwltool/releases/tag/${version}";
-    license = with licenses; [ asl20 ];
+    license = licenses.asl20;
     maintainers = with maintainers; [ veprbl ];
     mainProgram = "cwltool";
   };

--- a/pkgs/development/python-modules/cwl-upgrader/default.nix
+++ b/pkgs/development/python-modules/cwl-upgrader/default.nix
@@ -13,7 +13,7 @@
 
 buildPythonPackage rec {
   pname = "cwl-upgrader";
-  version = "1.2.11";
+  version = "1.2.12";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -22,7 +22,7 @@ buildPythonPackage rec {
     owner = "common-workflow-language";
     repo = "cwl-upgrader";
     rev = "refs/tags/v${version}";
-    hash = "sha256-P8607Io/KIJqAnrValM+rRK59tQITcC/jyGwkge8qN0=";
+    hash = "sha256-cfEd1XAu31u+NO27d3RNA5lhCpRpYK8NeaCxhQ/1GNU=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Diff: https://github.com/common-workflow-language/cwl-upgrader/compare/refs/tags/v1.2.11...v1.2.12

Changelog: https://github.com/common-workflow-language/cwl-upgrader/releases/tag/v1.2.12

This fixes also the build failure introduced by #349805
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
