### PR TITLE
k2pdfopt: disable tesseract support

### DIFF
--- a/pkgs/by-name/k2/k2pdfopt/package.nix
+++ b/pkgs/by-name/k2/k2pdfopt/package.nix
@@ -21,12 +21,15 @@
   mupdf,
   enableDJVU ? true,
   djvulibre,
-  enableGOCR ? false,
-  gocr, # Disabled by default due to crashes
-  enableTesseract ? true,
+  enableGOCR ? false, # Disabled by default due to crashes
+  gocr,
+  # Tesseract support is currently broken
+  # See: https://github.com/NixOS/nixpkgs/issues/368349
+  enableTesseract ? false,
   leptonica,
   tesseract5,
   opencl-headers,
+  fetchDebianPatch,
 }:
 
 # k2pdfopt is a pain to package. It requires modified versions of mupdf,
@@ -88,6 +91,20 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-Fix-CMakeLists.patch
+    (fetchDebianPatch {
+      inherit pname;
+      version = "${version}+ds";
+      debianRevision = "3.1";
+      patch = "0007-k2pdfoptlib-k2ocr.c-conditionally-enable-tesseract-r.patch";
+      hash = "sha256-uJ9Gpyq64n/HKqo0hkQ2dnkSLCKNN4DedItPGzHfqR8=";
+    })
+    (fetchDebianPatch {
+      inherit pname;
+      version = "${version}+ds";
+      debianRevision = "3.1";
+      patch = "0009-willuslib-CMakeLists.txt-conditionally-add-source-fi.patch";
+      hash = "sha256-cBSlcuhsw4YgAJtBJkKLW6u8tK5gFwWw7pZEJzVMJDE=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/by-name/k2/k2pdfopt/package.nix
+++ b/pkgs/by-name/k2/k2pdfopt/package.nix
@@ -26,8 +26,9 @@
   # Tesseract support is currently broken
   # See: https://github.com/NixOS/nixpkgs/issues/368349
   enableTesseract ? false,
-  leptonica,
   tesseract5,
+  enableLeptonica ? true,
+  leptonica,
   opencl-headers,
   fetchDebianPatch,
 }:
@@ -256,10 +257,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional enableMuPDF mupdf_modded
     ++ lib.optional enableDJVU djvulibre
     ++ lib.optional enableGOCR gocr
-    ++ lib.optionals enableTesseract [
-      leptonica_modded
-      tesseract_modded
-    ];
+    ++ lib.optional enableTesseract tesseract_modded
+    ++ lib.optional (enableLeptonica || enableTesseract) leptonica_modded;
 
   dontUseCmakeBuildDir = true;
 


### PR DESCRIPTION
- **k2pdfopt: disable tesseract-support**
fixes: #368349

Turns out k2pdfopt is quite broken. I've tried to get tesseract to work, but couldn't figure it out. This is now in line
with arch and debian, both of which also disable support for it.
Doesn't inspire confidence that no ones able to get the compile to work, but the precompiled binaries work.
Debian contains another 9 patches for various things, most of which im not sure if we need or not, so I've excluded them for
now.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
