### PR TITLE
dprint-plugins: init

### DIFF
--- a/pkgs/by-name/dp/dprint/plugins/default.nix
+++ b/pkgs/by-name/dp/dprint/plugins/default.nix
@@ -1,0 +1,44 @@
+{ lib, fetchurl }:
+let
+  mkDprintPlugin =
+    {
+      url,
+      hash,
+      pname,
+      version,
+      description,
+      initConfig,
+      updateUrl,
+      license ? lib.licenses.mit,
+      maintainers ? [ lib.maintainers.phanirithvij ],
+    }:
+    fetchurl {
+      inherit hash url;
+      name = "${pname}-${version}.wasm";
+      meta = {
+        inherit
+          description
+          license
+          maintainers
+          ;
+      };
+      passthru = {
+        updateScript = ./update-plugins.py;
+        inherit initConfig updateUrl;
+      };
+    };
+  inherit (lib)
+    filterAttrs
+    mapAttrs'
+    nameValuePair
+    removeSuffix
+    ;
+  files = filterAttrs (
+    name: type: type == "regular" && name != "default.nix" && lib.hasSuffix ".nix" name
+  ) (builtins.readDir ./.);
+  plugins = mapAttrs' (
+    name: _:
+    nameValuePair (removeSuffix ".nix" name) (import (./. + "/${name}") { inherit mkDprintPlugin; })
+  ) files;
+in
+plugins // { inherit mkDprintPlugin; }

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-biome.nix
@@ -1,0 +1,21 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "Biome (JS/TS) wrapper plugin.";
+  hash = "sha256-+zY+myazFAUxeNuWFigkvF4zpKBs+jzVYQT09jRWFKI=";
+  initConfig = {
+    configExcludes = [ "**/node_modules" ];
+    configKey = "biome";
+    fileExtensions = [
+      "ts"
+      "tsx"
+      "js"
+      "jsx"
+      "cjs"
+      "mjs"
+    ];
+  };
+  pname = "dprint-plugin-biome";
+  updateUrl = "https://plugins.dprint.dev/dprint/biome/latest.json";
+  url = "https://plugins.dprint.dev/biome-0.7.1.wasm";
+  version = "0.7.1";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-dockerfile.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-dockerfile.nix
@@ -1,0 +1,14 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "Dockerfile code formatter.";
+  hash = "sha256-gsfMLa4zw8AblOS459ZS9OZrkGCQi5gBN+a3hvOsspk=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "dockerfile";
+    fileExtensions = [ "dockerfile" ];
+  };
+  pname = "dprint-plugin-dockerfile";
+  updateUrl = "https://plugins.dprint.dev/dprint/dockerfile/latest.json";
+  url = "https://plugins.dprint.dev/dockerfile-0.3.2.wasm";
+  version = "0.3.2";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-json.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-json.nix
@@ -1,0 +1,14 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "JSON/JSONC code formatter.";
+  hash = "sha256-Sw+HkUb4K2wrLuQRZibr8gOCR3Rz36IeId4Vd4LijmY=";
+  initConfig = {
+    configExcludes = [ "**/*-lock.json" ];
+    configKey = "json";
+    fileExtensions = [ "json" ];
+  };
+  pname = "dprint-plugin-json";
+  updateUrl = "https://plugins.dprint.dev/dprint/json/latest.json";
+  url = "https://plugins.dprint.dev/json-0.19.4.wasm";
+  version = "0.19.4";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-jupyter.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-jupyter.nix
@@ -1,0 +1,14 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "Jupyter notebook code block formatter.";
+  hash = "sha256-877CEZbMlj9cHkFtl16XCnan37SeEGUL3BHaUKUv8S4=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "jupyter";
+    fileExtensions = [ "ipynb" ];
+  };
+  pname = "dprint-plugin-jupyter";
+  updateUrl = "https://plugins.dprint.dev/dprint/jupyter/latest.json";
+  url = "https://plugins.dprint.dev/jupyter-0.1.5.wasm";
+  version = "0.1.5";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-markdown.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-markdown.nix
@@ -1,0 +1,14 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "Markdown code formatter.";
+  hash = "sha256-PIEN9UnYC8doJpdzS7M6QEHQNQtj7WwXAgvewPsTjqs=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "markdown";
+    fileExtensions = [ "md" ];
+  };
+  pname = "dprint-plugin-markdown";
+  updateUrl = "https://plugins.dprint.dev/dprint/markdown/latest.json";
+  url = "https://plugins.dprint.dev/markdown-0.17.8.wasm";
+  version = "0.17.8";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-ruff.nix
@@ -1,0 +1,17 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "Ruff (Python) wrapper plugin.";
+  hash = "sha256-15InHQgF9c0Js4yUJxmZ1oNj1O16FBU12u/GOoaSAJ8=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "ruff";
+    fileExtensions = [
+      "py"
+      "pyi"
+    ];
+  };
+  pname = "dprint-plugin-ruff";
+  updateUrl = "https://plugins.dprint.dev/dprint/ruff/latest.json";
+  url = "https://plugins.dprint.dev/ruff-0.3.9.wasm";
+  version = "0.3.9";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-toml.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-toml.nix
@@ -1,0 +1,14 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "TOML code formatter.";
+  hash = "sha256-aDfo/sKfOeNpyfd/4N1LgL1bObTTnviYrA8T7M/1KNs=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "toml";
+    fileExtensions = [ "toml" ];
+  };
+  pname = "dprint-plugin-toml";
+  updateUrl = "https://plugins.dprint.dev/dprint/toml/latest.json";
+  url = "https://plugins.dprint.dev/toml-0.6.3.wasm";
+  version = "0.6.3";
+}

--- a/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
+++ b/pkgs/by-name/dp/dprint/plugins/dprint-plugin-typescript.nix
@@ -1,0 +1,21 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "TypeScript/JavaScript code formatter.";
+  hash = "sha256-urgKQOjgkoDJCH/K7DWLJCkD0iH0Ok+rvrNDI0i4uS0=";
+  initConfig = {
+    configExcludes = [ "**/node_modules" ];
+    configKey = "typescript";
+    fileExtensions = [
+      "ts"
+      "tsx"
+      "js"
+      "jsx"
+      "cjs"
+      "mjs"
+    ];
+  };
+  pname = "dprint-plugin-typescript";
+  updateUrl = "https://plugins.dprint.dev/dprint/typescript/latest.json";
+  url = "https://plugins.dprint.dev/typescript-0.93.3.wasm";
+  version = "0.93.3";
+}

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-malva.nix
@@ -1,0 +1,19 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "CSS, SCSS, Sass and Less formatter.";
+  hash = "sha256-zt7F1tgPhPAn+gtps6+JB5RtvjIZw2n/G85Bv6kazgU=";
+  initConfig = {
+    configExcludes = [ "**/node_modules" ];
+    configKey = "malva";
+    fileExtensions = [
+      "css"
+      "scss"
+      "sass"
+      "less"
+    ];
+  };
+  pname = "g-plane-malva";
+  updateUrl = "https://plugins.dprint.dev/g-plane/malva/latest.json";
+  url = "https://plugins.dprint.dev/g-plane/malva-v0.11.1.wasm";
+  version = "0.11.1";
+}

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-markup_fmt.nix
@@ -1,0 +1,24 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "HTML, Vue, Svelte, Astro, Angular, Jinja, Twig, Nunjucks, and Vento formatter.";
+  hash = "sha256-G8UnJbc+oZ60V3oi8W2SS6H06zEYfY3wpmSUp+1GF8k=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "markup";
+    fileExtensions = [
+      "html"
+      "vue"
+      "svelte"
+      "astro"
+      "jinja"
+      "jinja2"
+      "twig"
+      "njk"
+      "vto"
+    ];
+  };
+  pname = "g-plane-markup_fmt";
+  updateUrl = "https://plugins.dprint.dev/g-plane/markup_fmt/latest.json";
+  url = "https://plugins.dprint.dev/g-plane/markup_fmt-v0.18.0.wasm";
+  version = "0.18.0";
+}

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_graphql.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_graphql.nix
@@ -1,0 +1,17 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "GraphQL formatter.";
+  hash = "sha256-PlQwpR0tMsghMrOX7is+anN57t9xa9weNtoWpc0E9ec=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "graphql";
+    fileExtensions = [
+      "graphql"
+      "gql"
+    ];
+  };
+  pname = "g-plane-pretty_graphql";
+  updateUrl = "https://plugins.dprint.dev/g-plane/pretty_graphql/latest.json";
+  url = "https://plugins.dprint.dev/g-plane/pretty_graphql-v0.2.1.wasm";
+  version = "0.2.1";
+}

--- a/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
+++ b/pkgs/by-name/dp/dprint/plugins/g-plane-pretty_yaml.nix
@@ -1,0 +1,17 @@
+{ mkDprintPlugin }:
+mkDprintPlugin {
+  description = "YAML formatter.";
+  hash = "sha256-6ua021G7ZW7Ciwy/OHXTA1Joj9PGEx3SZGtvaA//gzo=";
+  initConfig = {
+    configExcludes = [ ];
+    configKey = "yaml";
+    fileExtensions = [
+      "yaml"
+      "yml"
+    ];
+  };
+  pname = "g-plane-pretty_yaml";
+  updateUrl = "https://plugins.dprint.dev/g-plane/pretty_yaml/latest.json";
+  url = "https://plugins.dprint.dev/g-plane/pretty_yaml-v0.5.0.wasm";
+  version = "0.5.0";
+}

--- a/pkgs/by-name/dp/dprint/plugins/update-plugins.py
+++ b/pkgs/by-name/dp/dprint/plugins/update-plugins.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i python -p nix nixfmt-rfc-style 'python3.withPackages (pp: [ pp.requests ])'
+
+import json
+import os
+from pathlib import Path
+import sys
+import subprocess
+import requests
+
+USAGE = """Usage: {0} [ | plugin-name | plugin-file-path]
+
+eg.
+  {0}
+  {0} dprint-plugin-json
+  {0} /path/to/dprint-plugin-json.nix"""
+
+FILE_PATH = Path(os.path.realpath(__file__))
+SCRIPT_DIR = FILE_PATH.parent
+
+pname = ""
+if len(sys.argv) > 1:
+    if "-help" in "".join(sys.argv):
+        print(USAGE.format(FILE_PATH.name))
+        exit(0)
+    pname = sys.argv[1]
+else:
+    pname = os.environ.get("UPDATE_NIX_PNAME", "")
+
+
+# get sri hash for a url, no unpack
+def nix_prefetch_url(url, name, algo="sha256"):
+    hash = (
+        subprocess.check_output(
+            ["nix-prefetch-url", "--type", algo, "--name", name, url]
+        )
+        .decode("utf-8")
+        .rstrip()
+    )
+    sri = (
+        subprocess.check_output(
+            # split by space is enough for this command
+            "nix --extra-experimental-features nix-command "
+            f"hash convert --hash-algo {algo} --to sri {hash}".split(" ")
+        )
+        .decode("utf-8")
+        .rstrip()
+    )
+    return sri
+
+
+# json object to nix string
+def json_to_nix(jsondata):
+    # to quote strings, dumps twice does it
+    json_str = json.dumps(json.dumps(jsondata))
+    return (
+        subprocess.check_output(
+            "nix --extra-experimental-features nix-command eval "
+            f"--expr 'builtins.fromJSON ''{json_str}''' --impure | nixfmt",
+            shell=True,
+        )
+        .decode("utf-8")
+        .rstrip()
+    )
+
+
+# nix string to json object
+def nix_to_json(nixstr):
+    return json.loads(
+        subprocess.check_output(
+            f"nix --extra-experimental-features nix-command eval --json --expr '{nixstr}'",
+            shell=True,
+        )
+        .decode("utf-8")
+        .rstrip()
+    )
+
+
+# nixfmt a file
+def nixfmt(nixfile):
+    subprocess.run(["nixfmt", nixfile])
+
+
+def get_update_url(plugin_url):
+    """Get a single plugin's update url given the plugin's url"""
+
+    # remove -version.wasm at the end
+    url = "-".join(plugin_url.split("-")[:-1])
+    names = url.split("/")[3:]
+    # if single name then -> dprint/<name>
+    if len(names) == 1:
+        names.insert(0, "dprint")
+    return "https://plugins.dprint.dev/" + "/".join(names) + "/latest.json"
+
+
+def write_plugin_derivation(drv_attrs):
+    drv = f"{{ mkDprintPlugin }}: mkDprintPlugin {json_to_nix(drv_attrs)}"
+    filepath = SCRIPT_DIR / f"{drv_attrs["pname"]}.nix"
+    with open(filepath, "w+", encoding="utf8") as f:
+        f.write(drv)
+    nixfmt(filepath)
+
+
+def update_plugin_by_name(name):
+    """Update a single plugin by name"""
+
+    # allow passing in filename as well as pname
+    if name.endswith(".nix"):
+        name = Path(name[:-4]).name
+    try:
+        p = (SCRIPT_DIR / f"{name}.nix").read_text().replace("\n", "")
+    except OSError as e:
+        print(f"failed to update plugin {name}: error: {e}")
+        exit(1)
+
+    start_idx = p.find("mkDprintPlugin {") + len("mkDprintPlugin {")
+    p = nix_to_json("{" + p[start_idx:].strip())
+
+    data = requests.get(p["updateUrl"]).json()
+    p["url"] = data["url"]
+    p["version"] = data["version"]
+    p["hash"] = nix_prefetch_url(data["url"], f"{name}-{data["version"]}.wasm")
+
+    write_plugin_derivation(p)
+
+
+def update_plugins():
+    """Update all the plugins"""
+
+    data = requests.get("https://plugins.dprint.dev/info.json").json()["latest"]
+
+    for e in data:
+        update_url = get_update_url(e["url"])
+        pname = e["name"]
+        if "/" in e["name"]:
+            pname = pname.replace("/", "-")
+        drv_attrs = {
+            "url": e["url"],
+            "hash": nix_prefetch_url(e["url"], f"{pname}-{e["version"]}.wasm"),
+            "updateUrl": update_url,
+            "pname": pname,
+            "version": e["version"],
+            "description": e["description"],
+            "initConfig": {
+                "configKey": e["configKey"],
+                "configExcludes": e["configExcludes"],
+                "fileExtensions": e["fileExtensions"],
+            },
+        }
+        write_plugin_derivation(drv_attrs)
+
+
+if pname != "":
+    update_plugin_by_name(pname)
+else:
+    update_plugins()

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5919,6 +5919,8 @@ with pkgs;
 
   devpi-server = python3Packages.callPackage ../development/tools/devpi-server { };
 
+  dprint-plugins = recurseIntoAttrs (callPackage ../by-name/dp/dprint/plugins { });
+
   elm2nix = haskell.lib.compose.justStaticExecutables haskellPackages.elm2nix;
 
   elmPackages = recurseIntoAttrs (callPackage ../development/compilers/elm { });


### PR DESCRIPTION
The plan is to keep track of official dprint plugins here, utilising nixpkgs' update infra. see https://github.com/numtide/treefmt-nix/issues/278#issuecomment-2565265766

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---
cc: @zimbatm @kachick