### PR TITLE
clipit: fix build on gcc14

### DIFF
--- a/pkgs/by-name/cl/clipit/package.nix
+++ b/pkgs/by-name/cl/clipit/package.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  fetchpatch,
   lib,
   stdenv,
   autoreconfHook,
@@ -27,16 +28,30 @@ stdenv.mkDerivation rec {
     intltoolize --copy --force --automake
   '';
 
+  patches = [
+    # Fixes for GCC14
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/clipit/-/raw/d4bafc28fcb445d1940cdfede6c70142cf3162f5/debian/patches/incompatible-pointer-types.patch";
+      hash = "sha256-STI1fpnoPdEqu1embQcUlTG712HPbJ+LPm930P13Ixo=";
+    })
+    (fetchpatch {
+      url = "https://salsa.debian.org/debian/clipit/-/raw/656d0814030c13437b10d40ee75615d0e8cd873e/debian/patches/missing-prototypes.patch";
+      hash = "sha256-UD183IjV5BprPHQK9bhmUBKfUYgqEZ9M1cRE+AmhAPA=";
+    })
+  ];
+
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook3
     autoreconfHook
     intltool
   ];
+
   configureFlags = [
     "--with-gtk3"
     "--enable-appindicator=yes"
   ];
+
   buildInputs = [
     gtk3
     libayatana-appindicator


### PR DESCRIPTION
## Things done

Package is not very alive, so this is probably the easiest way to unbreak it.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
