### PR TITLE
brscan3: init at 0.2.13-1

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -167,6 +167,13 @@ lib.mapAttrs mkLicense ({
     fullName = "Boost Software License 1.0";
   };
 
+  brotherEula = {
+    fullName = "Brother License Agreement";
+    url = "https://support.brother.com/g/s/agreement/English_eula/agree.html";
+    free = false;
+    redistributable = true;
+  };
+
   beerware = {
     spdxId = "Beerware";
     fullName = "Beerware License";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -13847,6 +13847,13 @@
     githubId = 30194994;
     name = "Felix Nilles";
   };
+  marcin-serwin = {
+    name = "Marcin Serwin";
+    github = "marcin-serwin";
+    githubId = 12128106;
+    email = "marcin@serwin.dev";
+    keys = [ { fingerprint = "F311 FA15 1A66 1875 0C4D  A88D 82F5 C70C DC49 FD1D"; } ];
+  };
   marcovergueira = {
     email = "vergueira.marco@gmail.com";
     github = "marcovergueira";

--- a/pkgs/by-name/br/brscan3/fopen_wrapper.c
+++ b/pkgs/by-name/br/brscan3/fopen_wrapper.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+
+FILE *fopen_wrapped(const char *restrict path,
+                    const char *restrict const mode) {
+  static const char ORIGINAL_DIR[] = "/usr/local/Brother/sane/";
+  static const char REAL_DIR[] = OUT "/local/Brother/sane/";
+  char buffer[PATH_MAX];
+
+  if (strstr(path, ORIGINAL_DIR) == path) {
+    const char *const relpath = path + sizeof ORIGINAL_DIR - 1;
+    const size_t relpath_size = strlen(relpath) + 1;
+    assert(sizeof REAL_DIR - 1 + relpath_size < PATH_MAX);
+
+    memcpy(buffer, REAL_DIR, sizeof REAL_DIR - 1);
+    memcpy(buffer + sizeof REAL_DIR - 1, relpath, relpath_size);
+
+    path = buffer;
+  }
+
+  return fopen(path, mode);
+}

--- a/pkgs/by-name/br/brscan3/package.nix
+++ b/pkgs/by-name/br/brscan3/package.nix
@@ -1,0 +1,96 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  dpkg,
+  patchelfUnstable, # unstable is needed for --rename-dynamic-symbols support
+  libusb-compat-0_1,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "brscan3";
+  version = "0.2.13-1";
+  src =
+    let
+      system = stdenv.hostPlatform.system;
+    in
+    {
+      "i686-linux" = fetchurl {
+        url = "https://download.brother.com/welcome/dlf006641/${finalAttrs.pname}-${finalAttrs.version}.i386.deb";
+        hash = "sha256-rQZmXKwyA1iT9hTZMF2r9zFFr0VPGutri3x/onAP4uY=";
+      };
+      "x86_64-linux" = fetchurl {
+        url = "https://download.brother.com/welcome/dlf006642/${finalAttrs.pname}-${finalAttrs.version}.amd64.deb";
+        hash = "sha256-RGrfUxvzkDKJLpUEzjS3v4ieD4YowHMs67O4P6+zJ7g=";
+      };
+    }
+    ."${system}" or (throw "unsupported system ${system}");
+
+  nativeBuildInputs = [
+    dpkg
+    patchelfUnstable
+  ];
+  buildInputs = [ libusb-compat-0_1 ];
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    RESOURCES_PATH=local/Brother/sane
+    mkdir -p $out/$RESOURCES_PATH
+    cp -rp usr/$RESOURCES_PATH/* $out/$RESOURCES_PATH
+
+    mkdir -p $out/bin
+    ln -s ../$RESOURCES_PATH/brsaneconfig3 $out/bin/brsaneconfig3
+
+    LIB_DIR=usr/lib${lib.optionalString stdenv.is64bit "64"}
+    install -D $LIB_DIR/libbrscandec3.so.1.0.0 \
+      $out/lib/libbrscandec3.so.1.0.0
+    ln -s -T libbrscandec3.so.1.0.0 $out/lib/libbrscandec3.so
+    ln -s -T libbrscandec3.so.1.0.0 $out/lib/libbrscandec3.so.1
+
+    install -D $LIB_DIR/sane/libsane-brother3.so.1.0.7 \
+      $out/lib/sane/libsane-brother3.so.1.0.7
+    ln -s -T libsane-brother3.so.1.0.7 $out/lib/sane/libsane-brother3.so
+    ln -s -T libsane-brother3.so.1.0.7 $out/lib/sane/libsane-brother3.so.1
+
+    $CC -O3 -DOUT=\"$out\" -fPIC -shared \
+      ${./fopen_wrapper.c} -o libfopen_wrapper.so
+    install -D libfopen_wrapper.so $out/libexec/libfopen_wrapper.so
+
+    mkdir -p $out/etc/sane.d
+    echo "brother3" > $out/etc/sane.d/dll.conf
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
+    patchelf --set-interpreter $(cat $NIX_CC/nix-support/dynamic-linker) \
+      $out/local/Brother/sane/brsaneconfig3
+
+    patchelf --set-rpath $out/lib:${libusb-compat-0_1}/lib \
+      $out/lib/sane/libsane-brother3.so.1.0.7
+
+    echo 'fopen fopen_wrapped' > name-map
+    patchelf \
+      --add-needed $out/libexec/libfopen_wrapper.so \
+      --rename-dynamic-symbols name-map \
+      $out/lib/sane/libsane-brother3.so.1.0.7
+
+    runHook postFixup
+  '';
+
+  meta = {
+    description = "Brother brscan3 sane backend driver";
+    homepage = "http://www.brother.com";
+    platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.brotherEula;
+    maintainers = [ lib.maintainers.marcin-serwin ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Adds `brscan3` sane backend driver similar to existing `brscan4` and `brscan5` backends.

Note that there is an ongoing discussion regarding the freeness of the EULA license in <https://github.com/NixOS/nixpkgs/pull/367380#discussion_r1894955134>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
