### PR TITLE
ecm: 7.0.4 -> 7.0.6

### DIFF
--- a/pkgs/by-name/ec/ecm/package.nix
+++ b/pkgs/by-name/ec/ecm/package.nix
@@ -8,7 +8,7 @@
 
 let
   pname = "ecm";
-  version = "7.0.4";
+  version = "7.0.6";
   name = "${pname}-${version}";
 in
 
@@ -16,9 +16,15 @@ stdenv.mkDerivation {
   inherit name;
 
   src = fetchurl {
-    url = "http://gforge.inria.fr/frs/download.php/file/36224/ecm-${version}.tar.gz";
-    sha256 = "0hxs24c2m3mh0nq1zz63z3sb7dhy1rilg2s1igwwcb26x3pb7xqc";
+    url = "https://gitlab.inria.fr/zimmerma/ecm/uploads/ad3e5019fef98819ceae58b78f4cce93/ecm-${version}.tar.gz";
+    hash = "sha256-fSDs5hq2ogrYXywYBkyr133Eapb/iUtSINuxbkZm6KU=";
   };
+
+  postPatch = ''
+    patchShebangs test.ecmfactor
+    patchShebangs test.ecm
+    substituteInPlace test.ecm --replace /bin/rm rm
+  '';
 
   # See https://trac.sagemath.org/ticket/19233
   configureFlags = lib.optional stdenv.hostPlatform.isDarwin "--disable-asm-redc";
@@ -33,8 +39,8 @@ stdenv.mkDerivation {
   meta = {
     description = "Elliptic Curve Method for Integer Factorization";
     mainProgram = "ecm";
-    license = lib.licenses.gpl2Plus;
-    homepage = "http://ecm.gforge.inria.fr/";
+    license = lib.licenses.gpl3Only;
+    homepage = "https://gitlab.inria.fr/zimmerma/ecm";
     maintainers = [ lib.maintainers.roconnor ];
     platforms = with lib.platforms; linux ++ darwin;
   };


### PR DESCRIPTION
INRIA seems to have moved from gforge to gitlab, so sources have been updated.

I also updated the license which was changed to gpl3 sometime ago.

Fixes #368655.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
