### PR TITLE
python312Packages.transforms3d: 0.4.1 -> 0.4.2

### DIFF
--- a/pkgs/development/python-modules/transforms3d/default.nix
+++ b/pkgs/development/python-modules/transforms3d/default.nix
@@ -3,6 +3,8 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
+  setuptools,
+  versioneer,
   pytestCheckHook,
   numpy,
   scipy,
@@ -11,32 +13,39 @@
 
 buildPythonPackage rec {
   pname = "transforms3d";
-  version = "0.4.1";
-  format = "setuptools";
+  version = "0.4.2";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "matthew-brett";
     repo = pname;
-    rev = "refs/tags/${version}";
-    hash = "sha256-GgnjvwAfyxnDfBGvgMFIPPbR88BWFiNGrScVORygq94=";
+    tag = version;
+    hash = "sha256-9wICu7zNYF54e6xcDpZxqctB4GVu5Knf79Z36016Rpw=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [
+    setuptools
+    versioneer
+  ];
+
+  dependencies = [
     numpy
-    sympy
   ];
 
   nativeCheckInputs = [
     pytestCheckHook
     scipy
+    sympy
   ];
+
   pythonImportsCheck = [ "transforms3d" ];
 
   meta = with lib; {
     homepage = "https://matthew-brett.github.io/transforms3d";
     description = "Convert between various geometric transformations";
+    changelog = "https://github.com/matthew-brett/transforms3d/blob/main/Changelog";
     license = licenses.bsd2;
     maintainers = with maintainers; [ bcdarwin ];
   };


### PR DESCRIPTION
Unbreaks the package due to added numpy 2.x support.

[changelog](https://github.com/matthew-brett/transforms3d/blob/main/Changelog)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
