### PR TITLE
umu-launcher[-unwrapped]: init at 1.1.4

### DIFF
--- a/pkgs/by-name/um/umu-launcher-unwrapped/no-umu-version-json.patch
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/no-umu-version-json.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index b82053d..37db8c9 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -50,7 +50,7 @@ fix_shebangs:
+ umu/umu_version.json: umu/umu_version.json.in
+ 	$(info :: Updating $(@) )
+ 	cp $(<) $(<).tmp
+-	sed 's|##UMU_VERSION##|$(shell git describe --always --long --tags)|g' -i $(<).tmp
++	sed 's|##UMU_VERSION##|@version@|g' -i $(<).tmp
+ 	mv $(<).tmp $(@)
+ 
+ .PHONY: version

--- a/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
+++ b/pkgs/by-name/um/umu-launcher-unwrapped/package.nix
@@ -1,0 +1,70 @@
+{
+  python3Packages,
+  fetchFromGitHub,
+  lib,
+  bash,
+  hatch,
+  scdoc,
+  replaceVars,
+  fetchpatch2,
+}:
+python3Packages.buildPythonPackage rec {
+  pname = "umu-launcher-unwrapped";
+  version = "1.1.4";
+
+  src = fetchFromGitHub {
+    owner = "Open-Wine-Components";
+    repo = "umu-launcher";
+    tag = version;
+    hash = "sha256-TOsVK6o2V8D7CLzVOkLs8AClrZmlVQTfeii32ZIQCu4=";
+  };
+
+  # Both patches can be safely removed with the next release
+  patches = [
+    # Patch to avoid running `git describe`
+    # Fixed by https://github.com/Open-Wine-Components/umu-launcher/pull/289 upstream
+    (replaceVars ./no-umu-version-json.patch { inherit version; })
+    # Patch to use PREFIX in the installer call
+    (fetchpatch2 {
+      url = "https://github.com/Open-Wine-Components/umu-launcher/commit/602a2f84a05a63f7b1b1c4d8ca85d99fdaec2cd2.diff";
+      hash = "sha256-BMinTXr926V3HlzHHabxHKvy8quEvxsZKu1hoTGQT00=";
+    })
+  ];
+
+  nativeBuildInputs = [
+    python3Packages.build
+    hatch
+    scdoc
+    python3Packages.installer
+  ];
+
+  pythonPath = [
+    python3Packages.filelock
+    python3Packages.xlib
+  ];
+
+  pyproject = false;
+  configureScript = "./configure.sh";
+
+  makeFlags = [
+    "PYTHONDIR=$(PREFIX)/${python3Packages.python.sitePackages}"
+    "PYTHON_INTERPRETER=${lib.getExe python3Packages.python}"
+    # Override RELEASEDIR to avoid running `git describe`
+    "RELEASEDIR=${pname}-${version}"
+    "SHELL_INTERPRETER=${lib.getExe bash}"
+  ];
+
+  meta = {
+    description = "Unified launcher for Windows games on Linux using the Steam Linux Runtime and Tools";
+    changelog = "https://github.com/Open-Wine-Components/umu-launcher/releases/tag/${version}";
+    homepage = "https://github.com/Open-Wine-Components/umu-launcher";
+    license = lib.licenses.gpl3;
+    mainProgram = "umu-run";
+    maintainers = with lib.maintainers; [
+      diniamo
+      MattSturgeon
+      fuzen
+    ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/um/umu-launcher/package.nix
+++ b/pkgs/by-name/um/umu-launcher/package.nix
@@ -1,0 +1,19 @@
+{
+  buildFHSEnv,
+  lib,
+  umu-launcher-unwrapped,
+}:
+buildFHSEnv {
+  pname = "umu-launcher";
+  inherit (umu-launcher-unwrapped) version meta;
+
+  targetPkgs = pkgs: [ pkgs.umu-launcher-unwrapped ];
+
+  executableName = umu-launcher-unwrapped.meta.mainProgram;
+  runScript = lib.getExe umu-launcher-unwrapped;
+
+  extraInstallCommands = ''
+    ln -s ${umu-launcher-unwrapped}/lib $out/lib
+    ln -s ${umu-launcher-unwrapped}/share $out/share
+  '';
+}


### PR DESCRIPTION
Closes #297662

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
