### PR TITLE
nixos: hardware.pulseaudio → services.pulseaudio

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -135,6 +135,8 @@
 
 - `programs.less.lessopen` is now null by default. To restore the previous behaviour, set it to `''|${lib.getExe' pkgs.lesspipe "lesspipe.sh"} %s''`.
 
+- `hardware.pulseaudio` has been renamed to `services.pulseaudio`.  The deprecated option names will continue to work, but causes a warning.
+
 - `minetest` has been renamed to `luanti` to match the upstream name change but aliases have been added. The new name hasn't resulted in many changes as of yet but older references to minetest should be sunset. See the [new name announcement](https://blog.minetest.net/2024/10/13/Introducing-Our-New-Name/) for more details.
 
 - `racket_7_9` has been removed, as it is insecure. It is recommended to use Racket 8 instead.

--- a/nixos/modules/installer/tools/tools.nix
+++ b/nixos/modules/installer/tools/tools.nix
@@ -96,7 +96,7 @@ let
       # services.printing.enable = true;
 
       # Enable sound.
-      # hardware.pulseaudio.enable = true;
+      # services.pulseaudio.enable = true;
       # OR
       # services.pipewire = {
       #   enable = true;

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -22,7 +22,6 @@
   ./config/nix-remote-build.nix
   ./config/nsswitch.nix
   ./config/power-management.nix
-  ./config/pulseaudio.nix
   ./config/qt.nix
   ./config/resolvconf.nix
   ./config/shells-environment.nix
@@ -406,6 +405,7 @@
   ./services/audio/mympd.nix
   ./services/audio/navidrome.nix
   ./services/audio/networkaudiod.nix
+  ./services/audio/pulseaudio.nix
   ./services/audio/roon-bridge.nix
   ./services/audio/roon-server.nix
   ./services/audio/slimserver.nix

--- a/nixos/modules/programs/steam.nix
+++ b/nixos/modules/programs/steam.nix
@@ -197,7 +197,7 @@ in {
     services.displayManager.sessionPackages = lib.mkIf cfg.gamescopeSession.enable [ gamescopeSessionFile ];
 
     # enable 32bit pulseaudio/pipewire support if needed
-    hardware.pulseaudio.support32Bit = config.hardware.pulseaudio.enable;
+    services.pulseaudio.support32Bit = config.services.pulseaudio.enable;
     services.pipewire.alsa.support32Bit = config.services.pipewire.alsa.enable;
 
     hardware.steam-hardware.enable = true;

--- a/nixos/modules/services/audio/jack.nix
+++ b/nixos/modules/services/audio/jack.nix
@@ -258,7 +258,7 @@ in
           {
             User = "jackaudio";
             SupplementaryGroups = lib.optional (
-              config.hardware.pulseaudio.enable && !config.hardware.pulseaudio.systemWide
+              config.services.pulseaudio.enable && !config.services.pulseaudio.systemWide
             ) "users";
             ExecStart = "${cfg.jackd.package}/bin/jackd ${lib.escapeShellArgs cfg.jackd.extraOptions}";
             LimitRTPRIO = 99;

--- a/nixos/modules/services/audio/pulseaudio.nix
+++ b/nixos/modules/services/audio/pulseaudio.nix
@@ -6,7 +6,7 @@
 }:
 let
 
-  cfg = config.hardware.pulseaudio;
+  cfg = config.services.pulseaudio;
 
   hasZeroconf =
     let
@@ -90,10 +90,13 @@ let
 
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule [ "hardware" "pulseaudio" ] [ "services" "pulseaudio" ])
+  ];
 
   options = {
 
-    hardware.pulseaudio = {
+    services.pulseaudio = {
       enable = lib.mkOption {
         type = lib.types.bool;
         default = false;
@@ -239,13 +242,13 @@ in
           "libao.conf".source = pkgs.writeText "libao.conf" "default_driver=pulse";
         };
 
-        hardware.pulseaudio.configFile = lib.mkDefault "${lib.getBin overriddenPackage}/etc/pulse/default.pa";
+        services.pulseaudio.configFile = lib.mkDefault "${lib.getBin overriddenPackage}/etc/pulse/default.pa";
 
         # Disable flat volumes to enable relative ones
-        hardware.pulseaudio.daemon.config.flat-volumes = lib.mkDefault "no";
+        services.pulseaudio.daemon.config.flat-volumes = lib.mkDefault "no";
 
         # Upstream defaults to speex-float-1 which results in audible artifacts
-        hardware.pulseaudio.daemon.config.resample-method = lib.mkDefault "speex-float-5";
+        services.pulseaudio.daemon.config.resample-method = lib.mkDefault "speex-float-5";
 
         # Allow PulseAudio to get realtime priority using rtkit.
         security.rtkit.enable = true;
@@ -257,7 +260,7 @@ in
       }
 
       (lib.mkIf (cfg.extraModules != [ ]) {
-        hardware.pulseaudio.daemon.config.dl-search-path =
+        services.pulseaudio.daemon.config.dl-search-path =
           let
             overriddenModules = builtins.map (
               drv: drv.override { pulseaudio = overriddenPackage; }

--- a/nixos/modules/services/desktop-managers/lomiri.nix
+++ b/nixos/modules/services/desktop-managers/lomiri.nix
@@ -146,7 +146,7 @@ in
               ayatana-indicator-power
             ]
             ++ lib.optionals config.hardware.bluetooth.enable [ ayatana-indicator-bluetooth ]
-            ++ lib.optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
+            ++ lib.optionals (config.services.pulseaudio.enable || config.services.pipewire.pulse.enable) [
               ayatana-indicator-sound
             ]
           )

--- a/nixos/modules/services/desktop-managers/plasma6.nix
+++ b/nixos/modules/services/desktop-managers/plasma6.nix
@@ -207,7 +207,7 @@ in
         pkgs.obexftp
       ]
       ++ lib.optional config.networking.networkmanager.enable plasma-nm
-      ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
+      ++ lib.optional config.services.pulseaudio.enable plasma-pa
       ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
       ++ lib.optional config.powerManagement.enable powerdevil
       ++ lib.optional config.services.printing.enable print-manager

--- a/nixos/modules/services/desktops/pipewire/pipewire.nix
+++ b/nixos/modules/services/desktops/pipewire/pipewire.nix
@@ -347,8 +347,8 @@ in
   config = mkIf cfg.enable {
     assertions = [
       {
-        assertion = cfg.audio.enable -> !config.hardware.pulseaudio.enable;
-        message = "Using PipeWire as the sound server conflicts with PulseAudio. This option requires `hardware.pulseaudio.enable` to be set to false";
+        assertion = cfg.audio.enable -> !config.services.pulseaudio.enable;
+        message = "Using PipeWire as the sound server conflicts with PulseAudio. This option requires `services.pulseaudio.enable` to be set to false";
       }
       {
         assertion = cfg.jack.enable -> !config.services.jack.jackd.enable;

--- a/nixos/modules/services/networking/shairport-sync.nix
+++ b/nixos/modules/services/networking/shairport-sync.nix
@@ -84,7 +84,7 @@ in
         createHome = true;
         home = "/var/lib/shairport-sync";
         group = cfg.group;
-        extraGroups = [ "audio" ] ++ optional (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) "pulse";
+        extraGroups = [ "audio" ] ++ optional (config.services.pulseaudio.enable || config.services.pipewire.pulse.enable) "pulse";
       };
       groups.${cfg.group} = {};
     };

--- a/nixos/modules/services/networking/xrdp.nix
+++ b/nixos/modules/services/networking/xrdp.nix
@@ -135,7 +135,7 @@ in
     (mkIf cfg.audio.enable {
       environment.systemPackages = [ cfg.audio.package ];  # needed for autostart
 
-      hardware.pulseaudio.extraModules = [ cfg.audio.package ];
+      services.pulseaudio.extraModules = [ cfg.audio.package ];
     })
 
     (mkIf cfg.enable {

--- a/nixos/modules/services/x11/desktop-managers/plasma5.nix
+++ b/nixos/modules/services/x11/desktop-managers/plasma5.nix
@@ -292,7 +292,7 @@ in
         # Optional hardware support features
         ++ lib.optionals config.hardware.bluetooth.enable [ bluedevil bluez-qt pkgs.openobex pkgs.obexftp ]
         ++ lib.optional config.networking.networkmanager.enable plasma-nm
-        ++ lib.optional config.hardware.pulseaudio.enable plasma-pa
+        ++ lib.optional config.services.pulseaudio.enable plasma-pa
         ++ lib.optional config.services.pipewire.pulse.enable plasma-pa
         ++ lib.optional config.powerManagement.enable powerdevil
         ++ lib.optional config.services.colord.enable pkgs.colord-kde
@@ -477,7 +477,7 @@ in
         }
         {
           # The user interface breaks without pulse
-          assertion = config.hardware.pulseaudio.enable || (config.services.pipewire.enable && config.services.pipewire.pulse.enable);
+          assertion = config.services.pulseaudio.enable || (config.services.pipewire.enable && config.services.pipewire.pulse.enable);
           message = "Plasma Mobile requires a Pulseaudio compatible sound server.";
         }
       ];

--- a/nixos/modules/services/x11/desktop-managers/xfce.nix
+++ b/nixos/modules/services/x11/desktop-managers/xfce.nix
@@ -132,7 +132,7 @@ in
     ] # TODO: NetworkManager doesn't belong here
       ++ optional config.networking.networkmanager.enable networkmanagerapplet
       ++ optional config.powerManagement.enable xfce.xfce4-power-manager
-      ++ optionals (config.hardware.pulseaudio.enable || config.services.pipewire.pulse.enable) [
+      ++ optionals (config.services.pulseaudio.enable || config.services.pipewire.pulse.enable) [
         pavucontrol
         # volume up/down keys support:
         # xfce4-pulseaudio-plugin includes all the functionalities of xfce4-volumed-pulse

--- a/nixos/modules/services/x11/display-managers/gdm.nix
+++ b/nixos/modules/services/x11/display-managers/gdm.nix
@@ -196,7 +196,7 @@ in
       [
         "d /run/gdm/.config 0711 gdm gdm"
       ]
-      ++ lib.optionals config.hardware.pulseaudio.enable [
+      ++ lib.optionals config.services.pulseaudio.enable [
         "d /run/gdm/.config/pulse 0711 gdm gdm"
         "L+ /run/gdm/.config/pulse/${pulseConfig.name} - - - - ${pulseConfig}"
       ]

--- a/nixos/modules/services/x11/display-managers/xpra.nix
+++ b/nixos/modules/services/x11/display-managers/xpra.nix
@@ -251,8 +251,8 @@ in
 
     environment.systemPackages = [pkgs.xpra];
 
-    hardware.pulseaudio.enable = mkDefault cfg.pulseaudio;
-    hardware.pulseaudio.systemWide = mkDefault cfg.pulseaudio;
+    services.pulseaudio.enable = mkDefault cfg.pulseaudio;
+    services.pulseaudio.systemWide = mkDefault cfg.pulseaudio;
   };
 
 }

--- a/nixos/tests/mpd.nix
+++ b/nixos/tests/mpd.nix
@@ -99,7 +99,7 @@ import ./make-test-python.nix (
             musicService = musicService { inherit (defaultMpdCfg) user group musicDirectory; };
           })
           {
-            hardware.pulseaudio = {
+            services.pulseaudio = {
               enable = true;
               systemWide = true;
               tcp.enable = true;

--- a/nixos/tests/pulseaudio.nix
+++ b/nixos/tests/pulseaudio.nix
@@ -38,7 +38,7 @@ let
 
           {
             imports = [ ./common/wayland-cage.nix ];
-            hardware.pulseaudio =
+            services.pulseaudio =
               {
                 enable = true;
                 support32Bit = true;

--- a/nixos/tests/xrdp-with-audio-pulseaudio.nix
+++ b/nixos/tests/xrdp-with-audio-pulseaudio.nix
@@ -27,7 +27,7 @@ import ./make-test-python.nix (
           services.xrdp.audio.enable = true;
           services.xrdp.defaultWindowManager = "${pkgs.xterm}/bin/xterm";
 
-          hardware.pulseaudio = {
+          services.pulseaudio = {
             enable = true;
           };
 
@@ -65,7 +65,7 @@ import ./make-test-python.nix (
           services.xrdp.audio.enable = true;
           services.xrdp.defaultWindowManager = "${pkgs.icewm}/bin/icewm";
 
-          hardware.pulseaudio = {
+          services.pulseaudio = {
             enable = true;
           };
         };

--- a/pkgs/development/python-modules/soundcard/test.nix
+++ b/pkgs/development/python-modules/soundcard/test.nix
@@ -6,8 +6,8 @@
     {
       environment.systemPackages = [ (pkgs.python3.withPackages (ps: [ ps.soundcard ])) ];
 
-      hardware.pulseaudio.enable = true;
-      hardware.pulseaudio.systemWide = true;
+      services.pulseaudio.enable = true;
+      services.pulseaudio.systemWide = true;
 
       virtualisation.qemu.options = [
         "-device virtio-sound-pci,audiodev=my_audiodev"


### PR DESCRIPTION
Rename the `hardware.pulseaudio` options to `services.pulseaudio`.

This is more consistent, considering:
- `pulseaudio` can be used without local audio hardware, nor is it necessary to use said hardware ;
- `jack` and `pipewire` are under `services`.


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - `nixosTests.pulseaudio`
  - `python3Packages.soundcard.tests`
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
