### PR TITLE
obs-studio-plugins.obs-transition-table: fix build failure

### DIFF
--- a/pkgs/applications/video/obs-studio/plugins/obs-transition-table.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-transition-table.nix
@@ -9,23 +9,19 @@
 
 stdenv.mkDerivation rec {
   pname = "obs-transition-table";
-  version = "0.2.7";
+  version = "0.2.7-unstable-2024-11-27";
 
   src = fetchFromGitHub {
     owner = "exeldro";
     repo = "obs-transition-table";
-    rev = version;
-    sha256 = "sha256-rGF7hugC5ybpZBAIIXDiy3YDooMawf/yYX2YucQm2/U=";
+    rev = "976fe236dac7082b6c953f950fcb9e50495ce624";
+    sha256 = "sha256-TPRqKjEXdvjv+RfHTaeeO4GHur2j/+onehcu0I/HdD0=";
   };
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     obs-studio
     qtbase
-  ];
-
-  cmakeFlags = [
-    "-DBUILD_OUT_OF_TREE=On"
   ];
 
   dontWrapQtApps = true;


### PR DESCRIPTION
Build from master branch that fixes deprecation warnings which were causing the build to fail.
- Fixes #361849

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>obs-studio-plugins.obs-transition-table</li>
  </ul>
</details>