### PR TITLE
electron_31: fix build after llvm bump

### DIFF
--- a/pkgs/development/tools/electron/electron-31-perfetto-missing-template-arg-list.patch
+++ b/pkgs/development/tools/electron/electron-31-perfetto-missing-template-arg-list.patch
@@ -1,0 +1,13 @@
+diff --git a/include/perfetto/tracing/internal/track_event_data_source.h b/include/perfetto/tracing/internal/track_event_data_source.h
+index 1d924b271..dba896262 100644
+--- a/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h
++++ b/third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h
+@@ -1061,7 +1061,7 @@ class TrackEventDataSource
+       const TrackType& track,
+       std::function<void(protos::pbzero::TrackDescriptor*)> callback) {
+     TrackRegistry::Get()->UpdateTrack(track, std::move(callback));
+-    Base::template Trace([&](typename Base::TraceContext ctx) {
++    Base::Trace([&](typename Base::TraceContext ctx) {
+       TrackEventInternal::WriteTrackDescriptor(
+           track, ctx.tls_inst_->trace_writer.get(), ctx.GetIncrementalState(),
+           *ctx.GetCustomTlsState(), TrackEventInternal::GetTraceTime());


### PR DESCRIPTION
Fixes #368172

This fixes the following build errors:

~~~
[2607/50420] CXX obj/third_party/perfetto/src/tracing/client_api_without_backends/track_event_legacy.o FAILED: obj/third_party/perfetto/src/tracing/client_api_without_backends/track_event_legacy.o clang++ -MD -MF [...]
In file included from ../../third_party/perfetto/src/tracing/track_event_legacy.cc:17: In file included from ../../third_party/perfetto/include/perfetto/tracing/track_event_legacy.h:26: In file included from ../../third_party/perfetto/include/perfetto/tracing/track_event.h:20: ../../third_party/perfetto/include/perfetto/tracing/internal/track_event_data_source.h:331:20: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  331 |     Base::template Trace([](typename Base::TraceContext ctx) { ctx.Flush(); });
      |                    ^
[...]
6 errors generated.
~~~

and

~~~
FAILED: obj/electron/electron_lib/keyboard_util.o
clang++ -MD -MF [...]
../../electron/shell/common/keyboard_util.cc:19:30: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
   19 | constexpr CodeAndShiftedChar KeyboardCodeFromKeyIdentifier(
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../electron/shell/common/keyboard_util.cc:111:33: note: non-constexpr function 'find' cannot be used in a constant expression
  111 |   if (auto* const iter = Lookup.find(str); iter != Lookup.end())
      |                                 ^
../../base/containers/flat_tree.h:310:18: note: declared here
  310 |   const_iterator find(const Key& key) const;
      |                  ^
1 error generated.
~~~

This is happening since staging has been merged into master, which included both a rustc and llvm bump.

Note that we inherit the llvm that rustc exposes.

This is not happening on release-24.11.

Will probably go to bed now and check the then hopefully successful build result tomorrow.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).