### PR TITLE
font-{alias,util}, gccmakedep, libp{ciacces,threadstub}s: refactor and migrate to pkgs/by-name from xorg namespace

### DIFF
--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -452,6 +452,11 @@ lib.mapAttrs mkLicense (
       fullName = "Common Public License 1.0";
     };
 
+    cronyx = {
+      spdxId = "Cronyx";
+      fullName = "Cronyx License";
+    };
+
     curl = {
       spdxId = "curl";
       fullName = "curl License";

--- a/lib/licenses.nix
+++ b/lib/licenses.nix
@@ -257,6 +257,11 @@ lib.mapAttrs mkLicense (
       fullName = "BSD Protection License";
     };
 
+    bsdSourceCode = {
+      spdxId = "BSD-Source-Code";
+      fullName = "BSD Source Code Attribution";
+    };
+
     bsl11 = {
       spdxId = "BUSL-1.1";
       fullName = "Business Source License 1.1";
@@ -942,6 +947,11 @@ lib.mapAttrs mkLicense (
       fullName = "MIT No Attribution";
     };
 
+    mitOpenGroup = {
+      spdxId = "MIT-open-group";
+      fullName = "MIT Open Group variant";
+    };
+
     mpl10 = {
       spdxId = "MPL-1.0";
       fullName = "Mozilla Public License 1.0";
@@ -1324,6 +1334,11 @@ lib.mapAttrs mkLicense (
     unicode-dfs-2016 = {
       spdxId = "Unicode-DFS-2016";
       fullName = "Unicode License Agreement - Data Files and Software (2016)";
+    };
+
+    unicodeTOU = {
+      spdxId = "Unicode-TOU";
+      fullName = "Unicode Terms of Use";
     };
 
     unlicense = {

--- a/pkgs/by-name/fo/font-alias/package.nix
+++ b/pkgs/by-name/fo/font-alias/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  writeScript,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-alias";
+  version = "1.0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-alias-${finalAttrs.version}.tar.xz";
+    hash = "sha256-n4niF7tz4ONjagpJP7+LfJlRVuDFPZoEdtIBtnwta24=";
+  };
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+  };
+
+  meta = {
+    description = "Common aliases for Xorg fonts";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/alias";
+    license = with lib.licenses; [
+      cronyx
+      mit
+    ];
+    maintainers = [ ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/fo/font-util/package.nix
+++ b/pkgs/by-name/fo/font-util/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  testers,
+  writeScript,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "font-util";
+  version = "1.4.1";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/font/font-util-${finalAttrs.version}.tar.xz";
+    hash = "sha256-XJ9kEjwZSxUP7okEmZFoc4bm/zbvKve4C6U++vNozJU=";
+  };
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/font/ \
+        | sort -V | tail -n1)"
+
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "X.Org font package creation/installation utilities";
+    homepage = "https://gitlab.freedesktop.org/xorg/font/util";
+    license = with lib.licenses; [
+      mit
+      bsd2
+      bsdSourceCode
+      mitOpenGroup
+      # there is a bit of a diff, but i think its close enough
+      # it was probably just adapted a bit to fit to the repository structure
+      # or its an older version that the one on spdx
+      unicodeTOU
+    ];
+    maintainers = [ ];
+    pkgConfigModules = [ "fontutil" ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/gc/gccmakedep/package.nix
+++ b/pkgs/by-name/gc/gccmakedep/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  writeScript,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gccmakedep";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/util/gccmakedep-${finalAttrs.version}.tar.xz";
+    hash = "sha256-UIj5h2n7Y8Mm6bnSy3yfSmMKKAHdHaBpcdCCkXbPJbY=";
+  };
+
+  passthru.updateScript = writeScript "update-${finalAttrs.pname}" ''
+    #!/usr/bin/env nix-shell
+    #!nix-shell -i bash -p common-updater-scripts
+
+    version="$(list-directory-versions --pname ${finalAttrs.pname} \
+      --url https://xorg.freedesktop.org/releases/individual/util/ \
+      | sort -V | tail -n1)"
+
+    update-source-version ${finalAttrs.pname} "$version"
+  '';
+
+  meta = {
+    description = "Creates dependencies in makefiles using 'gcc -M'";
+    homepage = "https://gitlab.freedesktop.org/xorg/util/gccmakedep";
+    license = with lib.licenses; [
+      # COPYING file suggests looking at the Copyright headers of every file:
+      # upstream issue: https://gitlab.freedesktop.org/xorg/util/gccmakedep/-/issues/1
+
+      # 1. build system files Copyright Red Hat
+      hpndSellVariant
+
+      # 2. gccmakedep.man was written by Colin Watson for Debian somewhen
+      # earlier than November 2003. While I wasn't able to trace the exact
+      # source, between 1997 and 2004 the "Debian Social Contract, Version
+      # 1.0" was in effect, which requires all components of the Debian
+      # Operating System to be free software, which includes this man page.
+      # https://www.debian.org/social_contract.1.0
+      free
+
+      # 3. gccmakedep.in, originally named gccmdep.cpp was copied from the
+      # XFree86 project around 2000. While it states to be "Based on
+      # mdepend.cpp and code supplied by Hongjiu Lu", that doesn't matter
+      # because it was supposedly completely rewritten by XFree86.
+      # XFree86 code without any explicit Copyright Statement is under X11.
+      x11
+
+      # 4. some files don't have any license info, but they are all trivial
+    ];
+    mainProgram = "gccmakedep";
+    maintainers = [ ];
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/li/libpciaccess/package.nix
+++ b/pkgs/by-name/li/libpciaccess/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  testers,
+  writeScript,
+  pkg-config,
+  meson,
+  ninja,
+  zlib,
+  netbsd,
+  hwdata,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libpciaccess";
+  version = "0.18.1";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libpciaccess-${finalAttrs.version}.tar.xz";
+    hash = "sha256-SvQ0RLOK21VF0O0cLORtlgjMR7McI4f8UYFlZ2Wm+nY=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs =
+    [ zlib ]
+    ++ lib.optionals stdenv.hostPlatform.isNetBSD [
+      netbsd.libarch
+      netbsd.libpci
+    ];
+
+  mesonFlags = [
+    (lib.mesonOption "pci-ids" "${hwdata}/share/hwdata")
+    (lib.mesonEnable "zlib" true)
+  ];
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Generic PCI access library";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/libpciaccess";
+    license = with lib.licenses; [
+      mit
+      isc
+      x11
+    ];
+    pkgConfigModules = [ "pciaccess" ];
+    # https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/blob/6cd5a4afbb70868c7746de8d50dea59e02e9acf2/configure.ac#L108-114
+    platforms =
+      with lib.platforms;
+      cygwin
+      ++ freebsd
+      ++ illumos
+      ++ linux
+      ++ lib.platforms.netbsd # otherwise netbsd from the function arguments is used
+      ++ openbsd;
+    badPlatforms = [
+      # mandatory shared library
+      lib.systems.inspect.platformPatterns.isStatic
+    ];
+  };
+})

--- a/pkgs/by-name/li/libpthread-stubs/package.nix
+++ b/pkgs/by-name/li/libpthread-stubs/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  testers,
+  writeScript,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libpthread-stubs";
+  version = "0.5";
+
+  src = fetchurl {
+    url = "mirror://xorg/individual/lib/libpthread-stubs-${finalAttrs.version}.tar.xz";
+    hash = "sha256-WdpWbezOunwqeXCkoDtI2ZBfEmL/lEEKZJIk4z0kQrw=";
+  };
+
+  passthru = {
+    updateScript = writeScript "update-${finalAttrs.pname}" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p common-updater-scripts
+
+      version="$(list-directory-versions --pname ${finalAttrs.pname} \
+        --url https://xorg.freedesktop.org/releases/individual/lib/ \
+        | sort -V | tail -n1)"
+
+      update-source-version ${finalAttrs.pname} "$version"
+    '';
+    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = {
+    description = "Provides a pkg-config file `pthread-stubs.pc` containing the Cflags/Libs flags applicable to programs/libraries that use only lightweight pthread API";
+    homepage = "https://gitlab.freedesktop.org/xorg/lib/pthread-stubs";
+    # gitlab says x11-distribute-modifications but it's not
+    # maybe due to https://github.com/spdx/spdx-online-tools/issues/540
+    license = lib.licenses.x11;
+    maintainers = [ ];
+    pkgConfigModules = [ "pthread-stubs" ];
+    # on these platforms according to the readme
+    platforms = with lib.platforms; linux ++ cygwin ++ darwin ++ [ "x86_64-solaris" ];
+  };
+})

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -3,14 +3,18 @@
   lib,
   font-alias,
   font-util,
+  gccmakedep,
   luit,
   pixman,
 }:
 
 self: with self; {
 
-  inherit pixman;
-  inherit luit;
+  inherit
+    gccmakedep
+    luit
+    pixman
+    ;
   fontalias = font-alias;
   fontutil = font-util;
 
@@ -1637,37 +1641,6 @@ self: with self; {
       buildInputs = [ fontutil ];
       configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
       postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  gccmakedep = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "gccmakedep";
-      version = "1.0.4";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/util/gccmakedep-1.0.4.tar.xz";
-        sha256 = "1di5rxv930nhf5ls07fx04l0lqsakxycplmrx4kc6qzvd63zk22h";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -4,6 +4,7 @@
   font-alias,
   font-util,
   gccmakedep,
+  libpciaccess,
   luit,
   pixman,
 }:
@@ -12,6 +13,7 @@ self: with self; {
 
   inherit
     gccmakedep
+    libpciaccess
     luit
     pixman
     ;
@@ -3192,37 +3194,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "fontenc" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libpciaccess = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libpciaccess";
-      version = "0.18.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/lib/libpciaccess-0.18.1.tar.xz";
-        sha256 = "0xpslrjnfrc1a7y8f8qwnd3wq24ndpj2q77ds12mbnwand239x2a";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "pciaccess" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -5,6 +5,7 @@
   font-util,
   gccmakedep,
   libpciaccess,
+  libpthread-stubs,
   luit,
   pixman,
 }:
@@ -19,6 +20,7 @@ self: with self; {
     ;
   fontalias = font-alias;
   fontutil = font-util;
+  libpthreadstubs = libpthread-stubs;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   appres = callPackage (
@@ -3194,37 +3196,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ "fontenc" ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  libpthreadstubs = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "libpthread-stubs";
-      version = "0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/xcb/libpthread-stubs-0.5.tar.xz";
-        sha256 = "1g224hyy694jch54357zc895z46r90xs193hg4m7rfnfxinmdnjr";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "pthread-stubs" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -2,6 +2,7 @@
 {
   lib,
   font-alias,
+  font-util,
   luit,
   pixman,
 }:
@@ -11,6 +12,7 @@ self: with self; {
   inherit pixman;
   inherit luit;
   fontalias = font-alias;
+  fontutil = font-util;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   appres = callPackage (
@@ -1560,37 +1562,6 @@ self: with self; {
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontutil = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-util";
-      version = "1.4.1";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-util-1.4.1.tar.xz";
-        sha256 = "15fcd3rzlgm51fwgfapg6vzyd1kkd28rj149xq7iajqr7h9697sw";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ "fontutil" ];
         platforms = lib.platforms.unix;
       };
     })

--- a/pkgs/servers/x11/xorg/default.nix
+++ b/pkgs/servers/x11/xorg/default.nix
@@ -1,14 +1,16 @@
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
-  pixman,
+  font-alias,
   luit,
+  pixman,
 }:
 
 self: with self; {
 
   inherit pixman;
   inherit luit;
+  fontalias = font-alias;
 
   # THIS IS A GENERATED FILE.  DO NOT EDIT!
   appres = callPackage (
@@ -405,37 +407,6 @@ self: with self; {
       buildInputs = [ fontutil ];
       configureFlags = [ "--with-fontrootdir=$(out)/lib/X11/fonts" ];
       postPatch = ''substituteInPlace configure --replace 'MAPFILES_PATH=`pkg-config' 'MAPFILES_PATH=`$PKG_CONFIG' '';
-      passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
-      meta = {
-        pkgConfigModules = [ ];
-        platforms = lib.platforms.unix;
-      };
-    })
-  ) { };
-
-  # THIS IS A GENERATED FILE.  DO NOT EDIT!
-  fontalias = callPackage (
-    {
-      stdenv,
-      pkg-config,
-      fetchurl,
-      testers,
-    }:
-    stdenv.mkDerivation (finalAttrs: {
-      pname = "font-alias";
-      version = "1.0.5";
-      builder = ./builder.sh;
-      src = fetchurl {
-        url = "mirror://xorg/individual/font/font-alias-1.0.5.tar.xz";
-        sha256 = "0vkb5mybc0fjfq29lgf5w1b536bwifzkyj8ad9iy7q3kpcby52cz";
-      };
-      hardeningDisable = [
-        "bindnow"
-        "relro"
-      ];
-      strictDeps = true;
-      nativeBuildInputs = [ pkg-config ];
-      buildInputs = [ ];
       passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
       meta = {
         pkgConfigModules = [ ];

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -260,14 +260,16 @@ print OUT <<EOF;
 # THIS IS A GENERATED FILE.  DO NOT EDIT!
 {
   lib,
-  pixman,
+  font-alias,
   luit,
+  pixman,
 }:
 
 self: with self; {
 
   inherit pixman;
   inherit luit;
+  fontalias = font-alias;
 
 EOF
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -38,6 +38,7 @@ $pcMap{"gbm"} = "libgbm";
 $pcMap{"hwdata"} = "hwdata";
 $pcMap{"fontutil"} = "fontutil";
 $pcMap{"pciaccess"} = "libpciaccess";
+$pcMap{"pthread-stubs"} = "libpthreadstubs";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "xorgproto";
 $pcMap{"\$DRI3PROTO"} = "xorgproto";
@@ -266,6 +267,7 @@ print OUT <<EOF;
   font-util,
   gccmakedep,
   libpciaccess,
+  libpthread-stubs,
   luit,
   pixman,
 }:
@@ -280,6 +282,7 @@ self: with self; {
     ;
   fontalias = font-alias;
   fontutil = font-util;
+  libpthreadstubs = libpthread-stubs;
 
 EOF
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -263,14 +263,18 @@ print OUT <<EOF;
   lib,
   font-alias,
   font-util,
+  gccmakedep,
   luit,
   pixman,
 }:
 
 self: with self; {
 
-  inherit pixman;
-  inherit luit;
+  inherit
+    gccmakedep
+    luit
+    pixman
+    ;
   fontalias = font-alias;
   fontutil = font-util;
 

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -37,6 +37,7 @@ $pcMap{"GL"} = "libGL";
 $pcMap{"gbm"} = "libgbm";
 $pcMap{"hwdata"} = "hwdata";
 $pcMap{"fontutil"} = "fontutil";
+$pcMap{"pciaccess"} = "libpciaccess";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "xorgproto";
 $pcMap{"\$DRI3PROTO"} = "xorgproto";
@@ -264,6 +265,7 @@ print OUT <<EOF;
   font-alias,
   font-util,
   gccmakedep,
+  libpciaccess,
   luit,
   pixman,
 }:
@@ -272,6 +274,7 @@ self: with self; {
 
   inherit
     gccmakedep
+    libpciaccess
     luit
     pixman
     ;

--- a/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
+++ b/pkgs/servers/x11/xorg/generate-expr-from-tarballs.pl
@@ -36,6 +36,7 @@ $pcMap{"gl"} = "libGL";
 $pcMap{"GL"} = "libGL";
 $pcMap{"gbm"} = "libgbm";
 $pcMap{"hwdata"} = "hwdata";
+$pcMap{"fontutil"} = "fontutil";
 $pcMap{"\$PIXMAN"} = "pixman";
 $pcMap{"\$RENDERPROTO"} = "xorgproto";
 $pcMap{"\$DRI3PROTO"} = "xorgproto";
@@ -261,6 +262,7 @@ print OUT <<EOF;
 {
   lib,
   font-alias,
+  font-util,
   luit,
   pixman,
 }:
@@ -270,6 +272,7 @@ self: with self; {
   inherit pixman;
   inherit luit;
   fontalias = font-alias;
+  fontutil = font-util;
 
 EOF
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -157,7 +157,6 @@ self: super:
     };
   });
 
-  gccmakedep = addMainProgram super.gccmakedep { };
   iceauth = addMainProgram super.iceauth { };
   ico = addMainProgram super.ico { };
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -620,38 +620,6 @@ self: super:
     ]; # mainly to avoid propagation
   });
 
-  libpciaccess = super.libpciaccess.overrideAttrs (attrs: {
-    nativeBuildInputs = attrs.nativeBuildInputs ++ [
-      meson
-      ninja
-    ];
-
-    buildInputs =
-      attrs.buildInputs
-      ++ [ zlib ]
-      ++ lib.optionals stdenv.hostPlatform.isNetBSD [
-        netbsd.libarch
-        netbsd.libpci
-      ];
-
-    mesonFlags = [
-      (lib.mesonOption "pci-ids" "${hwdata}/share/hwdata")
-      (lib.mesonEnable "zlib" true)
-    ];
-
-    meta = attrs.meta // {
-      # https://gitlab.freedesktop.org/xorg/lib/libpciaccess/-/blob/master/configure.ac#L108-114
-      platforms =
-        lib.fold (os: ps: ps ++ lib.platforms.${os})
-          [ ]
-          [ "cygwin" "freebsd" "linux" "netbsd" "openbsd" "illumos" ];
-      badPlatforms = [
-        # mandatory shared library
-        lib.systems.inspect.platformPatterns.isStatic
-      ];
-    };
-  });
-
   libpthreadstubs = super.libpthreadstubs.overrideAttrs (attrs: {
     # only contains a pkgconfig file on linux and windows
     meta = attrs.meta // {

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -620,13 +620,6 @@ self: super:
     ]; # mainly to avoid propagation
   });
 
-  libpthreadstubs = super.libpthreadstubs.overrideAttrs (attrs: {
-    # only contains a pkgconfig file on linux and windows
-    meta = attrs.meta // {
-      platforms = lib.platforms.unix ++ lib.platforms.windows;
-    };
-  });
-
   setxkbmap = super.setxkbmap.overrideAttrs (attrs: {
     postInstall = ''
       mkdir -p $out/share/man/man7

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -209,7 +209,6 @@ mirror://xorg/individual/lib/xtrans-1.6.0.tar.xz
 mirror://xorg/individual/proto/xcb-proto-1.17.0.tar.xz
 mirror://xorg/individual/proto/xorgproto-2024.1.tar.xz
 mirror://xorg/individual/util/bdftopcf-1.1.2.tar.xz
-mirror://xorg/individual/util/gccmakedep-1.0.4.tar.xz
 mirror://xorg/individual/util/imake-1.0.10.tar.xz
 mirror://xorg/individual/util/lndir-1.0.5.tar.xz
 mirror://xorg/individual/util/makedepend-1.0.9.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -132,7 +132,6 @@ mirror://xorg/individual/font/font-adobe-100dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-75dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-100dpi-1.0.5.tar.xz
 mirror://xorg/individual/font/font-adobe-utopia-type1-1.0.5.tar.xz
-mirror://xorg/individual/font/font-alias-1.0.5.tar.xz
 mirror://xorg/individual/font/font-arabic-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-75dpi-1.0.4.tar.xz
 mirror://xorg/individual/font/font-bh-100dpi-1.0.4.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -160,7 +160,6 @@ mirror://xorg/individual/font/font-schumacher-misc-1.1.3.tar.xz
 mirror://xorg/individual/font/font-screen-cyrillic-1.0.5.tar.xz
 mirror://xorg/individual/font/font-sony-misc-1.0.4.tar.xz
 mirror://xorg/individual/font/font-sun-misc-1.0.4.tar.xz
-mirror://xorg/individual/font/font-util-1.4.1.tar.xz
 mirror://xorg/individual/font/font-winitzki-cyrillic-1.0.4.tar.xz
 mirror://xorg/individual/font/font-xfree86-type1-1.0.5.tar.xz
 https://gitlab.freedesktop.org/xorg/lib/libAppleWM/-/archive/be972ebc3a97292e7d2b2350eff55ae12df99a42/libAppleWM-be972ebc3a97292e7d2b2350eff55ae12df99a42.tar.bz2

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -167,7 +167,6 @@ mirror://xorg/individual/lib/libdmx-1.1.5.tar.xz
 mirror://xorg/individual/lib/libfontenc-1.1.8.tar.xz
 mirror://xorg/individual/lib/libFS-1.0.10.tar.xz
 mirror://xorg/individual/lib/libICE-1.1.2.tar.xz
-mirror://xorg/individual/lib/libpciaccess-0.18.1.tar.xz
 mirror://xorg/individual/lib/libSM-1.2.5.tar.xz
 mirror://xorg/individual/lib/libWindowsWM-1.0.1.tar.bz2
 mirror://xorg/individual/lib/libX11-1.8.12.tar.xz

--- a/pkgs/servers/x11/xorg/tarballs.list
+++ b/pkgs/servers/x11/xorg/tarballs.list
@@ -1,4 +1,3 @@
-mirror://xorg/individual/xcb/libpthread-stubs-0.5.tar.xz
 mirror://xorg/individual/xcb/xcb-util-0.4.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-errors-1.0.1.tar.xz
 mirror://xorg/individual/xcb/xcb-util-image-0.4.1.tar.xz

--- a/pkgs/servers/x11/xorg/update.py
+++ b/pkgs/servers/x11/xorg/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure --keep NIX_PATH -i python3 -p nix git "python3.withPackages (ps: [ ps. packaging ps.beautifulsoup4 ps.requests ])"
+#!nix-shell --pure --keep NIX_PATH -i python3 -p nix git nixfmt-rfc-style "python3.withPackages (ps: [ ps. packaging ps.beautifulsoup4 ps.requests ])"
 
 # Usage: Run ./update.py from the directory containing tarballs.list. The script checks for the
 # latest versions of all packages, updates the expressions if any update is found, and commits
@@ -92,6 +92,10 @@ with open("./tarballs.list", "w") as f:
 print("Generating updated expr (slow)...")
 
 subprocess.run(["./generate-expr-from-tarballs.pl", "tarballs.list"], check=True)
+
+print("Formatting generated expr...")
+
+subprocess.run(["nixfmt", "default.nix"], check=True)
 
 print("Committing...")
 


### PR DESCRIPTION
This is my next step on refactoring and migrating all xorg packages to pkgs/by-name.
Split of #322521
This is ready for review now.

Done:
- [x] fontalias
- [x] fontutil
- [x] gccmakedep
- [x] libpciaccess
- [x] libpthreadstubs

Will move to another PR:
- [ ] libxcvt
- [ ] makedepend
- [ ] utilmacros
- [ ] xbitmaps
- [ ] xcbproto
- [ ] xkeyboardconfig
- [ ] xorgcffiles
- [ ] xorgdocs
- [ ] xorgsgmldoctools
- [ ] xtrans

the list of xorg packages that don't depend on other xorg packages was generated by this script:
```fish
#!/usr/bin/env fish

set names (cat pkgs/servers/x11/xorg/default.nix | \
	grep callPackage | \
	string trim | \
	string split -m 1 -f 1 ' ')

for line in (cat pkgs/servers/x11/xorg/default.nix | grep callPackage | string trim)
	set name (string split -m 1 -f 1 ' ' $line)
	set xorgdepscount (string split -m 1 -f 2 ' ' $line | grep -Eo (string join '|' $names) | wc -l)
	if test $xorgdepscount -eq 0
		echo $name
	end
end | sort
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
