### PR TITLE
gzdoom: 4.13.2 -> 4.14.0

### DIFF
--- a/pkgs/by-name/gz/gzdoom/package.nix
+++ b/pkgs/by-name/gz/gzdoom/package.nix
@@ -28,15 +28,17 @@
 
 stdenv.mkDerivation rec {
   pname = "gzdoom";
-  version = "4.13.2";
+  version = "4.14.0";
 
   src = fetchFromGitHub {
     owner = "ZDoom";
     repo = "gzdoom";
     rev = "g${version}";
     fetchSubmodules = true;
-    hash = "sha256-3nkdpJ3XO58YHtjVTwxdSdCL6CnMcih6mTnI7FXLm34=";
+    hash = "sha256-+gLWt1qBKl8xGK6sALnjqPuXcBexjWKbEkbRMFtLcbE=";
   };
+
+  patches = [ ./string_format.patch ];
 
   outputs = [
     "out"

--- a/pkgs/by-name/gz/gzdoom/string_format.patch
+++ b/pkgs/by-name/gz/gzdoom/string_format.patch
@@ -1,0 +1,13 @@
+diff --git a/src/common/engine/i_net.cpp b/src/common/engine/i_net.cpp
+index ad106bbc4..0a67062a0 100644
+--- a/src/common/engine/i_net.cpp
++++ b/src/common/engine/i_net.cpp
+@@ -1072,7 +1072,7 @@ void I_NetError(const char* error)
+ {
+ 	doomcom.numnodes = 0;
+ 	StartWindow->NetClose();
+-	I_FatalError(error);
++	I_FatalError("%s", error);
+ }
+ 
+ // todo: later these must be dispatched by the main menu, not the start screen.


### PR DESCRIPTION
https://github.com/ZDoom/gzdoom/releases/tag/g4.14.0
https://github.com/ZDoom/gzdoom/compare/g4.13.0...g4.14.0

Added a patch to fix the following error when building:
```
/build/source/src/common/engine/printf.h:26:41: warning: '%s' directive argument is null [-Wformat-overflow=]
   26 | #define TEXTCOLOR_RED                   "\034G"
/build/source/src/common/engine/i_net.cpp:1075:21: error: format not a string literal and no format arguments [-Werror=format-security]
 1075 |         I_FatalError(error);
      |         ~~~~~~~~~~~~^~~~~~~
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
