### PR TITLE
pineflash: init at 0.5.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -529,6 +529,13 @@
     githubId = 124545;
     name = "Anthony Cowley";
   };
+  acuteaangle = {
+    name = "Summer Tea";
+    email = "zestypurple@protonmail.com";
+    github = "acuteaangle";
+    githubId = 79724236;
+    keys = [ { fingerprint = "46C0 9BA8 A20E 5C50 1E1E  0597 0B6D 17F7 2BC4 7F61"; } ];
+  };
   acuteenvy = {
     matrix = "@acuteenvy:matrix.org";
     github = "acuteenvy";

--- a/pkgs/by-name/pi/pineflash/package.nix
+++ b/pkgs/by-name/pi/pineflash/package.nix
@@ -1,0 +1,88 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  autoPatchelfHook,
+  blisp,
+  dfu-util,
+  fontconfig,
+  glib,
+  gtk3,
+  openssl,
+  systemd,
+  libGL,
+  libxkbcommon,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "pineflash";
+  version = "0.5.5";
+
+  src = fetchFromGitHub {
+    owner = "Spagett1";
+    repo = "pineflash";
+    tag = version;
+    hash = "sha256-4tcwEok36vuXbtlZNUkLNw1kHFQPBEJM/gWRhRWNLPg=";
+  };
+
+  cargoHash = "sha256-l01It6mUflENlADW6PpOQvK1o4qOjbTsMLB6n+OIl0U=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ] ++ lib.optional stdenv.hostPlatform.isLinux autoPatchelfHook;
+
+  buildInputs = [
+    blisp
+    dfu-util
+    fontconfig
+    glib
+    gtk3
+    openssl
+    systemd
+  ];
+
+  runtimeDependencies = [
+    libGL
+    libxkbcommon
+  ];
+
+  postPatch =
+    ''
+      substituteInPlace src/submodules/flash.rs \
+        --replace-fail 'let command = Command::new("pkexec")' 'let command = Command::new("/run/wrappers/bin/pkexec")'
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      substituteInPlace src/submodules/flash.rs \
+        --replace-fail 'let blisppath = "blisp";' 'let blisppath = "${lib.getExe blisp}";' \
+        --replace-fail 'let dfupath = "dfu-util";' 'let dfupath = "${lib.getExe' dfu-util "dfu-util"}";'
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace src/submodules/flash.rs \
+        --replace-fail 'Command::new("blisp")' 'Command::new("${lib.getExe blisp}")' \
+        --replace-fail 'Command::new("dfu-util")' 'Command::new("${lib.getExe' dfu-util "dfu-util"}")'
+    '';
+
+  postInstall = ''
+    mkdir -p "$out/share/applications"
+    cp ./assets/Pineflash.desktop "$out/share/applications/Pineflash.desktop"
+    mkdir -p "$out/share/pixmaps"
+    cp ./assets/pine64logo.png "$out/share/pixmaps/pine64logo.png"
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "GUI tool to flash IronOS to the Pinecil V1 and V2";
+    homepage = "https://github.com/Spagett1/pineflash";
+    changelog = "https://github.com/Spagett1/pineflash/releases/tag/${version}";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [
+      acuteaangle
+    ];
+    mainProgram = "pineflash";
+  };
+}


### PR DESCRIPTION
Closes: gh-297715
Closes: gh-243312

This PR adds [PineFlash](https://github.com/Spagett1/PineFlash), a graphical utility for easily flashing [IronOS](https://github.com/Ralim/IronOS) to [Pinecil](https://pine64.com/product/pinecil-smart-mini-portable-soldering-iron/) soldering irons.

Note: This is my first package submission to nixpkgs, so I would greatly appreciate anyone reviewing or testing this pointing out anything obvious I missed, or any other advice/suggestions :)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
