### PR TITLE
ocamlPackages.h2: init h2-lwt, h2-lwt-unix at 0.13.0

### DIFF
--- a/pkgs/development/ocaml-modules/h2/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/h2/lwt-unix.nix
@@ -1,0 +1,23 @@
+{
+  buildDunePackage,
+  h2,
+  h2-lwt,
+  gluten-lwt-unix,
+  faraday-lwt-unix,
+}:
+
+buildDunePackage {
+  pname = "h2-lwt-unix";
+
+  inherit (h2) src version;
+
+  propagatedBuildInputs = [
+    gluten-lwt-unix
+    faraday-lwt-unix
+    h2-lwt
+  ];
+
+  meta = h2.meta // {
+    description = "Lwt Unix support for h2";
+  };
+}

--- a/pkgs/development/ocaml-modules/h2/lwt.nix
+++ b/pkgs/development/ocaml-modules/h2/lwt.nix
@@ -1,0 +1,22 @@
+{
+  buildDunePackage,
+  h2,
+  lwt,
+  gluten-lwt,
+}:
+
+buildDunePackage {
+  pname = "h2-lwt";
+
+  inherit (h2) src version;
+
+  propagatedBuildInputs = [
+    lwt
+    gluten-lwt
+    h2
+  ];
+
+  meta = h2.meta // {
+    description = "Lwt support for h2";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -668,6 +668,10 @@ let
 
     h2-eio = callPackage ../development/ocaml-modules/h2/eio.nix { };
 
+    h2-lwt = callPackage ../development/ocaml-modules/h2/lwt.nix { };
+
+    h2-lwt-unix = callPackage ../development/ocaml-modules/h2/lwt-unix.nix { };
+
     hack_parallel = callPackage ../development/ocaml-modules/hack_parallel { };
 
     hacl-star = callPackage ../development/ocaml-modules/hacl-star { };


### PR DESCRIPTION
## New packages based on `ocamlPackages.h2`

* Init `ocamlPackages.h2-lwt`
* Init `ocamlPackages.h2-lwt-unix`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
