### PR TITLE
python312Packages.xbox-webapi: disable failing test

### DIFF
--- a/pkgs/development/python-modules/xbox-webapi/default.nix
+++ b/pkgs/development/python-modules/xbox-webapi/default.nix
@@ -44,6 +44,10 @@ buildPythonPackage rec {
     respx
   ];
 
+  disabledTests = [
+    "test_import" # fails due to line splitting differences
+  ];
+
   meta = with lib; {
     changelog = "https://github.com/OpenXbox/xbox-webapi-python/blob/${src.rev}/CHANGELOG.md";
     description = "Library to authenticate with Windows Live/Xbox Live and use their API";


### PR DESCRIPTION
Test fails due to slight difference in newline distribution. Seems safe to disable

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).