### PR TITLE
bpfman: init at 0.5.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -101,6 +101,8 @@
 
 - [nvidia-gpu](https://github.com/utkuozdemir/nvidia_gpu_exporter), a Prometheus exporter that scrapes `nvidia-smi` for GPU metrics. Available as [services.prometheus.exporters.nvidia-gpu](#opt-services.prometheus.exporters.nvidia-gpu.enable).
 
+- [bpfman](https://bpfman.io), an eBPF Manager for Linux and Kubernetes. Available as [services.bpfman](#opt-services.bpfman.enable).
+
 - [InputPlumber](https://github.com/ShadowBlip/InputPlumber/), an open source input router and remapper daemon for Linux. Available as [services.inputplumber](#opt-services.inputplumber.enable).
 
 - [echoip](https://github.com/mpolden/echoip), a simple service for looking up your IP address. Available as [services.echoip](#opt-services.echoip.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1396,6 +1396,7 @@
   ./services/security/vaultwarden/default.nix
   ./services/security/yubikey-agent.nix
   ./services/system/automatic-timezoned.nix
+  ./services/system/bpfman.nix
   ./services/system/bpftune.nix
   ./services/system/cachix-agent/default.nix
   ./services/system/cachix-watch-store.nix

--- a/nixos/modules/services/system/bpfman.nix
+++ b/nixos/modules/services/system/bpfman.nix
@@ -1,0 +1,55 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.bpfman;
+  settingsFormat = pkgs.formats.toml { };
+
+  inherit (lib)
+    literalExpression
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    ;
+
+  inherit (lib.types) submodule;
+in
+{
+  options.services.bpfman = {
+    enable = mkEnableOption "bpfman";
+    package = mkPackageOption pkgs "bpfman" { };
+
+    settings = mkOption {
+      type = submodule {
+        freeformType = settingsFormat.type;
+      };
+
+      default = { };
+
+      example = literalExpression ''
+        {
+          signing.allow_unsigned = true;
+          database.max_retries = 10;
+        }
+      '';
+
+      description = ''
+        Configuration for bpfman.
+        Supported options can be found at the [docs](https://bpfman.io/v0.5.4/developer-guide/configuration).
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment = {
+      systemPackages = [ pkgs.bpfman ];
+      etc."bpfman/bpfman.toml".source = settingsFormat.generate "bpfman.toml" cfg.settings;
+    };
+
+    systemd.packages = [ pkgs.bpfman ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -169,6 +169,7 @@ in {
   borgmatic = handleTest ./borgmatic.nix {};
   botamusique = handleTest ./botamusique.nix {};
   bpf = handleTestOn ["x86_64-linux" "aarch64-linux"] ./bpf.nix {};
+  bpfman = runTest ./bpfman.nix;
   bpftune = handleTest ./bpftune.nix {};
   breitbandmessung = handleTest ./breitbandmessung.nix {};
   brscan5 = handleTest ./brscan5.nix {};

--- a/nixos/tests/bpfman.nix
+++ b/nixos/tests/bpfman.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+{
+  name = "bpfman";
+  meta.maintainers = with pkgs.lib.maintainers; [ pizzapim ];
+
+  nodes.machine =
+    { ... }:
+    {
+      services.bpfman.enable = true;
+    };
+
+  testScript = ''
+    machine.succeed("bpfman list | grep Program")
+  '';
+}

--- a/pkgs/by-name/bp/bpfman/package.nix
+++ b/pkgs/by-name/bp/bpfman/package.nix
@@ -1,0 +1,71 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  llvmPackages_12,
+  pkg-config,
+  openssl,
+  enableSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
+  installShellFiles,
+  stdenv,
+  systemd,
+  ...
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "bpfman";
+  version = "0.5.4";
+
+  src = fetchFromGitHub {
+    owner = "bpfman";
+    repo = "bpfman";
+    rev = "v${version}";
+    hash = "sha256-HD8Qdy7wvV2zGoPRLYZu+NpG28T5Q4WfLr5UnZB+bkg=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-X9qSGSXRX8WEGKD4Wc2iRhmky1uGCspG8muyCsyeIiQ=";
+
+  nativeBuildInputs = [
+    llvmPackages_12.llvm
+    pkg-config
+    installShellFiles
+  ];
+  buildInputs = [ openssl ];
+
+  postInstall =
+    ''
+      compdir=./.output/completions
+      cargo xtask build-completion
+      installShellCompletion --cmd bpfman \
+        --bash $compdir/bpfman.bash \
+        --fish $compdir/bpfman.fish
+    ''
+    + lib.optionalString enableSystemd ''
+      mkdir -p $out/lib/systemd/system
+      cp scripts/bpfman.socket $out/lib/systemd/system
+      substitute scripts/bpfman.service \
+                 $out/lib/systemd/system/bpfman.service \
+                 --replace /usr/sbin/bpfman-rpc $out/bin/bpfman-rpc
+    '';
+
+  checkFlags = [
+    # Tests needing network connectivity
+    "--skip=oci_utils::image_manager::tests::image_pull_and_bytecode_verify"
+    "--skip=oci_utils::image_manager::tests::image_pull_and_bytecode_verify_legacy"
+    "--skip=oci_utils::image_manager::tests::image_pull_failure"
+    "--skip=oci_utils::image_manager::tests::image_pull_policy_never_failure"
+    "--skip=oci_utils::image_manager::tests::private_image_pull_and_bytecode_verify"
+  ];
+
+  meta = {
+    description = "An eBPF Manager for Linux and Kubernetes";
+    mainProgram = "bpfman";
+    homepage = "https://bpfman.io";
+    license = with lib.licenses; [
+      asl20
+      bsd2
+      gpl2Only
+    ];
+    maintainers = with lib.maintainers; [ pizzapim ];
+  };
+}


### PR DESCRIPTION
Wanted to mess around with eBPF on NixOS and found that this project was missing from nixpkgs. The installation of the Systemd units is based on the one from [borgmatic](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/bo/borgmatic/package.nix#L5).

Note: bpfman can apparently also be used for Kubernetes. I have only tested the Linux side of it, which is what I am interested in.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
