### PR TITLE
avro-cpp: 1.11.3 -> 1.12.0, enable tests, libserdes: fix build with avro-cpp 1.12.0

### DIFF
--- a/pkgs/by-name/av/avro-cpp/0001-get-rid-of-fmt-fetchcontent.patch
+++ b/pkgs/by-name/av/avro-cpp/0001-get-rid-of-fmt-fetchcontent.patch
@@ -1,0 +1,21 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 19059a41b..6e3ae0ad7 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -82,15 +82,7 @@ endif ()
+ find_package (Boost 1.38 REQUIRED
+     COMPONENTS filesystem iostreams program_options regex system)
+ 
+-include(FetchContent)
+-FetchContent_Declare(
+-        fmt
+-        GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
+-        GIT_TAG         10.2.1
+-        GIT_PROGRESS    TRUE
+-        USES_TERMINAL_DOWNLOAD TRUE
+-)
+-FetchContent_MakeAvailable(fmt)
++find_package(fmt REQUIRED)
+ 
+ find_package(Snappy)
+ if (SNAPPY_FOUND)

--- a/pkgs/by-name/av/avro-cpp/package.nix
+++ b/pkgs/by-name/av/avro-cpp/package.nix
@@ -2,41 +2,34 @@
   lib,
   stdenv,
   fetchurl,
-  fetchpatch,
   cmake,
   boost,
   python3,
+  fmt,
 }:
 
 stdenv.mkDerivation rec {
   pname = "avro-c++";
-  version = "1.11.3";
+  version = "1.12.0";
 
   src = fetchurl {
     url = "mirror://apache/avro/avro-${version}/cpp/avro-cpp-${version}.tar.gz";
-    hash = "sha256-+6JCrvd+yBnQdWH8upN1FyGVbejQyujh8vMAtUszG64=";
+    hash = "sha256-8u33cSanWw7BrRZncr4Fg1HOo9dESL5+LO8gBQwPmKs=";
   };
+
   patches = [
-    # This patch fixes boost compatibility and can be removed when
-    # upgrading beyond 1.11.3 https://github.com/apache/avro/pull/1920
-    (fetchpatch {
-      name = "fix-boost-compatibility.patch";
-      url = "https://github.com/apache/avro/commit/016323828f147f185d03f50d2223a2f50bfafce1.patch";
-      hash = "sha256-hP/5J2JzSplMvg8EjEk98Vim8DfTyZ4hZ/WGiVwvM1A=";
-    })
+    ./0001-get-rid-of-fmt-fetchcontent.patch
   ];
-  patchFlags = [ "-p3" ];
 
   nativeBuildInputs = [
     cmake
     python3
   ];
-  buildInputs = [ boost ];
 
-  preConfigure = ''
-    substituteInPlace test/SchemaTests.cc --replace "BOOST_CHECKPOINT" "BOOST_TEST_CHECKPOINT"
-    substituteInPlace test/buffertest.cc --replace "BOOST_MESSAGE" "BOOST_TEST_MESSAGE"
-  '';
+  propagatedBuildInputs = [
+    boost
+    fmt
+  ];
 
   meta = {
     description = "C++ library which implements parts of the Avro Specification";

--- a/pkgs/by-name/av/avro-cpp/package.nix
+++ b/pkgs/by-name/av/avro-cpp/package.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     fmt
   ];
 
+  doCheck = true;
+
   meta = {
     description = "C++ library which implements parts of the Avro Specification";
     mainProgram = "avrogencpp";

--- a/pkgs/by-name/av/avro-cpp/package.nix
+++ b/pkgs/by-name/av/avro-cpp/package.nix
@@ -6,6 +6,7 @@
   boost,
   python3,
   fmt,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation rec {
@@ -32,6 +33,13 @@ stdenv.mkDerivation rec {
   ];
 
   doCheck = true;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/avrogencpp";
+  versionCheckProgramArg = [ "--version" ];
 
   meta = {
     description = "C++ library which implements parts of the Avro Specification";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This update gets pretty ugly because of the new dependency on fmt, which needs some patching and finagling.

Release notes: https://github.com/apache/avro/releases/tag/release-1.12.0.


Resolves https://github.com/NixOS/nixpkgs/issues/368981.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
