### PR TITLE
lib.packagesFromDirectoryRecursive: mark directories with `recurseIntoAttrs`

### DIFF
--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -433,23 +433,24 @@ in
     if pathExists defaultPath then
       # if `${directory}/package.nix` exists, call it directly
       callPackage defaultPath { }
-    else recurseIntoAttrs (
-      if args ? newScope then
-        # Create a new scope, letting the packages refer to each other.
-        # See:
-        #  [lib.makeScope](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope) and
-        #  [lib.recurseIntoAttrs](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope)
-        makeScope newScope (
-          self:
-          # generate the attrset representing the directory, using the new scope's `callPackage` and `newScope`
-          processDir (
-            args
-            // {
-              inherit (self) callPackage newScope;
-            }
+    else
+      recurseIntoAttrs (
+        if args ? newScope then
+          # Create a new scope, letting the packages refer to each other.
+          # See:
+          #  [lib.makeScope](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope) and
+          #  [lib.recurseIntoAttrs](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope)
+          makeScope newScope (
+            self:
+            # generate the attrset representing the directory, using the new scope's `callPackage` and `newScope`
+            processDir (
+              args
+              // {
+                inherit (self) callPackage newScope;
+              }
+            )
           )
-        )
-      else
-        processDir args
-    );
+        else
+          processDir args
+      );
 }

--- a/lib/filesystem.nix
+++ b/lib/filesystem.nix
@@ -380,7 +380,6 @@ in
     let
       inherit (lib)
         concatMapAttrs
-        id
         makeScope
         recurseIntoAttrs
         removeSuffix
@@ -434,13 +433,12 @@ in
     if pathExists defaultPath then
       # if `${directory}/package.nix` exists, call it directly
       callPackage defaultPath { }
-    else if args ? newScope then
-      # Create a new scope and mark it `recurseForDerivations`.
-      # This lets the packages refer to each other.
-      # See:
-      #  [lib.makeScope](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope) and
-      #  [lib.recurseIntoAttrs](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope)
-      recurseIntoAttrs (
+    else recurseIntoAttrs (
+      if args ? newScope then
+        # Create a new scope, letting the packages refer to each other.
+        # See:
+        #  [lib.makeScope](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope) and
+        #  [lib.recurseIntoAttrs](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.customisation.makeScope)
         makeScope newScope (
           self:
           # generate the attrset representing the directory, using the new scope's `callPackage` and `newScope`
@@ -451,7 +449,7 @@ in
             }
           )
         )
-      )
-    else
-      processDir args;
+      else
+        processDir args
+    );
 }

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3913,24 +3913,26 @@ runTests {
       callPackage = path: overrides: import path overrides;
       directory = ./packages-from-directory/plain;
     };
-    expected = let
-      inherit (lib) recurseIntoAttrs;
-    in recurseIntoAttrs {
-      a = "a";
-      b = "b";
-      # Note: Other files/directories in `./test-data/c/` are ignored and can be
-      # used by `package.nix`.
-      c = "c";
-      my-namespace = recurseIntoAttrs {
-        d = "d";
-        e = "e";
-        f = "f";
-        my-sub-namespace = recurseIntoAttrs {
-          g = "g";
-          h = "h";
+    expected =
+      let
+        inherit (lib) recurseIntoAttrs;
+      in
+      recurseIntoAttrs {
+        a = "a";
+        b = "b";
+        # Note: Other files/directories in `./test-data/c/` are ignored and can be
+        # used by `package.nix`.
+        c = "c";
+        my-namespace = recurseIntoAttrs {
+          d = "d";
+          e = "e";
+          f = "f";
+          my-sub-namespace = recurseIntoAttrs {
+            g = "g";
+            h = "h";
+          };
         };
       };
-    };
   };
 
   # Check that `packagesFromDirectoryRecursive` can process a directory with a

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -3913,17 +3913,19 @@ runTests {
       callPackage = path: overrides: import path overrides;
       directory = ./packages-from-directory/plain;
     };
-    expected = {
+    expected = let
+      inherit (lib) recurseIntoAttrs;
+    in recurseIntoAttrs {
       a = "a";
       b = "b";
       # Note: Other files/directories in `./test-data/c/` are ignored and can be
       # used by `package.nix`.
       c = "c";
-      my-namespace = {
+      my-namespace = recurseIntoAttrs {
         d = "d";
         e = "e";
         f = "f";
-        my-sub-namespace = {
+        my-sub-namespace = recurseIntoAttrs {
           g = "g";
           h = "h";
         };

--- a/pkgs/os-specific/bsd/freebsd/pkgs/bintrans.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/bintrans.nix
@@ -1,5 +1,10 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.bin/bintrans";
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/cap_mkdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/cap_mkdb.nix
@@ -1,6 +1,10 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.bin/cap_mkdb";
-
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
@@ -177,5 +177,7 @@ mkDerivation {
   # not needed when building for FreeBSD.
   meta.platforms = lib.platforms.linux;
 
+  meta.platforms = lib.platforms.unix;
+
   alwaysKeepStatic = true;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/compat/package.nix
@@ -177,7 +177,5 @@ mkDerivation {
   # not needed when building for FreeBSD.
   meta.platforms = lib.platforms.linux;
 
-  meta.platforms = lib.platforms.unix;
-
   alwaysKeepStatic = true;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/config.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/config.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   freebsdSetupHook,
@@ -32,4 +33,6 @@ mkDerivation {
     libnv
     libsbuf
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/file2c.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/file2c.nix
@@ -1,6 +1,10 @@
-{ mkDerivation }:
-
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.bin/file2c";
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/gencat.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/gencat.nix
@@ -1,3 +1,6 @@
-{ mkDerivation }:
+{ lib, mkDerivation }:
 
-mkDerivation { path = "usr.bin/gencat"; }
+mkDerivation {
+  path = "usr.bin/gencat";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/i18n.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/i18n.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   mkcsmapper,
   mkesdb,
@@ -17,4 +18,6 @@ mkDerivation {
   preBuild = ''
     export makeFlags="$makeFlags ESDBDIR=$out/share/i18n/esdb CSMAPPERDIR=$out/share/i18n/csmapper"
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
@@ -71,4 +71,6 @@ mkDerivation {
     "man"
     "test"
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/kldxref.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/kldxref.nix
@@ -14,4 +14,6 @@ mkDerivation {
   postPatch = ''
     sed -i 's/FTS_PHYSICAL/FTS_LOGICAL/' $BSDSRCDIR/usr.sbin/kldxref/kldxref.c
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcapsicum.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcapsicum.nix
@@ -1,1 +1,8 @@
-{ mkDerivation }: mkDerivation { path = "lib/libcapsicum"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "lib/libcapsicum";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libcasper.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libcasper.nix
@@ -23,4 +23,6 @@ mkDerivation {
     make -C $BSDSRCDIR/lib/libcasper/services $makeFlags CFLAGS="-DWITH_CASPER -I$out/include"
     make -C $BSDSRCDIR/lib/libcasper/services $makeFlags install
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libelf.nix
@@ -41,4 +41,6 @@ mkDerivation {
   preBuild = lib.optionalString stdenv.hostPlatform.isFreeBSD ''
     export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -B${csu}/lib"
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
@@ -27,4 +27,5 @@ mkDerivation {
   ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "INSTALL=boot-install";
 
   alwaysKeepStatic = true;
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnv.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnv.nix
@@ -1,5 +1,7 @@
-{ mkDerivation }:
-
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "lib/libnv";
   extraPaths = [
@@ -7,4 +9,6 @@ mkDerivation {
     "sys/sys"
   ];
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libsbuf.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libsbuf.nix
@@ -1,7 +1,12 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 
 mkDerivation {
   path = "lib/libsbuf";
   extraPaths = [ "sys/kern" ];
   env.MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libspl.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libspl.nix
@@ -16,7 +16,7 @@ mkDerivation {
   '';
 
   meta = with lib; {
-    platform = platforms.freebsd;
+    platforms = platforms.freebsd;
     license = licenses.cddl;
   };
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/localedef.nix
@@ -33,4 +33,6 @@ mkDerivation ({
   '';
 
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 })

--- a/pkgs/os-specific/bsd/freebsd/pkgs/locales.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/locales.nix
@@ -31,6 +31,8 @@ let
         mandoc
         groff
       ] ++ lib.optional needsLocaledef localedef;
+
+      meta.platforms = lib.platforms.unix;
     };
   directories = {
     colldef = true;

--- a/pkgs/os-specific/bsd/freebsd/pkgs/lorder.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/lorder.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   freebsdSetupHook,
@@ -22,4 +23,6 @@ mkDerivation {
     "out"
     "man"
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/makeMinimal.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/makeMinimal.nix
@@ -65,4 +65,6 @@ mkDerivation {
   '';
 
   extraPaths = make.extraPaths;
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/makefs.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/makefs.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   libnetbsd,
   compatIfNeeded,
@@ -21,4 +22,6 @@ mkDerivation {
   ];
   MK_TESTS = "no";
   MK_PIE = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkDerivation.nix
@@ -104,7 +104,7 @@ lib.makeOverridable (
           rhelmot
           artemist
         ];
-        platforms = lib.platforms.unix;
+        platforms = lib.platforms.freebsd;
         license = lib.licenses.bsd2;
       } // attrs.meta or { };
     }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkcsmapper.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkcsmapper.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   stdenv,
   mkDerivation,
   byacc,
@@ -17,4 +18,6 @@ mkDerivation {
     byacc
     flex
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkesdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkesdb.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   byacc,
   flex,
@@ -13,4 +14,6 @@ mkDerivation {
     byacc
     flex
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mkimg.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mkimg.nix
@@ -1,6 +1,11 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.bin/mkimg";
   extraPaths = [ "sys/sys/disk" ];
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mknod.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mknod.nix
@@ -1,3 +1,9 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 
-mkDerivation { path = "sbin/mknod"; }
+mkDerivation {
+  path = "sbin/mknod";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/mtree.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/mtree.nix
@@ -42,4 +42,6 @@ mkDerivation {
       )
     }"
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rcorder.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rcorder.nix
@@ -1,1 +1,8 @@
-{ mkDerivation }: mkDerivation { path = "sbin/rcorder"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "sbin/rcorder";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/freebsd/pkgs/rpcgen/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/rpcgen/package.nix
@@ -23,4 +23,6 @@ mkDerivation {
     # the problem is fixed properly in glibc.
     ./rpcgen-glibc-hack.patch
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/sed.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/sed.nix
@@ -1,6 +1,11 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 
 mkDerivation {
   path = "usr.bin/sed";
   MK_TESTS = "no";
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/services_mkdb.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/services_mkdb.nix
@@ -1,8 +1,13 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.sbin/services_mkdb";
   postInstall = ''
     mkdir -p $out/etc
     cp $BSDSRCDIR/usr.sbin/services_mkdb/services $out/etc/services
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/tsort.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/tsort.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   freebsdSetupHook,
@@ -24,4 +25,6 @@ mkDerivation {
     mandoc
     groff
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/vtfontcvt.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/vtfontcvt.nix
@@ -1,5 +1,10 @@
-{ mkDerivation }:
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.bin/vtfontcvt";
   extraPaths = [ "sys/cddl/contrib/opensolaris/common/lz4" ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/freebsd/pkgs/zfs-data.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/zfs-data.nix
@@ -5,5 +5,6 @@ mkDerivation {
 
   meta = with lib; {
     license = licenses.cddl;
+    platforms = platforms.unix;
   };
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/column.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/column.nix
@@ -1,3 +1,8 @@
-{ mkDerivation }:
-
-mkDerivation { path = "usr.bin/column"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/column";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/compat/package.nix
@@ -137,5 +137,7 @@ mkDerivation (
       "external/bsd/flex"
       "sys/sys"
     ];
+
+    meta.platforms = lib.platforms.unix;
   }
 )

--- a/pkgs/os-specific/bsd/netbsd/pkgs/config.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/config.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -24,4 +25,6 @@ mkDerivation {
   ];
   buildInputs = compatIfNeeded;
   extraPaths = [ cksum.path ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/dict.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/dict.nix
@@ -1,7 +1,13 @@
-{ mkDerivation, defaultMakeFlags }:
+{
+  lib,
+  mkDerivation,
+  defaultMakeFlags,
+}:
 
 mkDerivation {
   path = "share/dict";
   noCC = true;
   makeFlags = defaultMakeFlags ++ [ "BINDIR=$(out)/share" ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/fts/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/fts/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -38,4 +39,6 @@ mkDerivation {
     ../../../../../build-support/setup-hooks/role.bash
     ./fts-setup-hook.sh
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/genassym.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/genassym.nix
@@ -1,3 +1,8 @@
-{ mkDerivation }:
-
-mkDerivation { path = "usr.bin/genassym"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/genassym";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/netbsd/pkgs/gencat.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/gencat.nix
@@ -1,3 +1,8 @@
-{ mkDerivation }:
-
-mkDerivation { path = "usr.bin/gencat"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/gencat";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/netbsd/pkgs/getconf.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/getconf.nix
@@ -1,3 +1,8 @@
-{ mkDerivation }:
-
-mkDerivation { path = "usr.bin/getconf"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/getconf";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/netbsd/pkgs/getent/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/getent/package.nix
@@ -1,6 +1,10 @@
-{ mkDerivation }:
-
+{
+  lib,
+  mkDerivation,
+}:
 mkDerivation {
   path = "usr.bin/getent";
   patches = [ ./getent.patch ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/install/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/install/package.nix
@@ -56,4 +56,6 @@ mkDerivation {
     runHook postInstall
   '';
   setupHook = ./install-setup-hook.sh;
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/libterminfo.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/libterminfo.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -41,4 +42,6 @@ mkDerivation {
     make -C $BSDSRCDIR/share/terminfo $makeFlags BINDIR=$out/share install
   '';
   extraPaths = [ "share/terminfo" ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/lorder.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/lorder.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -18,4 +19,6 @@ mkDerivation {
     mandoc
     groff
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/make-rules.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/make-rules.nix
@@ -67,4 +67,6 @@ mkDerivation {
   installPhase = ''
     cp -r . $out
   '';
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/makeMinimal.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/makeMinimal.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -44,4 +45,6 @@ mkDerivation {
   '';
 
   extraPaths = [ make.path ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/misc.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/misc.nix
@@ -1,7 +1,12 @@
-{ mkDerivation, defaultMakeFlags }:
-
+{
+  lib,
+  mkDerivation,
+  defaultMakeFlags,
+}:
 mkDerivation {
   path = "share/misc";
   noCC = true;
   makeFlags = defaultMakeFlags ++ [ "BINDIR=$(out)/share" ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/mkDerivation.nix
@@ -96,7 +96,7 @@ lib.makeOverridable (
           matthewbauer
           qyliss
         ];
-        platforms = platforms.unix;
+        platforms = platforms.netbsd;
         license = licenses.bsd2;
       };
     }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/mknod.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/mknod.nix
@@ -1,3 +1,8 @@
-{ mkDerivation }:
-
-mkDerivation { path = "sbin/mknod"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "sbin/mknod";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/netbsd/pkgs/mtree.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/mtree.nix
@@ -1,6 +1,11 @@
-{ mkDerivation, mknod }:
-
+{
+  lib,
+  mkDerivation,
+  mknod,
+}:
 mkDerivation {
   path = "usr.sbin/mtree";
   extraPaths = [ mknod.path ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/nbperf.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/nbperf.nix
@@ -1,3 +1,8 @@
-{ mkDerivation }:
-
-mkDerivation { path = "usr.bin/nbperf"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/nbperf";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/netbsd/pkgs/rpcgen.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/rpcgen.nix
@@ -1,3 +1,8 @@
-{ mkDerivation }:
-
-mkDerivation { path = "usr.bin/rpcgen"; }
+{
+  lib,
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/rpcgen";
+  meta.platforms = lib.platforms.unix;
+}

--- a/pkgs/os-specific/bsd/netbsd/pkgs/stat/package.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/stat/package.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -21,4 +22,6 @@ mkDerivation {
     mandoc
     groff
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/tic.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/tic.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -31,4 +32,6 @@ mkDerivation {
     "usr.bin/tic"
     "tools/Makefile.host"
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/tsort.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/tsort.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   mkDerivation,
   bsdSetupHook,
   netbsdSetupHook,
@@ -18,4 +19,6 @@ mkDerivation {
     mandoc
     groff
   ];
+
+  meta.platforms = lib.platforms.unix;
 }

--- a/pkgs/os-specific/bsd/netbsd/pkgs/uudecode.nix
+++ b/pkgs/os-specific/bsd/netbsd/pkgs/uudecode.nix
@@ -8,4 +8,6 @@ mkDerivation {
   path = "usr.bin/uudecode";
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isLinux "-DNO_BASE64";
   NIX_LDFLAGS = lib.optional stdenv.hostPlatform.isDarwin "-lresolv";
+
+  meta.platforms = lib.platforms.unix;
 }


### PR DESCRIPTION
Split off #359984, at this requires fixes in the BSD package sets.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [x] tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests)
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Function updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
