### PR TITLE
libftdi: fix cross-compile

### DIFF
--- a/pkgs/development/libraries/libftdi/default.nix
+++ b/pkgs/development/libraries/libftdi/default.nix
@@ -27,7 +27,9 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ libusb-compat-0_1 ];
 
-  configureFlags = lib.optional (!stdenv.hostPlatform.isDarwin) "--with-async-mode";
+  configureFlags = [
+    "ac_cv_prog_HAVELIBUSB=${lib.getExe' (lib.getDev libusb-compat-0_1) "libusb-config"}"
+  ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) "--with-async-mode";
 
   # allow async mode. from ubuntu. see:
   #   https://bazaar.launchpad.net/~ubuntu-branches/ubuntu/trusty/libftdi/trusty/view/head:/debian/patches/04_async_mode.diff


### PR DESCRIPTION
libusb-config is required. Putting it in nativeBuildInputs won't work since it depends on having the correct hostPlatform set.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: regular and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).