### PR TITLE
thunderbird: fix darwin build

### DIFF
--- a/pkgs/applications/networking/mailreaders/thunderbird/0001-Implemented-char_traits-for-SEXP-octet_t.patch
+++ b/pkgs/applications/networking/mailreaders/thunderbird/0001-Implemented-char_traits-for-SEXP-octet_t.patch
@@ -1,0 +1,262 @@
+From 46744a14ffc235330bb99cebfaf294829c31bba4 Mon Sep 17 00:00:00 2001
+From: "Maxim [maxirmx] Samsonov" <m.samsonov@computer.org>
+Date: Mon, 3 Jun 2024 13:39:47 +0300
+Subject: [PATCH] Implemented char_traits for SEXP octet_t
+
+---
+ comm/third_party/rnp/src/libsexpp/include/sexpp/sexp.h                    |  95 ++++++++++++++++++-
+ comm/third_party/rnp/src/libsexpp/tests/src/traits-tests.cpp              | 116 ++++++++++++++++++++++++
+ comm/third_party/rnp/src/libsexpp/version.txt                             |   2 +-
+ 3 files changed, 208 insertions(+), 7 deletions(-)
+ create mode 100644 tests/src/traits-tests.cpp
+
+diff --git a/comm/third_party/rnp/src/libsexpp/include/sexpp/sexp.h b/comm/third_party/rnp/src/libsexpp/include/sexpp/sexp.h
+index bb6ae4e..3ffb735 100644
+--- a/comm/third_party/rnp/src/libsexpp/include/sexpp/sexp.h
++++ b/comm/third_party/rnp/src/libsexpp/include/sexpp/sexp.h
+@@ -44,8 +44,93 @@
+ #include "sexp-public.h"
+ #include "sexp-error.h"
+ 
++// We are implementing char traits for octet_t with trhe following restrictions
++//  -- limit visibility so that other traits for unsigned char are still possible
++//  -- create template specializatio in std workspace (use workspace specialization
++//     is not specified and causes issues at least with gcc 4.8
++
+ namespace sexp {
++using octet_t = uint8_t;
++} // namespace sexp
++
++namespace std {
++
++template <> struct char_traits<sexp::octet_t> {
++    typedef sexp::octet_t  char_type;
++    typedef int            int_type;
++    typedef std::streampos pos_type;
++    typedef std::streamoff off_type;
++    typedef mbstate_t      state_type;
++
++    static void assign(char_type &__c1, const char_type &__c2) noexcept { __c1 = __c2; }
++
++    static constexpr bool eq(const char_type &__c1, const char_type &__c2) noexcept
++    {
++        return __c1 == __c2;
++    }
++
++    static constexpr bool lt(const char_type &__c1, const char_type &__c2) noexcept
++    {
++        return __c1 < __c2;
++    }
++
++    static int compare(const char_type *__s1, const char_type *__s2, size_t __n)
++    {
++        return memcmp(__s1, __s2, __n);
++    }
++
++    static size_t length(const char_type *__s)
++    {
++        return strlen(reinterpret_cast<const char *>(__s));
++    }
++
++    static const char_type *find(const char_type *__s, size_t __n, const char_type &__a)
++    {
++        return static_cast<const char_type *>(memchr(__s, __a, __n));
++    }
++
++    static char_type *move(char_type *__s1, const char_type *__s2, size_t __n)
++    {
++        return static_cast<char_type *>(memmove(__s1, __s2, __n));
++    }
++
++    static char_type *copy(char_type *__s1, const char_type *__s2, size_t __n)
++    {
++        return static_cast<char_type *>(memcpy(__s1, __s2, __n));
++    }
++
++    static char_type *assign(char_type *__s, size_t __n, char_type __a)
++    {
++        return static_cast<char_type *>(memset(__s, __a, __n));
++    }
++
++    static constexpr char_type to_char_type(const int_type &__c) noexcept
++    {
++        return static_cast<char_type>(__c);
++    }
++
++    // To keep both the byte 0xff and the eof symbol 0xffffffff
++    // from ending up as 0xffffffff.
++    static constexpr int_type to_int_type(const char_type &__c) noexcept
++    {
++        return static_cast<int_type>(static_cast<unsigned char>(__c));
++    }
++
++    static constexpr bool eq_int_type(const int_type &__c1, const int_type &__c2) noexcept
++    {
++        return __c1 == __c2;
++    }
++
++    static constexpr int_type eof() noexcept { return static_cast<int_type>(0xFFFFFFFF); }
+ 
++    static constexpr int_type not_eof(const int_type &__c) noexcept
++    {
++        return (__c == eof()) ? 0 : __c;
++    }
++};
++} // namespace std
++
++namespace sexp {
+ /*
+  * SEXP octet_t definitions
+  * We maintain some presumable redundancy with ctype
+@@ -99,14 +184,14 @@ class sexp_input_stream_t;
+  * SEXP simple string
+  */
+ 
+-typedef uint8_t octet_t;
++using octet_traits = std::char_traits<octet_t>;
++using octet_string = std::basic_string<octet_t, octet_traits>;
+ 
+-class SEXP_PUBLIC_SYMBOL sexp_simple_string_t : public std::basic_string<octet_t>,
+-                                                private sexp_char_defs_t {
++class SEXP_PUBLIC_SYMBOL sexp_simple_string_t : public octet_string, private sexp_char_defs_t {
+   public:
+     sexp_simple_string_t(void) = default;
+-    sexp_simple_string_t(const octet_t *dt) : std::basic_string<octet_t>{dt} {}
+-    sexp_simple_string_t(const octet_t *bt, size_t ln) : std::basic_string<octet_t>{bt, ln} {}
++    sexp_simple_string_t(const octet_t *dt) : octet_string{dt} {}
++    sexp_simple_string_t(const octet_t *bt, size_t ln) : octet_string{bt, ln} {}
+     sexp_simple_string_t &append(int c)
+     {
+         (*this) += (octet_t)(c & 0xFF);
+diff --git a/comm/third_party/rnp/src/libsexpp/tests/src/traits-tests.cpp b/comm/third_party/rnp/src/libsexpp/tests/src/traits-tests.cpp
+new file mode 100644
+index 0000000..52e1019
+--- /dev/null
++++ b/comm/third_party/rnp/src/libsexpp/tests/src/traits-tests.cpp
+@@ -0,0 +1,116 @@
++/**
++ *
++ * Copyright 2024 Ribose Inc. (https://www.ribose.com)
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy of
++ * this software and associated documentation files (the "Software"), to deal in
++ * the Software without restriction, including without limitation the rights to
++ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
++ * the Software, and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
++ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
++ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
++ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
++ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ *
++ */
++
++#include "sexp-tests.h"
++
++using namespace sexp;
++
++namespace {
++
++TEST(OctetTraitsTest, Assign)
++{
++    octet_t a = 0x12;
++    octet_t b = 0x34;
++    octet_traits::assign(a, b);
++    EXPECT_EQ(a, b);
++}
++
++TEST(OctetTraitsTest, Eq)
++{
++    octet_t a = 0x12;
++    octet_t b = 0x12;
++    EXPECT_TRUE(octet_traits::eq(a, b));
++}
++
++TEST(OctetTraitsTest, Lt)
++{
++    octet_t a = 0x12;
++    octet_t b = 0x34;
++    EXPECT_TRUE(octet_traits::lt(a, b));
++}
++
++TEST(OctetTraitsTest, Compare)
++{
++    octet_t s1[] = {0x12, 0x34, 0x56};
++    octet_t s2[] = {0x12, 0x34, 0x57};
++    EXPECT_LT(octet_traits::compare(s1, s2, 3), 0);
++}
++
++TEST(OctetTraitsTest, Find)
++{
++    octet_t s[] = {0x12, 0x34, 0x56};
++    octet_t a = 0x34;
++    EXPECT_EQ(octet_traits::find(s, 3, a), s + 1);
++}
++
++TEST(OctetTraitsTest, Move)
++{
++    octet_t s1[] = {0x12, 0x34, 0x56};
++    octet_t s2[3];
++    octet_traits::move(s2, s1, 3);
++    EXPECT_EQ(memcmp(s1, s2, 3), 0);
++}
++
++TEST(OctetTraitsTest, Copy)
++{
++    octet_t s1[] = {0x12, 0x34, 0x56};
++    octet_t s2[3];
++    octet_traits::copy(s2, s1, 3);
++    EXPECT_EQ(memcmp(s1, s2, 3), 0);
++}
++
++TEST(OctetTraitsTest, AssignMultiple)
++{
++    octet_t s[3];
++    octet_t a = 0x12;
++    octet_traits::assign(s, 3, a);
++    for (int i = 0; i < 3; i++) {
++        EXPECT_EQ(s[i], a);
++    }
++}
++
++TEST(OctetTraitsTest, ToCharType)
++{
++    octet_traits::int_type a = 0x12;
++    EXPECT_EQ(octet_traits::to_char_type(a), 0x12);
++}
++
++TEST(OctetTraitsTest, ToIntType)
++{
++    octet_t a = 0x12;
++    EXPECT_EQ(octet_traits::to_int_type(a), 0x12);
++}
++
++TEST(OctetTraitsTest, EqIntType)
++{
++    octet_traits::int_type a = 0x12;
++    octet_traits::int_type b = 0x12;
++    EXPECT_TRUE(octet_traits::eq_int_type(a, b));
++}
++
++TEST(OctetTraitsTest, NotEof)
++{
++    octet_traits::int_type a = 0x12;
++    EXPECT_EQ(octet_traits::not_eof(a), 0x12);
++}
++} // namespace
+diff --git a/comm/third_party/rnp/src/libsexpp/version.txt b/comm/third_party/rnp/src/libsexpp/version.txt
+index 1e9b46b..6201b5f 100644
+--- a/comm/third_party/rnp/src/libsexpp/version.txt
++++ b/comm/third_party/rnp/src/libsexpp/version.txt
+@@ -1 +1 @@
+-0.8.7
++0.8.8
+-- 
+2.47.0
+

--- a/pkgs/applications/networking/mailreaders/thunderbird/0001-Removed-lookup-against-basic_string-uint8_t.patch
+++ b/pkgs/applications/networking/mailreaders/thunderbird/0001-Removed-lookup-against-basic_string-uint8_t.patch
@@ -1,0 +1,100 @@
+From 20419f739f632fb30666650544f0055e8d4f1afa Mon Sep 17 00:00:00 2001
+From: Maxim Samsonov <m.samsonov@computer.org>
+Date: Wed, 19 Jun 2024 16:52:08 +0300
+Subject: [PATCH] Removed lookup against basic_string<uint8_t>
+
+---
+ comm/third_party/rnp/src/lib/types.h                |  5 +----
+ comm/third_party/rnp/src/lib/utils.cpp              | 17 +----------------
+ comm/third_party/rnp/src/librekey/key_store_g10.cpp |  8 ++++----
+ 3 files changed, 7 insertions(+), 25 deletions(-)
+
+diff --git a/comm/third_party/rnp/src/lib/types.h b/comm/third_party/rnp/src/lib/types.h
+index f0c25d3d..a7eac3a1 100644
+--- a/comm/third_party/rnp/src/lib/types.h
++++ b/comm/third_party/rnp/src/lib/types.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2017-2021, [Ribose Inc](https://www.ribose.com).
++ * Copyright (c) 2017-2024, [Ribose Inc](https://www.ribose.com).
+  * Copyright (c) 2009 The NetBSD Foundation, Inc.
+  * All rights reserved.
+  *
+@@ -71,9 +71,6 @@ class id_str_pair {
+     static int         lookup(const id_str_pair           pair[],
+                               const std::vector<uint8_t> &bytes,
+                               int                         notfound = 0);
+-    static int         lookup(const id_str_pair                 pair[],
+-                              const std::basic_string<uint8_t> &bytes,
+-                              int                               notfound = 0);
+ };
+ 
+ /** pgp_fingerprint_t */
+diff --git a/comm/third_party/rnp/src/lib/utils.cpp b/comm/third_party/rnp/src/lib/utils.cpp
+index 3c6216c6..fd526379 100644
+--- a/comm/third_party/rnp/src/lib/utils.cpp
++++ b/comm/third_party/rnp/src/lib/utils.cpp
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2021, [Ribose Inc](https://www.ribose.com).
++ * Copyright (c) 2021, 2024 [Ribose Inc](https://www.ribose.com).
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+@@ -63,18 +63,3 @@ id_str_pair::lookup(const id_str_pair pair[], const std::vector<uint8_t> &bytes,
+     }
+     return notfound;
+ }
+-
+-int
+-id_str_pair::lookup(const id_str_pair                 pair[],
+-                    const std::basic_string<uint8_t> &bytes,
+-                    int                               notfound)
+-{
+-    while (pair && pair->str) {
+-        if ((strlen(pair->str) == bytes.size()) &&
+-            !memcmp(pair->str, bytes.data(), bytes.size())) {
+-            return pair->id;
+-        }
+-        pair++;
+-    }
+-    return notfound;
+-}
+diff --git a/comm/third_party/rnp/src/librekey/key_store_g10.cpp b/comm/third_party/rnp/src/librekey/key_store_g10.cpp
+index e646f02f..21136866 100644
+--- a/comm/third_party/rnp/src/librekey/key_store_g10.cpp
++++ b/comm/third_party/rnp/src/librekey/key_store_g10.cpp
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2017-2022, [Ribose Inc](https://www.ribose.com).
++ * Copyright (c) 2017-2024, [Ribose Inc](https://www.ribose.com).
+  * All rights reserved.
+  *
+  * Redistribution and use in source and binary forms, with or without
+@@ -311,12 +311,12 @@ read_curve(const sexp_list_t *list, const std::string &name, pgp_ec_key_t &key)
+ 
+     const auto &bytes = data->get_string();
+     pgp_curve_t curve = static_cast<pgp_curve_t>(
+-      id_str_pair::lookup(g10_curve_aliases, data->get_string(), PGP_CURVE_UNKNOWN));
++      id_str_pair::lookup(g10_curve_aliases, (const char *) bytes.data(), PGP_CURVE_UNKNOWN));
+     if (curve != PGP_CURVE_UNKNOWN) {
+         key.curve = curve;
+         return true;
+     }
+-    RNP_LOG("Unknown curve: %.*s", (int) bytes.size(), (char *) bytes.data());
++    RNP_LOG("Unknown curve: %.*s", (int) bytes.size(), (const char *) bytes.data());
+     return false;
+ }
+ 
+@@ -807,7 +807,7 @@ g23_parse_seckey(pgp_key_pkt_t &seckey,
+ 
+     auto &           alg_bt = alg_s_exp->sexp_string_at(0)->get_string();
+     pgp_pubkey_alg_t alg = static_cast<pgp_pubkey_alg_t>(
+-      id_str_pair::lookup(g10_alg_aliases, alg_bt.c_str(), PGP_PKA_NOTHING));
++      id_str_pair::lookup(g10_alg_aliases, (const char *) alg_bt.data(), PGP_PKA_NOTHING));
+     if (alg == PGP_PKA_NOTHING) {
+         RNP_LOG(
+           "Unsupported algorithm: '%.*s'", (int) alg_bt.size(), (const char *) alg_bt.data());
+-- 
+2.47.0
+

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -42,6 +42,12 @@ let
       extraPatches = [
         # The file to be patched is different from firefox's `no-buildconfig-ffx90.patch`.
         ./no-buildconfig.patch
+        # clang-19 fixes for char_traits build issue
+        # https://github.com/rnpgp/rnp/pull/2242/commits/e0790a2c4ff8e09d52522785cec1c9db23d304ac
+        # https://github.com/rnpgp/sexpp/pull/54/commits/46744a14ffc235330bb99cebfaf294829c31bba4
+        # Remove when upstream bumps bundled rnp version: https://bugzilla.mozilla.org/show_bug.cgi?id=1893950
+        ./0001-Removed-lookup-against-basic_string-uint8_t.patch
+        ./0001-Implemented-char_traits-for-SEXP-octet_t.patch
       ];
 
       extraPassthru = {


### PR DESCRIPTION
Add patches for bundled libraries (rnp and libsexpp) to handle clang 19 lack of char_traits for unsigned char.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
