### PR TITLE
mesa: fix cross compilation

### DIFF
--- a/pkgs/development/libraries/mesa/cross_clc.patch
+++ b/pkgs/development/libraries/mesa/cross_clc.patch
@@ -1,0 +1,90 @@
+commit f063e9f74b45f34e4ac570a90901253bf8e64efd
+Author: Mary Guillemard <mary.guillemard@collabora.com>
+Date:   2024-12-02 09:11:35 +0100
+
+    meson: Add mesa-clc and install-mesa-clc options
+    
+    Due to the cross build issues in current meson, we adds new options to
+    allow mesa_clc and vtn_bindgen to be installed or searched on the
+    system.
+    
+    Signed-off-by: Mary Guillemard <mary.guillemard@collabora.com>
+    Reviewed-by: Alyssa Rosenzweig <alyssa@rosenzweig.io>
+    Reviewed-by: Boris Brezillon <boris.brezillon@collabora.com>
+    Part-of: <https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32719>
+
+diff --git a/meson.build b/meson.build
+index de9c9af53a1..e37325ec176 100644
+--- a/meson.build
++++ b/meson.build
+@@ -808,7 +808,7 @@ if with_gallium_rusticl or with_nouveau_vk or with_tools.contains('etnaviv')
+ endif
+ 
+ with_clover_spirv = with_gallium_clover and get_option('opencl-spirv')
+-with_clc = with_microsoft_clc or with_intel_clc or with_gallium_asahi or with_asahi_vk or with_gallium_rusticl or with_clover_spirv
++with_clc = get_option('mesa-clc') != 'auto' or with_microsoft_clc or with_intel_clc or with_gallium_asahi or with_asahi_vk or with_gallium_rusticl
+ 
+ dep_clc = null_dep
+ if with_gallium_clover or with_clc
+diff --git a/meson_options.txt b/meson_options.txt
+index 79ee65e6094..8f22b36e5fb 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -744,3 +744,20 @@ option(
+     'none', 'dri2'
+   ],
+ )
++
++option(
++  'mesa-clc',
++  type : 'combo',
++  value : 'auto',
++  choices : [
++    'enabled', 'system', 'auto'
++  ],
++  description : 'Build the mesa-clc compiler or use a system version.'
++)
++
++option(
++  'install-mesa-clc',
++  type : 'boolean',
++  value : false,
++  description : 'Install the mesa-clc compiler (if needed for cross builds).'
++)
+diff --git a/src/compiler/clc/meson.build b/src/compiler/clc/meson.build
+index 74767d08de2..4875d71ca21 100644
+--- a/src/compiler/clc/meson.build
++++ b/src/compiler/clc/meson.build
+@@ -117,15 +117,20 @@ idep_mesaclc = declare_dependency(
+   link_args : _idep_mesaclc_link_args,
+ )
+ 
+-prog_mesa_clc = executable(
+-  'mesa_clc',
+-  ['mesa_clc.c'],
+-  include_directories : [inc_include, inc_src],
+-  c_args : [pre_args, no_override_init_args],
+-  link_args : [ld_args_build_id],
+-  dependencies : [idep_mesaclc, dep_llvm, dep_spirv_tools, idep_getopt],
+-  # If we can run host binaries directly, just build mesa_clc for the host.
+-  # Most commonly this happens when doing a cross compile from an x86_64 build
+-  # machine to an x86 host
+-  native : not meson.can_run_host_binaries(),
+-)
++if get_option('mesa-clc') == 'system'
++  prog_mesa_clc = find_program('mesa_clc', native : true)
++else
++  prog_mesa_clc = executable(
++    'mesa_clc',
++    ['mesa_clc.c'],
++    include_directories : [inc_include, inc_src],
++    c_args : [pre_args, no_override_init_args],
++    link_args : [ld_args_build_id],
++    dependencies : [idep_mesaclc, dep_llvm, dep_spirv_tools, idep_getopt],
++    # If we can run host binaries directly, just build mesa_clc for the host.
++    # Most commonly this happens when doing a cross compile from an x86_64 build
++    # machine to an x86 host
++    native : not meson.can_run_host_binaries(),
++    install : get_option('install-mesa-clc'),
++  )
++endif

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -138,6 +138,9 @@ in stdenv.mkDerivation {
 
   patches = [
     ./opencl.patch
+    # cherry-picked from https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32719
+    # safe to remove for versions > 24.3.2
+    ./cross_clc.patch
   ];
 
   postPatch = ''
@@ -204,6 +207,7 @@ in stdenv.mkDerivation {
 
     # Enable Intel RT stuff when available
     (lib.mesonBool "install-intel-clc" true)
+    (lib.mesonBool "install-mesa-clc" true)
     (lib.mesonEnable "intel-rt" stdenv.hostPlatform.isx86_64)
     (lib.mesonOption "clang-libdir" "${lib.getLib llvmPackages.clang-unwrapped}/lib")
 
@@ -222,6 +226,7 @@ in stdenv.mkDerivation {
     (lib.mesonOption "video-codecs" "all")
   ] ++ lib.optionals needNativeCLC [
     (lib.mesonOption "intel-clc" "system")
+    (lib.mesonOption "mesa-clc" "system")
   ];
 
   strictDeps = true;
@@ -333,6 +338,7 @@ in stdenv.mkDerivation {
     echo $opencl/lib/libRusticlOpenCL.so > $opencl/etc/OpenCL/vendors/rusticl.icd
 
     moveToOutput bin/intel_clc $driversdev
+    moveToOutput bin/mesa_clc $driversdev
     moveToOutput lib/gallium-pipe $opencl
     moveToOutput "lib/lib*OpenCL*" $opencl
     moveToOutput "lib/libOSMesa*" $osmesa


### PR DESCRIPTION
this follows the same pattern as used for mesa's `intel-clc` build helper:

1. build `mesa-clc` for the build machine.
2. provide the native `mesa-clc` when cross-compiling mesa.

the meson changes for this have been upstreamed into the next release:

https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32719


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux  (and `pkgsCross.aarch64-multiplatform.mesa`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
