### PR TITLE
treewide/nixos: remove `with lib;` part 10

### DIFF
--- a/nixos/modules/services/search/manticore.nix
+++ b/nixos/modules/services/search/manticore.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.manticore;
@@ -14,7 +11,7 @@ let
 
   toSphinx =
     {
-      mkKeyValue ? generators.mkKeyValueDefault { } "=",
+      mkKeyValue ? lib.generators.mkKeyValueDefault { } "=",
       listsAsDuplicateKeys ? true,
     }:
     attrsOfAttrs:
@@ -22,7 +19,7 @@ let
       # map function to string for each key val
       mapAttrsToStringsSep =
         sep: mapFn: attrs:
-        concatStringsSep sep (mapAttrsToList mapFn attrs);
+        lib.concatStringsSep sep (lib.mapAttrsToList mapFn attrs);
       mkSection =
         sectName: sectValues:
         ''
@@ -46,9 +43,9 @@ in
   options = {
     services.manticore = {
 
-      enable = mkEnableOption "Manticoresearch";
+      enable = lib.mkEnableOption "Manticoresearch";
 
-      settings = mkOption {
+      settings = lib.mkOption {
         default = {
           searchd = {
             listen = [
@@ -67,10 +64,10 @@ in
           <https://manual.manticoresearch.com/Server%20settings>
           for more information.
         '';
-        type = types.submodule {
+        type = lib.types.submodule {
           freeformType = format.type;
         };
-        example = literalExpression ''
+        example = lib.literalExpression ''
           {
             searchd = {
                 listen = [
@@ -90,7 +87,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     systemd = {
       packages = [ pkgs.manticoresearch ];

--- a/nixos/modules/services/search/meilisearch.nix
+++ b/nixos/modules/services/search/meilisearch.nix
@@ -4,16 +4,13 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.meilisearch;
 
 in
 {
 
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     Br1ght0ne
     happysalada
   ];
@@ -22,37 +19,37 @@ in
   ###### interface
 
   options.services.meilisearch = {
-    enable = mkEnableOption "MeiliSearch - a RESTful search API";
+    enable = lib.mkEnableOption "MeiliSearch - a RESTful search API";
 
-    package = mkPackageOption pkgs "meilisearch" {
+    package = lib.mkPackageOption pkgs "meilisearch" {
       extraDescription = ''
         Use this if you require specific features to be enabled. The default package has no features.
       '';
     };
 
-    listenAddress = mkOption {
+    listenAddress = lib.mkOption {
       description = "MeiliSearch listen address.";
       default = "127.0.0.1";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    listenPort = mkOption {
+    listenPort = lib.mkOption {
       description = "MeiliSearch port to listen on.";
       default = 7700;
-      type = types.port;
+      type = lib.types.port;
     };
 
-    environment = mkOption {
+    environment = lib.mkOption {
       description = "Defines the running environment of MeiliSearch.";
       default = "development";
-      type = types.enum [
+      type = lib.types.enum [
         "development"
         "production"
       ];
     };
 
     # TODO change this to LoadCredentials once possible
-    masterKeyEnvironmentFile = mkOption {
+    masterKeyEnvironmentFile = lib.mkOption {
       description = ''
         Path to file which contains the master key.
         By doing so, all routes will be protected and will require a key to be accessed.
@@ -61,10 +58,10 @@ in
         MEILI_MASTER_KEY=my_secret_key
       '';
       default = null;
-      type = with types; nullOr path;
+      type = with lib.types; nullOr path;
     };
 
-    noAnalytics = mkOption {
+    noAnalytics = lib.mkOption {
       description = ''
         Deactivates analytics.
         Analytics allow MeiliSearch to know how many users are using MeiliSearch,
@@ -72,10 +69,10 @@ in
         This process is entirely anonymous.
       '';
       default = true;
-      type = types.bool;
+      type = lib.types.bool;
     };
 
-    logLevel = mkOption {
+    logLevel = lib.mkOption {
       description = ''
         Defines how much detail should be present in MeiliSearch's logs.
         MeiliSearch currently supports four log levels, listed in order of increasing verbosity:
@@ -86,10 +83,10 @@ in
           Useful when diagnosing issues and debugging
       '';
       default = "INFO";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    maxIndexSize = mkOption {
+    maxIndexSize = lib.mkOption {
       description = ''
         Sets the maximum size of the index.
         Value must be given in bytes or explicitly stating a base unit.
@@ -97,10 +94,10 @@ in
         Default is 100 GiB
       '';
       default = "107374182400";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    payloadSizeLimit = mkOption {
+    payloadSizeLimit = lib.mkOption {
       description = ''
         Sets the maximum size of accepted JSON payloads.
         Value must be given in bytes or explicitly stating a base unit.
@@ -108,14 +105,14 @@ in
         Default is ~ 100 MB
       '';
       default = "104857600";
-      type = types.str;
+      type = lib.types.str;
     };
 
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     # used to restore dumps
     environment.systemPackages = [ cfg.package ];
@@ -127,7 +124,7 @@ in
       environment = {
         MEILI_DB_PATH = "/var/lib/meilisearch";
         MEILI_HTTP_ADDR = "${cfg.listenAddress}:${toString cfg.listenPort}";
-        MEILI_NO_ANALYTICS = boolToString cfg.noAnalytics;
+        MEILI_NO_ANALYTICS = lib.boolToString cfg.noAnalytics;
         MEILI_ENV = cfg.environment;
         MEILI_DUMP_DIR = "/var/lib/meilisearch/dumps";
         MEILI_LOG_LEVEL = cfg.logLevel;
@@ -137,7 +134,7 @@ in
         ExecStart = "${cfg.package}/bin/meilisearch";
         DynamicUser = true;
         StateDirectory = "meilisearch";
-        EnvironmentFile = mkIf (cfg.masterKeyEnvironmentFile != null) cfg.masterKeyEnvironmentFile;
+        EnvironmentFile = lib.mkIf (cfg.masterKeyEnvironmentFile != null) cfg.masterKeyEnvironmentFile;
       };
     };
   };

--- a/nixos/modules/services/search/opensearch.nix
+++ b/nixos/modules/services/search/opensearch.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.opensearch;
 
@@ -28,7 +25,7 @@ in
 {
 
   options.services.opensearch = {
-    enable = mkEnableOption "OpenSearch";
+    enable = lib.mkEnableOption "OpenSearch";
 
     package = lib.mkPackageOption pkgs "OpenSearch" {
       default = [ "opensearch" ];
@@ -113,13 +110,13 @@ in
         rootLogger.level = info
         rootLogger.appenderRef.console.ref = console
       '';
-      type = types.str;
+      type = lib.types.str;
     };
 
     dataDir = lib.mkOption {
       type = lib.types.path;
       default = "/var/lib/opensearch";
-      apply = converge (removeSuffix "/");
+      apply = lib.converge (lib.removeSuffix "/");
       description = ''
         Data directory for OpenSearch. If you change this, you need to
         manually create the directory. You also need to create the
@@ -173,7 +170,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.opensearch = {
       description = "OpenSearch Daemon";
       wantedBy = [ "multi-user.target" ];
@@ -194,7 +191,7 @@ in
                   set -o errexit -o pipefail -o nounset -o errtrace
                   shopt -s inherit_errexit
                 ''
-                + (optionalString (!config.boot.isContainer) ''
+                + (lib.optionalString (!config.boot.isContainer) ''
                   # Only set vm.max_map_count if lower than ES required minimum
                   # This avoids conflict if configured via boot.kernel.sysctl
                   if [ $(${pkgs.procps}/bin/sysctl -n vm.max_map_count) -lt 262144 ]; then
@@ -268,7 +265,7 @@ in
           TimeoutStartSec = "infinity";
           DynamicUser = usingDefaultUserAndGroup && usingDefaultDataDir;
         }
-        // (optionalAttrs (usingDefaultDataDir) {
+        // (lib.optionalAttrs (usingDefaultDataDir) {
           StateDirectory = "opensearch";
           StateDirectoryMode = "0700";
         });

--- a/nixos/modules/services/search/qdrant.nix
+++ b/nixos/modules/services/search/qdrant.nix
@@ -4,8 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
 let
 
   cfg = config.services.qdrant;
@@ -17,9 +15,9 @@ in
 
   options = {
     services.qdrant = {
-      enable = mkEnableOption "Vector Search Engine for the next generation of AI applications";
+      enable = lib.mkEnableOption "Vector Search Engine for the next generation of AI applications";
 
-      settings = mkOption {
+      settings = lib.mkOption {
         description = ''
           Configuration for Qdrant
           Refer to <https://github.com/qdrant/qdrant/blob/master/config/config.yaml> for details on supported values.
@@ -43,7 +41,7 @@ in
           telemetry_disabled = true;
         };
 
-        defaultText = literalExpression ''
+        defaultText = lib.literalExpression ''
           {
             storage = {
               storage_path = "/var/lib/qdrant/storage";
@@ -64,41 +62,41 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.qdrant.settings = {
-      service.static_content_dir = mkDefault pkgs.qdrant-web-ui;
-      storage.storage_path = mkDefault "/var/lib/qdrant/storage";
-      storage.snapshots_path = mkDefault "/var/lib/qdrant/snapshots";
+      service.static_content_dir = lib.mkDefault pkgs.qdrant-web-ui;
+      storage.storage_path = lib.mkDefault "/var/lib/qdrant/storage";
+      storage.snapshots_path = lib.mkDefault "/var/lib/qdrant/snapshots";
       # The following default values are the same as in the default config,
       # they are just written here for convenience.
-      storage.on_disk_payload = mkDefault true;
-      storage.wal.wal_capacity_mb = mkDefault 32;
-      storage.wal.wal_segments_ahead = mkDefault 0;
-      storage.performance.max_search_threads = mkDefault 0;
-      storage.performance.max_optimization_threads = mkDefault 1;
-      storage.optimizers.deleted_threshold = mkDefault 0.2;
-      storage.optimizers.vacuum_min_vector_number = mkDefault 1000;
-      storage.optimizers.default_segment_number = mkDefault 0;
-      storage.optimizers.max_segment_size_kb = mkDefault null;
-      storage.optimizers.memmap_threshold_kb = mkDefault null;
-      storage.optimizers.indexing_threshold_kb = mkDefault 20000;
-      storage.optimizers.flush_interval_sec = mkDefault 5;
-      storage.optimizers.max_optimization_threads = mkDefault 1;
-      storage.hnsw_index.m = mkDefault 16;
-      storage.hnsw_index.ef_construct = mkDefault 100;
-      storage.hnsw_index.full_scan_threshold_kb = mkDefault 10000;
-      storage.hnsw_index.max_indexing_threads = mkDefault 0;
-      storage.hnsw_index.on_disk = mkDefault false;
-      storage.hnsw_index.payload_m = mkDefault null;
-      service.max_request_size_mb = mkDefault 32;
-      service.max_workers = mkDefault 0;
-      service.http_port = mkDefault 6333;
-      service.grpc_port = mkDefault 6334;
-      service.enable_cors = mkDefault true;
-      cluster.enabled = mkDefault false;
+      storage.on_disk_payload = lib.mkDefault true;
+      storage.wal.wal_capacity_mb = lib.mkDefault 32;
+      storage.wal.wal_segments_ahead = lib.mkDefault 0;
+      storage.performance.max_search_threads = lib.mkDefault 0;
+      storage.performance.max_optimization_threads = lib.mkDefault 1;
+      storage.optimizers.deleted_threshold = lib.mkDefault 0.2;
+      storage.optimizers.vacuum_min_vector_number = lib.mkDefault 1000;
+      storage.optimizers.default_segment_number = lib.mkDefault 0;
+      storage.optimizers.max_segment_size_kb = lib.mkDefault null;
+      storage.optimizers.memmap_threshold_kb = lib.mkDefault null;
+      storage.optimizers.indexing_threshold_kb = lib.mkDefault 20000;
+      storage.optimizers.flush_interval_sec = lib.mkDefault 5;
+      storage.optimizers.max_optimization_threads = lib.mkDefault 1;
+      storage.hnsw_index.m = lib.mkDefault 16;
+      storage.hnsw_index.ef_construct = lib.mkDefault 100;
+      storage.hnsw_index.full_scan_threshold_kb = lib.mkDefault 10000;
+      storage.hnsw_index.max_indexing_threads = lib.mkDefault 0;
+      storage.hnsw_index.on_disk = lib.mkDefault false;
+      storage.hnsw_index.payload_m = lib.mkDefault null;
+      service.max_request_size_mb = lib.mkDefault 32;
+      service.max_workers = lib.mkDefault 0;
+      service.http_port = lib.mkDefault 6333;
+      service.grpc_port = lib.mkDefault 6334;
+      service.enable_cors = lib.mkDefault true;
+      cluster.enabled = lib.mkDefault false;
       # the following have been altered for security
-      service.host = mkDefault "127.0.0.1";
-      telemetry_disabled = mkDefault true;
+      service.host = lib.mkDefault "127.0.0.1";
+      telemetry_disabled = lib.mkDefault true;
     };
 
     systemd.services.qdrant = {

--- a/nixos/modules/services/search/quickwit.nix
+++ b/nixos/modules/services/search/quickwit.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.quickwit;
 
@@ -19,7 +16,7 @@ in
 {
 
   options.services.quickwit = {
-    enable = mkEnableOption "Quickwit";
+    enable = lib.mkEnableOption "Quickwit";
 
     package = lib.mkPackageOption pkgs "Quickwit" {
       default = [ "quickwit" ];
@@ -83,7 +80,7 @@ in
     dataDir = lib.mkOption {
       type = lib.types.path;
       default = "/var/lib/quickwit";
-      apply = converge (removeSuffix "/");
+      apply = lib.converge (lib.removeSuffix "/");
       description = ''
         Data directory for Quickwit. If you change this, you need to
         manually create the directory. You also need to create the
@@ -130,7 +127,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.quickwit = {
       description = "Quickwit";
       wantedBy = [ "multi-user.target" ];
@@ -143,7 +140,7 @@ in
         {
           ExecStart = ''
             ${cfg.package}/bin/quickwit run --config ${quickwitYml} \
-            ${escapeShellArgs cfg.extraFlags}
+            ${lib.escapeShellArgs cfg.extraFlags}
           '';
           User = cfg.user;
           Group = cfg.group;
@@ -186,7 +183,7 @@ in
             "@chown"
           ];
         }
-        // (optionalAttrs (usingDefaultDataDir) {
+        // (lib.optionalAttrs (usingDefaultDataDir) {
           StateDirectory = "quickwit";
           StateDirectoryMode = "0700";
         });

--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -4,15 +4,12 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.certmgr;
 
-  specs = mapAttrsToList (n: v: rec {
+  specs = lib.mapAttrsToList (n: v: rec {
     name = n + ".json";
-    path = if isAttrs v then pkgs.writeText name (builtins.toJSON v) else v;
+    path = if lib.isAttrs v then pkgs.writeText name (builtins.toJSON v) else v;
   }) cfg.specs;
 
   allSpecs = pkgs.linkFarm "certmgr.d" specs;
@@ -29,59 +26,59 @@ let
   );
 
   specPaths = map dirOf (
-    concatMap (
+    lib.concatMap (
       spec:
-      if isAttrs spec then
-        collect isString (filterAttrsRecursive (n: v: isAttrs v || n == "path") spec)
+      if lib.isAttrs spec then
+        lib.collect lib.isString (lib.filterAttrsRecursive (n: v: lib.isAttrs v || n == "path") spec)
       else
         [ spec ]
-    ) (attrValues cfg.specs)
+    ) (lib.attrValues cfg.specs)
   );
 
   preStart = ''
-    ${concatStringsSep " \\\n" ([ "mkdir -p" ] ++ map escapeShellArg specPaths)}
+    ${lib.concatStringsSep " \\\n" ([ "mkdir -p" ] ++ map lib.escapeShellArg specPaths)}
     ${cfg.package}/bin/certmgr -f ${certmgrYaml} check
   '';
 in
 {
   options.services.certmgr = {
-    enable = mkEnableOption "certmgr";
+    enable = lib.mkEnableOption "certmgr";
 
-    package = mkPackageOption pkgs "certmgr" { };
+    package = lib.mkPackageOption pkgs "certmgr" { };
 
-    defaultRemote = mkOption {
-      type = types.str;
+    defaultRemote = lib.mkOption {
+      type = lib.types.str;
       default = "127.0.0.1:8888";
       description = "The default CA host:port to use.";
     };
 
-    validMin = mkOption {
+    validMin = lib.mkOption {
       default = "72h";
-      type = types.str;
+      type = lib.types.str;
       description = "The interval before a certificate expires to start attempting to renew it.";
     };
 
-    renewInterval = mkOption {
+    renewInterval = lib.mkOption {
       default = "30m";
-      type = types.str;
+      type = lib.types.str;
       description = "How often to check certificate expirations and how often to update the cert_next_expires metric.";
     };
 
-    metricsAddress = mkOption {
+    metricsAddress = lib.mkOption {
       default = "127.0.0.1";
-      type = types.str;
+      type = lib.types.str;
       description = "The address for the Prometheus HTTP endpoint.";
     };
 
-    metricsPort = mkOption {
+    metricsPort = lib.mkOption {
       default = 9488;
-      type = types.ints.u16;
+      type = lib.types.ints.u16;
       description = "The port for the Prometheus HTTP endpoint.";
     };
 
-    specs = mkOption {
+    specs = lib.mkOption {
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           exampleCert =
           let
@@ -119,17 +116,17 @@ in
         }
       '';
       type =
-        with types;
+        with lib.types;
         attrsOf (
           either path (submodule {
             options = {
-              service = mkOption {
+              service = lib.mkOption {
                 type = nullOr str;
                 default = null;
                 description = "The service on which to perform \<action\> after fetching.";
               };
 
-              action = mkOption {
+              action = lib.mkOption {
                 type = addCheck str (
                   x:
                   cfg.svcManager == "command"
@@ -144,22 +141,22 @@ in
               };
 
               # These ought all to be specified according to certmgr spec def.
-              authority = mkOption {
+              authority = lib.mkOption {
                 type = attrs;
                 description = "certmgr spec authority object.";
               };
 
-              certificate = mkOption {
+              certificate = lib.mkOption {
                 type = nullOr attrs;
                 description = "certmgr spec certificate object.";
               };
 
-              private_key = mkOption {
+              private_key = lib.mkOption {
                 type = nullOr attrs;
                 description = "certmgr spec private_key object.";
               };
 
-              request = mkOption {
+              request = lib.mkOption {
                 type = nullOr attrs;
                 description = "certmgr spec request object.";
               };
@@ -173,9 +170,9 @@ in
       '';
     };
 
-    svcManager = mkOption {
+    svcManager = lib.mkOption {
       default = "systemd";
-      type = types.enum [
+      type = lib.types.enum [
         "circus"
         "command"
         "dummy"
@@ -193,7 +190,7 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.specs != { };
@@ -201,10 +198,10 @@ in
       }
       {
         assertion =
-          !any (hasAttrByPath [
+          !lib.any (lib.hasAttrByPath [
             "authority"
             "auth_key"
-          ]) (attrValues cfg.specs);
+          ]) (lib.attrValues cfg.specs);
         message = ''
           Inline services.certmgr.specs are added to the Nix store rendering them world readable.
           Specify paths as specs, if you want to use include auth_key - or use the auth_key_file option."
@@ -214,7 +211,7 @@ in
 
     systemd.services.certmgr = {
       description = "certmgr";
-      path = mkIf (cfg.svcManager == "command") [ pkgs.bash ];
+      path = lib.mkIf (cfg.svcManager == "command") [ pkgs.bash ];
       wants = [ "network-online.target" ];
       after = [ "network-online.target" ];
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/security/cfssl.nix
+++ b/nixos/modules/services/security/cfssl.nix
@@ -5,19 +5,16 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.cfssl;
 in
 {
   options.services.cfssl = {
-    enable = mkEnableOption "the CFSSL CA api-server";
+    enable = lib.mkEnableOption "the CFSSL CA api-server";
 
-    dataDir = mkOption {
+    dataDir = lib.mkOption {
       default = "/var/lib/cfssl";
-      type = types.path;
+      type = lib.types.path;
       description = ''
         The work directory for CFSSL.
 
@@ -30,51 +27,51 @@ in
       '';
     };
 
-    address = mkOption {
+    address = lib.mkOption {
       default = "127.0.0.1";
-      type = types.str;
+      type = lib.types.str;
       description = "Address to bind.";
     };
 
-    port = mkOption {
+    port = lib.mkOption {
       default = 8888;
-      type = types.port;
+      type = lib.types.port;
       description = "Port to bind.";
     };
 
-    ca = mkOption {
-      defaultText = literalExpression ''"''${cfg.dataDir}/ca.pem"'';
-      type = types.str;
+    ca = lib.mkOption {
+      defaultText = lib.literalExpression ''"''${cfg.dataDir}/ca.pem"'';
+      type = lib.types.str;
       description = "CA used to sign the new certificate -- accepts '[file:]fname' or 'env:varname'.";
     };
 
-    caKey = mkOption {
-      defaultText = literalExpression ''"file:''${cfg.dataDir}/ca-key.pem"'';
-      type = types.str;
+    caKey = lib.mkOption {
+      defaultText = lib.literalExpression ''"file:''${cfg.dataDir}/ca-key.pem"'';
+      type = lib.types.str;
       description = "CA private key -- accepts '[file:]fname' or 'env:varname'.";
     };
 
-    caBundle = mkOption {
+    caBundle = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Path to root certificate store.";
     };
 
-    intBundle = mkOption {
+    intBundle = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Path to intermediate certificate store.";
     };
 
-    intDir = mkOption {
+    intDir = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Intermediates directory.";
     };
 
-    metadata = mkOption {
+    metadata = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = ''
         Metadata file for root certificate presence.
         The content of the file is a json dictionary (k,v): each key k is
@@ -83,81 +80,81 @@ in
       '';
     };
 
-    remote = mkOption {
+    remote = lib.mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = lib.types.nullOr lib.types.str;
       description = "Remote CFSSL server.";
     };
 
-    configFile = mkOption {
+    configFile = lib.mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = lib.types.nullOr lib.types.str;
       description = "Path to configuration file. Do not put this in nix-store as it might contain secrets.";
     };
 
-    responder = mkOption {
+    responder = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Certificate for OCSP responder.";
     };
 
-    responderKey = mkOption {
+    responderKey = lib.mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = lib.types.nullOr lib.types.str;
       description = "Private key for OCSP responder certificate. Do not put this in nix-store.";
     };
 
-    tlsKey = mkOption {
+    tlsKey = lib.mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = lib.types.nullOr lib.types.str;
       description = "Other endpoint's CA private key. Do not put this in nix-store.";
     };
 
-    tlsCert = mkOption {
+    tlsCert = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Other endpoint's CA to set up TLS protocol.";
     };
 
-    mutualTlsCa = mkOption {
+    mutualTlsCa = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Mutual TLS - require clients be signed by this CA.";
     };
 
-    mutualTlsCn = mkOption {
+    mutualTlsCn = lib.mkOption {
       default = null;
-      type = types.nullOr types.str;
+      type = lib.types.nullOr lib.types.str;
       description = "Mutual TLS - regex for whitelist of allowed client CNs.";
     };
 
-    tlsRemoteCa = mkOption {
+    tlsRemoteCa = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "CAs to trust for remote TLS requests.";
     };
 
-    mutualTlsClientCert = mkOption {
+    mutualTlsClientCert = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Mutual TLS - client certificate to call remote instance requiring client certs.";
     };
 
-    mutualTlsClientKey = mkOption {
+    mutualTlsClientKey = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Mutual TLS - client key to call remote instance requiring client certs. Do not put this in nix-store.";
     };
 
-    dbConfig = mkOption {
+    dbConfig = lib.mkOption {
       default = null;
-      type = types.nullOr types.path;
+      type = lib.types.nullOr lib.types.path;
       description = "Certificate db configuration file. Path must be writeable.";
     };
 
-    logLevel = mkOption {
+    logLevel = lib.mkOption {
       default = 1;
-      type = types.enum [
+      type = lib.types.enum [
         0
         1
         2
@@ -169,7 +166,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     users.groups.cfssl = {
       gid = config.ids.gids.cfssl;
     };
@@ -223,7 +220,7 @@ in
               (opt "loglevel" (toString logLevel))
             ];
         }
-        (mkIf (cfg.dataDir == options.services.cfssl.dataDir.default) {
+        (lib.mkIf (cfg.dataDir == options.services.cfssl.dataDir.default) {
           StateDirectory = baseNameOf cfg.dataDir;
           StateDirectoryMode = 700;
         })
@@ -231,8 +228,8 @@ in
     };
 
     services.cfssl = {
-      ca = mkDefault "${cfg.dataDir}/ca.pem";
-      caKey = mkDefault "${cfg.dataDir}/ca-key.pem";
+      ca = lib.mkDefault "${cfg.dataDir}/ca.pem";
+      caKey = lib.mkDefault "${cfg.dataDir}/ca-key.pem";
     };
   };
 }

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -1,13 +1,12 @@
 { config, lib, pkgs, ... }:
-with lib;
 let
   clamavUser = "clamav";
   stateDir = "/var/lib/clamav";
   clamavGroup = clamavUser;
   cfg = config.services.clamav;
 
-  toKeyValue = generators.toKeyValue {
-    mkKeyValue = generators.mkKeyValueDefault { } " ";
+  toKeyValue = lib.generators.toKeyValue {
+    mkKeyValue = lib.generators.mkKeyValueDefault { } " ";
     listsAsDuplicateKeys = true;
   };
 
@@ -19,19 +18,19 @@ let
 in
 {
   imports = [
-    (mkRemovedOptionModule [ "services" "clamav" "updater" "config" ] "Use services.clamav.updater.settings instead.")
-    (mkRemovedOptionModule [ "services" "clamav" "updater" "extraConfig" ] "Use services.clamav.updater.settings instead.")
-    (mkRemovedOptionModule [ "services" "clamav" "daemon" "extraConfig" ] "Use services.clamav.daemon.settings instead.")
+    (lib.mkRemovedOptionModule [ "services" "clamav" "updater" "config" ] "Use services.clamav.updater.settings instead.")
+    (lib.mkRemovedOptionModule [ "services" "clamav" "updater" "extraConfig" ] "Use services.clamav.updater.settings instead.")
+    (lib.mkRemovedOptionModule [ "services" "clamav" "daemon" "extraConfig" ] "Use services.clamav.daemon.settings instead.")
   ];
 
   options = {
     services.clamav = {
-      package = mkPackageOption pkgs "clamav" { };
+      package = lib.mkPackageOption pkgs "clamav" { };
       daemon = {
-        enable = mkEnableOption "ClamAV clamd daemon";
+        enable = lib.mkEnableOption "ClamAV clamd daemon";
 
-        settings = mkOption {
-          type = with types; attrsOf (oneOf [ bool int str (listOf str) ]);
+        settings = lib.mkOption {
+          type = with lib.types; attrsOf (oneOf [ bool int str (listOf str) ]);
           default = { };
           description = ''
             ClamAV configuration. Refer to <https://linux.die.net/man/5/clamd.conf>,
@@ -40,18 +39,18 @@ in
         };
       };
       updater = {
-        enable = mkEnableOption "ClamAV freshclam updater";
+        enable = lib.mkEnableOption "ClamAV freshclam updater";
 
-        frequency = mkOption {
-          type = types.int;
+        frequency = lib.mkOption {
+          type = lib.types.int;
           default = 12;
           description = ''
             Number of database checks per day.
           '';
         };
 
-        interval = mkOption {
-          type = types.str;
+        interval = lib.mkOption {
+          type = lib.types.str;
           default = "hourly";
           description = ''
             How often freshclam is invoked. See systemd.time(7) for more
@@ -59,8 +58,8 @@ in
           '';
         };
 
-        settings = mkOption {
-          type = with types; attrsOf (oneOf [ bool int str (listOf str) ]);
+        settings = lib.mkOption {
+          type = with lib.types; attrsOf (oneOf [ bool int str (listOf str) ]);
           default = { };
           description = ''
             freshclam configuration. Refer to <https://linux.die.net/man/5/freshclam.conf>,
@@ -69,10 +68,10 @@ in
         };
       };
       fangfrisch = {
-        enable = mkEnableOption "ClamAV fangfrisch updater";
+        enable = lib.mkEnableOption "ClamAV fangfrisch updater";
 
-        interval = mkOption {
-          type = types.str;
+        interval = lib.mkOption {
+          type = lib.types.str;
           default = "hourly";
           description = ''
             How often freshclam is invoked. See systemd.time(7) for more
@@ -80,9 +79,9 @@ in
           '';
         };
 
-        settings = mkOption {
+        settings = lib.mkOption {
           type = lib.types.submodule {
-            freeformType = with types; attrsOf (attrsOf (oneOf [ str int bool ]));
+            freeformType = with lib.types; attrsOf (attrsOf (oneOf [ str int bool ]));
           };
           default = { };
           example = {
@@ -100,10 +99,10 @@ in
       };
 
       scanner = {
-        enable = mkEnableOption "ClamAV scanner";
+        enable = lib.mkEnableOption "ClamAV scanner";
 
-        interval = mkOption {
-          type = types.str;
+        interval = lib.mkOption {
+          type = lib.types.str;
           default = "*-*-* 04:00:00";
           description = ''
             How often clamdscan is invoked. See systemd.time(7) for more
@@ -112,8 +111,8 @@ in
           '';
         };
 
-        scanDirectories = mkOption {
-          type = with types; listOf str;
+        scanDirectories = lib.mkOption {
+          type = with lib.types; listOf str;
           default = [ "/home" "/var/lib" "/tmp" "/etc" "/var/tmp" ];
           description = ''
             List of directories to scan.
@@ -124,7 +123,7 @@ in
     };
   };
 
-  config = mkIf (cfg.updater.enable || cfg.daemon.enable) {
+  config = lib.mkIf (cfg.updater.enable || cfg.daemon.enable) {
     environment.systemPackages = [ cfg.package ];
 
     users.users.${clamavUser} = {
@@ -153,12 +152,12 @@ in
     };
 
     services.clamav.fangfrisch.settings = {
-      DEFAULT.db_url = mkDefault "sqlite:////var/lib/clamav/fangfrisch_db.sqlite";
-      DEFAULT.local_directory = mkDefault stateDir;
-      DEFAULT.log_level = mkDefault "INFO";
-      urlhaus.enabled = mkDefault "yes";
-      urlhaus.max_size = mkDefault "2MB";
-      sanesecurity.enabled = mkDefault "yes";
+      DEFAULT.db_url = lib.mkDefault "sqlite:////var/lib/clamav/fangfrisch_db.sqlite";
+      DEFAULT.local_directory = lib.mkDefault stateDir;
+      DEFAULT.log_level = lib.mkDefault "INFO";
+      urlhaus.enabled = lib.mkDefault "yes";
+      urlhaus.max_size = lib.mkDefault "2MB";
+      sanesecurity.enabled = lib.mkDefault "yes";
     };
 
     environment.etc."clamav/freshclam.conf".source = freshclamConfigFile;
@@ -168,10 +167,10 @@ in
       description = "ClamAV Antivirus Slice";
     };
 
-    systemd.services.clamav-daemon = mkIf cfg.daemon.enable {
+    systemd.services.clamav-daemon = lib.mkIf cfg.daemon.enable {
       description = "ClamAV daemon (clamd)";
-      after = optionals cfg.updater.enable [ "clamav-freshclam.service" ];
-      wants = optionals cfg.updater.enable [ "clamav-freshclam.service" ];
+      after = lib.optionals cfg.updater.enable [ "clamav-freshclam.service" ];
+      wants = lib.optionals cfg.updater.enable [ "clamav-freshclam.service" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ clamdConfigFile ];
 
@@ -189,7 +188,7 @@ in
       };
     };
 
-    systemd.timers.clamav-freshclam = mkIf cfg.updater.enable {
+    systemd.timers.clamav-freshclam = lib.mkIf cfg.updater.enable {
       description = "Timer for ClamAV virus database updater (freshclam)";
       wantedBy = [ "timers.target" ];
       timerConfig = {
@@ -198,7 +197,7 @@ in
       };
     };
 
-    systemd.services.clamav-freshclam = mkIf cfg.updater.enable {
+    systemd.services.clamav-freshclam = lib.mkIf cfg.updater.enable {
       description = "ClamAV virus database updater (freshclam)";
       restartTriggers = [ freshclamConfigFile ];
       requires = [ "network-online.target" ];
@@ -217,7 +216,7 @@ in
       };
     };
 
-    systemd.services.clamav-fangfrisch-init = mkIf cfg.fangfrisch.enable {
+    systemd.services.clamav-fangfrisch-init = lib.mkIf cfg.fangfrisch.enable {
       wantedBy = [ "multi-user.target" ];
       # if the sqlite file can be found assume the database has already been initialised
       script = ''
@@ -239,7 +238,7 @@ in
       };
     };
 
-    systemd.timers.clamav-fangfrisch = mkIf cfg.fangfrisch.enable {
+    systemd.timers.clamav-fangfrisch = lib.mkIf cfg.fangfrisch.enable {
       description = "Timer for ClamAV virus database updater (fangfrisch)";
       wantedBy = [ "timers.target" ];
       timerConfig = {
@@ -248,7 +247,7 @@ in
       };
     };
 
-    systemd.services.clamav-fangfrisch = mkIf cfg.fangfrisch.enable {
+    systemd.services.clamav-fangfrisch = lib.mkIf cfg.fangfrisch.enable {
       description = "ClamAV virus database updater (fangfrisch)";
       restartTriggers = [ fangfrischConfigFile ];
       requires = [ "network-online.target" ];
@@ -266,7 +265,7 @@ in
       };
     };
 
-    systemd.timers.clamdscan = mkIf cfg.scanner.enable {
+    systemd.timers.clamdscan = lib.mkIf cfg.scanner.enable {
       description = "Timer for ClamAV virus scanner";
       wantedBy = [ "timers.target" ];
       timerConfig = {
@@ -275,10 +274,10 @@ in
       };
     };
 
-    systemd.services.clamdscan = mkIf cfg.scanner.enable {
+    systemd.services.clamdscan = lib.mkIf cfg.scanner.enable {
       description = "ClamAV virus scanner";
-      after = optionals cfg.updater.enable [ "clamav-freshclam.service" ];
-      wants = optionals cfg.updater.enable [ "clamav-freshclam.service" ];
+      after = lib.optionals cfg.updater.enable [ "clamav-freshclam.service" ];
+      wants = lib.optionals cfg.updater.enable [ "clamav-freshclam.service" ];
 
       serviceConfig = {
         Type = "oneshot";

--- a/nixos/modules/services/security/endlessh-go.nix
+++ b/nixos/modules/services/security/endlessh-go.nix
@@ -4,20 +4,17 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.endlessh-go;
 in
 {
   options.services.endlessh-go = {
-    enable = mkEnableOption "endlessh-go service";
+    enable = lib.mkEnableOption "endlessh-go service";
 
-    package = mkPackageOption pkgs "endlessh-go" { };
+    package = lib.mkPackageOption pkgs "endlessh-go" { };
 
-    listenAddress = mkOption {
-      type = types.str;
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
       default = "0.0.0.0";
       example = "[::]";
       description = ''
@@ -25,8 +22,8 @@ in
       '';
     };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 2222;
       example = 22;
       description = ''
@@ -38,10 +35,10 @@ in
     };
 
     prometheus = {
-      enable = mkEnableOption "Prometheus integration";
+      enable = lib.mkEnableOption "Prometheus integration";
 
-      listenAddress = mkOption {
-        type = types.str;
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
         default = "0.0.0.0";
         example = "[::]";
         description = ''
@@ -50,8 +47,8 @@ in
         '';
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 2112;
         example = 9119;
         description = ''
@@ -61,8 +58,8 @@ in
       };
     };
 
-    extraOptions = mkOption {
-      type = with types; listOf str;
+    extraOptions = lib.mkOption {
+      type = with lib.types; listOf str;
       default = [ ];
       example = [
         "-conn_type=tcp4"
@@ -73,8 +70,8 @@ in
       '';
     };
 
-    openFirewall = mkOption {
-      type = types.bool;
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether to open a firewall port for the SSH listener.
@@ -82,7 +79,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.endlessh-go = {
       description = "SSH tarpit";
       requires = [ "network.target" ];
@@ -90,7 +87,7 @@ in
       serviceConfig =
         let
           needsPrivileges = cfg.port < 1024 || cfg.prometheus.port < 1024;
-          capabilities = [ "" ] ++ optionals needsPrivileges [ "CAP_NET_BIND_SERVICE" ];
+          capabilities = [ "" ] ++ lib.optionals needsPrivileges [ "CAP_NET_BIND_SERVICE" ];
           rootDirectory = "/run/endlessh-go";
         in
         {
@@ -155,5 +152,5 @@ in
     networking.firewall.allowedTCPPorts = with cfg; optionals openFirewall [ port ];
   };
 
-  meta.maintainers = with maintainers; [ azahi ];
+  meta.maintainers = with lib.maintainers; [ azahi ];
 }

--- a/nixos/modules/services/security/endlessh.nix
+++ b/nixos/modules/services/security/endlessh.nix
@@ -4,18 +4,15 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.endlessh;
 in
 {
   options.services.endlessh = {
-    enable = mkEnableOption "endlessh service";
+    enable = lib.mkEnableOption "endlessh service";
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 2222;
       example = 22;
       description = ''
@@ -26,8 +23,8 @@ in
       '';
     };
 
-    extraOptions = mkOption {
-      type = with types; listOf str;
+    extraOptions = lib.mkOption {
+      type = with lib.types; listOf str;
       default = [ ];
       example = [
         "-6"
@@ -39,8 +36,8 @@ in
       '';
     };
 
-    openFirewall = mkOption {
-      type = types.bool;
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether to open a firewall port for the SSH listener.
@@ -48,7 +45,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.endlessh = {
       description = "SSH tarpit";
       requires = [ "network.target" ];
@@ -56,7 +53,7 @@ in
       serviceConfig =
         let
           needsPrivileges = cfg.port < 1024;
-          capabilities = [ "" ] ++ optionals needsPrivileges [ "CAP_NET_BIND_SERVICE" ];
+          capabilities = [ "" ] ++ lib.optionals needsPrivileges [ "CAP_NET_BIND_SERVICE" ];
           rootDirectory = "/run/endlessh";
         in
         {
@@ -115,5 +112,5 @@ in
     networking.firewall.allowedTCPPorts = with cfg; optionals openFirewall [ port ];
   };
 
-  meta.maintainers = with maintainers; [ azahi ];
+  meta.maintainers = with lib.maintainers; [ azahi ];
 }

--- a/nixos/modules/services/security/fail2ban.nix
+++ b/nixos/modules/services/security/fail2ban.nix
@@ -4,47 +4,44 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.fail2ban;
 
   settingsFormat = pkgs.formats.keyValue { };
 
   configFormat = pkgs.formats.ini {
-    mkKeyValue = generators.mkKeyValueDefault { } " = ";
+    mkKeyValue = lib.generators.mkKeyValueDefault { } " = ";
   };
 
   mkJailConfig =
     name: attrs:
-    optionalAttrs (name != "DEFAULT") { inherit (attrs) enabled; }
-    // optionalAttrs (attrs.filter != null) {
-      filter = if (builtins.isString filter) then filter else name;
+    lib.optionalAttrs (name != "DEFAULT") { inherit (attrs) enabled; }
+    // lib.optionalAttrs (attrs.filter != null) {
+      filter = if (builtins.isString lib.filter) then lib.filter else name;
     }
     // attrs.settings;
 
   mkFilter =
     name: attrs:
-    nameValuePair "fail2ban/filter.d/${name}.conf" {
+    lib.nameValuePair "fail2ban/filter.d/${name}.conf" {
       source = configFormat.generate "filter.d/${name}.conf" attrs.filter;
     };
 
   fail2banConf = configFormat.generate "fail2ban.local" cfg.daemonSettings;
 
-  strJails = filterAttrs (_: builtins.isString) cfg.jails;
-  attrsJails = filterAttrs (_: builtins.isAttrs) cfg.jails;
+  strJails = lib.filterAttrs (_: builtins.isString) cfg.jails;
+  attrsJails = lib.filterAttrs (_: builtins.isAttrs) cfg.jails;
 
   jailConf =
     let
       configFile = configFormat.generate "jail.local" (
-        { INCLUDES.before = "paths-nixos.conf"; } // (mapAttrs mkJailConfig attrsJails)
+        { INCLUDES.before = "paths-nixos.conf"; } // (lib.mapAttrs mkJailConfig attrsJails)
       );
-      extraConfig = concatStringsSep "\n" (
-        attrValues (
-          mapAttrs (
+      extraConfig = lib.concatStringsSep "\n" (
+        lib.attrValues (
+          lib.mapAttrs (
             name: def:
-            optionalString (def != "") ''
+            lib.optionalString (def != "") ''
               [${name}]
               ${def}
             ''
@@ -74,12 +71,12 @@ in
 {
 
   imports = [
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "fail2ban"
       "daemonConfig"
     ] "The daemon is now configured through the attribute set `services.fail2ban.daemonSettings`.")
-    (mkRemovedOptionModule [ "services" "fail2ban" "extraSettings" ]
+    (lib.mkRemovedOptionModule [ "services" "fail2ban" "extraSettings" ]
       "The extra default configuration can now be set using `services.fail2ban.jails.DEFAULT.settings`."
     )
   ];
@@ -88,9 +85,9 @@ in
 
   options = {
     services.fail2ban = {
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Whether to enable the fail2ban service.
 
@@ -99,20 +96,20 @@ in
         '';
       };
 
-      package = mkPackageOption pkgs "fail2ban" {
+      package = lib.mkPackageOption pkgs "fail2ban" {
         example = "fail2ban_0_11";
       };
 
-      packageFirewall = mkOption {
+      packageFirewall = lib.mkOption {
         default = config.networking.firewall.package;
-        defaultText = literalExpression "config.networking.firewall.package";
-        type = types.package;
+        defaultText = lib.literalExpression "config.networking.firewall.package";
+        type = lib.types.package;
         description = "The firewall package used by fail2ban service. Defaults to the package for your firewall (iptables or nftables).";
       };
 
-      extraPackages = mkOption {
+      extraPackages = lib.mkOption {
         default = [ ];
-        type = types.listOf types.package;
+        type = lib.types.listOf lib.types.package;
         example = lib.literalExpression "[ pkgs.ipset ]";
         description = ''
           Extra packages to be made available to the fail2ban service. The example contains
@@ -120,23 +117,23 @@ in
         '';
       };
 
-      bantime = mkOption {
+      bantime = lib.mkOption {
         default = "10m";
-        type = types.str;
+        type = lib.types.str;
         example = "1h";
         description = "Number of seconds that a host is banned.";
       };
 
-      maxretry = mkOption {
+      maxretry = lib.mkOption {
         default = 3;
-        type = types.ints.unsigned;
+        type = lib.types.ints.unsigned;
         description = "Number of failures before a host gets banned.";
       };
 
-      banaction = mkOption {
+      banaction = lib.mkOption {
         default = if config.networking.nftables.enable then "nftables-multiport" else "iptables-multiport";
-        defaultText = literalExpression ''if config.networking.nftables.enable then "nftables-multiport" else "iptables-multiport"'';
-        type = types.str;
+        defaultText = lib.literalExpression ''if config.networking.nftables.enable then "nftables-multiport" else "iptables-multiport"'';
+        type = lib.types.str;
         description = ''
           Default banning action (e.g. iptables, iptables-new, iptables-multiport,
           iptables-ipset-proto6-allports, shorewall, etc). It is used to
@@ -145,10 +142,10 @@ in
         '';
       };
 
-      banaction-allports = mkOption {
+      banaction-allports = lib.mkOption {
         default = if config.networking.nftables.enable then "nftables-allports" else "iptables-allports";
-        defaultText = literalExpression ''if config.networking.nftables.enable then "nftables-allports" else "iptables-allports"'';
-        type = types.str;
+        defaultText = lib.literalExpression ''if config.networking.nftables.enable then "nftables-allports" else "iptables-allports"'';
+        type = lib.types.str;
         description = ''
           Default banning action (e.g. iptables, iptables-new, iptables-multiport,
           shorewall, etc) for "allports" jails. It is used to define action_* variables. Can be overridden
@@ -156,18 +153,18 @@ in
         '';
       };
 
-      bantime-increment.enable = mkOption {
+      bantime-increment.enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           "bantime.increment" allows to use database for searching of previously banned ip's to increase
           a default ban time using special formula, default it is banTime * 1, 2, 4, 8, 16, 32 ...
         '';
       };
 
-      bantime-increment.rndtime = mkOption {
+      bantime-increment.rndtime = lib.mkOption {
         default = null;
-        type = types.nullOr types.str;
+        type = lib.types.nullOr lib.types.str;
         example = "8m";
         description = ''
           "bantime.rndtime" is the max number of seconds using for mixing with random time
@@ -175,18 +172,18 @@ in
         '';
       };
 
-      bantime-increment.maxtime = mkOption {
+      bantime-increment.maxtime = lib.mkOption {
         default = null;
-        type = types.nullOr types.str;
+        type = lib.types.nullOr lib.types.str;
         example = "48h";
         description = ''
           "bantime.maxtime" is the max number of seconds using the ban time can reach (don't grows further)
         '';
       };
 
-      bantime-increment.factor = mkOption {
+      bantime-increment.factor = lib.mkOption {
         default = null;
-        type = types.nullOr types.str;
+        type = lib.types.nullOr lib.types.str;
         example = "4";
         description = ''
           "bantime.factor" is a coefficient to calculate exponent growing of the formula or common multiplier,
@@ -194,9 +191,9 @@ in
         '';
       };
 
-      bantime-increment.formula = mkOption {
+      bantime-increment.formula = lib.mkOption {
         default = null;
-        type = types.nullOr types.str;
+        type = lib.types.nullOr lib.types.str;
         example = "ban.Time * math.exp(float(ban.Count+1)*banFactor)/math.exp(1*banFactor)";
         description = ''
           "bantime.formula" used by default to calculate next value of ban time, default value below,
@@ -204,9 +201,9 @@ in
         '';
       };
 
-      bantime-increment.multipliers = mkOption {
+      bantime-increment.multipliers = lib.mkOption {
         default = null;
-        type = types.nullOr types.str;
+        type = lib.types.nullOr lib.types.str;
         example = "1 2 4 8 16 32 64";
         description = ''
           "bantime.multipliers" used to calculate next value of ban time instead of formula, corresponding
@@ -216,9 +213,9 @@ in
         '';
       };
 
-      bantime-increment.overalljails = mkOption {
+      bantime-increment.overalljails = lib.mkOption {
         default = null;
-        type = types.nullOr types.bool;
+        type = lib.types.nullOr lib.types.bool;
         example = true;
         description = ''
           "bantime.overalljails" (if true) specifies the search of IP in the database will be executed
@@ -226,9 +223,9 @@ in
         '';
       };
 
-      ignoreIP = mkOption {
+      ignoreIP = lib.mkOption {
         default = [ ];
-        type = types.listOf types.str;
+        type = lib.types.listOf lib.types.str;
         example = [
           "192.168.0.0/16"
           "2001:DB8::42"
@@ -239,10 +236,10 @@ in
         '';
       };
 
-      daemonSettings = mkOption {
+      daemonSettings = lib.mkOption {
         inherit (configFormat) type;
 
-        defaultText = literalExpression ''
+        defaultText = lib.literalExpression ''
           {
             Definition = {
               logtarget = "SYSLOG";
@@ -258,9 +255,9 @@ in
         '';
       };
 
-      jails = mkOption {
+      jails = lib.mkOption {
         default = { };
-        example = literalExpression ''
+        example = lib.literalExpression ''
           {
             apache-nohome-iptables = {
               settings = {
@@ -287,26 +284,26 @@ in
           };
         '';
         type =
-          with types;
+          with lib.types;
           attrsOf (
             either lines (
               submodule (
                 { name, ... }:
                 {
                   options = {
-                    enabled = mkEnableOption "this jail" // {
+                    enabled = lib.mkEnableOption "this jail" // {
                       default = true;
                       readOnly = name == "DEFAULT";
                     };
 
-                    filter = mkOption {
+                    filter = lib.mkOption {
                       type = nullOr (either str configFormat.type);
 
                       default = null;
                       description = "Content of the filter used for this jail.";
                     };
 
-                    settings = mkOption {
+                    settings = lib.mkOption {
                       inherit (settingsFormat) type;
 
                       default = { };
@@ -344,7 +341,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.bantime-increment.formula == null || cfg.bantime-increment.multipliers == null;
@@ -354,7 +351,7 @@ in
       }
     ];
 
-    warnings = mkIf (!config.networking.firewall.enable && !config.networking.nftables.enable) [
+    warnings = lib.mkIf (!config.networking.firewall.enable && !config.networking.nftables.enable) [
       "fail2ban can not be used without a firewall"
     ];
 
@@ -371,14 +368,14 @@ in
         "fail2ban/action.d".source = "${cfg.package}/etc/fail2ban/action.d/*.conf";
         "fail2ban/filter.d".source = "${cfg.package}/etc/fail2ban/filter.d/*.conf";
       }
-      // (mapAttrs' mkFilter (
-        filterAttrs (_: v: v.filter != null && !builtins.isString v.filter) attrsJails
+      // (lib.mapAttrs' mkFilter (
+        lib.filterAttrs (_: v: v.filter != null && !builtins.isString v.filter) attrsJails
       ));
 
     systemd.packages = [ cfg.package ];
     systemd.services.fail2ban = {
       wantedBy = [ "multi-user.target" ];
-      partOf = optional config.networking.firewall.enable "firewall.service";
+      partOf = lib.optional config.networking.firewall.enable "firewall.service";
 
       restartTriggers = [
         fail2banConf
@@ -423,29 +420,29 @@ in
 
     # Defaults for the daemon settings
     services.fail2ban.daemonSettings.Definition = {
-      logtarget = mkDefault "SYSLOG";
-      socket = mkDefault "/run/fail2ban/fail2ban.sock";
-      pidfile = mkDefault "/run/fail2ban/fail2ban.pid";
-      dbfile = mkDefault "/var/lib/fail2ban/fail2ban.sqlite3";
+      logtarget = lib.mkDefault "SYSLOG";
+      socket = lib.mkDefault "/run/fail2ban/fail2ban.sock";
+      pidfile = lib.mkDefault "/run/fail2ban/fail2ban.pid";
+      dbfile = lib.mkDefault "/var/lib/fail2ban/fail2ban.sqlite3";
     };
 
     # Add some reasonable default jails.  The special "DEFAULT" jail
     # sets default values for all other jails.
-    services.fail2ban.jails = mkMerge [
+    services.fail2ban.jails = lib.mkMerge [
       {
         DEFAULT.settings =
-          (optionalAttrs cfg.bantime-increment.enable (
+          (lib.optionalAttrs cfg.bantime-increment.enable (
             {
               "bantime.increment" = cfg.bantime-increment.enable;
             }
-            // (mapAttrs' (name: nameValuePair "bantime.${name}") (
-              filterAttrs (n: v: v != null && n != "enable") cfg.bantime-increment
+            // (lib.mapAttrs' (name: lib.nameValuePair "bantime.${name}") (
+              lib.filterAttrs (n: v: v != null && n != "enable") cfg.bantime-increment
             ))
           ))
           // {
             # Miscellaneous options
             inherit (cfg) banaction maxretry bantime;
-            ignoreip = ''127.0.0.1/8 ${optionalString config.networking.enableIPv6 "::1"} ${concatStringsSep " " cfg.ignoreIP}'';
+            ignoreip = ''127.0.0.1/8 ${lib.optionalString config.networking.enableIPv6 "::1"} ${lib.concatStringsSep " " cfg.ignoreIP}'';
             backend = "systemd";
             # Actions
             banaction_allports = cfg.banaction-allports;
@@ -453,15 +450,15 @@ in
       }
 
       # Block SSH if there are too many failing connection attempts.
-      (mkIf config.services.openssh.enable {
-        sshd.settings.port = mkDefault (
-          concatMapStringsSep "," builtins.toString config.services.openssh.ports
+      (lib.mkIf config.services.openssh.enable {
+        sshd.settings.port = lib.mkDefault (
+          lib.concatMapStringsSep "," builtins.toString config.services.openssh.ports
         );
       })
     ];
 
     # Benefits from verbose sshd logging to observe failed login attempts,
     # so we set that here unless the user overrode it.
-    services.openssh.settings.LogLevel = mkDefault "VERBOSE";
+    services.openssh.settings.LogLevel = lib.mkDefault "VERBOSE";
   };
 }

--- a/nixos/modules/services/security/fprintd.nix
+++ b/nixos/modules/services/security/fprintd.nix
@@ -1,7 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
 
   cfg = config.services.fprintd;
@@ -18,12 +15,12 @@ in
 
     services.fprintd = {
 
-      enable = mkEnableOption "fprintd daemon and PAM module for fingerprint readers handling";
+      enable = lib.mkEnableOption "fprintd daemon and PAM module for fingerprint readers handling";
 
-      package = mkOption {
-        type = types.package;
+      package = lib.mkOption {
+        type = lib.types.package;
         default = fprintdPkg;
-        defaultText = literalExpression "if config.services.fprintd.tod.enable then pkgs.fprintd-tod else pkgs.fprintd";
+        defaultText = lib.literalExpression "if config.services.fprintd.tod.enable then pkgs.fprintd-tod else pkgs.fprintd";
         description = ''
           fprintd package to use.
         '';
@@ -31,11 +28,11 @@ in
 
       tod = {
 
-        enable = mkEnableOption "Touch OEM Drivers library support";
+        enable = lib.mkEnableOption "Touch OEM Drivers library support";
 
-        driver = mkOption {
-          type = types.package;
-          example = literalExpression "pkgs.libfprint-2-tod1-goodix";
+        driver = lib.mkOption {
+          type = lib.types.package;
+          example = lib.literalExpression "pkgs.libfprint-2-tod1-goodix";
           description = ''
             Touch OEM Drivers (TOD) package to use.
           '';
@@ -47,7 +44,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     services.dbus.packages = [ cfg.package ];
 
@@ -55,7 +52,7 @@ in
 
     systemd.packages = [ cfg.package ];
 
-    systemd.services.fprintd.environment = mkIf cfg.tod.enable {
+    systemd.services.fprintd.environment = lib.mkIf cfg.tod.enable {
       FP_TOD_DRIVERS_DIR = "${cfg.tod.driver}${cfg.tod.driver.driverPath}";
     };
 

--- a/nixos/modules/services/security/haka.nix
+++ b/nixos/modules/services/security/haka.nix
@@ -1,14 +1,10 @@
 # This module defines global configuration for Haka.
-
 {
   config,
   lib,
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.haka;
@@ -23,14 +19,14 @@ let
       else
         "${haka}/share/haka/sample/${cfg.configFile}"
     }
-    ${optionalString (builtins.lessThan 0 cfg.threads) "thread = ${cfg.threads}"}
+    ${lib.optionalString (builtins.lessThan 0 cfg.threads) "thread = ${cfg.threads}"}
 
     [packet]
-    ${optionalString cfg.pcap ''module = "packet/pcap"''}
-    ${optionalString cfg.nfqueue ''module = "packet/nqueue"''}
-    ${optionalString cfg.dump.enable ''dump = "yes"''}
-    ${optionalString cfg.dump.enable ''dump_input = "${cfg.dump.input}"''}
-    ${optionalString cfg.dump.enable ''dump_output = "${cfg.dump.output}"''}
+    ${lib.optionalString cfg.pcap ''module = "packet/pcap"''}
+    ${lib.optionalString cfg.nfqueue ''module = "packet/nqueue"''}
+    ${lib.optionalString cfg.dump.enable ''dump = "yes"''}
+    ${lib.optionalString cfg.dump.enable ''dump_input = "${cfg.dump.input}"''}
+    ${lib.optionalString cfg.dump.enable ''dump_output = "${cfg.dump.output}"''}
 
     interfaces = "${lib.strings.concatStringsSep "," cfg.interfaces}"
 
@@ -62,14 +58,14 @@ in
 
     services.haka = {
 
-      enable = mkEnableOption "Haka";
+      enable = lib.mkEnableOption "Haka";
 
-      package = mkPackageOption pkgs "haka" { };
+      package = lib.mkPackageOption pkgs "haka" { };
 
-      configFile = mkOption {
+      configFile = lib.mkOption {
         default = "empty.lua";
         example = "/srv/haka/myfilter.lua";
-        type = types.str;
+        type = lib.types.str;
         description = ''
           Specify which configuration file Haka uses.
           It can be absolute path or a path relative to the sample directory of
@@ -77,46 +73,46 @@ in
         '';
       };
 
-      interfaces = mkOption {
+      interfaces = lib.mkOption {
         default = [ "eth0" ];
         example = [ "any" ];
-        type = with types; listOf str;
+        type = with lib.types; listOf str;
         description = ''
           Specify which interface(s) Haka listens to.
           Use 'any' to listen to all interfaces.
         '';
       };
 
-      threads = mkOption {
+      threads = lib.mkOption {
         default = 0;
         example = 4;
-        type = types.int;
+        type = lib.types.int;
         description = ''
           The number of threads that will be used.
           All system threads are used by default.
         '';
       };
 
-      pcap = mkOption {
+      pcap = lib.mkOption {
         default = true;
-        type = types.bool;
+        type = lib.types.bool;
         description = "Whether to enable pcap";
       };
 
-      nfqueue = mkEnableOption "nfqueue";
+      nfqueue = lib.mkEnableOption "nfqueue";
 
-      dump.enable = mkEnableOption "dump";
-      dump.input = mkOption {
+      dump.enable = lib.mkEnableOption "dump";
+      dump.input = lib.mkOption {
         default = "/tmp/input.pcap";
         example = "/path/to/file.pcap";
-        type = types.path;
+        type = lib.types.path;
         description = "Path to file where incoming packets are dumped";
       };
 
-      dump.output = mkOption {
+      dump.output = lib.mkOption {
         default = "/tmp/output.pcap";
         example = "/path/to/file.pcap";
-        type = types.path;
+        type = lib.types.path;
         description = "Path to file where outgoing packets are dumped";
       };
     };
@@ -124,7 +120,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     assertions = [
       {

--- a/nixos/modules/services/security/haveged.nix
+++ b/nixos/modules/services/security/haveged.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.haveged;
 
@@ -20,14 +17,14 @@ in
 
     services.haveged = {
 
-      enable = mkEnableOption ''
+      enable = lib.mkEnableOption ''
         haveged entropy daemon, which refills /dev/random when low.
         NOTE: does nothing on kernels newer than 5.6
       '';
       # source for the note https://github.com/jirka-h/haveged/issues/57
 
-      refill_threshold = mkOption {
-        type = types.int;
+      refill_threshold = lib.mkOption {
+        type = lib.types.int;
         default = 1024;
         description = ''
           The number of bits of available entropy beneath which
@@ -39,7 +36,7 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     # https://github.com/jirka-h/haveged/blob/a4b69d65a8dfc5a9f52ff8505c7f58dcf8b9234f/contrib/Fedora/haveged.service
     systemd.services.haveged = {

--- a/nixos/modules/services/security/hologram-agent.nix
+++ b/nixos/modules/services/security/hologram-agent.nix
@@ -4,9 +4,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.hologram-agent;
 
@@ -19,20 +16,20 @@ in
 {
   options = {
     services.hologram-agent = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to enable the Hologram agent for AWS instance credentials";
       };
 
-      dialAddress = mkOption {
-        type = types.str;
+      dialAddress = lib.mkOption {
+        type = lib.types.str;
         default = "localhost:3100";
         description = "Hologram server and port.";
       };
 
-      httpPort = mkOption {
-        type = types.str;
+      httpPort = lib.mkOption {
+        type = lib.types.str;
         default = "80";
         description = "Port for metadata service to listen on.";
       };
@@ -40,7 +37,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     boot.kernelModules = [ "dummy" ];
 
     networking.interfaces.dummy0.ipv4.addresses = [

--- a/nixos/modules/services/security/hologram-server.nix
+++ b/nixos/modules/services/security/hologram-server.nix
@@ -4,9 +4,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.hologram-server;
 
@@ -38,93 +35,93 @@ in
 {
   options = {
     services.hologram-server = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to enable the Hologram server for AWS instance credentials";
       };
 
-      listenAddress = mkOption {
-        type = types.str;
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
         default = "0.0.0.0:3100";
         description = "Address and port to listen on";
       };
 
-      ldapHost = mkOption {
-        type = types.str;
+      ldapHost = lib.mkOption {
+        type = lib.types.str;
         description = "Address of the LDAP server to use";
       };
 
-      ldapInsecure = mkOption {
-        type = types.bool;
+      ldapInsecure = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to connect to LDAP over SSL or not";
       };
 
-      ldapUserAttr = mkOption {
-        type = types.str;
+      ldapUserAttr = lib.mkOption {
+        type = lib.types.str;
         default = "cn";
         description = "The LDAP attribute for usernames";
       };
 
-      ldapBaseDN = mkOption {
-        type = types.str;
+      ldapBaseDN = lib.mkOption {
+        type = lib.types.str;
         description = "The base DN for your Hologram users";
       };
 
-      ldapBindDN = mkOption {
-        type = types.str;
+      ldapBindDN = lib.mkOption {
+        type = lib.types.str;
         description = "DN of account to use to query the LDAP server";
       };
 
-      ldapBindPassword = mkOption {
-        type = types.str;
+      ldapBindPassword = lib.mkOption {
+        type = lib.types.str;
         description = "Password of account to use to query the LDAP server";
       };
 
-      enableLdapRoles = mkOption {
-        type = types.bool;
+      enableLdapRoles = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to assign user roles based on the user's LDAP group memberships";
       };
 
-      groupClassAttr = mkOption {
-        type = types.str;
+      groupClassAttr = lib.mkOption {
+        type = lib.types.str;
         default = "groupOfNames";
         description = "The objectclass attribute to search for groups when enableLdapRoles is true";
       };
 
-      roleAttr = mkOption {
-        type = types.str;
+      roleAttr = lib.mkOption {
+        type = lib.types.str;
         default = "businessCategory";
         description = "Which LDAP group attribute to search for authorized role ARNs";
       };
 
-      awsAccount = mkOption {
-        type = types.str;
+      awsAccount = lib.mkOption {
+        type = lib.types.str;
         description = "AWS account number";
       };
 
-      awsDefaultRole = mkOption {
-        type = types.str;
+      awsDefaultRole = lib.mkOption {
+        type = lib.types.str;
         description = "AWS default role";
       };
 
-      statsAddress = mkOption {
-        type = types.str;
+      statsAddress = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = "Address of statsd server";
       };
 
-      cacheTimeoutSeconds = mkOption {
-        type = types.int;
+      cacheTimeoutSeconds = lib.mkOption {
+        type = lib.types.int;
         default = 3600;
         description = "How often (in seconds) to refresh the LDAP cache";
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.hologram-server = {
       description = "Provide EC2 instance credentials to machines outside of EC2";
       after = [ "network.target" ];

--- a/nixos/modules/services/security/infnoise.nix
+++ b/nixos/modules/services/security/infnoise.nix
@@ -4,38 +4,35 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.infnoise;
 in
 {
   options = {
     services.infnoise = {
-      enable = mkEnableOption "the Infinite Noise TRNG driver";
+      enable = lib.mkEnableOption "the Infinite Noise TRNG driver";
 
-      fillDevRandom = mkOption {
+      fillDevRandom = lib.mkOption {
         description = ''
           Whether to run the infnoise driver as a daemon to refill /dev/random.
 
           If disabled, you can use the `infnoise` command-line tool to
           manually obtain randomness.
         '';
-        type = types.bool;
+        type = lib.types.bool;
         default = true;
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.infnoise ];
 
     services.udev.extraRules = ''
       SUBSYSTEM=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", SYMLINK+="infnoise", TAG+="systemd", GROUP="dialout", MODE="0664", ENV{SYSTEMD_WANTS}="infnoise.service"
     '';
 
-    systemd.services.infnoise = mkIf cfg.fillDevRandom {
+    systemd.services.infnoise = lib.mkIf cfg.fillDevRandom {
       description = "Infinite Noise TRNG driver";
 
       bindsTo = [ "dev-infnoise.device" ];

--- a/nixos/modules/services/security/munge.nix
+++ b/nixos/modules/services/security/munge.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.munge;
@@ -20,11 +17,11 @@ in
   options = {
 
     services.munge = {
-      enable = mkEnableOption "munge service";
+      enable = lib.mkEnableOption "munge service";
 
-      password = mkOption {
+      password = lib.mkOption {
         default = "/etc/munge/munge.key";
-        type = types.path;
+        type = lib.types.path;
         description = ''
           The path to a daemon's secret key.
         '';
@@ -36,7 +33,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ pkgs.munge ];
 

--- a/nixos/modules/services/security/nginx-sso.nix
+++ b/nixos/modules/services/security/nginx-sso.nix
@@ -1,21 +1,18 @@
 { config, lib, pkgs, utils, ... }:
-
-with lib;
-
 let
   cfg = config.services.nginx.sso;
   format = pkgs.formats.yaml { };
   configPath = "/var/lib/nginx-sso/config.yaml";
 in {
   options.services.nginx.sso = {
-    enable = mkEnableOption "nginx-sso service";
+    enable = lib.mkEnableOption "nginx-sso service";
 
-    package = mkPackageOption pkgs "nginx-sso" { };
+    package = lib.mkPackageOption pkgs "nginx-sso" { };
 
-    configuration = mkOption {
+    configuration = lib.mkOption {
       type = format.type;
       default = {};
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           listen = { addr = "127.0.0.1"; port = 8080; };
 
@@ -48,7 +45,7 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.nginx-sso = {
       description = "Nginx SSO Backend";
       after = [ "network.target" ];

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -4,14 +4,11 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.opensnitch;
   format = pkgs.formats.json { };
 
-  predefinedRules = flip mapAttrs cfg.rules (
+  predefinedRules = lib.flip lib.mapAttrs cfg.rules (
     name: cfg: {
       file = pkgs.writeText "rule" (builtins.toJSON cfg);
     }
@@ -21,11 +18,11 @@ in
 {
   options = {
     services.opensnitch = {
-      enable = mkEnableOption "Opensnitch application firewall";
+      enable = lib.mkEnableOption "Opensnitch application firewall";
 
-      rules = mkOption {
+      rules = lib.mkOption {
         default = { };
-        example = literalExpression ''
+        example = lib.literalExpression ''
           {
             "tor" = {
               "name" = "tor";
@@ -50,28 +47,28 @@ in
           for available options.
         '';
 
-        type = types.submodule {
+        type = lib.types.submodule {
           freeformType = format.type;
         };
       };
 
-      settings = mkOption {
-        type = types.submodule {
+      settings = lib.mkOption {
+        type = lib.types.submodule {
           freeformType = format.type;
 
           options = {
             Server = {
 
-              Address = mkOption {
-                type = types.str;
+              Address = lib.mkOption {
+                type = lib.types.str;
                 description = ''
                   Unix socket path (unix:///tmp/osui.sock, the "unix:///" part is
                   mandatory) or TCP socket (192.168.1.100:50051).
                 '';
               };
 
-              LogFile = mkOption {
-                type = types.path;
+              LogFile = lib.mkOption {
+                type = lib.types.path;
                 description = ''
                   File to write logs to (use /dev/stdout to write logs to standard
                   output).
@@ -80,8 +77,8 @@ in
 
             };
 
-            DefaultAction = mkOption {
-              type = types.enum [
+            DefaultAction = lib.mkOption {
+              type = lib.types.enum [
                 "allow"
                 "deny"
               ];
@@ -91,15 +88,15 @@ in
               '';
             };
 
-            InterceptUnknown = mkOption {
-              type = types.bool;
+            InterceptUnknown = lib.mkOption {
+              type = lib.types.bool;
               description = ''
                 Whether to intercept spare connections.
               '';
             };
 
-            ProcMonitorMethod = mkOption {
-              type = types.enum [
+            ProcMonitorMethod = lib.mkOption {
+              type = lib.types.enum [
                 "ebpf"
                 "proc"
                 "ftrace"
@@ -110,8 +107,8 @@ in
               '';
             };
 
-            LogLevel = mkOption {
-              type = types.enum [
+            LogLevel = lib.mkOption {
+              type = lib.types.enum [
                 0
                 1
                 2
@@ -124,8 +121,8 @@ in
               '';
             };
 
-            Firewall = mkOption {
-              type = types.enum [
+            Firewall = lib.mkOption {
+              type = lib.types.enum [
                 "iptables"
                 "nftables"
               ];
@@ -136,15 +133,15 @@ in
 
             Stats = {
 
-              MaxEvents = mkOption {
-                type = types.int;
+              MaxEvents = lib.mkOption {
+                type = lib.types.int;
                 description = ''
                   Max events to send to the GUI.
                 '';
               };
 
-              MaxStats = mkOption {
-                type = types.int;
+              MaxStats = lib.mkOption {
+                type = lib.types.int;
                 description = ''
                   Max stats per item to keep in backlog.
                 '';
@@ -152,14 +149,14 @@ in
 
             };
 
-            Ebpf.ModulesPath = mkOption {
-              type = types.path;
+            Ebpf.ModulesPath = lib.mkOption {
+              type = lib.types.path;
               default =
                 if cfg.settings.ProcMonitorMethod == "ebpf" then
                   "${config.boot.kernelPackages.opensnitch-ebpf}/etc/opensnitchd"
                 else
                   null;
-              defaultText = literalExpression ''
+              defaultText = lib.literalExpression ''
                 if cfg.settings.ProcMonitorMethod == "ebpf" then
                   "\\$\\{config.boot.kernelPackages.opensnitch-ebpf\\}/etc/opensnitchd"
                 else null;
@@ -170,8 +167,8 @@ in
               '';
             };
 
-            Rules.Path = mkOption {
-              type = types.path;
+            Rules.Path = lib.mkOption {
+              type = lib.types.path;
               default = "/var/lib/opensnitch/rules";
               description = ''
                 Path to the directory where firewall rules can be found and will
@@ -189,10 +186,10 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     # pkg.opensnitch is referred to elsewhere in the module so we don't need to worry about it being garbage collected
-    services.opensnitch.settings = mapAttrs (_: v: mkDefault v) (
+    services.opensnitch.settings = lib.mapAttrs (_: v: lib.mkDefault v) (
       builtins.fromJSON (
         builtins.unsafeDiscardStringContext (
           builtins.readFile "${pkgs.opensnitch}/etc/opensnitchd/default-config.json"
@@ -210,9 +207,9 @@ in
             "${pkgs.opensnitch}/bin/opensnitchd --config-file ${format.generate "default-config.json" cfg.settings}"
           ];
         };
-        preStart = mkIf (cfg.rules != { }) (
+        preStart = lib.mkIf (cfg.rules != { }) (
           let
-            rules = flip mapAttrsToList predefinedRules (
+            rules = lib.flip lib.mapAttrsToList predefinedRules (
               file: content: {
                 inherit (content) file;
                 local = "${cfg.settings.Rules.Path}/${file}.json";
@@ -225,11 +222,11 @@ in
             # declared in `cfg.rules` (i.e. all networks that were "removed" from
             # `cfg.rules`).
             find ${cfg.settings.Rules.Path} -type l -lname '${builtins.storeDir}/*' ${
-              optionalString (rules != { }) ''
-                -not \( ${concatMapStringsSep " -o " ({ local, ... }: "-name '${baseNameOf local}*'") rules} \) \
+              lib.optionalString (rules != { }) ''
+                -not \( ${lib.concatMapStringsSep " -o " ({ local, ... }: "-name '${baseNameOf local}*'") rules} \) \
               ''
             } -delete
-            ${concatMapStrings (
+            ${lib.concatMapStrings (
               { file, local }:
               ''
                 ln -sf '${file}' "${local}"

--- a/nixos/modules/services/security/opensnitch.nix
+++ b/nixos/modules/services/security/opensnitch.nix
@@ -223,7 +223,9 @@ in
             # `cfg.rules`).
             find ${cfg.settings.Rules.Path} -type l -lname '${builtins.storeDir}/*' ${
               lib.optionalString (rules != { }) ''
-                -not \( ${lib.concatMapStringsSep " -o " ({ local, ... }: "-name '${baseNameOf local}*'") rules} \) \
+                -not \( ${
+                  lib.concatMapStringsSep " -o " ({ local, ... }: "-name '${baseNameOf local}*'") rules
+                } \) \
               ''
             } -delete
             ${lib.concatMapStrings (

--- a/nixos/modules/services/security/pass-secret-service.nix
+++ b/nixos/modules/services/security/pass-secret-service.nix
@@ -4,25 +4,22 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.passSecretService;
 in
 {
   options.services.passSecretService = {
-    enable = mkEnableOption "pass secret service";
+    enable = lib.mkEnableOption "pass secret service";
 
-    package = mkPackageOption pkgs "pass-secret-service" {
+    package = lib.mkPackageOption pkgs "pass-secret-service" {
       example = "pass-secret-service.override { python3 = pkgs.python310 }";
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.packages = [ cfg.package ];
     services.dbus.packages = [ cfg.package ];
   };
 
-  meta.maintainers = with maintainers; [ aidalgol ];
+  meta.maintainers = with lib.maintainers; [ aidalgol ];
 }

--- a/nixos/modules/services/security/physlock.nix
+++ b/nixos/modules/services/security/physlock.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.physlock;
 in
@@ -19,8 +16,8 @@ in
 
     services.physlock = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable the {command}`physlock` screen locking mechanism.
@@ -35,8 +32,8 @@ in
         '';
       };
 
-      allowAnyUser = mkOption {
-        type = types.bool;
+      allowAnyUser = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to allow any user to lock the screen. This will install a
@@ -46,24 +43,24 @@ in
         '';
       };
 
-      disableSysRq = mkOption {
-        type = types.bool;
+      disableSysRq = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Whether to disable SysRq when locked with physlock.
         '';
       };
 
-      lockMessage = mkOption {
-        type = types.str;
+      lockMessage = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           Message to show on physlock login terminal.
         '';
       };
 
-      muteKernelMessages = mkOption {
-        type = types.bool;
+      muteKernelMessages = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Disable kernel messages on console while physlock is running.
@@ -72,24 +69,24 @@ in
 
       lockOn = {
 
-        suspend = mkOption {
-          type = types.bool;
+        suspend = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Whether to lock screen with physlock just before suspend.
           '';
         };
 
-        hibernate = mkOption {
-          type = types.bool;
+        hibernate = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Whether to lock screen with physlock just before hibernate.
           '';
         };
 
-        extraTargets = mkOption {
-          type = types.listOf types.str;
+        extraTargets = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
           default = [ ];
           example = [ "display-manager.service" ];
           description = ''
@@ -110,7 +107,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable (mkMerge [
+  config = lib.mkIf cfg.enable (lib.mkMerge [
     {
 
       # for physlock -l and physlock -L
@@ -120,18 +117,18 @@ in
         enable = true;
         description = "Physlock";
         wantedBy =
-          optional cfg.lockOn.suspend "suspend.target"
-          ++ optional cfg.lockOn.hibernate "hibernate.target"
+          lib.optional cfg.lockOn.suspend "suspend.target"
+          ++ lib.optional cfg.lockOn.hibernate "hibernate.target"
           ++ cfg.lockOn.extraTargets;
         before =
-          optional cfg.lockOn.suspend "systemd-suspend.service"
-          ++ optional cfg.lockOn.hibernate "systemd-hibernate.service"
-          ++ optional (cfg.lockOn.hibernate || cfg.lockOn.suspend) "systemd-suspend-then-hibernate.service"
+          lib.optional cfg.lockOn.suspend "systemd-suspend.service"
+          ++ lib.optional cfg.lockOn.hibernate "systemd-hibernate.service"
+          ++ lib.optional (cfg.lockOn.hibernate || cfg.lockOn.suspend) "systemd-suspend-then-hibernate.service"
           ++ cfg.lockOn.extraTargets;
         serviceConfig = {
           Type = "forking";
-          ExecStart = "${pkgs.physlock}/bin/physlock -d${optionalString cfg.muteKernelMessages "m"}${optionalString cfg.disableSysRq "s"}${
-            optionalString (cfg.lockMessage != "") " -p \"${cfg.lockMessage}\""
+          ExecStart = "${pkgs.physlock}/bin/physlock -d${lib.optionalString cfg.muteKernelMessages "m"}${lib.optionalString cfg.disableSysRq "s"}${
+            lib.optionalString (cfg.lockMessage != "") " -p \"${cfg.lockMessage}\""
           }";
         };
       };
@@ -140,7 +137,7 @@ in
 
     }
 
-    (mkIf cfg.allowAnyUser {
+    (lib.mkIf cfg.allowAnyUser {
 
       security.wrappers.physlock = {
         setuid = true;

--- a/nixos/modules/services/security/physlock.nix
+++ b/nixos/modules/services/security/physlock.nix
@@ -107,46 +107,50 @@ in
 
   ###### implementation
 
-  config = lib.mkIf cfg.enable (lib.mkMerge [
-    {
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
 
-      # for physlock -l and physlock -L
-      environment.systemPackages = [ pkgs.physlock ];
+        # for physlock -l and physlock -L
+        environment.systemPackages = [ pkgs.physlock ];
 
-      systemd.services.physlock = {
-        enable = true;
-        description = "Physlock";
-        wantedBy =
-          lib.optional cfg.lockOn.suspend "suspend.target"
-          ++ lib.optional cfg.lockOn.hibernate "hibernate.target"
-          ++ cfg.lockOn.extraTargets;
-        before =
-          lib.optional cfg.lockOn.suspend "systemd-suspend.service"
-          ++ lib.optional cfg.lockOn.hibernate "systemd-hibernate.service"
-          ++ lib.optional (cfg.lockOn.hibernate || cfg.lockOn.suspend) "systemd-suspend-then-hibernate.service"
-          ++ cfg.lockOn.extraTargets;
-        serviceConfig = {
-          Type = "forking";
-          ExecStart = "${pkgs.physlock}/bin/physlock -d${lib.optionalString cfg.muteKernelMessages "m"}${lib.optionalString cfg.disableSysRq "s"}${
-            lib.optionalString (cfg.lockMessage != "") " -p \"${cfg.lockMessage}\""
-          }";
+        systemd.services.physlock = {
+          enable = true;
+          description = "Physlock";
+          wantedBy =
+            lib.optional cfg.lockOn.suspend "suspend.target"
+            ++ lib.optional cfg.lockOn.hibernate "hibernate.target"
+            ++ cfg.lockOn.extraTargets;
+          before =
+            lib.optional cfg.lockOn.suspend "systemd-suspend.service"
+            ++ lib.optional cfg.lockOn.hibernate "systemd-hibernate.service"
+            ++ lib.optional (
+              cfg.lockOn.hibernate || cfg.lockOn.suspend
+            ) "systemd-suspend-then-hibernate.service"
+            ++ cfg.lockOn.extraTargets;
+          serviceConfig = {
+            Type = "forking";
+            ExecStart = "${pkgs.physlock}/bin/physlock -d${lib.optionalString cfg.muteKernelMessages "m"}${lib.optionalString cfg.disableSysRq "s"}${
+              lib.optionalString (cfg.lockMessage != "") " -p \"${cfg.lockMessage}\""
+            }";
+          };
         };
-      };
 
-      security.pam.services.physlock = { };
+        security.pam.services.physlock = { };
 
-    }
+      }
 
-    (lib.mkIf cfg.allowAnyUser {
+      (lib.mkIf cfg.allowAnyUser {
 
-      security.wrappers.physlock = {
-        setuid = true;
-        owner = "root";
-        group = "root";
-        source = "${pkgs.physlock}/bin/physlock";
-      };
+        security.wrappers.physlock = {
+          setuid = true;
+          owner = "root";
+          group = "root";
+          source = "${pkgs.physlock}/bin/physlock";
+        };
 
-    })
-  ]);
+      })
+    ]
+  );
 
 }

--- a/nixos/modules/services/security/sks.nix
+++ b/nixos/modules/services/security/sks.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.sks;
   sksPkg = cfg.package;
@@ -16,7 +13,7 @@ let
 
 in
 {
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     calbrecht
     jcumming
   ];
@@ -25,15 +22,15 @@ in
 
     services.sks = {
 
-      enable = mkEnableOption ''
+      enable = lib.mkEnableOption ''
         SKS (synchronizing key server for OpenPGP) and start the database
         server. You need to create "''${dataDir}/dump/*.gpg" for the initial
         import'';
 
-      package = mkPackageOption pkgs "sks" { };
+      package = lib.mkPackageOption pkgs "sks" { };
 
-      dataDir = mkOption {
-        type = types.path;
+      dataDir = lib.mkOption {
+        type = lib.types.path;
         default = "/var/db/sks";
         example = "/var/lib/sks";
         # TODO: The default might change to "/var/lib/sks" as this is more
@@ -46,8 +43,8 @@ in
         '';
       };
 
-      extraDbConfig = mkOption {
-        type = types.str;
+      extraDbConfig = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           Set contents of the files "KDB/DB_CONFIG" and "PTree/DB_CONFIG" within
@@ -60,28 +57,28 @@ in
         '';
       };
 
-      hkpAddress = mkOption {
+      hkpAddress = lib.mkOption {
         default = [
           "127.0.0.1"
           "::1"
         ];
-        type = types.listOf types.str;
+        type = lib.types.listOf lib.types.str;
         description = ''
           Domain names, IPv4 and/or IPv6 addresses to listen on for HKP
           requests.
         '';
       };
 
-      hkpPort = mkOption {
+      hkpPort = lib.mkOption {
         default = 11371;
-        type = types.ints.u16;
+        type = lib.types.ints.u16;
         description = "HKP port to listen on.";
       };
 
-      webroot = mkOption {
-        type = types.nullOr types.path;
+      webroot = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = "${sksPkg.webSamples}/OpenPKG";
-        defaultText = literalExpression ''"''${package.webSamples}/OpenPKG"'';
+        defaultText = lib.literalExpression ''"''${package.webSamples}/OpenPKG"'';
         description = ''
           Source directory (will be symlinked, if not null) for the files the
           built-in webserver should serve. SKS (''${pkgs.sks.webSamples})
@@ -96,7 +93,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     users = {
       users.sks = {

--- a/nixos/modules/services/security/sslmate-agent.nix
+++ b/nixos/modules/services/security/sslmate-agent.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.sslmate-agent;
 
@@ -16,11 +13,11 @@ in
 
   options = {
     services.sslmate-agent = {
-      enable = mkEnableOption "sslmate-agent, a daemon for managing SSL/TLS certificates on a server";
+      enable = lib.mkEnableOption "sslmate-agent, a daemon for managing SSL/TLS certificates on a server";
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [ sslmate-agent ];
 
     systemd = {

--- a/nixos/modules/services/security/tang.nix
+++ b/nixos/modules/services/security/tang.nix
@@ -4,23 +4,22 @@
   pkgs,
   ...
 }:
-with lib;
 let
   cfg = config.services.tang;
 in
 {
   options.services.tang = {
-    enable = mkEnableOption "tang";
+    enable = lib.mkEnableOption "tang";
 
-    package = mkOption {
-      type = types.package;
+    package = lib.mkOption {
+      type = lib.types.package;
       default = pkgs.tang;
-      defaultText = literalExpression "pkgs.tang";
+      defaultText = lib.literalExpression "pkgs.tang";
       description = "The tang package to use.";
     };
 
-    listenStream = mkOption {
-      type = with types; listOf str;
+    listenStream = lib.mkOption {
+      type = with lib.types; listOf str;
       default = [ "7654" ];
       example = [
         "198.168.100.1:7654"
@@ -33,9 +32,9 @@ in
       '';
     };
 
-    ipAddressAllow = mkOption {
+    ipAddressAllow = lib.mkOption {
       example = [ "192.168.1.0/24" ];
-      type = types.listOf types.str;
+      type = lib.types.listOf lib.types.str;
       description = ''
         Whitelist a list of address prefixes.
         Preferably, internal addresses should be used.
@@ -43,7 +42,7 @@ in
     };
 
   };
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
     systemd.services."tangd@" = {

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -5,10 +5,7 @@
   pkgs,
   ...
 }:
-
 with builtins;
-with lib;
-
 let
   cfg = config.services.tor;
   opt = options.services.tor;
@@ -44,33 +41,33 @@ let
       ]);
   optionBool =
     optionName:
-    mkOption {
-      type = with types; nullOr bool;
+    lib.mkOption {
+      type = with lib.types; nullOr bool;
       default = null;
       description = (descriptionGeneric optionName);
     };
   optionInt =
     optionName:
-    mkOption {
-      type = with types; nullOr int;
+    lib.mkOption {
+      type = with lib.types; nullOr int;
       default = null;
       description = (descriptionGeneric optionName);
     };
   optionString =
     optionName:
-    mkOption {
-      type = with types; nullOr str;
+    lib.mkOption {
+      type = with lib.types; nullOr str;
       default = null;
       description = (descriptionGeneric optionName);
     };
   optionStrings =
     optionName:
-    mkOption {
-      type = with types; listOf str;
+    lib.mkOption {
+      type = with lib.types; listOf str;
       default = [ ];
       description = (descriptionGeneric optionName);
     };
-  optionAddress = mkOption {
+  optionAddress = lib.mkOption {
     type = with types; nullOr str;
     default = null;
     example = "0.0.0.0";
@@ -78,14 +75,14 @@ let
       IPv4 or IPv6 (if between brackets) address.
     '';
   };
-  optionUnix = mkOption {
+  optionUnix = lib.mkOption {
     type = with types; nullOr path;
     default = null;
     description = ''
       Unix domain socket path to use.
     '';
   };
-  optionPort = mkOption {
+  optionPort = lib.mkOption {
     type =
       with types;
       nullOr (oneOf [
@@ -96,13 +93,13 @@ let
   };
   optionPorts =
     optionName:
-    mkOption {
-      type = with types; listOf port;
+    lib.mkOption {
+      type = with lib.types; listOf port;
       default = [ ];
       description = (descriptionGeneric optionName);
     };
   optionIsolablePort =
-    with types;
+    with lib.types;
     oneOf [
       port
       (enum [ "auto" ])
@@ -114,14 +111,14 @@ let
               addr = optionAddress;
               port = optionPort;
               flags = optionFlags;
-              SessionGroup = mkOption {
+              SessionGroup = lib.mkOption {
                 type = nullOr int;
                 default = null;
               };
             }
-            // genAttrs isolateFlags (
+            // lib.genAttrs isolateFlags (
               name:
-              mkOption {
+              lib.mkOption {
                 type = types.bool;
                 default = false;
               }
@@ -136,9 +133,9 @@ let
     ];
   optionIsolablePorts =
     optionName:
-    mkOption {
+    lib.mkOption {
       default = [ ];
-      type = with types; either optionIsolablePort (listOf optionIsolablePort);
+      type = with lib.types; either optionIsolablePort (listOf optionIsolablePort);
       description = (descriptionGeneric optionName);
     };
   isolateFlags = [
@@ -171,7 +168,7 @@ let
         "WorldWritable"
       ] ++ isolateFlags;
     in
-    with types;
+    with lib.types;
     oneOf [
       port
       (submodule (
@@ -183,19 +180,19 @@ let
               addr = optionAddress;
               port = optionPort;
               flags = optionFlags;
-              SessionGroup = mkOption {
+              SessionGroup = lib.mkOption {
                 type = nullOr int;
                 default = null;
               };
             }
-            // genAttrs flags (
+            // lib.genAttrs flags (
               name:
-              mkOption {
+              lib.mkOption {
                 type = types.bool;
                 default = false;
               }
             );
-          config = mkIf doConfig {
+          config = lib.mkIf doConfig {
             # Only add flags in SOCKSPort to avoid duplicates
             flags =
               filter (name: config.${name} == true) flags
@@ -204,17 +201,17 @@ let
         }
       ))
     ];
-  optionFlags = mkOption {
+  optionFlags = lib.mkOption {
     type = with types; listOf str;
     default = [ ];
   };
   optionORPort =
     optionName:
-    mkOption {
+    lib.mkOption {
       default = [ ];
       example = 443;
       type =
-        with types;
+        with lib.types;
         oneOf [
           port
           (enum [ "auto" ])
@@ -238,9 +235,9 @@ let
                     port = optionPort;
                     flags = optionFlags;
                   }
-                  // genAttrs flags (
+                  // lib.genAttrs flags (
                     name:
-                    mkOption {
+                    lib.mkOption {
                       type = types.bool;
                       default = false;
                     }
@@ -256,15 +253,15 @@ let
     };
   optionBandwidth =
     optionName:
-    mkOption {
-      type = with types; nullOr (either int str);
+    lib.mkOption {
+      type = with lib.types; nullOr (either int str);
       default = null;
       description = (descriptionGeneric optionName);
     };
   optionPath =
     optionName:
-    mkOption {
-      type = with types; nullOr path;
+    lib.mkOption {
+      type = with lib.types; nullOr path;
       default = null;
       description = (descriptionGeneric optionName);
     };
@@ -323,119 +320,119 @@ let
 in
 {
   imports = [
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "client" "dns" "automapHostsSuffixes" ]
       [ "services" "tor" "settings" "AutomapHostsSuffixes" ]
     )
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "client"
       "dns"
       "isolationOptions"
     ] "Use services.tor.settings.DNSPort instead.")
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "client"
       "dns"
       "listenAddress"
     ] "Use services.tor.settings.DNSPort instead.")
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "client"
       "privoxy"
       "enable"
     ] "Use services.privoxy.enable and services.privoxy.enableTor instead.")
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "client"
       "socksIsolationOptions"
     ] "Use services.tor.settings.SOCKSPort instead.")
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "client"
       "socksListenAddressFaster"
     ] "Use services.tor.settings.SOCKSPort instead.")
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "client" "socksPolicy" ]
       [ "services" "tor" "settings" "SocksPolicy" ]
     )
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "client"
       "transparentProxy"
       "isolationOptions"
     ] "Use services.tor.settings.TransPort instead.")
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "client"
       "transparentProxy"
       "listenAddress"
     ] "Use services.tor.settings.TransPort instead.")
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "controlPort" ]
       [ "services" "tor" "settings" "ControlPort" ]
     )
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "extraConfig"
     ] "Please use services.tor.settings instead.")
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "hiddenServices" ]
       [ "services" "tor" "relay" "onionServices" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "accountingMax" ]
       [ "services" "tor" "settings" "AccountingMax" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "accountingStart" ]
       [ "services" "tor" "settings" "AccountingStart" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "address" ]
       [ "services" "tor" "settings" "Address" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "bandwidthBurst" ]
       [ "services" "tor" "settings" "BandwidthBurst" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "bandwidthRate" ]
       [ "services" "tor" "settings" "BandwidthRate" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "bridgeTransports" ]
       [ "services" "tor" "settings" "ServerTransportPlugin" "transports" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "contactInfo" ]
       [ "services" "tor" "settings" "ContactInfo" ]
     )
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "exitPolicy" ]
       [ "services" "tor" "settings" "ExitPolicy" ]
     )
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "tor"
       "relay"
       "isBridge"
     ] "Use services.tor.relay.role instead.")
-    (mkRemovedOptionModule [ "services" "tor" "relay" "isExit" ] "Use services.tor.relay.role instead.")
-    (mkRenamedOptionModule
+    (lib.mkRemovedOptionModule [ "services" "tor" "relay" "isExit" ] "Use services.tor.relay.role instead.")
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "nickname" ]
       [ "services" "tor" "settings" "Nickname" ]
     )
-    (mkRenamedOptionModule [ "services" "tor" "relay" "port" ] [ "services" "tor" "settings" "ORPort" ])
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule [ "services" "tor" "relay" "port" ] [ "services" "tor" "settings" "ORPort" ])
+    (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "portSpec" ]
       [ "services" "tor" "settings" "ORPort" ]
     )
@@ -443,17 +440,17 @@ in
 
   options = {
     services.tor = {
-      enable = mkEnableOption ''
+      enable = lib.mkEnableOption ''
         Tor daemon.
                 By default, the daemon is run without
                 relay, exit, bridge or client connectivity'';
 
-      openFirewall = mkEnableOption "opening of the relay port(s) in the firewall";
+      openFirewall = lib.mkEnableOption "opening of the relay port(s) in the firewall";
 
-      package = mkPackageOption pkgs "tor" { };
+      package = lib.mkPackageOption pkgs "tor" { };
 
       enableGeoIP =
-        mkEnableOption ''
+        lib.mkEnableOption ''
           use of GeoIP databases.
                   Disabling this will disable by-country statistics for bridges and relays
                   and some client and third-party software functionality''
@@ -461,19 +458,19 @@ in
           default = true;
         };
 
-      controlSocket.enable = mkEnableOption ''
+      controlSocket.enable = lib.mkEnableOption ''
         control socket,
                 created in `${runDir}/control`'';
 
       client = {
-        enable = mkEnableOption ''
+        enable = lib.mkEnableOption ''
           the routing of application connections.
                     You might want to disable this if you plan running a dedicated Tor relay'';
 
-        transparentProxy.enable = mkEnableOption "transparent proxy";
-        dns.enable = mkEnableOption "DNS resolver";
+        transparentProxy.enable = lib.mkEnableOption "transparent proxy";
+        dns.enable = lib.mkEnableOption "DNS resolver";
 
-        socksListenAddress = mkOption {
+        socksListenAddress = lib.mkOption {
           type = optionSOCKSPort false;
           default = {
             addr = "127.0.0.1";
@@ -491,7 +488,7 @@ in
           '';
         };
 
-        onionServices = mkOption {
+        onionServices = lib.mkOption {
           description = (descriptionGeneric "HiddenServiceDir");
           default = { };
           example = {
@@ -499,11 +496,11 @@ in
               clientAuthorizations = [ "/run/keys/tor/alice.prv.x25519" ];
             };
           };
-          type = types.attrsOf (
-            types.submodule (
+          type = lib.types.attrsOf (
+            lib.types.submodule (
               { name, config, ... }:
               {
-                options.clientAuthorizations = mkOption {
+                options.clientAuthorizations = lib.mkOption {
                   description = ''
                     Clients' authorizations for a v3 onion service,
                     as a list of files containing each one private key, in the format:
@@ -512,7 +509,7 @@ in
                     ```
                     ${descriptionGeneric "_client_authorization"}
                   '';
-                  type = with types; listOf path;
+                  type = with lib.types; listOf path;
                   default = [ ];
                   example = [ "/run/keys/tor/alice.prv.x25519" ];
                 };
@@ -523,7 +520,7 @@ in
       };
 
       relay = {
-        enable = mkEnableOption "tor relaying" // {
+        enable = lib.mkEnableOption "tor relaying" // {
           description = ''
             Whether to enable relaying of Tor traffic for others.
 
@@ -538,8 +535,8 @@ in
           '';
         };
 
-        role = mkOption {
-          type = types.enum [
+        role = lib.mkOption {
+          type = lib.types.enum [
             "exit"
             "relay"
             "bridge"
@@ -629,7 +626,7 @@ in
           '';
         };
 
-        onionServices = mkOption {
+        onionServices = lib.mkOption {
           description = (descriptionGeneric "HiddenServiceDir");
           default = { };
           example = {
@@ -640,12 +637,12 @@ in
               ];
             };
           };
-          type = types.attrsOf (
-            types.submodule (
+          type = lib.types.attrsOf (
+            lib.types.submodule (
               { name, config, ... }:
               {
-                options.path = mkOption {
-                  type = types.path;
+                options.path = lib.mkOption {
+                  type = lib.types.path;
                   description = ''
                     Path where to store the data files of the hidden service.
                     If the {option}`secretKey` is null
@@ -653,8 +650,8 @@ in
                     otherwise to `${runDir}/onion/$onion`.
                   '';
                 };
-                options.secretKey = mkOption {
-                  type = with types; nullOr path;
+                options.secretKey = lib.mkOption {
+                  type = with lib.types; nullOr path;
                   default = null;
                   example = "/run/keys/tor/onion/expyuzz4wqqyqhjn/hs_ed25519_secret_key";
                   description = ''
@@ -665,16 +662,16 @@ in
                     from this file if they do not exist.
                   '';
                 };
-                options.authorizeClient = mkOption {
+                options.authorizeClient = lib.mkOption {
                   description = (descriptionGeneric "HiddenServiceAuthorizeClient");
                   default = null;
-                  type = types.nullOr (
-                    types.submodule (
+                  type = lib.types.nullOr (
+                    lib.types.submodule (
                       { ... }:
                       {
                         options = {
-                          authType = mkOption {
-                            type = types.enum [
+                          authType = lib.mkOption {
+                            type = lib.types.enum [
                               "basic"
                               "stealth"
                             ];
@@ -684,8 +681,8 @@ in
                               that also hides service activity from unauthorized clients.
                             '';
                           };
-                          clientNames = mkOption {
-                            type = with types; nonEmptyListOf (strMatching "[A-Za-z0-9+-_]+");
+                          clientNames = lib.mkOption {
+                            type = with lib.types; nonEmptyListOf (strMatching "[A-Za-z0-9+-_]+");
                             description = ''
                               Only clients that are listed here are authorized to access the hidden service.
                               Generated authorization data can be found in {file}`${stateDir}/onion/$name/hostname`.
@@ -698,7 +695,7 @@ in
                     )
                   );
                 };
-                options.authorizedClients = mkOption {
+                options.authorizedClients = lib.mkOption {
                   description = ''
                     Authorized clients for a v3 onion service,
                     as a list of public key, in the format:
@@ -707,14 +704,14 @@ in
                     ```
                     ${descriptionGeneric "_client_authorization"}
                   '';
-                  type = with types; listOf str;
+                  type = with lib.types; listOf str;
                   default = [ ];
                   example = [ "descriptor:x25519:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" ];
                 };
-                options.map = mkOption {
+                options.map = lib.mkOption {
                   description = (descriptionGeneric "HiddenServicePort");
                   type =
-                    with types;
+                    with lib.types;
                     listOf (oneOf [
                       port
                       (submodule (
@@ -722,7 +719,7 @@ in
                         {
                           options = {
                             port = optionPort;
-                            target = mkOption {
+                            target = lib.mkOption {
                               default = null;
                               type = nullOr (
                                 submodule (
@@ -752,25 +749,25 @@ in
                       v
                   );
                 };
-                options.version = mkOption {
+                options.version = lib.mkOption {
                   description = (descriptionGeneric "HiddenServiceVersion");
                   type =
-                    with types;
+                    with lib.types;
                     nullOr (enum [
                       2
                       3
                     ]);
                   default = null;
                 };
-                options.settings = mkOption {
+                options.settings = lib.mkOption {
                   description = ''
                     Settings of the onion service.
                     ${descriptionGeneric "_hidden_service_options"}
                   '';
                   default = { };
-                  type = types.submodule {
+                  type = lib.types.submodule {
                     freeformType =
-                      with types;
+                      with lib.types;
                       (attrsOf (
                         nullOr (oneOf [
                           str
@@ -784,20 +781,20 @@ in
                       };
                     options.HiddenServiceAllowUnknownPorts = optionBool "HiddenServiceAllowUnknownPorts";
                     options.HiddenServiceDirGroupReadable = optionBool "HiddenServiceDirGroupReadable";
-                    options.HiddenServiceExportCircuitID = mkOption {
+                    options.HiddenServiceExportCircuitID = lib.mkOption {
                       description = (descriptionGeneric "HiddenServiceExportCircuitID");
-                      type = with types; nullOr (enum [ "haproxy" ]);
+                      type = with lib.types; nullOr (enum [ "haproxy" ]);
                       default = null;
                     };
-                    options.HiddenServiceMaxStreams = mkOption {
+                    options.HiddenServiceMaxStreams = lib.mkOption {
                       description = (descriptionGeneric "HiddenServiceMaxStreams");
-                      type = with types; nullOr (ints.between 0 65535);
+                      type = with lib.types; nullOr (ints.between 0 65535);
                       default = null;
                     };
                     options.HiddenServiceMaxStreamsCloseCircuit = optionBool "HiddenServiceMaxStreamsCloseCircuit";
-                    options.HiddenServiceNumIntroductionPoints = mkOption {
+                    options.HiddenServiceNumIntroductionPoints = lib.mkOption {
                       description = (descriptionGeneric "HiddenServiceNumIntroductionPoints");
-                      type = with types; nullOr (ints.between 0 20);
+                      type = with lib.types; nullOr (ints.between 0 20);
                       default = null;
                     };
                     options.HiddenServiceSingleHopMode = optionBool "HiddenServiceSingleHopMode";
@@ -822,15 +819,15 @@ in
         };
       };
 
-      settings = mkOption {
+      settings = lib.mkOption {
         description = ''
           See [torrc manual](https://2019.www.torproject.org/docs/tor-manual.html.en)
           for documentation.
         '';
         default = { };
-        type = types.submodule {
+        type = lib.types.submodule {
           freeformType =
-            with types;
+            with lib.types;
             (attrsOf (
               nullOr (oneOf [
                 str
@@ -872,10 +869,10 @@ in
           options.CellStatistics = optionBool "CellStatistics";
           options.ClientAutoIPv6ORPort = optionBool "ClientAutoIPv6ORPort";
           options.ClientDNSRejectInternalAddresses = optionBool "ClientDNSRejectInternalAddresses";
-          options.ClientOnionAuthDir = mkOption {
+          options.ClientOnionAuthDir = lib.mkOption {
             description = (descriptionGeneric "ClientOnionAuthDir");
             default = null;
-            type = with types; nullOr path;
+            type = with lib.types; nullOr path;
           };
           options.ClientPreferIPv6DirPort = optionBool "ClientPreferIPv6DirPort"; # default is null and like "auto"
           options.ClientPreferIPv6ORPort = optionBool "ClientPreferIPv6ORPort"; # default is null and like "auto"
@@ -885,12 +882,12 @@ in
           options.ConnDirectionStatistics = optionBool "ConnDirectionStatistics";
           options.ConstrainedSockets = optionBool "ConstrainedSockets";
           options.ContactInfo = optionString "ContactInfo";
-          options.ControlPort = mkOption rec {
+          options.ControlPort = lib.mkOption rec {
             description = (descriptionGeneric "ControlPort");
             default = [ ];
             example = [ { port = 9051; } ];
             type =
-              with types;
+              with lib.types;
               oneOf [
                 port
                 (enum [ "auto" ])
@@ -914,9 +911,9 @@ in
                           addr = optionAddress;
                           port = optionPort;
                         }
-                        // genAttrs flags (
+                        // lib.genAttrs flags (
                           name:
-                          mkOption {
+                          lib.mkOption {
                             type = types.bool;
                             default = false;
                           }
@@ -946,9 +943,9 @@ in
           options.DormantOnFirstStartup = optionBool "DormantOnFirstStartup";
           options.DormantTimeoutDisabledByIdleStreams = optionBool "DormantTimeoutDisabledByIdleStreams";
           options.DirCache = optionBool "DirCache";
-          options.DirPolicy = mkOption {
+          options.DirPolicy = lib.mkOption {
             description = (descriptionGeneric "DirPolicy");
-            type = with types; listOf str;
+            type = with lib.types; listOf str;
             default = [ ];
             example = [ "accept *:*" ];
           };
@@ -973,11 +970,11 @@ in
           options.ExitPolicyRejectPrivate = optionBool "ExitPolicyRejectPrivate";
           options.ExitPortStatistics = optionBool "ExitPortStatistics";
           options.ExitRelay = optionBool "ExitRelay"; # default is null and like "auto"
-          options.ExtORPort = mkOption {
+          options.ExtORPort = lib.mkOption {
             description = (descriptionGeneric "ExtORPort");
             default = null;
             type =
-              with types;
+              with lib.types;
               nullOr (oneOf [
                 port
                 (enum [ "auto" ])
@@ -1009,20 +1006,20 @@ in
           options.GeoIPFile = optionPath "GeoIPFile";
           options.GeoIPv6File = optionPath "GeoIPv6File";
           options.GuardfractionFile = optionPath "GuardfractionFile";
-          options.HidServAuth = mkOption {
+          options.HidServAuth = lib.mkOption {
             description = (descriptionGeneric "HidServAuth");
             default = [ ];
             type =
-              with types;
+              with lib.types;
               listOf (oneOf [
                 (submodule {
                   options = {
-                    onion = mkOption {
+                    onion = lib.mkOption {
                       type = strMatching "[a-z2-7]{16}\\.onion";
                       description = "Onion address.";
                       example = "xxxxxxxxxxxxxxxx.onion";
                     };
-                    auth = mkOption {
+                    auth = lib.mkOption {
                       type = strMatching "[A-Za-z0-9+/]{22}";
                       description = "Authentication cookie.";
                     };
@@ -1062,10 +1059,10 @@ in
           options.PidFile = optionPath "PidFile";
           options.ProtocolWarnings = optionBool "ProtocolWarnings";
           options.PublishHidServDescriptors = optionBool "PublishHidServDescriptors";
-          options.PublishServerDescriptor = mkOption {
+          options.PublishServerDescriptor = lib.mkOption {
             description = (descriptionGeneric "PublishServerDescriptor");
             type =
-              with types;
+              with lib.types;
               nullOr (enum [
                 false
                 true
@@ -1091,17 +1088,17 @@ in
           options.ServerDNSRandomizeCase = optionBool "ServerDNSRandomizeCase";
           options.ServerDNSResolvConfFile = optionPath "ServerDNSResolvConfFile";
           options.ServerDNSSearchDomains = optionBool "ServerDNSSearchDomains";
-          options.ServerTransportPlugin = mkOption {
+          options.ServerTransportPlugin = lib.mkOption {
             description = (descriptionGeneric "ServerTransportPlugin");
             default = null;
             type =
-              with types;
+              with lib.types;
               nullOr (
                 submodule (
                   { ... }:
                   {
                     options = {
-                      transports = mkOption {
+                      transports = lib.mkOption {
                         description = "List of pluggable transports.";
                         type = listOf str;
                         example = [
@@ -1111,7 +1108,7 @@ in
                           "scramblesuit"
                         ];
                       };
-                      exec = mkOption {
+                      exec = lib.mkOption {
                         type = types.str;
                         description = "Command of pluggable transport.";
                       };
@@ -1120,31 +1117,31 @@ in
                 )
               );
           };
-          options.ShutdownWaitLength = mkOption {
-            type = types.int;
+          options.ShutdownWaitLength = lib.mkOption {
+            type = lib.types.int;
             default = 30;
             description = (descriptionGeneric "ShutdownWaitLength");
           };
           options.SocksPolicy = optionStrings "SocksPolicy" // {
             example = [ "accept *:*" ];
           };
-          options.SOCKSPort = mkOption {
+          options.SOCKSPort = lib.mkOption {
             description = (descriptionGeneric "SOCKSPort");
             default = lib.optionals cfg.settings.HiddenServiceNonAnonymousMode [ { port = 0; } ];
-            defaultText = literalExpression ''
+            defaultText = lib.literalExpression ''
               if config.${opt.settings}.HiddenServiceNonAnonymousMode == true
               then [ { port = 0; } ]
               else [ ]
             '';
             example = [ { port = 9090; } ];
-            type = types.listOf (optionSOCKSPort true);
+            type = lib.types.listOf (optionSOCKSPort true);
           };
           options.TestingTorNetwork = optionBool "TestingTorNetwork";
           options.TransPort = optionIsolablePorts "TransPort";
-          options.TransProxyType = mkOption {
+          options.TransProxyType = lib.mkOption {
             description = (descriptionGeneric "TransProxyType");
             type =
-              with types;
+              with lib.types;
               nullOr (enum [
                 "default"
                 "TPROXY"
@@ -1168,7 +1165,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     # Not sure if `cfg.relay.role == "private-bridge"` helps as tor
     # sends a lot of stats
     warnings =
@@ -1295,7 +1292,7 @@ in
       ))
     ];
 
-    networking.firewall = mkIf cfg.openFirewall {
+    networking.firewall = lib.mkIf cfg.openFirewall {
       allowedTCPPorts =
         concatMap
           (

--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -426,12 +426,20 @@ in
       "relay"
       "isBridge"
     ] "Use services.tor.relay.role instead.")
-    (lib.mkRemovedOptionModule [ "services" "tor" "relay" "isExit" ] "Use services.tor.relay.role instead.")
+    (lib.mkRemovedOptionModule [
+      "services"
+      "tor"
+      "relay"
+      "isExit"
+    ] "Use services.tor.relay.role instead.")
     (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "nickname" ]
       [ "services" "tor" "settings" "Nickname" ]
     )
-    (lib.mkRenamedOptionModule [ "services" "tor" "relay" "port" ] [ "services" "tor" "settings" "ORPort" ])
+    (lib.mkRenamedOptionModule
+      [ "services" "tor" "relay" "port" ]
+      [ "services" "tor" "settings" "ORPort" ]
+    )
     (lib.mkRenamedOptionModule
       [ "services" "tor" "relay" "portSpec" ]
       [ "services" "tor" "settings" "ORPort" ]

--- a/nixos/modules/services/security/torify.nix
+++ b/nixos/modules/services/security/torify.nix
@@ -4,7 +4,6 @@
   pkgs,
   ...
 }:
-with lib;
 let
 
   cfg = config.services.tor;
@@ -29,8 +28,8 @@ in
 
     services.tor.tsocks = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to build tsocks wrapper script to relay application traffic via Tor.
@@ -45,8 +44,8 @@ in
         '';
       };
 
-      server = mkOption {
-        type = types.str;
+      server = lib.mkOption {
+        type = lib.types.str;
         default = "localhost:9050";
         example = "192.168.0.20";
         description = ''
@@ -54,8 +53,8 @@ in
         '';
       };
 
-      config = mkOption {
-        type = types.lines;
+      config = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = ''
           Extra configuration. Contents will be added verbatim to TSocks
@@ -69,13 +68,13 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.tsocks.enable {
+  config = lib.mkIf cfg.tsocks.enable {
 
     environment.systemPackages = [ torify ]; # expose it to the users
 
     services.tor.tsocks.config = ''
-      server = ${toString (head (splitString ":" cfg.tsocks.server))}
-      server_port = ${toString (tail (splitString ":" cfg.tsocks.server))}
+      server = ${toString (lib.head (lib.splitString ":" cfg.tsocks.server))}
+      server_port = ${toString (lib.tail (lib.splitString ":" cfg.tsocks.server))}
 
       local = 127.0.0.0/255.128.0.0
       local = 127.128.0.0/255.192.0.0

--- a/nixos/modules/services/security/torsocks.nix
+++ b/nixos/modules/services/security/torsocks.nix
@@ -1,14 +1,11 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.tor.torsocks;
-  optionalNullStr = b: v: optionalString (b != null) v;
+  optionalNullStr = b: v: lib.optionalString (b != null) v;
 
   configFile = server: ''
-    TorAddress ${toString (head (splitString ":" server))}
-    TorPort    ${toString (tail (splitString ":" server))}
+    TorAddress ${toString (lib.head (lib.splitString ":" server))}
+    TorPort    ${toString (lib.tail (lib.splitString ":" server))}
 
     OnionAddrRange ${cfg.onionAddrRange}
 
@@ -34,18 +31,18 @@ in
 {
   options = {
     services.tor.torsocks = {
-      enable = mkOption {
-        type        = types.bool;
+      enable = lib.mkOption {
+        type        = lib.types.bool;
         default     = config.services.tor.enable && config.services.tor.client.enable;
-        defaultText = literalExpression "config.services.tor.enable && config.services.tor.client.enable";
+        defaultText = lib.literalExpression "config.services.tor.enable && config.services.tor.client.enable";
         description = ''
           Whether to build `/etc/tor/torsocks.conf`
           containing the specified global torsocks configuration.
         '';
       };
 
-      server = mkOption {
-        type    = types.str;
+      server = lib.mkOption {
+        type    = lib.types.str;
         default = "127.0.0.1:9050";
         example = "192.168.0.20:1234";
         description = ''
@@ -54,8 +51,8 @@ in
         '';
       };
 
-      fasterServer = mkOption {
-        type    = types.str;
+      fasterServer = lib.mkOption {
+        type    = lib.types.str;
         default = "127.0.0.1:9063";
         example = "192.168.0.20:1234";
         description = ''
@@ -64,8 +61,8 @@ in
         '';
       };
 
-      onionAddrRange = mkOption {
-        type    = types.str;
+      onionAddrRange = lib.mkOption {
+        type    = lib.types.str;
         default = "127.42.42.0/24";
         description = ''
           Tor hidden sites do not have real IP addresses. This
@@ -77,8 +74,8 @@ in
         '';
       };
 
-      socks5Username = mkOption {
-        type    = types.nullOr types.str;
+      socks5Username = lib.mkOption {
+        type    = lib.types.nullOr lib.types.str;
         default = null;
         example = "bob";
         description = ''
@@ -87,8 +84,8 @@ in
         '';
       };
 
-      socks5Password = mkOption {
-        type    = types.nullOr types.str;
+      socks5Password = lib.mkOption {
+        type    = lib.types.nullOr lib.types.str;
         default = null;
         example = "sekret";
         description = ''
@@ -97,8 +94,8 @@ in
         '';
       };
 
-      allowInbound = mkOption {
-        type    = types.bool;
+      allowInbound = lib.mkOption {
+        type    = lib.types.bool;
         default = false;
         description = ''
           Set Torsocks to accept inbound connections. If set to
@@ -110,7 +107,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ pkgs.torsocks (wrapTorsocks "torsocks-faster" cfg.fasterServer) ];
 
     environment.etc."tor/torsocks.conf" =

--- a/nixos/modules/services/security/usbguard.nix
+++ b/nixos/modules/services/security/usbguard.nix
@@ -4,14 +4,12 @@
   pkgs,
   ...
 }:
-
-with lib;
 let
   cfg = config.services.usbguard;
 
   # valid policy options
   policy = (
-    types.enum [
+    lib.types.enum [
       "allow"
       "block"
       "reject"
@@ -30,13 +28,13 @@ let
     PresentDevicePolicy=${cfg.presentDevicePolicy}
     PresentControllerPolicy=${cfg.presentControllerPolicy}
     InsertedDevicePolicy=${cfg.insertedDevicePolicy}
-    RestoreControllerDeviceState=${boolToString cfg.restoreControllerDeviceState}
+    RestoreControllerDeviceState=${lib.boolToString cfg.restoreControllerDeviceState}
     # this does not seem useful for endusers to change
     DeviceManagerBackend=uevent
-    IPCAllowedUsers=${concatStringsSep " " cfg.IPCAllowedUsers}
-    IPCAllowedGroups=${concatStringsSep " " cfg.IPCAllowedGroups}
+    IPCAllowedUsers=${lib.concatStringsSep " " cfg.IPCAllowedUsers}
+    IPCAllowedGroups=${lib.concatStringsSep " " cfg.IPCAllowedGroups}
     IPCAccessControlFiles=/var/lib/usbguard/IPCAccessControl.d/
-    DeviceRulesWithPort=${boolToString cfg.deviceRulesWithPort}
+    DeviceRulesWithPort=${lib.boolToString cfg.deviceRulesWithPort}
     # HACK: that way audit logs still land in the journal
     AuditFilePath=/dev/null
   '';
@@ -50,16 +48,16 @@ in
 
   options = {
     services.usbguard = {
-      enable = mkEnableOption "USBGuard daemon";
+      enable = lib.mkEnableOption "USBGuard daemon";
 
-      package = mkPackageOption pkgs "usbguard" {
+      package = lib.mkPackageOption pkgs "usbguard" {
         extraDescription = ''
           If you do not need the Qt GUI, use `pkgs.usbguard-nox` to save disk space.
         '';
       };
 
-      ruleFile = mkOption {
-        type = types.nullOr types.path;
+      ruleFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = "/var/lib/usbguard/rules.conf";
         example = "/run/secrets/usbguard-rules";
         description = ''
@@ -71,8 +69,8 @@ in
         '';
 
       };
-      rules = mkOption {
-        type = types.nullOr types.lines;
+      rules = lib.mkOption {
+        type = lib.types.nullOr lib.types.lines;
         default = null;
         example = ''
           allow with-interface equals { 08:*:* }
@@ -92,8 +90,8 @@ in
         '';
       };
 
-      implicitPolicyTarget = mkOption {
-        type = types.enum [
+      implicitPolicyTarget = lib.mkOption {
+        type = lib.types.enum [
           "allow"
           "block"
           "reject"
@@ -106,7 +104,7 @@ in
         '';
       };
 
-      presentDevicePolicy = mkOption {
+      presentDevicePolicy = lib.mkOption {
         type = policy;
         default = "apply-policy";
         description = ''
@@ -117,7 +115,7 @@ in
         '';
       };
 
-      presentControllerPolicy = mkOption {
+      presentControllerPolicy = lib.mkOption {
         type = policy;
         default = "keep";
         description = ''
@@ -126,8 +124,8 @@ in
         '';
       };
 
-      insertedDevicePolicy = mkOption {
-        type = types.enum [
+      insertedDevicePolicy = lib.mkOption {
+        type = lib.types.enum [
           "block"
           "reject"
           "apply-policy"
@@ -139,8 +137,8 @@ in
         '';
       };
 
-      restoreControllerDeviceState = mkOption {
-        type = types.bool;
+      restoreControllerDeviceState = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           The  USBGuard  daemon  modifies  some attributes of controller
@@ -151,8 +149,8 @@ in
         '';
       };
 
-      IPCAllowedUsers = mkOption {
-        type = types.listOf types.str;
+      IPCAllowedUsers = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [ "root" ];
         example = [
           "root"
@@ -163,8 +161,8 @@ in
         '';
       };
 
-      IPCAllowedGroups = mkOption {
-        type = types.listOf types.str;
+      IPCAllowedGroups = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [ ];
         example = [ "wheel" ];
         description = ''
@@ -173,21 +171,21 @@ in
         '';
       };
 
-      deviceRulesWithPort = mkOption {
-        type = types.bool;
+      deviceRulesWithPort = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Generate device specific rules including the "via-port" attribute.
         '';
       };
 
-      dbus.enable = mkEnableOption "USBGuard dbus daemon";
+      dbus.enable = lib.mkEnableOption "USBGuard dbus daemon";
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ cfg.package ];
 
@@ -239,7 +237,7 @@ in
         };
       };
 
-      usbguard-dbus = mkIf cfg.dbus.enable {
+      usbguard-dbus = lib.mkIf cfg.dbus.enable {
         description = "USBGuard D-Bus Service";
 
         wantedBy = [ "multi-user.target" ];
@@ -261,7 +259,7 @@ in
         groupCheck =
           (lib.concatStrings (map (g: "subject.isInGroup(\"${g}\") || ") cfg.IPCAllowedGroups)) + "false";
       in
-      optionalString cfg.dbus.enable ''
+      lib.optionalString cfg.dbus.enable ''
         polkit.addRule(function(action, subject) {
             if ((action.id == "org.usbguard.Policy1.listRules" ||
                  action.id == "org.usbguard.Policy1.appendRule" ||
@@ -278,15 +276,15 @@ in
       '';
   };
   imports = [
-    (mkRemovedOptionModule [ "services" "usbguard" "IPCAccessControlFiles" ]
+    (lib.mkRemovedOptionModule [ "services" "usbguard" "IPCAccessControlFiles" ]
       "The usbguard module now hardcodes IPCAccessControlFiles to /var/lib/usbguard/IPCAccessControl.d."
     )
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "usbguard"
       "auditFilePath"
     ] "Removed usbguard module audit log files. Audit logs can be found in the systemd journal.")
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "usbguard" "implictPolicyTarget" ]
       [ "services" "usbguard" "implicitPolicyTarget" ]
     )

--- a/nixos/modules/services/security/vault-agent.nix
+++ b/nixos/modules/services/security/vault-agent.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   format = pkgs.formats.json { };
   commonOptions =
@@ -14,26 +11,26 @@ let
       pkgName,
       flavour ? pkgName,
     }:
-    mkOption {
+    lib.mkOption {
       default = { };
       description = ''
         Attribute set of ${flavour} instances.
         Creates independent `${flavour}-''${name}.service` systemd units for each instance defined here.
       '';
       type =
-        with types;
+        with lib.types;
         attrsOf (
           submodule (
             { name, ... }:
             {
               options = {
-                enable = mkEnableOption "this ${flavour} instance" // {
+                enable = lib.mkEnableOption "this ${flavour} instance" // {
                   default = true;
                 };
 
-                package = mkPackageOption pkgs pkgName { };
+                package = lib.mkPackageOption pkgs pkgName { };
 
-                user = mkOption {
+                user = lib.mkOption {
                   type = types.str;
                   default = "root";
                   description = ''
@@ -41,7 +38,7 @@ let
                   '';
                 };
 
-                group = mkOption {
+                group = lib.mkOption {
                   type = types.str;
                   default = "root";
                   description = ''
@@ -49,12 +46,12 @@ let
                   '';
                 };
 
-                settings = mkOption {
+                settings = lib.mkOption {
                   type = types.submodule {
                     freeformType = format.type;
 
                     options = {
-                      pid_file = mkOption {
+                      pid_file = lib.mkOption {
                         default = "/run/${flavour}/${name}.pid";
                         type = types.str;
                         description = ''
@@ -62,7 +59,7 @@ let
                         '';
                       };
 
-                      template = mkOption {
+                      template = lib.mkOption {
                         default = null;
                         type = with types; nullOr (listOf (attrsOf anything));
                         description =
@@ -116,7 +113,7 @@ let
     let
       configFile = format.generate "${name}.json" instance.settings;
     in
-    mkIf (instance.enable) {
+    lib.mkIf (instance.enable) {
       description = "${flavour} daemon - ${name}";
       wantedBy = [ "multi-user.target" ];
       after = [ "network.target" ];
@@ -127,8 +124,8 @@ let
         User = instance.user;
         Group = instance.group;
         RuntimeDirectory = flavour;
-        ExecStart = "${getExe instance.package} ${
-          optionalString ((getName instance.package) == "vault") "agent"
+        ExecStart = "${lib.getExe instance.package} ${
+          lib.optionalString ((lib.getName instance.package) == "vault") "agent"
         } -config ${configFile}";
         ExecReload = "${pkgs.coreutils}/bin/kill -SIGHUP $MAINPID";
         KillSignal = "SIGINT";
@@ -146,17 +143,17 @@ in
     };
   };
 
-  config = mkMerge (
+  config = lib.mkMerge (
     map
       (
         flavour:
         let
           cfg = config.services.${flavour};
         in
-        mkIf (cfg.instances != { }) {
-          systemd.services = mapAttrs' (
+        lib.mkIf (cfg.instances != { }) {
+          systemd.services = lib.mapAttrs' (
             name: instance:
-            nameValuePair "${flavour}-${name}" (createAgentInstance {
+            lib.nameValuePair "${flavour}-${name}" (createAgentInstance {
               inherit name instance flavour;
             })
           ) cfg.instances;
@@ -168,7 +165,7 @@ in
       ]
   );
 
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     emilylange
     tcheronneau
   ];

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -5,9 +5,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.vault;
   opt = options.services.vault;
@@ -32,10 +29,10 @@ let
       }
     ''}
     storage "${cfg.storageBackend}" {
-      ${optionalString (cfg.storagePath != null) ''path = "${cfg.storagePath}"''}
-      ${optionalString (cfg.storageConfig != null) cfg.storageConfig}
+      ${lib.optionalString (cfg.storagePath != null) ''path = "${cfg.storagePath}"''}
+      ${lib.optionalString (cfg.storageConfig != null) cfg.storageConfig}
     }
-    ${optionalString (cfg.telemetryConfig != "") ''
+    ${lib.optionalString (cfg.telemetryConfig != "") ''
       telemetry {
         ${cfg.telemetryConfig}
       }
@@ -44,10 +41,10 @@ let
   '';
 
   allConfigPaths = [ configFile ] ++ cfg.extraSettingsPaths;
-  configOptions = escapeShellArgs (
+  configOptions = lib.escapeShellArgs (
     lib.optional cfg.dev "-dev"
     ++ lib.optional (cfg.dev && cfg.devRootTokenID != null) "-dev-root-token-id=${cfg.devRootTokenID}"
-    ++ (concatMap (p: [
+    ++ (lib.concatMap (p: [
       "-config"
       p
     ]) allConfigPaths)
@@ -58,56 +55,56 @@ in
 {
   options = {
     services.vault = {
-      enable = mkEnableOption "Vault daemon";
+      enable = lib.mkEnableOption "Vault daemon";
 
-      package = mkPackageOption pkgs "vault" { };
+      package = lib.mkPackageOption pkgs "vault" { };
 
-      dev = mkOption {
-        type = types.bool;
+      dev = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           In this mode, Vault runs in-memory and starts unsealed. This option is not meant production but for development and testing i.e. for nixos tests.
         '';
       };
 
-      devRootTokenID = mkOption {
-        type = types.nullOr types.str;
+      devRootTokenID = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Initial root token. This only applies when {option}`services.vault.dev` is true
         '';
       };
 
-      address = mkOption {
-        type = types.str;
+      address = lib.mkOption {
+        type = lib.types.str;
         default = "127.0.0.1:8200";
         description = "The name of the ip interface to listen to";
       };
 
-      tlsCertFile = mkOption {
-        type = types.nullOr types.str;
+      tlsCertFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/path/to/your/cert.pem";
         description = "TLS certificate file. TLS will be disabled unless this option is set";
       };
 
-      tlsKeyFile = mkOption {
-        type = types.nullOr types.str;
+      tlsKeyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/path/to/your/key.pem";
         description = "TLS private key file. TLS will be disabled unless this option is set";
       };
 
-      listenerExtraConfig = mkOption {
-        type = types.lines;
+      listenerExtraConfig = lib.mkOption {
+        type = lib.types.lines;
         default = ''
           tls_min_version = "tls12"
         '';
         description = "Extra text appended to the listener section.";
       };
 
-      storageBackend = mkOption {
-        type = types.enum [
+      storageBackend = lib.mkOption {
+        type = lib.types.enum [
           "inmem"
           "file"
           "consul"
@@ -127,11 +124,11 @@ in
         description = "The name of the type of storage backend";
       };
 
-      storagePath = mkOption {
-        type = types.nullOr types.path;
+      storagePath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default =
           if cfg.storageBackend == "file" || cfg.storageBackend == "raft" then "/var/lib/vault" else null;
-        defaultText = literalExpression ''
+        defaultText = lib.literalExpression ''
           if config.${opt.storageBackend} == "file" || cfg.storageBackend == "raft"
           then "/var/lib/vault"
           else null
@@ -139,8 +136,8 @@ in
         description = "Data directory for file backend";
       };
 
-      storageConfig = mkOption {
-        type = types.nullOr types.lines;
+      storageConfig = lib.mkOption {
+        type = lib.types.nullOr lib.types.lines;
         default = null;
         description = ''
           HCL configuration to insert in the storageBackend section.
@@ -152,20 +149,20 @@ in
         '';
       };
 
-      telemetryConfig = mkOption {
-        type = types.lines;
+      telemetryConfig = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = "Telemetry configuration";
       };
 
-      extraConfig = mkOption {
-        type = types.lines;
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = "Extra text appended to {file}`vault.hcl`.";
       };
 
-      extraSettingsPaths = mkOption {
-        type = types.listOf types.path;
+      extraSettingsPaths = lib.mkOption {
+        type = lib.types.listOf lib.types.path;
         default = [ ];
         description = ''
           Configuration files to load besides the immutable one defined by the NixOS module.
@@ -196,7 +193,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.storageBackend == "inmem" -> (cfg.storagePath == null && cfg.storageConfig == null);
@@ -219,7 +216,7 @@ in
     };
     users.groups.vault.gid = config.ids.gids.vault;
 
-    systemd.tmpfiles.rules = optional (
+    systemd.tmpfiles.rules = lib.optional (
       cfg.storagePath != null
     ) "d '${cfg.storagePath}' 0700 vault vault - -";
 
@@ -229,7 +226,7 @@ in
       wantedBy = [ "multi-user.target" ];
       after = [
         "network.target"
-      ] ++ optional (config.services.consul.enable && cfg.storageBackend == "consul") "consul.service";
+      ] ++ lib.optional (config.services.consul.enable && cfg.storageBackend == "consul") "consul.service";
 
       restartIfChanged = false; # do not restart on "nixos-rebuild switch". It would seal the storage and disrupt the clients.
 
@@ -255,7 +252,7 @@ in
         Restart = "on-failure";
       };
 
-      unitConfig.RequiresMountsFor = optional (cfg.storagePath != null) cfg.storagePath;
+      unitConfig.RequiresMountsFor = lib.optional (cfg.storagePath != null) cfg.storagePath;
     };
   };
 

--- a/nixos/modules/services/security/vault.nix
+++ b/nixos/modules/services/security/vault.nix
@@ -224,9 +224,11 @@ in
       description = "Vault server daemon";
 
       wantedBy = [ "multi-user.target" ];
-      after = [
-        "network.target"
-      ] ++ lib.optional (config.services.consul.enable && cfg.storageBackend == "consul") "consul.service";
+      after =
+        [
+          "network.target"
+        ]
+        ++ lib.optional (config.services.consul.enable && cfg.storageBackend == "consul") "consul.service";
 
       restartIfChanged = false; # do not restart on "nixos-rebuild switch". It would seal the storage and disrupt the clients.
 

--- a/nixos/modules/services/security/yubikey-agent.nix
+++ b/nixos/modules/services/security/yubikey-agent.nix
@@ -41,10 +41,12 @@ in
 
     # This overrides the systemd user unit shipped with the
     # yubikey-agent package
-    systemd.user.services.yubikey-agent = lib.mkIf (config.programs.gnupg.agent.pinentryPackage != null) {
-      path = [ config.programs.gnupg.agent.pinentryPackage ];
-      wantedBy = [ "default.target" ];
-    };
+    systemd.user.services.yubikey-agent =
+      lib.mkIf (config.programs.gnupg.agent.pinentryPackage != null)
+        {
+          path = [ config.programs.gnupg.agent.pinentryPackage ];
+          wantedBy = [ "default.target" ];
+        };
 
     # Yubikey-agent expects pcsd to be running in order to function.
     services.pcscd.enable = true;

--- a/nixos/modules/services/security/yubikey-agent.nix
+++ b/nixos/modules/services/security/yubikey-agent.nix
@@ -1,21 +1,17 @@
 # Global configuration for yubikey-agent.
-
 {
   config,
   lib,
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.yubikey-agent;
 in
 {
   ###### interface
 
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     philandstuff
     rawkode
   ];
@@ -23,8 +19,8 @@ in
   options = {
 
     services.yubikey-agent = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to start yubikey-agent when you log in.  Also sets
@@ -35,17 +31,17 @@ in
         '';
       };
 
-      package = mkPackageOption pkgs "yubikey-agent" { };
+      package = lib.mkPackageOption pkgs "yubikey-agent" { };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
     systemd.packages = [ cfg.package ];
 
     # This overrides the systemd user unit shipped with the
     # yubikey-agent package
-    systemd.user.services.yubikey-agent = mkIf (config.programs.gnupg.agent.pinentryPackage != null) {
+    systemd.user.services.yubikey-agent = lib.mkIf (config.programs.gnupg.agent.pinentryPackage != null) {
       path = [ config.programs.gnupg.agent.pinentryPackage ];
       wantedBy = [ "default.target" ];
     };

--- a/nixos/modules/services/system/automatic-timezoned.nix
+++ b/nixos/modules/services/system/automatic-timezoned.nix
@@ -4,17 +4,14 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.automatic-timezoned;
 in
 {
   options = {
     services.automatic-timezoned = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Enable `automatic-timezoned`, simple daemon for keeping the system
@@ -28,11 +25,11 @@ in
           to make the choice deliberate. An error will be presented otherwise.
         '';
       };
-      package = mkPackageOption pkgs "automatic-timezoned" { };
+      package = lib.mkPackageOption pkgs "automatic-timezoned" { };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     # This will give users an error if they have set an explicit time
     # zone, rather than having the service silently override it.
     time.timeZone = null;

--- a/nixos/modules/services/system/cachix-agent/default.nix
+++ b/nixos/modules/services/system/cachix-agent/default.nix
@@ -4,9 +4,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.cachix-agent;
 in
@@ -14,37 +11,37 @@ in
   meta.maintainers = [ lib.maintainers.domenkozar ];
 
   options.services.cachix-agent = {
-    enable = mkEnableOption "Cachix Deploy Agent: https://docs.cachix.org/deploy/";
+    enable = lib.mkEnableOption "Cachix Deploy Agent: https://docs.cachix.org/deploy/";
 
-    name = mkOption {
-      type = types.str;
+    name = lib.mkOption {
+      type = lib.types.str;
       description = "Agent name, usually same as the hostname";
       default = config.networking.hostName;
       defaultText = "config.networking.hostName";
     };
 
-    verbose = mkOption {
-      type = types.bool;
+    verbose = lib.mkOption {
+      type = lib.types.bool;
       description = "Enable verbose output";
       default = false;
     };
 
-    profile = mkOption {
-      type = types.nullOr types.str;
+    profile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       description = "Profile name, defaults to 'system' (NixOS).";
     };
 
-    host = mkOption {
-      type = types.nullOr types.str;
+    host = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       description = "Cachix uri to use.";
     };
 
-    package = mkPackageOption pkgs "cachix" { };
+    package = lib.mkPackageOption pkgs "cachix" { };
 
-    credentialsFile = mkOption {
-      type = types.path;
+    credentialsFile = lib.mkOption {
+      type = lib.types.path;
       default = "/etc/cachix-agent.token";
       description = ''
         Required file that needs to contain CACHIX_AGENT_TOKEN=...
@@ -52,7 +49,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.cachix-agent = {
       description = "Cachix Deploy Agent";
       wants = [ "network-online.target" ];
@@ -76,7 +73,7 @@ in
           ${cfg.package}/bin/cachix ${lib.optionalString cfg.verbose "--verbose"} ${
             lib.optionalString (cfg.host != null) "--host ${cfg.host}"
           } \
-            deploy agent ${cfg.name} ${optionalString (cfg.profile != null) cfg.profile}
+            deploy agent ${cfg.name} ${lib.optionalString (cfg.profile != null) cfg.profile}
         '';
       };
     };

--- a/nixos/modules/services/system/cachix-watch-store.nix
+++ b/nixos/modules/services/system/cachix-watch-store.nix
@@ -4,9 +4,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.cachix-watch-store;
 in
@@ -17,56 +14,56 @@ in
   ];
 
   options.services.cachix-watch-store = {
-    enable = mkEnableOption "Cachix Watch Store: https://docs.cachix.org";
+    enable = lib.mkEnableOption "Cachix Watch Store: https://docs.cachix.org";
 
-    cacheName = mkOption {
-      type = types.str;
+    cacheName = lib.mkOption {
+      type = lib.types.str;
       description = "Cachix binary cache name";
     };
 
-    cachixTokenFile = mkOption {
-      type = types.path;
+    cachixTokenFile = lib.mkOption {
+      type = lib.types.path;
       description = ''
         Required file that needs to contain the cachix auth token.
       '';
     };
 
-    signingKeyFile = mkOption {
-      type = types.nullOr types.path;
+    signingKeyFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       description = ''
         Optional file containing a self-managed signing key to sign uploaded store paths.
       '';
       default = null;
     };
 
-    compressionLevel = mkOption {
-      type = types.nullOr types.int;
+    compressionLevel = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
       description = "The compression level for ZSTD compression (between 0 and 16)";
       default = null;
     };
 
-    jobs = mkOption {
-      type = types.nullOr types.int;
+    jobs = lib.mkOption {
+      type = lib.types.nullOr lib.types.int;
       description = "Number of threads used for pushing store paths";
       default = null;
     };
 
-    host = mkOption {
-      type = types.nullOr types.str;
+    host = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       description = "Cachix host to connect to";
     };
 
-    verbose = mkOption {
-      type = types.bool;
+    verbose = lib.mkOption {
+      type = lib.types.bool;
       description = "Enable verbose output";
       default = false;
     };
 
-    package = mkPackageOption pkgs "cachix" { };
+    package = lib.mkPackageOption pkgs "cachix" { };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.cachix-watch-store-agent = {
       description = "Cachix watch store Agent";
       wants = [ "network-online.target" ];

--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.cloud-init;
   path =
@@ -31,8 +28,8 @@ in
 {
   options = {
     services.cloud-init = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Enable the cloud-init service. This services reads
@@ -50,35 +47,35 @@ in
         '';
       };
 
-      btrfs.enable = mkOption {
-        type = types.bool;
+      btrfs.enable = lib.mkOption {
+        type = lib.types.bool;
         default = hasFs "btrfs";
-        defaultText = literalExpression ''hasFs "btrfs"'';
+        defaultText = lib.literalExpression ''hasFs "btrfs"'';
         description = ''
           Allow the cloud-init service to operate `btrfs` filesystem.
         '';
       };
 
-      ext4.enable = mkOption {
-        type = types.bool;
+      ext4.enable = lib.mkOption {
+        type = lib.types.bool;
         default = hasFs "ext4";
-        defaultText = literalExpression ''hasFs "ext4"'';
+        defaultText = lib.literalExpression ''hasFs "ext4"'';
         description = ''
           Allow the cloud-init service to operate `ext4` filesystem.
         '';
       };
 
-      xfs.enable = mkOption {
-        type = types.bool;
+      xfs.enable = lib.mkOption {
+        type = lib.types.bool;
         default = hasFs "xfs";
-        defaultText = literalExpression ''hasFs "xfs"'';
+        defaultText = lib.literalExpression ''hasFs "xfs"'';
         description = ''
           Allow the cloud-init service to operate `xfs` filesystem.
         '';
       };
 
-      network.enable = mkOption {
-        type = types.bool;
+      network.enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Allow the cloud-init service to configure network interfaces
@@ -86,26 +83,26 @@ in
         '';
       };
 
-      extraPackages = mkOption {
-        type = types.listOf types.package;
+      extraPackages = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
         default = [ ];
         description = ''
           List of additional packages to be available within cloud-init jobs.
         '';
       };
 
-      settings = mkOption {
+      settings = lib.mkOption {
         description = ''
           Structured cloud-init configuration.
         '';
-        type = types.submodule {
+        type = lib.types.submodule {
           freeformType = settingsFormat.type;
         };
         default = { };
       };
 
-      config = mkOption {
-        type = types.str;
+      config = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = ''
           raw cloud-init configuration.
@@ -118,20 +115,20 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.cloud-init.settings = {
-      system_info = mkDefault {
+      system_info = lib.mkDefault {
         distro = "nixos";
         network = {
           renderers = [ "networkd" ];
         };
       };
 
-      users = mkDefault [ "root" ];
-      disable_root = mkDefault false;
-      preserve_hostname = mkDefault false;
+      users = lib.mkDefault [ "root" ];
+      disable_root = lib.mkDefault false;
+      preserve_hostname = lib.mkDefault false;
 
-      cloud_init_modules = mkDefault [
+      cloud_init_modules = lib.mkDefault [
         "migrator"
         "seed_random"
         "bootcmd"
@@ -145,7 +142,7 @@ in
         "users-groups"
       ];
 
-      cloud_config_modules = mkDefault [
+      cloud_config_modules = lib.mkDefault [
         "disk_setup"
         "mounts"
         "ssh-import-id"
@@ -156,7 +153,7 @@ in
         "ssh"
       ];
 
-      cloud_final_modules = mkDefault [
+      cloud_final_modules = lib.mkDefault [
         "rightscale_userdata"
         "scripts-vendor"
         "scripts-per-once"
@@ -174,7 +171,7 @@ in
     environment.etc."cloud/cloud.cfg" =
       if cfg.config == "" then { source = cfgfile; } else { text = cfg.config; };
 
-    systemd.network.enable = mkIf cfg.network.enable true;
+    systemd.network.enable = lib.mkIf cfg.network.enable true;
 
     systemd.services.cloud-init-local = {
       description = "Initial cloud-init job (pre-networking)";
@@ -272,5 +269,5 @@ in
     };
   };
 
-  meta.maintainers = [ maintainers.zimbatm ];
+  meta.maintainers = [ lib.maintainers.zimbatm ];
 }

--- a/nixos/modules/services/system/localtimed.nix
+++ b/nixos/modules/services/system/localtimed.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.localtimed;
 in
@@ -15,8 +12,8 @@ in
 
   options = {
     services.localtimed = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Enable `localtimed`, a simple daemon for keeping the
@@ -29,12 +26,12 @@ in
           to make the choice deliberate. An error will be presented otherwise.
         '';
       };
-      package = mkPackageOption pkgs "localtime" { };
-      geoclue2Package = mkPackageOption pkgs "Geoclue2" { default = "geoclue2-with-demo-agent"; };
+      package = lib.mkPackageOption pkgs "localtime" { };
+      geoclue2Package = lib.mkPackageOption pkgs "Geoclue2" { default = "geoclue2-with-demo-agent"; };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     # This will give users an error if they have set an explicit time
     # zone, rather than having the service silently override it.
     time.timeZone = null;

--- a/nixos/modules/services/system/nix-daemon.nix
+++ b/nixos/modules/services/system/nix-daemon.nix
@@ -1,6 +1,5 @@
 /*
   Declares what makes the nix-daemon work on systemd.
-
   See also
    - nixos/modules/config/nix.nix: the nix.conf
    - nixos/modules/config/nix-remote-build.nix: the nix.conf
@@ -11,16 +10,13 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.nix;
 
   nixPackage = cfg.package.out;
 
-  isNixAtLeast = versionAtLeast (getVersion nixPackage);
+  isNixAtLeast = lib.versionAtLeast (lib.getVersion nixPackage);
 
   makeNixBuildUser = nr: {
     name = "nixbld${toString nr}";
@@ -39,13 +35,13 @@ let
     };
   };
 
-  nixbldUsers = listToAttrs (map makeNixBuildUser (range 1 cfg.nrBuildUsers));
+  nixbldUsers = lib.listToAttrs (map makeNixBuildUser (lib.range 1 cfg.nrBuildUsers));
 
 in
 
 {
   imports = [
-    (mkRenamedOptionModuleWith {
+    (lib.mkRenamedOptionModuleWith {
       sinceRelease = 2205;
       from = [
         "nix"
@@ -56,7 +52,7 @@ in
         "daemonIOSchedPriority"
       ];
     })
-    (mkRenamedOptionModuleWith {
+    (lib.mkRenamedOptionModuleWith {
       sinceRelease = 2211;
       from = [
         "nix"
@@ -67,7 +63,7 @@ in
         "readOnlyNixStore"
       ];
     })
-    (mkRemovedOptionModule [ "nix" "daemonNiceLevel" ] "Consider nix.daemonCPUSchedPolicy instead.")
+    (lib.mkRemovedOptionModule [ "nix" "daemonNiceLevel" ] "Consider nix.daemonCPUSchedPolicy instead.")
   ];
 
   ###### interface
@@ -76,8 +72,8 @@ in
 
     nix = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Whether to enable Nix.
@@ -85,17 +81,17 @@ in
         '';
       };
 
-      package = mkOption {
-        type = types.package;
+      package = lib.mkOption {
+        type = lib.types.package;
         default = pkgs.nix;
-        defaultText = literalExpression "pkgs.nix";
+        defaultText = lib.literalExpression "pkgs.nix";
         description = ''
           This option specifies the Nix package instance to use throughout the system.
         '';
       };
 
-      daemonCPUSchedPolicy = mkOption {
-        type = types.enum [
+      daemonCPUSchedPolicy = lib.mkOption {
+        type = lib.types.enum [
           "other"
           "batch"
           "idle"
@@ -128,8 +124,8 @@ in
         '';
       };
 
-      daemonIOSchedClass = mkOption {
-        type = types.enum [
+      daemonIOSchedClass = lib.mkOption {
+        type = lib.types.enum [
           "best-effort"
           "idle"
         ];
@@ -154,8 +150,8 @@ in
         '';
       };
 
-      daemonIOSchedPriority = mkOption {
-        type = types.int;
+      daemonIOSchedPriority = lib.mkOption {
+        type = lib.types.int;
         default = 4;
         example = 1;
         description = ''
@@ -168,15 +164,15 @@ in
       };
 
       # Environment variables for running Nix.
-      envVars = mkOption {
-        type = types.attrs;
+      envVars = lib.mkOption {
+        type = lib.types.attrs;
         internal = true;
         default = { };
         description = "Environment variables used by Nix.";
       };
 
-      nrBuildUsers = mkOption {
-        type = types.int;
+      nrBuildUsers = lib.mkOption {
+        type = lib.types.int;
         description = ''
           Number of `nixbld` user accounts created to
           perform secure concurrent builds.  If you receive an error
@@ -189,19 +185,19 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [
       nixPackage
       pkgs.nix-info
-    ] ++ optional (config.programs.bash.completion.enable) pkgs.nix-bash-completions;
+    ] ++ lib.optional (config.programs.bash.completion.enable) pkgs.nix-bash-completions;
 
     systemd.packages = [ nixPackage ];
 
-    systemd.tmpfiles = mkMerge [
-      (mkIf (isNixAtLeast "2.8") {
+    systemd.tmpfiles = lib.mkMerge [
+      (lib.mkIf (isNixAtLeast "2.8") {
         packages = [ nixPackage ];
       })
-      (mkIf (!isNixAtLeast "2.8") {
+      (lib.mkIf (!isNixAtLeast "2.8") {
         rules = [
           "d /nix/var/nix/daemon-socket 0755 root root - -"
         ];
@@ -215,7 +211,7 @@ in
         nixPackage
         pkgs.util-linux
         config.programs.ssh.package
-      ] ++ optionals cfg.distributedBuilds [ pkgs.gzip ];
+      ] ++ lib.optionals cfg.distributedBuilds [ pkgs.gzip ];
 
       environment =
         cfg.envVars
@@ -274,20 +270,20 @@ in
     # Set up the environment variables for running Nix.
     environment.sessionVariables = cfg.envVars;
 
-    nix.nrBuildUsers = mkDefault (
+    nix.nrBuildUsers = lib.mkDefault (
       if cfg.settings.auto-allocate-uids or false then
         0
       else
-        max 32 (if cfg.settings.max-jobs == "auto" then 0 else cfg.settings.max-jobs)
+        lib.max 32 (if cfg.settings.max-jobs == "auto" then 0 else cfg.settings.max-jobs)
     );
 
     users.users = nixbldUsers;
 
-    services.displayManager.hiddenUsers = attrNames nixbldUsers;
+    services.displayManager.hiddenUsers = lib.attrNames nixbldUsers;
 
     # Legacy configuration conversion.
-    nix.settings = mkMerge [
-      (mkIf (isNixAtLeast "2.3pre") { sandbox-fallback = false; })
+    nix.settings = lib.mkMerge [
+      (lib.mkIf (isNixAtLeast "2.3pre") { sandbox-fallback = false; })
     ];
 
   };

--- a/nixos/modules/services/system/nscd.nix
+++ b/nixos/modules/services/system/nscd.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   nssModulesPath = config.system.nssModules.path;
@@ -22,8 +19,8 @@ in
 
     services.nscd = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Whether to enable the Name Service Cache Daemon.
@@ -32,8 +29,8 @@ in
         '';
       };
 
-      enableNsncd = mkOption {
-        type = types.bool;
+      enableNsncd = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Whether to use nsncd instead of nscd from glibc.
@@ -42,24 +39,24 @@ in
         '';
       };
 
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "nscd";
         description = ''
           User account under which nscd runs.
         '';
       };
 
-      group = mkOption {
-        type = types.str;
+      group = lib.mkOption {
+        type = lib.types.str;
         default = "nscd";
         description = ''
           User group under which nscd runs.
         '';
       };
 
-      config = mkOption {
-        type = types.lines;
+      config = lib.mkOption {
+        type = lib.types.lines;
         default = builtins.readFile ./nscd.conf;
         description = ''
           Configuration to use for Name Service Cache Daemon.
@@ -67,8 +64,8 @@ in
         '';
       };
 
-      package = mkOption {
-        type = types.package;
+      package = lib.mkOption {
+        type = lib.types.package;
         default =
           if pkgs.stdenv.hostPlatform.libc == "glibc" then pkgs.stdenv.cc.libc.bin else pkgs.glibc.bin;
         defaultText = lib.literalExpression ''
@@ -88,7 +85,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.etc."nscd.conf".text = cfg.config;
 
     users.users.${cfg.user} = {
@@ -125,7 +122,7 @@ in
           config.environment.etc."nsswitch.conf".source
           config.environment.etc."nscd.conf".source
         ]
-        ++ optionals config.users.mysql.enable [
+        ++ lib.optionals config.users.mysql.enable [
           config.environment.etc."libnss-mysql.cfg".source
           config.environment.etc."libnss-mysql-root.cfg".source
         ]

--- a/nixos/modules/services/system/saslauthd.nix
+++ b/nixos/modules/services/system/saslauthd.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.saslauthd;
@@ -21,18 +18,18 @@ in
 
     services.saslauthd = {
 
-      enable = mkEnableOption "saslauthd, the Cyrus SASL authentication daemon";
+      enable = lib.mkEnableOption "saslauthd, the Cyrus SASL authentication daemon";
 
-      package = mkPackageOption pkgs [ "cyrus_sasl" "bin" ] { };
+      package = lib.mkPackageOption pkgs [ "cyrus_sasl" "bin" ] { };
 
-      mechanism = mkOption {
-        type = types.str;
+      mechanism = lib.mkOption {
+        type = lib.types.str;
         default = "pam";
         description = "Auth mechanism to use";
       };
 
-      config = mkOption {
-        type = types.lines;
+      config = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = "Configuration to use for Cyrus SASL authentication daemon.";
       };
@@ -43,7 +40,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     systemd.services.saslauthd = {
       description = "Cyrus SASL authentication daemon";

--- a/nixos/modules/services/system/uptimed.nix
+++ b/nixos/modules/services/system/uptimed.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.uptimed;
   stateDir = "/var/lib/uptimed";
@@ -14,8 +11,8 @@ in
 {
   options = {
     services.uptimed = {
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Enable `uptimed`, allowing you to track
@@ -25,7 +22,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ pkgs.uptimed ];
 

--- a/nixos/modules/services/torrent/deluge.nix
+++ b/nixos/modules/services/torrent/deluge.nix
@@ -1,16 +1,13 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.deluge;
   cfg_web = config.services.deluge.web;
-  isDeluge1 = versionOlder cfg.package.version "2.0.0";
+  isDeluge1 = lib.versionOlder cfg.package.version "2.0.0";
 
   openFilesLimit = 4096;
   listenPortsDefault = [ 6881 6889 ];
 
-  listToRange = x: { from = elemAt x 0; to = elemAt x 1; };
+  listToRange = x: { from = lib.elemAt x 0; to = lib.elemAt x 1; };
 
   configDir = "${cfg.dataDir}/.config/deluge";
   configFile = pkgs.writeText "core.conf" (builtins.toJSON cfg.config);
@@ -37,20 +34,20 @@ in {
   options = {
     services = {
       deluge = {
-        enable = mkEnableOption "Deluge daemon";
+        enable = lib.mkEnableOption "Deluge daemon";
 
-        openFilesLimit = mkOption {
+        openFilesLimit = lib.mkOption {
           default = openFilesLimit;
-          type = types.either types.int types.str;
+          type = lib.types.either lib.types.int lib.types.str;
           description = ''
             Number of files to allow deluged to open.
           '';
         };
 
-        config = mkOption {
-          type = types.attrs;
+        config = lib.mkOption {
+          type = lib.types.attrs;
           default = {};
-          example = literalExpression ''
+          example = lib.literalExpression ''
             {
               download_location = "/srv/torrents/";
               max_upload_speed = "1000.0";
@@ -70,8 +67,8 @@ in {
           '';
         };
 
-        declarative = mkOption {
-          type = types.bool;
+        declarative = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Whether to use a declarative deluge configuration.
@@ -83,9 +80,9 @@ in {
           '';
         };
 
-        openFirewall = mkOption {
+        openFirewall = lib.mkOption {
           default = false;
-          type = types.bool;
+          type = lib.types.bool;
           description = ''
             Whether to open the firewall for the ports in
             {option}`services.deluge.config.listen_ports`. It only takes effet if
@@ -99,16 +96,16 @@ in {
           '';
         };
 
-        dataDir = mkOption {
-          type = types.path;
+        dataDir = lib.mkOption {
+          type = lib.types.path;
           default = "/var/lib/deluge";
           description = ''
             The directory where deluge will create files.
           '';
         };
 
-        authFile = mkOption {
-          type = types.path;
+        authFile = lib.mkOption {
+          type = lib.types.path;
           example = "/run/keys/deluge-auth";
           description = ''
             The file managing the authentication for deluge, the format of this
@@ -121,24 +118,24 @@ in {
           '';
         };
 
-        user = mkOption {
-          type = types.str;
+        user = lib.mkOption {
+          type = lib.types.str;
           default = "deluge";
           description = ''
             User account under which deluge runs.
           '';
         };
 
-        group = mkOption {
-          type = types.str;
+        group = lib.mkOption {
+          type = lib.types.str;
           default = "deluge";
           description = ''
             Group under which deluge runs.
           '';
         };
 
-        extraPackages = mkOption {
-          type = types.listOf types.package;
+        extraPackages = lib.mkOption {
+          type = lib.types.listOf lib.types.package;
           default = [];
           description = ''
             Extra packages available at runtime to enable Deluge's plugins. For example,
@@ -147,22 +144,22 @@ in {
           '';
         };
 
-        package = mkPackageOption pkgs "deluge-2_x" { };
+        package = lib.mkPackageOption pkgs "deluge-2_x" { };
       };
 
       deluge.web = {
-        enable = mkEnableOption "Deluge Web daemon";
+        enable = lib.mkEnableOption "Deluge Web daemon";
 
-        port = mkOption {
-          type = types.port;
+        port = lib.mkOption {
+          type = lib.types.port;
           default = 8112;
           description = ''
             Deluge web UI port.
           '';
         };
 
-        openFirewall = mkOption {
-          type = types.bool;
+        openFirewall = lib.mkOption {
+          type = lib.types.bool;
           default = false;
           description = ''
             Open ports in the firewall for deluge web daemon
@@ -172,10 +169,10 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
-    services.deluge.package = mkDefault (
-      if versionAtLeast config.system.stateVersion "20.09" then
+    services.deluge.package = lib.mkDefault (
+      if lib.versionAtLeast config.system.stateVersion "20.09" then
         pkgs.deluge-2_x
       else
         # deluge-1_x is no longer packaged and this will resolve to an error
@@ -201,13 +198,13 @@ in {
       "${cfg.dataDir}/.config".d = defaultConfig;
       "${cfg.dataDir}/.config/deluge".d = defaultConfig;
     }
-    // optionalAttrs (cfg.config ? download_location) {
+    // lib.optionalAttrs (cfg.config ? download_location) {
       ${cfg.config.download_location}.d = defaultConfig;
     }
-    // optionalAttrs (cfg.config ? torrentfiles_location) {
+    // lib.optionalAttrs (cfg.config ? torrentfiles_location) {
       ${cfg.config.torrentfiles_location}.d = defaultConfig;
     }
-    // optionalAttrs (cfg.config ? move_completed_path) {
+    // lib.optionalAttrs (cfg.config ? move_completed_path) {
       ${cfg.config.move_completed_path}.d = defaultConfig;
     };
 
@@ -233,7 +230,7 @@ in {
       preStart = preStart;
     };
 
-    systemd.services.delugeweb = mkIf cfg_web.enable {
+    systemd.services.delugeweb = lib.mkIf cfg_web.enable {
       after = [ "network.target" "deluged.service"];
       requires = [ "deluged.service" ];
       description = "Deluge BitTorrent WebUI";
@@ -242,7 +239,7 @@ in {
       serviceConfig = {
         ExecStart = ''
           ${cfg.package}/bin/deluge-web \
-            ${optionalString (!isDeluge1) "--do-not-daemonize"} \
+            ${lib.optionalString (!isDeluge1) "--do-not-daemonize"} \
             --config ${configDir} \
             --port ${toString cfg.web.port}
         '';
@@ -251,19 +248,19 @@ in {
       };
     };
 
-    networking.firewall = mkMerge [
-      (mkIf (cfg.declarative && cfg.openFirewall && !(cfg.config.random_port or true)) {
-        allowedTCPPortRanges = singleton (listToRange (cfg.config.listen_ports or listenPortsDefault));
-        allowedUDPPortRanges = singleton (listToRange (cfg.config.listen_ports or listenPortsDefault));
+    networking.firewall = lib.mkMerge [
+      (lib.mkIf (cfg.declarative && cfg.openFirewall && !(cfg.config.random_port or true)) {
+        allowedTCPPortRanges = lib.singleton (listToRange (cfg.config.listen_ports or listenPortsDefault));
+        allowedUDPPortRanges = lib.singleton (listToRange (cfg.config.listen_ports or listenPortsDefault));
       })
-      (mkIf (cfg.web.openFirewall) {
+      (lib.mkIf (cfg.web.openFirewall) {
         allowedTCPPorts = [ cfg.web.port ];
       })
     ];
 
     environment.systemPackages = [ cfg.package ];
 
-    users.users = mkIf (cfg.user == "deluge") {
+    users.users = lib.mkIf (cfg.user == "deluge") {
       deluge = {
         group = cfg.group;
         uid = config.ids.uids.deluge;
@@ -272,7 +269,7 @@ in {
       };
     };
 
-    users.groups = mkIf (cfg.group == "deluge") {
+    users.groups = lib.mkIf (cfg.group == "deluge") {
       deluge = {
         gid = config.ids.gids.deluge;
       };

--- a/nixos/modules/services/torrent/flexget.nix
+++ b/nixos/modules/services/torrent/flexget.nix
@@ -4,63 +4,60 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.flexget;
   pkg = cfg.package;
   ymlFile = pkgs.writeText "flexget.yml" ''
     ${cfg.config}
 
-    ${optionalString cfg.systemScheduler "schedules: no"}
+    ${lib.optionalString cfg.systemScheduler "schedules: no"}
   '';
   configFile = "${toString cfg.homeDir}/flexget.yml";
 in
 {
   options = {
     services.flexget = {
-      enable = mkEnableOption "FlexGet daemon";
+      enable = lib.mkEnableOption "FlexGet daemon";
 
-      package = mkPackageOption pkgs "flexget" { };
+      package = lib.mkPackageOption pkgs "flexget" { };
 
-      user = mkOption {
+      user = lib.mkOption {
         default = "deluge";
         example = "some_user";
-        type = types.str;
+        type = lib.types.str;
         description = "The user under which to run flexget.";
       };
 
-      homeDir = mkOption {
+      homeDir = lib.mkOption {
         default = "/var/lib/deluge";
         example = "/home/flexget";
-        type = types.path;
+        type = lib.types.path;
         description = "Where files live.";
       };
 
-      interval = mkOption {
+      interval = lib.mkOption {
         default = "10m";
         example = "1h";
-        type = types.str;
+        type = lib.types.str;
         description = "When to perform a {command}`flexget` run. See {command}`man 7 systemd.time` for the format.";
       };
 
-      systemScheduler = mkOption {
+      systemScheduler = lib.mkOption {
         default = true;
         example = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = "When true, execute the runs via the flexget-runner.timer. If false, you have to specify the settings yourself in the YML file.";
       };
 
-      config = mkOption {
+      config = lib.mkOption {
         default = "";
-        type = types.lines;
+        type = lib.types.lines;
         description = "The YAML configuration for FlexGet.";
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     environment.systemPackages = [ pkg ];
 
@@ -81,7 +78,7 @@ in
         wantedBy = [ "multi-user.target" ];
       };
 
-      flexget-runner = mkIf cfg.systemScheduler {
+      flexget-runner = lib.mkIf cfg.systemScheduler {
         description = "FlexGet Runner";
         after = [ "flexget.service" ];
         wants = [ "flexget.service" ];
@@ -94,7 +91,7 @@ in
       };
     };
 
-    systemd.timers.flexget-runner = mkIf cfg.systemScheduler {
+    systemd.timers.flexget-runner = lib.mkIf cfg.systemScheduler {
       description = "Run FlexGet every ${cfg.interval}";
       wantedBy = [ "timers.target" ];
       timerConfig = {

--- a/nixos/modules/services/torrent/magnetico.nix
+++ b/nixos/modules/services/torrent/magnetico.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.magnetico;
 
@@ -22,7 +19,7 @@ let
       );
 
   # default options in magneticod/main.go
-  dbURI = concatStrings [
+  dbURI = lib.concatStrings [
     "sqlite3://${dataDir}/database.sqlite3"
     "?_journal_mode=WAL"
     "&_busy_timeout=3000"
@@ -63,10 +60,10 @@ in
   ###### interface
 
   options.services.magnetico = {
-    enable = mkEnableOption "Magnetico, Bittorrent DHT crawler";
+    enable = lib.mkEnableOption "Magnetico, Bittorrent DHT crawler";
 
-    crawler.address = mkOption {
-      type = types.str;
+    crawler.address = lib.mkOption {
+      type = lib.types.str;
       default = "0.0.0.0";
       example = "1.2.3.4";
       description = ''
@@ -74,8 +71,8 @@ in
       '';
     };
 
-    crawler.port = mkOption {
-      type = types.port;
+    crawler.port = lib.mkOption {
+      type = lib.types.port;
       default = 0;
       description = ''
         Port to be used for indexing DHT nodes.
@@ -84,8 +81,8 @@ in
       '';
     };
 
-    crawler.maxNeighbors = mkOption {
-      type = types.ints.positive;
+    crawler.maxNeighbors = lib.mkOption {
+      type = lib.types.ints.positive;
       default = 1000;
       description = ''
         Maximum number of simultaneous neighbors of an indexer.
@@ -95,24 +92,24 @@ in
       '';
     };
 
-    crawler.maxLeeches = mkOption {
-      type = types.ints.positive;
+    crawler.maxLeeches = lib.mkOption {
+      type = lib.types.ints.positive;
       default = 200;
       description = ''
         Maximum number of simultaneous leeches.
       '';
     };
 
-    crawler.extraOptions = mkOption {
-      type = types.listOf types.str;
+    crawler.extraOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
         Extra command line arguments to pass to magneticod.
       '';
     };
 
-    web.address = mkOption {
-      type = types.str;
+    web.address = lib.mkOption {
+      type = lib.types.str;
       default = "localhost";
       example = "1.2.3.4";
       description = ''
@@ -120,16 +117,16 @@ in
       '';
     };
 
-    web.port = mkOption {
-      type = types.port;
+    web.port = lib.mkOption {
+      type = lib.types.port;
       default = 8080;
       description = ''
         Port the web interface will listen to.
       '';
     };
 
-    web.credentials = mkOption {
-      type = types.attrsOf types.str;
+    web.credentials = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
       default = { };
       example = lib.literalExpression ''
         {
@@ -156,8 +153,8 @@ in
       '';
     };
 
-    web.credentialsFile = mkOption {
-      type = types.nullOr types.path;
+    web.credentialsFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
         The path to the file holding the credentials to access the web
@@ -174,8 +171,8 @@ in
       '';
     };
 
-    web.extraOptions = mkOption {
-      type = types.listOf types.str;
+    web.extraOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [ ];
       description = ''
         Extra command line arguments to pass to magneticow.
@@ -186,7 +183,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     users.users.magnetico = {
       description = "Magnetico daemons user";

--- a/nixos/modules/services/torrent/opentracker.nix
+++ b/nixos/modules/services/torrent/opentracker.nix
@@ -4,19 +4,17 @@
   pkgs,
   ...
 }:
-
-with lib;
 let
   cfg = config.services.opentracker;
 in
 {
   options.services.opentracker = {
-    enable = mkEnableOption "opentracker";
+    enable = lib.mkEnableOption "opentracker";
 
-    package = mkPackageOption pkgs "opentracker" { };
+    package = lib.mkPackageOption pkgs "opentracker" { };
 
-    extraOptions = mkOption {
-      type = types.separatedString " ";
+    extraOptions = lib.mkOption {
+      type = lib.types.separatedString " ";
       description = ''
         Configuration Arguments for opentracker
         See https://erdgeist.org/arts/software/opentracker/ for all params

--- a/nixos/modules/services/torrent/peerflix.nix
+++ b/nixos/modules/services/torrent/peerflix.nix
@@ -5,9 +5,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.peerflix;
   opt = options.services.peerflix;
@@ -25,29 +22,29 @@ in
   ###### interface
 
   options.services.peerflix = {
-    enable = mkOption {
+    enable = lib.mkOption {
       description = "Whether to enable peerflix service.";
       default = false;
-      type = types.bool;
+      type = lib.types.bool;
     };
 
-    stateDir = mkOption {
+    stateDir = lib.mkOption {
       description = "Peerflix state directory.";
       default = "/var/lib/peerflix";
-      type = types.path;
+      type = lib.types.path;
     };
 
-    downloadDir = mkOption {
+    downloadDir = lib.mkOption {
       description = "Peerflix temporary download directory.";
       default = "${cfg.stateDir}/torrents";
-      defaultText = literalExpression ''"''${config.${opt.stateDir}}/torrents"'';
-      type = types.path;
+      defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/torrents"'';
+      type = lib.types.path;
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.tmpfiles.rules = [
       "d '${cfg.stateDir}' - peerflix - - -"
     ];


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
