### PR TITLE
treewide/nixos: remove `with lib;` part 11

### DIFF
--- a/nixos/modules/services/torrent/rtorrent.nix
+++ b/nixos/modules/services/torrent/rtorrent.nix
@@ -5,9 +5,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.rtorrent;
@@ -18,18 +15,18 @@ in
   meta.maintainers = with lib.maintainers; [ thiagokokada ];
 
   options.services.rtorrent = {
-    enable = mkEnableOption "rtorrent";
+    enable = lib.mkEnableOption "rtorrent";
 
-    dataDir = mkOption {
-      type = types.str;
+    dataDir = lib.mkOption {
+      type = lib.types.str;
       default = "/var/lib/rtorrent";
       description = ''
         The directory where rtorrent stores its data files.
       '';
     };
 
-    dataPermissions = mkOption {
-      type = types.str;
+    dataPermissions = lib.mkOption {
+      type = lib.types.str;
       default = "0750";
       example = "0755";
       description = ''
@@ -37,51 +34,51 @@ in
       '';
     };
 
-    downloadDir = mkOption {
-      type = types.str;
+    downloadDir = lib.mkOption {
+      type = lib.types.str;
       default = "${cfg.dataDir}/download";
-      defaultText = literalExpression ''"''${config.${opt.dataDir}}/download"'';
+      defaultText = lib.literalExpression ''"''${config.${opt.dataDir}}/download"'';
       description = ''
         Where to put downloaded files.
       '';
     };
 
-    user = mkOption {
-      type = types.str;
+    user = lib.mkOption {
+      type = lib.types.str;
       default = "rtorrent";
       description = ''
         User account under which rtorrent runs.
       '';
     };
 
-    group = mkOption {
-      type = types.str;
+    group = lib.mkOption {
+      type = lib.types.str;
       default = "rtorrent";
       description = ''
         Group under which rtorrent runs.
       '';
     };
 
-    package = mkPackageOption pkgs "rtorrent" { };
+    package = lib.mkPackageOption pkgs "rtorrent" { };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 50000;
       description = ''
         The rtorrent port.
       '';
     };
 
-    openFirewall = mkOption {
-      type = types.bool;
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether to open the firewall for the port in {option}`services.rtorrent.port`.
       '';
     };
 
-    rpcSocket = mkOption {
-      type = types.str;
+    rpcSocket = lib.mkOption {
+      type = lib.types.str;
       readOnly = true;
       default = "/run/rtorrent/rpc.sock";
       description = ''
@@ -89,8 +86,8 @@ in
       '';
     };
 
-    configText = mkOption {
-      type = types.lines;
+    configText = lib.mkOption {
+      type = lib.types.lines;
       default = "";
       description = ''
         The content of {file}`rtorrent.rc`. The [modernized configuration template](https://rtorrent-docs.readthedocs.io/en/latest/cookbook.html#modernized-configuration-template) with the values specified in this module will be prepended using mkBefore. You can use mkForce to overwrite the config completely.
@@ -98,13 +95,13 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
-    users.groups = mkIf (cfg.group == "rtorrent") {
+    users.groups = lib.mkIf (cfg.group == "rtorrent") {
       rtorrent = { };
     };
 
-    users.users = mkIf (cfg.user == "rtorrent") {
+    users.users = lib.mkIf (cfg.user == "rtorrent") {
       rtorrent = {
         group = cfg.group;
         shell = pkgs.bashInteractive;
@@ -114,9 +111,9 @@ in
       };
     };
 
-    networking.firewall.allowedTCPPorts = mkIf (cfg.openFirewall) [ cfg.port ];
+    networking.firewall.allowedTCPPorts = lib.mkIf (cfg.openFirewall) [ cfg.port ];
 
-    services.rtorrent.configText = mkBefore ''
+    services.rtorrent.configText = lib.mkBefore ''
       # Instance layout (base paths)
       method.insert = cfg.basedir, private|const|string, (cat,"${cfg.dataDir}/")
       method.insert = cfg.watch,   private|const|string, (cat,(cfg.basedir),"watch/")

--- a/nixos/modules/services/ttys/getty.nix
+++ b/nixos/modules/services/ttys/getty.nix
@@ -1,20 +1,17 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.getty;
 
   baseArgs = [
     "--login-program" "${cfg.loginProgram}"
-  ] ++ optionals (cfg.autologinUser != null && !cfg.autologinOnce) [
+  ] ++ lib.optionals (cfg.autologinUser != null && !cfg.autologinOnce) [
     "--autologin" cfg.autologinUser
-  ] ++ optionals (cfg.loginOptions != null) [
+  ] ++ lib.optionals (cfg.loginOptions != null) [
     "--login-options" cfg.loginOptions
   ] ++ cfg.extraArgs;
 
   gettyCmd = args:
-    "${lib.getExe' pkgs.util-linux "agetty"} ${escapeShellArgs baseArgs} ${args}";
+    "${lib.getExe' pkgs.util-linux "agetty"} ${lib.escapeShellArgs baseArgs} ${args}";
 
   autologinScript = ''
     otherArgs="--noclear --keep-baud $TTY 115200,38400,9600 $TERM";
@@ -35,16 +32,16 @@ in
   ###### interface
 
   imports = [
-    (mkRenamedOptionModule [ "services" "mingetty" ] [ "services" "getty" ])
-    (mkRemovedOptionModule [ "services" "getty" "serialSpeed" ] ''set non-standard baudrates with `boot.kernelParams` i.e. boot.kernelParams = ["console=ttyS2,1500000"];'')
+    (lib.mkRenamedOptionModule [ "services" "mingetty" ] [ "services" "getty" ])
+    (lib.mkRemovedOptionModule [ "services" "getty" "serialSpeed" ] ''set non-standard baudrates with `boot.kernelParams` i.e. boot.kernelParams = ["console=ttyS2,1500000"];'')
   ];
 
   options = {
 
     services.getty = {
 
-      autologinUser = mkOption {
-        type = types.nullOr types.str;
+      autologinUser = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Username of the account that will be automatically logged in at the console.
@@ -52,8 +49,8 @@ in
         '';
       };
 
-      autologinOnce = mkOption {
-        type = types.bool;
+      autologinOnce = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           If enabled the automatic login will only happen in the first tty
@@ -62,17 +59,17 @@ in
         '';
       };
 
-      loginProgram = mkOption {
-        type = types.path;
+      loginProgram = lib.mkOption {
+        type = lib.types.path;
         default = "${pkgs.shadow}/bin/login";
-        defaultText = literalExpression ''"''${pkgs.shadow}/bin/login"'';
+        defaultText = lib.literalExpression ''"''${pkgs.shadow}/bin/login"'';
         description = ''
           Path to the login binary executed by agetty.
         '';
       };
 
-      loginOptions = mkOption {
-        type = types.nullOr types.str;
+      loginOptions = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = ''
           Template for arguments to be passed to
@@ -86,8 +83,8 @@ in
         example = "-h darkstar -- \\u";
       };
 
-      extraArgs = mkOption {
-        type = types.listOf types.str;
+      extraArgs = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [ ];
         description = ''
           Additional arguments passed to agetty.
@@ -95,16 +92,16 @@ in
         example = [ "--nohostname" ];
       };
 
-      greetingLine = mkOption {
-        type = types.str;
+      greetingLine = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Welcome line printed by agetty.
           The default shows current NixOS version label, machine type and tty.
         '';
       };
 
-      helpLine = mkOption {
-        type = types.lines;
+      helpLine = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = ''
           Help line printed by agetty below the welcome line.
@@ -123,8 +120,8 @@ in
   config = {
     # Note: this is set here rather than up there so that changing
     # nixos.label would not rebuild manual pages
-    services.getty.greetingLine = mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';
-    services.getty.helpLine = mkIf (config.documentation.nixos.enable && config.documentation.doc.enable) "\nRun 'nixos-help' for the NixOS manual.";
+    services.getty.greetingLine = lib.mkDefault ''<<< Welcome to ${config.system.nixos.distroName} ${config.system.nixos.label} (\m) - \l >>>'';
+    services.getty.helpLine = lib.mkIf (config.documentation.nixos.enable && config.documentation.doc.enable) "\nRun 'nixos-help' for the NixOS manual.";
 
     systemd.services."getty@" =
       { serviceConfig.ExecStart = [
@@ -167,10 +164,10 @@ in
         ];
         serviceConfig.Restart = "always";
         restartIfChanged = false;
-        enable = mkDefault config.boot.isContainer;
+        enable = lib.mkDefault config.boot.isContainer;
       };
 
-    environment.etc.issue = mkDefault
+    environment.etc.issue = lib.mkDefault
       { # Friendly greeting on the virtual consoles.
         source = pkgs.writeText "issue" ''
 
@@ -182,5 +179,5 @@ in
 
   };
 
-  meta.maintainers = with maintainers; [ RossComputerGuy ];
+  meta.maintainers = with lib.maintainers; [ RossComputerGuy ];
 }

--- a/nixos/modules/services/ttys/gpm.nix
+++ b/nixos/modules/services/ttys/gpm.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.gpm;
@@ -21,8 +18,8 @@ in
 
     services.gpm = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether to enable GPM, the General Purpose Mouse daemon,
@@ -30,8 +27,8 @@ in
         '';
       };
 
-      protocol = mkOption {
-        type = types.str;
+      protocol = lib.mkOption {
+        type = lib.types.str;
         default = "ps/2";
         description = "Mouse protocol to use.";
       };
@@ -42,7 +39,7 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     systemd.services.gpm = {
       description = "Console Mouse Daemon";

--- a/nixos/modules/services/video/mirakurun.nix
+++ b/nixos/modules/services/video/mirakurun.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.mirakurun;
   mirakurun = pkgs.mirakurun;
@@ -29,10 +26,10 @@ in
 {
   options = {
     services.mirakurun = {
-      enable = mkEnableOption "the Mirakurun DVR Tuner Server";
+      enable = lib.mkEnableOption "the Mirakurun DVR Tuner Server";
 
-      port = mkOption {
-        type = with types; nullOr port;
+      port = lib.mkOption {
+        type = with lib.types; nullOr port;
         default = 40772;
         description = ''
           Port to listen on. If `null`, it won't listen on
@@ -40,8 +37,8 @@ in
         '';
       };
 
-      openFirewall = mkOption {
-        type = types.bool;
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Open ports in the firewall for Mirakurun.
@@ -54,8 +51,8 @@ in
         '';
       };
 
-      unixSocket = mkOption {
-        type = with types; nullOr path;
+      unixSocket = lib.mkOption {
+        type = with lib.types; nullOr path;
         default = "/var/run/mirakurun/mirakurun.sock";
         description = ''
           Path to unix socket to listen on. If `null`, it
@@ -63,8 +60,8 @@ in
         '';
       };
 
-      allowSmartCardAccess = mkOption {
-        type = types.bool;
+      allowSmartCardAccess = lib.mkOption {
+        type = lib.types.bool;
         default = true;
         description = ''
           Install polkit rules to allow Mirakurun to access smart card readers
@@ -72,10 +69,10 @@ in
         '';
       };
 
-      serverSettings = mkOption {
+      serverSettings = lib.mkOption {
         type = settingsFmt.type;
         default = { };
-        example = literalExpression ''
+        example = lib.literalExpression ''
           {
             highWaterMark = 25165824;
             overflowTimeLimit = 30000;
@@ -89,10 +86,10 @@ in
         '';
       };
 
-      tunerSettings = mkOption {
-        type = with types; nullOr settingsFmt.type;
+      tunerSettings = lib.mkOption {
+        type = with lib.types; nullOr settingsFmt.type;
         default = null;
-        example = literalExpression ''
+        example = lib.literalExpression ''
           [
             {
               name = "tuner-name";
@@ -110,10 +107,10 @@ in
         '';
       };
 
-      channelSettings = mkOption {
-        type = with types; nullOr settingsFmt.type;
+      channelSettings = lib.mkOption {
+        type = with lib.types; nullOr settingsFmt.type;
         default = null;
-        example = literalExpression ''
+        example = lib.literalExpression ''
           [
             {
               name = "channel";
@@ -133,17 +130,17 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    environment.systemPackages = [ mirakurun ] ++ optional cfg.allowSmartCardAccess polkitRule;
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ mirakurun ] ++ lib.optional cfg.allowSmartCardAccess polkitRule;
     environment.etc = {
       "mirakurun/server.yml".source = settingsFmt.generate "server.yml" cfg.serverSettings;
-      "mirakurun/tuners.yml" = mkIf (cfg.tunerSettings != null) {
+      "mirakurun/tuners.yml" = lib.mkIf (cfg.tunerSettings != null) {
         source = settingsFmt.generate "tuners.yml" cfg.tunerSettings;
         mode = "0644";
         user = username;
         group = groupname;
       };
-      "mirakurun/channels.yml" = mkIf (cfg.channelSettings != null) {
+      "mirakurun/channels.yml" = lib.mkIf (cfg.channelSettings != null) {
         source = settingsFmt.generate "channels.yml" cfg.channelSettings;
         mode = "0644";
         user = username;
@@ -151,8 +148,8 @@ in
       };
     };
 
-    networking.firewall = mkIf cfg.openFirewall {
-      allowedTCPPorts = mkIf (cfg.port != null) [ cfg.port ];
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = lib.mkIf (cfg.port != null) [ cfg.port ];
     };
 
     users.users.mirakurun = {
@@ -165,9 +162,9 @@ in
     };
 
     services.mirakurun.serverSettings = {
-      logLevel = mkDefault 2;
-      path = mkIf (cfg.unixSocket != null) cfg.unixSocket;
-      port = mkIf (cfg.port != null) cfg.port;
+      logLevel = lib.mkDefault 2;
+      path = lib.mkIf (cfg.unixSocket != null) cfg.unixSocket;
+      port = lib.mkIf (cfg.port != null) cfg.port;
     };
 
     systemd.tmpfiles.settings."10-mirakurun"."/etc/mirakurun".d = {
@@ -208,8 +205,8 @@ in
             [
               "server"
             ]
-            ++ optional (cfg.tunerSettings != null) "tuners"
-            ++ optional (cfg.channelSettings != null) "channels";
+            ++ lib.optional (cfg.tunerSettings != null) "tuners"
+            ++ lib.optional (cfg.channelSettings != null) "channels";
         in
         (map getconf targets);
     };

--- a/nixos/modules/services/wayland/cage.nix
+++ b/nixos/modules/services/wayland/cage.nix
@@ -4,33 +4,30 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.cage;
 in
 {
-  options.services.cage.enable = mkEnableOption "cage kiosk service";
+  options.services.cage.enable = lib.mkEnableOption "cage kiosk service";
 
-  options.services.cage.user = mkOption {
-    type = types.str;
+  options.services.cage.user = lib.mkOption {
+    type = lib.types.str;
     default = "demo";
     description = ''
       User to log-in as.
     '';
   };
 
-  options.services.cage.extraArguments = mkOption {
-    type = types.listOf types.str;
+  options.services.cage.extraArguments = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
     default = [ ];
-    defaultText = literalExpression "[]";
+    defaultText = lib.literalExpression "[]";
     description = "Additional command line arguments to pass to Cage.";
     example = [ "-d" ];
   };
 
-  options.services.cage.environment = mkOption {
-    type = types.attrsOf types.str;
+  options.services.cage.environment = lib.mkOption {
+    type = lib.types.attrsOf lib.types.str;
     default = { };
     example = {
       WLR_LIBINPUT_NO_DEVICES = "1";
@@ -38,18 +35,18 @@ in
     description = "Additional environment variables to pass to Cage.";
   };
 
-  options.services.cage.program = mkOption {
-    type = types.path;
+  options.services.cage.program = lib.mkOption {
+    type = lib.types.path;
     default = "${pkgs.xterm}/bin/xterm";
-    defaultText = literalExpression ''"''${pkgs.xterm}/bin/xterm"'';
+    defaultText = lib.literalExpression ''"''${pkgs.xterm}/bin/xterm"'';
     description = ''
       Program to run in cage.
     '';
   };
 
-  options.services.cage.package = mkPackageOption pkgs "cage" { };
+  options.services.cage.package = lib.mkPackageOption pkgs "cage" { };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     # The service is partially based off of the one provided in the
     # cage wiki at
@@ -77,7 +74,7 @@ in
       serviceConfig = {
         ExecStart = ''
           ${cfg.package}/bin/cage \
-            ${escapeShellArgs cfg.extraArguments} \
+            ${lib.escapeShellArgs cfg.extraArguments} \
             -- ${cfg.program}
         '';
         User = cfg.user;
@@ -113,7 +110,7 @@ in
       session required ${config.systemd.package}/lib/security/pam_systemd.so
     '';
 
-    hardware.graphics.enable = mkDefault true;
+    hardware.graphics.enable = lib.mkDefault true;
 
     systemd.targets.graphical.wants = [ "cage-tty1.service" ];
 

--- a/nixos/modules/services/web-apps/alps.nix
+++ b/nixos/modules/services/web-apps/alps.nix
@@ -4,34 +4,31 @@
   config,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.alps;
 in
 {
   options.services.alps = {
-    enable = mkEnableOption "alps";
+    enable = lib.mkEnableOption "alps";
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 1323;
       description = ''
         TCP port the service should listen on.
       '';
     };
 
-    bindIP = mkOption {
+    bindIP = lib.mkOption {
       default = "[::]";
-      type = types.str;
+      type = lib.types.str;
       description = ''
         The IP the service should listen on.
       '';
     };
 
-    theme = mkOption {
-      type = types.enum [
+    theme = lib.mkOption {
+      type = lib.types.enum [
         "alps"
         "sourcehut"
       ];
@@ -42,16 +39,16 @@ in
     };
 
     imaps = {
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 993;
         description = ''
           The IMAPS server port.
         '';
       };
 
-      host = mkOption {
-        type = types.str;
+      host = lib.mkOption {
+        type = lib.types.str;
         default = "[::1]";
         example = "mail.example.org";
         description = ''
@@ -61,16 +58,16 @@ in
     };
 
     smtps = {
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 465;
         description = ''
           The SMTPS server port.
         '';
       };
 
-      host = mkOption {
-        type = types.str;
+      host = lib.mkOption {
+        type = lib.types.str;
         default = cfg.imaps.host;
         defaultText = "services.alps.imaps.host";
         example = "mail.example.org";
@@ -80,15 +77,15 @@ in
       };
     };
 
-    package = mkOption {
+    package = lib.mkOption {
       internal = true;
-      type = types.package;
+      type = lib.types.package;
       default = pkgs.alps;
     };
 
-    args = mkOption {
+    args = lib.mkOption {
       internal = true;
-      type = types.listOf types.str;
+      type = lib.types.listOf lib.types.str;
       default = [
         "-addr"
         "${cfg.bindIP}:${toString cfg.port}"
@@ -100,7 +97,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.alps = {
       description = "alps is a simple and extensible webmail.";
       documentation = [ "https://git.sr.ht/~migadu/alps" ];
@@ -112,7 +109,7 @@ in
       ];
 
       serviceConfig = {
-        ExecStart = "${cfg.package}/bin/alps ${escapeShellArgs cfg.args}";
+        ExecStart = "${cfg.package}/bin/alps ${lib.escapeShellArgs cfg.args}";
         AmbientCapabilities = "";
         CapabilityBoundingSet = "";
         DynamicUser = true;

--- a/nixos/modules/services/web-apps/audiobookshelf.nix
+++ b/nixos/modules/services/web-apps/audiobookshelf.nix
@@ -4,59 +4,56 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.audiobookshelf;
 in
 {
   options = {
     services.audiobookshelf = {
-      enable = mkEnableOption "Audiobookshelf, self-hosted audiobook and podcast server";
+      enable = lib.mkEnableOption "Audiobookshelf, self-hosted audiobook and podcast server";
 
-      package = mkPackageOption pkgs "audiobookshelf" { };
+      package = lib.mkPackageOption pkgs "audiobookshelf" { };
 
-      dataDir = mkOption {
+      dataDir = lib.mkOption {
         description = "Path to Audiobookshelf config and metadata inside of /var/lib.";
         default = "audiobookshelf";
-        type = types.str;
+        type = lib.types.str;
       };
 
-      host = mkOption {
+      host = lib.mkOption {
         description = "The host Audiobookshelf binds to.";
         default = "127.0.0.1";
         example = "0.0.0.0";
-        type = types.str;
+        type = lib.types.str;
       };
 
-      port = mkOption {
+      port = lib.mkOption {
         description = "The TCP port Audiobookshelf will listen on.";
         default = 8000;
-        type = types.port;
+        type = lib.types.port;
       };
 
-      user = mkOption {
+      user = lib.mkOption {
         description = "User account under which Audiobookshelf runs.";
         default = "audiobookshelf";
-        type = types.str;
+        type = lib.types.str;
       };
 
-      group = mkOption {
+      group = lib.mkOption {
         description = "Group under which Audiobookshelf runs.";
         default = "audiobookshelf";
-        type = types.str;
+        type = lib.types.str;
       };
 
-      openFirewall = mkOption {
+      openFirewall = lib.mkOption {
         description = "Open ports in the firewall for the Audiobookshelf web interface.";
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.audiobookshelf = {
       description = "Audiobookshelf is a self-hosted audiobook and podcast server";
 
@@ -74,7 +71,7 @@ in
       };
     };
 
-    users.users = mkIf (cfg.user == "audiobookshelf") {
+    users.users = lib.mkIf (cfg.user == "audiobookshelf") {
       audiobookshelf = {
         isSystemUser = true;
         group = cfg.group;
@@ -82,14 +79,14 @@ in
       };
     };
 
-    users.groups = mkIf (cfg.group == "audiobookshelf") {
+    users.groups = lib.mkIf (cfg.group == "audiobookshelf") {
       audiobookshelf = { };
     };
 
-    networking.firewall = mkIf cfg.openFirewall {
+    networking.firewall = lib.mkIf cfg.openFirewall {
       allowedTCPPorts = [ cfg.port ];
     };
   };
 
-  meta.maintainers = with maintainers; [ wietsedv ];
+  meta.maintainers = with lib.maintainers; [ wietsedv ];
 }

--- a/nixos/modules/services/web-apps/bookstack.nix
+++ b/nixos/modules/services/web-apps/bookstack.nix
@@ -1,7 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.services.bookstack;
   bookstack = cfg.package.override {
@@ -28,35 +25,35 @@ let
 
 in {
   imports = [
-    (mkRemovedOptionModule [ "services" "bookstack" "extraConfig" ] "Use services.bookstack.config instead.")
-    (mkRemovedOptionModule [ "services" "bookstack" "cacheDir" ] "The cache directory is now handled automatically.")
+    (lib.mkRemovedOptionModule [ "services" "bookstack" "extraConfig" ] "Use services.bookstack.config instead.")
+    (lib.mkRemovedOptionModule [ "services" "bookstack" "cacheDir" ] "The cache directory is now handled automatically.")
   ];
 
   options.services.bookstack = {
-    enable = mkEnableOption "BookStack";
+    enable = lib.mkEnableOption "BookStack";
 
-    package = mkPackageOption pkgs "bookstack" { };
+    package = lib.mkPackageOption pkgs "bookstack" { };
 
-    user = mkOption {
+    user = lib.mkOption {
       default = "bookstack";
       description = "User bookstack runs as.";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    group = mkOption {
+    group = lib.mkOption {
       default = "bookstack";
       description = "Group bookstack runs as.";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    appKeyFile = mkOption {
+    appKeyFile = lib.mkOption {
       description = ''
         A file containing the Laravel APP_KEY - a 32 character long,
         base64 encoded key used for encryption where needed. Can be
         generated with `head -c 32 /dev/urandom | base64`.
       '';
       example = "/run/keys/bookstack-appkey";
-      type = types.path;
+      type = lib.types.path;
     };
 
     hostname = lib.mkOption {
@@ -69,7 +66,7 @@ in {
       '';
     };
 
-    appURL = mkOption {
+    appURL = lib.mkOption {
       description = ''
         The root URL that you want to host BookStack on. All URLs in BookStack will be generated using this value.
         If you change this in the future you may need to run a command to update stored URLs in the database. Command example: `php artisan bookstack:update-url https://old.example.com https://new.example.com`
@@ -77,39 +74,39 @@ in {
       default = "http${lib.optionalString tlsEnabled "s"}://${cfg.hostname}";
       defaultText = ''http''${lib.optionalString tlsEnabled "s"}://''${cfg.hostname}'';
       example = "https://example.com";
-      type = types.str;
+      type = lib.types.str;
     };
 
-    dataDir = mkOption {
+    dataDir = lib.mkOption {
       description = "BookStack data directory";
       default = "/var/lib/bookstack";
-      type = types.path;
+      type = lib.types.path;
     };
 
     database = {
-      host = mkOption {
-        type = types.str;
+      host = lib.mkOption {
+        type = lib.types.str;
         default = "localhost";
         description = "Database host address.";
       };
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 3306;
         description = "Database host port.";
       };
-      name = mkOption {
-        type = types.str;
+      name = lib.mkOption {
+        type = lib.types.str;
         default = "bookstack";
         description = "Database name.";
       };
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = user;
-        defaultText = literalExpression "user";
+        defaultText = lib.literalExpression "user";
         description = "Database username.";
       };
-      passwordFile = mkOption {
-        type = with types; nullOr path;
+      passwordFile = lib.mkOption {
+        type = with lib.types; nullOr path;
         default = null;
         example = "/run/keys/bookstack-dbpassword";
         description = ''
@@ -117,47 +114,47 @@ in {
           {option}`database.user`.
         '';
       };
-      createLocally = mkOption {
-        type = types.bool;
+      createLocally = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Create the database and database user locally.";
       };
     };
 
     mail = {
-      driver = mkOption {
-        type = types.enum [ "smtp" "sendmail" ];
+      driver = lib.mkOption {
+        type = lib.types.enum [ "smtp" "sendmail" ];
         default = "smtp";
         description = "Mail driver to use.";
       };
-      host = mkOption {
-        type = types.str;
+      host = lib.mkOption {
+        type = lib.types.str;
         default = "localhost";
         description = "Mail host address.";
       };
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 1025;
         description = "Mail host port.";
       };
-      fromName = mkOption {
-        type = types.str;
+      fromName = lib.mkOption {
+        type = lib.types.str;
         default = "BookStack";
         description = "Mail \"from\" name.";
       };
-      from = mkOption {
-        type = types.str;
+      from = lib.mkOption {
+        type = lib.types.str;
         default = "mail@bookstackapp.com";
         description = "Mail \"from\" email.";
       };
-      user = mkOption {
-        type = with types; nullOr str;
+      user = lib.mkOption {
+        type = with lib.types; nullOr str;
         default = null;
         example = "bookstack";
         description = "Mail username.";
       };
-      passwordFile = mkOption {
-        type = with types; nullOr path;
+      passwordFile = lib.mkOption {
+        type = with lib.types; nullOr path;
         default = null;
         example = "/run/keys/bookstack-mailpassword";
         description = ''
@@ -165,22 +162,22 @@ in {
           {option}`mail.user`.
         '';
       };
-      encryption = mkOption {
-        type = with types; nullOr (enum [ "tls" ]);
+      encryption = lib.mkOption {
+        type = with lib.types; nullOr (enum [ "tls" ]);
         default = null;
         description = "SMTP encryption mechanism to use.";
       };
     };
 
-    maxUploadSize = mkOption {
-      type = types.str;
+    maxUploadSize = lib.mkOption {
+      type = lib.types.str;
       default = "18M";
       example = "1G";
       description = "The maximum size for uploads (e.g. images).";
     };
 
-    poolConfig = mkOption {
-      type = with types; attrsOf (oneOf [ str int bool ]);
+    poolConfig = lib.mkOption {
+      type = with lib.types; attrsOf (oneOf [ str int bool ]);
       default = {
         "pm" = "dynamic";
         "pm.max_children" = 32;
@@ -195,13 +192,13 @@ in {
       '';
     };
 
-    nginx = mkOption {
-      type = types.submodule (
-        recursiveUpdate
+    nginx = lib.mkOption {
+      type = lib.types.submodule (
+        lib.recursiveUpdate
           (import ../web-servers/nginx/vhost-options.nix { inherit config lib; }) {}
       );
       default = {};
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           serverAliases = [
             "bookstack.''${config.networking.domain}"
@@ -216,8 +213,8 @@ in {
       '';
     };
 
-    config = mkOption {
-      type = with types;
+    config = lib.mkOption {
+      type = with lib.types;
         attrsOf
           (nullOr
             (either
@@ -230,7 +227,7 @@ in {
               ])
               (submodule {
                 options = {
-                  _secret = mkOption {
+                  _secret = lib.mkOption {
                     type = nullOr str;
                     description = ''
                       The path to a file containing the value the
@@ -241,7 +238,7 @@ in {
                 };
               })));
       default = {};
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           ALLOWED_IFRAME_HOSTS = "https://example.com";
           WKHTMLTOPDF = "/home/user/bins/wkhtmltopdf";
@@ -274,7 +271,7 @@ in {
 
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     assertions = [
       { assertion = db.createLocally -> db.user == user;
@@ -311,9 +308,9 @@ in {
 
     environment.systemPackages = [ artisan ];
 
-    services.mysql = mkIf db.createLocally {
+    services.mysql = lib.mkIf db.createLocally {
       enable = true;
-      package = mkDefault pkgs.mariadb;
+      package = lib.mkDefault pkgs.mariadb;
       ensureDatabases = [ db.name ];
       ensureUsers = [
         { name = db.user;
@@ -338,12 +335,12 @@ in {
     };
 
     services.nginx = {
-      enable = mkDefault true;
+      enable = lib.mkDefault true;
       recommendedTlsSettings = true;
       recommendedOptimisation = true;
       recommendedGzipSettings = true;
-      virtualHosts.${cfg.hostname} = mkMerge [ cfg.nginx {
-        root = mkForce "${bookstack}/public";
+      virtualHosts.${cfg.hostname} = lib.mkMerge [ cfg.nginx {
+        root = lib.mkForce "${bookstack}/public";
         locations = {
           "/" = {
             index = "index.php";
@@ -362,7 +359,7 @@ in {
     systemd.services.bookstack-setup = {
       description = "Preparation tasks for BookStack";
       before = [ "phpfpm-bookstack.service" ];
-      after = optional db.createLocally "mysql.service";
+      after = lib.optional db.createLocally "mysql.service";
       wantedBy = [ "multi-user.target" ];
       serviceConfig = {
         Type = "oneshot";
@@ -375,7 +372,7 @@ in {
       path = [ pkgs.replace-secret ];
       script =
         let
-          isSecret = v: isAttrs v && v ? _secret && isString v._secret;
+          isSecret = v: lib.isAttrs v && v ? _secret && lib.isString v._secret;
           bookstackEnvVars = lib.generators.toKeyValue {
             mkKeyValue = lib.flip lib.generators.mkKeyValueDefault "=" {
               mkValueString = v: with builtins;
@@ -389,10 +386,10 @@ in {
           };
           secretPaths = lib.mapAttrsToList (_: v: v._secret) (lib.filterAttrs (_: isSecret) cfg.config);
           mkSecretReplacement = file: ''
-            replace-secret ${escapeShellArgs [ (builtins.hashString "sha256" file) file "${cfg.dataDir}/.env" ]}
+            replace-secret ${lib.escapeShellArgs [ (builtins.hashString "sha256" file) file "${cfg.dataDir}/.env" ]}
           '';
           secretReplacements = lib.concatMapStrings mkSecretReplacement secretPaths;
-          filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! elem v [ {} null ])) cfg.config;
+          filteredConfig = lib.converge (lib.filterAttrsRecursive (_: v: ! lib.elem v [ {} null ])) cfg.config;
           bookstackEnv = pkgs.writeText "bookstack.env" (bookstackEnvVars filteredConfig);
         in ''
         # error handling
@@ -434,19 +431,19 @@ in {
     };
 
     users = {
-      users = mkIf (user == "bookstack") {
+      users = lib.mkIf (user == "bookstack") {
         bookstack = {
           inherit group;
           isSystemUser = true;
         };
         "${config.services.nginx.user}".extraGroups = [ group ];
       };
-      groups = mkIf (group == "bookstack") {
+      groups = lib.mkIf (group == "bookstack") {
         bookstack = {};
       };
     };
 
   };
 
-  meta.maintainers = with maintainers; [ ymarkus ];
+  meta.maintainers = with lib.maintainers; [ ymarkus ];
 }

--- a/nixos/modules/services/web-apps/chatgpt-retrieval-plugin.nix
+++ b/nixos/modules/services/web-apps/chatgpt-retrieval-plugin.nix
@@ -4,31 +4,28 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.chatgpt-retrieval-plugin;
 in
 {
   options.services.chatgpt-retrieval-plugin = {
-    enable = mkEnableOption "chatgpt-retrieval-plugin service";
+    enable = lib.mkEnableOption "chatgpt-retrieval-plugin service";
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 8080;
       description = "Port the chatgpt-retrieval-plugin service listens on.";
     };
 
-    host = mkOption {
-      type = types.str;
+    host = lib.mkOption {
+      type = lib.types.str;
       default = "127.0.0.1";
       example = "0.0.0.0";
       description = "The hostname or IP address for chatgpt-retrieval-plugin to bind to.";
     };
 
-    bearerTokenPath = mkOption {
-      type = types.path;
+    bearerTokenPath = lib.mkOption {
+      type = lib.types.path;
       description = ''
         Path to the secret bearer token used for the http api authentication.
       '';
@@ -36,8 +33,8 @@ in
       example = "config.age.secrets.CHATGPT_RETRIEVAL_PLUGIN_BEARER_TOKEN.path";
     };
 
-    openaiApiKeyPath = mkOption {
-      type = types.path;
+    openaiApiKeyPath = lib.mkOption {
+      type = lib.types.path;
       description = ''
         Path to the secret openai api key used for embeddings.
       '';
@@ -45,8 +42,8 @@ in
       example = "config.age.secrets.CHATGPT_RETRIEVAL_PLUGIN_OPENAI_API_KEY.path";
     };
 
-    datastore = mkOption {
-      type = types.enum [
+    datastore = lib.mkOption {
+      type = lib.types.enum [
         "pinecone"
         "weaviate"
         "zilliz"
@@ -58,8 +55,8 @@ in
       description = "This specifies the vector database provider you want to use to store and query embeddings.";
     };
 
-    qdrantCollection = mkOption {
-      type = types.str;
+    qdrantCollection = lib.mkOption {
+      type = lib.types.str;
       description = ''
         name of the qdrant collection used to store documents.
       '';
@@ -67,7 +64,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     assertions = [
       {
@@ -106,7 +103,7 @@ in
 
       environment = {
         DATASTORE = cfg.datastore;
-        QDRANT_COLLECTION = mkIf (cfg.datastore == "qdrant") cfg.qdrantCollection;
+        QDRANT_COLLECTION = lib.mkIf (cfg.datastore == "qdrant") cfg.qdrantCollection;
       };
     };
 

--- a/nixos/modules/services/web-apps/cloudlog.nix
+++ b/nixos/modules/services/web-apps/cloudlog.nix
@@ -4,9 +4,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.cloudlog;
   dbFile =
@@ -77,51 +74,51 @@ let
   };
 in
 {
-  options.services.cloudlog = with types; {
-    enable = mkEnableOption "Cloudlog";
-    dataDir = mkOption {
+  options.services.cloudlog = with lib.types; {
+    enable = lib.mkEnableOption "Cloudlog";
+    dataDir = lib.mkOption {
       type = str;
       default = "/var/lib/cloudlog";
       description = "Cloudlog data directory.";
     };
-    baseUrl = mkOption {
+    baseUrl = lib.mkOption {
       type = str;
       default = "http://localhost";
       description = "Cloudlog base URL";
     };
-    user = mkOption {
+    user = lib.mkOption {
       type = str;
       default = "cloudlog";
       description = "User account under which Cloudlog runs.";
     };
     database = {
-      createLocally = mkOption {
+      createLocally = lib.mkOption {
         type = types.bool;
         default = true;
         description = "Create the database and database user locally.";
       };
-      host = mkOption {
+      host = lib.mkOption {
         type = str;
         description = "MySQL database host";
         default = "localhost";
       };
-      name = mkOption {
+      name = lib.mkOption {
         type = str;
         description = "MySQL database name.";
         default = "cloudlog";
       };
-      user = mkOption {
+      user = lib.mkOption {
         type = str;
         description = "MySQL user name.";
         default = "cloudlog";
       };
-      passwordFile = mkOption {
+      passwordFile = lib.mkOption {
         type = nullOr str;
         description = "MySQL user password file.";
         default = null;
       };
     };
-    poolConfig = mkOption {
+    poolConfig = lib.mkOption {
       type = attrsOf (oneOf [
         str
         int
@@ -139,7 +136,7 @@ in
         Options for Cloudlog's PHP-FPM pool.
       '';
     };
-    virtualHost = mkOption {
+    virtualHost = lib.mkOption {
       type = nullOr str;
       default = "localhost";
       description = ''
@@ -147,7 +144,7 @@ in
          any virtualhost.
       '';
     };
-    extraConfig = mkOption {
+    extraConfig = lib.mkOption {
       description = ''
         Any additional text to be appended to the config.php
         configuration file. This is a PHP script. For configuration
@@ -160,7 +157,7 @@ in
       '';
     };
     upload-lotw = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -169,7 +166,7 @@ in
            option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "daily";
         description = ''
@@ -179,7 +176,7 @@ in
       };
     };
     upload-clublog = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -187,7 +184,7 @@ in
           timer will run the log upload task as specified by the interval option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "daily";
         description = ''
@@ -197,7 +194,7 @@ in
       };
     };
     update-lotw-users = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -206,7 +203,7 @@ in
           option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "weekly";
         description = ''
@@ -216,7 +213,7 @@ in
       };
     };
     update-dok = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -224,7 +221,7 @@ in
           systemd timer will run the update task as specified by the interval option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "monthly";
         description = ''
@@ -234,7 +231,7 @@ in
       };
     };
     update-clublog-scp = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -243,7 +240,7 @@ in
           option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "monthly";
         description = ''
@@ -253,7 +250,7 @@ in
       };
     };
     update-wwff = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -262,7 +259,7 @@ in
           option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "monthly";
         description = ''
@@ -272,7 +269,7 @@ in
       };
     };
     upload-qrz = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -280,7 +277,7 @@ in
           timer will run the update task as specified by the interval option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "daily";
         description = ''
@@ -290,7 +287,7 @@ in
       };
     };
     update-sota = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -298,7 +295,7 @@ in
           systemd timer will run the update task as specified by the interval option.
         '';
       };
-      interval = mkOption {
+      interval = lib.mkOption {
         type = str;
         default = "monthly";
         description = ''
@@ -308,7 +305,7 @@ in
       };
     };
   };
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     assertions = [
       {
@@ -328,7 +325,7 @@ in
       };
     };
 
-    services.nginx = mkIf (cfg.virtualHost != null) {
+    services.nginx = lib.mkIf (cfg.virtualHost != null) {
       enable = true;
       virtualHosts = {
         "${cfg.virtualHost}" = {
@@ -345,7 +342,7 @@ in
       };
     };
 
-    services.mysql = mkIf cfg.database.createLocally {
+    services.mysql = lib.mkIf cfg.database.createLocally {
       enable = true;
       ensureDatabases = [ cfg.database.name ];
       ensureUsers = [
@@ -360,7 +357,7 @@ in
 
     systemd = {
       services = {
-        cloudlog-setup-database = mkIf cfg.database.createLocally {
+        cloudlog-setup-database = lib.mkIf cfg.database.createLocally {
           description = "Set up cloudlog database";
           serviceConfig = {
             Type = "oneshot";
@@ -518,5 +515,5 @@ in
     };
   };
 
-  meta.maintainers = with maintainers; [ melling ];
+  meta.maintainers = with lib.maintainers; [ melling ];
 }

--- a/nixos/modules/services/web-apps/coder.nix
+++ b/nixos/modules/services/web-apps/coder.nix
@@ -5,9 +5,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.coder;
   name = "coder";
@@ -15,10 +12,10 @@ in
 {
   options = {
     services.coder = {
-      enable = mkEnableOption "Coder service";
+      enable = lib.mkEnableOption "Coder service";
 
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "coder";
         description = ''
           User under which the coder service runs.
@@ -30,8 +27,8 @@ in
         '';
       };
 
-      group = mkOption {
-        type = types.str;
+      group = lib.mkOption {
+        type = lib.types.str;
         default = "coder";
         description = ''
           Group under which the coder service runs.
@@ -43,26 +40,26 @@ in
         '';
       };
 
-      package = mkPackageOption pkgs "coder" { };
+      package = lib.mkPackageOption pkgs "coder" { };
 
-      homeDir = mkOption {
-        type = types.str;
+      homeDir = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Home directory for coder user.
         '';
         default = "/var/lib/coder";
       };
 
-      listenAddress = mkOption {
-        type = types.str;
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Listen address.
         '';
         default = "127.0.0.1:3000";
       };
 
-      accessUrl = mkOption {
-        type = types.nullOr types.str;
+      accessUrl = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         description = ''
           Access URL should be a external IP address or domain with DNS records pointing to Coder.
         '';
@@ -70,8 +67,8 @@ in
         example = "https://coder.example.com";
       };
 
-      wildcardAccessUrl = mkOption {
-        type = types.nullOr types.str;
+      wildcardAccessUrl = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         description = ''
           If you are providing TLS certificates directly to the Coder server, you must use a single certificate for the root and wildcard domains.
         '';
@@ -80,8 +77,8 @@ in
       };
 
       environment = {
-        extra = mkOption {
-          type = types.attrs;
+        extra = lib.mkOption {
+          type = lib.types.attrs;
           description = "Extra environment variables to pass run Coder's server with. See Coder documentation.";
           default = { };
           example = {
@@ -89,56 +86,56 @@ in
             CODER_OAUTH2_GITHUB_ALLOWED_ORGS = "your-org";
           };
         };
-        file = mkOption {
-          type = types.nullOr types.path;
+        file = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
           description = "Systemd environment file to add to Coder.";
           default = null;
         };
       };
 
       database = {
-        createLocally = mkOption {
-          type = types.bool;
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
           default = true;
           description = ''
             Create the database and database user locally.
           '';
         };
 
-        host = mkOption {
-          type = types.str;
+        host = lib.mkOption {
+          type = lib.types.str;
           default = "/run/postgresql";
           description = ''
             Hostname hosting the database.
           '';
         };
 
-        database = mkOption {
-          type = types.str;
+        database = lib.mkOption {
+          type = lib.types.str;
           default = "coder";
           description = ''
             Name of database.
           '';
         };
 
-        username = mkOption {
-          type = types.str;
+        username = lib.mkOption {
+          type = lib.types.str;
           default = "coder";
           description = ''
             Username for accessing the database.
           '';
         };
 
-        password = mkOption {
-          type = types.nullOr types.str;
+        password = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = null;
           description = ''
             Password for accessing the database.
           '';
         };
 
-        sslmode = mkOption {
-          type = types.nullOr types.str;
+        sslmode = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
           default = "disable";
           description = ''
             Password for accessing the database.
@@ -146,16 +143,16 @@ in
         };
       };
 
-      tlsCert = mkOption {
-        type = types.nullOr types.path;
+      tlsCert = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         description = ''
           The path to the TLS certificate.
         '';
         default = null;
       };
 
-      tlsKey = mkOption {
-        type = types.nullOr types.path;
+      tlsKey = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         description = ''
           The path to the TLS key.
         '';
@@ -164,7 +161,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion =
@@ -183,12 +180,12 @@ in
         CODER_ACCESS_URL = cfg.accessUrl;
         CODER_WILDCARD_ACCESS_URL = cfg.wildcardAccessUrl;
         CODER_PG_CONNECTION_URL = "user=${cfg.database.username} ${
-          optionalString (cfg.database.password != null) "password=${cfg.database.password}"
+          lib.optionalString (cfg.database.password != null) "password=${cfg.database.password}"
         } database=${cfg.database.database} host=${cfg.database.host} ${
-          optionalString (cfg.database.sslmode != null) "sslmode=${cfg.database.sslmode}"
+          lib.optionalString (cfg.database.sslmode != null) "sslmode=${cfg.database.sslmode}"
         }";
         CODER_ADDRESS = cfg.listenAddress;
-        CODER_TLS_ENABLE = optionalString (cfg.tlsCert != null) "1";
+        CODER_TLS_ENABLE = lib.optionalString (cfg.tlsCert != null) "1";
         CODER_TLS_CERT_FILE = cfg.tlsCert;
         CODER_TLS_KEY_FILE = cfg.tlsKey;
       };
@@ -225,10 +222,10 @@ in
       ];
     };
 
-    users.groups = optionalAttrs (cfg.group == name) {
+    users.groups = lib.optionalAttrs (cfg.group == name) {
       "${cfg.group}" = { };
     };
-    users.users = optionalAttrs (cfg.user == name) {
+    users.users = lib.optionalAttrs (cfg.user == name) {
       ${name} = {
         description = "Coder service user";
         group = cfg.group;

--- a/nixos/modules/services/web-apps/convos.nix
+++ b/nixos/modules/services/web-apps/convos.nix
@@ -4,29 +4,26 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.convos;
 in
 {
   options.services.convos = {
-    enable = mkEnableOption "Convos";
-    listenPort = mkOption {
-      type = types.port;
+    enable = lib.mkEnableOption "Convos";
+    listenPort = lib.mkOption {
+      type = lib.types.port;
       default = 3000;
       example = 8080;
       description = "Port the web interface should listen on";
     };
-    listenAddress = mkOption {
-      type = types.str;
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
       default = "*";
       example = "127.0.0.1";
       description = "Address or host the web interface should listen on";
     };
-    reverseProxy = mkOption {
-      type = types.bool;
+    reverseProxy = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Enables reverse proxy support. This will allow Convos to automatically
@@ -37,7 +34,7 @@ in
       '';
     };
   };
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.convos = {
       description = "Convos Service";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/dex.nix
+++ b/nixos/modules/services/web-apps/dex.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.dex;
   fixClient =
@@ -20,18 +17,18 @@ let
       )
     else
       client;
-  filteredSettings = mapAttrs (
+  filteredSettings = lib.mapAttrs (
     n: v: if n == "staticClients" then (builtins.map fixClient v) else v
   ) cfg.settings;
-  secretFiles = flatten (
-    builtins.map (c: optional (c ? secretFile) c.secretFile) (cfg.settings.staticClients or [ ])
+  secretFiles = lib.flatten (
+    builtins.map (c: lib.optional (c ? secretFile) c.secretFile) (cfg.settings.staticClients or [ ])
   );
 
   settingsFormat = pkgs.formats.yaml { };
   configFile = settingsFormat.generate "config.yaml" filteredSettings;
 
   startPreScript = pkgs.writeShellScript "dex-start-pre" (
-    concatStringsSep "\n" (
+    lib.concatStringsSep "\n" (
       map (file: ''
         replace-secret '${file}' '${file}' /run/dex/config.yaml
       '') secretFiles
@@ -40,15 +37,15 @@ let
 
   restartTriggers =
     [ ]
-    ++ (optionals (cfg.environmentFile != null) [ cfg.environmentFile ])
-    ++ (filter (file: builtins.typeOf file == "path") secretFiles);
+    ++ (lib.optionals (cfg.environmentFile != null) [ cfg.environmentFile ])
+    ++ (lib.filter (file: builtins.typeOf file == "path") secretFiles);
 in
 {
   options.services.dex = {
-    enable = mkEnableOption "the OpenID Connect and OAuth2 identity provider";
+    enable = lib.mkEnableOption "the OpenID Connect and OAuth2 identity provider";
 
-    environmentFile = mkOption {
-      type = types.nullOr types.path;
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       default = null;
       description = ''
         Environment file (see `systemd.exec(5)`
@@ -57,10 +54,10 @@ in
       '';
     };
 
-    settings = mkOption {
+    settings = lib.mkOption {
       type = settingsFormat.type;
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           # External url
           issuer = "http://127.0.0.1:5556/dex";
@@ -92,13 +89,13 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.dex = {
       description = "dex identity provider";
       wantedBy = [ "multi-user.target" ];
       after = [
         "networking.target"
-      ] ++ (optional (cfg.settings.storage.type == "postgres") "postgresql.service");
+      ] ++ (lib.optional (cfg.settings.storage.type == "postgres") "postgresql.service");
       path = with pkgs; [ replace-secret ];
       restartTriggers = restartTriggers;
       serviceConfig =
@@ -119,7 +116,7 @@ in
             "-/etc/resolv.conf"
             "-/etc/ssl/certs/ca-certificates.crt"
           ];
-          BindPaths = optional (cfg.settings.storage.type == "postgres") "/var/run/postgresql";
+          BindPaths = lib.optional (cfg.settings.storage.type == "postgres") "/var/run/postgresql";
           # ProtectClock= adds DeviceAllow=char-rtc r
           DeviceAllow = "";
           DynamicUser = true;
@@ -157,7 +154,7 @@ in
           ];
           UMask = "0066";
         }
-        // optionalAttrs (cfg.environmentFile != null) {
+        // lib.optionalAttrs (cfg.environmentFile != null) {
           EnvironmentFile = cfg.environmentFile;
         };
     };

--- a/nixos/modules/services/web-apps/documize.nix
+++ b/nixos/modules/services/web-apps/documize.nix
@@ -4,30 +4,27 @@
   config,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.documize;
 
   mkParams =
     optional:
-    concatMapStrings (
+    lib.concatMapStrings (
       name:
       let
         predicate = optional -> cfg.${name} != null;
         template = " -${name} '${toString cfg.${name}}'";
       in
-      optionalString predicate template
+      lib.optionalString predicate template
     );
 
 in
 {
   options.services.documize = {
-    enable = mkEnableOption "Documize Wiki";
+    enable = lib.mkEnableOption "Documize Wiki";
 
-    stateDirectoryName = mkOption {
-      type = types.str;
+    stateDirectoryName = lib.mkOption {
+      type = lib.types.str;
       default = "documize";
       description = ''
         The name of the directory below {file}`/var/lib/private`
@@ -35,10 +32,10 @@ in
       '';
     };
 
-    package = mkPackageOption pkgs "documize-community" { };
+    package = lib.mkPackageOption pkgs "documize-community" { };
 
-    salt = mkOption {
-      type = types.nullOr types.str;
+    salt = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       example = "3edIYV6c8B28b19fh";
       description = ''
@@ -46,40 +43,40 @@ in
       '';
     };
 
-    cert = mkOption {
-      type = types.nullOr types.str;
+    cert = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       description = ''
         The {file}`cert.pem` file used for https.
       '';
     };
 
-    key = mkOption {
-      type = types.nullOr types.str;
+    key = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       description = ''
         The {file}`key.pem` file used for https.
       '';
     };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 5001;
       description = ''
         The http/https port number.
       '';
     };
 
-    forcesslport = mkOption {
-      type = types.nullOr types.port;
+    forcesslport = lib.mkOption {
+      type = lib.types.nullOr lib.types.port;
       default = null;
       description = ''
         Redirect given http port number to TLS.
       '';
     };
 
-    offline = mkOption {
-      type = types.bool;
+    offline = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Set `true` for offline mode.
@@ -87,8 +84,8 @@ in
       apply = v: if true == v then 1 else 0;
     };
 
-    dbtype = mkOption {
-      type = types.enum [
+    dbtype = lib.mkOption {
+      type = lib.types.enum [
         "mysql"
         "percona"
         "mariadb"
@@ -101,8 +98,8 @@ in
       '';
     };
 
-    db = mkOption {
-      type = types.str;
+    db = lib.mkOption {
+      type = lib.types.str;
       description = ''
         Database specific connection string for example:
         - MySQL/Percona/MariaDB:
@@ -117,8 +114,8 @@ in
       '';
     };
 
-    location = mkOption {
-      type = types.nullOr types.str;
+    location = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       description = ''
         reserved
@@ -126,14 +123,14 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.documize-server = {
       description = "Documize Wiki";
       documentation = [ "https://documize.com/" ];
       wantedBy = [ "multi-user.target" ];
 
       serviceConfig = {
-        ExecStart = concatStringsSep " " [
+        ExecStart = lib.concatStringsSep " " [
           "${cfg.package}/bin/documize"
           (mkParams false [
             "db"

--- a/nixos/modules/services/web-apps/dokuwiki.nix
+++ b/nixos/modules/services/web-apps/dokuwiki.nix
@@ -1,7 +1,4 @@
 { config, pkgs, lib, ... }:
-
-with lib;
-
 let
   inherit (lib.options) showOption showFiles;
 
@@ -10,8 +7,8 @@ let
   user = "dokuwiki";
   webserver = config.services.${cfg.webserver};
 
-  mkPhpIni = generators.toKeyValue {
-    mkKeyValue = generators.mkKeyValueDefault {} " = ";
+  mkPhpIni = lib.generators.toKeyValue {
+    mkKeyValue = lib.generators.mkKeyValueDefault {} " = ";
   };
   mkPhpPackage = cfg: cfg.phpPackage.buildEnv {
     extraConfig = mkPhpIni cfg.phpOptions;
@@ -19,18 +16,18 @@ let
 
   # "you're escaped" -> "'you\'re escaped'"
   # https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.single
-  toPhpString = s: "'${escape [ "'" "\\" ] s}'";
+  toPhpString = s: "'${lib.escape [ "'" "\\" ] s}'";
 
   dokuwikiAclAuthConfig = hostName: cfg: let
     inherit (cfg) acl;
-    acl_gen = concatMapStringsSep "\n" (l: "${l.page} \t ${l.actor} \t ${toString l.level}");
+    acl_gen = lib.concatMapStringsSep "\n" (l: "${l.page} \t ${l.actor} \t ${toString l.level}");
   in pkgs.writeText "acl.auth-${hostName}.php" ''
     # acl.auth.php
     # <?php exit()?>
     #
     # Access Control Lists
     #
-    ${if isString acl then acl else acl_gen acl}
+    ${if lib.isString acl then acl else acl_gen acl}
   '';
 
   mergeConfig = cfg: {
@@ -45,37 +42,37 @@ let
   };
 
   mkPhpValue = v: let
-    isHasAttr = s: isAttrs v && hasAttr s v;
+    isHasAttr = s: lib.isAttrs v && lib.hasAttr s v;
   in
-    if isString v then toPhpString v
+    if lib.isString v then toPhpString v
     # NOTE: If any value contains a , (comma) this will not get escaped
-    else if isList v && strings.isConvertibleWithToString v then toPhpString (concatMapStringsSep "," toString v)
-    else if isInt v then toString v
-    else if isBool v then toString (if v then 1 else 0)
+    else if lib.isList v && lib.strings.isConvertibleWithToString v then toPhpString (lib.concatMapStringsSep "," toString v)
+    else if lib.isInt v then toString v
+    else if lib.isBool v then toString (if v then 1 else 0)
     else if isHasAttr "_file" then "trim(file_get_contents(${toPhpString (toString v._file)}))"
     else if isHasAttr "_raw" then v._raw
     else abort "The dokuwiki localConf value ${lib.generators.toPretty {} v} can not be encoded."
   ;
 
-  mkPhpAttrVals = v: flatten (mapAttrsToList mkPhpKeyVal v);
+  mkPhpAttrVals = v: lib.flatten (lib.mapAttrsToList mkPhpKeyVal v);
   mkPhpKeyVal = k: v: let
-    values = if (isAttrs v && (hasAttr "_file" v || hasAttr "_raw" v )) || !isAttrs v then
+    values = if (lib.isAttrs v && (lib.hasAttr "_file" v || lib.hasAttr "_raw" v )) || !lib.isAttrs v then
       [" = ${mkPhpValue v};"]
     else
       mkPhpAttrVals v;
-  in map (e: "[${toPhpString k}]${e}") (flatten values);
+  in map (e: "[${toPhpString k}]${e}") (lib.flatten values);
 
   dokuwikiLocalConfig = hostName: cfg: let
     conf_gen = c: map (v: "$conf${v}") (mkPhpAttrVals c);
   in writePhpFile "local-${hostName}.php" ''
-    ${concatStringsSep "\n" (conf_gen cfg.mergedConfig)}
+    ${lib.concatStringsSep "\n" (conf_gen cfg.mergedConfig)}
   '';
 
   dokuwikiPluginsLocalConfig = hostName: cfg: let
     pc = cfg.pluginsConfig;
-    pc_gen = pc: concatStringsSep "\n" (mapAttrsToList (n: v: "$plugins['${n}'] = ${boolToString v};") pc);
+    pc_gen = pc: lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "$plugins['${n}'] = ${lib.boolToString v};") pc);
   in writePhpFile "plugins.local-${hostName}.php" ''
-    ${if isString pc then pc else pc_gen pc}
+    ${if lib.isString pc then pc else pc_gen pc}
   '';
 
 
@@ -93,14 +90,14 @@ let
   aclOpts = { ... }: {
     options = {
 
-      page = mkOption {
-        type = types.str;
+      page = lib.mkOption {
+        type = lib.types.str;
         description = "Page or namespace to restrict";
         example = "start";
       };
 
-      actor = mkOption {
-        type = types.str;
+      actor = lib.mkOption {
+        type = lib.types.str;
         description = "User or group to restrict";
         example = "@external";
       };
@@ -114,9 +111,9 @@ let
           "upload" = 8;
           "delete" = 16;
         };
-      in mkOption {
-        type = types.enum ((attrValues available) ++ (attrNames available));
-        apply = x: if isInt x then x else available.${x};
+      in lib.mkOption {
+        type = lib.types.enum ((lib.attrValues available) ++ (lib.attrNames available));
+        apply = x: if lib.isInt x then x else available.${x};
         description = ''
           Permission level to restrict the actor(s) to.
           See <https://www.dokuwiki.org/acl#background_info> for explanation
@@ -130,20 +127,20 @@ let
     {
 
       options = {
-        enable = mkEnableOption "DokuWiki web application";
+        enable = lib.mkEnableOption "DokuWiki web application";
 
-        package = mkPackageOption pkgs "dokuwiki" { };
+        package = lib.mkPackageOption pkgs "dokuwiki" { };
 
-        stateDir = mkOption {
-          type = types.path;
+        stateDir = lib.mkOption {
+          type = lib.types.path;
           default = "/var/lib/dokuwiki/${name}/data";
           description = "Location of the DokuWiki state directory.";
         };
 
-        acl = mkOption {
-          type = with types; nullOr (listOf (submodule aclOpts));
+        acl = lib.mkOption {
+          type = with lib.types; nullOr (listOf (submodule aclOpts));
           default = null;
-          example = literalExpression ''
+          example = lib.literalExpression ''
             [
               {
                 page = "start";
@@ -167,8 +164,8 @@ let
           '';
         };
 
-        aclFile = mkOption {
-          type = with types; nullOr str;
+        aclFile = lib.mkOption {
+          type = with lib.types; nullOr str;
           default = if (config.mergedConfig.useacl && config.acl == null) then "/var/lib/dokuwiki/${name}/acl.auth.php" else null;
           description = ''
             Location of the dokuwiki acl rules. Mutually exclusive with services.dokuwiki.acl
@@ -179,8 +176,8 @@ let
           example = "/var/lib/dokuwiki/${name}/acl.auth.php";
         };
 
-        pluginsConfig = mkOption {
-          type = with types; attrsOf bool;
+        pluginsConfig = lib.mkOption {
+          type = with lib.types; attrsOf bool;
           default = {
             authad = false;
             authldap = false;
@@ -192,8 +189,8 @@ let
           '';
         };
 
-        usersFile = mkOption {
-          type = with types; nullOr str;
+        usersFile = lib.mkOption {
+          type = with lib.types; nullOr str;
           default = if config.mergedConfig.useacl then "/var/lib/dokuwiki/${name}/users.auth.php" else null;
           description = ''
             Location of the dokuwiki users file. List of users. Format:
@@ -209,8 +206,8 @@ let
           example = "/var/lib/dokuwiki/${name}/users.auth.php";
         };
 
-        plugins = mkOption {
-          type = types.listOf types.path;
+        plugins = lib.mkOption {
+          type = lib.types.listOf lib.types.path;
           default = [];
           description = ''
                 List of path(s) to respective plugin(s) which are copied from the 'plugin' directory.
@@ -219,7 +216,7 @@ let
                 These plugins need to be packaged before use, see example.
                 :::
           '';
-          example = literalExpression ''
+          example = lib.literalExpression ''
                 let
                   plugin-icalevents = pkgs.stdenv.mkDerivation rec {
                     name = "icalevents";
@@ -236,8 +233,8 @@ let
           '';
         };
 
-        templates = mkOption {
-          type = types.listOf types.path;
+        templates = lib.mkOption {
+          type = lib.types.listOf lib.types.path;
           default = [];
           description = ''
                 List of path(s) to respective template(s) which are copied from the 'tpl' directory.
@@ -246,7 +243,7 @@ let
                 These templates need to be packaged before use, see example.
                 :::
           '';
-          example = literalExpression ''
+          example = lib.literalExpression ''
                 let
                   template-bootstrap3 = pkgs.stdenv.mkDerivation rec {
                   name = "bootstrap3";
@@ -264,8 +261,8 @@ let
           '';
         };
 
-        poolConfig = mkOption {
-          type = with types; attrsOf (oneOf [ str int bool ]);
+        poolConfig = lib.mkOption {
+          type = with lib.types; attrsOf (oneOf [ str int bool ]);
           default = {
             "pm" = "dynamic";
             "pm.max_children" = 32;
@@ -280,18 +277,18 @@ let
           '';
         };
 
-        phpPackage = mkPackageOption pkgs "php" {
+        phpPackage = lib.mkPackageOption pkgs "php" {
           default = "php81";
           example = "php82";
         };
 
-        phpOptions = mkOption {
-          type = types.attrsOf types.str;
+        phpOptions = lib.mkOption {
+          type = lib.types.attrsOf lib.types.str;
           default = {};
           description = ''
             Options for PHP's php.ini file for this dokuwiki site.
           '';
-          example = literalExpression ''
+          example = lib.literalExpression ''
           {
             "opcache.interned_strings_buffer" = "8";
             "opcache.max_accelerated_files" = "10000";
@@ -302,8 +299,8 @@ let
           '';
         };
 
-        settings = mkOption {
-          type = types.attrsOf types.anything;
+        settings = lib.mkOption {
+          type = lib.types.attrsOf lib.types.anything;
           default = {
             useacl = true;
             superuser = "admin";
@@ -316,7 +313,7 @@ let
             loaded from a file using `._file` or obtained from any
             PHP function calls using `._raw`.
           '';
-          example = literalExpression ''
+          example = lib.literalExpression ''
             {
               title = "My Wiki";
               userewrite = 1;
@@ -329,10 +326,10 @@ let
           '';
         };
 
-        mergedConfig = mkOption {
+        mergedConfig = lib.mkOption {
           readOnly = true;
           default = mergeConfig config;
-          defaultText = literalExpression ''
+          defaultText = lib.literalExpression ''
             {
               useacl = true;
             }
@@ -349,14 +346,14 @@ in
   options = {
     services.dokuwiki = {
 
-      sites = mkOption {
-        type = types.attrsOf (types.submodule siteOpts);
+      sites = lib.mkOption {
+        type = lib.types.attrsOf (lib.types.submodule siteOpts);
         default = {};
         description = "Specification of one or more DokuWiki sites to serve";
       };
 
-      webserver = mkOption {
-        type = types.enum [ "nginx" "caddy" ];
+      webserver = lib.mkOption {
+        type = lib.types.enum [ "nginx" "caddy" ];
         default = "nginx";
         description = ''
           Whether to use nginx or caddy for virtual host management.
@@ -373,17 +370,17 @@ in
   };
 
   # implementation
-  config = mkIf (eachSite != {}) (mkMerge [{
+  config = lib.mkIf (eachSite != {}) (lib.mkMerge [{
 
-    services.phpfpm.pools = mapAttrs' (hostName: cfg: (
-      nameValuePair "dokuwiki-${hostName}" {
+    services.phpfpm.pools = lib.mapAttrs' (hostName: cfg: (
+      lib.nameValuePair "dokuwiki-${hostName}" {
         inherit user;
         group = webserver.group;
 
         phpPackage = mkPhpPackage cfg;
-        phpEnv = optionalAttrs (cfg.usersFile != null) {
+        phpEnv = lib.optionalAttrs (cfg.usersFile != null) {
           DOKUWIKI_USERS_AUTH_CONFIG = "${cfg.usersFile}";
-        } // optionalAttrs (cfg.mergedConfig.useacl) {
+        } // lib.optionalAttrs (cfg.mergedConfig.useacl) {
           DOKUWIKI_ACL_AUTH_CONFIG = if (cfg.acl != null) then "${dokuwikiAclAuthConfig hostName cfg}" else "${toString cfg.aclFile}";
         };
 
@@ -397,7 +394,7 @@ in
   }
 
   {
-    systemd.tmpfiles.rules = flatten (mapAttrsToList (hostName: cfg: [
+    systemd.tmpfiles.rules = lib.flatten (lib.mapAttrsToList (hostName: cfg: [
       "d ${cfg.stateDir}/attic 0750 ${user} ${webserver.group} - -"
       "d ${cfg.stateDir}/cache 0750 ${user} ${webserver.group} - -"
       "d ${cfg.stateDir}/index 0750 ${user} ${webserver.group} - -"
@@ -419,11 +416,11 @@ in
     };
   }
 
-  (mkIf (cfg.webserver == "nginx") {
+  (lib.mkIf (cfg.webserver == "nginx") {
     services.nginx = {
       enable = true;
-      virtualHosts = mapAttrs (hostName: cfg: {
-        serverName = mkDefault hostName;
+      virtualHosts = lib.mapAttrs (hostName: cfg: {
+        serverName = lib.mkDefault hostName;
         root = "${pkg hostName cfg}/share/dokuwiki";
 
         locations = {
@@ -471,11 +468,11 @@ in
     };
   })
 
-  (mkIf (cfg.webserver == "caddy") {
+  (lib.mkIf (cfg.webserver == "caddy") {
     services.caddy = {
       enable = true;
-      virtualHosts = mapAttrs' (hostName: cfg: (
-        nameValuePair hostName {
+      virtualHosts = lib.mapAttrs' (hostName: cfg: (
+        lib.nameValuePair hostName {
           extraConfig = ''
             root * ${pkg hostName cfg}/share/dokuwiki
             file_server
@@ -514,7 +511,7 @@ in
 
   ]);
 
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     _1000101
     onny
     dandellion

--- a/nixos/modules/services/web-apps/eintopf.nix
+++ b/nixos/modules/services/web-apps/eintopf.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.eintopf;
@@ -15,17 +12,17 @@ in
 {
   options.services.eintopf = {
 
-    enable = mkEnableOption "Eintopf community event calendar web app";
+    enable = lib.mkEnableOption "Eintopf community event calendar web app";
 
-    settings = mkOption {
-      type = types.attrsOf types.str;
+    settings = lib.mkOption {
+      type = lib.types.attrsOf lib.types.str;
       default = { };
       description = ''
         Settings to configure web service. See
         <https://codeberg.org/Klasse-Methode/eintopf/src/branch/main/DEPLOYMENT.md>
         for available options.
       '';
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           EINTOPF_ADDR = ":1234";
           EINTOPF_ADMIN_EMAIL = "admin@example.org";
@@ -35,7 +32,7 @@ in
     };
 
     secrets = lib.mkOption {
-      type = with types; listOf path;
+      type = with lib.types; listOf path;
       description = ''
         A list of files containing the various secrets. Should be in the
         format expected by systemd's `EnvironmentFile` directory.
@@ -45,7 +42,7 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     systemd.services.eintopf = {
       description = "Community event calendar web app";

--- a/nixos/modules/services/web-apps/ethercalc.nix
+++ b/nixos/modules/services/web-apps/ethercalc.nix
@@ -4,18 +4,15 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.ethercalc;
 in
 {
   options = {
     services.ethercalc = {
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           ethercalc, an online collaborative spreadsheet server.
 
@@ -30,23 +27,23 @@ in
         '';
       };
 
-      package = mkPackageOption pkgs "ethercalc" { };
+      package = lib.mkPackageOption pkgs "ethercalc" { };
 
-      host = mkOption {
-        type = types.str;
+      host = lib.mkOption {
+        type = lib.types.str;
         default = "0.0.0.0";
         description = "Address to listen on (use 0.0.0.0 to allow access from any address).";
       };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 8000;
         description = "Port to bind to.";
       };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.services.ethercalc = {
       description = "Ethercalc service";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/web-apps/flarum.nix
+++ b/nixos/modules/services/web-apps/flarum.nix
@@ -4,9 +4,6 @@
   config,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.flarum;
 
@@ -30,69 +27,69 @@ let
 in
 {
   options.services.flarum = {
-    enable = mkEnableOption "Flarum discussion platform";
+    enable = lib.mkEnableOption "Flarum discussion platform";
 
-    package = mkPackageOption pkgs "flarum" { };
+    package = lib.mkPackageOption pkgs "flarum" { };
 
-    forumTitle = mkOption {
-      type = types.str;
+    forumTitle = lib.mkOption {
+      type = lib.types.str;
       default = "A Flarum Forum on NixOS";
       description = "Title of the forum.";
     };
 
-    domain = mkOption {
-      type = types.str;
+    domain = lib.mkOption {
+      type = lib.types.str;
       default = "localhost";
       example = "forum.example.com";
       description = "Domain to serve on.";
     };
 
-    baseUrl = mkOption {
-      type = types.str;
+    baseUrl = lib.mkOption {
+      type = lib.types.str;
       default = "http://localhost";
       example = "https://forum.example.com";
       description = "Change `domain` instead.";
     };
 
-    adminUser = mkOption {
-      type = types.str;
+    adminUser = lib.mkOption {
+      type = lib.types.str;
       default = "flarum";
       description = "Username for first web application administrator";
     };
 
-    adminEmail = mkOption {
-      type = types.str;
+    adminEmail = lib.mkOption {
+      type = lib.types.str;
       default = "admin@example.com";
       description = "Email for first web application administrator";
     };
 
-    initialAdminPassword = mkOption {
-      type = types.str;
+    initialAdminPassword = lib.mkOption {
+      type = lib.types.str;
       default = "flarum";
       description = "Initial password for the adminUser";
     };
 
-    user = mkOption {
-      type = types.str;
+    user = lib.mkOption {
+      type = lib.types.str;
       default = "flarum";
       description = "System user to run Flarum";
     };
 
-    group = mkOption {
-      type = types.str;
+    group = lib.mkOption {
+      type = lib.types.str;
       default = "flarum";
       description = "System group to run Flarum";
     };
 
-    stateDir = mkOption {
-      type = types.path;
+    stateDir = lib.mkOption {
+      type = lib.types.path;
       default = "/var/lib/flarum";
       description = "Home directory for writable storage";
     };
 
-    database = mkOption rec {
+    database = lib.mkOption rec {
       type =
-        with types;
+        with lib.types;
         attrsOf (oneOf [
           str
           bool
@@ -118,8 +115,8 @@ in
       };
     };
 
-    createDatabaseLocally = mkOption {
-      type = types.bool;
+    createDatabaseLocally = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Create the database and database user locally, and run installation.
@@ -131,7 +128,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     users.users.${cfg.user} = {
       isSystemUser = true;
       home = cfg.stateDir;
@@ -147,12 +144,12 @@ in
         "listen.owner" = config.services.nginx.user;
         "listen.group" = config.services.nginx.group;
         "listen.mode" = "0600";
-        "pm" = mkDefault "dynamic";
-        "pm.max_children" = mkDefault 10;
-        "pm.max_requests" = mkDefault 500;
-        "pm.start_servers" = mkDefault 2;
-        "pm.min_spare_servers" = mkDefault 1;
-        "pm.max_spare_servers" = mkDefault 3;
+        "pm" = lib.mkDefault "dynamic";
+        "pm.max_children" = lib.mkDefault 10;
+        "pm.max_requests" = lib.mkDefault 500;
+        "pm.start_servers" = lib.mkDefault 2;
+        "pm.min_spare_servers" = lib.mkDefault 1;
+        "pm.max_spare_servers" = lib.mkDefault 3;
       };
       phpOptions = ''
         error_log = syslog
@@ -175,7 +172,7 @@ in
       };
     };
 
-    services.mysql = mkIf cfg.enable {
+    services.mysql = lib.mkIf cfg.enable {
       enable = true;
       package = pkgs.mariadb;
       ensureDatabases = [ cfg.database.database ];
@@ -217,7 +214,7 @@ in
           ln -sf ${cfg.package}/share/php/flarum/vendor .
           ln -sf ${cfg.package}/share/php/flarum/public/index.php public/
         ''
-        + optionalString (cfg.createDatabaseLocally && cfg.database.driver == "mysql") ''
+        + lib.optionalString (cfg.createDatabaseLocally && cfg.database.driver == "mysql") ''
           if [ ! -f config.php ]; then
             php flarum install --file=${flarumInstallConfig}
           fi

--- a/nixos/modules/services/web-apps/fluidd.nix
+++ b/nixos/modules/services/web-apps/fluidd.nix
@@ -1,26 +1,25 @@
 { config, lib, pkgs, ... }:
-with lib;
 let
   cfg = config.services.fluidd;
   moonraker = config.services.moonraker;
 in
 {
   options.services.fluidd = {
-    enable = mkEnableOption "Fluidd, a Klipper web interface for managing your 3d printer";
+    enable = lib.mkEnableOption "Fluidd, a Klipper web interface for managing your 3d printer";
 
-    package = mkPackageOption pkgs "fluidd" { };
+    package = lib.mkPackageOption pkgs "fluidd" { };
 
-    hostName = mkOption {
-      type = types.str;
+    hostName = lib.mkOption {
+      type = lib.types.str;
       default = "localhost";
       description = "Hostname to serve fluidd on";
     };
 
-    nginx = mkOption {
-      type = types.submodule
+    nginx = lib.mkOption {
+      type = lib.types.submodule
         (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           serverAliases = [ "fluidd.''${config.networking.domain}" ];
         }
@@ -29,14 +28,14 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.nginx = {
       enable = true;
       upstreams.fluidd-apiserver.servers."${moonraker.address}:${toString moonraker.port}" = { };
-      virtualHosts."${cfg.hostName}" = mkMerge [
+      virtualHosts."${cfg.hostName}" = lib.mkMerge [
         cfg.nginx
         {
-          root = mkForce "${cfg.package}/share/fluidd/htdocs";
+          root = lib.mkForce "${cfg.package}/share/fluidd/htdocs";
           locations = {
             "/" = {
               index = "index.html";

--- a/nixos/modules/services/web-apps/freshrss.nix
+++ b/nixos/modules/services/web-apps/freshrss.nix
@@ -1,6 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
 let
   cfg = config.services.freshrss;
 
@@ -14,18 +12,18 @@ let
   };
 in
 {
-  meta.maintainers = with maintainers; [ etu stunkymonkey mattchrist ];
+  meta.maintainers = with lib.maintainers; [ etu stunkymonkey mattchrist ];
 
   options.services.freshrss = {
-    enable = mkEnableOption "FreshRSS RSS aggregator and reader with php-fpm backend";
+    enable = lib.mkEnableOption "FreshRSS RSS aggregator and reader with php-fpm backend";
 
-    package = mkPackageOption pkgs "freshrss" { };
+    package = lib.mkPackageOption pkgs "freshrss" { };
 
-    extensions = mkOption {
-      type = types.listOf types.package;
+    extensions = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
       default = [ ];
-      defaultText = literalExpression "[]";
-      example = literalExpression ''
+      defaultText = lib.literalExpression "[]";
+      example = lib.literalExpression ''
         with freshrss-extensions; [
           youtube
         ] ++ [
@@ -46,90 +44,90 @@ in
       description = "Additional extensions to be used.";
     };
 
-    defaultUser = mkOption {
-      type = types.str;
+    defaultUser = lib.mkOption {
+      type = lib.types.str;
       default = "admin";
       description = "Default username for FreshRSS.";
       example = "eva";
     };
 
-    passwordFile = mkOption {
-      type = types.nullOr types.path;
+    passwordFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
       default = null;
       description = "Password for the defaultUser for FreshRSS.";
       example = "/run/secrets/freshrss";
     };
 
-    baseUrl = mkOption {
-      type = types.str;
+    baseUrl = lib.mkOption {
+      type = lib.types.str;
       description = "Default URL for FreshRSS.";
       example = "https://freshrss.example.com";
     };
 
-    language = mkOption {
-      type = types.str;
+    language = lib.mkOption {
+      type = lib.types.str;
       default = "en";
       description = "Default language for FreshRSS.";
       example = "de";
     };
 
     database = {
-      type = mkOption {
-        type = types.enum [ "sqlite" "pgsql" "mysql" ];
+      type = lib.mkOption {
+        type = lib.types.enum [ "sqlite" "pgsql" "mysql" ];
         default = "sqlite";
         description = "Database type.";
         example = "pgsql";
       };
 
-      host = mkOption {
-        type = types.nullOr types.str;
+      host = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = "localhost";
         description = "Database host for FreshRSS.";
       };
 
-      port = mkOption {
-        type = types.nullOr types.port;
+      port = lib.mkOption {
+        type = lib.types.nullOr lib.types.port;
         default = null;
         description = "Database port for FreshRSS.";
         example = 3306;
       };
 
-      user = mkOption {
-        type = types.nullOr types.str;
+      user = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = "freshrss";
         description = "Database user for FreshRSS.";
       };
 
-      passFile = mkOption {
-        type = types.nullOr types.path;
+      passFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
         default = null;
         description = "Database password file for FreshRSS.";
         example = "/run/secrets/freshrss";
       };
 
-      name = mkOption {
-        type = types.nullOr types.str;
+      name = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = "freshrss";
         description = "Database name for FreshRSS.";
       };
 
-      tableprefix = mkOption {
-        type = types.nullOr types.str;
+      tableprefix = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         description = "Database table prefix for FreshRSS.";
         example = "freshrss";
       };
     };
 
-    dataDir = mkOption {
-      type = types.str;
+    dataDir = lib.mkOption {
+      type = lib.types.str;
       default = "/var/lib/freshrss";
       description = "Default data folder for FreshRSS.";
       example = "/mnt/freshrss";
     };
 
-    virtualHost = mkOption {
-      type = types.nullOr types.str;
+    virtualHost = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = "freshrss";
       description = ''
         Name of the nginx virtualhost to use and setup. If null, do not setup any virtualhost.
@@ -138,8 +136,8 @@ in
       '';
     };
 
-    pool = mkOption {
-      type = types.nullOr types.str;
+    pool = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = "freshrss";
       description = ''
         Name of the php-fpm pool to use and setup. If not specified, a pool will be created
@@ -147,14 +145,14 @@ in
       '';
     };
 
-    user = mkOption {
-      type = types.str;
+    user = lib.mkOption {
+      type = lib.types.str;
       default = "freshrss";
       description = "User under which FreshRSS runs.";
     };
 
-    authType = mkOption {
-      type = types.enum [ "form" "http_auth" "none" ];
+    authType = lib.mkOption {
+      type = lib.types.enum [ "form" "http_auth" "none" ];
       default = "form";
       description = "Authentication type for FreshRSS.";
     };
@@ -194,8 +192,8 @@ in
         WorkingDirectory = cfg.package;
       };
     in
-    mkIf cfg.enable {
-      assertions = mkIf (cfg.authType == "form") [
+    lib.mkIf cfg.enable {
+      assertions = lib.mkIf (cfg.authType == "form") [
         {
           assertion = cfg.passwordFile != null;
           message = ''
@@ -204,7 +202,7 @@ in
         }
       ];
       # Set up a Nginx virtual host.
-      services.nginx = mkIf (cfg.virtualHost != null) {
+      services.nginx = lib.mkIf (cfg.virtualHost != null) {
         enable = true;
         virtualHosts.${cfg.virtualHost} = {
           root = "${cfg.package}/p";
@@ -232,7 +230,7 @@ in
       };
 
       # Set up phpfpm pool
-      services.phpfpm.pools = mkIf (cfg.pool != null) {
+      services.phpfpm.pools = lib.mkIf (cfg.pool != null) {
         ${cfg.pool} = {
           user = "freshrss";
           settings = {
@@ -266,8 +264,8 @@ in
 
       systemd.services.freshrss-config =
         let
-          settingsFlags = concatStringsSep " \\\n    "
-            (mapAttrsToList (k: v: "${k} ${toString v}") {
+          settingsFlags = lib.concatStringsSep " \\\n    "
+            (lib.mapAttrsToList (k: v: "${k} ${toString v}") {
               "--default-user" = ''"${cfg.defaultUser}"'';
               "--auth-type" = ''"${cfg.authType}"'';
               "--base-url" = ''"${cfg.baseUrl}"'';
@@ -297,11 +295,11 @@ in
 
           script =
             let
-              userScriptArgs = ''--user ${cfg.defaultUser} ${optionalString (cfg.authType == "form") ''--password "$(cat ${cfg.passwordFile})"''}'';
-              updateUserScript = optionalString (cfg.authType == "form" || cfg.authType == "none") ''
+              userScriptArgs = ''--user ${cfg.defaultUser} ${lib.optionalString (cfg.authType == "form") ''--password "$(cat ${cfg.passwordFile})"''}'';
+              updateUserScript = lib.optionalString (cfg.authType == "form" || cfg.authType == "none") ''
                 ./cli/update-user.php ${userScriptArgs}
               '';
-              createUserScript = optionalString (cfg.authType == "form" || cfg.authType == "none") ''
+              createUserScript = lib.optionalString (cfg.authType == "form" || cfg.authType == "none") ''
                 ./cli/create-user.php ${userScriptArgs}
               '';
             in

--- a/nixos/modules/services/web-apps/galene.nix
+++ b/nixos/modules/services/web-apps/galene.nix
@@ -1,6 +1,4 @@
 { config, lib, options, pkgs, ... }:
-
-with lib;
 let
   cfg = config.services.galene;
   opt = options.services.galene;
@@ -12,11 +10,11 @@ in
 {
   options = {
     services.galene = {
-      enable = mkEnableOption "Galene Service";
+      enable = lib.mkEnableOption "Galene Service";
 
-      stateDir = mkOption {
+      stateDir = lib.mkOption {
         default = defaultstateDir;
-        type = types.str;
+        type = lib.types.str;
         description = ''
           The directory where Galene stores its internal state. If left as the default
           value this directory will automatically be created before the Galene server
@@ -25,20 +23,20 @@ in
         '';
       };
 
-      user = mkOption {
-        type = types.str;
+      user = lib.mkOption {
+        type = lib.types.str;
         default = "galene";
         description = "User account under which galene runs.";
       };
 
-      group = mkOption {
-        type = types.str;
+      group = lib.mkOption {
+        type = lib.types.str;
         default = "galene";
         description = "Group under which galene runs.";
       };
 
-      insecure = mkOption {
-        type = types.bool;
+      insecure = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = ''
           Whether Galene should listen in http or in https. If left as the default
@@ -46,8 +44,8 @@ in
         '';
       };
 
-      certFile = mkOption {
-        type = types.nullOr types.str;
+      certFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/path/to/your/cert.pem";
         description = ''
@@ -56,8 +54,8 @@ in
         '';
       };
 
-      keyFile = mkOption {
-        type = types.nullOr types.str;
+      keyFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
         default = null;
         example = "/path/to/your/key.pem";
         description = ''
@@ -66,62 +64,62 @@ in
         '';
       };
 
-      httpAddress = mkOption {
-        type = types.str;
+      httpAddress = lib.mkOption {
+        type = lib.types.str;
         default = "";
         description = "HTTP listen address for galene.";
       };
 
-      httpPort = mkOption {
-        type = types.port;
+      httpPort = lib.mkOption {
+        type = lib.types.port;
         default = 8443;
         description = "HTTP listen port.";
       };
 
-      turnAddress = mkOption {
-        type = types.str;
+      turnAddress = lib.mkOption {
+        type = lib.types.str;
         default = "auto";
         example = "127.0.0.1:1194";
         description = "Built-in TURN server listen address and port. Set to \"\" to disable.";
       };
 
-      staticDir = mkOption {
-        type = types.str;
+      staticDir = lib.mkOption {
+        type = lib.types.str;
         default = "${cfg.package.static}/static";
-        defaultText = literalExpression ''"''${package.static}/static"'';
+        defaultText = lib.literalExpression ''"''${package.static}/static"'';
         example = "/var/lib/galene/static";
         description = "Web server directory.";
       };
 
-      recordingsDir = mkOption {
-        type = types.str;
+      recordingsDir = lib.mkOption {
+        type = lib.types.str;
         default = defaultrecordingsDir;
-        defaultText = literalExpression ''"''${config.${opt.stateDir}}/recordings"'';
+        defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/recordings"'';
         example = "/var/lib/galene/recordings";
         description = "Recordings directory.";
       };
 
-      dataDir = mkOption {
-        type = types.str;
+      dataDir = lib.mkOption {
+        type = lib.types.str;
         default = defaultdataDir;
-        defaultText = literalExpression ''"''${config.${opt.stateDir}}/data"'';
+        defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/data"'';
         example = "/var/lib/galene/data";
         description = "Data directory.";
       };
 
-      groupsDir = mkOption {
-        type = types.str;
+      groupsDir = lib.mkOption {
+        type = lib.types.str;
         default = defaultgroupsDir;
-        defaultText = literalExpression ''"''${config.${opt.stateDir}}/groups"'';
+        defaultText = lib.literalExpression ''"''${config.${opt.stateDir}}/groups"'';
         example = "/var/lib/galene/groups";
         description = "Web server directory.";
       };
 
-      package = mkPackageOption pkgs "galene" { };
+      package = lib.mkPackageOption pkgs "galene" { };
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     assertions = [
       {
         assertion = cfg.insecure || (cfg.certFile != null && cfg.keyFile != null);
@@ -138,20 +136,20 @@ in
       wantedBy = [ "multi-user.target" ];
 
       preStart = ''
-        ${optionalString (cfg.insecure != true) ''
+        ${lib.optionalString (cfg.insecure != true) ''
            install -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.certFile} ${cfg.dataDir}/cert.pem
            install -m 700 -o '${cfg.user}' -g '${cfg.group}' ${cfg.keyFile} ${cfg.dataDir}/key.pem
         ''}
       '';
 
-      serviceConfig = mkMerge [
+      serviceConfig = lib.mkMerge [
         {
           Type = "simple";
           User = cfg.user;
           Group = cfg.group;
           WorkingDirectory = cfg.stateDir;
           ExecStart = ''${cfg.package}/bin/galene \
-          ${optionalString (cfg.insecure) "-insecure"} \
+          ${lib.optionalString (cfg.insecure) "-insecure"} \
           -http ${cfg.httpAddress}:${cfg.httpPort} \
           -turn ${cfg.turnAddress} \
           -data ${cfg.dataDir} \
@@ -162,10 +160,10 @@ in
           # Upstream Requirements
           LimitNOFILE = 65536;
           StateDirectory = [ ] ++
-            optional (cfg.stateDir == defaultstateDir) "galene" ++
-            optional (cfg.dataDir == defaultdataDir) "galene/data" ++
-            optional (cfg.groupsDir == defaultgroupsDir) "galene/groups" ++
-            optional (cfg.recordingsDir == defaultrecordingsDir) "galene/recordings";
+            lib.optional (cfg.stateDir == defaultstateDir) "galene" ++
+            lib.optional (cfg.dataDir == defaultdataDir) "galene/data" ++
+            lib.optional (cfg.groupsDir == defaultgroupsDir) "galene/groups" ++
+            lib.optional (cfg.recordingsDir == defaultrecordingsDir) "galene/recordings";
 
           # Hardening
           CapabilityBoundingSet = [ "" ];
@@ -199,7 +197,7 @@ in
       ];
     };
 
-    users.users = mkIf (cfg.user == "galene")
+    users.users = lib.mkIf (cfg.user == "galene")
       {
         galene = {
           description = "galene Service";
@@ -208,7 +206,7 @@ in
         };
       };
 
-    users.groups = mkIf (cfg.group == "galene") {
+    users.groups = lib.mkIf (cfg.group == "galene") {
       galene = { };
     };
   };

--- a/nixos/modules/services/web-apps/gerrit.nix
+++ b/nixos/modules/services/web-apps/gerrit.nix
@@ -1,11 +1,9 @@
 { config, lib, pkgs, ... }:
-
-with lib;
 let
   cfg = config.services.gerrit;
 
   # NixOS option type for git-like configs
-  gitIniType = with types;
+  gitIniType = with lib.types;
     let
       primitiveType = either str (either bool int);
       multipleType = either primitiveType (listOf primitiveType);
@@ -59,14 +57,14 @@ in
 {
   options = {
     services.gerrit = {
-      enable = mkEnableOption "Gerrit service";
+      enable = lib.mkEnableOption "Gerrit service";
 
-      package = mkPackageOption pkgs "gerrit" { };
+      package = lib.mkPackageOption pkgs "gerrit" { };
 
-      jvmPackage = mkPackageOption pkgs "jre_headless" { };
+      jvmPackage = lib.mkPackageOption pkgs "jre_headless" { };
 
-      jvmOpts = mkOption {
-        type = types.listOf types.str;
+      jvmOpts = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [
           "-Dflogger.backend_factory=com.google.common.flogger.backend.log4j.Log4jBackendFactory#getInstance"
           "-Dflogger.logging_context=com.google.gerrit.server.logging.LoggingContext#getInstance"
@@ -74,16 +72,16 @@ in
         description = "A list of JVM options to start gerrit with.";
       };
 
-      jvmHeapLimit = mkOption {
-        type = types.str;
+      jvmHeapLimit = lib.mkOption {
+        type = lib.types.str;
         default = "1024m";
         description = ''
           How much memory to allocate to the JVM heap
         '';
       };
 
-      listenAddress = mkOption {
-        type = types.str;
+      listenAddress = lib.mkOption {
+        type = lib.types.str;
         default = "[::]:8080";
         description = ''
           `hostname:port` to listen for HTTP traffic.
@@ -92,7 +90,7 @@ in
         '';
       };
 
-      settings = mkOption {
+      settings = lib.mkOption {
         type = gitIniType;
         default = {};
         description = ''
@@ -101,7 +99,7 @@ in
         '';
       };
 
-      replicationSettings = mkOption {
+      replicationSettings = lib.mkOption {
         type = gitIniType;
         default = {};
         description = ''
@@ -110,8 +108,8 @@ in
         '';
       };
 
-      plugins = mkOption {
-        type = types.listOf types.package;
+      plugins = lib.mkOption {
+        type = lib.types.listOf lib.types.package;
         default = [];
         description = ''
           List of plugins to add to Gerrit. Each derivation is a jar file
@@ -119,8 +117,8 @@ in
         '';
       };
 
-      builtinPlugins = mkOption {
-        type = types.listOf (types.enum cfg.package.passthru.plugins);
+      builtinPlugins = lib.mkOption {
+        type = lib.types.listOf (lib.types.enum cfg.package.passthru.plugins);
         default = [];
         description = ''
           List of builtins plugins to install. Those are shipped in the
@@ -128,8 +126,8 @@ in
         '';
       };
 
-      serverId = mkOption {
-        type = types.str;
+      serverId = lib.mkOption {
+        type = lib.types.str;
         description = ''
           Set a UUID that uniquely identifies the server.
 
@@ -140,11 +138,11 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     assertions = [
       {
-        assertion = cfg.replicationSettings != {} -> elem "replication" cfg.builtinPlugins;
+        assertion = cfg.replicationSettings != {} -> lib.elem "replication" cfg.builtinPlugins;
         message = "Gerrit replicationSettings require enabling the replication plugin";
       }
     ];

--- a/nixos/modules/services/web-apps/grocy.nix
+++ b/nixos/modules/services/web-apps/grocy.nix
@@ -4,27 +4,24 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.grocy;
 in
 {
   options.services.grocy = {
-    enable = mkEnableOption "grocy";
+    enable = lib.mkEnableOption "grocy";
 
-    package = mkPackageOption pkgs "grocy" { };
+    package = lib.mkPackageOption pkgs "grocy" { };
 
-    hostName = mkOption {
-      type = types.str;
+    hostName = lib.mkOption {
+      type = lib.types.str;
       description = ''
         FQDN for the grocy instance.
       '';
     };
 
-    nginx.enableSSL = mkOption {
-      type = types.bool;
+    nginx.enableSSL = lib.mkOption {
+      type = lib.types.bool;
       default = true;
       description = ''
         Whether or not to enable SSL (with ACME and let's encrypt)
@@ -32,9 +29,9 @@ in
       '';
     };
 
-    phpfpm.settings = mkOption {
+    phpfpm.settings = lib.mkOption {
       type =
-        with types;
+        with lib.types;
         attrsOf (oneOf [
           int
           str
@@ -58,8 +55,8 @@ in
       '';
     };
 
-    dataDir = mkOption {
-      type = types.str;
+    dataDir = lib.mkOption {
+      type = lib.types.str;
       default = "/var/lib/grocy";
       description = ''
         Home directory of the `grocy` user which contains
@@ -68,8 +65,8 @@ in
     };
 
     settings = {
-      currency = mkOption {
-        type = types.str;
+      currency = lib.mkOption {
+        type = lib.types.str;
         default = "USD";
         example = "EUR";
         description = ''
@@ -77,8 +74,8 @@ in
         '';
       };
 
-      culture = mkOption {
-        type = types.enum [
+      culture = lib.mkOption {
+        type = lib.types.enum [
           "de"
           "en"
           "da"
@@ -103,16 +100,16 @@ in
       };
 
       calendar = {
-        showWeekNumber = mkOption {
+        showWeekNumber = lib.mkOption {
           default = true;
-          type = types.bool;
+          type = lib.types.bool;
           description = ''
             Show the number of the weeks in the calendar views.
           '';
         };
-        firstDayOfWeek = mkOption {
+        firstDayOfWeek = lib.mkOption {
           default = null;
-          type = types.nullOr (types.enum (range 0 6));
+          type = lib.types.nullOr (lib.types.enum (lib.range 0 6));
           description = ''
             Which day of the week (0=Sunday, 1=Monday etc.) should be the
             first day.
@@ -122,13 +119,13 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.etc."grocy/config.php".text = ''
       <?php
       Setting('CULTURE', '${cfg.settings.culture}');
       Setting('CURRENCY', '${cfg.settings.currency}');
       Setting('CALENDAR_FIRST_DAY_OF_WEEK', '${toString cfg.settings.calendar.firstDayOfWeek}');
-      Setting('CALENDAR_SHOW_WEEK_OF_YEAR', ${boolToString cfg.settings.calendar.showWeekNumber});
+      Setting('CALENDAR_SHOW_WEEK_OF_YEAR', ${lib.boolToString cfg.settings.calendar.showWeekNumber});
     '';
 
     users.users.grocy = {
@@ -176,7 +173,7 @@ in
 
     services.nginx = {
       enable = true;
-      virtualHosts."${cfg.hostName}" = mkMerge [
+      virtualHosts."${cfg.hostName}" = lib.mkMerge [
         {
           root = "${cfg.package}/public";
           locations."/".extraConfig = ''
@@ -202,7 +199,7 @@ in
             try_files $uri /index.php;
           '';
         }
-        (mkIf cfg.nginx.enableSSL {
+        (lib.mkIf cfg.nginx.enableSSL {
           enableACME = true;
           forceSSL = true;
         })
@@ -211,7 +208,7 @@ in
   };
 
   meta = {
-    maintainers = with maintainers; [ ];
+    maintainers = with lib.maintainers; [ ];
     doc = ./grocy.md;
   };
 }

--- a/nixos/modules/services/web-apps/healthchecks.nix
+++ b/nixos/modules/services/web-apps/healthchecks.nix
@@ -6,9 +6,6 @@
   buildEnv,
   ...
 }:
-
-with lib;
-
 let
   defaultUser = "healthchecks";
   cfg = config.services.healthchecks;
@@ -36,18 +33,18 @@ let
 in
 {
   options.services.healthchecks = {
-    enable = mkEnableOption "healthchecks" // {
+    enable = lib.mkEnableOption "healthchecks" // {
       description = ''
         Enable healthchecks.
         It is expected to be run behind a HTTP reverse proxy.
       '';
     };
 
-    package = mkPackageOption pkgs "healthchecks" { };
+    package = lib.mkPackageOption pkgs "healthchecks" { };
 
-    user = mkOption {
+    user = lib.mkOption {
       default = defaultUser;
-      type = types.str;
+      type = lib.types.str;
       description = ''
         User account under which healthchecks runs.
 
@@ -59,9 +56,9 @@ in
       '';
     };
 
-    group = mkOption {
+    group = lib.mkOption {
       default = defaultUser;
-      type = types.str;
+      type = lib.types.str;
       description = ''
         Group account under which healthchecks runs.
 
@@ -73,20 +70,20 @@ in
       '';
     };
 
-    listenAddress = mkOption {
-      type = types.str;
+    listenAddress = lib.mkOption {
+      type = lib.types.str;
       default = "localhost";
       description = "Address the server will listen on.";
     };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 8000;
       description = "Port the server will listen on.";
     };
 
-    dataDir = mkOption {
-      type = types.str;
+    dataDir = lib.mkOption {
+      type = lib.types.str;
       default = "/var/lib/healthchecks";
       description = ''
         The directory used to store all data for healthchecks.
@@ -128,31 +125,31 @@ in
 
         If the same variable is set in both `settings` and `settingsFile` the value from `settingsFile` has priority.
       '';
-      type = types.submodule (settings: {
-        freeformType = types.attrsOf types.str;
+      type = lib.types.submodule (settings: {
+        freeformType = lib.types.attrsOf lib.types.str;
         options = {
           ALLOWED_HOSTS = lib.mkOption {
-            type = types.listOf types.str;
+            type = lib.types.listOf lib.types.str;
             default = [ "*" ];
             description = "The host/domain names that this site can serve.";
             apply = lib.concatStringsSep ",";
           };
 
-          SECRET_KEY_FILE = mkOption {
-            type = types.nullOr types.path;
+          SECRET_KEY_FILE = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
             description = "Path to a file containing the secret key.";
             default = null;
           };
 
-          DEBUG = mkOption {
-            type = types.bool;
+          DEBUG = lib.mkOption {
+            type = lib.types.bool;
             default = false;
             description = "Enable debug mode.";
             apply = boolToPython;
           };
 
-          REGISTRATION_OPEN = mkOption {
-            type = types.bool;
+          REGISTRATION_OPEN = lib.mkOption {
+            type = lib.types.bool;
             default = false;
             description = ''
               A boolean that controls whether site visitors can create new accounts.
@@ -165,8 +162,8 @@ in
             apply = boolToPython;
           };
 
-          DB = mkOption {
-            type = types.enum [
+          DB = lib.mkOption {
+            type = lib.types.enum [
               "sqlite"
               "postgres"
               "mysql"
@@ -175,8 +172,8 @@ in
             description = "Database engine to use.";
           };
 
-          DB_NAME = mkOption {
-            type = types.str;
+          DB_NAME = lib.mkOption {
+            type = lib.types.str;
             default = if settings.config.DB == "sqlite" then "${cfg.dataDir}/healthchecks.sqlite" else "hc";
             defaultText = lib.literalExpression ''
               if config.${settings.options.DB} == "sqlite"
@@ -190,7 +187,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ healthchecksManageScript ];
 
     systemd.targets.healthchecks = {
@@ -212,8 +209,8 @@ in
           EnvironmentFile = [
             environmentFile
           ] ++ lib.optional (cfg.settingsFile != null) cfg.settingsFile;
-          StateDirectory = mkIf (cfg.dataDir == "/var/lib/healthchecks") "healthchecks";
-          StateDirectoryMode = mkIf (cfg.dataDir == "/var/lib/healthchecks") "0750";
+          StateDirectory = lib.mkIf (cfg.dataDir == "/var/lib/healthchecks") "healthchecks";
+          StateDirectoryMode = lib.mkIf (cfg.dataDir == "/var/lib/healthchecks") "0750";
         };
       in
       {
@@ -279,7 +276,7 @@ in
         };
       };
 
-    users.users = optionalAttrs (cfg.user == defaultUser) {
+    users.users = lib.optionalAttrs (cfg.user == defaultUser) {
       ${defaultUser} = {
         description = "healthchecks service owner";
         isSystemUser = true;
@@ -287,7 +284,7 @@ in
       };
     };
 
-    users.groups = optionalAttrs (cfg.user == defaultUser) {
+    users.groups = lib.optionalAttrs (cfg.user == defaultUser) {
       ${defaultUser} = {
         members = [ defaultUser ];
       };

--- a/nixos/modules/services/web-apps/hledger-web.nix
+++ b/nixos/modules/services/web-apps/hledger-web.nix
@@ -4,27 +4,26 @@
   config,
   ...
 }:
-with lib;
 let
   cfg = config.services.hledger-web;
 in
 {
   options.services.hledger-web = {
 
-    enable = mkEnableOption "hledger-web service";
+    enable = lib.mkEnableOption "hledger-web service";
 
-    serveApi = mkEnableOption "serving only the JSON web API, without the web UI";
+    serveApi = lib.mkEnableOption "serving only the JSON web API, without the web UI";
 
-    host = mkOption {
-      type = types.str;
+    host = lib.mkOption {
+      type = lib.types.str;
       default = "127.0.0.1";
       description = ''
         Address to listen on.
       '';
     };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 5000;
       example = 80;
       description = ''
@@ -32,8 +31,8 @@ in
       '';
     };
 
-    allow = mkOption {
-      type = types.enum [
+    allow = lib.mkOption {
+      type = lib.types.enum [
         "view"
         "add"
         "edit"
@@ -50,8 +49,8 @@ in
       '';
     };
 
-    stateDir = mkOption {
-      type = types.path;
+    stateDir = lib.mkOption {
+      type = lib.types.path;
       default = "/var/lib/hledger-web";
       description = ''
         Path the service has access to. If left as the default value this
@@ -61,16 +60,16 @@ in
       '';
     };
 
-    journalFiles = mkOption {
-      type = types.listOf types.str;
+    journalFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [ ".hledger.journal" ];
       description = ''
         Paths to journal files relative to {option}`services.hledger-web.stateDir`.
       '';
     };
 
-    baseUrl = mkOption {
-      type = with types; nullOr str;
+    baseUrl = lib.mkOption {
+      type = with lib.types; nullOr str;
       default = null;
       example = "https://example.org";
       description = ''
@@ -78,8 +77,8 @@ in
       '';
     };
 
-    extraOptions = mkOption {
-      type = types.listOf types.str;
+    extraOptions = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [ ];
       example = [ "--forecast" ];
       description = ''
@@ -90,14 +89,14 @@ in
   };
 
   imports = [
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "hledger-web"
       "capabilities"
     ] "This option has been replaced by new option `services.hledger-web.allow`.")
   ];
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     users.users.hledger = {
       name = "hledger";
@@ -131,7 +130,7 @@ in
         documentation = [ "https://hledger.org/hledger-web.html" ];
         wantedBy = [ "multi-user.target" ];
         after = [ "networking.target" ];
-        serviceConfig = mkMerge [
+        serviceConfig = lib.mkMerge [
           {
             ExecStart = "${pkgs.hledger-web}/bin/hledger-web ${serverArgs}";
             Restart = "always";
@@ -140,7 +139,7 @@ in
             Group = "hledger";
             PrivateTmp = true;
           }
-          (mkIf (cfg.stateDir == "/var/lib/hledger-web") {
+          (lib.mkIf (cfg.stateDir == "/var/lib/hledger-web") {
             StateDirectory = "hledger-web";
           })
         ];

--- a/nixos/modules/services/web-apps/invoiceplane.nix
+++ b/nixos/modules/services/web-apps/invoiceplane.nix
@@ -4,9 +4,6 @@
   lib,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.invoiceplane;
   eachSite = cfg.sites;
@@ -24,7 +21,7 @@ let
       DB_USERNAME=${cfg.database.user}
       # NOTE: file_get_contents adds newline at the end of returned string
       DB_PASSWORD=${
-        optionalString (
+        lib.optionalString (
           cfg.database.passwordFile != null
         ) "trim(file_get_contents('${cfg.database.passwordFile}'), \"\\r\\n\")"
       }
@@ -41,24 +38,24 @@ let
 
   mkPhpValue =
     v:
-    if isString v then
-      escapeShellArg v
+    if lib.isString v then
+      lib.escapeShellArg v
     # NOTE: If any value contains a , (comma) this will not get escaped
-    else if isList v && strings.isConvertibleWithToString v then
-      escapeShellArg (concatMapStringsSep "," toString v)
-    else if isInt v then
+    else if lib.isList v && lib.strings.isConvertibleWithToString v then
+      lib.escapeShellArg (lib.concatMapStringsSep "," toString v)
+    else if lib.isInt v then
       toString v
-    else if isBool v then
-      boolToString v
+    else if lib.isBool v then
+      lib.boolToString v
     else
       abort "The Invoiceplane config value ${lib.generators.toPretty { } v} can not be encoded.";
 
   extraConfig =
     hostName: cfg:
     let
-      settings = mapAttrsToList (k: v: "${k}=${mkPhpValue v}") cfg.settings;
+      settings = lib.mapAttrsToList (k: v: "${k}=${mkPhpValue v}") cfg.settings;
     in
-    pkgs.writeText "extraConfig.php" (concatStringsSep "\n" settings);
+    pkgs.writeText "extraConfig.php" (lib.concatStringsSep "\n" settings);
 
   pkg =
     hostName: cfg:
@@ -90,7 +87,7 @@ let
         ln -s ${extraConfig hostName cfg} $out/extraConfig.php
 
         # symlink additional templates
-        ${concatMapStringsSep "\n" (
+        ${lib.concatMapStringsSep "\n" (
           template: "cp -r ${template}/. $out/application/views/invoice_templates/pdf/"
         ) cfg.invoiceTemplates}
       '';
@@ -101,10 +98,10 @@ let
     {
       options = {
 
-        enable = mkEnableOption "InvoicePlane web application";
+        enable = lib.mkEnableOption "InvoicePlane web application";
 
-        stateDir = mkOption {
-          type = types.path;
+        stateDir = lib.mkOption {
+          type = lib.types.path;
           default = "/var/lib/invoiceplane/${name}";
           description = ''
             This directory is used for uploads of attachments and cache.
@@ -114,32 +111,32 @@ let
         };
 
         database = {
-          host = mkOption {
-            type = types.str;
+          host = lib.mkOption {
+            type = lib.types.str;
             default = "localhost";
             description = "Database host address.";
           };
 
-          port = mkOption {
-            type = types.port;
+          port = lib.mkOption {
+            type = lib.types.port;
             default = 3306;
             description = "Database host port.";
           };
 
-          name = mkOption {
-            type = types.str;
+          name = lib.mkOption {
+            type = lib.types.str;
             default = "invoiceplane";
             description = "Database name.";
           };
 
-          user = mkOption {
-            type = types.str;
+          user = lib.mkOption {
+            type = lib.types.str;
             default = "invoiceplane";
             description = "Database user.";
           };
 
-          passwordFile = mkOption {
-            type = types.nullOr types.path;
+          passwordFile = lib.mkOption {
+            type = lib.types.nullOr lib.types.path;
             default = null;
             example = "/run/keys/invoiceplane-dbpassword";
             description = ''
@@ -148,15 +145,15 @@ let
             '';
           };
 
-          createLocally = mkOption {
-            type = types.bool;
+          createLocally = lib.mkOption {
+            type = lib.types.bool;
             default = true;
             description = "Create the database and database user locally.";
           };
         };
 
-        invoiceTemplates = mkOption {
-          type = types.listOf types.path;
+        invoiceTemplates = lib.mkOption {
+          type = lib.types.listOf lib.types.path;
           default = [ ];
           description = ''
             List of path(s) to respective template(s) which are copied from the 'invoice_templates/pdf' directory.
@@ -165,7 +162,7 @@ let
             These templates need to be packaged before use, see example.
             :::
           '';
-          example = literalExpression ''
+          example = lib.literalExpression ''
             let
               # Let's package an example template
               template-vtdirektmarketing = pkgs.stdenv.mkDerivation {
@@ -187,9 +184,9 @@ let
           '';
         };
 
-        poolConfig = mkOption {
+        poolConfig = lib.mkOption {
           type =
-            with types;
+            with lib.types;
             attrsOf (oneOf [
               str
               int
@@ -209,15 +206,15 @@ let
           '';
         };
 
-        settings = mkOption {
-          type = types.attrsOf types.anything;
+        settings = lib.mkOption {
+          type = lib.types.attrsOf lib.types.anything;
           default = { };
           description = ''
             Structural InvoicePlane configuration. Refer to
             <https://github.com/InvoicePlane/InvoicePlane/blob/master/ipconfig.php.example>
             for details and supported values.
           '';
-          example = literalExpression ''
+          example = lib.literalExpression ''
             {
               SETUP_COMPLETED = true;
               DISABLE_SETUP = true;
@@ -227,8 +224,8 @@ let
         };
 
         cron = {
-          enable = mkOption {
-            type = types.bool;
+          enable = lib.mkOption {
+            type = lib.types.bool;
             default = false;
             description = ''
               Enable cron service which periodically runs Invoiceplane tasks.
@@ -237,8 +234,8 @@ let
               on how to configure it.
             '';
           };
-          key = mkOption {
-            type = types.str;
+          key = lib.mkOption {
+            type = lib.types.str;
             description = "Cron key taken from the administration page.";
           };
         };
@@ -250,17 +247,17 @@ in
 {
   # interface
   options = {
-    services.invoiceplane = mkOption {
-      type = types.submodule {
+    services.invoiceplane = lib.mkOption {
+      type = lib.types.submodule {
 
-        options.sites = mkOption {
-          type = types.attrsOf (types.submodule siteOpts);
+        options.sites = lib.mkOption {
+          type = lib.types.attrsOf (lib.types.submodule siteOpts);
           default = { };
           description = "Specification of one or more InvoicePlane sites to serve";
         };
 
-        options.webserver = mkOption {
-          type = types.enum [
+        options.webserver = lib.mkOption {
+          type = lib.types.enum [
             "caddy"
             "nginx"
           ];
@@ -278,11 +275,11 @@ in
   };
 
   # implementation
-  config = mkIf (eachSite != { }) (mkMerge [
+  config = lib.mkIf (eachSite != { }) (lib.mkMerge [
     {
 
-      assertions = flatten (
-        mapAttrsToList (hostName: cfg: [
+      assertions = lib.flatten (
+        lib.mapAttrsToList (hostName: cfg: [
           {
             assertion = cfg.database.createLocally -> cfg.database.user == user;
             message = ''services.invoiceplane.sites."${hostName}".database.user must be ${user} if the database is to be automatically provisioned'';
@@ -298,11 +295,11 @@ in
         ]) eachSite
       );
 
-      services.mysql = mkIf (any (v: v.database.createLocally) (attrValues eachSite)) {
+      services.mysql = lib.mkIf (lib.any (v: v.database.createLocally) (lib.attrValues eachSite)) {
         enable = true;
-        package = mkDefault pkgs.mariadb;
-        ensureDatabases = mapAttrsToList (hostName: cfg: cfg.database.name) eachSite;
-        ensureUsers = mapAttrsToList (hostName: cfg: {
+        package = lib.mkDefault pkgs.mariadb;
+        ensureDatabases = lib.mapAttrsToList (hostName: cfg: cfg.database.name) eachSite;
+        ensureUsers = lib.mapAttrsToList (hostName: cfg: {
           name = cfg.database.user;
           ensurePermissions = {
             "${cfg.database.name}.*" = "ALL PRIVILEGES";
@@ -312,9 +309,9 @@ in
 
       services.phpfpm = {
         phpPackage = pkgs.php81;
-        pools = mapAttrs' (
+        pools = lib.mapAttrs' (
           hostName: cfg:
-          (nameValuePair "invoiceplane-${hostName}" {
+          (lib.nameValuePair "invoiceplane-${hostName}" {
             inherit user;
             group = webserver.group;
             settings = {
@@ -329,8 +326,8 @@ in
 
     {
 
-      systemd.tmpfiles.rules = flatten (
-        mapAttrsToList (hostName: cfg: [
+      systemd.tmpfiles.rules = lib.flatten (
+        lib.mapAttrsToList (hostName: cfg: [
           "d ${cfg.stateDir} 0750 ${user} ${webserver.group} - -"
           "f ${cfg.stateDir}/ipconfig.php 0750 ${user} ${webserver.group} - -"
           "d ${cfg.stateDir}/logs 0750 ${user} ${webserver.group} - -"
@@ -345,8 +342,8 @@ in
 
       systemd.services.invoiceplane-config = {
         serviceConfig.Type = "oneshot";
-        script = concatStrings (
-          mapAttrsToList (hostName: cfg: ''
+        script = lib.concatStrings (
+          lib.mapAttrsToList (hostName: cfg: ''
             mkdir -p ${cfg.stateDir}/logs \
                      ${cfg.stateDir}/uploads
             if ! grep -q IP_URL "${cfg.stateDir}/ipconfig.php"; then
@@ -367,10 +364,10 @@ in
 
       # Cron service implementation
 
-      systemd.timers = mapAttrs' (
+      systemd.timers = lib.mapAttrs' (
         hostName: cfg:
-        (nameValuePair "invoiceplane-cron-${hostName}" (
-          mkIf cfg.cron.enable {
+        (lib.nameValuePair "invoiceplane-cron-${hostName}" (
+          lib.mkIf cfg.cron.enable {
             wantedBy = [ "timers.target" ];
             timerConfig = {
               OnBootSec = "5m";
@@ -381,10 +378,10 @@ in
         ))
       ) eachSite;
 
-      systemd.services = mapAttrs' (
+      systemd.services = lib.mapAttrs' (
         hostName: cfg:
-        (nameValuePair "invoiceplane-cron-${hostName}" (
-          mkIf cfg.cron.enable {
+        (lib.nameValuePair "invoiceplane-cron-${hostName}" (
+          lib.mkIf cfg.cron.enable {
             serviceConfig = {
               Type = "oneshot";
               User = user;
@@ -396,12 +393,12 @@ in
 
     }
 
-    (mkIf (cfg.webserver == "caddy") {
+    (lib.mkIf (cfg.webserver == "caddy") {
       services.caddy = {
         enable = true;
-        virtualHosts = mapAttrs' (
+        virtualHosts = lib.mapAttrs' (
           hostName: cfg:
-          (nameValuePair "http://${hostName}" {
+          (lib.nameValuePair "http://${hostName}" {
             extraConfig = ''
               root * ${pkg hostName cfg}
               file_server
@@ -412,12 +409,12 @@ in
       };
     })
 
-    (mkIf (cfg.webserver == "nginx") {
+    (lib.mkIf (cfg.webserver == "nginx") {
       services.nginx = {
         enable = true;
-        virtualHosts = mapAttrs' (
+        virtualHosts = lib.mapAttrs' (
           hostName: cfg:
-          (nameValuePair hostName {
+          (lib.nameValuePair hostName {
             root = pkg hostName cfg;
             extraConfig = ''
               index index.php index.html index.htm;

--- a/nixos/modules/services/web-apps/jirafeau.nix
+++ b/nixos/modules/services/web-apps/jirafeau.nix
@@ -1,13 +1,11 @@
 { config, lib, pkgs, ... }:
-
-with lib;
 let
   cfg = config.services.jirafeau;
 
   group = config.services.nginx.group;
   user = config.services.nginx.user;
 
-  withTrailingSlash = str: if hasSuffix "/" str then str else "${str}/";
+  withTrailingSlash = str: if lib.hasSuffix "/" str then str else "${str}/";
 
   localConfig = pkgs.writeText "config.local.php" ''
     <?php
@@ -22,24 +20,24 @@ let
 in
 {
   options.services.jirafeau = {
-    adminPasswordSha256 = mkOption {
-      type = types.str;
+    adminPasswordSha256 = lib.mkOption {
+      type = lib.types.str;
       default = "";
       description = ''
         SHA-256 of the desired administration password. Leave blank/unset for no password.
       '';
     };
 
-    dataDir = mkOption {
-      type = types.path;
+    dataDir = lib.mkOption {
+      type = lib.types.path;
       default = "/var/lib/jirafeau/data/";
       description = "Location of Jirafeau storage directory.";
     };
 
-    enable = mkEnableOption "Jirafeau file upload application";
+    enable = lib.mkEnableOption "Jirafeau file upload application";
 
-    extraConfig = mkOption {
-      type = types.lines;
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
       default = "";
       example = ''
         $cfg['style'] = 'courgette';
@@ -54,20 +52,20 @@ in
         '';
     };
 
-    hostName = mkOption {
-      type = types.str;
+    hostName = lib.mkOption {
+      type = lib.types.str;
       default = "localhost";
       description = "URL of instance. Must have trailing slash.";
     };
 
-    maxUploadSizeMegabytes = mkOption {
-      type = types.int;
+    maxUploadSizeMegabytes = lib.mkOption {
+      type = lib.types.int;
       default = 0;
       description = "Maximum upload size of accepted files.";
     };
 
-    maxUploadTimeout = mkOption {
-      type = types.str;
+    maxUploadTimeout = lib.mkOption {
+      type = lib.types.str;
       default = "30m";
       description = let
         nginxCoreDocumentation = "http://nginx.org/en/docs/http/ngx_http_core_module.html";
@@ -78,11 +76,11 @@ in
         '';
     };
 
-    nginxConfig = mkOption {
-      type = types.submodule
+    nginxConfig = lib.mkOption {
+      type = lib.types.submodule
         (import ../web-servers/nginx/vhost-options.nix { inherit config lib; });
       default = {};
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           serverAliases = [ "wiki.''${config.networking.domain}" ];
         }
@@ -90,10 +88,10 @@ in
       description = "Extra configuration for the nginx virtual host of Jirafeau.";
     };
 
-    package = mkPackageOption pkgs "jirafeau" { };
+    package = lib.mkPackageOption pkgs "jirafeau" { };
 
-    poolConfig = mkOption {
-      type = with types; attrsOf (oneOf [ str int bool ]);
+    poolConfig = lib.mkOption {
+      type = with lib.types; attrsOf (oneOf [ str int bool ]);
       default = {
         "pm" = "dynamic";
         "pm.max_children" = 32;
@@ -110,11 +108,11 @@ in
   };
 
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services = {
       nginx = {
         enable = true;
-        virtualHosts."${cfg.hostName}" = mkMerge [
+        virtualHosts."${cfg.hostName}" = lib.mkMerge [
           cfg.nginxConfig
           {
             extraConfig = let
@@ -137,7 +135,7 @@ in
                 fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
               '';
             };
-            root = mkForce "${cfg.package}";
+            root = lib.mkForce "${cfg.package}";
           }
         ];
       };

--- a/nixos/modules/services/web-apps/jitsi-meet.nix
+++ b/nixos/modules/services/web-apps/jitsi-meet.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.jitsi-meet;
 
@@ -29,7 +26,7 @@ let
         echo "var ${varName} = "
         ${pkgs.jq}/bin/jq -s '.[0] * .[1]' default.json ${userJson}
         echo ";"
-        echo ${escapeShellArg appendExtra}
+        echo ${lib.escapeShellArg appendExtra}
       ) > $out
     '');
 
@@ -52,10 +49,10 @@ let
   };
 in
 {
-  options.services.jitsi-meet = with types; {
-    enable = mkEnableOption "Jitsi Meet - Secure, Simple and Scalable Video Conferences";
+  options.services.jitsi-meet = with lib.types; {
+    enable = lib.mkEnableOption "Jitsi Meet - Secure, Simple and Scalable Video Conferences";
 
-    hostName = mkOption {
+    hostName = lib.mkOption {
       type = str;
       example = "meet.example.org";
       description = ''
@@ -63,10 +60,10 @@ in
       '';
     };
 
-    config = mkOption {
+    config = lib.mkOption {
       type = attrs;
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           enableWelcomePage = false;
           defaultLang = "fi";
@@ -80,7 +77,7 @@ in
       '';
     };
 
-    extraConfig = mkOption {
+    extraConfig = lib.mkOption {
       type = lines;
       default = "";
       description = ''
@@ -90,10 +87,10 @@ in
       '';
     };
 
-    interfaceConfig = mkOption {
+    interfaceConfig = lib.mkOption {
       type = attrs;
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           SHOW_JITSI_WATERMARK = false;
           SHOW_WATERMARK_FOR_GUESTS = false;
@@ -108,7 +105,7 @@ in
     };
 
     videobridge = {
-      enable = mkOption {
+      enable = lib.mkOption {
         type = bool;
         default = true;
         description = ''
@@ -118,7 +115,7 @@ in
         '';
       };
 
-      passwordFile = mkOption {
+      passwordFile = lib.mkOption {
         type = nullOr str;
         default = null;
         example = "/run/keys/videobridge";
@@ -131,7 +128,7 @@ in
       };
     };
 
-    jicofo.enable = mkOption {
+    jicofo.enable = lib.mkOption {
       type = bool;
       default = true;
       description = ''
@@ -141,7 +138,7 @@ in
       '';
     };
 
-    jibri.enable = mkOption {
+    jibri.enable = lib.mkOption {
       type = bool;
       default = false;
       description = ''
@@ -152,7 +149,7 @@ in
       '';
     };
 
-    jigasi.enable = mkOption {
+    jigasi.enable = lib.mkOption {
       type = bool;
       default = false;
       description = ''
@@ -162,7 +159,7 @@ in
       '';
     };
 
-    nginx.enable = mkOption {
+    nginx.enable = lib.mkOption {
       type = bool;
       default = true;
       description = ''
@@ -176,9 +173,9 @@ in
       '';
     };
 
-    caddy.enable = mkEnableOption "caddy reverse proxy to expose jitsi-meet";
+    caddy.enable = lib.mkEnableOption "caddy reverse proxy to expose jitsi-meet";
 
-    prosody.enable = mkOption {
+    prosody.enable = lib.mkOption {
       type = bool;
       default = true;
       example = false;
@@ -187,7 +184,7 @@ in
         off if you want to configure it manually.
       '';
     };
-    prosody.lockdown = mkOption {
+    prosody.lockdown = lib.mkOption {
       type = bool;
       default = false;
       example = true;
@@ -202,16 +199,16 @@ in
       '';
     };
 
-    excalidraw.enable = mkEnableOption "Excalidraw collaboration backend for Jitsi";
-    excalidraw.port = mkOption {
+    excalidraw.enable = lib.mkEnableOption "Excalidraw collaboration backend for Jitsi";
+    excalidraw.port = lib.mkOption {
       type = types.port;
       default = 3002;
       description = ''The port which the Excalidraw backend for Jitsi should listen to.'';
     };
 
     secureDomain = {
-      enable = mkEnableOption "Authenticated room creation";
-      authentication = mkOption {
+      enable = lib.mkEnableOption "Authenticated room creation";
+      authentication = lib.mkOption {
         type = types.str;
         default = "internal_hashed";
         description = ''The authentication type to be used by jitsi'';
@@ -219,23 +216,23 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    services.prosody = mkIf cfg.prosody.enable {
-      enable = mkDefault true;
-      xmppComplianceSuite = mkDefault false;
+  config = lib.mkIf cfg.enable {
+    services.prosody = lib.mkIf cfg.prosody.enable {
+      enable = lib.mkDefault true;
+      xmppComplianceSuite = lib.mkDefault false;
       modules = {
-        admin_adhoc = mkDefault false;
-        bosh = mkDefault true;
-        ping = mkDefault true;
-        roster = mkDefault true;
-        saslauth = mkDefault true;
-        smacks = mkDefault true;
-        tls = mkDefault true;
-        websocket = mkDefault true;
-        proxy65 = mkIf cfg.prosody.lockdown (mkDefault false);
+        admin_adhoc = lib.mkDefault false;
+        bosh = lib.mkDefault true;
+        ping = lib.mkDefault true;
+        roster = lib.mkDefault true;
+        saslauth = lib.mkDefault true;
+        smacks = lib.mkDefault true;
+        tls = lib.mkDefault true;
+        websocket = lib.mkDefault true;
+        proxy65 = lib.mkIf cfg.prosody.lockdown (lib.mkDefault false);
       };
-      httpInterfaces = mkIf cfg.prosody.lockdown (mkDefault [ "127.0.0.1" ]);
-      httpsPorts = mkIf cfg.prosody.lockdown (mkDefault [ ]);
+      httpInterfaces = lib.mkIf cfg.prosody.lockdown (lib.mkDefault [ "127.0.0.1" ]);
+      httpsPorts = lib.mkIf cfg.prosody.lockdown (lib.mkDefault [ ]);
       muc = [
         {
           domain = "conference.${cfg.hostName}";
@@ -301,7 +298,7 @@ in
       ];
       extraPluginPaths = [ "${pkgs.jitsi-meet-prosody}/share/prosody-plugins" ];
       extraConfig = lib.mkMerge [
-        (mkAfter ''
+        (lib.mkAfter ''
           Component "focus.${cfg.hostName}" "client_proxy"
             target_address = "focus@auth.${cfg.hostName}"
 
@@ -324,7 +321,7 @@ in
             muc_component = "conference.${cfg.hostName}"
             breakout_rooms_component = "breakout.${cfg.hostName}"
         '')
-        (mkBefore (
+        (lib.mkBefore (
           ''
             muc_mapper_domain_base = "${cfg.hostName}"
 
@@ -336,7 +333,7 @@ in
               "jvb@auth.${cfg.hostName}"
             }
           ''
-          + optionalString cfg.prosody.lockdown ''
+          + lib.optionalString cfg.prosody.lockdown ''
             c2s_interfaces = { "127.0.0.1" };
             modules_disabled = { "s2s" };
           ''
@@ -400,7 +397,7 @@ in
         '';
       };
     };
-    systemd.services.prosody = mkIf cfg.prosody.enable {
+    systemd.services.prosody = lib.mkIf cfg.prosody.enable {
       preStart =
         let
           videobridgeSecret =
@@ -416,7 +413,7 @@ in
           ${config.services.prosody.package}/bin/prosodyctl register jibri auth.${cfg.hostName} "$(cat /var/lib/jitsi-meet/jibri-auth-secret)"
           ${config.services.prosody.package}/bin/prosodyctl register recorder recorder.${cfg.hostName} "$(cat /var/lib/jitsi-meet/jibri-recorder-secret)"
         ''
-        + optionalString cfg.jigasi.enable ''
+        + lib.optionalString cfg.jigasi.enable ''
           ${config.services.prosody.package}/bin/prosodyctl register jigasi auth.${cfg.hostName} "$(cat /var/lib/jitsi-meet/jigasi-user-secret)"
         '';
 
@@ -439,8 +436,8 @@ in
           "jicofo.service"
           "jitsi-videobridge2.service"
         ]
-        ++ (optional cfg.prosody.enable "prosody.service")
-        ++ (optional cfg.jigasi.enable "jigasi.service");
+        ++ (lib.optional cfg.prosody.enable "prosody.service")
+        ++ (lib.optional cfg.jigasi.enable "jigasi.service");
       serviceConfig = {
         Type = "oneshot";
         UMask = "027";
@@ -458,14 +455,14 @@ in
               "jibri-auth-secret"
               "jibri-recorder-secret"
             ]
-            ++ (optionals cfg.jigasi.enable [
+            ++ (lib.optionals cfg.jigasi.enable [
               "jigasi-user-secret"
               "jigasi-component-secret"
             ])
-            ++ (optional (cfg.videobridge.passwordFile == null) "videobridge-secret");
+            ++ (lib.optional (cfg.videobridge.passwordFile == null) "videobridge-secret");
         in
         ''
-          ${concatMapStringsSep "\n" (s: ''
+          ${lib.concatMapStringsSep "\n" (s: ''
             if [ ! -f ${s} ]; then
               tr -dc a-zA-Z0-9 </dev/urandom | head -c 64 > ${s}
             fi
@@ -475,10 +472,10 @@ in
           echo "JICOFO_COMPONENT_SECRET=$(cat jicofo-component-secret)" > secrets-env
           echo "JIGASI_COMPONENT_SECRET=$(cat jigasi-component-secret)" >> secrets-env
         ''
-        + optionalString cfg.prosody.enable ''
+        + lib.optionalString cfg.prosody.enable ''
           # generate self-signed certificates
           if [ ! -f /var/lib/jitsi-meet/jitsi-meet.crt ]; then
-            ${getBin pkgs.openssl}/bin/openssl req \
+            ${lib.getBin pkgs.openssl}/bin/openssl req \
               -x509 \
               -newkey rsa:4096 \
               -keyout /var/lib/jitsi-meet/jitsi-meet.key \
@@ -491,7 +488,7 @@ in
         '';
     };
 
-    systemd.services.jitsi-excalidraw = mkIf cfg.excalidraw.enable {
+    systemd.services.jitsi-excalidraw = lib.mkIf cfg.excalidraw.enable {
       description = "Excalidraw collaboration backend for Jitsi";
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
@@ -533,11 +530,11 @@ in
       };
     };
 
-    services.nginx = mkIf cfg.nginx.enable {
-      enable = mkDefault true;
+    services.nginx = lib.mkIf cfg.nginx.enable {
+      enable = lib.mkDefault true;
       virtualHosts.${cfg.hostName} = {
-        enableACME = mkDefault true;
-        forceSSL = mkDefault true;
+        enableACME = lib.mkDefault true;
+        forceSSL = lib.mkDefault true;
         root = pkgs.jitsi-meet;
         extraConfig = ''
           ssi on;
@@ -558,7 +555,7 @@ in
             proxy_set_header Host $host;
           '';
         };
-        locations."=/external_api.js" = mkDefault {
+        locations."=/external_api.js" = lib.mkDefault {
           alias = "${pkgs.jitsi-meet}/libs/external_api.min.js";
         };
         locations."=/_api/room-info" = {
@@ -568,25 +565,25 @@ in
             proxy_set_header Host $host;
           '';
         };
-        locations."=/config.js" = mkDefault {
+        locations."=/config.js" = lib.mkDefault {
           alias =
-            overrideJs "${pkgs.jitsi-meet}/config.js" "config" (recursiveUpdate defaultCfg cfg.config)
+            overrideJs "${pkgs.jitsi-meet}/config.js" "config" (lib.recursiveUpdate defaultCfg cfg.config)
               cfg.extraConfig;
         };
-        locations."=/interface_config.js" = mkDefault {
+        locations."=/interface_config.js" = lib.mkDefault {
           alias =
             overrideJs "${pkgs.jitsi-meet}/interface_config.js" "interfaceConfig" cfg.interfaceConfig
               "";
         };
-        locations."/socket.io/" = mkIf cfg.excalidraw.enable {
+        locations."/socket.io/" = lib.mkIf cfg.excalidraw.enable {
           proxyPass = "http://127.0.0.1:${toString cfg.excalidraw.port}";
           proxyWebsockets = true;
         };
       };
     };
 
-    services.caddy = mkIf cfg.caddy.enable {
-      enable = mkDefault true;
+    services.caddy = lib.mkIf cfg.caddy.enable {
+      enable = lib.mkDefault true;
       virtualHosts.${cfg.hostName} = {
         extraConfig =
           let
@@ -599,7 +596,7 @@ in
               rm interface_config.js
               cp -R . $out
               cp ${
-                overrideJs "${pkgs.jitsi-meet}/config.js" "config" (recursiveUpdate defaultCfg cfg.config)
+                overrideJs "${pkgs.jitsi-meet}/config.js" "config" (lib.recursiveUpdate defaultCfg cfg.config)
                   cfg.extraConfig
               } $out/config.js
               cp ${
@@ -608,7 +605,7 @@ in
               cp ./libs/external_api.min.js $out/external_api.js
             '';
           in
-          (optionalString cfg.excalidraw.enable ''
+          (lib.optionalString cfg.excalidraw.enable ''
             handle /socket.io/ {
               reverse_proxy 127.0.0.1:${toString cfg.excalidraw.port}
             }
@@ -633,20 +630,20 @@ in
     };
 
     services.jitsi-meet.config =
-      recursiveUpdate
-        (mkIf cfg.excalidraw.enable {
+      lib.recursiveUpdate
+        (lib.mkIf cfg.excalidraw.enable {
           whiteboard = {
             enabled = true;
             collabServerBaseUrl = "https://${cfg.hostName}";
           };
         })
         (
-          mkIf cfg.secureDomain.enable {
+          lib.mkIf cfg.secureDomain.enable {
             hosts.anonymousdomain = "guest.${cfg.hostName}";
           }
         );
 
-    services.jitsi-videobridge = mkIf cfg.videobridge.enable {
+    services.jitsi-videobridge = lib.mkIf cfg.videobridge.enable {
       enable = true;
       xmppConfigs."localhost" = {
         userName = "jvb";
@@ -657,7 +654,7 @@ in
       };
     };
 
-    services.jicofo = mkIf cfg.jicofo.enable {
+    services.jicofo = lib.mkIf cfg.jicofo.enable {
       enable = true;
       xmppHost = "localhost";
       xmppDomain = cfg.hostName;
@@ -666,7 +663,7 @@ in
       userPasswordFile = "/var/lib/jitsi-meet/jicofo-user-secret";
       componentPasswordFile = "/var/lib/jitsi-meet/jicofo-component-secret";
       bridgeMuc = "jvbbrewery@internal.auth.${cfg.hostName}";
-      config = mkMerge [
+      config = lib.mkMerge [
         {
           jicofo.xmpp.service.disable-certificate-verification = true;
           jicofo.xmpp.client.disable-certificate-verification = true;
@@ -690,7 +687,7 @@ in
       ];
     };
 
-    services.jibri = mkIf cfg.jibri.enable {
+    services.jibri = lib.mkIf cfg.jibri.enable {
       enable = true;
 
       xmppEnvironments."jitsi-meet" = {
@@ -721,7 +718,7 @@ in
       };
     };
 
-    services.jigasi = mkIf cfg.jigasi.enable {
+    services.jigasi = lib.mkIf cfg.jigasi.enable {
       enable = true;
       xmppHost = "localhost";
       xmppDomain = cfg.hostName;

--- a/nixos/modules/services/web-apps/lemmy.nix
+++ b/nixos/modules/services/web-apps/lemmy.nix
@@ -5,17 +5,16 @@
   utils,
   ...
 }:
-with lib;
 let
   cfg = config.services.lemmy;
   settingsFormat = pkgs.formats.json { };
 in
 {
-  meta.maintainers = with maintainers; [ happysalada ];
+  meta.maintainers = with lib.maintainers; [ happysalada ];
   meta.doc = ./lemmy.md;
 
   imports = [
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "lemmy"
       "jwtSecretPath"
@@ -24,86 +23,86 @@ in
 
   options.services.lemmy = {
 
-    enable = mkEnableOption "lemmy a federated alternative to reddit in rust";
+    enable = lib.mkEnableOption "lemmy a federated alternative to reddit in rust";
 
     server = {
-      package = mkPackageOption pkgs "lemmy-server" { };
+      package = lib.mkPackageOption pkgs "lemmy-server" { };
     };
 
     ui = {
-      package = mkPackageOption pkgs "lemmy-ui" { };
+      package = lib.mkPackageOption pkgs "lemmy-ui" { };
 
-      port = mkOption {
-        type = types.port;
+      port = lib.mkOption {
+        type = lib.types.port;
         default = 1234;
         description = "Port where lemmy-ui should listen for incoming requests.";
       };
     };
 
-    caddy.enable = mkEnableOption "exposing lemmy with the caddy reverse proxy";
-    nginx.enable = mkEnableOption "exposing lemmy with the nginx reverse proxy";
+    caddy.enable = lib.mkEnableOption "exposing lemmy with the caddy reverse proxy";
+    nginx.enable = lib.mkEnableOption "exposing lemmy with the nginx reverse proxy";
 
     database = {
-      createLocally = mkEnableOption "creation of database on the instance";
+      createLocally = lib.mkEnableOption "creation of database on the instance";
 
-      uri = mkOption {
-        type = with types; nullOr str;
+      uri = lib.mkOption {
+        type = with lib.types; nullOr str;
         default = null;
         description = "The connection URI to use. Takes priority over the configuration file if set.";
       };
 
-      uriFile = mkOption {
-        type = with types; nullOr path;
+      uriFile = lib.mkOption {
+        type = with lib.types; nullOr path;
         default = null;
         description = "File which contains the database uri.";
       };
     };
 
-    pictrsApiKeyFile = mkOption {
-      type = with types; nullOr path;
+    pictrsApiKeyFile = lib.mkOption {
+      type = with lib.types; nullOr path;
       default = null;
       description = "File which contains the value of `pictrs.api_key`.";
     };
 
-    smtpPasswordFile = mkOption {
-      type = with types; nullOr path;
+    smtpPasswordFile = lib.mkOption {
+      type = with lib.types; nullOr path;
       default = null;
       description = "File which contains the value of `email.smtp_password`.";
     };
 
-    adminPasswordFile = mkOption {
-      type = with types; nullOr path;
+    adminPasswordFile = lib.mkOption {
+      type = with lib.types; nullOr path;
       default = null;
       description = "File which contains the value of `setup.admin_password`.";
     };
 
-    settings = mkOption {
+    settings = lib.mkOption {
       default = { };
       description = "Lemmy configuration";
 
-      type = types.submodule {
+      type = lib.types.submodule {
         freeformType = settingsFormat.type;
 
-        options.hostname = mkOption {
-          type = types.str;
+        options.hostname = lib.mkOption {
+          type = lib.types.str;
           default = null;
           description = "The domain name of your instance (eg 'lemmy.ml').";
         };
 
-        options.port = mkOption {
-          type = types.port;
+        options.port = lib.mkOption {
+          type = lib.types.port;
           default = 8536;
           description = "Port where lemmy should listen for incoming requests.";
         };
 
         options.captcha = {
-          enabled = mkOption {
-            type = types.bool;
+          enabled = lib.mkOption {
+            type = lib.types.bool;
             default = true;
             description = "Enable Captcha.";
           };
-          difficulty = mkOption {
-            type = types.enum [
+          difficulty = lib.mkOption {
+            type = lib.types.enum [
               "easy"
               "medium"
               "hard"
@@ -154,7 +153,7 @@ in
       services.lemmy.settings =
         lib.attrsets.recursiveUpdate
           (
-            mapAttrs (name: mkDefault) {
+            lib.mapAttrs (name: lib.mkDefault) {
               bind = "127.0.0.1";
               tls_enabled = true;
               pictrs = {
@@ -172,7 +171,7 @@ in
               rate_limit.image_per_second = 3600;
             }
             // {
-              database = mapAttrs (name: mkDefault) {
+              database = lib.mapAttrs (name: lib.mkDefault) {
                 user = "lemmy";
                 host = "/run/postgresql";
                 port = 5432;
@@ -189,7 +188,7 @@ in
           );
       # the option name is the id of the credential loaded by LoadCredential
 
-      services.postgresql = mkIf cfg.database.createLocally {
+      services.postgresql = lib.mkIf cfg.database.createLocally {
         enable = true;
         ensureDatabases = [ cfg.settings.database.database ];
         ensureUsers = [
@@ -202,8 +201,8 @@ in
 
       services.pict-rs.enable = true;
 
-      services.caddy = mkIf cfg.caddy.enable {
-        enable = mkDefault true;
+      services.caddy = lib.mkIf cfg.caddy.enable {
+        enable = lib.mkDefault true;
         virtualHosts."${cfg.settings.hostname}" = {
           extraConfig = ''
             handle_path /static/* {
@@ -240,8 +239,8 @@ in
         };
       };
 
-      services.nginx = mkIf cfg.nginx.enable {
-        enable = mkDefault true;
+      services.nginx = lib.mkIf cfg.nginx.enable {
+        enable = lib.mkDefault true;
         virtualHosts."${cfg.settings.hostname}".locations =
           let
             ui = "http://127.0.0.1:${toString cfg.ui.port}";
@@ -291,8 +290,8 @@ in
         }
         {
           assertion =
-            (!(hasAttrByPath [ "federation" ] cfg.settings))
-            && (!(hasAttrByPath [ "federation" "enabled" ] cfg.settings));
+            (!(lib.hasAttrByPath [ "federation" ] cfg.settings))
+            && (!(lib.hasAttrByPath [ "federation" "enabled" ] cfg.settings));
           message = "`services.lemmy.settings.federation` was removed in 0.17.0 and no longer has any effect";
         }
         {
@@ -315,7 +314,7 @@ in
               if cfg.database.uri != null then
                 cfg.database.uri
               else
-                (mkIf (cfg.database.createLocally) "postgres:///lemmy?host=/run/postgresql&user=lemmy");
+                (lib.mkIf (cfg.database.createLocally) "postgres:///lemmy?host=/run/postgresql&user=lemmy");
           };
 
           documentation = [
@@ -331,7 +330,7 @@ in
 
           # substitute secrets and prevent others from reading the result
           # if somehow $CREDENTIALS_DIRECTORY is not set we fail
-          preStart = mkIf (secrets != { }) ''
+          preStart = lib.mkIf (secrets != { }) ''
             set -u
             umask u=rw,g=,o=
             cd "$CREDENTIALS_DIRECTORY"

--- a/nixos/modules/services/x11/window-managers/jwm.nix
+++ b/nixos/modules/services/x11/window-managers/jwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.jwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.jwm.enable = mkEnableOption "jwm";
+    services.xserver.windowManager.jwm.enable = lib.mkEnableOption "jwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "jwm";
       start = ''
         ${pkgs.jwm}/bin/jwm &

--- a/nixos/modules/services/x11/window-managers/tinywm.nix
+++ b/nixos/modules/services/x11/window-managers/tinywm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.tinywm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.tinywm.enable = mkEnableOption "tinywm";
+    services.xserver.windowManager.tinywm.enable = lib.mkEnableOption "tinywm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "tinywm";
       start = ''
         ${pkgs.tinywm}/bin/tinywm &

--- a/nixos/modules/services/x11/window-managers/twm.nix
+++ b/nixos/modules/services/x11/window-managers/twm.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.services.xserver.windowManager.twm;
@@ -18,14 +15,14 @@ in
   ###### interface
 
   options = {
-    services.xserver.windowManager.twm.enable = mkEnableOption "twm";
+    services.xserver.windowManager.twm.enable = lib.mkEnableOption "twm";
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
-    services.xserver.windowManager.session = singleton {
+    services.xserver.windowManager.session = lib.singleton {
       name = "twm";
       start = ''
         ${pkgs.xorg.twm}/bin/twm &

--- a/nixos/modules/services/x11/window-managers/wmderland.nix
+++ b/nixos/modules/services/x11/window-managers/wmderland.nix
@@ -4,27 +4,24 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.wmderland;
 in
 
 {
   options.services.xserver.windowManager.wmderland = {
-    enable = mkEnableOption "wmderland";
+    enable = lib.mkEnableOption "wmderland";
 
-    extraSessionCommands = mkOption {
+    extraSessionCommands = lib.mkOption {
       default = "";
-      type = types.lines;
+      type = lib.types.lines;
       description = ''
         Shell commands executed just before wmderland is started.
       '';
     };
 
-    extraPackages = mkOption {
-      type = with types; listOf package;
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
       default = with pkgs; [
         rofi
         dunst
@@ -33,7 +30,7 @@ in
         feh
         rxvt-unicode
       ];
-      defaultText = literalExpression ''
+      defaultText = lib.literalExpression ''
         with pkgs; [
           rofi
           dunst
@@ -49,8 +46,8 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "wmderland";
       start = ''
         ${cfg.extraSessionCommands}

--- a/nixos/modules/services/x11/window-managers/wmii.nix
+++ b/nixos/modules/services/x11/window-managers/wmii.nix
@@ -4,20 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
 let
   cfg = config.services.xserver.windowManager.wmii;
   wmii = pkgs.wmii_hg;
 in
 {
   options = {
-    services.xserver.windowManager.wmii.enable = mkEnableOption "wmii";
+    services.xserver.windowManager.wmii.enable = lib.mkEnableOption "wmii";
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.xserver.windowManager.session =
-      singleton
+      lib.singleton
         # stop wmii by
         #   $wmiir xwrite /ctl quit
         # this will cause wmii exiting with exit code 0

--- a/nixos/modules/services/x11/xfs.nix
+++ b/nixos/modules/services/x11/xfs.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   configFile = ./xfs.conf;
@@ -21,8 +18,8 @@ in
 
     services.xfs = {
 
-      enable = mkOption {
-        type = types.bool;
+      enable = lib.mkOption {
+        type = lib.types.bool;
         default = false;
         description = "Whether to enable the X Font Server.";
       };
@@ -33,8 +30,8 @@ in
 
   ###### implementation
 
-  config = mkIf config.services.xfs.enable {
-    assertions = singleton {
+  config = lib.mkIf config.services.xfs.enable {
+    assertions = lib.singleton {
       assertion = config.fonts.enableFontDir;
       message = "Please enable fonts.enableFontDir to use the X Font Server.";
     };

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -1,11 +1,8 @@
 # generate the script used to activate the configuration.
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
 
-  addAttributeName = mapAttrs (a: v: v // {
+  addAttributeName = lib.mapAttrs (a: v: v // {
     text = ''
       #### Activation script snippet ${a}:
       _localstatus=0
@@ -18,7 +15,7 @@ let
   });
 
   systemActivationScript = set: onlyDry: let
-    set' = mapAttrs (_: v: if isString v then (noDepEntry v) // { supportsDryActivation = false; } else v) set;
+    set' = lib.mapAttrs (_: v: if lib.isString v then (lib.noDepEntry v) // { supportsDryActivation = false; } else v) set;
     withHeadlines = addAttributeName set';
     # When building a dry activation script, this replaces all activation scripts
     # that do not support dry mode with a comment that does nothing. Filtering these
@@ -26,7 +23,7 @@ let
     # does not work because when an activation script that supports dry mode depends on
     # an activation script that does not, the dependency cannot be resolved and the eval
     # fails.
-    withDrySnippets = mapAttrs (a: v: if onlyDry && !v.supportsDryActivation then v // {
+    withDrySnippets = lib.mapAttrs (a: v: if onlyDry && !v.supportsDryActivation then v // {
       text = "#### Activation script snippet ${a} does not support dry activation.";
     } else v) withHeadlines;
   in
@@ -48,9 +45,9 @@ let
       # Ensure a consistent umask.
       umask 0022
 
-      ${textClosureMap id (withDrySnippets) (attrNames withDrySnippets)}
+      ${lib.textClosureMap lib.id (withDrySnippets) (lib.attrNames withDrySnippets)}
 
-    '' + optionalString (!onlyDry) ''
+    '' + lib.optionalString (!onlyDry) ''
       # Make this configuration the current configuration.
       # The readlink is there to ensure that when $systemConfig = /system
       # (which is a symlink to the store), /run/current-system is still
@@ -60,7 +57,7 @@ let
       exit $_status
     '';
 
-  path = with pkgs; map getBin
+  path = with pkgs; map lib.getBin
     [ coreutils
       gnugrep
       findutils
@@ -71,19 +68,19 @@ let
       util-linux # needed for mount and mountpoint
     ];
 
-  scriptType = withDry: with types;
+  scriptType = withDry: with lib.types;
     let scriptOptions =
-      { deps = mkOption
+      { deps = lib.mkOption
           { type = types.listOf types.str;
             default = [ ];
             description = "List of dependencies. The script will run after these.";
           };
-        text = mkOption
+        text = lib.mkOption
           { type = types.lines;
             description = "The content of the script.";
           };
-      } // optionalAttrs withDry {
-        supportsDryActivation = mkOption
+      } // lib.optionalAttrs withDry {
+        supportsDryActivation = lib.mkOption
           { type = types.bool;
             default = false;
             description = ''
@@ -106,10 +103,10 @@ in
 
   options = {
 
-    system.activationScripts = mkOption {
+    system.activationScripts = lib.mkOption {
       default = {};
 
-      example = literalExpression ''
+      example = lib.literalExpression ''
         {
           stdio = {
             # Run after /dev has been mounted
@@ -135,24 +132,24 @@ in
         idempotent and fast.
       '';
 
-      type = types.attrsOf (scriptType true);
+      type = lib.types.attrsOf (scriptType true);
       apply = set: set // {
         script = systemActivationScript set false;
       };
     };
 
-    system.dryActivationScript = mkOption {
+    system.dryActivationScript = lib.mkOption {
       description = "The shell script that is to be run when dry-activating a system.";
       readOnly = true;
       internal = true;
       default = systemActivationScript (removeAttrs config.system.activationScripts [ "script" ]) true;
-      defaultText = literalMD "generated activation script";
+      defaultText = lib.literalMD "generated activation script";
     };
 
-    system.userActivationScripts = mkOption {
+    system.userActivationScripts = lib.mkOption {
       default = {};
 
-      example = literalExpression ''
+      example = lib.literalExpression ''
         { plasmaSetup = {
             text = '''
               ''${pkgs.libsForQt5.kservice}/bin/kbuildsycoca5"
@@ -171,7 +168,7 @@ in
         idempotent and fast.
       '';
 
-      type = with types; attrsOf (scriptType false);
+      type = with lib.types; attrsOf (scriptType false);
 
       apply = set: {
         script = ''
@@ -185,9 +182,9 @@ in
 
           ${
             let
-              set' = mapAttrs (n: v: if isString v then noDepEntry v else v) set;
+              set' = lib.mapAttrs (n: v: if lib.isString v then lib.noDepEntry v else v) set;
               withHeadlines = addAttributeName set';
-            in textClosureMap id (withHeadlines) (attrNames withHeadlines)
+            in lib.textClosureMap lib.id (withHeadlines) (lib.attrNames withHeadlines)
           }
 
           exit $_status
@@ -196,11 +193,11 @@ in
 
     };
 
-    environment.usrbinenv = mkOption {
+    environment.usrbinenv = lib.mkOption {
       default = "${pkgs.coreutils}/bin/env";
-      defaultText = literalExpression ''"''${pkgs.coreutils}/bin/env"'';
-      example = literalExpression ''"''${pkgs.busybox}/bin/env"'';
-      type = types.nullOr types.path;
+      defaultText = lib.literalExpression ''"''${pkgs.coreutils}/bin/env"'';
+      example = lib.literalExpression ''"''${pkgs.busybox}/bin/env"'';
+      type = lib.types.nullOr lib.types.path;
       visible = false;
       description = ''
         The env(1) executable that is linked system-wide to
@@ -208,7 +205,7 @@ in
       '';
     };
 
-    system.build.installBootLoader = mkOption {
+    system.build.installBootLoader = lib.mkOption {
       internal = true;
       default = pkgs.writeShellScript "no-bootloader" ''
         echo 'Warning: do not know how to make this configuration bootable; please enable a boot loader.' 1>&2
@@ -223,13 +220,13 @@ in
 
         See `nixos/modules/system/activation/switch-to-configuration.pl`.
       '';
-      type = types.unique {
+      type = lib.types.unique {
         message = ''
           Only one bootloader can be enabled at a time. This requirement has not
           been checked until NixOS 22.05. Earlier versions defaulted to the last
           definition. Change your configuration to enable only one bootloader.
         '';
-      } (types.either types.str types.package);
+      } (lib.types.either lib.types.str lib.types.package);
     };
 
   };

--- a/nixos/modules/system/activation/no-clone.nix
+++ b/nixos/modules/system/activation/no-clone.nix
@@ -1,9 +1,6 @@
 { lib, ... }:
-
-with lib;
-
 {
-  boot.loader.grub.device = mkOverride 0 "nodev";
-  specialisation = mkOverride 0 { };
-  isSpecialisation = mkOverride 0 true;
+  boot.loader.grub.device = lib.mkOverride 0 "nodev";
+  specialisation = lib.mkOverride 0 { };
+  isSpecialisation = lib.mkOverride 0 true;
 }

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -1,7 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   systemBuilder =
     ''
@@ -37,9 +34,9 @@ let
 
       cp "$extraDependenciesPath" "$out/extra-dependencies"
 
-      ${optionalString (!config.boot.isContainer && config.boot.bootspec.enable) ''
+      ${lib.optionalString (!config.boot.isContainer && config.boot.bootspec.enable) ''
         ${config.boot.bootspec.writer}
-        ${optionalString config.boot.bootspec.enableValidation
+        ${lib.optionalString config.boot.bootspec.enableValidation
           ''${config.boot.bootspec.validator} "$out/${config.boot.bootspec.filename}"''}
       ''}
 
@@ -67,11 +64,11 @@ let
 
   # Handle assertions and warnings
 
-  failedAssertions = map (x: x.message) (filter (x: !x.assertion) config.assertions);
+  failedAssertions = map (x: x.message) (lib.filter (x: !x.assertion) config.assertions);
 
   baseSystemAssertWarn = if failedAssertions != []
-    then throw "\nFailed assertions:\n${concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
-    else showWarnings config.warnings baseSystem;
+    then throw "\nFailed assertions:\n${lib.concatStringsSep "\n" (map (x: "- ${x}") failedAssertions)}"
+    else lib.showWarnings config.warnings baseSystem;
 
   # Replace runtime dependencies
   system = let inherit (config.system.replaceDependencies) replacements cutoffPackages; in
@@ -100,15 +97,15 @@ in
 {
   imports = [
     ../build.nix
-    (mkRemovedOptionModule [ "nesting" "clone" ] "Use `specialisation.«name» = { inheritParentConfig = true; configuration = { ... }; }` instead.")
-    (mkRemovedOptionModule [ "nesting" "children" ] "Use `specialisation.«name».configuration = { ... }` instead.")
-    (mkRenamedOptionModule [ "system" "forbiddenDependenciesRegex" ] [ "system" "forbiddenDependenciesRegexes" ])
-    (mkRenamedOptionModule [ "system" "replaceRuntimeDependencies" ] [ "system" "replaceDependencies" "replacements" ])
+    (lib.mkRemovedOptionModule [ "nesting" "clone" ] "Use `specialisation.«name» = { inheritParentConfig = true; configuration = { ... }; }` instead.")
+    (lib.mkRemovedOptionModule [ "nesting" "children" ] "Use `specialisation.«name».configuration = { ... }` instead.")
+    (lib.mkRenamedOptionModule [ "system" "forbiddenDependenciesRegex" ] [ "system" "forbiddenDependenciesRegexes" ])
+    (lib.mkRenamedOptionModule [ "system" "replaceRuntimeDependencies" ] [ "system" "replaceDependencies" "replacements" ])
   ];
 
   options = {
 
-    system.boot.loader.id = mkOption {
+    system.boot.loader.id = lib.mkOption {
       internal = true;
       default = "";
       description = ''
@@ -116,28 +113,28 @@ in
       '';
     };
 
-    system.boot.loader.kernelFile = mkOption {
+    system.boot.loader.kernelFile = lib.mkOption {
       internal = true;
       default = pkgs.stdenv.hostPlatform.linux-kernel.target;
-      defaultText = literalExpression "pkgs.stdenv.hostPlatform.linux-kernel.target";
-      type = types.str;
+      defaultText = lib.literalExpression "pkgs.stdenv.hostPlatform.linux-kernel.target";
+      type = lib.types.str;
       description = ''
         Name of the kernel file to be passed to the bootloader.
       '';
     };
 
-    system.boot.loader.initrdFile = mkOption {
+    system.boot.loader.initrdFile = lib.mkOption {
       internal = true;
       default = "initrd";
-      type = types.str;
+      type = lib.types.str;
       description = ''
         Name of the initrd file to be passed to the bootloader.
       '';
     };
 
     system.build = {
-      toplevel = mkOption {
-        type = types.package;
+      toplevel = lib.mkOption {
+        type = lib.types.package;
         readOnly = true;
         description = ''
           This option contains the store path that typically represents a NixOS system.
@@ -148,8 +145,8 @@ in
     };
 
 
-    system.copySystemConfiguration = mkOption {
-      type = types.bool;
+    system.copySystemConfiguration = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         If enabled, copies the NixOS configuration file
@@ -160,8 +157,8 @@ in
       '';
     };
 
-    system.systemBuilderCommands = mkOption {
-      type = types.lines;
+    system.systemBuilderCommands = lib.mkOption {
+      type = lib.types.lines;
       internal = true;
       default = "";
       description = ''
@@ -169,8 +166,8 @@ in
       '';
     };
 
-    system.systemBuilderArgs = mkOption {
-      type = types.attrsOf types.unspecified;
+    system.systemBuilderArgs = lib.mkOption {
+      type = lib.types.attrsOf lib.types.unspecified;
       internal = true;
       default = {};
       description = ''
@@ -178,18 +175,18 @@ in
       '';
     };
 
-    system.forbiddenDependenciesRegexes = mkOption {
+    system.forbiddenDependenciesRegexes = lib.mkOption {
       default = [];
       example = ["-dev$"];
-      type = types.listOf types.str;
+      type = lib.types.listOf lib.types.str;
       description = ''
         POSIX Extended Regular Expressions that match store paths that
         should not appear in the system closure, with the exception of {option}`system.extraDependencies`, which is not checked.
       '';
     };
 
-    system.extraSystemBuilderCmds = mkOption {
-      type = types.lines;
+    system.extraSystemBuilderCmds = lib.mkOption {
+      type = lib.types.lines;
       internal = true;
       default = "";
       description = ''
@@ -197,8 +194,8 @@ in
       '';
     };
 
-    system.extraDependencies = mkOption {
-      type = types.listOf types.pathInStore;
+    system.extraDependencies = lib.mkOption {
+      type = lib.types.listOf lib.types.pathInStore;
       default = [];
       description = ''
         A list of paths that should be included in the system
@@ -210,8 +207,8 @@ in
       '';
     };
 
-    system.checks = mkOption {
-      type = types.listOf types.package;
+    system.checks = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
       default = [];
       description = ''
         Packages that are added as dependencies of the system's build, usually
@@ -223,23 +220,23 @@ in
     };
 
     system.replaceDependencies = {
-      replacements = mkOption {
+      replacements = lib.mkOption {
         default = [];
         example = lib.literalExpression "[ ({ oldDependency = pkgs.openssl; newDependency = pkgs.callPackage /path/to/openssl { }; }) ]";
-        type = types.listOf (types.submodule (
+        type = lib.types.listOf (lib.types.submodule (
           { ... }: {
             imports = [
-              (mkRenamedOptionModule [ "original" ] [ "oldDependency" ])
-              (mkRenamedOptionModule [ "replacement" ] [ "newDependency" ])
+              (lib.mkRenamedOptionModule [ "original" ] [ "oldDependency" ])
+              (lib.mkRenamedOptionModule [ "replacement" ] [ "newDependency" ])
             ];
 
-            options.oldDependency = mkOption {
-              type = types.package;
+            options.oldDependency = lib.mkOption {
+              type = lib.types.package;
               description = "The original package to override.";
             };
 
-            options.newDependency = mkOption {
-              type = types.package;
+            options.newDependency = lib.mkOption {
+              type = lib.types.package;
               description = "The replacement package.";
             };
           })
@@ -254,10 +251,10 @@ in
         '';
       };
 
-      cutoffPackages = mkOption {
+      cutoffPackages = lib.mkOption {
         default = [ config.system.build.initialRamdisk ];
-        defaultText = literalExpression "[ config.system.build.initialRamdisk ]";
-        type = types.listOf types.package;
+        defaultText = lib.literalExpression "[ config.system.build.initialRamdisk ]";
+        type = lib.types.listOf lib.types.package;
         description = ''
           Packages to which no replacements should be applied.
           The initrd is matched by default, because its structure renders the replacement process ineffective and prone to breakage.
@@ -265,13 +262,13 @@ in
       };
     };
 
-    system.name = mkOption {
-      type = types.str;
+    system.name = lib.mkOption {
+      type = lib.types.str;
       default =
         if config.networking.hostName == ""
         then "unnamed"
         else config.networking.hostName;
-      defaultText = literalExpression ''
+      defaultText = lib.literalExpression ''
         if config.networking.hostName == ""
         then "unnamed"
         else config.networking.hostName;
@@ -284,8 +281,8 @@ in
       '';
     };
 
-    system.includeBuildDependencies = mkOption {
-      type = types.bool;
+    system.includeBuildDependencies = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Whether to include the build closure of the whole system in
@@ -317,12 +314,12 @@ in
     ];
 
     system.extraSystemBuilderCmds =
-      optionalString
+      lib.optionalString
         config.system.copySystemConfiguration
         ''ln -s '${import ../../../lib/from-env.nix "NIXOS_CONFIG" <nixos-config>}' \
             "$out/configuration.nix"
         '' +
-      optionalString
+      lib.optionalString
         (config.system.forbiddenDependenciesRegexes != []) (lib.concatStringsSep "\n" (map (regex: ''
           if [[ ${regex} != "" && -n $closureInfo ]]; then
             if forbiddenPaths="$(grep -E -- "${regex}" $closureInfo/store-paths)"; then
@@ -351,7 +348,7 @@ in
       # In fact, using them runs the risk of accidentally adding unneeded paths
       # to the system closure, which defeats the purpose of the `system.checks`
       # option, as opposed to `system.extraDependencies`.
-      passedChecks = concatStringsSep " " config.system.checks;
+      passedChecks = lib.concatStringsSep " " config.system.checks;
     }
     // lib.optionalAttrs (config.system.forbiddenDependenciesRegexes != []) {
       closureInfo = pkgs.closureInfo { rootPaths = [

--- a/nixos/modules/system/boot/loader/init-script/init-script.nix
+++ b/nixos/modules/system/boot/loader/init-script/init-script.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   initScriptBuilder = pkgs.substituteAll {
@@ -31,9 +28,9 @@ in
 
     boot.loader.initScript = {
 
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Some systems require a /sbin/init script which is started.
           Or having it makes starting NixOS easier.
@@ -51,7 +48,7 @@ in
 
   ###### implementation
 
-  config = mkIf config.boot.loader.initScript.enable {
+  config = lib.mkIf config.boot.loader.initScript.enable {
 
     system.build.installBootLoader = initScriptBuilder;
 

--- a/nixos/modules/tasks/filesystems/exfat.nix
+++ b/nixos/modules/tasks/filesystems/exfat.nix
@@ -4,11 +4,8 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 {
-  config = mkIf (config.boot.supportedFilesystems.exfat or false) {
+  config = lib.mkIf (config.boot.supportedFilesystems.exfat or false) {
     system.fsPackages =
       if config.boot.kernelPackages.kernelOlder "5.7" then
         [

--- a/nixos/modules/tasks/filesystems/vboxsf.nix
+++ b/nixos/modules/tasks/filesystems/vboxsf.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   inInitrd = config.boot.initrd.supportedFilesystems.vboxsf or false;
@@ -18,11 +15,11 @@ let
 in
 
 {
-  config = mkIf (config.boot.supportedFilesystems.vboxsf or false) {
+  config = lib.mkIf (config.boot.supportedFilesystems.vboxsf or false) {
 
     system.fsPackages = [ package ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [ "vboxsf" ];
+    boot.initrd.kernelModules = lib.mkIf inInitrd [ "vboxsf" ];
 
   };
 }

--- a/nixos/modules/tasks/filesystems/vfat.nix
+++ b/nixos/modules/tasks/filesystems/vfat.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   inInitrd = config.boot.initrd.supportedFilesystems.vfat or false;
@@ -14,25 +11,25 @@ let
 in
 
 {
-  config = mkIf (config.boot.supportedFilesystems.vfat or false) {
+  config = lib.mkIf (config.boot.supportedFilesystems.vfat or false) {
 
     system.fsPackages = [
       pkgs.dosfstools
       pkgs.mtools
     ];
 
-    boot.initrd.kernelModules = mkIf inInitrd [
+    boot.initrd.kernelModules = lib.mkIf inInitrd [
       "vfat"
       "nls_cp437"
       "nls_iso8859-1"
     ];
 
-    boot.initrd.extraUtilsCommands = mkIf (inInitrd && !config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUtilsCommands = lib.mkIf (inInitrd && !config.boot.initrd.systemd.enable) ''
       copy_bin_and_libs ${pkgs.dosfstools}/sbin/dosfsck
       ln -sv dosfsck $out/bin/fsck.vfat
     '';
 
-    boot.initrd.systemd.initrdBin = mkIf inInitrd [ pkgs.dosfstools ];
+    boot.initrd.systemd.initrdBin = lib.mkIf inInitrd [ pkgs.dosfstools ];
 
   };
 }

--- a/nixos/modules/tasks/filesystems/xfs.nix
+++ b/nixos/modules/tasks/filesystems/xfs.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   inInitrd = config.boot.initrd.supportedFilesystems.xfs or false;
@@ -14,25 +11,25 @@ let
 in
 
 {
-  config = mkIf (config.boot.supportedFilesystems.xfs or false) {
+  config = lib.mkIf (config.boot.supportedFilesystems.xfs or false) {
 
     system.fsPackages = [ pkgs.xfsprogs.bin ];
 
-    boot.initrd.availableKernelModules = mkIf inInitrd [
+    boot.initrd.availableKernelModules = lib.mkIf inInitrd [
       "xfs"
       "crc32c"
     ];
 
-    boot.initrd.extraUtilsCommands = mkIf (inInitrd && !config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUtilsCommands = lib.mkIf (inInitrd && !config.boot.initrd.systemd.enable) ''
       copy_bin_and_libs ${pkgs.xfsprogs.bin}/bin/fsck.xfs
       copy_bin_and_libs ${pkgs.xfsprogs.bin}/bin/xfs_repair
     '';
 
     # Trick just to set 'sh' after the extraUtils nuke-refs.
-    boot.initrd.extraUtilsCommandsTest = mkIf (inInitrd && !config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUtilsCommandsTest = lib.mkIf (inInitrd && !config.boot.initrd.systemd.enable) ''
       sed -i -e 's,^#!.*,#!'$out/bin/sh, $out/bin/fsck.xfs
     '';
 
-    boot.initrd.systemd.initrdBin = mkIf inInitrd [ pkgs.xfsprogs.bin ];
+    boot.initrd.systemd.initrdBin = lib.mkIf inInitrd [ pkgs.xfsprogs.bin ];
   };
 }

--- a/nixos/modules/tasks/trackpoint.nix
+++ b/nixos/modules/tasks/trackpoint.nix
@@ -1,7 +1,4 @@
 { config, lib, ... }:
-
-with lib;
-
 {
   ###### interface
 
@@ -9,45 +6,45 @@ with lib;
 
     hardware.trackpoint = {
 
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Enable sensitivity and speed configuration for trackpoints.
         '';
       };
 
-      sensitivity = mkOption {
+      sensitivity = lib.mkOption {
         default = 128;
         example = 255;
-        type = types.int;
+        type = lib.types.int;
         description = ''
           Configure the trackpoint sensitivity. By default, the kernel
           configures 128.
         '';
       };
 
-      speed = mkOption {
+      speed = lib.mkOption {
         default = 97;
         example = 255;
-        type = types.int;
+        type = lib.types.int;
         description = ''
           Configure the trackpoint speed. By default, the kernel
           configures 97.
         '';
       };
 
-      emulateWheel = mkOption {
+      emulateWheel = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Enable scrolling while holding the middle mouse button.
         '';
       };
 
-      fakeButtons = mkOption {
+      fakeButtons = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Switch to "bare" PS/2 mouse support in case Trackpoint buttons are not recognized
           properly. This can happen for example on models like the L430, T450, T450s, on
@@ -55,9 +52,9 @@ with lib;
         '';
       };
 
-      device = mkOption {
+      device = lib.mkOption {
         default = "TPPS/2 IBM TrackPoint";
-        type = types.str;
+        type = lib.types.str;
         description = ''
           The device name of the trackpoint. You can check with xinput.
           Some newer devices (example x1c6) use "TPPS/2 Elan TrackPoint".
@@ -74,8 +71,8 @@ with lib;
     let
       cfg = config.hardware.trackpoint;
     in
-    mkMerge [
-      (mkIf cfg.enable {
+    lib.mkMerge [
+      (lib.mkIf cfg.enable {
         services.udev.extraRules = ''
           ACTION=="add|change", SUBSYSTEM=="input", ATTR{name}=="${cfg.device}", ATTR{device/speed}="${toString cfg.speed}", ATTR{device/sensitivity}="${toString cfg.sensitivity}"
         '';
@@ -96,7 +93,7 @@ with lib;
         };
       })
 
-      (mkIf (cfg.emulateWheel) {
+      (lib.mkIf (cfg.emulateWheel) {
         services.xserver.inputClassSections = [
           ''
             Identifier "Trackpoint Wheel Emulation"
@@ -116,7 +113,7 @@ with lib;
         ];
       })
 
-      (mkIf cfg.fakeButtons {
+      (lib.mkIf cfg.fakeButtons {
         boot.extraModprobeConfig = "options psmouse proto=bare";
       })
     ];

--- a/nixos/modules/virtualisation/digital-ocean-init.nix
+++ b/nixos/modules/virtualisation/digital-ocean-init.nix
@@ -4,7 +4,6 @@
   lib,
   ...
 }:
-with lib;
 let
   cfg = config.virtualisation.digitalOcean;
   defaultConfigFile = pkgs.writeText "digitalocean-configuration.nix" ''
@@ -17,16 +16,16 @@ let
   '';
 in
 {
-  options.virtualisation.digitalOcean.rebuildFromUserData = mkOption {
-    type = types.bool;
+  options.virtualisation.digitalOcean.rebuildFromUserData = lib.mkOption {
+    type = lib.types.bool;
     default = true;
     example = true;
     description = "Whether to reconfigure the system from Digital Ocean user data";
   };
-  options.virtualisation.digitalOcean.defaultConfigFile = mkOption {
-    type = types.path;
+  options.virtualisation.digitalOcean.defaultConfigFile = lib.mkOption {
+    type = lib.types.path;
     default = defaultConfigFile;
-    defaultText = literalMD ''
+    defaultText = lib.literalMD ''
       The default configuration imports user-data if applicable and
       `(modulesPath + "/virtualisation/digital-ocean-config.nix")`.
     '';
@@ -38,7 +37,7 @@ in
   };
 
   config = {
-    systemd.services.digitalocean-init = mkIf cfg.rebuildFromUserData {
+    systemd.services.digitalocean-init = lib.mkIf cfg.rebuildFromUserData {
       description = "Reconfigure the system from Digital Ocean userdata on startup";
       wantedBy = [ "network-online.target" ];
       unitConfig = {
@@ -65,7 +64,7 @@ in
       ];
       environment = {
         HOME = "/root";
-        NIX_PATH = concatStringsSep ":" [
+        NIX_PATH = lib.concatStringsSep ":" [
           "/nix/var/nix/profiles/per-user/root/channels/nixos"
           "nixos-config=/etc/nixos/configuration.nix"
           "/nix/var/nix/profiles/per-user/root/channels"
@@ -107,7 +106,7 @@ in
       '';
     };
   };
-  meta.maintainers = with maintainers; [
+  meta.maintainers = with lib.maintainers; [
     arianvp
     eamsden
   ];


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
