### PR TITLE
ryzenadj: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/ry/ryzenadj/package.nix
+++ b/pkgs/by-name/ry/ryzenadj/package.nix
@@ -17,9 +17,14 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pciutils
     cmake
   ];
+
+  buildInputs = [
+    pciutils
+  ];
+
+  strictDeps = true;
 
   installPhase = ''
     install -D libryzenadj.so $out/lib/libryzenadj.so


### PR DESCRIPTION
Simple fix

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).