### PR TITLE
python312Packages.chex: temporarily disable tests on python 3.13

### DIFF
--- a/pkgs/development/python-modules/chex/default.nix
+++ b/pkgs/development/python-modules/chex/default.nix
@@ -18,6 +18,7 @@
   cloudpickle,
   dm-tree,
   pytestCheckHook,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
@@ -50,6 +51,11 @@ buildPythonPackage rec {
     dm-tree
     pytestCheckHook
   ];
+
+  # AttributeError: module 'unittest' has no attribute 'makeSuite'
+  # https://github.com/google-deepmind/chex/issues/371
+  # TODO: re-enable at next release
+  doCheck = pythonOlder "3.13";
 
   meta = {
     description = "Library of utilities for helping to write reliable JAX code";


### PR DESCRIPTION
## Things done

```
=========================== short test summary info ============================
FAILED chex/_src/dataclass_test.py::DataclassesTest::test_tree_flatten_with_keys - ValueError: The truth value of an array with more than one element is ambig...
FAILED chex/_src/variants_test.py::FailedTestsTest::test_useful_errors - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::FailedTestsTest::test_useful_failures - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::OneFailedVariantTest::test_useful_failure - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::WrongBaseClassTest::test_wrong_base_class - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::BaseClassesTest::test_inheritance_parameterized - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::BaseClassesTest::test_inheritance_variants - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::BaseClassesTest::test_inheritance_variants_and_parameterized - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::VariantsTestCaseWithParameterizedTest::test_should_pass - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::UnusedVariantTest::test_unused_variant - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::UnknownVariantArgumentsTest::test_unknown_argument - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::VariantTypesTest::test_var_type_fetch - AttributeError: module 'unittest' has no attribute 'makeSuite'
FAILED chex/_src/variants_test.py::CountVariantsTest::test_counters - AttributeError: module 'unittest' has no attribute 'makeSuite'
============ 13 failed, 554 passed, 85 skipped in 84.20s (0:01:24) =============
```

https://github.com/google-deepmind/chex/issues/371
https://github.com/google-deepmind/chex/pull/372

cc @ndl

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
