### PR TITLE
nixel: 4.1.0 -> 5.1.1 + Add Update Script

### DIFF
--- a/pkgs/by-name/ni/nixel/package.nix
+++ b/pkgs/by-name/ni/nixel/package.nix
@@ -2,6 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
+  nix-update-script,
   testers,
   nixel,
 }:
@@ -27,6 +28,7 @@ rustPlatform.buildRustPackage rec {
   passthru.tests = {
     version = testers.testVersion { package = nixel; };
   };
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Lexer, Parser, Abstract Syntax Tree and Concrete Syntax Tree for the Nix Expressions Language";

--- a/pkgs/by-name/ni/nixel/package.nix
+++ b/pkgs/by-name/ni/nixel/package.nix
@@ -3,22 +3,33 @@
   rustPlatform,
   fetchFromGitHub,
   nix-update-script,
+  clang_16,
   testers,
   nixel,
 }:
-
-rustPlatform.buildRustPackage rec {
+let
+  clang = clang_16; # Until bindgen is updated with clang19 support
+  rustPlatform' = rustPlatform // {
+    bindgenHook = rustPlatform.bindgenHook.override { inherit clang; };
+  };
+in
+rustPlatform'.buildRustPackage rec {
   pname = "nixel";
-  version = "4.1.0";
+  version = "5.1.1";
 
   src = fetchFromGitHub {
     owner = "kamadorueda";
     repo = pname;
     rev = version;
-    sha256 = "sha256-dQ3wzBTjteqk9rju+FMAO+ydimnGu24Y2DEDLX/P+1A=";
+    sha256 = "sha256-wIXZd8iujLqbgbV+abWmIfjDgQ8i6nyE5jTAs3OczXM=";
   };
 
-  cargoHash = "sha256-1OsHs0W3ji9Kgpv7nGY9XyGxJ4c0faN2VuFLsdwkgKY=";
+  cargoHash = "sha256-GJ2UO8MvujRxFjzdt2Tfrlfzv1jot9XCrmfBqTFVngI=";
+
+  nativeBuildInputs = [
+    # Workaround borrowed here where the same error were observed: https://github.com/NixOS/nixpkgs/issues/331240#issuecomment-2260565324
+    rustPlatform'.bindgenHook # with override { clang = clang_16; }
+  ];
 
   # Package requires a non reproducible submodule
   # https://github.com/kamadorueda/nixel/blob/2873bd84bf4fc540d0ae8af062e109cc9ad40454/.gitmodules#L7


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Enabled basic update script then ran it on my computer :+1: 

 + Adapted rustPlatform bindgen dependency for using clang16 or I encountered exactly the same issue as #331240 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

```
➜ nix-shell -I nixpkgs=$HOME/Documents/nixpkgs -p nixel --run 'nixel --version'
NixEL 5.1.1

```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
