### PR TITLE
rofi: 1.7.5 -> 1.7.6

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -139,6 +139,8 @@
 
 - `racket_7_9` has been removed, as it is insecure. It is recommended to use Racket 8 instead.
 
+- `rofi` has been updated from 1.7.5 to 1.7.6 which introduces some breaking changes to binary plugins, and also contains a lot of new features and bug fixes. This is highlighted because the patch version bump does not indicate the volume of changes by itself. See the [upstream release notes](https://github.com/davatorium/rofi/releases/tag/1.7.6) for the full list of changes.
+
 - `ente-auth` now uses the name `enteauth` for its binary. The previous name was `ente_auth`.
 
 - `fluxus` has been removed, as it depends on `racket_7_9` and had no updates in 9 years.

--- a/pkgs/applications/misc/rofi/default.nix
+++ b/pkgs/applications/misc/rofi/default.nix
@@ -11,10 +11,11 @@
   git,
   cairo,
   libxcb,
+  xcb-util-cursor,
+  xcbutilkeysyms,
   xcbutil,
   xcbutilwm,
   xcbutilxrm,
-  xcb-util-cursor,
   libstartup_notification,
   bison,
   flex,
@@ -26,14 +27,14 @@
 
 stdenv.mkDerivation rec {
   pname = "rofi-unwrapped";
-  version = "1.7.5";
+  version = "1.7.6";
 
   src = fetchFromGitHub {
     owner = "davatorium";
     repo = "rofi";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-3XFusKeckagEPfbLtt1xAVTEfn1Qebdi/Iq1AYbHCR4=";
+    hash = "sha256-hT9FMCAwY8hZx4y1l0vHfcReIJUBxSmixZJhKP8nRpw=";
   };
 
   preConfigure = ''
@@ -63,10 +64,11 @@ stdenv.mkDerivation rec {
     check
     libstartup_notification
     libxcb
+    xcb-util-cursor
+    xcbutilkeysyms
     xcbutil
     xcbutilwm
     xcbutilxrm
-    xcb-util-cursor
     which
   ];
 


### PR DESCRIPTION
New dependency: xcbutilkeysyms

Despite the [1.7.6 release](https://github.com/davatorium/rofi/releases/tag/1.7.6) being marked as a patch release, it contains a lot of new features, some dependency updates, a breaking plugin ABI update, and several years of other misc changes. Binary plugins built for 1.7.5 will not load in 1.7.6 and vice versa.

I'm not sure if we should treat this similarly to a minor/major version and add release notes or not. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
