### PR TITLE
libretro: fix build with GCC 14

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/fbalpha2012.nix
+++ b/pkgs/applications/emulators/libretro/cores/fbalpha2012.nix
@@ -2,8 +2,10 @@
   lib,
   fetchFromGitHub,
   mkLibretroCore,
+  runCommand,
+  zlib,
 }:
-mkLibretroCore {
+mkLibretroCore rec {
   core = "fbalpha2012";
   version = "0-unstable-2024-10-21";
 
@@ -14,8 +16,29 @@ mkLibretroCore {
     hash = "sha256-giEV09dT/e82bmDlRkxpkW04JcsEZc/enIPecqYtg3c=";
   };
 
+  sourceRoot = "${src.name}/svn-current/trunk";
+
+  # unvendor zlib and broken minizip code
+  postPatch =
+    let
+      minizip-src = runCommand "minizip-src" { } ''
+        mkdir $out
+        unpackFile ${zlib.src}
+        cp */contrib/minizip/{unzip.*,ioapi.*,crypt.h} $out/
+      '';
+    in
+    ''
+      substituteInPlace ${makefile} \
+        --replace-fail '-I$(FBA_LIB_DIR)/zlib' ""
+
+      cp ${minizip-src}/* src/burner
+    '';
+
+  buildInputs = [ zlib ];
+
+  makeFlags = [ "EXTERNAL_ZLIB=1" ];
+
   makefile = "makefile.libretro";
-  preBuild = "cd svn-current/trunk";
 
   meta = {
     description = "Port of Final Burn Alpha ~2012 to libretro";

--- a/pkgs/applications/emulators/libretro/cores/mame2003.nix
+++ b/pkgs/applications/emulators/libretro/cores/mame2003.nix
@@ -5,14 +5,17 @@
 }:
 mkLibretroCore {
   core = "mame2003";
-  version = "0-unstable-2024-11-01";
+  version = "0-unstable-2024-12-10";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "mame2003-libretro";
-    rev = "6d543115531fc96422b73c989a628600cacbea50";
-    hash = "sha256-jFzFQVB0uiSRa82sq1fiMEXyzzDJqRANNgq5hj/ZAl4=";
+    rev = "b6c6d52d8d630d1a172b6b771443dcbbdb45b76d";
+    hash = "sha256-E0kymRxy5aubvcwE5sHcS4T3OEY924TAOXtJN69wp+8=";
   };
+
+  # Fix build with GCC 14
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
 
   makefile = "Makefile";
 

--- a/pkgs/applications/emulators/libretro/cores/mame2016.nix
+++ b/pkgs/applications/emulators/libretro/cores/mame2016.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   mkLibretroCore,
   python3,
+  rapidjson,
 }:
 mkLibretroCore {
   core = "mame2016";
@@ -16,14 +17,22 @@ mkLibretroCore {
     hash = "sha256-IsM7f/zlzvomVOYlinJVqZllUhDfy4NNTeTPtNmdVak=";
   };
 
+  postPatch = ''
+    rm -r 3rdparty/rapidjson
+    ln -s ${lib.getInclude rapidjson} 3rdparty/rapidjson
+  '';
+
   patches = [ ./patches/mame2016-python311.patch ];
   extraNativeBuildInputs = [ python3 ];
   extraBuildInputs = [ alsa-lib ];
   makeFlags = [ "PYTHON_EXECUTABLE=python3" ];
-  # Build failures when this is set to a bigger number
-  NIX_BUILD_CORES = 8;
-  # Fix build errors in GCC13
-  NIX_CFLAGS_COMPILE = "-Wno-error -fpermissive";
+
+  env = {
+    # Build failures when this is set to a bigger number
+    NIX_BUILD_CORES = 8;
+    # Fix build errors in GCC 13
+    NIX_CFLAGS_COMPILE = "-Wno-error -fpermissive";
+  };
 
   meta = {
     description = "Port of MAME ~2016 to libretro, compatible with MAME 0.174 sets";

--- a/pkgs/applications/emulators/libretro/cores/np2kai.nix
+++ b/pkgs/applications/emulators/libretro/cores/np2kai.nix
@@ -21,6 +21,12 @@ mkLibretroCore rec {
     "NP2KAI_HASH=${builtins.substring 0 7 src.rev}"
   ];
 
+  # Fix build with GCC 14
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=incompatible-pointer-types"
+    "-Wno-error=int-conversion"
+  ];
+
   preBuild = "cd sdl";
 
   meta = {

--- a/pkgs/applications/emulators/libretro/mkLibretroCore.nix
+++ b/pkgs/applications/emulators/libretro/mkLibretroCore.nix
@@ -83,7 +83,9 @@ stdenv.mkDerivation (
 
     passthru = {
       inherit core libretroCore;
-      updateScript = unstableGitUpdater { };
+      # libretro repos sometimes has a fake tag like "Current", ignore
+      # it by setting hardcodeZeroVersion
+      updateScript = unstableGitUpdater { hardcodeZeroVersion = true; };
     } // (args.passthru or { });
 
     meta =


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix `retroarch-full`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
