### PR TITLE
 makeDesktopItem: allow configuring output directory 

### DIFF
--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -1,119 +1,142 @@
-{ lib, writeTextFile, buildPackages }:
+{
+  lib,
+  writeTextFile,
+  buildPackages,
+}:
 
 # All possible values as defined by the spec, version 1.4.
 # Please keep in spec order for easier maintenance.
 # When adding a new value, don't forget to update the Version field below!
 # See https://specifications.freedesktop.org/desktop-entry-spec/latest
-lib.makeOverridable ({ name # The name of the desktop file
-, type ? "Application"
-# version is hardcoded
-, desktopName # The name of the application
-, genericName ? null
-, noDisplay ? null
-, comment ? null
-, icon ? null
-# we don't support the Hidden key - if you don't need something, just don't install it
-, onlyShowIn ? []
-, notShowIn ? []
-, dbusActivatable ? null
-, tryExec ? null
-, exec ? null
-, path ? null
-, terminal ? null
-, actions ? {} # An attrset of [internal name] -> { name, exec?, icon? }
-, mimeTypes ? [] # The spec uses "MimeType" as singular, use plural here to signify list-ness
-, categories ? []
-, implements ? []
-, keywords ? []
-, startupNotify ? null
-, startupWMClass ? null
-, url ? null
-, prefersNonDefaultGPU ? null
-# not supported until version 1.5, which is not supported by our desktop-file-utils as of 2022-02-23
-# , singleMainWindow ? null
-, extraConfig ? {} # Additional values to be added literally to the final item, e.g. vendor extensions
-}:
-let
-  # There are multiple places in the FDO spec that make "boolean" values actually tristate,
-  # e.g. StartupNotify, where "unset" is literally defined as "do something reasonable".
-  # So, handle null values separately.
-  boolOrNullToString = value:
-    if value == null then null
-    else if builtins.isBool value then lib.boolToString value
-    else throw "makeDesktopItem: value must be a boolean or null!";
+lib.makeOverridable (
+  {
+    name, # The name of the desktop file
+    type ? "Application",
+    # version is hardcoded
+    desktopName, # The name of the application
+    genericName ? null,
+    noDisplay ? null,
+    comment ? null,
+    icon ? null,
+    # we don't support the Hidden key - if you don't need something, just don't install it
+    onlyShowIn ? [ ],
+    notShowIn ? [ ],
+    dbusActivatable ? null,
+    tryExec ? null,
+    exec ? null,
+    path ? null,
+    terminal ? null,
+    actions ? { }, # An attrset of [internal name] -> { name, exec?, icon? }
+    mimeTypes ? [ ], # The spec uses "MimeType" as singular, use plural here to signify list-ness
+    categories ? [ ],
+    implements ? [ ],
+    keywords ? [ ],
+    startupNotify ? null,
+    startupWMClass ? null,
+    url ? null,
+    prefersNonDefaultGPU ? null,
+    # not supported until version 1.5, which is not supported by our desktop-file-utils as of 2022-02-23
+    # singleMainWindow ? null,
+    extraConfig ? { }, # Additional values to be added literally to the final item, e.g. vendor extensions
+  }:
+  let
+    # There are multiple places in the FDO spec that make "boolean" values actually tristate,
+    # e.g. StartupNotify, where "unset" is literally defined as "do something reasonable".
+    # So, handle null values separately.
+    boolOrNullToString =
+      value:
+      if value == null then
+        null
+      else if builtins.isBool value then
+        lib.boolToString value
+      else
+        throw "makeDesktopItem: value must be a boolean or null!";
 
-  # Multiple values are represented as one string, joined by semicolons.
-  # Technically, it's possible to escape semicolons in values with \;, but this is currently not implemented.
-  renderList = key: value:
-    if !builtins.isList value then throw "makeDesktopItem: value for ${key} must be a list!"
-    else if builtins.any (item: lib.hasInfix ";" item) value then throw "makeDesktopItem: values in ${key} list must not contain semicolons!"
-    else if value == [] then null
-    else builtins.concatStringsSep ";" value;
+    # Multiple values are represented as one string, joined by semicolons.
+    # Technically, it's possible to escape semicolons in values with \;, but this is currently not implemented.
+    renderList =
+      key: value:
+      if !builtins.isList value then
+        throw "makeDesktopItem: value for ${key} must be a list!"
+      else if builtins.any (item: lib.hasInfix ";" item) value then
+        throw "makeDesktopItem: values in ${key} list must not contain semicolons!"
+      else if value == [ ] then
+        null
+      else
+        builtins.concatStringsSep ";" value;
 
-  # The [Desktop Entry] section of the desktop file, as an attribute set.
-  # Please keep in spec order.
-  mainSection = {
-    "Type" = type;
-    "Version" = "1.4";
-    "Name" = desktopName;
-    "GenericName" = genericName;
-    "NoDisplay" = boolOrNullToString noDisplay;
-    "Comment" = comment;
-    "Icon" = icon;
-    "OnlyShowIn" = renderList "onlyShowIn" onlyShowIn;
-    "NotShowIn" = renderList "notShowIn" notShowIn;
-    "DBusActivatable" = boolOrNullToString dbusActivatable;
-    "TryExec" = tryExec;
-    "Exec" = exec;
-    "Path" = path;
-    "Terminal" = boolOrNullToString terminal;
-    "Actions" = renderList "actions" (builtins.attrNames actions);
-    "MimeType" = renderList "mimeTypes" mimeTypes;
-    "Categories" = renderList "categories" categories;
-    "Implements" = renderList "implements" implements;
-    "Keywords" = renderList "keywords" keywords;
-    "StartupNotify" = boolOrNullToString startupNotify;
-    "StartupWMClass" = startupWMClass;
-    "URL" = url;
-    "PrefersNonDefaultGPU" = boolOrNullToString prefersNonDefaultGPU;
-    # "SingleMainWindow" = boolOrNullToString singleMainWindow;
-  } // extraConfig;
+    # The [Desktop Entry] section of the desktop file, as an attribute set.
+    # Please keep in spec order.
+    mainSection = {
+      "Type" = type;
+      "Version" = "1.4";
+      "Name" = desktopName;
+      "GenericName" = genericName;
+      "NoDisplay" = boolOrNullToString noDisplay;
+      "Comment" = comment;
+      "Icon" = icon;
+      "OnlyShowIn" = renderList "onlyShowIn" onlyShowIn;
+      "NotShowIn" = renderList "notShowIn" notShowIn;
+      "DBusActivatable" = boolOrNullToString dbusActivatable;
+      "TryExec" = tryExec;
+      "Exec" = exec;
+      "Path" = path;
+      "Terminal" = boolOrNullToString terminal;
+      "Actions" = renderList "actions" (builtins.attrNames actions);
+      "MimeType" = renderList "mimeTypes" mimeTypes;
+      "Categories" = renderList "categories" categories;
+      "Implements" = renderList "implements" implements;
+      "Keywords" = renderList "keywords" keywords;
+      "StartupNotify" = boolOrNullToString startupNotify;
+      "StartupWMClass" = startupWMClass;
+      "URL" = url;
+      "PrefersNonDefaultGPU" = boolOrNullToString prefersNonDefaultGPU;
+      # "SingleMainWindow" = boolOrNullToString singleMainWindow;
+    } // extraConfig;
 
-  # Render a single attribute pair to a Key=Value line.
-  # FIXME: this isn't entirely correct for arbitrary strings, as some characters
-  # need to be escaped. There are currently none in nixpkgs though, so this is OK.
-  renderLine = name: value: if value != null then "${name}=${value}" else null;
+    # Render a single attribute pair to a Key=Value line.
+    # FIXME: this isn't entirely correct for arbitrary strings, as some characters
+    # need to be escaped. There are currently none in nixpkgs though, so this is OK.
+    renderLine = name: value: if value != null then "${name}=${value}" else null;
 
-  # Render a full section of the file from an attrset.
-  # Null values are intentionally left out.
-  renderSection = sectionName: attrs:
-    lib.pipe attrs [
-      (lib.mapAttrsToList renderLine)
-      (builtins.filter (v: v != null))
-      (builtins.concatStringsSep "\n")
-      (section: ''
-        [${sectionName}]
-        ${section}
-      '')
-    ];
+    # Render a full section of the file from an attrset.
+    # Null values are intentionally left out.
+    renderSection =
+      sectionName: attrs:
+      lib.pipe attrs [
+        (lib.mapAttrsToList renderLine)
+        (builtins.filter (v: v != null))
+        (builtins.concatStringsSep "\n")
+        (section: ''
+          [${sectionName}]
+          ${section}
+        '')
+      ];
 
-  mainSectionRendered = renderSection "Desktop Entry" mainSection;
+    mainSectionRendered = renderSection "Desktop Entry" mainSection;
 
-  # Convert from javaCase names as used in Nix to PascalCase as used in the spec.
-  preprocessAction = { name, icon ? null, exec ? null }: {
-    "Name" = name;
-    "Icon" = icon;
-    "Exec" = exec;
-  };
-  renderAction = name: attrs: renderSection "Desktop Action ${name}" (preprocessAction attrs);
-  actionsRendered = lib.mapAttrsToList renderAction actions;
+    # Convert from javaCase names as used in Nix to PascalCase as used in the spec.
+    preprocessAction =
+      {
+        name,
+        icon ? null,
+        exec ? null,
+      }:
+      {
+        "Name" = name;
+        "Icon" = icon;
+        "Exec" = exec;
+      };
+    renderAction = name: attrs: renderSection "Desktop Action ${name}" (preprocessAction attrs);
+    actionsRendered = lib.mapAttrsToList renderAction actions;
 
-  extension = if type == "Directory" then "directory" else "desktop";
-  content = [ mainSectionRendered ] ++ actionsRendered;
-in
-writeTextFile {
-  name = "${name}.${extension}";
-  destination = "/share/applications/${name}.${extension}";
-  text = builtins.concatStringsSep "\n" content;
-  checkPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
-})
+    extension = if type == "Directory" then "directory" else "desktop";
+    content = [ mainSectionRendered ] ++ actionsRendered;
+  in
+  writeTextFile {
+    name = "${name}.${extension}";
+    destination = "/share/applications/${name}.${extension}";
+    text = builtins.concatStringsSep "\n" content;
+    checkPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
+  }
+)

--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -4,10 +4,74 @@
   buildPackages,
 }:
 
-# All possible values as defined by the spec, version 1.4.
-# Please keep in spec order for easier maintenance.
-# When adding a new value, don't forget to update the Version field below!
-# See https://specifications.freedesktop.org/desktop-entry-spec/latest
+
+/**
+  A utility builder to create a desktop entry file at a predetermined location (by default, $out/share/applications).
+
+  # Examples
+
+  ```nix
+  makeDesktopItem {
+    name = "Eclipse";
+    exec = "eclipse";
+    icon = "eclipse";
+    comment = "Integrated Development Environment";
+    desktopName = "Eclipse IDE";
+    genericName = "Integrated Development Environment";
+    categories = [ "Development" ];
+  }
+  => «derivation /nix/store/sh017x5n50i2qwns2na1sxdp7zb2zgcw-Eclipse.desktop.drv»
+  ```
+
+  # Type
+
+  ```
+  makeDesktopItem :: AttrSet -> Derivation
+  ```
+
+  # Input
+
+  `attrs`
+
+  : An AttrSet with the following definitions. See https://specifications.freedesktop.org/desktop-entry-spec/1.4/recognized-keys.html#id-1.7.6 for definitions.
+
+    - `name` (string): The name of the desktop file (excluding the .desktop or .directory file extensions)
+    - `destination` (string): The directory that will contain the desktop entry file (Default: "/share/applications")
+    - `type` ("Application" | "Link" | "Directory"): The `Type` of the desktop entry
+    - `desktopName` (string): The `Name` of the desktop entry
+    - `genericName` (string): The `GenericName` of the desktop entry
+    - `noDisplay` (bool): The `NoDisplay` of the desktop entry
+    - `comment` (string): The `Comment` of the desktop entry
+    - `icon` (string): The `Icon` of the desktop entry
+    - `onlyShowIn` (string[]): The `OnlyShowIn` of the desktop entry
+    - `notShowIn` (string[]): The `NotShowIn` of the desktop entry
+    - `dbusActivatable` (bool): The `DBusActivatable` of the desktop entry
+    - `tryExec` (string): The `TryExec` of the desktop entry
+    - `exec` (string): The `Exec` of the desktop entry
+    - `path` (string): The `Path` of the desktop entry
+    - `terminal` (bool): The `Terminal` of the desktop entry
+    - `actions` (AttrSet): An attrset of [internal name] -> { name, exec?, icon? } representing the `Actions` of the desktop entry
+    - `mimeTypes` (string[]): The `MimeType` of the desktop entry
+    - `categories` (string[]): The `Categories` of the desktop entry; see https://specifications.freedesktop.org/menu-spec/1.0/category-registry.html for possible values
+    - `implements` (string[]): The `Implements` of the desktop entry
+    - `keywords` (string[]): The `Keywords` of the desktop entry
+    - `startupNotify` (bool): The `StartupNotify` of the desktop entry
+    - `startupWMClass` (string): The `StartupWMClass` of the desktop entry
+    - `url` (string): The `URL` of the Link-type desktop entry
+    - `prefersNonDefaultGPU` (bool): The `PrefersNonDefaultGPU` (non-standard) of the desktop entry
+    - `extraConfig` (AttrSet): Additional values to be added literally to the final item, e.g. vendor extensions
+
+  # Output
+
+  A derivation that contains the output desktop entry file.
+
+  # Developer Note
+
+  All possible values are as defined by the spec, version 1.4.
+  Please keep in spec order for easier maintenance.
+  When adding a new value, don't forget to update the Version field below!
+  See https://specifications.freedesktop.org/desktop-entry-spec/latest
+*/
 lib.makeOverridable (
   {
     name, # The name of the desktop file

--- a/pkgs/build-support/make-desktopitem/default.nix
+++ b/pkgs/build-support/make-desktopitem/default.nix
@@ -11,6 +11,7 @@
 lib.makeOverridable (
   {
     name, # The name of the desktop file
+    destination ? "/share/applications",
     type ? "Application",
     # version is hardcoded
     desktopName, # The name of the application
@@ -135,7 +136,7 @@ lib.makeOverridable (
   in
   writeTextFile {
     name = "${name}.${extension}";
-    destination = "/share/applications/${name}.${extension}";
+    destination = "${destination}/${name}.${extension}";
     text = builtins.concatStringsSep "\n" content;
     checkPhase = ''${buildPackages.desktop-file-utils}/bin/desktop-file-validate "$target"'';
   }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

See discussion at https://github.com/NixOS/nixpkgs/pull/368017#discussion_r1897056329

Also nixfmts and adds Noogle-compatible documentation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
