### PR TITLE
owmods-gui: init at 0.15.0

### DIFF
--- a/pkgs/by-name/ow/owmods-gui/package.nix
+++ b/pkgs/by-name/ow/owmods-gui/package.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  libsoup_3,
+  dbus,
+  glib,
+  glib-networking,
+  librsvg,
+  webkitgtk_4_1,
+  pkg-config,
+  wrapGAppsHook3,
+  makeDesktopItem,
+  copyDesktopItems,
+  rustPlatform,
+  buildNpmPackage,
+  fetchFromGitHub,
+  mono,
+  wrapWithMono ? true,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "owmods-gui";
+  version = "0.15.0";
+
+  src = fetchFromGitHub {
+    owner = "ow-mods";
+    repo = "ow-mod-man";
+    tag = "gui_v${version}";
+    hash = "sha256-rTANG+yHE8YfWYUyELoKgj4El+1ZW6vI9NkgADD40pw=";
+  };
+
+  cargoHash = "sha256-rFkh2G7kFuQI7nlZIwaqvt7x9bKLqmWU21YwZu2+wUA=";
+
+  buildFeatures = [
+    "tauri/custom-protocol"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    copyDesktopItems
+    wrapGAppsHook3
+  ];
+
+  buildInputs = [
+    dbus
+    libsoup_3
+    glib
+    librsvg
+    glib-networking
+    webkitgtk_4_1
+  ];
+
+  buildAndTestSubdir = "owmods_gui/backend";
+
+  preFixup = lib.optionalString wrapWithMono "gappsWrapperArgs+=(--prefix PATH : '${mono}/bin')";
+
+  postPatch =
+    let
+      frontend = buildNpmPackage {
+        inherit version;
+
+        env.VITE_VERSION_SUFFIX = "-nix";
+
+        pname = "owmods-gui-ui";
+        src = "${src}/owmods_gui/frontend";
+
+        packageJSON = "${src}/owmods_gui/frontend/package.json";
+        npmDepsHash = "sha256-h6e+hQzd52G3XtufioEYlBuXNu6I+ZTQcNgJaQdaAck=";
+
+        postBuild = ''
+          cp -r ../dist/ $out
+        '';
+        distPhase = "true";
+        dontInstall = true;
+        installInPlace = true;
+        distDir = "../dist";
+
+        meta = {
+          description = "Web frontend for the Outer Wilds Mod Manager";
+          homepage = "https://github.com/ow-mods/ow-mod-man/tree/main/owmods_gui/frontend";
+          license = lib.licenses.gpl3Plus;
+        };
+      };
+    in
+    ''
+      substituteInPlace owmods_gui/backend/tauri.conf.json \
+        --replace-fail '"frontendDist": "../dist"' '"frontendDist": "${frontend}"'
+    '';
+
+  postInstall = ''
+    install -DT owmods_gui/backend/icons/128x128@2x.png $out/share/icons/hicolor/256x256@2/apps/outer-wilds-mod-manager.png
+    install -DT owmods_gui/backend/icons/128x128.png $out/share/icons/hicolor/128x128/apps/outer-wilds-mod-manager.png
+    install -DT owmods_gui/backend/icons/32x32.png $out/share/icons/hicolor/32x32/apps/outer-wilds-mod-manager.png
+
+    mv $out/bin/owmods_gui $out/bin/outer-wilds-mod-manager
+  '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "outer-wilds-mod-manager";
+      exec = "outer-wilds-mod-manager %u";
+      icon = "outer-wilds-mod-manager";
+      desktopName = "Outer Wilds Mod Manager";
+      categories = [ "Game" ];
+      comment = "Manage Outer Wilds Mods";
+      mimeTypes = [ "x-scheme-handler/owmods" ];
+    })
+  ];
+
+  meta = {
+    description = "GUI version of the mod manager for Outer Wilds Mod Loader";
+    homepage = "https://github.com/ow-mods/ow-mod-man/tree/main/owmods_gui";
+    downloadPage = "https://github.com/ow-mods/ow-mod-man/releases/tag/gui_v${version}";
+    changelog = "https://github.com/ow-mods/ow-mod-man/releases/tag/gui_v${version}";
+    mainProgram = "outer-wilds-mod-manager";
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      bwc9876
+      locochoco
+      spoonbaker
+    ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A GUI mod manager for the game Outer Wilds. Uses webkit2gtk to render the frontend, requires Mono in order to run the mod loader.

Homepage: <https://github.com/ow-mods/ow-mod-man/tree/main/owmods_gui>

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
