### PR TITLE
distant: init at 0.20.0

### DIFF
--- a/pkgs/by-name/di/distant/package.nix
+++ b/pkgs/by-name/di/distant/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  openssl,
+  zlib,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "distant";
+  version = "0.20.0";
+
+  src = fetchFromGitHub {
+    owner = "chipsenkbeil";
+    repo = "distant";
+    tag = "v${version}";
+    hash = "sha256-DcnleJUAeYg3GSLZljC3gO9ihiFz04dzT/ddMnypr48=";
+  };
+
+  cargoHash = "sha256-7MNNdm4b9u5YNX04nBtKcrw+phUlpzIXo0tJVfcgb40=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+    zlib
+  ];
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+  };
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  checkFlags =
+    [
+      # Requires network access:
+      # failed to lookup address information: Temporary failure in name resolution
+      "--skip=options::common::address::tests::resolve_should_properly_resolve_bind_address"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Timeout on darwin
+      # Custom { kind: TimedOut, error: "" }
+      "--skip=cli::api::watch::should_support_json_reporting_changes_using_correct_request_id"
+      "--skip=cli::api::watch::should_support_json_watching_directory_recursively"
+      "--skip=cli::api::watch::should_support_json_watching_single_file"
+      "--skip=cli::client::fs_watch::should_support_watching_a_directory_recursively"
+      "--skip=cli::client::fs_watch::should_support_watching_a_single_file"
+    ];
+
+  __darwinAllowLocalNetworking = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Library and tooling that supports remote filesystem and process operations";
+    homepage = "https://github.com/chipsenkbeil/distant";
+    changelog = "https://github.com/chipsenkbeil/distant/blob/${version}/CHANGELOG.md";
+    # From the README:
+    # "This project is licensed under either of Apache License, Version 2.0, MIT license at your option."
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "distant";
+  };
+}


### PR DESCRIPTION
## Things done

Add [distant](https://github.com/chipsenkbeil/distant), the binary used by `vimPlugins.distant-nvim`.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
