### PR TITLE
albyhub: init at 1.17.1

### DIFF
--- a/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node-go/default.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  ldkNode,
+}:
+
+buildGoModule rec {
+  pname = "ldk-node-go";
+  version = "0-unstable-2025-05-21";
+
+  src = fetchFromGitHub {
+    owner = "getAlby";
+    repo = "ldk-node-go";
+    rev = "ca26307fa2d8ee4d30da9affd0b202897f9919f6";
+    hash = "sha256-UdsfN6UL9lKPQSCfF8oA89U0M3pqj/TcFcs01E7WoXs=";
+  };
+
+  vendorHash = null;
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  buildInputs = [
+    ldkNode
+  ];
+
+  propagatedBuildInputs = [ ldkNode ];
+
+  meta = {
+    description = "Experimental Go bindings for LDK-node";
+    homepage = "https://github.com/getAlby/ldk-node-go";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bleetube ];
+  };
+}

--- a/pkgs/by-name/al/albyhub/ldk-node/default.nix
+++ b/pkgs/by-name/al/albyhub/ldk-node/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  cmake,
+  llvmPackages,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "ldk-node";
+  version = "0-unstable-2025-05-21";
+
+  src = fetchFromGitHub {
+    owner = "getAlby";
+    repo = "ldk-node";
+    rev = "9bb381ad38dbaa71e17816738789d993158fc1a2";
+    hash = "sha256-Ie7FOSOd12mwmkEjD4r0p1ZmeYkXm5eN1LlQhWl0VG4=";
+  };
+
+  buildFeatures = [ "uniffi" ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-hM6VCU0kIg5ZmJM8C4HoybSc/VXNj6GTE/oFLfqGMcY=";
+
+  # Skip tests because they download bitcoin-core and electrs zip files, and then fail
+  doCheck = false;
+
+  nativeBuildInputs = [
+    cmake
+    llvmPackages.clang
+    rustPlatform.bindgenHook
+  ];
+
+  # Add CFLAGS to suppress the stringop-overflow error during aws-lc-sys compilation.
+  NIX_CFLAGS_COMPILE = "-Wno-error=stringop-overflow";
+
+  meta = {
+    description = "Embeds the LDK node implementation compiled as shared library objects";
+    homepage = "https://github.com/getAlby/ldk-node";
+    changelog = "https://github.com/getAlby/ldk-node/blob/${src.rev}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bleetube ];
+  };
+}

--- a/pkgs/by-name/al/albyhub/package.nix
+++ b/pkgs/by-name/al/albyhub/package.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchYarnDeps,
+  fixup-yarn-lock,
+  nodejs,
+  pkgs,
+  yarn,
+  stdenv,
+  makeWrapper,
+  callPackage,
+  go,
+}:
+
+let
+  ldkNode = callPackage ./ldk-node { };
+  ldkNodeGo = callPackage ./ldk-node-go {
+    inherit ldkNode;
+  };
+
+in
+
+buildGoModule rec {
+  pname = "albyhub";
+  version = "1.17.1";
+
+  src = fetchFromGitHub {
+    owner = "getAlby";
+    repo = "hub";
+    tag = "v${version}";
+    hash = "sha256-ZDTCA3nMJEA8I7PeSgwQAe+wU8Wk0GaH3ItQLzPhOBQ=";
+  };
+
+  vendorHash = "sha256-4e75SqQiRUEEjtDZKDZsGSRavZFh5ulJdMz0Ne7gME0=";
+  proxyVendor = true; # needed for secp256k1-zkp CGO bindings
+
+  nativeBuildInputs = [
+    fixup-yarn-lock
+    nodejs
+    yarn
+    makeWrapper
+  ];
+
+  buildInputs = [
+    ldkNodeGo
+    (lib.getLib stdenv.cc.cc)
+  ];
+
+  frontendYarnOfflineCache = fetchYarnDeps {
+    yarnLock = src + "/frontend/yarn.lock";
+    hash = "sha256-SStTJGqeqPvXBKjFMPjKEts+jg6A9Vaqi+rZkr/ytdc=";
+  };
+
+  preBuild = ''
+    export HOME=$TMPDIR
+    pushd frontend
+      fixup-yarn-lock yarn.lock
+      yarn config set yarn-offline-mirror "${frontendYarnOfflineCache}"
+      yarn install --offline --frozen-lockfile --ignore-platform --ignore-scripts --no-progress --non-interactive
+      patchShebangs node_modules
+      yarn --offline build:http
+    popd
+  '';
+
+  subPackages = [
+    "cmd/http"
+  ];
+
+  ldflags = [
+    "-X github.com/getAlby/hub/version.Tag=v${version}"
+    "-s"
+    "-w"
+  ];
+
+  postInstall = ''
+    mv $out/bin/http $out/bin/albyhub
+  '';
+
+  preFixup = ''
+    patchelf --set-rpath ${
+      lib.makeLibraryPath [
+        ldkNode
+        ldkNodeGo
+        (lib.getLib stdenv.cc.cc)
+      ]
+    } $out/bin/albyhub
+  '';
+
+  meta = {
+    description = "Control lightning wallets over nostr";
+    homepage = "https://github.com/getAlby/hub";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ bleetube ];
+    mainProgram = "albyhub";
+  };
+}


### PR DESCRIPTION
#369196

This turned out to be yarn + Go + CGO + Rust shared libraries with Go bindings Nix derivation. Most of this was new territory for me! I used the [Dockerfile](https://github.com/getAlby/hub/blob/master/Dockerfile) as a starting point for how this is supposed to be built.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Progress:

- [x] prebuild frontend artifacts
- [x] buildinput for precompiled ldk_node
- [x]  buildinput for precompiled breez_sdk
- [x]  buildinput for precompiled "glalby_bindings"
- [x] clean RPATHs
- [x] build and run `http`
- [x] minor cleanup
- [x] set up build imports, somehow
- [x] handle the LDK cargo.lock without including the whole thing
- [x] rename the binary name from `http` to `albyhub`
- [x] request clarity for the lnd-node-go [license](https://github.com/getAlby/ldk-node-go/issues/27)

[breez and glalby are no longer supported](https://github.com/getAlby/glalby/issues/18) and slated to be removed in 1.16. This package currently pulls them in as pre-compiled shared libraries. I was going to build them from source, which is when I discovered they are being removed. Just as well, there were quite a few issues trying to get them to build. I think keeping the pre-compiled bins is good enough for the package init. I'd maybe hold off on adding the package to a stable channel until 1.16.0 lands and they can be removed. Hopefully by then the license will be clarified on the lnd-node-go submodule too.


Minor note on the pre-compiled breez/glalby libs: I tried to use `autoPatchelfHook` to clean the RPATHs, but the resulting binary would still have forbidden references to /build/. So to clean the RPATHs I had to add a postInstall step with `patchelf --set-rpath "${lib.makeLibraryPath buildInputs}" $out/bin/http`. It'll be nice to remove all of this when 1.16.0 lands.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
