### PR TITLE
kbd: 2.6.4 -> 2.7.1

### DIFF
--- a/pkgs/by-name/kb/kbd/package.nix
+++ b/pkgs/by-name/kb/kbd/package.nix
@@ -18,11 +18,11 @@
 
 stdenv.mkDerivation rec {
   pname = "kbd";
-  version = "2.6.4";
+  version = "2.7.1";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/kbd/${pname}-${version}.tar.xz";
-    sha256 = "sha256-UZ+NCHrsyn4KM80IS++SwGbrGXMWZmU9zHDJ1xqkCSY=";
+    sha256 = "sha256-8WfYmdkrVszxL29JNVFz+ThwqV8V2K7r9f3NKKYhrKg=";
   };
 
   # vlock is moved into its own output, since it depends on pam. This
@@ -58,10 +58,10 @@ stdenv.mkDerivation rec {
 
     # Fix paths to decompressors. Trailing space to avoid replacing `xz` in `".xz"`.
     substituteInPlace src/libkbdfile/kbdfile.c \
-      --replace 'gzip '  '${gzip}/bin/gzip ' \
-      --replace 'bzip2 ' '${bzip2.bin}/bin/bzip2 ' \
-      --replace 'xz '    '${xz.bin}/bin/xz ' \
-      --replace 'zstd '  '${zstd.bin}/bin/zstd '
+      --replace-fail 'gzip '  '${gzip}/bin/gzip ' \
+      --replace-fail 'bzip2 ' '${bzip2.bin}/bin/bzip2 ' \
+      --replace-fail 'xz '    '${xz.bin}/bin/xz ' \
+      --replace-fail 'zstd '  '${zstd.bin}/bin/zstd '
 
     sed -i '
       1i prefix:=$(vlock)

--- a/pkgs/by-name/kb/kbd/search-paths.patch
+++ b/pkgs/by-name/kb/kbd/search-paths.patch
@@ -41,7 +41,7 @@ Without this patch, kbd will only look inside
  };
 @@ -55,5 +58,6 @@ static const char *const unisuffixes[] = {
  /* hide partial fonts a bit - loading a single one is a bad idea */
- const char *const partfontdirpath[]  = {
+ static const char *const partfontdirpath[]  = {
 +	"/etc/kbd/" FONTDIR "/" PARTIALDIR "/",
  	DATADIR "/" FONTDIR "/" PARTIALDIR "/",
  	NULL
@@ -68,13 +68,14 @@ Without this patch, kbd will only look inside
 --- a/src/setfont.c
 +++ b/src/setfont.c
 @@ -48,8 +48,8 @@ usage(void)
- 	                    "    -v         Be verbose.\n"
- 	                    "    -C <cons>  Indicate console device to be used.\n"
- 	                    "    -V         Print version and exit.\n"
--	                    "Files are loaded from the current directory or %s/*/.\n"),
--	        DATADIR);
-+	                    "Files are loaded from the current directory or %s/*/ or %s/*/.\n"),
-+	        DATADIR, "/etc/kbd");
- 	exit(EX_USAGE);
+ 		  "\n"
+-		  "Files are loaded from the %s/*/.\n"),
+-		DATADIR);
++		  "Files are loaded from the %s/*/ or %s/*/.\n"),
++		DATADIR, "/etc/kbd");
+ 
+ 	print_report_bugs();
+ 
+ 	exit(retcode);
  }
  


### PR DESCRIPTION
Changes:
- https://git.kernel.org/pub/scm/linux/kernel/git/legion/kbd.git/tag/?h=v2.7
- https://git.kernel.org/pub/scm/linux/kernel/git/legion/kbd.git/tag/?h=v2.7.1


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
