### PR TITLE
[Backport release-24.11] hyprland: 0.45.2 -> 0.46.2, hyprland-qtutils: init at 0.1.1, hyprgraphics: init at 0.1.1, hyprpaper 0.7.1 -> 0.7.2, xdg-desktop-portal-hyprland: 1.3.6 -> 1.3.9, aquamarine: 0.4.4 -> 0.5.1, hyprlandPlugins: version bumps and update script tweaks

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/default.nix
@@ -2,14 +2,12 @@
   lib,
   callPackage,
   pkg-config,
-  stdenv,
-  hyprland,
 }:
 let
   mkHyprlandPlugin =
     hyprland:
     args@{ pluginName, ... }:
-    stdenv.mkDerivation (
+    hyprland.stdenv.mkDerivation (
       args
       // {
         pname = "${pluginName}";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
@@ -3,18 +3,18 @@
   mkHyprlandPlugin,
   fetchFromGitHub,
   hyprland,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 mkHyprlandPlugin hyprland {
   pluginName = "hypr-dynamic-cursors";
-  version = "0-unstable-2024-11-19";
+  version = "0-unstable-2024-12-14";
 
   src = fetchFromGitHub {
     owner = "VirtCode";
     repo = "hypr-dynamic-cursors";
-    rev = "81f4b964f997a3174596ef22c7a1dee8a5f616c7";
-    hash = "sha256-3SDwq2i2QW9nu7HBCPuDtLmrwLt2kajzImBsawKRZ+s=";
+    rev = "f0cef070c531e3a3a1f713b7062bded357b4c468";
+    hash = "sha256-XFQqJWxo6xUqLpAKqc0bHg1pZ21eFQ1HueDTxw7N6r8=";
   };
 
   dontUseCmakeConfigure = true;
@@ -28,7 +28,7 @@ mkHyprlandPlugin hyprland {
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     description = "Plugin to make your Hyprland cursor more realistic";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprfocus.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprfocus.nix
@@ -3,6 +3,7 @@
   mkHyprlandPlugin,
   hyprland,
   fetchFromGitHub,
+  nix-update-script,
 }:
 
 mkHyprlandPlugin hyprland {
@@ -25,6 +26,7 @@ mkHyprlandPlugin hyprland {
     runHook postInstall
   '';
 
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
   meta = {
     homepage = "https://github.com/pyt0xic/hyprfocus";
     description = "Focus animation plugin for Hyprland inspired by Flashfocus";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
@@ -13,13 +13,13 @@
 
 mkHyprlandPlugin hyprland {
   pluginName = "hyprgrass";
-  version = "0.8.2-unstable-2024-10-30";
+  version = "0.8.2-unstable-2024-12-13";
 
   src = fetchFromGitHub {
     owner = "horriblename";
     repo = "hyprgrass";
-    rev = "f97b6ac2b7de3bae194b776c388467db2604929f";
-    hash = "sha256-Jg5Q/v8tcNjopTMbra82y5n9QQdCnrbEFNgT1kA7pQE=";
+    rev = "dc19ccb209147312a4f60d76193b995c2634e756";
+    hash = "sha256-3ALmrImk37KT+UHt1EMi6PAHyj8WhL9Xw/Ar/ys4rtk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
@@ -14,13 +14,13 @@ let
             mkHyprlandPlugin,
           }:
           let
-            version = "0.45.0";
+            version = "0.46.0";
 
             hyprland-plugins-src = fetchFromGitHub {
               owner = "hyprwm";
               repo = "hyprland-plugins";
               rev = "refs/tags/v${version}";
-              hash = "sha256-hOljwsXpY4Y6guvcr51tWCnXo6c56yaBknnLXk1m3Vk=";
+              hash = "sha256-Q9bXV9d6xqxr8V1UKmmmHdCgky3I4n2hk1TDxZ/pBto=";
             };
           in
           mkHyprlandPlugin hyprland {

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprscroller.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprscroller.nix
@@ -4,18 +4,18 @@
   hyprland,
   cmake,
   fetchFromGitHub,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 mkHyprlandPlugin hyprland {
   pluginName = "hyprscroller";
-  version = "0-unstable-2024-11-23";
+  version = "0-unstable-2024-12-17";
 
   src = fetchFromGitHub {
     owner = "dawsers";
     repo = "hyprscroller";
-    rev = "f1e09fd86d0fff30aff0b9ca2e429c7331bab5ac";
-    hash = "sha256-5j7IqHKiXfmaq193ltGX4/150NA1YWNXNB1GIFwEfuc=";
+    rev = "9dc46c3c98e875a8f3b2a118ef3859a3c714c887";
+    hash = "sha256-CifZc4Ev+CG4qHHOH6e6NLBLQNbFVn4gZEFNCX8e0QQ=";
   };
 
   nativeBuildInputs = [ cmake ];
@@ -29,7 +29,7 @@ mkHyprlandPlugin hyprland {
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     homepage = "https://github.com/dawsers/hyprscroller";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
@@ -3,18 +3,18 @@
   fetchFromGitHub,
   hyprland,
   mkHyprlandPlugin,
-  unstableGitUpdater,
+  nix-update-script,
 }:
 
 mkHyprlandPlugin hyprland {
   pluginName = "hyprspace";
-  version = "0-unstable-2024-11-02";
+  version = "0-unstable-2024-12-08";
 
   src = fetchFromGitHub {
     owner = "KZDKM";
     repo = "hyprspace";
-    rev = "260f386075c7f6818033b05466a368d8821cde2d";
-    hash = "sha256-cwbcYg+rPmvHFFtAEie7nw5IaBidrTYe5XsTlhOyoyQ=";
+    rev = "e2d561c933cd085d68bf0b39c4f78870ad0abbc2";
+    hash = "sha256-YiLUDw14NaavML8y9rxXxO7q+j3b/ghQhBmIy0+/Zmk=";
   };
 
   dontUseCmakeConfigure = true;
@@ -28,7 +28,7 @@ mkHyprlandPlugin hyprland {
     runHook postInstall
   '';
 
-  passthru.updateScript = unstableGitUpdater { };
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
 
   meta = {
     homepage = "https://github.com/KZDKM/Hyprspace";

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprsplit.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprsplit.nix
@@ -5,22 +5,25 @@
   hyprland,
   ninja,
   mkHyprlandPlugin,
+  nix-update-script,
 }:
 mkHyprlandPlugin hyprland rec {
   pluginName = "hyprsplit";
-  version = "0.45.0";
+  version = "0.46.0";
 
   src = fetchFromGitHub {
     owner = "shezdy";
     repo = "hyprsplit";
     rev = "refs/tags/v${version}";
-    hash = "sha256-otDIivy4sMZBN2t9eHVI5PaFacg2Je4U9gBPPcH/Vpo=";
+    hash = "sha256-R/aLxJTLUi3bYQu38vVosTDPrFHAYwz4n34JbO1PPm0=";
   };
 
   nativeBuildInputs = [
     meson
     ninja
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     homepage = "https://github.com/shezdy/hyprsplit";

--- a/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   cmake,
   makeWrapper,
@@ -18,22 +18,22 @@
   qtbase,
   qttools,
   qtwayland,
-  sdbus-cpp,
+  sdbus-cpp_2,
   slurp,
   systemd,
   wayland,
   wayland-protocols,
   wayland-scanner,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-hyprland";
-  version = "1.3.6";
+  version = "1.3.8";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "xdg-desktop-portal-hyprland";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-1DGktDtSWIJpnDbVoj/qpvJSH5zg6JbOfuh6xqZMap0=";
+    hash = "sha256-V+CvM2UBJ6KjXD+B7T6vy8EYwLvLX88tZb8KP73MPSo=";
   };
 
   depsBuildBuild = [
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
     qttools
     qtwayland
-    sdbus-cpp
+    sdbus-cpp_2
     systemd
     wayland
     wayland-protocols

--- a/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/default.nix
+++ b/pkgs/applications/window-managers/hyprwm/xdg-desktop-portal-hyprland/default.nix
@@ -27,13 +27,13 @@
 }:
 gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-desktop-portal-hyprland";
-  version = "1.3.8";
+  version = "1.3.9";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "xdg-desktop-portal-hyprland";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-V+CvM2UBJ6KjXD+B7T6vy8EYwLvLX88tZb8KP73MPSo=";
+    hash = "sha256-sAObJHBZjJHzYR62g+BLNBNq19cqb5LTw73H8m57K0w=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/aq/aquamarine/package.nix
+++ b/pkgs/by-name/aq/aquamarine/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "aquamarine";
-  version = "0.4.4";
+  version = "0.5.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "aquamarine";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-6DQM7jT2CzfxYceyrtcBQSL9BOEGfuin8GAyMjCpAzc=";
+    hash = "sha256-1Dxryiw8u2ejntxrrv3sMtIE8WHKxmlN4KeH+uMGbmc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/aq/aquamarine/package.nix
+++ b/pkgs/by-name/aq/aquamarine/package.nix
@@ -23,13 +23,13 @@
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "aquamarine";
-  version = "0.5.0";
+  version = "0.5.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "aquamarine";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-1Dxryiw8u2ejntxrrv3sMtIE8WHKxmlN4KeH+uMGbmc=";
+    hash = "sha256-Gxv1kTz5jEvIzmkF6XgsdKglL2jmjJOQdZ+hO9uVnlQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/hy/hyprcursor/package.nix
+++ b/pkgs/by-name/hy/hyprcursor/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -11,8 +11,9 @@
   xcur2png,
   tomlplusplus,
   nix-update-script,
+  fetchpatch,
 }:
-stdenv.mkDerivation (finalAttrs: {
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprcursor";
   version = "0.1.10";
 
@@ -43,6 +44,14 @@ stdenv.mkDerivation (finalAttrs: {
     "lib"
   ];
 
+  patches = [
+    # NOTE: remove after next release
+    (fetchpatch {
+      name = "001-add-fstream-include";
+      url = "https://github.com/hyprwm/hyprcursor/commit/c18572a92eb39e4921b4f4c2bca8521b6f701b58.patch";
+      hash = "sha256-iHRRd/18xEAgvJgmZeSzMp53s+zdIpuaP/sayRfcft4=";
+    })
+  ];
   passthru.updateScript = nix-update-script { };
 
   meta = {

--- a/pkgs/by-name/hy/hyprgraphics/package.nix
+++ b/pkgs/by-name/hy/hyprgraphics/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  gcc14Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  cairo,
+  file,
+  hyprutils,
+  libjpeg,
+  libjxl,
+  libwebp,
+  pixman,
+}:
+
+gcc14Stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprgraphics";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprgraphics";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-FFLJzFTyNhS7tBEEECx0B8Ye/bpmxhFVEKlECgMLc6c=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    cairo
+    file
+    hyprutils
+    libjpeg
+    libjxl
+    libwebp
+    pixman
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://github.com/hyprwm/hyprlang";
+    description = "Official implementation library for the hypr config language";
+    license = lib.licenses.lgpl3Only;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
+      fufexan
+      khaneliman
+    ];
+  };
+})

--- a/pkgs/by-name/hy/hypridle/package.nix
+++ b/pkgs/by-name/hy/hypridle/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   pkg-config,
   cmake,
@@ -14,7 +14,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "hypridle";
   version = "0.1.5";
 

--- a/pkgs/by-name/hy/hyprland-qtutils/package.nix
+++ b/pkgs/by-name/hy/hyprland-qtutils/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  gcc14Stdenv,
+  fetchFromGitHub,
+  cmake,
+  pkg-config,
+  hyprutils,
+  pciutils,
+  qt6,
+}:
+let
+  inherit (lib.strings) makeBinPath;
+in
+gcc14Stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprland-qtutils";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprland-qtutils";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Zp2cQOo1D7WH7ml5nV7mLyto0l19gTaWnbDb6zty1Qs=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    hyprutils
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.qtwayland
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(--prefix PATH : "${makeBinPath [ pciutils ]}")
+  '';
+
+  meta = {
+    description = "Hyprland QT/qml utility apps";
+    homepage = "https://github.com/hyprwm/hyprland-qtutils";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.fufexan ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/hy/hyprland/info.json
+++ b/pkgs/by-name/hy/hyprland/info.json
@@ -1,7 +1,7 @@
 {
-  "branch": "v0.46.1-b",
-  "commit_hash": "254fc2bc6000075f660b4b8ed818a6af544d1d64",
-  "commit_message": "version: bump to 0.46.1",
-  "date": "2024-12-17",
-  "tag": "v0.46.1"
+  "branch": "v0.46.2-b",
+  "commit_hash": "0bd541f2fd902dbfa04c3ea2ccf679395e316887",
+  "commit_message": "version: bump to 0.46.2",
+  "date": "2024-12-19",
+  "tag": "v0.46.2"
 }

--- a/pkgs/by-name/hy/hyprland/info.json
+++ b/pkgs/by-name/hy/hyprland/info.json
@@ -1,7 +1,7 @@
 {
-  "branch": "v0.45.2-b",
-  "commit_hash": "12f9a0d0b93f691d4d9923716557154d74777b0a",
-  "commit_message": "[gha] Nix: update inputs",
-  "date": "2024-11-19",
-  "tag": "v0.45.2"
+  "branch": "v0.46.1-b",
+  "commit_hash": "254fc2bc6000075f660b4b8ed818a6af544d1d64",
+  "commit_message": "version: bump to 0.46.1",
+  "date": "2024-12-17",
+  "tag": "v0.46.1"
 }

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -14,6 +14,7 @@
   epoll-shim,
   git,
   hyprcursor,
+  hyprgraphics,
   hyprlang,
   hyprutils,
   hyprwayland-scanner,
@@ -28,6 +29,7 @@
   pciutils,
   pkgconf,
   python3,
+  re2,
   systemd,
   tomlplusplus,
   wayland,
@@ -82,14 +84,14 @@ assert assertMsg (!hidpiXWayland)
 
 customStdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + optionalString debug "-debug";
-  version = "0.45.2";
+  version = "0.46.1";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprland";
     fetchSubmodules = true;
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-1pNsLGNStCFjXiBc2zMUxKzKk45CePTf+GwKlzTmrCY=";
+    hash = "sha256-0SVRQJeKsdwaTO7pMM0MwTXyVwKNQ4m1f2mvcPnZttM=";
   };
 
   postPatch = ''
@@ -138,6 +140,7 @@ customStdenv.mkDerivation (finalAttrs: {
       cairo
       git
       hyprcursor.dev
+      hyprgraphics
       hyprlang
       hyprutils
       libGL
@@ -148,6 +151,7 @@ customStdenv.mkDerivation (finalAttrs: {
       mesa
       pango
       pciutils
+      re2
       tomlplusplus
       wayland
       wayland-protocols

--- a/pkgs/by-name/hy/hyprland/package.nix
+++ b/pkgs/by-name/hy/hyprland/package.nix
@@ -15,6 +15,7 @@
   git,
   hyprcursor,
   hyprgraphics,
+  hyprland-qtutils,
   hyprlang,
   hyprutils,
   hyprwayland-scanner,
@@ -84,14 +85,14 @@ assert assertMsg (!hidpiXWayland)
 
 customStdenv.mkDerivation (finalAttrs: {
   pname = "hyprland" + optionalString debug "-debug";
-  version = "0.46.1";
+  version = "0.46.2";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprland";
     fetchSubmodules = true;
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-0SVRQJeKsdwaTO7pMM0MwTXyVwKNQ4m1f2mvcPnZttM=";
+    hash = "sha256-dj9dpVwpyTmUyVu4jtaIU39bHgVkoZjv6cgYfWyHc9E=";
   };
 
   postPatch = ''
@@ -192,6 +193,7 @@ customStdenv.mkDerivation (finalAttrs: {
         --suffix PATH : ${
           makeBinPath [
             binutils
+            hyprland-qtutils
             pciutils
             pkgconf
           ]

--- a/pkgs/by-name/hy/hyprlang/package.nix
+++ b/pkgs/by-name/hy/hyprlang/package.nix
@@ -1,23 +1,30 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   cmake,
+  pkg-config,
+  hyprutils,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprlang";
-  version = "0.5.2";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprlang";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-Jq9hHYFL5nMHArWgJIcrDHGnzs/MjDi95cyB7cUZIJ4=";
+    hash = "sha256-oj8V4kvzor5AOStzj4/B4W1ZIObAPxT9K4NfXx7dyKE=";
   };
 
   nativeBuildInputs = [
     cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    hyprutils
   ];
 
   outputs = [

--- a/pkgs/by-name/hy/hyprlock/package.nix
+++ b/pkgs/by-name/hy/hyprlock/package.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
   cmake,
   pkg-config,
@@ -24,7 +24,7 @@
   nix-update-script,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprlock";
   version = "0.5.0";
 

--- a/pkgs/by-name/hy/hyprpaper/package.nix
+++ b/pkgs/by-name/hy/hyprpaper/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
-  stdenv,
+  gcc14Stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   cairo,
   expat,
@@ -12,6 +11,7 @@
   libdatrie,
   libGL,
   libjpeg,
+  libjxl,
   libselinux,
   libsepol,
   libthai,
@@ -27,26 +27,19 @@
   wayland-scanner,
   hyprwayland-scanner,
   hyprutils,
+  hyprgraphics,
 }:
 
-stdenv.mkDerivation (finalAttrs: {
+gcc14Stdenv.mkDerivation (finalAttrs: {
   pname = "hyprpaper";
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchFromGitHub {
     owner = "hyprwm";
     repo = "hyprpaper";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-HIK7XJWQCM0BAnwW5uC7P0e7DAkVTy5jlxQ0NwoSy4M=";
+    hash = "sha256-bXWLq/0Ji13CM4uX4tnBgWpvRysh4H3N1OC1t6d1Sfc=";
   };
-
-  patches = [
-    # CMakeLists: look for wayland.xml protocol in wayland-scanner pkgdata
-    (fetchpatch {
-      url = "https://github.com/hyprwm/hyprpaper/commit/6c6e54faa84d2de94d2321eda43a8a669ebf3312.patch";
-      hash = "sha256-Ns7HlUPVgBDIocZRGR6kIW58Mt92kJPQRMSKTvp6Vik=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -64,6 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     libdatrie
     libGL
     libjpeg
+    libjxl
     libselinux
     libsepol
     libthai
@@ -76,11 +70,12 @@ stdenv.mkDerivation (finalAttrs: {
     wayland
     wayland-protocols
     hyprutils
+    hyprgraphics
   ];
 
   prePatch = ''
     substituteInPlace src/main.cpp \
-      --replace GIT_COMMIT_HASH '"${finalAttrs.src.rev}"'
+      --replace-fail GIT_COMMIT_HASH '"${finalAttrs.src.rev}"'
   '';
 
   meta = with lib; {
@@ -93,7 +88,7 @@ stdenv.mkDerivation (finalAttrs: {
       wozeparrot
     ];
     inherit (wayland.meta) platforms;
-    broken = stdenv.hostPlatform.isDarwin;
+    broken = gcc14Stdenv.hostPlatform.isDarwin;
     mainProgram = "hyprpaper";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Backport
- https://github.com/NixOS/nixpkgs/pull/367113
- https://github.com/NixOS/nixpkgs/pull/365776
- https://github.com/NixOS/nixpkgs/pull/358565
- https://github.com/NixOS/nixpkgs/pull/367355
- https://github.com/NixOS/nixpkgs/pull/365295
- https://github.com/NixOS/nixpkgs/pull/367337
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
