### PR TITLE
prometheus-rasdaemon-exporter: backport fixes

### DIFF
--- a/pkgs/by-name/pr/prometheus-rasdaemon-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-rasdaemon-exporter/package.nix
@@ -2,6 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
+  fetchpatch2,
 }:
 
 python3Packages.buildPythonApplication {
@@ -15,6 +16,19 @@ python3Packages.buildPythonApplication {
     rev = "e37084edeb4d397dd360298cb22f18f83a35ff46";
     hash = "sha256-O0Zzog+5jDixFRGbqmjPYi6JDpHbxpU4hKfsqTnexS8=";
   };
+
+  patches = [
+    # Normalization of metric names
+    # https://github.com/sanecz/prometheus-rasdaemon-exporter/pull/1
+    (fetchpatch2 {
+      url = "https://github.com/sanecz/prometheus-rasdaemon-exporter/commit/46d379ba205c2340a0b266bf3cd48ec88ce025d0.patch";
+      hash = "sha256-kqo1Tjn51M1FzArS4K0ylQ2/rFDOAiZU3OUt/oBhGhM=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/sanecz/prometheus-rasdaemon-exporter/commit/c9ab08e8918497edb8f1ab0f933fa270cb7860a8.patch";
+      hash = "sha256-QtjzXuxPG7e+cgUDVbAVNY4VyBp3W5+vQDAvFJ9t92I=";
+    })
+  ];
 
   build-system = with python3Packages; [
     setuptools

--- a/pkgs/by-name/pr/prometheus-rasdaemon-exporter/package.nix
+++ b/pkgs/by-name/pr/prometheus-rasdaemon-exporter/package.nix
@@ -28,6 +28,12 @@ python3Packages.buildPythonApplication {
       url = "https://github.com/sanecz/prometheus-rasdaemon-exporter/commit/c9ab08e8918497edb8f1ab0f933fa270cb7860a8.patch";
       hash = "sha256-QtjzXuxPG7e+cgUDVbAVNY4VyBp3W5+vQDAvFJ9t92I=";
     })
+    # Fix sqlite3.connect URI passing
+    # https://github.com/sanecz/prometheus-rasdaemon-exporter/pull/2
+    (fetchpatch2 {
+      url = "https://github.com/sanecz/prometheus-rasdaemon-exporter/commit/52f6c47b77f480cd7f83853a2baffffb45f77b37.patch";
+      hash = "sha256-XYeWMkAhWJIOUKLeTstIJr3P37Jwt8tzRURCvlrrxVs=";
+    })
   ];
 
   build-system = with python3Packages; [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Submitted upstream, but want to apply them early, so I can move forward with deploying the exporter and creating the proper rules.

```shell
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 265.0
python_gc_objects_collected_total{generation="1"} 6.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 34.0
python_gc_collections_total{generation="1"} 3.0
python_gc_collections_total{generation="2"} 0.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="12",patchlevel="8",version="3.12.8"} 1.0
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.9001344e+08
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 2.2544384e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.73560228487e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.07
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 7.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP rasdaemon_aer_events_total Total of AER Events occured
# TYPE rasdaemon_aer_events_total counter
# HELP rasdaemon_mce_records_total Total of MCE record occured
# TYPE rasdaemon_mce_records_total counter
rasdaemon_mce_records_total{mce_msg="Corrected error, no action required."} 20.0
# HELP rasdaemon_mc_events_total Total of Memory Controller events occured
# TYPE rasdaemon_mc_events_total counter
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
