### PR TITLE
[Backport release-24.11] evdi: 1.14.7 -> 1.14.8

### DIFF
--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -16,13 +16,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "evdi";
-  version = "1.14.7";
+  version = "1.14.8";
 
   src = fetchFromGitHub {
     owner = "DisplayLink";
     repo = "evdi";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-z3GawjaokbmmUC1LihwGSnF3tUp9n/FO+kDiWvBq+mY=";
+    hash = "sha256-57DP8kKsPEK1C5A6QfoZZDmm76pn4SaUKEKu9cicyKI=";
   };
 
   env.NIX_CFLAGS_COMPILE = toString [


### PR DESCRIPTION
Bot-based backport to `release-24.11` by label in https://github.com/NixOS/nixpkgs/pull/366775 failed.