### PR TITLE
ride: bump nan version to fix build with nodejs_22

### DIFF
--- a/pkgs/by-name/ri/ride/package.nix
+++ b/pkgs/by-name/ri/ride/package.nix
@@ -25,7 +25,7 @@ buildNpmPackage rec {
     hash = "sha256-xR+HVC1JVrPkgPhIJZxdTVG52+QbanmD1c/uO5l84oc=";
   };
 
-  npmDepsHash = "sha256-h+48/9h7/cD8woyA0UCLtzKuE9jCrfpDk6IeoDWnYik=";
+  npmDepsHash = "sha256-C8puCz/w5xkaR4QVXXOdoO8n4gNZrRWMcB9/f1DcuMc=";
 
   patches = [
     # Adds support for electron versions >=28
@@ -39,6 +39,9 @@ buildNpmPackage rec {
     (replaceVars ./mk.patch {
       inherit version;
     })
+
+    # would not build with nodejs_22 and above without this
+    ./update-nan.patch
   ];
 
   postPatch = ''

--- a/pkgs/by-name/ri/ride/update-nan.patch
+++ b/pkgs/by-name/ri/ride/update-nan.patch
@@ -1,0 +1,31 @@
+diff --git a/package-lock.json b/package-lock.json
+index a0bd285..5a5ec59 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -8034,9 +8034,10 @@
+       "dev": true
+     },
+     "node_modules/nan": {
+-      "version": "2.17.0",
+-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
++      "version": "2.22.0",
++      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
++      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
++      "license": "MIT",
+       "optional": true
+     },
+     "node_modules/nanomatch": {
+@@ -18258,9 +18259,9 @@
+       "dev": true
+     },
+     "nan": {
+-      "version": "2.17.0",
+-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
++      "version": "2.22.0",
++      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
++      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+       "optional": true
+     },
+     "nanomatch": {


### PR DESCRIPTION
Fixes the build of `ride`
https://hydra.nixos.org/build/282401398/nixlog/2

Will probably report this upstream later.

Generated the patch by running `npm update nan`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
