### PR TITLE
treewide/nixos: remove `with lib;` part 13

### DIFF
--- a/nixos/modules/services/x11/window-managers/evilwm.nix
+++ b/nixos/modules/services/x11/window-managers/evilwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.evilwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.evilwm.enable = mkEnableOption "evilwm";
+    services.xserver.windowManager.evilwm.enable = lib.mkEnableOption "evilwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "evilwm";
       start = ''
         ${pkgs.evilwm}/bin/evilwm &

--- a/nixos/modules/services/x11/window-managers/exwm.nix
+++ b/nixos/modules/services/x11/window-managers/exwm.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.exwm;
   loadScript = pkgs.writeText "emacs-exwm-load" ''
@@ -18,17 +15,17 @@ in
 {
 
   imports = [
-    (mkRemovedOptionModule [ "services" "xserver" "windowManager" "exwm" "enableDefaultConfig" ]
+    (lib.mkRemovedOptionModule [ "services" "xserver" "windowManager" "exwm" "enableDefaultConfig" ]
       "The upstream EXWM project no longer provides a default configuration, instead copy (parts of) exwm-config.el to your local config."
     )
   ];
 
   options = {
     services.xserver.windowManager.exwm = {
-      enable = mkEnableOption "exwm";
-      loadScript = mkOption {
+      enable = lib.mkEnableOption "exwm";
+      loadScript = lib.mkOption {
         default = "(require 'exwm)";
-        type = types.lines;
+        type = lib.types.lines;
         example = ''
           (require 'exwm)
           (exwm-enable)
@@ -38,11 +35,11 @@ in
           file.
         '';
       };
-      extraPackages = mkOption {
-        type = types.functionTo (types.listOf types.package);
+      extraPackages = lib.mkOption {
+        type = lib.types.functionTo (lib.types.listOf lib.types.package);
         default = epkgs: [ ];
-        defaultText = literalExpression "epkgs: []";
-        example = literalExpression ''
+        defaultText = lib.literalExpression "epkgs: []";
+        example = lib.literalExpression ''
           epkgs: [
             epkgs.emms
             epkgs.magit
@@ -58,8 +55,8 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "exwm";
       start = ''
         ${exwm-emacs}/bin/emacs -l ${loadScript}

--- a/nixos/modules/services/x11/window-managers/fluxbox.nix
+++ b/nixos/modules/services/x11/window-managers/fluxbox.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.fluxbox;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.fluxbox.enable = mkEnableOption "fluxbox";
+    services.xserver.windowManager.fluxbox.enable = lib.mkEnableOption "fluxbox";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "fluxbox";
       start = ''
         ${pkgs.fluxbox}/bin/startfluxbox &

--- a/nixos/modules/services/x11/window-managers/fvwm2.nix
+++ b/nixos/modules/services/x11/window-managers/fvwm2.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.fvwm2;
   fvwm2 = pkgs.fvwm2.override { enableGestures = cfg.gestures; };
@@ -15,7 +12,7 @@ in
 {
 
   imports = [
-    (mkRenamedOptionModule
+    (lib.mkRenamedOptionModule
       [ "services" "xserver" "windowManager" "fvwm" ]
       [ "services" "xserver" "windowManager" "fvwm2" ]
     )
@@ -25,11 +22,11 @@ in
 
   options = {
     services.xserver.windowManager.fvwm2 = {
-      enable = mkEnableOption "Fvwm2 window manager";
+      enable = lib.mkEnableOption "Fvwm2 window manager";
 
-      gestures = mkOption {
+      gestures = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = "Whether or not to enable libstroke for gesture support";
       };
     };
@@ -37,8 +34,8 @@ in
 
   ###### implementation
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "fvwm2";
       start = ''
         ${fvwm2}/bin/fvwm &

--- a/nixos/modules/services/x11/window-managers/fvwm3.nix
+++ b/nixos/modules/services/x11/window-managers/fvwm3.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.fvwm3;
   inherit (pkgs) fvwm3;
@@ -18,14 +15,14 @@ in
 
   options = {
     services.xserver.windowManager.fvwm3 = {
-      enable = mkEnableOption "Fvwm3 window manager";
+      enable = lib.mkEnableOption "Fvwm3 window manager";
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "fvwm3";
       start = ''
         ${fvwm3}/bin/fvwm3 &

--- a/nixos/modules/services/x11/window-managers/hackedbox.nix
+++ b/nixos/modules/services/x11/window-managers/hackedbox.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.hackedbox;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.hackedbox.enable = mkEnableOption "hackedbox";
+    services.xserver.windowManager.hackedbox.enable = lib.mkEnableOption "hackedbox";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "hackedbox";
       start = ''
         ${pkgs.hackedbox}/bin/hackedbox &

--- a/nixos/modules/services/x11/window-managers/herbstluftwm.nix
+++ b/nixos/modules/services/x11/window-managers/herbstluftwm.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.herbstluftwm;
 in
@@ -14,13 +11,13 @@ in
 {
   options = {
     services.xserver.windowManager.herbstluftwm = {
-      enable = mkEnableOption "herbstluftwm";
+      enable = lib.mkEnableOption "herbstluftwm";
 
-      package = mkPackageOption pkgs "herbstluftwm" { };
+      package = lib.mkPackageOption pkgs "herbstluftwm" { };
 
-      configFile = mkOption {
+      configFile = lib.mkOption {
         default = null;
-        type = with types; nullOr path;
+        type = with lib.types; nullOr path;
         description = ''
           Path to the herbstluftwm configuration file.  If left at the
           default value, $XDG_CONFIG_HOME/herbstluftwm/autostart will
@@ -30,12 +27,12 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "herbstluftwm";
       start =
         let
-          configFileClause = optionalString (cfg.configFile != null) ''-c "${cfg.configFile}"'';
+          configFileClause = lib.optionalString (cfg.configFile != null) ''-c "${cfg.configFile}"'';
         in
         ''
           ${cfg.package}/bin/herbstluftwm ${configFileClause} &

--- a/nixos/modules/services/x11/window-managers/hypr.nix
+++ b/nixos/modules/services/x11/window-managers/hypr.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.hypr;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.hypr.enable = mkEnableOption "hypr";
+    services.xserver.windowManager.hypr.enable = lib.mkEnableOption "hypr";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "hypr";
       start = ''
         ${pkgs.hypr}/bin/Hypr &

--- a/nixos/modules/services/x11/window-managers/i3.nix
+++ b/nixos/modules/services/x11/window-managers/i3.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.i3;
   updateSessionEnvironmentScript = ''
@@ -17,44 +14,44 @@ in
 
 {
   options.services.xserver.windowManager.i3 = {
-    enable = mkEnableOption "i3 window manager";
+    enable = lib.mkEnableOption "i3 window manager";
 
-    configFile = mkOption {
+    configFile = lib.mkOption {
       default = null;
-      type = with types; nullOr path;
+      type = with lib.types; nullOr path;
       description = ''
         Path to the i3 configuration file.
         If left at the default value, $HOME/.i3/config will be used.
       '';
     };
 
-    updateSessionEnvironment = mkOption {
+    updateSessionEnvironment = lib.mkOption {
       default = true;
-      type = types.bool;
+      type = lib.types.bool;
       description = ''
         Whether to run dbus-update-activation-environment and systemctl import-environment before session start.
         Required for xdg portals to function properly.
       '';
     };
 
-    extraSessionCommands = mkOption {
+    extraSessionCommands = lib.mkOption {
       default = "";
-      type = types.lines;
+      type = lib.types.lines;
       description = ''
         Shell commands executed just before i3 is started.
       '';
     };
 
-    package = mkPackageOption pkgs "i3" { };
+    package = lib.mkPackageOption pkgs "i3" { };
 
-    extraPackages = mkOption {
-      type = with types; listOf package;
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
       default = with pkgs; [
         dmenu
         i3status
         i3lock
       ];
-      defaultText = literalExpression ''
+      defaultText = lib.literalExpression ''
         with pkgs; [
           dmenu
           i3status
@@ -67,7 +64,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.xserver.windowManager.session = [
       {
         name = "i3";
@@ -76,19 +73,19 @@ in
 
           ${lib.optionalString cfg.updateSessionEnvironment updateSessionEnvironmentScript}
 
-          ${cfg.package}/bin/i3 ${optionalString (cfg.configFile != null) "-c /etc/i3/config"} &
+          ${cfg.package}/bin/i3 ${lib.optionalString (cfg.configFile != null) "-c /etc/i3/config"} &
           waitPID=$!
         '';
       }
     ];
     environment.systemPackages = [ cfg.package ] ++ cfg.extraPackages;
-    environment.etc."i3/config" = mkIf (cfg.configFile != null) {
+    environment.etc."i3/config" = lib.mkIf (cfg.configFile != null) {
       source = cfg.configFile;
     };
   };
 
   imports = [
-    (mkRemovedOptionModule [
+    (lib.mkRemovedOptionModule [
       "services"
       "xserver"
       "windowManager"

--- a/nixos/modules/services/x11/window-managers/icewm.nix
+++ b/nixos/modules/services/x11/window-managers/icewm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.icewm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.icewm.enable = mkEnableOption "icewm";
+    services.xserver.windowManager.icewm.enable = lib.mkEnableOption "icewm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "icewm";
       start = ''
         ${pkgs.icewm}/bin/icewm-session &

--- a/nixos/modules/services/x11/window-managers/leftwm.nix
+++ b/nixos/modules/services/x11/window-managers/leftwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.leftwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.leftwm.enable = mkEnableOption "leftwm";
+    services.xserver.windowManager.leftwm.enable = lib.mkEnableOption "leftwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "leftwm";
       start = ''
         ${pkgs.leftwm}/bin/leftwm &

--- a/nixos/modules/services/x11/window-managers/lwm.nix
+++ b/nixos/modules/services/x11/window-managers/lwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.lwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.lwm.enable = mkEnableOption "lwm";
+    services.xserver.windowManager.lwm.enable = lib.mkEnableOption "lwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "lwm";
       start = ''
         ${pkgs.lwm}/bin/lwm &

--- a/nixos/modules/services/x11/window-managers/mlvwm.nix
+++ b/nixos/modules/services/x11/window-managers/mlvwm.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.mlvwm;
 
@@ -14,11 +11,11 @@ in
 {
 
   options.services.xserver.windowManager.mlvwm = {
-    enable = mkEnableOption "Macintosh-like Virtual Window Manager";
+    enable = lib.mkEnableOption "Macintosh-like Virtual Window Manager";
 
-    configFile = mkOption {
+    configFile = lib.mkOption {
       default = null;
-      type = with types; nullOr path;
+      type = with lib.types; nullOr path;
       description = ''
         Path to the mlvwm configuration file.
         If left at the default value, $HOME/.mlvwmrc will be used.
@@ -26,19 +23,19 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     services.xserver.windowManager.session = [
       {
         name = "mlvwm";
         start = ''
-          ${pkgs.mlvwm}/bin/mlvwm ${optionalString (cfg.configFile != null) "-f /etc/mlvwm/mlvwmrc"} &
+          ${pkgs.mlvwm}/bin/mlvwm ${lib.optionalString (cfg.configFile != null) "-f /etc/mlvwm/mlvwmrc"} &
           waitPID=$!
         '';
       }
     ];
 
-    environment.etc."mlvwm/mlvwmrc" = mkIf (cfg.configFile != null) {
+    environment.etc."mlvwm/mlvwmrc" = lib.mkIf (cfg.configFile != null) {
       source = cfg.configFile;
     };
 

--- a/nixos/modules/services/x11/window-managers/mwm.nix
+++ b/nixos/modules/services/x11/window-managers/mwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.mwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.mwm.enable = mkEnableOption "mwm";
+    services.xserver.windowManager.mwm.enable = lib.mkEnableOption "mwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "mwm";
       start = ''
         ${pkgs.motif}/bin/mwm &

--- a/nixos/modules/services/x11/window-managers/nimdow.nix
+++ b/nixos/modules/services/x11/window-managers/nimdow.nix
@@ -4,25 +4,22 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.nimdow;
 in
 {
   options = {
-    services.xserver.windowManager.nimdow.enable = mkEnableOption "nimdow";
-    services.xserver.windowManager.nimdow.package = mkOption {
-      type = types.package;
+    services.xserver.windowManager.nimdow.enable = lib.mkEnableOption "nimdow";
+    services.xserver.windowManager.nimdow.package = lib.mkOption {
+      type = lib.types.package;
       default = pkgs.nimdow;
       defaultText = "pkgs.nimdow";
       description = "nimdow package to use";
     };
   };
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "nimdow";
       start = ''
         ${cfg.package}/bin/nimdow &

--- a/nixos/modules/services/x11/window-managers/notion.nix
+++ b/nixos/modules/services/x11/window-managers/notion.nix
@@ -4,19 +4,16 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.notion;
 in
 
 {
   options = {
-    services.xserver.windowManager.notion.enable = mkEnableOption "notion";
+    services.xserver.windowManager.notion.enable = lib.mkEnableOption "notion";
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.xserver.windowManager = {
       session = [
         {

--- a/nixos/modules/services/x11/window-managers/openbox.nix
+++ b/nixos/modules/services/x11/window-managers/openbox.nix
@@ -4,18 +4,16 @@
   config,
   ...
 }:
-
-with lib;
 let
   cfg = config.services.xserver.windowManager.openbox;
 in
 
 {
   options = {
-    services.xserver.windowManager.openbox.enable = mkEnableOption "openbox";
+    services.xserver.windowManager.openbox.enable = lib.mkEnableOption "openbox";
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.xserver.windowManager = {
       session = [
         {

--- a/nixos/modules/services/x11/window-managers/pekwm.nix
+++ b/nixos/modules/services/x11/window-managers/pekwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.pekwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.pekwm.enable = mkEnableOption "pekwm";
+    services.xserver.windowManager.pekwm.enable = lib.mkEnableOption "pekwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "pekwm";
       start = ''
         ${pkgs.pekwm}/bin/pekwm &

--- a/nixos/modules/services/x11/window-managers/qtile.nix
+++ b/nixos/modules/services/x11/window-managers/qtile.nix
@@ -1,35 +1,32 @@
 { config, pkgs, lib, ... }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.qtile;
 in
 
 {
   imports = [
-    (mkRemovedOptionModule [ "services" "xserver" "windowManager" "qtile" "backend" ] "The qtile package now provides separate display sessions for both X11 and Wayland.")
+    (lib.mkRemovedOptionModule [ "services" "xserver" "windowManager" "qtile" "backend" ] "The qtile package now provides separate display sessions for both X11 and Wayland.")
   ];
 
   options.services.xserver.windowManager.qtile = {
-    enable = mkEnableOption "qtile";
+    enable = lib.mkEnableOption "qtile";
 
-    package = mkPackageOption pkgs "qtile-unwrapped" { };
+    package = lib.mkPackageOption pkgs "qtile-unwrapped" { };
 
-    configFile = mkOption {
-      type = with types; nullOr path;
+    configFile = lib.mkOption {
+      type = with lib.types; nullOr path;
       default = null;
-      example = literalExpression "./your_config.py";
+      example = lib.literalExpression "./your_config.py";
       description = ''
           Path to the qtile configuration file.
           If null, $XDG_CONFIG_HOME/qtile/config.py will be used.
       '';
     };
 
-    extraPackages = mkOption {
-        type = types.functionTo (types.listOf types.package);
+    extraPackages = lib.mkOption {
+        type = lib.types.functionTo (lib.types.listOf lib.types.package);
         default = _: [];
-        defaultText = literalExpression ''
+        defaultText = lib.literalExpression ''
           python3Packages: with python3Packages; [];
         '';
         description = ''
@@ -37,29 +34,29 @@ in
           An example would be to include `python3Packages.qtile-extras`
           for additional unofficial widgets.
         '';
-        example = literalExpression ''
+        example = lib.literalExpression ''
           python3Packages: with python3Packages; [
             qtile-extras
           ];
         '';
       };
 
-    finalPackage = mkOption {
-      type = types.package;
+    finalPackage = lib.mkOption {
+      type = lib.types.package;
       visible = false;
       readOnly = true;
       description = "The resulting Qtile package, bundled with extra packages";
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services = {
       xserver.windowManager.qtile.finalPackage = pkgs.python3.pkgs.qtile.override { extraPackages = cfg.extraPackages pkgs.python3.pkgs; };
       displayManager.sessionPackages = [ cfg.finalPackage ];
     };
 
     environment = {
-      etc."xdg/qtile/config.py" = mkIf (cfg.configFile != null) { source = cfg.configFile; };
+      etc."xdg/qtile/config.py" = lib.mkIf (cfg.configFile != null) { source = cfg.configFile; };
       systemPackages = [ cfg.finalPackage ];
     };
   };

--- a/nixos/modules/services/x11/window-managers/ragnarwm.nix
+++ b/nixos/modules/services/x11/window-managers/ragnarwm.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.ragnarwm;
 in
@@ -15,14 +12,14 @@ in
 
   options = {
     services.xserver.windowManager.ragnarwm = {
-      enable = mkEnableOption "ragnarwm";
-      package = mkPackageOption pkgs "ragnarwm" { };
+      enable = lib.mkEnableOption "ragnarwm";
+      package = lib.mkPackageOption pkgs "ragnarwm" { };
     };
   };
 
   ###### implementation
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.displayManager.sessionPackages = [ cfg.package ];
     environment.systemPackages = [ cfg.package ];
   };

--- a/nixos/modules/services/x11/window-managers/ratpoison.nix
+++ b/nixos/modules/services/x11/window-managers/ratpoison.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.ratpoison;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.ratpoison.enable = mkEnableOption "ratpoison";
+    services.xserver.windowManager.ratpoison.enable = lib.mkEnableOption "ratpoison";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "ratpoison";
       start = ''
         ${pkgs.ratpoison}/bin/ratpoison &

--- a/nixos/modules/services/x11/window-managers/sawfish.nix
+++ b/nixos/modules/services/x11/window-managers/sawfish.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.sawfish;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.sawfish.enable = mkEnableOption "sawfish";
+    services.xserver.windowManager.sawfish.enable = lib.mkEnableOption "sawfish";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "sawfish";
       start = ''
         ${pkgs.sawfish}/bin/sawfish &

--- a/nixos/modules/services/x11/window-managers/smallwm.nix
+++ b/nixos/modules/services/x11/window-managers/smallwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.smallwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.smallwm.enable = mkEnableOption "smallwm";
+    services.xserver.windowManager.smallwm.enable = lib.mkEnableOption "smallwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "smallwm";
       start = ''
         ${pkgs.smallwm}/bin/smallwm &

--- a/nixos/modules/services/x11/window-managers/spectrwm.nix
+++ b/nixos/modules/services/x11/window-managers/spectrwm.nix
@@ -4,19 +4,16 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.spectrwm;
 in
 
 {
   options = {
-    services.xserver.windowManager.spectrwm.enable = mkEnableOption "spectrwm";
+    services.xserver.windowManager.spectrwm.enable = lib.mkEnableOption "spectrwm";
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     services.xserver.windowManager = {
       session = [
         {

--- a/nixos/modules/services/x11/window-managers/stumpwm.nix
+++ b/nixos/modules/services/x11/window-managers/stumpwm.nix
@@ -4,20 +4,17 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.stumpwm;
 in
 
 {
   options = {
-    services.xserver.windowManager.stumpwm.enable = mkEnableOption "stumpwm";
+    services.xserver.windowManager.stumpwm.enable = lib.mkEnableOption "stumpwm";
   };
 
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "stumpwm";
       start = ''
         ${pkgs.sbclPackages.stumpwm}/bin/stumpwm &

--- a/nixos/modules/services/x11/window-managers/windowmaker.nix
+++ b/nixos/modules/services/x11/window-managers/windowmaker.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.windowmaker;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.windowmaker.enable = mkEnableOption "windowmaker";
+    services.xserver.windowManager.windowmaker.enable = lib.mkEnableOption "windowmaker";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "windowmaker";
       start = ''
         ${pkgs.windowmaker}/bin/wmaker &

--- a/nixos/modules/services/x11/window-managers/xmonad.nix
+++ b/nixos/modules/services/x11/window-managers/xmonad.nix
@@ -1,6 +1,4 @@
 {pkgs, lib, config, ...}:
-
-with lib;
 let
   inherit (lib) mkOption mkIf optionals literalExpression optionalString;
   cfg = config.services.xserver.windowManager.xmonad;
@@ -38,17 +36,17 @@ let
 
   xmonad = if (cfg.config != null) then xmonad-config else xmonad-vanilla;
 in {
-  meta.maintainers = with maintainers; [ lassulus xaverdh ivanbrennan slotThe ];
+  meta.maintainers = with lib.maintainers; [ lassulus xaverdh ivanbrennan slotThe ];
 
   options = {
     services.xserver.windowManager.xmonad = {
-      enable = mkEnableOption "xmonad";
+      enable = lib.mkEnableOption "xmonad";
 
       haskellPackages = mkOption {
         default = pkgs.haskellPackages;
         defaultText = literalExpression "pkgs.haskellPackages";
         example = literalExpression "pkgs.haskell.packages.ghc810";
-        type = types.attrs;
+        type = lib.types.attrs;
         description = ''
           haskellPackages used to build Xmonad and other packages.
           This can be used to change the GHC version used to build
@@ -58,7 +56,7 @@ in {
       };
 
       extraPackages = mkOption {
-        type = types.functionTo (types.listOf types.package);
+        type = lib.types.functionTo (lib.types.listOf lib.types.package);
         default = self: [];
         defaultText = literalExpression "self: []";
         example = literalExpression ''

--- a/nixos/modules/services/x11/window-managers/yeahwm.nix
+++ b/nixos/modules/services/x11/window-managers/yeahwm.nix
@@ -4,21 +4,18 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.windowManager.yeahwm;
 in
 {
   ###### interface
   options = {
-    services.xserver.windowManager.yeahwm.enable = mkEnableOption "yeahwm";
+    services.xserver.windowManager.yeahwm.enable = lib.mkEnableOption "yeahwm";
   };
 
   ###### implementation
-  config = mkIf cfg.enable {
-    services.xserver.windowManager.session = singleton {
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.session = lib.singleton {
       name = "yeahwm";
       start = ''
         ${pkgs.yeahwm}/bin/yeahwm &

--- a/nixos/modules/services/x11/xautolock.nix
+++ b/nixos/modules/services/x11/xautolock.nix
@@ -4,85 +4,82 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xserver.xautolock;
 in
 {
   options = {
     services.xserver.xautolock = {
-      enable = mkEnableOption "xautolock";
-      enableNotifier = mkEnableOption "xautolock.notify" // {
+      enable = lib.mkEnableOption "xautolock";
+      enableNotifier = lib.mkEnableOption "xautolock.notify" // {
         description = ''
           Whether to enable the notifier feature of xautolock.
           This publishes a notification before the autolock.
         '';
       };
 
-      time = mkOption {
+      time = lib.mkOption {
         default = 15;
-        type = types.int;
+        type = lib.types.int;
 
         description = ''
           Idle time (in minutes) to wait until xautolock locks the computer.
         '';
       };
 
-      locker = mkOption {
+      locker = lib.mkOption {
         default = "${pkgs.xlockmore}/bin/xlock"; # default according to `man xautolock`
-        defaultText = literalExpression ''"''${pkgs.xlockmore}/bin/xlock"'';
-        example = literalExpression ''"''${pkgs.i3lock}/bin/i3lock -i /path/to/img"'';
-        type = types.str;
+        defaultText = lib.literalExpression ''"''${pkgs.xlockmore}/bin/xlock"'';
+        example = lib.literalExpression ''"''${pkgs.i3lock}/bin/i3lock -i /path/to/img"'';
+        type = lib.types.str;
 
         description = ''
           The script to use when automatically locking the computer.
         '';
       };
 
-      nowlocker = mkOption {
+      nowlocker = lib.mkOption {
         default = null;
-        example = literalExpression ''"''${pkgs.i3lock}/bin/i3lock -i /path/to/img"'';
-        type = types.nullOr types.str;
+        example = lib.literalExpression ''"''${pkgs.i3lock}/bin/i3lock -i /path/to/img"'';
+        type = lib.types.nullOr lib.types.str;
 
         description = ''
           The script to use when manually locking the computer with {command}`xautolock -locknow`.
         '';
       };
 
-      notify = mkOption {
+      notify = lib.mkOption {
         default = 10;
-        type = types.int;
+        type = lib.types.int;
 
         description = ''
           Time (in seconds) before the actual lock when the notification about the pending lock should be published.
         '';
       };
 
-      notifier = mkOption {
+      notifier = lib.mkOption {
         default = null;
-        example = literalExpression ''"''${pkgs.libnotify}/bin/notify-send 'Locking in 10 seconds'"'';
-        type = types.nullOr types.str;
+        example = lib.literalExpression ''"''${pkgs.libnotify}/bin/notify-send 'Locking in 10 seconds'"'';
+        type = lib.types.nullOr lib.types.str;
 
         description = ''
           Notification script to be used to warn about the pending autolock.
         '';
       };
 
-      killer = mkOption {
+      killer = lib.mkOption {
         default = null; # default according to `man xautolock` is none
         example = "/run/current-system/systemd/bin/systemctl suspend";
-        type = types.nullOr types.str;
+        type = lib.types.nullOr lib.types.str;
 
         description = ''
           The script to use when nothing has happened for as long as {option}`killtime`
         '';
       };
 
-      killtime = mkOption {
+      killtime = lib.mkOption {
         default = 20; # default according to `man xautolock`
-        type = types.int;
+        type = lib.types.int;
 
         description = ''
           Minutes xautolock waits until it executes the script specified in {option}`killer`
@@ -90,8 +87,8 @@ in
         '';
       };
 
-      extraOptions = mkOption {
-        type = types.listOf types.str;
+      extraOptions = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
         default = [ ];
         example = [ "-detectsleep" ];
         description = ''
@@ -102,7 +99,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = with pkgs; [ xautolock ];
     systemd.user.services.xautolock = {
       description = "xautolock service";

--- a/nixos/modules/services/x11/xbanish.nix
+++ b/nixos/modules/services/x11/xbanish.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.services.xbanish;
 
@@ -14,17 +11,17 @@ in
 {
   options.services.xbanish = {
 
-    enable = mkEnableOption "xbanish";
+    enable = lib.mkEnableOption "xbanish";
 
-    arguments = mkOption {
+    arguments = lib.mkOption {
       description = "Arguments to pass to xbanish command";
       default = "";
       example = "-d -i shift";
-      type = types.str;
+      type = lib.types.str;
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     systemd.user.services.xbanish = {
       description = "xbanish hides the mouse pointer";
       wantedBy = [ "graphical-session.target" ];

--- a/nixos/modules/system/boot/grow-partition.nix
+++ b/nixos/modules/system/boot/grow-partition.nix
@@ -1,26 +1,22 @@
 # This module automatically grows the root partition.
 # This allows an instance to be created with a bigger root filesystem
 # than provided by the machine image.
-
 {
   config,
   lib,
   pkgs,
   ...
 }:
-
-with lib;
-
 {
   imports = [
-    (mkRenamedOptionModule [ "virtualisation" "growPartition" ] [ "boot" "growPartition" ])
+    (lib.mkRenamedOptionModule [ "virtualisation" "growPartition" ] [ "boot" "growPartition" ])
   ];
 
   options = {
-    boot.growPartition = mkEnableOption "growing the root partition on boot";
+    boot.growPartition = lib.mkEnableOption "growing the root partition on boot";
   };
 
-  config = mkIf config.boot.growPartition {
+  config = lib.mkIf config.boot.growPartition {
     assertions = [
       {
         assertion = !config.boot.initrd.systemd.repart.enable && !config.systemd.repart.enable;

--- a/nixos/modules/system/boot/initrd-network.nix
+++ b/nixos/modules/system/boot/initrd-network.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.boot.initrd.network;
@@ -55,8 +52,8 @@ in
 
   options = {
 
-    boot.initrd.network.enable = mkOption {
-      type = types.bool;
+    boot.initrd.network.enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Add network connectivity support to initrd. The network may be
@@ -73,8 +70,8 @@ in
       '';
     };
 
-    boot.initrd.network.flushBeforeStage2 = mkOption {
-      type = types.bool;
+    boot.initrd.network.flushBeforeStage2 = lib.mkOption {
+      type = lib.types.bool;
       default = !config.boot.initrd.systemd.enable;
       defaultText = "!config.boot.initrd.systemd.enable";
       description = ''
@@ -87,10 +84,10 @@ in
       '';
     };
 
-    boot.initrd.network.udhcpc.enable = mkOption {
+    boot.initrd.network.udhcpc.enable = lib.mkOption {
       default = config.networking.useDHCP && !config.boot.initrd.systemd.enable;
       defaultText = "networking.useDHCP";
-      type = types.bool;
+      type = lib.types.bool;
       description = ''
         Enables the udhcpc service during stage 1 of the boot process. This
         defaults to {option}`networking.useDHCP`. Therefore, this useful if
@@ -98,9 +95,9 @@ in
       '';
     };
 
-    boot.initrd.network.udhcpc.extraArgs = mkOption {
+    boot.initrd.network.udhcpc.extraArgs = lib.mkOption {
       default = [ ];
-      type = types.listOf types.str;
+      type = lib.types.listOf lib.types.str;
       description = ''
         Additional command-line arguments passed verbatim to
         udhcpc if {option}`boot.initrd.network.enable` and
@@ -108,9 +105,9 @@ in
       '';
     };
 
-    boot.initrd.network.postCommands = mkOption {
+    boot.initrd.network.postCommands = lib.mkOption {
       default = "";
-      type = types.lines;
+      type = lib.types.lines;
       description = ''
         Shell commands to be executed after stage 1 of the
         boot has initialised the network.
@@ -119,16 +116,16 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     boot.initrd.kernelModules = [ "af_packet" ];
 
-    boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
       copy_bin_and_libs ${pkgs.klibc}/lib/klibc/bin.static/ipconfig
     '';
 
-    boot.initrd.preLVMCommands = mkIf (!config.boot.initrd.systemd.enable) (
-      mkBefore (
+    boot.initrd.preLVMCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (
+      lib.mkBefore (
         # Search for interface definitions in command line.
         ''
           ifaces=""
@@ -142,7 +139,7 @@ in
         ''
 
         # Otherwise, use DHCP.
-        + optionalString doDhcp ''
+        + lib.optionalString doDhcp ''
           # Bring up all interfaces.
           for iface in ${dhcpIfShellExpr}; do
             echo "bringing up network interface $iface..."
@@ -161,7 +158,7 @@ in
     );
 
     boot.initrd.postMountCommands =
-      mkIf (cfg.flushBeforeStage2 && !config.boot.initrd.systemd.enable)
+      lib.mkIf (cfg.flushBeforeStage2 && !config.boot.initrd.systemd.enable)
         ''
           for iface in $ifaces; do
             ip address flush dev "$iface"

--- a/nixos/modules/system/boot/initrd-openvpn.nix
+++ b/nixos/modules/system/boot/initrd-openvpn.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.boot.initrd.network.openvpn;
@@ -17,8 +14,8 @@ in
 
   options = {
 
-    boot.initrd.network.openvpn.enable = mkOption {
-      type = types.bool;
+    boot.initrd.network.openvpn.enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Starts an OpenVPN client during initrd boot. It can be used to e.g.
@@ -28,8 +25,8 @@ in
       '';
     };
 
-    boot.initrd.network.openvpn.configuration = mkOption {
-      type = types.path; # Same type as boot.initrd.secrets
+    boot.initrd.network.openvpn.configuration = lib.mkOption {
+      type = lib.types.path; # Same type as boot.initrd.secrets
       description = ''
         The configuration file for OpenVPN.
 
@@ -38,12 +35,12 @@ in
         is stored insecurely in the global Nix store.
         :::
       '';
-      example = literalExpression "./configuration.ovpn";
+      example = lib.literalExpression "./configuration.ovpn";
     };
 
   };
 
-  config = mkIf (config.boot.initrd.network.enable && cfg.enable) {
+  config = lib.mkIf (config.boot.initrd.network.enable && cfg.enable) {
     assertions = [
       {
         assertion = cfg.configuration != null;
@@ -59,7 +56,7 @@ in
 
     # Add openvpn and ip binaries to the initrd
     # The shared libraries are required for DNS resolution
-    boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
       copy_bin_and_libs ${pkgs.openvpn}/bin/openvpn
       copy_bin_and_libs ${pkgs.iproute2}/bin/ip
 
@@ -79,11 +76,11 @@ in
     };
 
     # openvpn --version would exit with 1 instead of 0
-    boot.initrd.extraUtilsCommandsTest = mkIf (!config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUtilsCommandsTest = lib.mkIf (!config.boot.initrd.systemd.enable) ''
       $out/bin/openvpn --show-gateway
     '';
 
-    boot.initrd.network.postCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+    boot.initrd.network.postCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
       openvpn /etc/initrd.ovpn &
     '';
 

--- a/nixos/modules/system/boot/initrd-ssh.nix
+++ b/nixos/modules/system/boot/initrd-ssh.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
 
   cfg = config.boot.initrd.network.ssh;
@@ -24,8 +21,8 @@ in
 {
 
   options.boot.initrd.network.ssh = {
-    enable = mkOption {
-      type = types.bool;
+    enable = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Start SSH service during initrd boot. It can be used to debug failing
@@ -37,16 +34,16 @@ in
       '';
     };
 
-    port = mkOption {
-      type = types.port;
+    port = lib.mkOption {
+      type = lib.types.port;
       default = 22;
       description = ''
         Port on which SSH initrd service should listen.
       '';
     };
 
-    shell = mkOption {
-      type = types.nullOr types.str;
+    shell = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       defaultText = ''"/bin/ash"'';
       description = ''
@@ -54,8 +51,8 @@ in
       '';
     };
 
-    hostKeys = mkOption {
-      type = types.listOf (types.either types.str types.path);
+    hostKeys = lib.mkOption {
+      type = lib.types.listOf (lib.types.either lib.types.str lib.types.path);
       default = [ ];
       example = [
         "/etc/secrets/initrd/ssh_host_rsa_key"
@@ -87,8 +84,8 @@ in
       '';
     };
 
-    ignoreEmptyHostKeys = mkOption {
-      type = types.bool;
+    ignoreEmptyHostKeys = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         Allow leaving {option}`config.boot.initrd.network.ssh.hostKeys` empty,
@@ -96,10 +93,10 @@ in
       '';
     };
 
-    authorizedKeys = mkOption {
-      type = types.listOf types.str;
+    authorizedKeys = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = config.users.users.root.openssh.authorizedKeys.keys;
-      defaultText = literalExpression "config.users.users.root.openssh.authorizedKeys.keys";
+      defaultText = lib.literalExpression "config.users.users.root.openssh.authorizedKeys.keys";
       description = ''
         Authorized keys for the root user on initrd.
         You can combine the `authorizedKeys` and `authorizedKeyFiles` options.
@@ -110,18 +107,18 @@ in
       ];
     };
 
-    authorizedKeyFiles = mkOption {
-      type = types.listOf types.path;
+    authorizedKeyFiles = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
       default = config.users.users.root.openssh.authorizedKeys.keyFiles;
-      defaultText = literalExpression "config.users.users.root.openssh.authorizedKeys.keyFiles";
+      defaultText = lib.literalExpression "config.users.users.root.openssh.authorizedKeys.keyFiles";
       description = ''
         Authorized keys taken from files for the root user on initrd.
         You can combine the `authorizedKeyFiles` and `authorizedKeys` options.
       '';
     };
 
-    extraConfig = mkOption {
-      type = types.lines;
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
       default = "";
       description = "Verbatim contents of {file}`sshd_config`.";
     };
@@ -131,7 +128,7 @@ in
     map
       (
         opt:
-        mkRemovedOptionModule
+        lib.mkRemovedOptionModule
           (
             [
               "boot"
@@ -161,13 +158,13 @@ in
       # as an awful hack we drop the first character of the hash.
       initrdKeyPath =
         path:
-        if isString path then
+        if lib.isString path then
           path
         else
           let
             name = builtins.baseNameOf path;
           in
-          builtins.unsafeDiscardStringContext ("/etc/ssh/" + substring 1 (stringLength name) name);
+          builtins.unsafeDiscardStringContext ("/etc/ssh/" + lib.substring 1 (lib.stringLength name) name);
 
       sshdCfg = config.services.openssh;
 
@@ -180,19 +177,19 @@ in
           AuthorizedKeysFile %h/.ssh/authorized_keys %h/.ssh/authorized_keys2 /etc/ssh/authorized_keys.d/%u
           ChallengeResponseAuthentication no
 
-          ${flip concatMapStrings cfg.hostKeys (path: ''
+          ${lib.flip lib.concatMapStrings cfg.hostKeys (path: ''
             HostKey ${initrdKeyPath path}
           '')}
 
         ''
         + lib.optionalString (sshdCfg.settings.KexAlgorithms != null) ''
-          KexAlgorithms ${concatStringsSep "," sshdCfg.settings.KexAlgorithms}
+          KexAlgorithms ${lib.concatStringsSep "," sshdCfg.settings.KexAlgorithms}
         ''
         + lib.optionalString (sshdCfg.settings.Ciphers != null) ''
-          Ciphers ${concatStringsSep "," sshdCfg.settings.Ciphers}
+          Ciphers ${lib.concatStringsSep "," sshdCfg.settings.Ciphers}
         ''
         + lib.optionalString (sshdCfg.settings.Macs != null) ''
-          MACs ${concatStringsSep "," sshdCfg.settings.Macs}
+          MACs ${lib.concatStringsSep "," sshdCfg.settings.Macs}
         ''
         + ''
 
@@ -209,14 +206,14 @@ in
               ''
           }
 
-          ${optionalString (!config.boot.initrd.systemd.enable) ''
+          ${lib.optionalString (!config.boot.initrd.systemd.enable) ''
             SshdSessionPath /bin/sshd-session
           ''}
 
           ${cfg.extraConfig}
         '';
     in
-    mkIf enabled {
+    lib.mkIf enabled {
       assertions = [
         {
           assertion = cfg.authorizedKeys != [ ] || cfg.authorizedKeyFiles != [ ];
@@ -237,25 +234,25 @@ in
         Please set 'boot.initrd.systemd.users.root.shell' instead of 'boot.initrd.network.ssh.shell'
       '';
 
-      boot.initrd.extraUtilsCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+      boot.initrd.extraUtilsCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         copy_bin_and_libs ${package}/bin/sshd
         copy_bin_and_libs ${package}/libexec/sshd-session
         cp -pv ${pkgs.glibc.out}/lib/libnss_files.so.* $out/lib
       '';
 
-      boot.initrd.extraUtilsCommandsTest = mkIf (!config.boot.initrd.systemd.enable) ''
+      boot.initrd.extraUtilsCommandsTest = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         # sshd requires a host key to check config, so we pass in the test's
         tmpkey="$(mktemp initrd-ssh-testkey.XXXXXXXXXX)"
         cp "${../../../tests/initrd-network-ssh/ssh_host_ed25519_key}" "$tmpkey"
         # keys from Nix store are world-readable, which sshd doesn't like
         chmod 600 "$tmpkey"
-        echo -n ${escapeShellArg sshdConfig} |
+        echo -n ${lib.escapeShellArg sshdConfig} |
           $out/bin/sshd -t -f /dev/stdin \
           -h "$tmpkey"
         rm "$tmpkey"
       '';
 
-      boot.initrd.network.postCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+      boot.initrd.network.postCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         echo '${shell}' > /etc/shells
         echo 'root:x:0:0:root:/root:${shell}' > /etc/passwd
         echo 'sshd:x:1:1:sshd:/var/empty:/bin/nologin' >> /etc/passwd
@@ -265,24 +262,24 @@ in
         touch /var/log/lastlog
 
         mkdir -p /etc/ssh
-        echo -n ${escapeShellArg sshdConfig} > /etc/ssh/sshd_config
+        echo -n ${lib.escapeShellArg sshdConfig} > /etc/ssh/sshd_config
 
         echo "export PATH=$PATH" >> /etc/profile
         echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> /etc/profile
 
         mkdir -p /root/.ssh
-        ${concatStrings (
+        ${lib.concatStrings (
           map (key: ''
-            echo ${escapeShellArg key} >> /root/.ssh/authorized_keys
+            echo ${lib.escapeShellArg key} >> /root/.ssh/authorized_keys
           '') cfg.authorizedKeys
         )}
-        ${concatStrings (
+        ${lib.concatStrings (
           map (keyFile: ''
             cat ${keyFile} >> /root/.ssh/authorized_keys
           '') cfg.authorizedKeyFiles
         )}
 
-        ${flip concatMapStrings cfg.hostKeys (path: ''
+        ${lib.flip lib.concatMapStrings cfg.hostKeys (path: ''
           # keys from Nix store are world-readable, which sshd doesn't like
           chmod 0600 "${initrdKeyPath path}"
         '')}
@@ -290,7 +287,7 @@ in
         /bin/sshd -e
       '';
 
-      boot.initrd.postMountCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+      boot.initrd.postMountCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
         # Stop sshd cleanly before stage 2.
         #
         # If you want to keep it around to debug post-mount SSH issues,
@@ -301,12 +298,12 @@ in
         fi
       '';
 
-      boot.initrd.secrets = listToAttrs (
-        map (path: nameValuePair (initrdKeyPath path) path) cfg.hostKeys
+      boot.initrd.secrets = lib.listToAttrs (
+        map (path: lib.nameValuePair (initrdKeyPath path) path) cfg.hostKeys
       );
 
       # Systemd initrd stuff
-      boot.initrd.systemd = mkIf config.boot.initrd.systemd.enable {
+      boot.initrd.systemd = lib.mkIf config.boot.initrd.systemd.enable {
         users.sshd = {
           uid = 1;
           group = "sshd";
@@ -315,13 +312,13 @@ in
           gid = 1;
         };
 
-        users.root.shell = mkIf (
+        users.root.shell = lib.mkIf (
           config.boot.initrd.network.ssh.shell != null
         ) config.boot.initrd.network.ssh.shell;
 
         contents = {
           "/etc/ssh/sshd_config".text = sshdConfig;
-          "/etc/ssh/authorized_keys.d/root".text = concatStringsSep "\n" (
+          "/etc/ssh/authorized_keys.d/root".text = lib.concatStringsSep "\n" (
             config.boot.initrd.network.ssh.authorizedKeys
             ++ (map (file: lib.fileContents file) config.boot.initrd.network.ssh.authorizedKeyFiles)
           );
@@ -344,7 +341,7 @@ in
           # Keys from Nix store are world-readable, which sshd doesn't
           # like. If this were a real nix store and not the initrd, we
           # neither would nor could do this
-          preStart = flip concatMapStrings cfg.hostKeys (path: ''
+          preStart = lib.flip lib.concatMapStrings cfg.hostKeys (path: ''
             /bin/chmod 0600 "${initrdKeyPath path}"
           '');
           unitConfig.DefaultDependencies = false;

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -1,7 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
 
   inherit (config.boot) kernelPatches;
@@ -10,7 +7,7 @@ let
 
   kernelModulesConf = pkgs.writeText "nixos.conf"
     ''
-      ${concatStringsSep "\n" config.boot.kernelModules}
+      ${lib.concatStringsSep "\n" config.boot.kernelModules}
     '';
 
 in
@@ -20,13 +17,13 @@ in
   ###### interface
 
   options = {
-    boot.kernel.enable = mkEnableOption "the Linux kernel. This is useful for systemd-like containers which do not require a kernel" // {
+    boot.kernel.enable = lib.mkEnableOption "the Linux kernel. This is useful for systemd-like containers which do not require a kernel" // {
       default = true;
     };
 
-    boot.kernel.features = mkOption {
+    boot.kernel.features = lib.mkOption {
       default = {};
-      example = literalExpression "{ debug = true; }";
+      example = lib.literalExpression "{ debug = true; }";
       internal = true;
       description = ''
         This option allows to enable or disable certain kernel features.
@@ -37,9 +34,9 @@ in
       '';
     };
 
-    boot.kernelPackages = mkOption {
+    boot.kernelPackages = lib.mkOption {
       default = pkgs.linuxPackages;
-      type = types.raw;
+      type = lib.types.raw;
       apply = kernelPackages: kernelPackages.extend (self: super: {
         kernel = super.kernel.override (originalArgs: {
           inherit randstructSeed;
@@ -49,8 +46,8 @@ in
       });
       # We don't want to evaluate all of linuxPackages for the manual
       # - some of it might not even evaluate correctly.
-      defaultText = literalExpression "pkgs.linuxPackages";
-      example = literalExpression "pkgs.linuxKernel.packages.linux_5_10";
+      defaultText = lib.literalExpression "pkgs.linuxPackages";
+      example = lib.literalExpression "pkgs.linuxKernel.packages.linux_5_10";
       description = ''
         This option allows you to override the Linux kernel used by
         NixOS.  Since things like external kernel module packages are
@@ -70,10 +67,10 @@ in
       '';
     };
 
-    boot.kernelPatches = mkOption {
-      type = types.listOf types.attrs;
+    boot.kernelPatches = lib.mkOption {
+      type = lib.types.listOf lib.types.attrs;
       default = [];
-      example = literalExpression ''
+      example = lib.literalExpression ''
         [
           {
             name = "foo";
@@ -123,8 +120,8 @@ in
       '';
     };
 
-    boot.kernel.randstructSeed = mkOption {
-      type = types.str;
+    boot.kernel.randstructSeed = lib.mkOption {
+      type = lib.types.str;
       default = "";
       example = "my secret seed";
       description = ''
@@ -136,8 +133,8 @@ in
       '';
     };
 
-    boot.kernelParams = mkOption {
-      type = types.listOf (types.strMatching ''([^"[:space:]]|"[^"]*")+'' // {
+    boot.kernelParams = lib.mkOption {
+      type = lib.types.listOf (lib.types.strMatching ''([^"[:space:]]|"[^"]*")+'' // {
         name = "kernelParam";
         description = "string, with spaces inside double quotes";
       });
@@ -145,8 +142,8 @@ in
       description = "Parameters added to the kernel command line.";
     };
 
-    boot.consoleLogLevel = mkOption {
-      type = types.int;
+    boot.consoleLogLevel = lib.mkOption {
+      type = lib.types.int;
       default = 4;
       description = ''
         The kernel console `loglevel`. All Kernel Messages with a log level smaller
@@ -154,8 +151,8 @@ in
       '';
     };
 
-    boot.vesa = mkOption {
-      type = types.bool;
+    boot.vesa = lib.mkOption {
+      type = lib.types.bool;
       default = false;
       description = ''
         (Deprecated) This option, if set, activates the VESA 800x600 video
@@ -167,15 +164,15 @@ in
       '';
     };
 
-    boot.extraModulePackages = mkOption {
-      type = types.listOf types.package;
+    boot.extraModulePackages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
       default = [];
-      example = literalExpression "[ config.boot.kernelPackages.nvidia_x11 ]";
+      example = lib.literalExpression "[ config.boot.kernelPackages.nvidia_x11 ]";
       description = "A list of additional packages supplying kernel modules.";
     };
 
-    boot.kernelModules = mkOption {
-      type = types.listOf types.str;
+    boot.kernelModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [];
       description = ''
         The set of kernel modules to be loaded in the second stage of
@@ -186,8 +183,8 @@ in
       '';
     };
 
-    boot.initrd.availableKernelModules = mkOption {
-      type = types.listOf types.str;
+    boot.initrd.availableKernelModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [];
       example = [ "sata_nv" "ext3" ];
       description = ''
@@ -207,14 +204,14 @@ in
       '';
     };
 
-    boot.initrd.kernelModules = mkOption {
-      type = types.listOf types.str;
+    boot.initrd.kernelModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [];
       description = "List of modules that are always loaded by the initrd.";
     };
 
-    boot.initrd.includeDefaultModules = mkOption {
-      type = types.bool;
+    boot.initrd.includeDefaultModules = lib.mkOption {
+      type = lib.types.bool;
       default = true;
       description = ''
         This option, if set, adds a collection of default kernel modules
@@ -223,8 +220,8 @@ in
       '';
     };
 
-    system.modulesTree = mkOption {
-      type = types.listOf types.path;
+    system.modulesTree = lib.mkOption {
+      type = lib.types.listOf lib.types.path;
       internal = true;
       default = [];
       description = ''
@@ -238,9 +235,9 @@ in
       in modules: (pkgs.aggregateModules modules).override { name = kernel-name + "-modules"; };
     };
 
-    system.requiredKernelConfig = mkOption {
+    system.requiredKernelConfig = lib.mkOption {
       default = [];
-      example = literalExpression ''
+      example = lib.literalExpression ''
         with config.lib.kernelConfig; [
           (isYes "MODULES")
           (isEnabled "FB_CON_DECOR")
@@ -248,7 +245,7 @@ in
         ]
       '';
       internal = true;
-      type = types.listOf types.attrs;
+      type = lib.types.listOf lib.types.attrs;
       description = ''
         This option allows modules to specify the kernel config options that
         must be set (or unset) for the module to work. Please use the
@@ -261,10 +258,10 @@ in
 
   ###### implementation
 
-  config = mkMerge
-    [ (mkIf config.boot.initrd.enable {
+  config = lib.mkMerge
+    [ (lib.mkIf config.boot.initrd.enable {
         boot.initrd.availableKernelModules =
-          optionals config.boot.initrd.includeDefaultModules ([
+          lib.optionals config.boot.initrd.includeDefaultModules ([
             # Note: most of these (especially the SATA/PATA modules)
             # shouldn't be included by default since nixos-generate-config
             # detects them, but I'm keeping them for now for backwards
@@ -303,19 +300,19 @@ in
             "hid_logitech_hidpp" "hid_logitech_dj" "hid_microsoft" "hid_cherry"
             "hid_corsair"
 
-          ] ++ optionals pkgs.stdenv.hostPlatform.isx86 [
+          ] ++ lib.optionals pkgs.stdenv.hostPlatform.isx86 [
             # Misc. x86 keyboard stuff.
             "pcips2" "atkbd" "i8042"
           ]);
 
         boot.initrd.kernelModules =
-          optionals config.boot.initrd.includeDefaultModules [
+          lib.optionals config.boot.initrd.includeDefaultModules [
             # For LVM.
             "dm_mod"
           ];
       })
 
-      (mkIf config.boot.kernel.enable {
+      (lib.mkIf config.boot.kernel.enable {
         system.build = { inherit kernel; };
 
         system.modulesTree = [ kernel ] ++ config.boot.extraModulePackages;
@@ -339,7 +336,7 @@ in
 
             ln -s ${kernelPath} $out/kernel
             ln -s ${config.system.modulesTree} $out/kernel-modules
-            ${optionalString (config.hardware.deviceTree.package != null) ''
+            ${lib.optionalString (config.hardware.deviceTree.package != null) ''
               ln -s ${config.hardware.deviceTree.package} $out/dtbs
             ''}
 
@@ -356,9 +353,9 @@ in
         # (so you don't need to reboot to have changes take effect).
         boot.kernelParams =
           [ "loglevel=${toString config.boot.consoleLogLevel}" ] ++
-          optionals config.boot.vesa [ "vga=0x317" "nomodeset" ];
+          lib.optionals config.boot.vesa [ "vga=0x317" "nomodeset" ];
 
-        boot.kernel.sysctl."kernel.printk" = mkDefault config.boot.consoleLogLevel;
+        boot.kernel.sysctl."kernel.printk" = lib.mkDefault config.boot.consoleLogLevel;
 
         boot.kernelModules = [ "loop" "atkbd" ];
 

--- a/nixos/modules/system/boot/loader/external/external.nix
+++ b/nixos/modules/system/boot/loader/external/external.nix
@@ -4,15 +4,12 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.boot.loader.external;
 in
 {
   meta = {
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       cole-h
       grahamc
       raitobezarius
@@ -21,10 +18,10 @@ in
   };
 
   options.boot.loader.external = {
-    enable = mkEnableOption "using an external tool to install your bootloader";
+    enable = lib.mkEnableOption "using an external tool to install your bootloader";
 
-    installHook = mkOption {
-      type = with types; path;
+    installHook = lib.mkOption {
+      type = with lib.types; path;
       description = ''
         The full path to a program of your choosing which performs the bootloader installation process.
 
@@ -33,11 +30,11 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     boot.loader = {
-      grub.enable = mkDefault false;
-      systemd-boot.enable = mkDefault false;
-      supportsInitrdSecrets = mkDefault false;
+      grub.enable = lib.mkDefault false;
+      systemd-boot.enable = lib.mkDefault false;
+      supportsInitrdSecrets = lib.mkDefault false;
     };
 
     system.build.installBootLoader = cfg.installHook;

--- a/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
+++ b/nixos/modules/system/boot/loader/generations-dir/generations-dir.nix
@@ -1,7 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
 
   generationsDirBuilder = pkgs.substituteAll {
@@ -19,9 +16,9 @@ in
 
     boot.loader.generationsDir = {
 
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Whether to create symlinks to the system generations under
           `/boot`.  When enabled,
@@ -38,9 +35,9 @@ in
         '';
       };
 
-      copyKernels = mkOption {
+      copyKernels = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Whether to copy the necessary boot files into /boot, so
           /nix/store is not needed by the boot loader.
@@ -52,7 +49,7 @@ in
   };
 
 
-  config = mkIf config.boot.loader.generationsDir.enable {
+  config = lib.mkIf config.boot.loader.generationsDir.enable {
 
     system.build.installBootLoader = generationsDirBuilder;
     system.boot.loader.id = "generationsDir";

--- a/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
+++ b/nixos/modules/system/boot/loader/generic-extlinux-compatible/default.nix
@@ -1,7 +1,4 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   blCfg = config.boot.loader;
   dtCfg = config.hardware.deviceTree;
@@ -17,9 +14,9 @@ in
 {
   options = {
     boot.loader.generic-extlinux-compatible = {
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Whether to generate an extlinux-compatible configuration file
           under `/boot/extlinux.conf`.  For instance,
@@ -30,9 +27,9 @@ in
         '';
       };
 
-      useGenerationDeviceTree = mkOption {
+      useGenerationDeviceTree = lib.mkOption {
         default = true;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Whether to generate Device Tree-related directives in the
           extlinux configuration.
@@ -45,16 +42,16 @@ in
         '';
       };
 
-      configurationLimit = mkOption {
+      configurationLimit = lib.mkOption {
         default = 20;
         example = 10;
-        type = types.int;
+        type = lib.types.int;
         description = ''
           Maximum number of configurations in the boot menu.
         '';
       };
 
-      mirroredBoots = mkOption {
+      mirroredBoots = lib.mkOption {
         default = [ { path = "/boot"; } ];
         example = [
           { path = "/boot1"; }
@@ -64,9 +61,9 @@ in
           Mirror the boot configuration to multiple paths.
         '';
 
-        type = with types; listOf (submodule {
+        type = with lib.types; listOf (submodule {
           options = {
-            path = mkOption {
+            path = lib.mkOption {
               example = "/boot1";
               type = types.str;
               description = ''
@@ -78,8 +75,8 @@ in
         });
       };
 
-      populateCmd = mkOption {
-        type = types.str;
+      populateCmd = lib.mkOption {
+        type = lib.types.str;
         readOnly = true;
         description = ''
           Contains the builder command used to populate an image,
@@ -99,11 +96,11 @@ in
     installBootLoader = pkgs.writeScript "install-extlinux-conf.sh" (''
       #!${pkgs.runtimeShell}
       set -e
-    '' + flip concatMapStrings cfg.mirroredBoots (args: ''
+    '' + lib.flip lib.concatMapStrings cfg.mirroredBoots (args: ''
       ${builder} ${builderArgs} -d '${args.path}' -c "$@"
     ''));
   in
-    mkIf cfg.enable {
+    lib.mkIf cfg.enable {
       system.build.installBootLoader = installBootLoader;
       system.boot.loader.id = "generic-extlinux-compatible";
 

--- a/nixos/modules/system/boot/loader/grub/ipxe.nix
+++ b/nixos/modules/system/boot/loader/grub/ipxe.nix
@@ -1,14 +1,10 @@
 # This module adds a scripted iPXE entry to the GRUB boot menu.
-
 {
   config,
   lib,
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   scripts = builtins.attrNames config.boot.loader.grub.ipxe;
 
@@ -29,14 +25,14 @@ let
 in
 {
   options = {
-    boot.loader.grub.ipxe = mkOption {
-      type = types.attrsOf (types.either types.path types.str);
+    boot.loader.grub.ipxe = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.either lib.types.path lib.types.str);
       description = ''
         Set of iPXE scripts available for
         booting from the GRUB boot menu.
       '';
       default = { };
-      example = literalExpression ''
+      example = lib.literalExpression ''
         { demo = '''
             #!ipxe
             dhcp
@@ -47,7 +43,7 @@ in
     };
   };
 
-  config = mkIf (builtins.length scripts != 0) {
+  config = lib.mkIf (builtins.length scripts != 0) {
 
     boot.loader.grub.extraEntries = toString (map grubEntry scripts);
 

--- a/nixos/modules/system/boot/loader/grub/memtest.nix
+++ b/nixos/modules/system/boot/loader/grub/memtest.nix
@@ -5,9 +5,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   memtest86 = pkgs.memtest86plus;
   cfg = config.boot.loader.grub.memtest86;
@@ -18,19 +15,19 @@ in
 
     boot.loader.grub.memtest86 = {
 
-      enable = mkOption {
+      enable = lib.mkOption {
         default = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Make Memtest86+, a memory testing program, available from the GRUB
           boot menu.
         '';
       };
 
-      params = mkOption {
+      params = lib.mkOption {
         default = [ ];
         example = [ "console=ttyS0,115200" ];
-        type = types.listOf types.str;
+        type = lib.types.listOf lib.types.str;
         description = ''
           Parameters added to the Memtest86+ command line. As of memtest86+ 5.01
           the following list of (apparently undocumented) parameters are
@@ -63,7 +60,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     boot.loader.grub.extraEntries = ''
       menuentry "Memtest86+" {
         linux @bootRoot@/memtest.bin ${toString cfg.params}

--- a/nixos/modules/system/boot/loader/loader.nix
+++ b/nixos/modules/system/boot/loader/loader.nix
@@ -1,17 +1,14 @@
 { lib, ... }:
-
-with lib;
-
 {
   imports = [
-    (mkRenamedOptionModule [ "boot" "loader" "grub" "timeout" ] [ "boot" "loader" "timeout" ])
-    (mkRenamedOptionModule [ "boot" "loader" "gummiboot" "timeout" ] [ "boot" "loader" "timeout" ])
+    (lib.mkRenamedOptionModule [ "boot" "loader" "grub" "timeout" ] [ "boot" "loader" "timeout" ])
+    (lib.mkRenamedOptionModule [ "boot" "loader" "gummiboot" "timeout" ] [ "boot" "loader" "timeout" ])
   ];
 
   options = {
-    boot.loader.timeout = mkOption {
+    boot.loader.timeout = lib.mkOption {
       default = 5;
-      type = types.nullOr types.int;
+      type = lib.types.nullOr lib.types.int;
       description = ''
         Timeout (in seconds) until loader boots the default menu item. Use null if the loader menu should be displayed indefinitely.
       '';

--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -4,28 +4,25 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 {
 
   ###### interface
 
   options = {
     boot.modprobeConfig.enable =
-      mkEnableOption "modprobe config. This is useful for systems like containers which do not require a kernel"
+      lib.mkEnableOption "modprobe config. This is useful for systems like containers which do not require a kernel"
       // {
         default = true;
       };
 
     boot.modprobeConfig.useUbuntuModuleBlacklist =
-      mkEnableOption "Ubuntu distro's module blacklist"
+      lib.mkEnableOption "Ubuntu distro's module blacklist"
       // {
         default = true;
       };
 
-    boot.blacklistedKernelModules = mkOption {
-      type = types.listOf types.str;
+    boot.blacklistedKernelModules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [ ];
       example = [
         "cirrusfb"
@@ -37,7 +34,7 @@ with lib;
       '';
     };
 
-    boot.extraModprobeConfig = mkOption {
+    boot.extraModprobeConfig = lib.mkOption {
       default = "";
       example = ''
         options parport_pc io=0x378 irq=7 dma=1
@@ -48,23 +45,23 @@ with lib;
         specify module options.  See
         {manpage}`modprobe.d(5)` for details.
       '';
-      type = types.lines;
+      type = lib.types.lines;
     };
 
   };
 
   ###### implementation
 
-  config = mkIf config.boot.modprobeConfig.enable {
+  config = lib.mkIf config.boot.modprobeConfig.enable {
 
     environment.etc."modprobe.d/ubuntu.conf" =
-      mkIf config.boot.modprobeConfig.useUbuntuModuleBlacklist
+      lib.mkIf config.boot.modprobeConfig.useUbuntuModuleBlacklist
         {
           source = "${pkgs.kmod-blacklist-ubuntu}/modprobe.conf";
         };
 
     environment.etc."modprobe.d/nixos.conf".text = ''
-      ${flip concatMapStrings config.boot.blacklistedKernelModules (name: ''
+      ${lib.flip lib.concatMapStrings config.boot.blacklistedKernelModules (name: ''
         blacklist ${name}
       '')}
       ${config.boot.extraModprobeConfig}
@@ -76,7 +73,7 @@ with lib;
 
     environment.systemPackages = [ pkgs.kmod ];
 
-    system.activationScripts.modprobe = stringAfter [ "specialfs" ] ''
+    system.activationScripts.modprobe = lib.stringAfter [ "specialfs" ] ''
       # Allow the kernel to find our wrapped modprobe (which searches
       # in the right location in the Nix store for kernel modules).
       # We need this when the kernel (or some module) auto-loads a

--- a/nixos/modules/system/boot/plymouth.nix
+++ b/nixos/modules/system/boot/plymouth.nix
@@ -1,7 +1,4 @@
 { config, lib, options, pkgs, ... }:
-
-with lib;
-
 let
 
   plymouth = pkgs.plymouth.override {
@@ -68,44 +65,44 @@ in
 
     boot.plymouth = {
 
-      enable = mkEnableOption "Plymouth boot splash screen";
+      enable = lib.mkEnableOption "Plymouth boot splash screen";
 
-      font = mkOption {
+      font = lib.mkOption {
         default = "${pkgs.dejavu_fonts.minimal}/share/fonts/truetype/DejaVuSans.ttf";
-        defaultText = literalExpression ''"''${pkgs.dejavu_fonts.minimal}/share/fonts/truetype/DejaVuSans.ttf"'';
-        type = types.path;
+        defaultText = lib.literalExpression ''"''${pkgs.dejavu_fonts.minimal}/share/fonts/truetype/DejaVuSans.ttf"'';
+        type = lib.types.path;
         description = ''
           Font file made available for displaying text on the splash screen.
         '';
       };
 
-      themePackages = mkOption {
+      themePackages = lib.mkOption {
         default = lib.optional (cfg.theme == "breeze") nixosBreezePlymouth;
-        defaultText = literalMD ''
+        defaultText = lib.literalMD ''
           A NixOS branded variant of the breeze theme when
           `config.${opt.theme} == "breeze"`, otherwise
           `[ ]`.
         '';
-        type = types.listOf types.package;
+        type = lib.types.listOf lib.types.package;
         description = ''
           Extra theme packages for plymouth.
         '';
       };
 
-      theme = mkOption {
+      theme = lib.mkOption {
         default = "bgrt";
-        type = types.str;
+        type = lib.types.str;
         description = ''
           Splash screen theme.
         '';
       };
 
-      logo = mkOption {
-        type = types.path;
+      logo = lib.mkOption {
+        type = lib.types.path;
         # Dimensions are 48x48 to match GDM logo
         default = "${pkgs.nixos-icons}/share/icons/hicolor/48x48/apps/nix-snowflake-white.png";
-        defaultText = literalExpression ''"''${pkgs.nixos-icons}/share/icons/hicolor/48x48/apps/nix-snowflake-white.png"'';
-        example = literalExpression ''
+        defaultText = lib.literalExpression ''"''${pkgs.nixos-icons}/share/icons/hicolor/48x48/apps/nix-snowflake-white.png"'';
+        example = lib.literalExpression ''
           pkgs.fetchurl {
             url = "https://nixos.org/logo/nixos-hires.png";
             sha256 = "1ivzgd7iz0i06y36p8m5w48fd8pjqwxhdaavc0pxs7w1g7mcy5si";
@@ -117,8 +114,8 @@ in
         '';
       };
 
-      extraConfig = mkOption {
-        type = types.lines;
+      extraConfig = lib.mkOption {
+        type = lib.types.lines;
         default = "";
         description = ''
           Literal string to append to `configFile`
@@ -130,7 +127,7 @@ in
 
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     boot.kernelParams = [ "splash" ];
 
@@ -226,7 +223,7 @@ in
         # Fonts
         "/etc/plymouth/fonts".source = pkgs.runCommand "plymouth-initrd-fonts" {} ''
           mkdir -p $out
-          cp ${escapeShellArg cfg.font} $out
+          cp ${lib.escapeShellArg cfg.font} $out
         '';
         "/etc/fonts/fonts.conf".text = ''
           <?xml version="1.0"?>
@@ -321,18 +318,18 @@ in
       EOF
     '';
 
-    boot.initrd.extraUtilsCommandsTest = mkIf (!config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUtilsCommandsTest = lib.mkIf (!config.boot.initrd.systemd.enable) ''
       $out/bin/plymouthd --help >/dev/null
       $out/bin/plymouth --help >/dev/null
     '';
 
-    boot.initrd.extraUdevRulesCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+    boot.initrd.extraUdevRulesCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
       cp ${config.systemd.package}/lib/udev/rules.d/{70-uaccess,71-seat}.rules $out
       sed -i '/loginctl/d' $out/71-seat.rules
     '';
 
     # We use `mkAfter` to ensure that LUKS password prompt would be shown earlier than the splash screen.
-    boot.initrd.preLVMCommands = mkIf (!config.boot.initrd.systemd.enable) (mkAfter ''
+    boot.initrd.preLVMCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (lib.mkAfter ''
       mkdir -p /etc/plymouth
       mkdir -p /run/plymouth
       ln -s $extraUtils/etc/plymouth/logo.png /etc/plymouth/logo.png
@@ -346,12 +343,12 @@ in
       plymouth show-splash
     '');
 
-    boot.initrd.postMountCommands = mkIf (!config.boot.initrd.systemd.enable) ''
+    boot.initrd.postMountCommands = lib.mkIf (!config.boot.initrd.systemd.enable) ''
       plymouth update-root-fs --new-root-dir="$targetRoot"
     '';
 
     # `mkBefore` to ensure that any custom prompts would be visible.
-    boot.initrd.preFailCommands = mkIf (!config.boot.initrd.systemd.enable) (mkBefore ''
+    boot.initrd.preFailCommands = lib.mkIf (!config.boot.initrd.systemd.enable) (lib.mkBefore ''
       plymouth quit --wait
     '');
 

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -14,7 +14,9 @@ let
     ${lib.optionalString (
       config.networking.nameservers != [ ]
     ) "DNS=${lib.concatStringsSep " " config.networking.nameservers}"}
-    ${lib.optionalString (cfg.fallbackDns != null) "FallbackDNS=${lib.concatStringsSep " " cfg.fallbackDns}"}
+    ${lib.optionalString (
+      cfg.fallbackDns != null
+    ) "FallbackDNS=${lib.concatStringsSep " " cfg.fallbackDns}"}
     ${lib.optionalString (cfg.domains != [ ]) "Domains=${lib.concatStringsSep " " cfg.domains}"}
     LLMNR=${cfg.llmnr}
     DNSSEC=${cfg.dnssec}

--- a/nixos/modules/system/boot/resolved.nix
+++ b/nixos/modules/system/boot/resolved.nix
@@ -4,8 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
 let
   cfg = config.services.resolved;
 
@@ -13,11 +11,11 @@ let
 
   resolvedConf = ''
     [Resolve]
-    ${optionalString (
+    ${lib.optionalString (
       config.networking.nameservers != [ ]
-    ) "DNS=${concatStringsSep " " config.networking.nameservers}"}
-    ${optionalString (cfg.fallbackDns != null) "FallbackDNS=${concatStringsSep " " cfg.fallbackDns}"}
-    ${optionalString (cfg.domains != [ ]) "Domains=${concatStringsSep " " cfg.domains}"}
+    ) "DNS=${lib.concatStringsSep " " config.networking.nameservers}"}
+    ${lib.optionalString (cfg.fallbackDns != null) "FallbackDNS=${lib.concatStringsSep " " cfg.fallbackDns}"}
+    ${lib.optionalString (cfg.domains != [ ]) "Domains=${lib.concatStringsSep " " cfg.domains}"}
     LLMNR=${cfg.llmnr}
     DNSSEC=${cfg.dnssec}
     DNSOverTLS=${cfg.dnsovertls}
@@ -29,9 +27,9 @@ in
 
   options = {
 
-    services.resolved.enable = mkOption {
+    services.resolved.enable = lib.mkOption {
       default = false;
-      type = types.bool;
+      type = lib.types.bool;
       description = ''
         Whether to enable the systemd DNS resolver daemon, `systemd-resolved`.
 
@@ -39,13 +37,13 @@ in
       '';
     };
 
-    services.resolved.fallbackDns = mkOption {
+    services.resolved.fallbackDns = lib.mkOption {
       default = null;
       example = [
         "8.8.8.8"
         "2001:4860:4860::8844"
       ];
-      type = types.nullOr (types.listOf types.str);
+      type = lib.types.nullOr (lib.types.listOf lib.types.str);
       description = ''
         A list of IPv4 and IPv6 addresses to use as the fallback DNS servers.
         If this option is null, a compiled-in list of DNS servers is used instead.
@@ -53,11 +51,11 @@ in
       '';
     };
 
-    services.resolved.domains = mkOption {
+    services.resolved.domains = lib.mkOption {
       default = config.networking.search;
-      defaultText = literalExpression "config.networking.search";
+      defaultText = lib.literalExpression "config.networking.search";
       example = [ "example.com" ];
-      type = types.listOf types.str;
+      type = lib.types.listOf lib.types.str;
       description = ''
         A list of domains. These domains are used as search suffixes
         when resolving single-label host names (domain names which
@@ -71,10 +69,10 @@ in
       '';
     };
 
-    services.resolved.llmnr = mkOption {
+    services.resolved.llmnr = lib.mkOption {
       default = "true";
       example = "false";
-      type = types.enum [
+      type = lib.types.enum [
         "true"
         "resolve"
         "false"
@@ -90,10 +88,10 @@ in
       '';
     };
 
-    services.resolved.dnssec = mkOption {
+    services.resolved.dnssec = lib.mkOption {
       default = "false";
       example = "true";
-      type = types.enum [
+      type = lib.types.enum [
         "true"
         "allow-downgrade"
         "false"
@@ -123,10 +121,10 @@ in
       '';
     };
 
-    services.resolved.dnsovertls = mkOption {
+    services.resolved.dnsovertls = lib.mkOption {
       default = "false";
       example = "true";
-      type = types.enum [
+      type = lib.types.enum [
         "true"
         "opportunistic"
         "false"
@@ -150,15 +148,15 @@ in
       '';
     };
 
-    services.resolved.extraConfig = mkOption {
+    services.resolved.extraConfig = lib.mkOption {
       default = "";
-      type = types.lines;
+      type = lib.types.lines;
       description = ''
         Extra config to append to resolved.conf.
       '';
     };
 
-    boot.initrd.services.resolved.enable = mkOption {
+    boot.initrd.services.resolved.enable = lib.mkOption {
       default = config.boot.initrd.systemd.network.enable;
       defaultText = "config.boot.initrd.systemd.network.enable";
       description = ''
@@ -169,8 +167,8 @@ in
 
   };
 
-  config = mkMerge [
-    (mkIf cfg.enable {
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
 
       assertions = [
         {
@@ -184,7 +182,7 @@ in
       # add resolve to nss hosts database if enabled and nscd enabled
       # system.nssModules is configured in nixos/modules/system/boot/systemd.nix
       # added with order 501 to allow modules to go before with mkBefore
-      system.nssDatabases.hosts = (mkOrder 501 [ "resolve [!UNAVAIL=return]" ]);
+      system.nssDatabases.hosts = (lib.mkOrder 501 [ "resolve [!UNAVAIL=return]" ]);
 
       systemd.additionalUpstreamSystemUnits = [
         "systemd-resolved.service"
@@ -204,7 +202,7 @@ in
           # https://www.freedesktop.org/software/systemd/man/systemd-resolved.html#/etc/resolv.conf
           "resolv.conf".source = "/run/systemd/resolve/stub-resolv.conf";
         }
-        // optionalAttrs dnsmasqResolve {
+        // lib.optionalAttrs dnsmasqResolve {
           "dnsmasq-resolv.conf".source = "/run/systemd/resolve/resolv.conf";
         };
 
@@ -215,7 +213,7 @@ in
 
     })
 
-    (mkIf config.boot.initrd.services.resolved.enable {
+    (lib.mkIf config.boot.initrd.services.resolved.enable {
 
       assertions = [
         {

--- a/nixos/modules/system/boot/systemd/coredump.nix
+++ b/nixos/modules/system/boot/systemd/coredump.nix
@@ -5,18 +5,15 @@
   utils,
   ...
 }:
-
-with lib;
-
 let
   cfg = config.systemd.coredump;
   systemd = config.systemd.package;
 in
 {
   options = {
-    systemd.coredump.enable = mkOption {
+    systemd.coredump.enable = lib.mkOption {
       default = true;
-      type = types.bool;
+      type = lib.types.bool;
       description = ''
         Whether core dumps should be processed by
         {command}`systemd-coredump`. If disabled, core dumps
@@ -24,9 +21,9 @@ in
       '';
     };
 
-    systemd.coredump.extraConfig = mkOption {
+    systemd.coredump.extraConfig = lib.mkOption {
       default = "";
-      type = types.lines;
+      type = lib.types.lines;
       example = "Storage=journal";
       description = ''
         Extra config options for systemd-coredump. See coredump.conf(5) man page
@@ -35,9 +32,9 @@ in
     };
   };
 
-  config = mkMerge [
+  config = lib.mkMerge [
 
-    (mkIf cfg.enable {
+    (lib.mkIf cfg.enable {
       systemd.additionalUpstreamSystemUnits = [
         "systemd-coredump.socket"
         "systemd-coredump@.service"
@@ -78,8 +75,8 @@ in
       users.groups.systemd-coredump = { };
     })
 
-    (mkIf (!cfg.enable) {
-      boot.kernel.sysctl."kernel.core_pattern" = mkDefault "core";
+    (lib.mkIf (!cfg.enable) {
+      boot.kernel.sysctl."kernel.core_pattern" = lib.mkDefault "core";
     })
 
   ];

--- a/nixos/modules/system/boot/systemd/tmpfiles.nix
+++ b/nixos/modules/system/boot/systemd/tmpfiles.nix
@@ -1,13 +1,10 @@
 { config, lib, pkgs, ... }:
-
-with lib;
-
 let
   cfg = config.systemd.tmpfiles;
   initrdCfg = config.boot.initrd.systemd.tmpfiles;
   systemd = config.systemd.package;
 
-  attrsWith' = placeholder: elemType: types.attrsWith {
+  attrsWith' = placeholder: elemType: lib.types.attrsWith {
     inherit elemType placeholder;
   };
 
@@ -29,9 +26,9 @@ let
       };
     };
     default = {};
-    type = attrsWith' "config-name" (attrsWith' "tmpfiles-type" (attrsWith' "path" (types.submodule ({ name, config, ... }: {
-      options.type = mkOption {
-        type = types.str;
+    type = attrsWith' "config-name" (attrsWith' "tmpfiles-type" (attrsWith' "path" (lib.types.submodule ({ name, config, ... }: {
+      options.type = lib.mkOption {
+        type = lib.types.str;
         default = name;
         example = "d";
         description = ''
@@ -45,16 +42,16 @@ let
           <https://www.freedesktop.org/software/systemd/man/tmpfiles.d>
         '';
       };
-      options.mode = mkOption {
-        type = types.str;
+      options.mode = lib.mkOption {
+        type = lib.types.str;
         default = "-";
         example = "0755";
         description = ''
           The file access mode to use when creating this file or directory.
         '';
       };
-      options.user = mkOption {
-        type = types.str;
+      options.user = lib.mkOption {
+        type = lib.types.str;
         default = "-";
         example = "root";
         description = ''
@@ -66,8 +63,8 @@ let
           invokes systemd-tmpfiles is used.
         '';
       };
-      options.group = mkOption {
-        type = types.str;
+      options.group = lib.mkOption {
+        type = lib.types.str;
         default = "-";
         example = "root";
         description = ''
@@ -79,8 +76,8 @@ let
           invokes systemd-tmpfiles is used.
         '';
       };
-      options.age = mkOption {
-        type = types.str;
+      options.age = lib.mkOption {
+        type = lib.types.str;
         default = "-";
         example = "10d";
         description = ''
@@ -92,8 +89,8 @@ let
           If set to `"-"` no automatic clean-up is done.
         '';
       };
-      options.argument = mkOption {
-        type = types.str;
+      options.argument = lib.mkOption {
+        type = lib.types.str;
         default = "";
         example = "";
         description = ''
@@ -113,18 +110,18 @@ let
   '';
 
   # generates a list of tmpfiles.d rules from the attrs (paths) under tmpfiles.settings.<name>
-  pathsToRules = mapAttrsToList (path: types:
-    concatStrings (
-      mapAttrsToList (_type: settingsEntryToRule path) types
+  pathsToRules = lib.mapAttrsToList (path: types:
+    lib.concatStrings (
+      lib.mapAttrsToList (_type: settingsEntryToRule path) types
     )
   );
 
-  mkRuleFileContent = paths: concatStrings (pathsToRules paths);
+  mkRuleFileContent = paths: lib.concatStrings (pathsToRules paths);
 in
 {
   options = {
-    systemd.tmpfiles.rules = mkOption {
-      type = types.listOf types.str;
+    systemd.tmpfiles.rules = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
       default = [];
       example = [ "d /tmp 1777 root root 10d" ];
       description = ''
@@ -135,9 +132,9 @@ in
       '';
     };
 
-    systemd.tmpfiles.settings = mkOption settingsOption;
+    systemd.tmpfiles.settings = lib.mkOption settingsOption;
 
-    boot.initrd.systemd.tmpfiles.settings = mkOption (settingsOption // {
+    boot.initrd.systemd.tmpfiles.settings = lib.mkOption (settingsOption // {
       description = ''
         Similar to {option}`systemd.tmpfiles.settings` but the rules are
         only applied by systemd-tmpfiles before `initrd-switch-root.target`.
@@ -146,11 +143,11 @@ in
       '';
     });
 
-    systemd.tmpfiles.packages = mkOption {
-      type = types.listOf types.package;
+    systemd.tmpfiles.packages = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
       default = [];
-      example = literalExpression "[ pkgs.lvm2 ]";
-      apply = map getLib;
+      example = lib.literalExpression "[ pkgs.lvm2 ]";
+      apply = map lib.getLib;
       description = ''
         List of packages containing {command}`systemd-tmpfiles` rules.
 
@@ -241,8 +238,8 @@ in
               exit 1
             )
           done
-        '' + concatMapStrings (name: optionalString (hasPrefix "tmpfiles.d/" name) ''
-          rm -f $out/${removePrefix "tmpfiles.d/" name}
+        '' + lib.concatMapStrings (name: lib.optionalString (lib.hasPrefix "tmpfiles.d/" name) ''
+          rm -f $out/${lib.removePrefix "tmpfiles.d/" name}
         '') config.system.build.etc.passthru.targets;
       }) + "/*";
       "mtab" = {
@@ -277,10 +274,10 @@ in
           # This file is created automatically and should not be modified.
           # Please change the option ‘systemd.tmpfiles.rules’ instead.
 
-          ${concatStringsSep "\n" cfg.rules}
+          ${lib.concatStringsSep "\n" cfg.rules}
         '';
       })
-    ] ++ (mapAttrsToList (name: paths:
+    ] ++ (lib.mapAttrsToList (name: paths:
       pkgs.writeTextDir "lib/tmpfiles.d/${name}.conf" (mkRuleFileContent paths)
     ) cfg.settings);
 
@@ -347,9 +344,9 @@ in
 
       };
 
-      contents."/etc/tmpfiles.d" = mkIf (initrdCfg.settings != { }) {
+      contents."/etc/tmpfiles.d" = lib.mkIf (initrdCfg.settings != { }) {
         source = pkgs.linkFarm "initrd-tmpfiles.d" (
-          mapAttrsToList
+          lib.mapAttrsToList
             (name: paths: {
               name = "${name}.conf";
               path = pkgs.writeText "${name}.conf" (mkRuleFileContent paths);

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -1,7 +1,4 @@
 { config, lib, ... }:
-
-with lib;
-
 let
   cfg = config.services.timesyncd;
 in
@@ -9,16 +6,16 @@ in
 
   options = {
 
-    services.timesyncd = with types; {
-      enable = mkOption {
+    services.timesyncd = with lib.types; {
+      enable = lib.mkOption {
         default = !config.boot.isContainer;
-        defaultText = literalExpression "!config.boot.isContainer";
+        defaultText = lib.literalExpression "!config.boot.isContainer";
         type = bool;
         description = ''
           Enables the systemd NTP client daemon.
         '';
       };
-      servers = mkOption {
+      servers = lib.mkOption {
         default = null;
         type = nullOr (listOf str);
         description = ''
@@ -31,9 +28,9 @@ in
           See man:timesyncd.conf(5) for details.
         '';
       };
-      fallbackServers = mkOption {
+      fallbackServers = lib.mkOption {
         default = config.networking.timeServers;
-        defaultText = literalExpression "config.networking.timeServers";
+        defaultText = lib.literalExpression "config.networking.timeServers";
         type = nullOr (listOf str);
         description = ''
           The set of fallback NTP servers from which to synchronise.
@@ -45,7 +42,7 @@ in
           See man:timesyncd.conf(5) for details.
         '';
       };
-      extraConfig = mkOption {
+      extraConfig = lib.mkOption {
         default = "";
         type = lines;
         example = ''
@@ -60,7 +57,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
 
     systemd.additionalUpstreamSystemUnits = [ "systemd-timesyncd.service" ];
 
@@ -91,7 +88,7 @@ in
           # workaround an issue of systemd-timesyncd not starting due to upstream systemd reverting their dynamic users changes
           #  - https://github.com/NixOS/nixpkgs/pull/61321#issuecomment-492423742
           #  - https://github.com/systemd/systemd/issues/12131
-          (lib.optionalString (versionOlder config.system.stateVersion "19.09") ''
+          (lib.optionalString (lib.versionOlder config.system.stateVersion "19.09") ''
             if [ -L /var/lib/systemd/timesync ]; then
               rm /var/lib/systemd/timesync
               mv /var/lib/private/systemd/timesync /var/lib/systemd/timesync
@@ -104,11 +101,11 @@ in
       ''
         [Time]
       ''
-      + optionalString (cfg.servers != null) ''
-        NTP=${concatStringsSep " " cfg.servers}
+      + lib.optionalString (cfg.servers != null) ''
+        NTP=${lib.concatStringsSep " " cfg.servers}
       ''
-      + optionalString (cfg.fallbackServers != null) ''
-        FallbackNTP=${concatStringsSep " " cfg.fallbackServers}
+      + lib.optionalString (cfg.fallbackServers != null) ''
+        FallbackNTP=${lib.concatStringsSep " " cfg.fallbackServers}
       ''
       + cfg.extraConfig;
 

--- a/nixos/modules/tasks/cpu-freq.nix
+++ b/nixos/modules/tasks/cpu-freq.nix
@@ -4,9 +4,6 @@
   pkgs,
   ...
 }:
-
-with lib;
-
 let
   cpupower = config.boot.kernelPackages.cpupower;
   cfg = config.powerManagement;
@@ -19,8 +16,8 @@ in
 
     # TODO: This should be aliased to powerManagement.cpufreq.governor.
     # https://github.com/NixOS/nixpkgs/pull/53041#commitcomment-31825338
-    cpuFreqGovernor = mkOption {
-      type = types.nullOr types.str;
+    cpuFreqGovernor = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
       default = null;
       example = "ondemand";
       description = ''
@@ -35,8 +32,8 @@ in
 
     cpufreq = {
 
-      max = mkOption {
-        type = types.nullOr types.ints.unsigned;
+      max = lib.mkOption {
+        type = lib.types.nullOr lib.types.ints.unsigned;
         default = null;
         example = 2200000;
         description = ''
@@ -44,8 +41,8 @@ in
         '';
       };
 
-      min = mkOption {
-        type = types.nullOr types.ints.unsigned;
+      min = lib.mkOption {
+        type = lib.types.nullOr lib.types.ints.unsigned;
         default = null;
         example = 800000;
         description = ''
@@ -65,9 +62,9 @@ in
       minEnable = cfg.cpufreq.min != null;
       enable = !config.boot.isContainer && (governorEnable || maxEnable || minEnable);
     in
-    mkIf enable {
+    lib.mkIf enable {
 
-      boot.kernelModules = optional governorEnable "cpufreq_${cfg.cpuFreqGovernor}";
+      boot.kernelModules = lib.optional governorEnable "cpufreq_${cfg.cpuFreqGovernor}";
 
       environment.systemPackages = [ cpupower ];
 
@@ -85,9 +82,9 @@ in
           RemainAfterExit = "yes";
           ExecStart =
             "${cpupower}/bin/cpupower frequency-set "
-            + optionalString governorEnable "--governor ${cfg.cpuFreqGovernor} "
-            + optionalString maxEnable "--max ${toString cfg.cpufreq.max} "
-            + optionalString minEnable "--min ${toString cfg.cpufreq.min} ";
+            + lib.optionalString governorEnable "--governor ${cfg.cpuFreqGovernor} "
+            + lib.optionalString maxEnable "--max ${toString cfg.cpufreq.max} "
+            + lib.optionalString minEnable "--min ${toString cfg.cpufreq.min} ";
           SuccessExitStatus = "0 237";
         };
       };


### PR DESCRIPTION
## Description of changes

part of #208242

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
