### PR TITLE
notesnook-sync-server: init at 1.0-beta.1

### DIFF
--- a/pkgs/by-name/no/notesnook-sync-server/deps.json
+++ b/pkgs/by-name/no/notesnook-sync-server/deps.json
@@ -1,0 +1,2497 @@
+[
+  {
+    "pname": "AdvancedStringBuilder",
+    "version": "0.1.0",
+    "hash": "sha256-r+CTTJHKosAUHQeUbE8FDpARSS7uV8zqAur39p4u+9I="
+  },
+  {
+    "pname": "AspNetCore.HealthChecks.MongoDb",
+    "version": "6.0.1-rc2.2",
+    "hash": "sha256-YzS/qn6S/Mk+j1oChgyOYOuUA8N1kLqGY3nSQik/MoE="
+  },
+  {
+    "pname": "AspNetCore.Identity.Mongo",
+    "version": "8.3.3",
+    "hash": "sha256-KCgry4zCsdhKBxnKGUUxvxPvhsUkxrFlXbDPD7wXvHg="
+  },
+  {
+    "pname": "AutoMapper",
+    "version": "10.0.0",
+    "hash": "sha256-04RTwbbr7BnA/9+mPor6Tviho9/7/AOj9p8OCaktKww="
+  },
+  {
+    "pname": "AWSSDK.Core",
+    "version": "3.7.100.14",
+    "hash": "sha256-EBKTAEOtbVXLly0ihAefzGNStIwGmuK0KqANWPQuPKo="
+  },
+  {
+    "pname": "AWSSDK.Core",
+    "version": "3.7.304.31",
+    "hash": "sha256-0Uuye273jlpBivLkP9DtcaO4ajOIFs2L8kB+EPZrEdA="
+  },
+  {
+    "pname": "AWSSDK.S3",
+    "version": "3.7.310.8",
+    "hash": "sha256-PCUEA/tJvUTtO7gBbx+KQHnmPF9nr+BIuuLuEdd+W+Q="
+  },
+  {
+    "pname": "AWSSDK.SecurityToken",
+    "version": "3.7.100.14",
+    "hash": "sha256-BagRMpeyBh//AeMxvxUhk/j9uDa1y9SSaj4+KaMnkVE="
+  },
+  {
+    "pname": "DnsClient",
+    "version": "1.3.1",
+    "hash": "sha256-NJH3uRnC+Fvie6VT4rCdxmCzRnX196OpZ8zoBMmG8cM="
+  },
+  {
+    "pname": "DnsClient",
+    "version": "1.4.0",
+    "hash": "sha256-AiVEpoC81U3O/Ilqn0m/LoQS8UZRjviq2oWyPv+jcvc="
+  },
+  {
+    "pname": "DnsClient",
+    "version": "1.6.1",
+    "hash": "sha256-3AcBTY4IhMnKUqYsZsYKh8suH2s+lwv5H19VXEA3DC8="
+  },
+  {
+    "pname": "DotNetEnv",
+    "version": "2.3.0",
+    "hash": "sha256-39x9vMcpYiGWxV7VDnd7oHbTlu5H5lSQPVYYlhjGd3U="
+  },
+  {
+    "pname": "Fleck",
+    "version": "1.1.0",
+    "hash": "sha256-3WcNPlEsuwxoBYgMkO8oM5IubY0ezJA99ZnbmVa2yz0="
+  },
+  {
+    "pname": "Geralt",
+    "version": "3.1.0",
+    "hash": "sha256-9da5h0Oo6Le/tbIn8AMNq5yKmv0mM7Qukb+RvczNCbk="
+  },
+  {
+    "pname": "IdentityModel",
+    "version": "4.4.0",
+    "hash": "sha256-RASiI+b9sCsgUU+uKtOJNAUGOTS6L2OTaretBPHN83s="
+  },
+  {
+    "pname": "IdentityModel",
+    "version": "6.0.0",
+    "hash": "sha256-VMBu60aBpGSj+t5pH4yM1gPfcI1EBONxCdjiA4TllCA="
+  },
+  {
+    "pname": "IdentityModel.AspNetCore.OAuth2Introspection",
+    "version": "6.2.0",
+    "hash": "sha256-+gLfdVDq8q3uRGoDioYDBUXC/DPPw0nuQe73fyTWgQo="
+  },
+  {
+    "pname": "IdentityServer4",
+    "version": "4.1.2",
+    "hash": "sha256-+7wPftgUNvCiBpIkb2owcYw9wLTaN4czUJMxyrexRq8="
+  },
+  {
+    "pname": "IdentityServer4.AspNetIdentity",
+    "version": "4.1.2",
+    "hash": "sha256-Xygl7B/psRml56CvM0QFG9FgI/V3JB4Oz9MdgpXQCik="
+  },
+  {
+    "pname": "IdentityServer4.Contrib.MongoDB",
+    "version": "4.0.0-rc.2",
+    "hash": "sha256-ADReS3QIgqchdiBdbA+hlgl7Pt3pHP7O8Sck2uGQRT8="
+  },
+  {
+    "pname": "IdentityServer4.EntityFramework",
+    "version": "4.1.2",
+    "hash": "sha256-Wmb5r7FIizpGmDM6nUiWkSs2w2G28fUyOr7dQen80bs="
+  },
+  {
+    "pname": "IdentityServer4.EntityFramework.Storage",
+    "version": "4.1.2",
+    "hash": "sha256-aiMwVdz6x3rirNw/aZSBBQjWAKZbrk9FkMoP5Gm9HbM="
+  },
+  {
+    "pname": "IdentityServer4.Storage",
+    "version": "4.1.2",
+    "hash": "sha256-jlLVReDx1ktIh1ptOnolDc/woqrNz6gLTf9gNQFc7yo="
+  },
+  {
+    "pname": "JWT",
+    "version": "8.2.3",
+    "hash": "sha256-7J7mbQkz0m/8dHSw+Yos4aFFmN7udmFdSSiGYVhDAow="
+  },
+  {
+    "pname": "Lib.AspNetCore.ServerSentEvents",
+    "version": "6.0.0",
+    "hash": "sha256-OyJL/Fv242CybtsNqJxe9sJmAhi0W3d76Rz11YPrWPs="
+  },
+  {
+    "pname": "libsodium",
+    "version": "1.0.20",
+    "hash": "sha256-BsitQQnUSm1YupzI5N/LFx0kPFdk1FP8VdM1S3uttvs="
+  },
+  {
+    "pname": "MailKit",
+    "version": "3.4.3",
+    "hash": "sha256-ZE6Zz/Xvwo5rlHKVTwrxZryqmX6pYygN6WCNpG+geOc="
+  },
+  {
+    "pname": "MessageBird",
+    "version": "3.2.0",
+    "hash": "sha256-kREaR8PqbncpoYE447fDuN5tuvnOblJSkqHLh2JX3OQ="
+  },
+  {
+    "pname": "MessagePack",
+    "version": "2.1.90",
+    "hash": "sha256-ES1qxK755XkimMoYfpp3lAvXdlTqGznUK9YerA6VvMg="
+  },
+  {
+    "pname": "MessagePack.Annotations",
+    "version": "2.1.90",
+    "hash": "sha256-IVRblUZj6XISUzLhG8I2rzfrGYd0gkdTlAeivziETyM="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authentication.JwtBearer",
+    "version": "5.0.0",
+    "hash": "sha256-TTrTowxezDEqDEN8jKHksIMsBCocvesvgwjv0CDR0RA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authentication.JwtBearer",
+    "version": "6.0.0",
+    "hash": "sha256-G/XueXqhy/yVXN/sq61qglbA3ZZPlF7fo/31WlF8GZI="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+    "version": "3.1.0",
+    "hash": "sha256-4pxCSLgqWA9iG26tnJn5CThRtuZlewf6eD2Ytc2eFNk="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+    "version": "5.0.0",
+    "hash": "sha256-WnILGv4kz7K8jf5okKS7FAJDbc+Z6BT/hm4TcfQ4570="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Authentication.OpenIdConnect",
+    "version": "6.0.0",
+    "hash": "sha256-1F54yIlTG49BeZH3W3qO3L10Vpu1zJpXsvUFo8I2+SI="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Connections.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-MoieWAe7zT/0a7PAn3gMKO8YpHTbOtiGIwF/sFAmieY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Connections.Abstractions",
+    "version": "6.0.3",
+    "hash": "sha256-kd+CJ3V5aU4eQDymvjfFHs+2EPyEC9J9qCfqpSUmiFU="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Cors",
+    "version": "2.2.0",
+    "hash": "sha256-TB+sGspJ9kmKco1R0ecMQi3PmMLe4U7ncpOceNBfU2M="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Cryptography.Internal",
+    "version": "6.0.0",
+    "hash": "sha256-9JRiA1RML3b8WHLzvxYMmf/rrtKvjNyHApwPu2jnpm0="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Cryptography.Internal",
+    "version": "7.0.4",
+    "hash": "sha256-FAJ6eP7DeqBIeDDWAsCgRtbW1+1ATPD3V7xdQcsWLf4="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Cryptography.KeyDerivation",
+    "version": "6.0.0",
+    "hash": "sha256-R7bSFcy2UFGoLVpmg0YmQHgFtpHjfwx/ij8SyG+/hCw="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.DataProtection",
+    "version": "7.0.4",
+    "hash": "sha256-/H0ci72VWYKbWe6VIUrrSnGwNYGXI/psMykF0hQgYVo="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.DataProtection.Abstractions",
+    "version": "7.0.4",
+    "hash": "sha256-hAmcYaz88dJwlSwODYrVcK8G7EUAYDjNf2qwbCVwiGI="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Hosting.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-GzqYrTqCCVy41AOfmgIRY1kkqxekn5T0gFC7tUMxcxA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Hosting.Server.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-8PnZFCkMwAeEHySmmjJOnQvOyx2199PesYHBnfka51s="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Http",
+    "version": "2.2.0",
+    "hash": "sha256-+ARZomTXSD1m/PR3TWwifXb67cQtoqDVWEqfoq5Tmbk="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Http.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-y3j3Wo9Xl7kUdGkfnUc8Wexwbc2/vgxy7c3fJk1lSI8="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Http.Extensions",
+    "version": "2.2.0",
+    "hash": "sha256-1rXxGQnkNR+SiNMtDShYoQVGOZbvu4P4ZtWj5Wq4D4U="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Http.Features",
+    "version": "2.2.0",
+    "hash": "sha256-odvntHm669YtViNG5fJIxU4B+akA2SL8//DvYCLCNHc="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Identity.EntityFrameworkCore",
+    "version": "6.0.0",
+    "hash": "sha256-uznXkaHzdo8ypCc7YNBfsyylctQGp/GiidzLu6xmKpE="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Server.Kestrel.Core",
+    "version": "2.2.0",
+    "hash": "sha256-+aTIllcBnMkUHoAwaZPPWMV309aLIPeBvuhyiHRzrhw="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Server.Kestrel.Https",
+    "version": "2.2.0",
+    "hash": "sha256-DOm2ebBGpa4SFeYxzphPT5+Q7ShDq1pposP/lfkh5CM="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-y+2Dx2p2dE5p/CB6IyMQgbyZohIbeZ1D919/4n9JciE="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Common",
+    "version": "6.0.3",
+    "hash": "sha256-7hZ+ddAeVJu3MMCfnNXbqW401XzrpsUKONub/FIXQoc="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.SignalR.Protocols.MessagePack",
+    "version": "6.0.3",
+    "hash": "sha256-tOJGha8xykJ7XbdpKGkIcbSMQfJDe92Dkoq8bOka6WU="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.WebSockets",
+    "version": "2.2.1",
+    "hash": "sha256-GRqBI6zYDOAMW/V9GBo9CYqZtUwm1eC/Rb858UOe8T8="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.WebUtilities",
+    "version": "2.2.0",
+    "hash": "sha256-UdfOwSWqOUXdb0mGrSMx6Z+d536/P+v5clSRZyN5QTM="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "1.0.0",
+    "hash": "sha256-cC29sl84h4uVyJq2IPiRNk1G27Zx/Ebn7hLPXbMqvQE="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "1.1.0",
+    "hash": "sha256-QYVojfqSZKbF8P6D/aacfxfumMaRUD9SEEQbzw73Bbc="
+  },
+  {
+    "pname": "Microsoft.Bcl.HashCode",
+    "version": "1.1.0",
+    "hash": "sha256-IFvXCMV2joahytylQ2BGSpZd2tdX0Rss++ZcClVT+r0="
+  },
+  {
+    "pname": "Microsoft.CSharp",
+    "version": "4.0.1",
+    "hash": "sha256-0huoqR2CJ3Z9Q2peaKD09TV3E6saYSqDGZ290K8CrH8="
+  },
+  {
+    "pname": "Microsoft.CSharp",
+    "version": "4.3.0",
+    "hash": "sha256-a3dAiPaVuky0wpcHmpTVtAQJNGZ2v91/oArA+dpJgj8="
+  },
+  {
+    "pname": "Microsoft.CSharp",
+    "version": "4.5.0",
+    "hash": "sha256-dAhj/CgXG5VIy2dop1xplUsLje7uBPFjxasz9rdFIgY="
+  },
+  {
+    "pname": "Microsoft.CSharp",
+    "version": "4.7.0",
+    "hash": "sha256-Enknv2RsFF68lEPdrf5M+BpV1kHoLTVRApKUwuk/pj0="
+  },
+  {
+    "pname": "Microsoft.DotNet.PlatformAbstractions",
+    "version": "2.0.4",
+    "hash": "sha256-Eu3aY2f4gZWQLJHdVV98tu5Rn1uQ8f9UKQumGomlv7k="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "3.1.0",
+    "hash": "sha256-qsF29DpaoKfzJ7QvJtkFsD1mZ+JpgWrlLTu7HqamItA="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore",
+    "version": "6.0.0",
+    "hash": "sha256-2qDkLnUoKKqwTdanUV5i651tyhqYbPdxjThhoVtwe4k="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "3.1.0",
+    "hash": "sha256-7Q4I8CqC0MgRNyyrHbPZ0BZXYm9XYxLo+IdcbmmEpq0="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-Iu3zLvP1LEPG1S/a9inykGmH9Dj6bDZqDYy+OyUegas="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "3.1.0",
+    "hash": "sha256-BQxP6tT0sIivzg1lk4ypFlTTJwmhUb/OVVG/DjknVt4="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Analyzers",
+    "version": "6.0.0",
+    "hash": "sha256-221OacXSEo4NQ4OonaDMNtmdElzu5ZRrIDqvTgeNOmQ="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "3.1.0",
+    "hash": "sha256-pdikyLoh+7z3dbxesW94D8w6OJNsyxe1Z/cewQzHW0k="
+  },
+  {
+    "pname": "Microsoft.EntityFrameworkCore.Relational",
+    "version": "6.0.0",
+    "hash": "sha256-k1fhg4llJQ/41MdCrKnckVO75qOswI5RI3/rSABAWew="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "3.1.0",
+    "hash": "sha256-gOWo9FmbeIBlthL7b9BCZ8cyWhX5QvDX/t/zjIgStUg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-aGp1qcL1hVmb+HqCWrao3YVXOpGyiDJFDz2Td0cDw2I="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "3.1.0",
+    "hash": "sha256-wcsDSuecL9nnkIPM3Kqf0aHrFLZnLCbxLMJedYgJJsI="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "6.0.0",
+    "hash": "sha256-GOZjXMEZnaY7yUj7Rks+XkMypyLRHJmNSFd/YdLpATc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Caching.Memory",
+    "version": "6.0.1",
+    "hash": "sha256-8xXb65hiKNlCeTCpuZ2yAEFB4FgXYre/BCQn8FajQGU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "2.0.0",
+    "hash": "sha256-SSemrjaokMnzOF8ynrgEV6xEh4TlesUE7waW2BLuWns="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "2.2.0",
+    "hash": "sha256-dGJjKmio5BNFdwhK09NxJyCBapwVtO3eWxjLoTMGRQg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "3.1.0",
+    "hash": "sha256-KI1WXvnF/Xe9cKTdDjzm0vd5h9bmM+3KinuWlsF/X+c="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "3.1.2",
+    "hash": "sha256-GbxDDzVFQVZRY29OTQtSYVLFK3K6pkwlcoswlcrAsRk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "6.0.0",
+    "hash": "sha256-SIO/Q+OD2bG+Q0EoOXRgJYzZMhahGXDG1fXZn0VUvv0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration",
+    "version": "8.0.0",
+    "hash": "sha256-9BPsASlxrV8ilmMCjdb3TiUcm5vFZxkBnAI/fNBSEyA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "2.0.0",
+    "hash": "sha256-jveXZPNvx30uWT3q80OA1YaSb4K/KGOhlyun97IXn8Y="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "2.1.0",
+    "hash": "sha256-rd8zK6YWSxSP5HLrP+IR8o5/+/sheTNDtj3I9Eem/w0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "2.1.1",
+    "hash": "sha256-3DdHcNmy+JKWB4Q8ixzE4N/hUAvx2o4YlYal4Riwiyw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-5Jjn+0WZQ6OiN8AkNlGV0XIaw8L+a/wAq9hBD88RZbs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "3.1.0",
+    "hash": "sha256-GMxvf0iAiWUWo0awlDczzcxNo8+MITBLp0/SqqYo8Lg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "3.1.2",
+    "hash": "sha256-aXGQ4z1msZ4Q956/9FJuSwp/rt0nfWH6SmmTTGd82tU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-Evg+Ynj2QUa6Gz+zqF+bUyfGD0HI5A2fHmxZEXbn3HA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "7.0.0",
+    "hash": "sha256-QwX//PcURR6aGhH1QFkVmSayqnHaCsFPeE9d8J9nSKs="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "2.0.0",
+    "hash": "sha256-7GVLiJupIL3BS5XgB44M95TxzF4KwvVUsShko+pqO98="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "2.2.0",
+    "hash": "sha256-cigv0t9SntPWjJyRWMy3Q5KnuF17HoDyeKq26meTHoM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "3.1.0",
+    "hash": "sha256-/B7WjPZPvRM+CPgfaCQunSi2mpclH4orrFxHGLs8Uo4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "3.1.2",
+    "hash": "sha256-eRHgIGKLiJmhRbfHsXEMFU3CTLxHgh+K9q+/TaGdeso="
+  },
+  {
+    "pname": "Microsoft.Extensions.Configuration.Binder",
+    "version": "8.0.0",
+    "hash": "sha256-GanfInGzzoN2bKeNwON8/Hnamr6l7RTpYLA49CNXD9Q="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "3.1.0",
+    "hash": "sha256-S72hzDAYWzrfCH5JLJBRtwPEM/Xjh17HwcKuA3wLhvU="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "3.1.2",
+    "hash": "sha256-LAawn5WO3nMFkm2WEq08SzEvpJ1kb8GcQgN5Z/Nve3w="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "6.0.0",
+    "hash": "sha256-gZuMaunMJVyvvepuzNodGPRc6eqKH//bks3957dYkPI="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection",
+    "version": "8.0.0",
+    "hash": "sha256-+qIDR8hRzreCHNEDtUcPfVHQdurzWPo/mqviCH78+EQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "2.0.0",
+    "hash": "sha256-H1rEnq/veRWvmp8qmUsrQkQIcVlKilUNzmmKsxJ0md8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "2.1.0",
+    "hash": "sha256-WgS/QtxbITCpVjs1JPCWuJRrZSoplOtY7VfOXjLqDDA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-pf+UQToJnhAe8VuGjxyCTvua1nIX8n5NHzAUk3Jz38s="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "3.1.0",
+    "hash": "sha256-cG0XS3ibJ9siu8eaQGJnyRwlEbQ9c/eGCtvPjs7Rdd8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "3.1.2",
+    "hash": "sha256-4MzEfKDs2qfzUzvJePxEH8qjQSV+gRHCBAaYqNAYAUo="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-SZke0jNKIqJvvukdta+MgIlGsrP2EdPkkS8lfLg7Ju4="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "7.0.0",
+    "hash": "sha256-55lsa2QdX1CJn1TpW1vTnkvbGXKCeE9P0O6AkW49LaA="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
+  },
+  {
+    "pname": "Microsoft.Extensions.DependencyModel",
+    "version": "2.0.4",
+    "hash": "sha256-qcu4Lwd+aqFwBjOYJ37duL5bXkCz/d6pev+uyOgOMRA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-USD5uZOaahMqi6u7owNWx/LR4EDrOwqPrAAim7iRpJY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.HealthChecks",
+    "version": "2.2.0",
+    "hash": "sha256-uofB7ua6gkc/P0/xdT/0qfEz7N51wRFJC2moWF17+Bo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.HealthChecks",
+    "version": "6.0.0",
+    "hash": "sha256-7ZoLwY+speTYWKd4rR1kBItVEEXLHIMAkICtQnZ3/7o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-ugV6xyMSp3QXanSWNA3TvHv/LZE67N8HJ7jlyEtgRUY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-wwjC3R6nvd4QjNw4BS3ca/hkYe92o/MjsMbqpUDtmJA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Features",
+    "version": "6.0.3",
+    "hash": "sha256-90ocEQ5XNmIFxOioooCLBjwmwbbQ9G9r9PxhWElR8ng="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "2.1.0",
+    "hash": "sha256-w6L1rVatVIMhHK3CDAcy5IBf8dQFLM5Q5mA9VlzRtOs="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "2.1.1",
+    "hash": "sha256-2nfsrYlWR3VE30Fa5Lleh4Acav+kdYD7zIfNz9htFOo="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-pLAxP15+PncMiRrUT5bBAhWg7lC6/dfQk5TLTpZzA7k="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-uBjWjHKEXjZ9fDfFxMjOou3lhfTNhs1yO+e3fpWreLk="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "7.0.0",
+    "hash": "sha256-DaCwAukg2y9/56sVUE8p7UH8Plten+3bl/5JT6cHwjk="
+  },
+  {
+    "pname": "Microsoft.Extensions.FileProviders.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-uQSXmt47X2HGoVniavjLICbPtD2ReQOYQMgy3l0xuMU="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "2.1.0",
+    "hash": "sha256-aRLNBTB3jgY1FSIzvgZtfxWI7J3v/izupeN9KVtNdRM="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "2.1.1",
+    "hash": "sha256-FCQqPxMNaaN+CD8xE42+evaxKjPWdznJ45U+qoVf8e0="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-YZcyKXL6jOpyGrDbFLu46vncfUw2FuqhclMdbEPuh/U="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-ksIPO6RhfbYx/i3su4J3sDhoL+TDnITKsgIpEqnpktc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "7.0.0",
+    "hash": "sha256-OEmUL/iQEKyvg0BbpyNkoyBhhvEosCTb1lS1kLX7usA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Hosting.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-0JBx+wwt5p1SPfO4m49KxNOXPAzAU0A+8tEc/itvpQE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Identity.Core",
+    "version": "6.0.0",
+    "hash": "sha256-xFMzqrulbvOEgxZ5KlIjMbF2qKcK+5kIKzGTQDk1pfY="
+  },
+  {
+    "pname": "Microsoft.Extensions.Identity.Stores",
+    "version": "6.0.0",
+    "hash": "sha256-jTR+yhcpd+6xjkCwb8/QWPV2AwwjiIQwnRabeSUyHd8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "3.1.0",
+    "hash": "sha256-BDrsqgiLYAphIOlnEuXy6iLoED/ykFO53merHCSGfrQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "3.1.2",
+    "hash": "sha256-V42+wLzNHenFOfTozq4v2id6rgZ1MbpYpoqIuv36BHo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "6.0.0",
+    "hash": "sha256-8WsZKRGfXW5MsXkMmNVf6slrkw+cR005czkOP2KUqTk="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging",
+    "version": "8.0.0",
+    "hash": "sha256-Meh0Z0X7KyOEG4l0RWBcuHHihcABcvCyfUXgasmQ91o="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "2.0.0",
+    "hash": "sha256-cBBNcoREIdCDnwZtnTG+BoAFmVb71P1nhFOAH07UsfQ="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "2.1.0",
+    "hash": "sha256-0i4YUnMQ4DE0KDp47pssJLUIw8YAsHf2NZN0xoOLb78="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "2.1.1",
+    "hash": "sha256-TzbYgz4EemrYKHMvB9HWDkFmq0BkTetKPUwBpYHk9+k="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "2.2.0",
+    "hash": "sha256-lJeKyhBnDc4stX2Wd7WpcG+ZKxPTFHILZSezKM2Fhws="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "3.1.0",
+    "hash": "sha256-D3GHIGN0r6zLHHP2/5jt6hB0oMvRyl5ysvVrPVmmyv8="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "3.1.2",
+    "hash": "sha256-Y5xhNw+c5PC8OKfEshFL22guK4ndaaBUqjx82wrjOz4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "6.0.0",
+    "hash": "sha256-QNqcQ3x+MOK7lXbWkCzSOWa/2QyYNbdM/OEEbWN15Sw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "7.0.0",
+    "hash": "sha256-uoMkX/TnwP0YabThacTMmyxdc9itQp73CN7xEFFox74="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Abstractions",
+    "version": "8.0.0",
+    "hash": "sha256-Jmddjeg8U5S+iBTwRlVAVLeIHxc4yrrNgqVMOB7EjM4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Logging.Configuration",
+    "version": "8.0.0",
+    "hash": "sha256-mzmstNsVjKT0EtQcdAukGRifD30T82BMGYlSu8k4K7U="
+  },
+  {
+    "pname": "Microsoft.Extensions.ObjectPool",
+    "version": "2.2.0",
+    "hash": "sha256-P+QUM50j/V8f45zrRqat8fz6Gu3lFP+hDjESwTZNOFg="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "2.0.0",
+    "hash": "sha256-EMvaXxGzueI8lT97bYJQr0kAj1IK0pjnAcWN82hTnzw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "2.1.1",
+    "hash": "sha256-dCPA56Wv9cLuz720PmVbk2oXda1t9ZSAlP8/clDU93E="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "2.2.0",
+    "hash": "sha256-YBtPoWBEs+dlHPQ7qOmss+U9gnvG0T1irZY8NwD0QKw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "3.1.0",
+    "hash": "sha256-0EOsmu/oLAz9WXp1CtMlclzdvs5jea0zJmokeyFnbCo="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "3.1.2",
+    "hash": "sha256-daY7zTN79ysMN61hbQ2TsxnxjBGhRDwVK1tYg7MgrgA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "6.0.0",
+    "hash": "sha256-DxnEgGiCXpkrxFkxXtOXqwaiAtoIjA8VSSWCcsW0FwE="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "7.0.1",
+    "hash": "sha256-uI5Mo+e+8x7mhDcFyDEW2Nwg+LTpw+0R38LZ/ognHz4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options",
+    "version": "8.0.0",
+    "hash": "sha256-n2m4JSegQKUTlOsKLZUUHHKMq926eJ0w9N9G+I3FoFw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "2.0.0",
+    "hash": "sha256-lD4xwvlLRLdJ2WdaHWGpEIRWOtWcvbr4ccD8v2QeTMc="
+  },
+  {
+    "pname": "Microsoft.Extensions.Options.ConfigurationExtensions",
+    "version": "8.0.0",
+    "hash": "sha256-A5Bbzw1kiNkgirk5x8kyxwg9lLTcSngojeD+ocpG1RI="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "2.0.0",
+    "hash": "sha256-q44LtMvyNEKSvgERvA+BrasKapP92Sc91QR4u2TJ9/Y="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "2.1.0",
+    "hash": "sha256-q1oDnqfQiiKgzlv/WDHgNGTlWfm+fkuY1R6t6hr/L+U="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "2.1.1",
+    "hash": "sha256-nbu2OeQGWeG8QKpoAOxIQ8aPzDbWHgbzLXh55xqeeQw="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "2.2.0",
+    "hash": "sha256-DMCTC3HW+sHaRlh/9F1sDwof+XgvVp9IzAqzlZWByn4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "3.1.0",
+    "hash": "sha256-K/cDq+LMfK4cBCvKWkmWAC+IB6pEWolR1J5zL60QPvA="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "3.1.2",
+    "hash": "sha256-S6KkM0QugYT0l7QvNv02Uh6TC+NOg+rLetml0vJZDRI="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "6.0.0",
+    "hash": "sha256-AgvysszpQ11AiTBJFkvSy8JnwIWTj15Pfek7T7ThUc4="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "7.0.0",
+    "hash": "sha256-AGnfNNDvZDGZ0Er9JQxeyLoUbVH+jfXF3anFr12qk6w="
+  },
+  {
+    "pname": "Microsoft.Extensions.Primitives",
+    "version": "8.0.0",
+    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Abstractions",
+    "version": "6.19.0",
+    "hash": "sha256-6qf0mV62jt97bRWGo6NQJ/b5JSq4LLFHjOw0ekKJXuA="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "5.6.0",
+    "hash": "sha256-H7LnTA7wZcZ5FnSUrxavDOLE+lUHcF8C+pRnxI+233E="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "6.10.0",
+    "hash": "sha256-LQvxWJIawyHA0i0IRaZ6CW9D4x4A3xR2f2quLFlnHHM="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "6.19.0",
+    "hash": "sha256-oQzYRiAnu579/PDnf4jSme/TlwWOb1x3A7if+F6rp6w="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.JsonWebTokens",
+    "version": "6.7.1",
+    "hash": "sha256-83LBopI8j9TpIjB5eIbAhHNtO6BOJEvWppHiCaNulao="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "5.6.0",
+    "hash": "sha256-m4i1v0ZXLk5j9hJC4Eh8/ssvcvdMDyCyxVJ8+TTK4mo="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "6.10.0",
+    "hash": "sha256-zm8JQfPK5g+jOXK8mJ9ryInJtNlMPwMlNT8j+pkg5zk="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "6.19.0",
+    "hash": "sha256-Dwxzi/TOJ8W09qRBzgZ6iIs+Oypng1F7XYyqRu7EUWo="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Logging",
+    "version": "6.7.1",
+    "hash": "sha256-NXG97DIA/TEX2t9LTnMoMNKZJqQdCEpEqSmzavsidWg="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols",
+    "version": "5.6.0",
+    "hash": "sha256-4y137RpBfRA345LCAGTOZRLZMECuxY3HMdERsGdE5Uk="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols",
+    "version": "6.10.0",
+    "hash": "sha256-+I8n45xO2TAbIjDs7oKfouAa2NN2oVY6czuXO28flZ0="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols",
+    "version": "6.7.1",
+    "hash": "sha256-acSlOQM+xbRoSYiS3yDvshvkPI18Qq+5A7yzJ48/AdA="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+    "version": "5.6.0",
+    "hash": "sha256-Q/VDMNXEdqzvobpVerv8AWRSt38jXQcMV5vjDJaHuX0="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+    "version": "6.10.0",
+    "hash": "sha256-o9bG81VpdFMMMR+as39wdnI6vFau+xwBk2Vv7nFpyaI="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Protocols.OpenIdConnect",
+    "version": "6.7.1",
+    "hash": "sha256-YdAXjtXH2Tp39dF0nfIcKBeimP76AVORXSNZfRS1VeI="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "5.6.0",
+    "hash": "sha256-HMCXiyQvcQAE10ZpMw5z+pQIDK8NvZriGPdysh3Pios="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "6.10.0",
+    "hash": "sha256-Hs4D6DuYCgxpsGt3kPWSQn8fvzL068np6fz9Lq0uj+I="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "6.19.0",
+    "hash": "sha256-nvDNGg82cW4go5p9YSKSweoLGm8ZY5XbDHVSUYrA8L0="
+  },
+  {
+    "pname": "Microsoft.IdentityModel.Tokens",
+    "version": "6.7.1",
+    "hash": "sha256-sZv7QqORLmu6UjWdD6+/p6+S2vJMTT4YsybaGpByafU="
+  },
+  {
+    "pname": "Microsoft.Net.Http.Headers",
+    "version": "2.2.0",
+    "hash": "sha256-pb8AoacSvy8hGNGodU6Lhv1ooWtUSCZwjmwd89PM1HA="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.0.1",
+    "hash": "sha256-mZotlGZqtrqDSoBrZhsxFe6fuOv5/BIo0w2Z2x0zVAU="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.1",
+    "hash": "sha256-8hLiUKvy/YirCWlFwzdejD2Db3DaXhHxT7GSZx/znJg="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "2.1.2",
+    "hash": "sha256-gYQQO7zsqG+OtN4ywYQyfsiggS2zmxw4+cPXlK+FB5Q="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "3.1.0",
+    "hash": "sha256-cnygditsEaU86bnYtIthNMymAHqaT/sf9Gjykhzqgb0="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "5.0.0",
+    "hash": "sha256-LIcg1StDcQLPOABp4JRXIs837d7z0ia6+++3SF3jl1c="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.0.1",
+    "hash": "sha256-lxxw/Gy32xHi0fLgFWNj4YTFBSBkjx5l6ucmbTyf7V4="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.3",
+    "hash": "sha256-WLsf1NuUfRWyr7C7Rl9jiua9jximnVvzy6nk2D2bVRc="
+  },
+  {
+    "pname": "Microsoft.Win32.Primitives",
+    "version": "4.0.1",
+    "hash": "sha256-B4t5El/ViBdxALMcpZulewc4j/3SIXf71HhJWhm4Ctk="
+  },
+  {
+    "pname": "Microsoft.Win32.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg="
+  },
+  {
+    "pname": "Microsoft.Win32.Registry",
+    "version": "4.0.0",
+    "hash": "sha256-M/06F/Z2wTHCh4pZOgtCjUGLD1FJXEJKCmzOeFMl7uo="
+  },
+  {
+    "pname": "Microsoft.Win32.Registry",
+    "version": "5.0.0",
+    "hash": "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA="
+  },
+  {
+    "pname": "Microsoft.Win32.SystemEvents",
+    "version": "4.7.0",
+    "hash": "sha256-GHxnD1Plb32GJWVWSv0Y51Kgtlb+cdKgOYVBYZSgVF4="
+  },
+  {
+    "pname": "MimeKit",
+    "version": "3.4.3",
+    "hash": "sha256-aOC9Ylp++IP9NpEbejx0XAYymQb0jzye3u1S71fPDwY="
+  },
+  {
+    "pname": "MongoDB.Bson",
+    "version": "2.10.4",
+    "hash": "sha256-Al5sWmyYgW1XOqgUpjz9wqisuGFs4/IZJJUXuy6vYss="
+  },
+  {
+    "pname": "MongoDB.Bson",
+    "version": "2.13.2",
+    "hash": "sha256-lhtXpGnfggB+v9qu9HC6zpDmpGqRd2/EwqBl3Vmc4IE="
+  },
+  {
+    "pname": "MongoDB.Bson",
+    "version": "2.22.0",
+    "hash": "sha256-Iit5z+bAGXa6/7H/G8wHDkWZFnq1SBFvreq3kzNiS9U="
+  },
+  {
+    "pname": "MongoDB.Driver",
+    "version": "2.10.4",
+    "hash": "sha256-N96IcSL68mOPLDFvG4hJmNkUKiHR4qLRpYrCw+h4G64="
+  },
+  {
+    "pname": "MongoDB.Driver",
+    "version": "2.13.2",
+    "hash": "sha256-LMlj70pmPHpXDK267sUZIHf51XM+yHj8tanQwVe2ohM="
+  },
+  {
+    "pname": "MongoDB.Driver",
+    "version": "2.22.0",
+    "hash": "sha256-WvdBzoDJYQfER/bWmGJ5abZcOXaICjcFov7f13eCYp0="
+  },
+  {
+    "pname": "MongoDB.Driver.Core",
+    "version": "2.10.4",
+    "hash": "sha256-cmuG0tnNPDbtIqQl0vb4avGaTzjZa7L7lbsjhtLTwg0="
+  },
+  {
+    "pname": "MongoDB.Driver.Core",
+    "version": "2.13.2",
+    "hash": "sha256-dGuLQijSsyU2mTBpBe9D/1+wIw6I6gR7VcjjMdhJOhI="
+  },
+  {
+    "pname": "MongoDB.Driver.Core",
+    "version": "2.22.0",
+    "hash": "sha256-dzcE7wyS3SqZWRj4h50vBrMZxWv8i+f1yEpsScy8faY="
+  },
+  {
+    "pname": "MongoDB.Libmongocrypt",
+    "version": "1.0.0",
+    "hash": "sha256-1RfJr1aX4GB/p/dW9CzDDzXJs0U4Qy5AlGlFPn2GJdA="
+  },
+  {
+    "pname": "MongoDB.Libmongocrypt",
+    "version": "1.2.2",
+    "hash": "sha256-frxJ4aARq4tbioM5upecRwob/OuzjP6fAkKC7nASeTE="
+  },
+  {
+    "pname": "MongoDB.Libmongocrypt",
+    "version": "1.8.0",
+    "hash": "sha256-s2vNb+bRWKK36ZlVD09g1+1FYf9tdkxrqaNH50Fmod0="
+  },
+  {
+    "pname": "MsgPack.Cli",
+    "version": "1.0.1",
+    "hash": "sha256-Gf0Ed9XHH4oFpJIkzhg/xhDVpenunSol65qa8IZeYrY="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "1.6.1",
+    "hash": "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "10.0.1",
+    "hash": "sha256-Gw7dQIsmYfmcR5ASTuMsB8cqaI4g3osw0j+LO1jEzJY="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "11.0.2",
+    "hash": "sha256-YhlAbGfwoxQzxb3Hef4iyV9eGdPQJJNd2GgSR0jsBJ0="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "12.0.2",
+    "hash": "sha256-BW7sXT2LKpP3ylsCbTTZ1f6Mg1sR4yL68aJVHaJcTnA="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.1",
+    "hash": "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "9.0.1",
+    "hash": "sha256-mYCBrgUhIJFzRuLLV9SIiIFHovzfR8Uuqfg6e08EnlU="
+  },
+  {
+    "pname": "Newtonsoft.Msgpack",
+    "version": "0.1.11",
+    "hash": "sha256-ftNWj92XmPOWSBzhFmm3/weH0Iadc8+PDC9a8qJllwU="
+  },
+  {
+    "pname": "NewtonsoftMessagePack",
+    "version": "0.1.11",
+    "hash": "sha256-u159J4nNbe5UM2d4sRgXrnsR2ITb7U+8xgabxHkjEl8="
+  },
+  {
+    "pname": "Ng.UserAgentService",
+    "version": "1.1.2",
+    "hash": "sha256-LyCOV00H4/y0dXVrnbVUWrsiKxSX6ndS7jRzTIel/24="
+  },
+  {
+    "pname": "NUglify",
+    "version": "1.20.2",
+    "hash": "sha256-Ih0DjL8rDaq6sRgj425WlY1J7/94Zl9+U+DAMIKIztQ="
+  },
+  {
+    "pname": "OpenTelemetry",
+    "version": "1.8.1",
+    "hash": "sha256-AldbsateY7uhKy/0JM2sEgiOF1wGr5CwTifsuH6Tnuo="
+  },
+  {
+    "pname": "OpenTelemetry.Api",
+    "version": "1.8.1",
+    "hash": "sha256-xdMOKY90bGTcvRdBsBqj08Du3qRmDC1BecX+aK3dTTA="
+  },
+  {
+    "pname": "OpenTelemetry.Api.ProviderBuilderExtensions",
+    "version": "1.8.1",
+    "hash": "sha256-j4XUh9cnF5SbyhRoNwjOWS3EXIl9ZSEFgkJZjQEN2lM="
+  },
+  {
+    "pname": "OpenTelemetry.Exporter.Prometheus.AspNetCore",
+    "version": "1.9.0-alpha.2",
+    "hash": "sha256-BF5e8ZWOM5vBnKb+O+g6NRCgHZwmXyympYL4MmGZwJw="
+  },
+  {
+    "pname": "OpenTelemetry.Extensions.Hosting",
+    "version": "1.8.1",
+    "hash": "sha256-uA8Lfof/cvQknxBoSDBxTdljAA+oMCOSiUVIsbBOcQc="
+  },
+  {
+    "pname": "Portable.BouncyCastle",
+    "version": "1.9.0",
+    "hash": "sha256-GOXM4TdTTodWlGzEfbMForTfTQI/ObJGnFZMSD6X8E4="
+  },
+  {
+    "pname": "Quartz",
+    "version": "3.5.0",
+    "hash": "sha256-ercEnMhA7VGA552I+e/lA85GY9trWWWsp4SC0HRY13I="
+  },
+  {
+    "pname": "Quartz.AspNetCore",
+    "version": "3.5.0",
+    "hash": "sha256-/29PdsvUY/0Zq5LBFZHSUnOJitxmxlWwPLJogBDFzco="
+  },
+  {
+    "pname": "Quartz.Extensions.DependencyInjection",
+    "version": "3.5.0",
+    "hash": "sha256-bn5IaI0BQyO/kHsrTU/bIPvUBKZX7ZDNMms3CZrD5rU="
+  },
+  {
+    "pname": "Quartz.Extensions.Hosting",
+    "version": "3.5.0",
+    "hash": "sha256-hO+x4CYQRZu6YdPMxuG1cMd0/zOHK+bMJwFBghlHoWk="
+  },
+  {
+    "pname": "runtime.any.System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-4PGZqyWhZ6/HCTF2KddDsbmTTjxs2oW79YfkberDZS8="
+  },
+  {
+    "pname": "runtime.any.System.Diagnostics.Tools",
+    "version": "4.3.0",
+    "hash": "sha256-8yLKFt2wQxkEf7fNfzB+cPUCjYn2qbqNgQ1+EeY2h/I="
+  },
+  {
+    "pname": "runtime.any.System.Diagnostics.Tracing",
+    "version": "4.3.0",
+    "hash": "sha256-dsmTLGvt8HqRkDWP8iKVXJCS+akAzENGXKPV18W2RgI="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Globalization.Calendars",
+    "version": "4.3.0",
+    "hash": "sha256-AYh39tgXJVFu8aLi9Y/4rK8yWMaza4S4eaxjfcuEEL4="
+  },
+  {
+    "pname": "runtime.any.System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE="
+  },
+  {
+    "pname": "runtime.any.System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-Y2AnhOcJwJVYv7Rp6Jz6ma0fpITFqJW+8rsw106K2X8="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ="
+  },
+  {
+    "pname": "runtime.any.System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-9EvnmZslLgLLhJ00o5MWaPuJQlbUFcUF8itGQNVkcQ4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-PQRACwnSUuxgVySO1840KvqCC9F8iI9iTzxNW0RcBS4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-Kaw5PnLYIiqWbsoF3VKJhy7pkpoGsUwn4ZDCKscbbzA="
+  },
+  {
+    "pname": "runtime.any.System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs="
+  },
+  {
+    "pname": "runtime.any.System.Text.Encoding.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-6MYj0RmLh4EVqMtO/MRqBi0HOn5iG4x9JimgCCJ+EFM="
+  },
+  {
+    "pname": "runtime.any.System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4="
+  },
+  {
+    "pname": "runtime.any.System.Threading.Timer",
+    "version": "4.3.0",
+    "hash": "sha256-BgHxXCIbicVZtpgMimSXixhFC3V+p5ODqeljDjO8hCs="
+  },
+  {
+    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps="
+  },
+  {
+    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-EbnOqPOrAgI9eNheXLR++VnY4pHzMsEKw1dFPJ/Fl2c="
+  },
+  {
+    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I="
+  },
+  {
+    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-mVg02TNvJc1BuHU03q3fH3M6cMgkKaQPBxraSHl/Btg="
+  },
+  {
+    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA="
+  },
+  {
+    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-g9Uiikrl+M40hYe0JMlGHe/lrR0+nN05YF64wzLmBBA="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.0.0",
+    "hash": "sha256-bmaM0ovT4X4aqDJOR255Yda/u3fmHZskU++lMnsy894="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.native.System.IO.Compression",
+    "version": "4.3.0",
+    "hash": "sha256-DWnXs4vlKoU6WxxvCArTJupV6sX3iBbZh8SbqfHace8="
+  },
+  {
+    "pname": "runtime.native.System.Net.Http",
+    "version": "4.3.0",
+    "hash": "sha256-c556PyheRwpYhweBjSfIwEyZHnAUB8jWioyKEcp/2dg="
+  },
+  {
+    "pname": "runtime.native.System.Net.Security",
+    "version": "4.3.0",
+    "hash": "sha256-I8vYld/7WtU2/rrD4XfSRgpO/DY3qXghG14VQjiU2DY="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.Apple",
+    "version": "4.3.0",
+    "hash": "sha256-2IhBv0i6pTcOyr8FFIyfPEaaCHUmJZ8DYwLUwJ+5waw="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-xqF6LbbtpzNC9n1Ua16PnYgXHU0LvblEROTfK4vIxX8="
+  },
+  {
+    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM="
+  },
+  {
+    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-aJBu6Frcg6webvzVcKNoUP1b462OAqReF2giTSyBzCQ="
+  },
+  {
+    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4="
+  },
+  {
+    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-Mpt7KN2Kq51QYOEVesEjhWcCGTqWckuPf8HlQ110qLY="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+    "version": "4.3.0",
+    "hash": "sha256-serkd4A7F6eciPiPJtUyJyxzdAtupEcWIZQ9nptEzIM="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-JvMltmfVC53mCZtKDHE69G3RT6Id28hnskntP9MMP9U="
+  },
+  {
+    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4="
+  },
+  {
+    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-QfFxWTVRNBhN4Dm1XRbCf+soNQpy81PsZed3x6op/bI="
+  },
+  {
+    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g="
+  },
+  {
+    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-EaJHVc9aDZ6F7ltM2JwlIuiJvqM67CKRq682iVSo+pU="
+  },
+  {
+    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc="
+  },
+  {
+    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-PHR0+6rIjJswn89eoiWYY1DuU8u6xRJLrtjykAMuFmA="
+  },
+  {
+    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw="
+  },
+  {
+    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.2",
+    "hash": "sha256-LFkh7ua7R4rI5w2KGjcHlGXLecsncCy6kDXLuy4qD/Q="
+  },
+  {
+    "pname": "runtime.unix.Microsoft.Win32.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LZb23lRXzr26tRS5aA0xyB08JxiblPDoA7HBvn6awXg="
+  },
+  {
+    "pname": "runtime.unix.System.Console",
+    "version": "4.3.1",
+    "hash": "sha256-dxyn/1Px4FKLZ2QMUrkFpW619Y1lhPeTiGLWYM6IbpY="
+  },
+  {
+    "pname": "runtime.unix.System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-ReoazscfbGH+R6s6jkg5sIEHWNEvjEoHtIsMbpc7+tI="
+  },
+  {
+    "pname": "runtime.unix.System.IO.FileSystem",
+    "version": "4.3.0",
+    "hash": "sha256-Pf4mRl6YDK2x2KMh0WdyNgv0VUNdSKVDLlHqozecy5I="
+  },
+  {
+    "pname": "runtime.unix.System.Net.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-pHJ+I6i16MV6m77uhTC6GPY6jWGReE3SSP3fVB59ti0="
+  },
+  {
+    "pname": "runtime.unix.System.Net.Sockets",
+    "version": "4.3.0",
+    "hash": "sha256-IvgOeA2JuBjKl5yAVGjPYMPDzs9phb3KANs95H9v1w4="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "runtime.unix.System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-l8S9gt6dk3qYG6HYonHtdlYtBKyPb29uQ6NDjmrt3V4="
+  },
+  {
+    "pname": "Scriban",
+    "version": "5.5.1",
+    "hash": "sha256-kZm4Iz1BgwHkvbMnG0Sa7YAe4jHvj/qW+Gu7GpPDUKw="
+  },
+  {
+    "pname": "SendGrid",
+    "version": "9.24.4",
+    "hash": "sha256-5DBQnNPY6DqKZYcYTVL6pFtRhbyfSawFQGcv+IdfeLs="
+  },
+  {
+    "pname": "Serilog",
+    "version": "2.9.0",
+    "hash": "sha256-JpK8hQvk0LHtq9vaEyegi1oo2Id+LSSOSkKsxAVaEXw="
+  },
+  {
+    "pname": "Serilog.AspNetCore",
+    "version": "3.4.0",
+    "hash": "sha256-Ty12+Jks49mcKP9PJLFIYBwQEaduQyONmhQiVa/+qcw="
+  },
+  {
+    "pname": "Serilog.Extensions.Hosting",
+    "version": "3.1.0",
+    "hash": "sha256-pWum7durSDjglLEAnSF2TPX4kcpAOYDuhIVetaewAVg="
+  },
+  {
+    "pname": "Serilog.Extensions.Logging",
+    "version": "3.0.1",
+    "hash": "sha256-KtHMMnepmEpOlHrIGlUkK6Vq1L0iBBnFGavbUtvxOBk="
+  },
+  {
+    "pname": "Serilog.Formatting.Compact",
+    "version": "1.1.0",
+    "hash": "sha256-nnnKC8AZv/0hp66LqJrx3rfKHslE0ZQfEAvGLIOEePA="
+  },
+  {
+    "pname": "Serilog.Settings.Configuration",
+    "version": "3.1.0",
+    "hash": "sha256-ZU0eb88tVMRKrfz9ewcmtCmWFqZeVLdeGGMcYElVRbI="
+  },
+  {
+    "pname": "Serilog.Sinks.Console",
+    "version": "3.1.1",
+    "hash": "sha256-1hGDxkO/hgK+NVK6SldccSNgQfZwcr4VNDP4QIxWKUk="
+  },
+  {
+    "pname": "Serilog.Sinks.Debug",
+    "version": "1.0.1",
+    "hash": "sha256-Qrg/iiltlIpkq+XZZIkbPyHFvl8+ADzfSiVPUsSqySQ="
+  },
+  {
+    "pname": "Serilog.Sinks.File",
+    "version": "4.1.0",
+    "hash": "sha256-ir1quhEV0eLu65sZfJd+SlTcyJVQ/iJDVJb+4GC6x+c="
+  },
+  {
+    "pname": "SharpCompress",
+    "version": "0.23.0",
+    "hash": "sha256-tKXK36lMvw2V6E/3Da4HX9NQ5yhe4zH5Yd+zrJ0WRgk="
+  },
+  {
+    "pname": "SharpCompress",
+    "version": "0.30.1",
+    "hash": "sha256-kBCwIfrK54VarA+1jxGX7ypFtbA4VP+Z5jPSLDsUK8I="
+  },
+  {
+    "pname": "Snappier",
+    "version": "1.0.0",
+    "hash": "sha256-Bv6PkPtYUf/sPCmhrA6F9ZE66pYSsYrRBOEFwetC+Sk="
+  },
+  {
+    "pname": "Sprache",
+    "version": "2.3.1",
+    "hash": "sha256-RbpqpBsC6RszUU2QOYd+TBCpj3qco9Bhul4SFEx0ijI="
+  },
+  {
+    "pname": "starkbank-ecdsa",
+    "version": "1.3.1",
+    "hash": "sha256-xuxRhy3AK7lRNB5rn2rX7TPwOUGLg81UpMWyZ4bkzUY="
+  },
+  {
+    "pname": "Streetwriters.IdentityServer4.KeyRack",
+    "version": "0.2.0",
+    "hash": "sha256-rUckNyVg75m1bdOYA2uk7ouLZwr50J7Yy3+00icb9As="
+  },
+  {
+    "pname": "Streetwriters.IdentityServer4.KeyRack.DataProtection",
+    "version": "0.1.0",
+    "hash": "sha256-6PAg8bpPuplqmQ/03P3xcgluJHZUw4x6SwjOML2j+Yo="
+  },
+  {
+    "pname": "System.AppContext",
+    "version": "4.1.0",
+    "hash": "sha256-v6YfyfrKmhww+EYHUq6cwYUMj00MQ6SOfJtcGVRlYzs="
+  },
+  {
+    "pname": "System.AppContext",
+    "version": "4.3.0",
+    "hash": "sha256-yg95LNQOwFlA1tWxXdQkVyJqT4AnoDc+ACmrNvzGiZg="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.3.0",
+    "hash": "sha256-XqZWb4Kd04960h4U9seivjKseGA/YEIpdplfHYHQ9jk="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.5.0",
+    "hash": "sha256-THw2znu+KibfJRfD7cE3nRYHsm7Fyn5pjOOZVonFjvs="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.5.1",
+    "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
+  },
+  {
+    "pname": "System.CodeDom",
+    "version": "4.4.0",
+    "hash": "sha256-L1xyspJ8pDJNVPYKl+FMGf4Zwm0tlqtAyQCNW6pT6/0="
+  },
+  {
+    "pname": "System.Collections",
+    "version": "4.0.11",
+    "hash": "sha256-puoFMkx4Z55C1XPxNw3np8nzNGjH+G24j43yTIsDRL0="
+  },
+  {
+    "pname": "System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc="
+  },
+  {
+    "pname": "System.Collections.Concurrent",
+    "version": "4.3.0",
+    "hash": "sha256-KMY5DfJnDeIsa13DpqvyN8NkReZEMAFnlmNglVoFIXI="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "1.5.0",
+    "hash": "sha256-BliqYlL9ntbMXo5d7NUrKXwYN+PqdyqDIS5bp4qVr7Q="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "1.7.0",
+    "hash": "sha256-/RMBxUUublGaWERAnTk74QmrSQbX+xs84yFqmawmM74="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "6.0.0",
+    "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
+  },
+  {
+    "pname": "System.Collections.NonGeneric",
+    "version": "4.0.1",
+    "hash": "sha256-jdCVXmGOsJ+2F0xAagCkiMZ91SGAm9iOhO2u4ksmKaU="
+  },
+  {
+    "pname": "System.Collections.NonGeneric",
+    "version": "4.3.0",
+    "hash": "sha256-8/yZmD4jjvq7m68SPkJZLBQ79jOTOyT5lyzX4SCYAx8="
+  },
+  {
+    "pname": "System.Collections.Specialized",
+    "version": "4.0.1",
+    "hash": "sha256-qao6hk9XKdRtpsqdks2uOx5jqT41KpuTCb1cg4w/e/E="
+  },
+  {
+    "pname": "System.Collections.Specialized",
+    "version": "4.3.0",
+    "hash": "sha256-QNg0JJNx+zXMQ26MJRPzH7THdtqjrNtGLUgaR1SdvOk="
+  },
+  {
+    "pname": "System.ComponentModel",
+    "version": "4.0.1",
+    "hash": "sha256-X5T36S49q1odsn6wAET6EGNlsxOyd66naMr5T3G9mGw="
+  },
+  {
+    "pname": "System.ComponentModel",
+    "version": "4.3.0",
+    "hash": "sha256-i00uujMO4JEDIEPKLmdLY3QJ6vdSpw6Gh9oOzkFYBiU="
+  },
+  {
+    "pname": "System.ComponentModel.Annotations",
+    "version": "4.5.0",
+    "hash": "sha256-15yE2NoT9vmL9oGCaxHClQR1jLW1j1ef5hHMg55xRso="
+  },
+  {
+    "pname": "System.ComponentModel.Annotations",
+    "version": "4.7.0",
+    "hash": "sha256-PxG9lvf2v/IAIs7LhO4Ur+EpX/L5nYbEs0D21gypoRs="
+  },
+  {
+    "pname": "System.ComponentModel.Primitives",
+    "version": "4.1.0",
+    "hash": "sha256-AIcFeZDeYbaI4V9lY8TtUG+xkUyhA8K8dYSDp5StZXE="
+  },
+  {
+    "pname": "System.ComponentModel.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-IOMJleuIBppmP4ECB3uftbdcgL7CCd56+oAD/Sqrbus="
+  },
+  {
+    "pname": "System.ComponentModel.TypeConverter",
+    "version": "4.1.0",
+    "hash": "sha256-HmzGTU2NVj8qUn1xCGxifOQ/e/HZCVvgIECzcJPaDJ0="
+  },
+  {
+    "pname": "System.ComponentModel.TypeConverter",
+    "version": "4.3.0",
+    "hash": "sha256-PSDiPYt8PgTdTUBz+GH6lHCaM1YgfObneHnZsc8Fz54="
+  },
+  {
+    "pname": "System.Configuration.ConfigurationManager",
+    "version": "4.7.0",
+    "hash": "sha256-rYjp/UmagI4ZULU1ocia/AiXxLNL8uhMV8LBF4QFW10="
+  },
+  {
+    "pname": "System.Console",
+    "version": "4.3.0",
+    "hash": "sha256-Xh3PPBZr0pDbDaK8AEHbdGz7ePK6Yi1ZyRWI1JM6mbo="
+  },
+  {
+    "pname": "System.Diagnostics.Debug",
+    "version": "4.0.11",
+    "hash": "sha256-P+rSQJVoN6M56jQbs76kZ9G3mAWFdtF27P/RijN8sj4="
+  },
+  {
+    "pname": "System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "4.3.0",
+    "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "4.7.0",
+    "hash": "sha256-wSJTNjJGcEa0tOrXXHGNVkjPpBPnLLP7ZKpQ9FvZIDM="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "4.7.1",
+    "hash": "sha256-l2TM1pfyRF70Xmzoz1dAqWkB8+/K6b8t5Tj7aF1UO9Y="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "6.0.0",
+    "hash": "sha256-RY9uWSPdK2fgSwlj1OHBGBVo3ZvGQgBJNzAsS5OGMWc="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "8.0.0",
+    "hash": "sha256-+aODaDEQMqla5RYZeq0Lh66j+xkPYxykrVvSCmJQ+Vs="
+  },
+  {
+    "pname": "System.Diagnostics.Process",
+    "version": "4.1.0",
+    "hash": "sha256-OgW6ogQ+oYADYS0PHmwXdhrOKQJpqXlwzSvmfjTLNBg="
+  },
+  {
+    "pname": "System.Diagnostics.TextWriterTraceListener",
+    "version": "4.0.0",
+    "hash": "sha256-GmInHGlq5ZTnT7qsxpKnXid11hcRXVBhA1N1zyePL/Y="
+  },
+  {
+    "pname": "System.Diagnostics.Tools",
+    "version": "4.0.1",
+    "hash": "sha256-vSBqTbmWXylvRa37aWyktym+gOpsvH43mwr6A962k6U="
+  },
+  {
+    "pname": "System.Diagnostics.Tools",
+    "version": "4.3.0",
+    "hash": "sha256-gVOv1SK6Ape0FQhCVlNOd9cvQKBvMxRX9K0JPVi8w0Y="
+  },
+  {
+    "pname": "System.Diagnostics.TraceSource",
+    "version": "4.3.0",
+    "hash": "sha256-xpxwaXsRcgso8Gj0cqY4+Hvvz6vZkmEMh5/J204j3M8="
+  },
+  {
+    "pname": "System.Diagnostics.Tracing",
+    "version": "4.3.0",
+    "hash": "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q="
+  },
+  {
+    "pname": "System.Drawing.Common",
+    "version": "4.7.0",
+    "hash": "sha256-D3qG+xAe78lZHvlco9gHK2TEAM370k09c6+SQi873Hk="
+  },
+  {
+    "pname": "System.Dynamic.Runtime",
+    "version": "4.0.11",
+    "hash": "sha256-qWqFVxuXioesVftv2RVJZOnmojUvRjb7cS3Oh3oTit4="
+  },
+  {
+    "pname": "System.Dynamic.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-k75gjOYimIQtLBD5NDzwwi3ZMUBPRW3jmc3evDMMJbU="
+  },
+  {
+    "pname": "System.Formats.Asn1",
+    "version": "6.0.0",
+    "hash": "sha256-KaMHgIRBF7Nf3VwOo+gJS1DcD+41cJDPWFh+TDQ8ee8="
+  },
+  {
+    "pname": "System.Formats.Asn1",
+    "version": "7.0.0",
+    "hash": "sha256-eMF+SD/yeslf/wOIlOTlpfpj3LtP6HUilGeSj++bJKg="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.0.11",
+    "hash": "sha256-rbSgc2PIEc2c2rN6LK3qCREAX3DqA2Nq1WcLrZYsDBw="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Globalization.Calendars",
+    "version": "4.3.0",
+    "hash": "sha256-uNOD0EOVFgnS2fMKvMiEtI9aOw00+Pfy/H+qucAQlPc="
+  },
+  {
+    "pname": "System.Globalization.Extensions",
+    "version": "4.0.1",
+    "hash": "sha256-zLtkPryJwqTGcJqMC6zoMMvMrT+aAL5GoumjmMtqUEI="
+  },
+  {
+    "pname": "System.Globalization.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mmJWA27T0GRVuFP9/sj+4TrR4GJWrzNIk2PDrbr7RQk="
+  },
+  {
+    "pname": "System.IdentityModel.Tokens.Jwt",
+    "version": "5.6.0",
+    "hash": "sha256-UJyrB6TLwPSQX5jsz9mfaDZcFNCsDc6/EDMeZOHfypA="
+  },
+  {
+    "pname": "System.IdentityModel.Tokens.Jwt",
+    "version": "6.10.0",
+    "hash": "sha256-NLJnOpVUQTDAfrk3jLcwwQS9TU+VFFUGa0b2lURmYwI="
+  },
+  {
+    "pname": "System.IdentityModel.Tokens.Jwt",
+    "version": "6.19.0",
+    "hash": "sha256-hVx9kKMNUpvXZuYGuPcBbytnjdDNNDt9J4KCNY/wma4="
+  },
+  {
+    "pname": "System.IdentityModel.Tokens.Jwt",
+    "version": "6.7.1",
+    "hash": "sha256-1dkGdCR2Ccm0rPoyVrLTMisdyH/CODx5QZxqcGnuXcc="
+  },
+  {
+    "pname": "System.IO",
+    "version": "4.1.0",
+    "hash": "sha256-V6oyQFwWb8NvGxAwvzWnhPxy9dKOfj/XBM3tEC5aHrw="
+  },
+  {
+    "pname": "System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY="
+  },
+  {
+    "pname": "System.IO.Compression",
+    "version": "4.3.0",
+    "hash": "sha256-f5PrQlQgj5Xj2ZnHxXW8XiOivaBvfqDao9Sb6AVinyA="
+  },
+  {
+    "pname": "System.IO.Compression.ZipFile",
+    "version": "4.3.0",
+    "hash": "sha256-WQl+JgWs+GaRMeiahTFUbrhlXIHapzcpTFXbRvAtvvs="
+  },
+  {
+    "pname": "System.IO.FileSystem",
+    "version": "4.0.1",
+    "hash": "sha256-4VKXFgcGYCTWVXjAlniAVq0dO3o5s8KHylg2wg2/7k0="
+  },
+  {
+    "pname": "System.IO.FileSystem",
+    "version": "4.3.0",
+    "hash": "sha256-vNIYnvlayuVj0WfRfYKpDrhDptlhp1pN8CYmlVd2TXw="
+  },
+  {
+    "pname": "System.IO.FileSystem.Primitives",
+    "version": "4.0.1",
+    "hash": "sha256-IpigKMomqb6pmYWkrlf0ZdpILtRluX2cX5sOKVW0Feg="
+  },
+  {
+    "pname": "System.IO.FileSystem.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "4.5.2",
+    "hash": "sha256-AXsErCMtJnoT1ZhYlChyObzAimwEp1Cl1L6X6fewuhA="
+  },
+  {
+    "pname": "System.IO.Pipelines",
+    "version": "6.0.2",
+    "hash": "sha256-7oFZm9JebE1qcqnrnZeJApgRMAKyvOd5LvW+fhmgWDk="
+  },
+  {
+    "pname": "System.Linq",
+    "version": "4.1.0",
+    "hash": "sha256-ZQpFtYw5N1F1aX0jUK3Tw+XvM5tnlnshkTCNtfVA794="
+  },
+  {
+    "pname": "System.Linq",
+    "version": "4.3.0",
+    "hash": "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A="
+  },
+  {
+    "pname": "System.Linq.Expressions",
+    "version": "4.1.0",
+    "hash": "sha256-7zqB+FXgkvhtlBzpcZyd81xczWP0D3uWssyAGw3t7b4="
+  },
+  {
+    "pname": "System.Linq.Expressions",
+    "version": "4.3.0",
+    "hash": "sha256-+3pvhZY7rip8HCbfdULzjlC9FPZFpYoQxhkcuFm2wk8="
+  },
+  {
+    "pname": "System.Linq.Queryable",
+    "version": "4.0.1",
+    "hash": "sha256-XOFRO+lyoxsWtIUJfg5JCqv9Gx35ASOc94WIR8ZMVoY="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.0",
+    "hash": "sha256-YOz1pCR4RpP1ywYoJsgXnVlzsWtC2uYKQJTg0NnFXtE="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.1",
+    "hash": "sha256-7JhQNSvE6JigM1qmmhzOX3NiZ6ek82R4whQNb+FpBzg="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.3",
+    "hash": "sha256-Cvl7RbRbRu9qKzeRBWjavUkseT2jhZBUWV1SPipUWFk="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.5",
+    "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
+  },
+  {
+    "pname": "System.Net.Http",
+    "version": "4.3.0",
+    "hash": "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q="
+  },
+  {
+    "pname": "System.Net.NameResolution",
+    "version": "4.3.0",
+    "hash": "sha256-eGZwCBExWsnirWBHyp2sSSSXp6g7I6v53qNmwPgtJ5c="
+  },
+  {
+    "pname": "System.Net.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE="
+  },
+  {
+    "pname": "System.Net.Security",
+    "version": "4.3.2",
+    "hash": "sha256-CAuJ0uLmDKRqbG42rBhHjHcKelYTE5gpjRlrvYNigas="
+  },
+  {
+    "pname": "System.Net.Sockets",
+    "version": "4.3.0",
+    "hash": "sha256-il7dr5VT/QWDg/0cuh+4Es2u8LY//+qqiY9BZmYxSus="
+  },
+  {
+    "pname": "System.Net.WebSockets.WebSocketProtocol",
+    "version": "4.5.3",
+    "hash": "sha256-DDH8Y+TkiTKYRdKzqba5hyj/SZV34DKgvs/gOZtlLH0="
+  },
+  {
+    "pname": "System.Numerics.Vectors",
+    "version": "4.3.0",
+    "hash": "sha256-eog2Sp8CAntRlyp2Aar1tpAwDrojGFZ5LIdqsmuIchY="
+  },
+  {
+    "pname": "System.Numerics.Vectors",
+    "version": "4.5.0",
+    "hash": "sha256-qdSTIFgf2htPS+YhLGjAGiLN8igCYJnCCo6r78+Q+c8="
+  },
+  {
+    "pname": "System.ObjectModel",
+    "version": "4.0.12",
+    "hash": "sha256-MudZ/KYcvYsn2cST3EE049mLikrNkmE7QoUoYKKby+s="
+  },
+  {
+    "pname": "System.ObjectModel",
+    "version": "4.3.0",
+    "hash": "sha256-gtmRkWP2Kwr3nHtDh0yYtce38z1wrGzb6fjm4v8wN6Q="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.2",
+    "hash": "sha256-jB2+W3tTQ6D9XHy5sEFMAazIe1fu2jrENUO0cb48OgU="
+  },
+  {
+    "pname": "System.Reactive",
+    "version": "4.1.6",
+    "hash": "sha256-7cCQDi0STFlwxHVMKrFuhEW5hRJDM+tjHSgA6wZDRhg="
+  },
+  {
+    "pname": "System.Reflection",
+    "version": "4.1.0",
+    "hash": "sha256-idZHGH2Yl/hha1CM4VzLhsaR8Ljo/rV7TYe7mwRJSMs="
+  },
+  {
+    "pname": "System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.0.1",
+    "hash": "sha256-F1MvYoQWHCY89/O4JBwswogitqVvKuVfILFqA7dmuHk="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.3.0",
+    "hash": "sha256-5LhkDmhy2FkSxulXR+bsTtMzdU3VyyuZzsxp7/DwyIU="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.6.0",
+    "hash": "sha256-HH+DiczPJ317QteIulKsvYXqe86TTNu5PjDZVXA5A6I="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.7.0",
+    "hash": "sha256-Fw/CSRD+wajH1MqfKS3Q/sIrUH7GN4K+F+Dx68UPNIg="
+  },
+  {
+    "pname": "System.Reflection.Emit.ILGeneration",
+    "version": "4.0.1",
+    "hash": "sha256-YG+eJBG5P+5adsHiw/lhJwvREnvdHw6CJyS8ZV4Ujd0="
+  },
+  {
+    "pname": "System.Reflection.Emit.ILGeneration",
+    "version": "4.3.0",
+    "hash": "sha256-mKRknEHNls4gkRwrEgi39B+vSaAz/Gt3IALtS98xNnA="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.0.1",
+    "hash": "sha256-uVvNOnL64CPqsgZP2OLqNmxdkZl6Q0fTmKmv9gcBi+g="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.3.0",
+    "hash": "sha256-rKx4a9yZKcajloSZHr4CKTVJ6Vjh95ni+zszPxWjh2I="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.6.0",
+    "hash": "sha256-913OIkt3v3N12Yke328IRxTtgYUQYNs/eSzOs8wUPkM="
+  },
+  {
+    "pname": "System.Reflection.Extensions",
+    "version": "4.0.1",
+    "hash": "sha256-NsfmzM9G/sN3H8X2cdnheTGRsh7zbRzvegnjDzDH/FQ="
+  },
+  {
+    "pname": "System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mMOCYzUenjd4rWIfq7zIX9PFYk/daUyF0A8l1hbydAk="
+  },
+  {
+    "pname": "System.Reflection.Primitives",
+    "version": "4.0.1",
+    "hash": "sha256-SFSfpWEyCBMAOerrMCOiKnpT+UAWTvRcmoRquJR6Vq0="
+  },
+  {
+    "pname": "System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.1.0",
+    "hash": "sha256-R0YZowmFda+xzKNR4kKg7neFoE30KfZwp/IwfRSKVK4="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.3.0",
+    "hash": "sha256-4U4/XNQAnddgQIHIJq3P2T80hN0oPdU2uCeghsDTWng="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.7.0",
+    "hash": "sha256-GEtCGXwtOnkYejSV+Tfl+DqyGq5jTUaVyL9eMupMHBM="
+  },
+  {
+    "pname": "System.Resources.ResourceManager",
+    "version": "4.0.1",
+    "hash": "sha256-cZ2/3/fczLjEpn6j3xkgQV9ouOVjy4Kisgw5xWw9kSw="
+  },
+  {
+    "pname": "System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.1.0",
+    "hash": "sha256-FViNGM/4oWtlP6w0JC0vJU+k9efLKZ+yaXrnEeabDQo="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "4.4.0",
+    "hash": "sha256-SeTI4+yVRO2SmAKgOrMni4070OD+Oo8L1YiEVeKDyig="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "4.5.0",
+    "hash": "sha256-g9jIdQtXSAhY+ezQtYNgHEUoQR3HzznHs3JMzD9bip4="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "4.5.1",
+    "hash": "sha256-Lucrfpuhz72Ns+DOS7MjuNT2KWgi+m4bJkg87kqXmfU="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "4.5.2",
+    "hash": "sha256-8eUXXGWO2LL7uATMZye2iCpQOETn2jCcjUhG6coR5O8="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "5.0.0",
+    "hash": "sha256-neARSpLPUzPxEKhJRwoBzhPxK+cKIitLx7WBYncsYgo="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "6.0.0",
+    "hash": "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I="
+  },
+  {
+    "pname": "System.Runtime.Extensions",
+    "version": "4.1.0",
+    "hash": "sha256-X7DZ5CbPY7jHs20YZ7bmcXs9B5Mxptu/HnBUvUnNhGc="
+  },
+  {
+    "pname": "System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o="
+  },
+  {
+    "pname": "System.Runtime.Handles",
+    "version": "4.0.1",
+    "hash": "sha256-j2QgVO9ZOjv7D1het98CoFpjoYgxjupuIhuBUmLLH7w="
+  },
+  {
+    "pname": "System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms="
+  },
+  {
+    "pname": "System.Runtime.InteropServices",
+    "version": "4.1.0",
+    "hash": "sha256-QceAYlJvkPRJc/+5jR+wQpNNI3aqGySWWSO30e/FfQY="
+  },
+  {
+    "pname": "System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI="
+  },
+  {
+    "pname": "System.Runtime.InteropServices.RuntimeInformation",
+    "version": "4.0.0",
+    "hash": "sha256-5j53amb76A3SPiE3B0llT2XPx058+CgE7OXL4bLalT4="
+  },
+  {
+    "pname": "System.Runtime.InteropServices.RuntimeInformation",
+    "version": "4.3.0",
+    "hash": "sha256-MYpl6/ZyC6hjmzWRIe+iDoldOMW1mfbwXsduAnXIKGA="
+  },
+  {
+    "pname": "System.Runtime.InteropServices.WindowsRuntime",
+    "version": "4.3.0",
+    "hash": "sha256-6b51jL+5CO5iMqXun95mPXsCvbko0uTL9VlU7EPy+i4="
+  },
+  {
+    "pname": "System.Runtime.Numerics",
+    "version": "4.3.0",
+    "hash": "sha256-P5jHCgMbgFMYiONvzmaKFeOqcAIDPu/U8bOVrNPYKqc="
+  },
+  {
+    "pname": "System.Runtime.Serialization.Formatters",
+    "version": "4.3.0",
+    "hash": "sha256-Feic7MGKVG4imh7kpLkPHmApQzYjq7SxHnazh2wZkoQ="
+  },
+  {
+    "pname": "System.Runtime.Serialization.Primitives",
+    "version": "4.1.1",
+    "hash": "sha256-80B05oxJbPLGq2pGOSl6NlZvintX9A1CNpna2aN0WRA="
+  },
+  {
+    "pname": "System.Runtime.Serialization.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-zu5m1M9usend+i9sbuD6Xbizdo8Z6N5PEF9DAtEVewc="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "4.7.0",
+    "hash": "sha256-/9ZCPIHLdhzq7OW4UKqTsR0O93jjHd6BRG1SRwgHE1g="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "5.0.0",
+    "hash": "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54="
+  },
+  {
+    "pname": "System.Security.Claims",
+    "version": "4.3.0",
+    "hash": "sha256-Fua/rDwAqq4UByRVomAxMPmDBGd5eImRqHVQIeSxbks="
+  },
+  {
+    "pname": "System.Security.Cryptography.Algorithms",
+    "version": "4.3.0",
+    "hash": "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8="
+  },
+  {
+    "pname": "System.Security.Cryptography.Cng",
+    "version": "4.3.0",
+    "hash": "sha256-u17vy6wNhqok91SrVLno2M1EzLHZm6VMca85xbVChsw="
+  },
+  {
+    "pname": "System.Security.Cryptography.Cng",
+    "version": "4.5.0",
+    "hash": "sha256-9llRbEcY1fHYuTn3vGZaCxsFxSAqXl4bDA6Rz9b0pN4="
+  },
+  {
+    "pname": "System.Security.Cryptography.Csp",
+    "version": "4.3.0",
+    "hash": "sha256-oefdTU/Z2PWU9nlat8uiRDGq/PGZoSPRgkML11pmvPQ="
+  },
+  {
+    "pname": "System.Security.Cryptography.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-Yuge89N6M+NcblcvXMeyHZ6kZDfwBv3LPMDiF8HhJss="
+  },
+  {
+    "pname": "System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-DL+D2sc2JrQiB4oAcUggTFyD8w3aLEjJfod5JPe+Oz4="
+  },
+  {
+    "pname": "System.Security.Cryptography.Pkcs",
+    "version": "6.0.0",
+    "hash": "sha256-xMSJGgn+UGGe9eGNaZ04OsyiFO7fYtDfz7zsya/9AOE="
+  },
+  {
+    "pname": "System.Security.Cryptography.Pkcs",
+    "version": "7.0.0",
+    "hash": "sha256-3J3vL9hcKSuZjT2GKappa2A9p2xJm1nH2asTNAl8ZCA="
+  },
+  {
+    "pname": "System.Security.Cryptography.Primitives",
+    "version": "4.0.0",
+    "hash": "sha256-sEdPftfTxQd/8DpdpqUZC2XWC0SjVCPqAkEleLl17EQ="
+  },
+  {
+    "pname": "System.Security.Cryptography.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-fnFi7B3SnVj5a+BbgXnbjnGNvWrCEU6Hp/wjsjWz318="
+  },
+  {
+    "pname": "System.Security.Cryptography.ProtectedData",
+    "version": "4.7.0",
+    "hash": "sha256-dZfs5q3Ij1W1eJCfYjxI2o+41aSiFpaAugpoECaCOug="
+  },
+  {
+    "pname": "System.Security.Cryptography.X509Certificates",
+    "version": "4.3.0",
+    "hash": "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0="
+  },
+  {
+    "pname": "System.Security.Cryptography.Xml",
+    "version": "7.0.1",
+    "hash": "sha256-CH8+JVC8LyCSW75/6ZQ7ecMbSOAE1c16z4dG8JTp01w="
+  },
+  {
+    "pname": "System.Security.Permissions",
+    "version": "4.7.0",
+    "hash": "sha256-BGgXMLUi5rxVmmChjIhcXUxisJjvlNToXlyaIbUxw40="
+  },
+  {
+    "pname": "System.Security.Principal",
+    "version": "4.3.0",
+    "hash": "sha256-rjudVUHdo8pNJg2EVEn0XxxwNo5h2EaYo+QboPkXlYk="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "4.3.0",
+    "hash": "sha256-mbdLVUcEwe78p3ZnB6jYsizNEqxMaCAWI3tEQNhRQAE="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "4.7.0",
+    "hash": "sha256-rWBM2U8Kq3rEdaa1MPZSYOOkbtMGgWyB8iPrpIqmpqg="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "5.0.0",
+    "hash": "sha256-CBOQwl9veFkrKK2oU8JFFEiKIh/p+aJO+q9Tc2Q/89Y="
+  },
+  {
+    "pname": "System.Security.SecureString",
+    "version": "4.0.0",
+    "hash": "sha256-XxZUSqSe/oiXzyXsQX6+kgJ8mLRwa/J1fLCgYogr2Ag="
+  },
+  {
+    "pname": "System.Text.Encoding",
+    "version": "4.0.11",
+    "hash": "sha256-PEailOvG05CVgPTyKLtpAgRydlSHmtd5K0Y8GSHY2Lc="
+  },
+  {
+    "pname": "System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg="
+  },
+  {
+    "pname": "System.Text.Encoding.CodePages",
+    "version": "4.5.1",
+    "hash": "sha256-PIhkv59IXjyiuefdhKxS9hQfEwO9YWRuNudpo53HQfw="
+  },
+  {
+    "pname": "System.Text.Encoding.CodePages",
+    "version": "6.0.0",
+    "hash": "sha256-nGc2A6XYnwqGcq8rfgTRjGr+voISxNe/76k2K36coj4="
+  },
+  {
+    "pname": "System.Text.Encoding.Extensions",
+    "version": "4.0.11",
+    "hash": "sha256-+kf7J3dEhgCbnCM5vHYlsTm5/R/Ud0Jr6elpHm922iI="
+  },
+  {
+    "pname": "System.Text.Encoding.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
+    "version": "4.5.0",
+    "hash": "sha256-o+jikyFOG30gX57GoeZztmuJ878INQ5SFMmKovYqLWs="
+  },
+  {
+    "pname": "System.Text.Encodings.Web",
+    "version": "4.7.0",
+    "hash": "sha256-w3KhanXU1v+0uWZuLECd1oChvYeUrGhN5blk5WBco2k="
+  },
+  {
+    "pname": "System.Text.RegularExpressions",
+    "version": "4.1.0",
+    "hash": "sha256-x6OQN6MCN7S0fJ6EFTfv4rczdUWjwuWE9QQ0P6fbh9c="
+  },
+  {
+    "pname": "System.Text.RegularExpressions",
+    "version": "4.3.0",
+    "hash": "sha256-VLCk1D1kcN2wbAe3d0YQM/PqCsPHOuqlBY1yd2Yo+K0="
+  },
+  {
+    "pname": "System.Threading",
+    "version": "4.0.11",
+    "hash": "sha256-mob1Zv3qLQhQ1/xOLXZmYqpniNUMCfn02n8ZkaAhqac="
+  },
+  {
+    "pname": "System.Threading",
+    "version": "4.3.0",
+    "hash": "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc="
+  },
+  {
+    "pname": "System.Threading.Tasks",
+    "version": "4.0.11",
+    "hash": "sha256-5SLxzFg1df6bTm2t09xeI01wa5qQglqUwwJNlQPJIVs="
+  },
+  {
+    "pname": "System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w="
+  },
+  {
+    "pname": "System.Threading.Tasks.Dataflow",
+    "version": "4.9.0",
+    "hash": "sha256-ZTZBJTrP5kzO38ec9lPxuNUYgEoeGNdQ8hF98uRN2rw="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.0.0",
+    "hash": "sha256-+YdcPkMhZhRbMZHnfsDwpNbUkr31X7pQFGxXYcAPZbE="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-X2hQ5j+fxcmnm88Le/kSavjiGOmkcumBGTZKBLvorPc="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.5.1",
+    "hash": "sha256-3NeBC+r7eTVz3f+cEm1NkVhxSr7LrYGX/NdUwje9ecY="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.5.2",
+    "hash": "sha256-EqJF9TppMHTKvpR6emrdA61zalMW3HwrZ7j6Bn4bBuo="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.5.3",
+    "hash": "sha256-8TglbC6KBHlDeSfgr6d5dGn7wu8td4XERl2JUyo0+Tw="
+  },
+  {
+    "pname": "System.Threading.Thread",
+    "version": "4.0.0",
+    "hash": "sha256-7EtSJuKqcW107FYA5Ko9NFXEWUPIzNDtlfKaQV2pvb8="
+  },
+  {
+    "pname": "System.Threading.Thread",
+    "version": "4.3.0",
+    "hash": "sha256-pMs6RNFC3nQOGz9EqIcyWmO8YLaqay+q/Qde5hqPXXg="
+  },
+  {
+    "pname": "System.Threading.ThreadPool",
+    "version": "4.0.10",
+    "hash": "sha256-/fowWjM/0ZZFC1Rwu0i5N71iRxV2JOd3jQV2Jn0wuTk="
+  },
+  {
+    "pname": "System.Threading.ThreadPool",
+    "version": "4.3.0",
+    "hash": "sha256-wW0QdvssRoaOfQLazTGSnwYTurE4R8FxDx70pYkL+gg="
+  },
+  {
+    "pname": "System.Threading.Timer",
+    "version": "4.0.1",
+    "hash": "sha256-5lU6zt1O9JDSPr2KAHw4BYgysHnt0yyZrMNa5IIjxZY="
+  },
+  {
+    "pname": "System.Threading.Timer",
+    "version": "4.3.0",
+    "hash": "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s="
+  },
+  {
+    "pname": "System.Windows.Extensions",
+    "version": "4.7.0",
+    "hash": "sha256-yW+GvQranReaqPw5ZFv+mSjByQ5y1pRLl05JIEf3tYU="
+  },
+  {
+    "pname": "System.Xml.ReaderWriter",
+    "version": "4.0.11",
+    "hash": "sha256-haZAFFQ9Sl2DhfvEbdx2YRqKEoxNMU5STaqpMmXw0zA="
+  },
+  {
+    "pname": "System.Xml.ReaderWriter",
+    "version": "4.3.0",
+    "hash": "sha256-QQ8KgU0lu4F5Unh+TbechO//zaAGZ4MfgvW72Cn1hzA="
+  },
+  {
+    "pname": "System.Xml.XDocument",
+    "version": "4.0.11",
+    "hash": "sha256-KPz1kxe0RUBM+aoktJ/f9p51GudMERU8Pmwm//HdlFg="
+  },
+  {
+    "pname": "System.Xml.XDocument",
+    "version": "4.3.0",
+    "hash": "sha256-rWtdcmcuElNOSzCehflyKwHkDRpiOhJJs8CeQ0l1CCI="
+  },
+  {
+    "pname": "System.Xml.XmlDocument",
+    "version": "4.3.0",
+    "hash": "sha256-kbuV4Y7rVJkfMp2Kgoi8Zvdatm9CZNmlKB3GZgANvy4="
+  },
+  {
+    "pname": "Twilio",
+    "version": "6.13.0",
+    "hash": "sha256-+1+oNjq48C8YIo5G3wJ7Q+s9ou6Sy0JBLR7H4Ln/KmA="
+  },
+  {
+    "pname": "WampSharp",
+    "version": "20.1.1",
+    "hash": "sha256-zHSs7oLcChdVXUbS7WU2ch8hKZPKhwbUNGJ9outadB4="
+  },
+  {
+    "pname": "WampSharp.AspNetCore.WebSockets.Server",
+    "version": "20.1.1",
+    "hash": "sha256-lg3S8hWKV3vm0C9EmN3GloKidkhW3aAJvB9NHw0DXdQ="
+  },
+  {
+    "pname": "WampSharp.Default",
+    "version": "20.1.1",
+    "hash": "sha256-YjHdd/OQV38YgUy24g4X1+1gq7yMu4VmZLOj9ex9Nec="
+  },
+  {
+    "pname": "WampSharp.Default.Client",
+    "version": "20.1.1",
+    "hash": "sha256-hMbJUMZcr5Z0G1UxocJWBHTP7DAgYu+eXxCFo+9X/do="
+  },
+  {
+    "pname": "WampSharp.Default.Router",
+    "version": "20.1.1",
+    "hash": "sha256-38I/AKG2tX/etnvo5GSwVix4VHTyVEiMmXliSct4otI="
+  },
+  {
+    "pname": "WampSharp.Fleck",
+    "version": "20.1.1",
+    "hash": "sha256-SgizGDyt1/mtUmNJ67fMiI/LImisbqUfcWfRqCRr6yw="
+  },
+  {
+    "pname": "WampSharp.NewtonsoftJson",
+    "version": "20.1.1",
+    "hash": "sha256-WwvxFONoq5/Atk9myXx7+B1TaKifDCspedFjXG3kKbA="
+  },
+  {
+    "pname": "WampSharp.NewtonsoftMessagePack",
+    "version": "20.1.1",
+    "hash": "sha256-CHe6Vo1ltfAJdCog6SMj00Kh3DvYjyap9048C+aN2fo="
+  },
+  {
+    "pname": "WampSharp.NewtonsoftMsgpack",
+    "version": "20.1.1",
+    "hash": "sha256-R+Khj56ElSn1brAZMfCiT7cWaxp3YaOAwGZyUW6GHP4="
+  },
+  {
+    "pname": "WampSharp.WebSockets",
+    "version": "20.1.1",
+    "hash": "sha256-nV9t4bbedfFClyIrguPqek2kGT4IoOevaCpmyaEiBcY="
+  },
+  {
+    "pname": "WebMarkupMin.Core",
+    "version": "2.13.0",
+    "hash": "sha256-/M22iNVxb4OyRGI4DdCkXQ41YO0MfB6WJ76XrupQBRw="
+  },
+  {
+    "pname": "WebMarkupMin.NUglify",
+    "version": "2.12.0",
+    "hash": "sha256-sOUS0N5p/8xr1xKY1gbUrvmjIHC6EDKSu0hDDK5vqVA="
+  },
+  {
+    "pname": "ZstdSharp.Port",
+    "version": "0.6.2",
+    "hash": "sha256-KFnU18uLr9MxnOTZcyD9nfhIxLfkc0Gsu5BSOwOVfZE="
+  }
+]

--- a/pkgs/by-name/no/notesnook-sync-server/package.nix
+++ b/pkgs/by-name/no/notesnook-sync-server/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildDotnetModule,
+  dotnetCorePackages,
+  fetchFromGitHub,
+  _experimental-update-script-combinators,
+  gitUpdater,
+}:
+
+buildDotnetModule rec {
+  pname = "notesnook-sync-server";
+  version = "1.0-beta.1";
+
+  src = fetchFromGitHub {
+    owner = "streetwriters";
+    repo = "notesnook-sync-server";
+    tag = "v${version}";
+    hash = "sha256-A2RM/1k9YAwal2MUEfuZMJU9ixf0jOH0rj3JPnGdgws=";
+  };
+
+  nugetDeps = ./deps.json;
+
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnetCorePackages.aspnetcore_8_0;
+
+  dotnetBuildFlags = [
+    # fix for "The process cannot access the file '...deps.json' because it is being used by another process."
+    "/maxcpucount:1"
+  ];
+
+  executables = [
+    "Notesnook.API"
+    "Streetwriters.Identity"
+    "Streetwriters.Messenger"
+  ];
+
+  passthru.updateScript = _experimental-update-script-combinators.sequence [
+    (gitUpdater { }).command
+    (passthru.fetch-deps)
+  ];
+
+  meta = {
+    description = "Sync server for Notesnook (self-hosting in alpha)";
+    homepage = "https://github.com/streetwriters/notesnook-sync-server";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [
+      gepbird
+    ];
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[notesnook-sync-server](https://github.com/streetwriters/notesnook-sync-server) is for self-hosting the storage (and other components?) for [notesnook](https://notesnook.com/) ([existing nix package](https://search.nixos.org/packages?channel=unstable&show=notesnook&type=packages&query=notesnook)).

The package builds, but without tinkering a lot this isn't really useful without a nixos module. The docs for using this is not there yet, but I'll try to figure it out soon.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
