### PR TITLE
flexget: 3.13.2 -> 3.13.5, add tests

### DIFF
--- a/pkgs/by-name/fl/flexget/package.nix
+++ b/pkgs/by-name/fl/flexget/package.nix
@@ -6,7 +6,7 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "flexget";
-  version = "3.13.2";
+  version = "3.13.5";
   pyproject = true;
 
   # Fetch from GitHub in order to use `requirements.in`
@@ -14,7 +14,7 @@ python3.pkgs.buildPythonApplication rec {
     owner = "Flexget";
     repo = "Flexget";
     tag = "v${version}";
-    hash = "sha256-UjKYHZwAOOv3Adj13r2zJkVmxwEpJLQk87UslddX9Qk=";
+    hash = "sha256-R6E5NWnrnezJsDm+Nnqgibv4e6mXVrOrKaCl/MBqUnY=";
   };
 
   # relax dep constrains, keep environment constraints

--- a/pkgs/by-name/fl/flexget/package.nix
+++ b/pkgs/by-name/fl/flexget/package.nix
@@ -1,10 +1,11 @@
 {
   lib,
-  python3,
+  python3Packages,
   fetchFromGitHub,
+  stdenv,
 }:
 
-python3.pkgs.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "flexget";
   version = "3.13.5";
   pyproject = true;
@@ -20,9 +21,9 @@ python3.pkgs.buildPythonApplication rec {
   # relax dep constrains, keep environment constraints
   pythonRelaxDeps = true;
 
-  build-system = with python3.pkgs; [ setuptools ];
+  build-system = with python3Packages; [ setuptools ];
 
-  dependencies = with python3.pkgs; [
+  dependencies = with python3Packages; [
     # See https://github.com/Flexget/Flexget/blob/master/pyproject.toml
     # and https://github.com/Flexget/Flexget/blob/develop/requirements.txt
     apscheduler
@@ -40,6 +41,7 @@ python3.pkgs.buildPythonApplication rec {
     pyrss2gen
     python-dateutil
     pyyaml
+    rarfile
     rebulk
     requests
     rich
@@ -66,6 +68,7 @@ python3.pkgs.buildPythonApplication rec {
     deluge-client
     cloudscraper
     python-telegram-bot
+    boto3
   ];
 
   pythonImportsCheck = [
@@ -93,14 +96,69 @@ python3.pkgs.buildPythonApplication rec {
     "flexget.plugins.services.pogcal_acquired"
   ];
 
-  # ~400 failures
-  doCheck = false;
+  nativeCheckInputs = [
+    python3Packages.pytestCheckHook
+    python3Packages.pytest-vcr
+    python3Packages.paramiko
+  ];
 
-  meta = with lib; {
+  doCheck = !stdenv.isDarwin;
+
+  disabledTests = [
+    # reach the Internet
+    "TestExistsMovie"
+    "TestImdb"
+    "TestImdbLookup"
+    "TestImdbParser"
+    "TestInputHtml"
+    "TestInputSites"
+    "TestNfoLookupWithMovies"
+    "TestNpoWatchlistInfo"
+    "TestNpoWatchlistLanguageTheTVDBLookup"
+    "TestNpoWatchlistPremium"
+    "TestPlex"
+    "TestRadarrListActions"
+    "TestRssOnline"
+    "TestSeriesRootAPI"
+    "TestSftpDownload"
+    "TestSftpList"
+    "TestSonarrListActions"
+    "TestSubtitleList"
+    "TestTMDBMovieLookupAPI"
+    "TestTVDBEpisodeABSLookupAPI"
+    "TestTVDBEpisodeAirDateLookupAPI"
+    "TestTVDBEpisodeLookupAPI"
+    "TestTVDBExpire"
+    "TestTVDBFavorites"
+    "TestTVDBLanguages"
+    "TestTVDBList"
+    "TestTVDBLookup"
+    "TestTVDBLookup"
+    "TestTVDBSeriesActorsLookupAPI"
+    "TestTVDBSeriesLookupAPI"
+    "TestTVDSearchIMDBLookupAPI"
+    "TestTVDSearchNameLookupAPI"
+    "TestTVDSearchZAP2ITLookupAPI"
+    "TestTVMAzeSeriesLookupAPI"
+    "TestTVMazeSeasonLookup"
+    "TestTVMazeShowLookup"
+    "TestTVMazeUnicodeLookup"
+    "TestTaskParsing::test_selected_parser_cleared"
+    "TestTheTVDBLanguages"
+    "TestTheTVDBList"
+    "TestTmdbLookup"
+    "TestURLRewriters"
+    "TestURLRewriters::test_ettv"
+    # others
+    "TestRegexp"
+    "TestYamlLists"
+  ];
+
+  meta = {
     homepage = "https://flexget.com/";
     changelog = "https://github.com/Flexget/Flexget/releases/tag/v${version}";
     description = "Multipurpose automation tool for all of your media";
-    license = licenses.mit;
-    maintainers = with maintainers; [ pbsds ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbsds ];
   };
 }

--- a/pkgs/development/python-modules/flask-restx/default.nix
+++ b/pkgs/development/python-modules/flask-restx/default.nix
@@ -17,6 +17,7 @@
   pytest-flask,
   pytest-mock,
   pytest-benchmark,
+  pytest-vcr,
   pytestCheckHook,
   setuptools,
 }:
@@ -55,6 +56,7 @@ buildPythonPackage rec {
     pytest-benchmark
     pytest-flask
     pytest-mock
+    pytest-vcr
     pytestCheckHook
   ];
 
@@ -70,6 +72,7 @@ buildPythonPackage rec {
     ];
 
   disabledTests = [
+    "test_specs_endpoint_host_and_subdomain"
     # broken in werkzeug 2.3 upgrade
     "test_media_types_method"
     "test_media_types_q"


### PR DESCRIPTION
Closes https://github.com/NixOS/nixpkgs/issues/369256
- **flexget 3.13.2 -> 3.13.5**
- **flexget: minor tweaks**
- **flexget: enable tests**


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
