### PR TITLE
alacritty-theme: use `sparseCheckout`

### DIFF
--- a/pkgs/by-name/al/alacritty-theme/package.nix
+++ b/pkgs/by-name/al/alacritty-theme/package.nix
@@ -14,7 +14,8 @@ stdenvNoCC.mkDerivation (self: {
     owner = "alacritty";
     repo = "alacritty-theme";
     rev = "95a7d695605863ede5b7430eb80d9e80f5f504bc";
-    hash = "sha256-D37MQtNS20ESny5UhW1u6ELo9czP4l+q0S8neH7Wdbc=";
+    hash = "sha256-IsUIfoacXJYilTPQBKXnDEuyQCt9ofBMJ8UZ1McFwXM=";
+    sparseCheckout = [ "themes" ];
   };
 
   dontConfigure = true;


### PR DESCRIPTION
alacritty-themes: use `sparseCheckout`

This saves downloading (and storing) 37 MiB of images, and more in the future (as more images are added for new themes)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
