### PR TITLE
obs-studio: 30.2.3 -> 31.0.1

### DIFF
--- a/pkgs/applications/video/obs-studio/CMakeUserPresets.json
+++ b/pkgs/applications/video/obs-studio/CMakeUserPresets.json
@@ -1,0 +1,17 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "nixpkgs-linux",
+      "displayName": "Nixpkgs (Linux)",
+      "inherits": ["ubuntu"],
+      "binaryDir": "${sourceDir}/build"
+    },
+    {
+      "name": "nixpkgs-darwin",
+      "displayName": "Nixpkgs (Darwin)",
+      "inherits": ["macos"],
+      "binaryDir": "${sourceDir}/build"
+    }
+  ]
+}

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -65,13 +65,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "obs-studio";
-  version = "30.2.3";
+  version = "31.0.1";
 
   src = fetchFromGitHub {
     owner = "obsproject";
     repo = "obs-studio";
     rev = finalAttrs.version;
-    hash = "sha256-4bAzW62xX9apKOAJyn3iys1bFdHj4re2reMZtlGsn5s=";
+    hash = "sha256-dwS/90j4WfcneAsGFwuABM7xqvq1+VSD2uDVdU/GgQo=";
     fetchSubmodules = true;
   };
 
@@ -81,29 +81,6 @@ stdenv.mkDerivation (finalAttrs: {
     # Lets obs-browser build against CEF 90.1.0+
     ./Enable-file-access-and-universal-access-for-file-URL.patch
     ./fix-nix-plugin-path.patch
-
-    # Fix libobs.pc for plugins on non-x86 systems
-    (fetchpatch {
-      name = "fix-arm64-cmake.patch";
-      url = "https://git.alpinelinux.org/aports/plain/community/obs-studio/broken-config.patch?id=a92887564dcc65e07b6be8a6224fda730259ae2b";
-      hash = "sha256-yRSw4VWDwMwysDB3Hw/tsmTjEQUhipvrVRQcZkbtuoI=";
-      includes = [ "*/CompilerConfig.cmake" ];
-    })
-
-    (fetchpatch {
-      name = "qt-6.8.patch";
-      url = "https://github.com/obsproject/obs-websocket/commit/d9befb9e0a4898695eef5ccbc91a4fac02027854.patch";
-      extraPrefix = "plugins/obs-websocket/";
-      stripLen = 1;
-      hash = "sha256-7SDBRr9G40b9DfbgdaYJxTeiDSLUfVixtMtM3cLTVZs=";
-    })
-
-    # Fix lossless audio, ffmpeg 7,1 compatibility issue
-    (fetchpatch {
-      name = "fix-lossless-audio.patch";
-      url = "https://github.com/obsproject/obs-studio/commit/dfc3a69c5276edf84c933035ff2a7e278fa13c9a.patch";
-      hash = "sha256-wiF3nolBpZKp7LR7NloNfJ+v4Uq/nBgwCVoKZX+VEMA=";
-    })
   ];
 
   nativeBuildInputs = [

--- a/pkgs/applications/video/obs-studio/default.nix
+++ b/pkgs/applications/video/obs-studio/default.nix
@@ -1,62 +1,62 @@
-{ config
-, uthash
-, lib
-, stdenv
-, ninja
-, nv-codec-headers-12
-, fetchFromGitHub
-, fetchpatch
-, addDriverRunpath
-, cmake
-, fdk_aac
-, ffmpeg
-, jansson
-, libjack2
-, libxkbcommon
-, libpthreadstubs
-, libXdmcp
-, qtbase
-, qtsvg
-, speex
-, libv4l
-, x264
-, curl
-, wayland
-, xorg
-, pkg-config
-, libvlc
-, libGL
-, mbedtls
-, wrapGAppsHook3
-, scriptingSupport ? true
-, luajit
-, swig
-, python3
-, alsaSupport ? stdenv.hostPlatform.isLinux
-, alsa-lib
-, pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux
-, libpulseaudio
-, libcef
-, pciutils
-, pipewireSupport ? stdenv.hostPlatform.isLinux
-, withFdk ? true
-, pipewire
-, libdrm
-, librist
-, cjson
-, libva
-, srt
-, qtwayland
-, wrapQtAppsHook
-, nlohmann_json
-, websocketpp
-, asio
-, decklinkSupport ? false
-, blackmagic-desktop-video
-, libdatachannel
-, libvpl
-, qrcodegencpp
-, nix-update-script
+{
+  config,
+  uthash,
+  lib,
+  stdenv,
+  ninja,
+  nv-codec-headers-12,
+  fetchFromGitHub,
+  addDriverRunpath,
+  cmake,
+  fdk_aac,
+  ffmpeg,
+  jansson,
+  libjack2,
+  libxkbcommon,
+  libpthreadstubs,
+  libXdmcp,
+  qtbase,
+  qtsvg,
+  speex,
+  libv4l,
+  x264,
+  curl,
+  wayland,
+  xorg,
+  pkg-config,
+  libvlc,
+  libGL,
+  mbedtls,
+  wrapGAppsHook3,
+  scriptingSupport ? true,
+  luajit,
+  swig,
+  python3,
+  alsaSupport ? stdenv.hostPlatform.isLinux,
+  alsa-lib,
+  pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  libpulseaudio,
+  libcef,
+  pciutils,
+  pipewireSupport ? stdenv.hostPlatform.isLinux,
+  withFdk ? true,
+  pipewire,
+  libdrm,
+  librist,
+  cjson,
+  libva,
+  srt,
+  qtwayland,
+  wrapQtAppsHook,
+  nlohmann_json,
+  websocketpp,
+  asio,
+  decklinkSupport ? false,
+  blackmagic-desktop-video,
+  libdatachannel,
+  libvpl,
+  qrcodegencpp,
+  nix-update-script,
 }:
 
 let
@@ -90,46 +90,52 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     wrapGAppsHook3
     wrapQtAppsHook
-  ]
-  ++ optional scriptingSupport swig;
+  ] ++ optional scriptingSupport swig;
 
-  buildInputs = [
-    curl
-    ffmpeg
-    jansson
-    libcef
-    libjack2
-    libv4l
-    libxkbcommon
-    libpthreadstubs
-    libXdmcp
-    qtbase
-    qtsvg
-    speex
-    wayland
-    x264
-    libvlc
-    mbedtls
-    pciutils
-    librist
-    cjson
-    libva
-    srt
-    qtwayland
-    nlohmann_json
-    websocketpp
-    asio
-    libdatachannel
-    libvpl
-    qrcodegencpp
-    uthash
-    nv-codec-headers-12
-  ]
-  ++ optionals scriptingSupport [ luajit python3 ]
-  ++ optional alsaSupport alsa-lib
-  ++ optional pulseaudioSupport libpulseaudio
-  ++ optionals pipewireSupport [ pipewire libdrm ]
-  ++ optional withFdk fdk_aac;
+  buildInputs =
+    [
+      curl
+      ffmpeg
+      jansson
+      libcef
+      libjack2
+      libv4l
+      libxkbcommon
+      libpthreadstubs
+      libXdmcp
+      qtbase
+      qtsvg
+      speex
+      wayland
+      x264
+      libvlc
+      mbedtls
+      pciutils
+      librist
+      cjson
+      libva
+      srt
+      qtwayland
+      nlohmann_json
+      websocketpp
+      asio
+      libdatachannel
+      libvpl
+      qrcodegencpp
+      uthash
+      nv-codec-headers-12
+    ]
+    ++ optionals scriptingSupport [
+      luajit
+      python3
+    ]
+    ++ optional alsaSupport alsa-lib
+    ++ optional pulseaudioSupport libpulseaudio
+    ++ optionals pipewireSupport [
+      pipewire
+      libdrm
+    ]
+    ++ optional withFdk fdk_aac;
 
   # Copied from the obs-linuxbrowser
   postUnpack = ''
@@ -149,7 +155,8 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   cmakeFlags = [
-    "--preset" "nixpkgs-${if stdenv.hostPlatform.isDarwin then "darwin" else "linux"}"
+    "--preset"
+    "nixpkgs-${if stdenv.hostPlatform.isDarwin then "darwin" else "linux"}"
     "-DOBS_VERSION_OVERRIDE=${finalAttrs.version}"
     "-Wno-dev" # kill dev warnings that are useless for packaging
     # Add support for browser source
@@ -172,28 +179,32 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   dontWrapGApps = true;
-  preFixup = let
-    wrapperLibraries = [
-      xorg.libX11
-      libvlc
-      libGL
-    ] ++ optionals decklinkSupport [
-      blackmagic-desktop-video
-    ];
-  in ''
-    # Remove cef components before patchelf, otherwise it will fail
-    rm $out/lib/obs-plugins/libcef.so
-    rm $out/lib/obs-plugins/libEGL.so
-    rm $out/lib/obs-plugins/libGLESv2.so
-    rm $out/lib/obs-plugins/libvk_swiftshader.so
-    rm $out/lib/obs-plugins/libvulkan.so.1
-    rm $out/lib/obs-plugins/chrome-sandbox
+  preFixup =
+    let
+      wrapperLibraries =
+        [
+          xorg.libX11
+          libvlc
+          libGL
+        ]
+        ++ optionals decklinkSupport [
+          blackmagic-desktop-video
+        ];
+    in
+    ''
+      # Remove cef components before patchelf, otherwise it will fail
+      rm $out/lib/obs-plugins/libcef.so
+      rm $out/lib/obs-plugins/libEGL.so
+      rm $out/lib/obs-plugins/libGLESv2.so
+      rm $out/lib/obs-plugins/libvk_swiftshader.so
+      rm $out/lib/obs-plugins/libvulkan.so.1
+      rm $out/lib/obs-plugins/chrome-sandbox
 
-    qtWrapperArgs+=(
-      --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}"
-      ''${gappsWrapperArgs[@]}
-    )
-  '';
+      qtWrapperArgs+=(
+        --prefix LD_LIBRARY_PATH : "$out/lib:${lib.makeLibraryPath wrapperLibraries}"
+        ''${gappsWrapperArgs[@]}
+      )
+    '';
 
   postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
     addDriverRunpath $out/lib/lib*.so
@@ -214,9 +225,17 @@ stdenv.mkDerivation (finalAttrs: {
       video content, efficiently
     '';
     homepage = "https://obsproject.com";
-    maintainers = with maintainers; [ jb55 materus fpletz ];
+    maintainers = with maintainers; [
+      jb55
+      materus
+      fpletz
+    ];
     license = with licenses; [ gpl2Plus ] ++ optional withFdk fraunhofer-fdk;
-    platforms = [ "x86_64-linux" "i686-linux" "aarch64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+      "aarch64-linux"
+    ];
     mainProgram = "obs";
   };
 })

--- a/pkgs/applications/video/obs-studio/fix-nix-plugin-path.patch
+++ b/pkgs/applications/video/obs-studio/fix-nix-plugin-path.patch
@@ -1,16 +1,3 @@
-diff --git a/cmake/Modules/ObsDefaults_Linux.cmake b/cmake/Modules/ObsDefaults_Linux.cmake
-index fe8d72364..1c590fcdb 100644
---- a/cmake/Modules/ObsDefaults_Linux.cmake
-+++ b/cmake/Modules/ObsDefaults_Linux.cmake
-@@ -76,7 +76,7 @@ macro(setup_obs_project)
-     set(OBS_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
-     set(OBS_DATA_PATH "${OBS_DATA_DESTINATION}")
- 
--    set(OBS_SCRIPT_PLUGIN_PATH "${CMAKE_INSTALL_PREFIX}/${OBS_SCRIPT_PLUGIN_DESTINATION}")
-+    set(OBS_SCRIPT_PLUGIN_PATH "${OBS_SCRIPT_PLUGIN_DESTINATION}")
-     set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${OBS_LIBRARY_DESTINATION}")
-   else()
-     set(OBS_EXECUTABLE_DESTINATION "bin/${_ARCH_SUFFIX}bit")
 diff --git a/libobs/obs-nix.c b/libobs/obs-nix.c
 index 77c36be5e..fe8a04813 100644
 --- a/libobs/obs-nix.c

--- a/pkgs/applications/video/obs-studio/plugins/wlrobs.nix
+++ b/pkgs/applications/video/obs-studio/plugins/wlrobs.nix
@@ -12,14 +12,14 @@
 
 stdenv.mkDerivation {
   pname = "wlrobs";
-  version = "unstable-2023-08-23";
+  version = "unstable-2024-12-24";
 
   src = fetchFromSourcehut {
     vc = "hg";
     owner = "~scoopta";
     repo = "wlrobs";
-    rev = "f72d5cb3cbbd3983ae6cfd86cb1940be7372681c";
-    hash = "sha256-hiM0d38SSUqbyisP3fAtKRLBDjVKZdU2U1xyXci7yNk=";
+    rev = "b8668b4d6d6d33e3de86ce3fa4331249bc0abc8b";
+    hash = "sha256-gqGnDrfID5hTcpX3EkSGg4yDwa/ZKCQCqJ3feq44I1I=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This is a bump for OBS Studio from 30 to 31, which is a little bit more involved than most. There is a change from the "old" build system to a newer build system, which is still CMake-based but has been reworked to make use of the CMake presets system.

There are a few patches we (seem to) no longer need, so they've been dropped, but I haven't had a chance to test how this goes on macOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
