### PR TITLE
ocamlPackages.raylib: init at 1.4.0

### DIFF
--- a/pkgs/development/ocaml-modules/patch/default.nix
+++ b/pkgs/development/ocaml-modules/patch/default.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  gitUpdater,
+  alcotest,
+  crowbar,
+}:
+
+buildDunePackage rec {
+  pname = "patch";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "hannesm";
+    repo = "patch";
+    tag = "v${version}";
+    hash = "sha256-xqcUZaKlbyXF2//MbCom7/pGA2ej6KHYI3rizXwoqTY=";
+  };
+
+  checkInputs = [
+    alcotest
+    crowbar
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Patch library purely in OCaml";
+    longDescription = ''
+      This is a library which parses unified diff and git diff output, and can apply a patch in memory.
+    '';
+    homepage = "https://github.com/hannesm/patch";
+    maintainers = with lib.maintainers; [ r17x ];
+    license = lib.licenses.isc;
+  };
+}

--- a/pkgs/development/ocaml-modules/raylib/default.nix
+++ b/pkgs/development/ocaml-modules/raylib/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+  dune-configurator,
+  ctypes,
+  integers,
+  patch,
+  gitUpdater,
+}:
+
+buildDunePackage rec {
+  pname = "raylib";
+  version = "1.4.0";
+
+  src = fetchFromGitHub {
+    owner = "tjammer";
+    repo = "raylib-ocaml";
+    tag = version;
+    hash = "sha256-Fh79YnmboQF5Kn3VF//JKLaIFKl8QJWVOqRexTzxF0U=";
+    # enable submodules for vendored raylib sources
+    fetchSubmodules = true;
+  };
+
+  propagatedBuildInputs = [
+    dune-configurator
+    ctypes
+    integers
+    patch
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "OCaml bindings for Raylib (5.0.0)";
+    homepage = "https://tjammer.github.io/raylib-ocaml";
+    maintainers = with lib.maintainers; [ r17x ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/development/ocaml-modules/raylib/raygui.nix
+++ b/pkgs/development/ocaml-modules/raylib/raygui.nix
@@ -1,0 +1,18 @@
+{
+  buildDunePackage,
+  raylib,
+}:
+
+buildDunePackage {
+  pname = "raygui";
+
+  inherit (raylib) src version;
+
+  propagatedBuildInputs = [
+    raylib
+  ];
+
+  meta = raylib.meta // {
+    description = "OCaml bindings for raygui";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1489,6 +1489,8 @@ let
 
     parse-argv = callPackage ../development/ocaml-modules/parse-argv { };
 
+    patch = callPackage ../development/ocaml-modules/patch { };
+
     path_glob = callPackage ../development/ocaml-modules/path_glob { };
 
     pbkdf = callPackage ../development/ocaml-modules/pbkdf { };
@@ -1651,6 +1653,10 @@ let
     ### R ###
 
     randomconv = callPackage ../development/ocaml-modules/randomconv { };
+
+    raylib = callPackage ../development/ocaml-modules/raylib { };
+
+    raygui = callPackage ../development/ocaml-modules/raylib/raygui.nix { };
 
     rdbg = callPackage ../development/ocaml-modules/rdbg { };
 


### PR DESCRIPTION
Closes  #281456
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR resolves issue #281456 by introducing three new OCaml packages:

* ocamlPackages.raylib: OCaml bindings for the Raylib library, used for game development.
* ocamlPackages.raygui: OCaml bindings for Raylib's GUI library.
* ocamlPackages.patch: Utility package for patch management in OCaml projects.
These additions expand the OCaml ecosystem in nixpkgs, supporting development workflows involving Raylib and its related tools.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
