### PR TITLE
exercism: install shell completions

### DIFF
--- a/pkgs/by-name/ex/exercism/package.nix
+++ b/pkgs/by-name/ex/exercism/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildGoModule,
+  installShellFiles,
   fetchFromGitHub,
   nix-update-script,
 }:
@@ -22,7 +23,16 @@ buildGoModule rec {
 
   subPackages = [ "./exercism" ];
 
+  nativeBuildInputs = [ installShellFiles ];
+
   passthru.updateScript = nix-update-script { };
+
+  postInstall = ''
+    installShellCompletion --cmd exercism \
+      --bash shell/exercism_completion.bash \
+      --fish shell/exercism.fish \
+      --zsh shell/exercism_completion.zsh
+  '';
 
   meta = with lib; {
     inherit (src.meta) homepage;


### PR DESCRIPTION
Exercism ships both with pre-generated completions [0], and has
`completion` command to generate completions for
bash/zsh/fish/powershell.
So this makes use of the latter and `installShellCompletion`.

[0] https://github.com/exercism/cli/tree/main/shell
