### PR TITLE
cyphernetes: init at 0.14.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21600,6 +21600,12 @@
     githubId = 203168;
     name = "Stefan Fehrenbach";
   };
+  stefankeidel = {
+    email = "stefan@keidel.me";
+    github = "stefankeidel";
+    githubId = 1188614;
+    name = "Stefan Keidel";
+  };
   stehessel = {
     email = "stephan@stehessel.de";
     github = "stehessel";

--- a/pkgs/by-name/cy/cyphernetes/package.nix
+++ b/pkgs/by-name/cy/cyphernetes/package.nix
@@ -1,4 +1,10 @@
-{ stdenv, lib, buildGoModule, fetchFromGitHub, cyphernetes }:
+{
+  stdenv,
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  cyphernetes,
+}:
 
 buildGoModule rec {
   pname = "cyphernetes";

--- a/pkgs/by-name/cy/cyphernetes/package.nix
+++ b/pkgs/by-name/cy/cyphernetes/package.nix
@@ -1,0 +1,34 @@
+{ stdenv, lib, buildGoModule, fetchFromGitHub, cyphernetes }:
+
+buildGoModule rec {
+  pname = "cyphernetes";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "AvitalTamir";
+    repo = "cyphernetes";
+    rev = "v${version}";
+    hash = "sha256-rxZWI+2eWMNTjphxS+lsxAoZUXD8wWF1pfe6hLBxtuM=";
+  };
+
+  ldflags = [
+    "-X main.Version=${version}"
+  ];
+
+  vendorHash = "sha256-DRzYgpHShZn+17R1Jj/arwAP5lyTpWelmwloUxT3n5Y=";
+  doCheck = false; # kubeconfig doesn't have a current context, ignore for now
+
+  # we build only the cli in this first iteration. webserver and other components might follow
+  subPackages = [
+    "cmd/cyphernetes"
+  ];
+
+  meta = with lib; {
+    description = "A Kubernetes Query Language ";
+    homepage = "https://github.com/AvitalTamir/cyphernetes";
+    changelog = "https://github.com/AvitalTamir/cyphernetes/releases/tag/v${version}";
+    license = licenses.asl20;
+    mainProgram = "cyphernetes";
+    maintainers = with maintainers; [ stefankeidel ];
+  };
+}


### PR DESCRIPTION
Added cyphernetes CLI as new package. Other components might follow.

- [package repository](https://github.com/AvitalTamir/cyphernetes)
- [website](https://cyphernet.es/)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
