### PR TITLE
rockcraft: actually use sources for 1.7.0, add passthru.tests.version

### DIFF
--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -4,6 +4,9 @@
   fetchFromGitHub,
   dpkg,
   nix-update-script,
+  testers,
+  rockcraft,
+  cacert,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -49,7 +52,14 @@ python3Packages.buildPythonApplication rec {
     "test_run_init_django"
   ];
 
-  passthru.updateScript = nix-update-script { };
+  passthru = {
+    updateScript = nix-update-script { };
+    tests.version = testers.testVersion {
+      package = rockcraft;
+      command = "env SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt HOME=$(mktemp -d) rockcraft --version";
+      version = "rockcraft ${version}";
+    };
+  };
 
   meta = {
     mainProgram = "rockcraft";

--- a/pkgs/by-name/ro/rockcraft/package.nix
+++ b/pkgs/by-name/ro/rockcraft/package.nix
@@ -13,18 +13,11 @@ python3Packages.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "canonical";
     repo = "rockcraft";
-    rev = "1d87e33cf207b3a2f16eb125743ec11546fa0cb1";
-    hash = "sha256-QnW3BMu4Tuvj8PCt5eYJbNMiojXpyJ1uza6hpMxxSOE=";
+    rev = version;
+    hash = "sha256-2Bo3qtpSSfNvqszlt9cCc9/rurDNDMySAaqLbvRmjjw=";
   };
 
-  postPatch = ''
-    substituteInPlace rockcraft/__init__.py \
-      --replace-fail "dev" "${version}"
-
-    substituteInPlace rockcraft/utils.py \
-      --replace-fail "distutils.util" "setuptools.dist"
-  '';
-
+  pyproject = true;
   build-system = with python3Packages; [ setuptools-scm ];
 
   dependencies = with python3Packages; [
@@ -32,6 +25,7 @@ python3Packages.buildPythonApplication rec {
     craft-archives
     craft-platforms
     spdx-lookup
+    tabulate
   ];
 
   nativeCheckInputs =
@@ -42,7 +36,6 @@ python3Packages.buildPythonApplication rec {
       pytest-mock
       pytest-subprocess
       pytestCheckHook
-      tabulate
     ]
     ++ [ dpkg ];
 
@@ -51,7 +44,10 @@ python3Packages.buildPythonApplication rec {
     export HOME="$(pwd)/check-phase"
   '';
 
-  disabledTests = [ "test_expand_extensions" ];
+  disabledTests = [
+    "test_run_init_flask"
+    "test_run_init_django"
+  ];
 
   passthru.updateScript = nix-update-script { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Not sure what went wrong here, but automatic updates were broken for this package: https://github.com/NixOS/nixpkgs/pull/368735. Maybe patching sources with the version messed up version checks? Anyway, fixed the derivation to use appropriate sources and added a `passthru.tests.version`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
