### PR TITLE
usbkvm: init at 0.1.0

### DIFF
--- a/pkgs/by-name/us/usbkvm/package.nix
+++ b/pkgs/by-name/us/usbkvm/package.nix
@@ -1,0 +1,99 @@
+{
+  buildGoModule,
+  fetchzip,
+  gst_all_1,
+  gtkmm3,
+  hidapi,
+  lib,
+  makeWrapper,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  stdenv,
+  wrapGAppsHook3,
+}:
+
+let
+  version = "0.1.0";
+
+  src = fetchzip {
+    url = "https://github.com/carrotIndustries/usbkvm/releases/download/v${version}/usbkvm-v${version}.tar.gz";
+    sha256 = "sha256-OuZ7+IjsvK7/PaiTRwssaQFJDFWJ8HX+kqV13CUyTZA=";
+  };
+
+  ms-tools-lib = buildGoModule {
+    pname = "usbkvm-ms-tools-lib";
+    inherit version;
+
+    inherit src;
+    sourceRoot = "source/ms-tools";
+    vendorHash = "sha256-imHpsos7RDpATSZFWRxug67F7VgjRTT1SkLt7cWk6tU=";
+
+    buildInputs = [
+      hidapi
+    ];
+
+    buildPhase = ''
+      mkdir -p $out/
+      go build -C lib/ -o $out/ -buildmode=c-archive mslib.go
+    '';
+  };
+in
+stdenv.mkDerivation {
+  pname = "usbkvm";
+  inherit version src;
+
+  nativeBuildInputs = [
+    pkg-config
+    python3
+    meson
+    ninja
+    makeWrapper
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    gst_all_1.gstreamer
+    gtkmm3
+    hidapi
+  ];
+
+  # The package includes instructions to build the "mslib.{a,h}" files using a
+  # Go compiler, but that doesn't work in the Nix sandbox. We patch out this
+  # build step to instead copy those files from the Nix store:
+  patches = [
+    ./precompiled-mslib.patch
+  ];
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace-fail "@MSLIB_A_PRECOMPILED@" "${ms-tools-lib}/mslib.a" \
+      --replace-fail "@MSLIB_H_PRECOMPILED@" "${ms-tools-lib}/mslib.h"
+  '';
+
+  postFixup =
+    let
+      GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
+        gst_all_1.gst-plugins-base
+        (gst_all_1.gst-plugins-good.override { gtkSupport = true; })
+      ];
+    in
+    lib.optionalString stdenv.hostPlatform.isLinux ''
+      wrapProgram $out/bin/usbkvm \
+        --prefix GST_PLUGIN_PATH : "${GST_PLUGIN_PATH}"
+    '';
+
+  postInstall = ''
+    mkdir -p $out/lib/udev/rules.d/
+    cp ../70-usbkvm.rules $out/lib/udev/rules.d/
+  '';
+
+  meta = {
+    homepage = "https://github.com/carrotIndustries/usbkvm";
+    description = "An open-source USB KVM (Keyboard, Video and Mouse) adapter";
+    changelog = "https://github.com/carrotIndustries/usbkvm/releases/tag/v${version}";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ lschuermann ];
+    mainProgram = "usbkvm";
+  };
+}

--- a/pkgs/by-name/us/usbkvm/precompiled-mslib.patch
+++ b/pkgs/by-name/us/usbkvm/precompiled-mslib.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 6e60b0b..b25da9d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -125,7 +125,7 @@ mslib = custom_target(
+     'mslib',
+     output: ['mslib.a', 'mslib.h'],
+     input: 'ms-tools/lib/mslib.go',
+-    command: ['go', 'build', '-C',  join_paths(meson.current_source_dir(), 'ms-tools/lib'), '-o', join_paths(meson.current_build_dir(), '@OUTPUT0@'), '-buildmode=c-archive', 'mslib.go']
++    command: ['cp', '@MSLIB_A_PRECOMPILED@', '@MSLIB_H_PRECOMPILED@', join_paths(meson.current_build_dir(), '@OUTDIR@')]
+     
+ )
+ 


### PR DESCRIPTION
This packages the [USBKVM](https://github.com/carrotIndustries/usbkvm) desktop application, a GTK application to control a USB keyboard, video and mouse adapter based around the MS2109 HDMI to USB capture IC.

I initially packaged the Git source, building the device firmware as part of the Nix build process. However, this led to issues with an old version of the `gcc-arm-embedded` package with broken LTO, which ended up soft-bricking my device. Furthermore, the USBKVM developer (@carrotIndustries) kindly requested to package the release tarball instead of the source, as this contains a known-good device firmware version. I'm happy to add an option to build from source in addition to the tarball, if that's reasonable for Nixpkgs.

This was packaged based on initial work done by @rubenhoenle. I can add them as a co-maintainer if they'd like.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
