### PR TITLE
cgdb: fix compilation with GCC14

### DIFF
--- a/pkgs/by-name/cg/cgdb/gcc14.patch
+++ b/pkgs/by-name/cg/cgdb/gcc14.patch
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index c564dc1..e13c67c 100755
+--- a/configure
++++ b/configure
+@@ -6512,7 +6512,7 @@ else
+ #include <stdlib.h>
+ #include <readline/readline.h>
+ 
+-main()
++int main()
+ {
+ 	FILE *fp;
+ 	fp = fopen("conftest.rlv", "w");

--- a/pkgs/by-name/cg/cgdb/package.nix
+++ b/pkgs/by-name/cg/cgdb/package.nix
@@ -2,9 +2,9 @@
   lib,
   stdenv,
   fetchurl,
+  flex,
   ncurses,
   readline,
-  flex,
   texinfo,
 }:
 
@@ -20,9 +20,14 @@ stdenv.mkDerivation rec {
   buildInputs = [
     ncurses
     readline
+  ];
+
+  nativeBuildInputs = [
     flex
     texinfo
   ];
+
+  strictDeps = true;
 
   meta = with lib; {
     description = "Curses interface to gdb";

--- a/pkgs/by-name/cg/cgdb/package.nix
+++ b/pkgs/by-name/cg/cgdb/package.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-DTi1JNN3JXsQa61thW2K4zBBQOHuJAhTQ+bd8bZYEfE=";
   };
 
+  patches = [
+    ./gcc14.patch
+  ];
+
   buildInputs = [
     ncurses
     readline

--- a/pkgs/by-name/cg/cgdb/package.nix
+++ b/pkgs/by-name/cg/cgdb/package.nix
@@ -8,12 +8,12 @@
   texinfo,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "cgdb";
   version = "0.8.0";
 
   src = fetchurl {
-    url = "https://cgdb.me/files/${pname}-${version}.tar.gz";
+    url = "https://cgdb.me/files/cgdb-${finalAttrs.version}.tar.gz";
     sha256 = "sha256-DTi1JNN3JXsQa61thW2K4zBBQOHuJAhTQ+bd8bZYEfE=";
   };
 
@@ -40,4 +40,4 @@ stdenv.mkDerivation rec {
     platforms = with platforms; linux ++ cygwin;
     maintainers = [ ];
   };
-}
+})


### PR DESCRIPTION
This pull request adapts cgdb to compile with GCC14.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
