### PR TITLE
actions/no-channel-pr: re run when base branch is updated

### DIFF
--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -1,18 +1,17 @@
 name: "No channel PR"
 
 on:
-  pull_request:
+  pull_request_target:
+    # Re-run should be triggered when the base branch is updated, instead of silently failing
+    types: [opened, synchronize, reopened, edited]
     branches:
       - 'nixos-**'
       - 'nixpkgs-**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   fail:
-    permissions:
-      contents: none
     name: "This PR is is targeting a channel branch"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Additionally, no permissions are needed so set it to an empty set
Signed-off-by: John Titor <50095635+JohnRTitor@users.noreply.github.com>

Fixes a bug with this action reported in https://github.com/NixOS/nixpkgs/issues/355847#issuecomment-2564687743