### PR TITLE
ghostty: improve darwin expression

### DIFF
--- a/pkgs/by-name/gh/ghostty/darwin.nix
+++ b/pkgs/by-name/gh/ghostty/darwin.nix
@@ -1,31 +1,28 @@
 {
   lib,
   stdenvNoCC,
-  fetchurl,
   _7zz,
+  fetchurl,
   makeBinaryWrapper,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   src = fetchurl {
     url = "https://release.files.ghostty.org/${finalAttrs.version}/Ghostty.dmg";
-    sha256 = "sha256-CR96Kz9BYKFtfVKygiEku51XFJk4FfYqfXACeYQ3JlI=";
+    hash = "sha256-CR96Kz9BYKFtfVKygiEku51XFJk4FfYqfXACeYQ3JlI=";
   };
+
+  sourceRoot = ".";
 
   nativeBuildInputs = [
     _7zz
     makeBinaryWrapper
   ];
 
-  sourceRoot = ".";
-  installPhase = ''
-    runHook preInstall
-
+  postInstall = ''
     mkdir -p $out/Applications
     mv Ghostty.app $out/Applications/
     makeWrapper $out/Applications/Ghostty.app/Contents/MacOS/ghostty $out/bin/ghostty
-
-    runHook postInstall
   '';
 
   # For use in our shared postFixup

--- a/pkgs/by-name/gh/ghostty/darwin.nix
+++ b/pkgs/by-name/gh/ghostty/darwin.nix
@@ -1,8 +1,4 @@
 {
-  pname,
-  version,
-  outputs,
-  meta,
   lib,
   stdenvNoCC,
   fetchurl,
@@ -11,8 +7,6 @@
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
-  inherit pname version outputs;
-
   src = fetchurl {
     url = "https://release.files.ghostty.org/${finalAttrs.version}/Ghostty.dmg";
     sha256 = "sha256-CR96Kz9BYKFtfVKygiEku51XFJk4FfYqfXACeYQ3JlI=";
@@ -56,7 +50,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       done
     '';
 
-  meta = meta // {
+  meta = {
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 })

--- a/pkgs/by-name/gh/ghostty/darwin.nix
+++ b/pkgs/by-name/gh/ghostty/darwin.nix
@@ -28,48 +28,15 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  /**
-    Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
+  # For use in our shared postFixup
+  resourceDir = "${placeholder "out"}/Applications/Ghostty.app/Contents/Resources";
 
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
-
-    terminfo and shell integration should also be installable on remote machines
-
-    ```nix
-    { pkgs, ... }: {
-      environment.systemPackages = [ pkgs.ghostty.terminfo ];
-
-      programs.bash = {
-        interactiveShellInit = ''
-          if [[ "$TERM" == "xterm-ghostty" ]]; then
-            builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
-          fi
-        '';
-      };
-    }
-    ```
-  */
-  postFixup =
-    let
-      resources = "$out/Applications/Ghostty.app/Contents/Resources";
-    in
-    ''
-      mkdir -p $man/share
-      mv ${resources}/man $man/share/man
-      ln -s $man/share/man ${resources}/man
-
-      mkdir -p $terminfo/share
-      mv ${resources}/terminfo $terminfo/share/terminfo
-      ln -s $terminfo/share/terminfo ${resources}/terminfo
-
-      mv ${resources}/shell-integration $shell_integration
-      ln -s $shell_integration ${resources}/shell-integration
-
-      mv ${resources}/vim/vimfiles $vim
-      ln -s $vim ${resources}/vim/vimfiles
-    '';
+  # Usually the multiple-outputs hook would take care of this, but
+  # our manpages are in the .app bundle
+  preFixup = ''
+    mkdir -p $man/share
+    mv $resourceDir/man $man/share/man
+  '';
 
   meta = {
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];

--- a/pkgs/by-name/gh/ghostty/darwin.nix
+++ b/pkgs/by-name/gh/ghostty/darwin.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   fetchurl,
   _7zz,
-  makeWrapper,
+  makeBinaryWrapper,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -14,7 +14,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     _7zz
-    makeWrapper
+    makeBinaryWrapper
   ];
 
   sourceRoot = ".";

--- a/pkgs/by-name/gh/ghostty/linux.nix
+++ b/pkgs/by-name/gh/ghostty/linux.nix
@@ -1,8 +1,4 @@
 {
-  pname,
-  version,
-  outputs,
-  meta,
   lib,
   stdenv,
   bzip2,
@@ -47,13 +43,6 @@ let
 in
 
 stdenv.mkDerivation (finalAttrs: {
-  inherit
-    pname
-    version
-    outputs
-    meta
-    ;
-
   src = fetchFromGitHub {
     owner = "ghostty-org";
     repo = "ghostty";
@@ -174,5 +163,4 @@ stdenv.mkDerivation (finalAttrs: {
       nixos = nixosTests.terminal-emulators.ghostty;
     };
   };
-
 })

--- a/pkgs/by-name/gh/ghostty/linux.nix
+++ b/pkgs/by-name/gh/ghostty/linux.nix
@@ -110,43 +110,11 @@ stdenv.mkDerivation (finalAttrs: {
   # Unit tests currently fail inside the sandbox
   doCheck = false;
 
-  /**
-    Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
+  # For use in our shared postFixup
+  resourceDir = "${placeholder "out"}/share";
 
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
-
-    terminfo and shell integration should also be installable on remote machines
-
-    ```nix
-    { pkgs, ... }: {
-      environment.systemPackages = [ pkgs.ghostty.terminfo ];
-
-      programs.bash = {
-        interactiveShellInit = ''
-          if [[ "$TERM" == "xterm-ghostty" ]]; then
-            builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
-          fi
-        '';
-      };
-    }
-    ```
-  */
-  postFixup = ''
-    ln -s $man/share/man $out/share/man
-
-    moveToOutput share/terminfo $terminfo
-    ln -s $terminfo/share/terminfo $out/share/terminfo
-
-    mv $out/share/ghostty/shell-integration $shell_integration
-    ln -s $shell_integration $out/share/ghostty/shell-integration
-
-    mv $out/share/vim/vimfiles $vim
-    rmdir $out/share/vim
-    ln -s $vim $out/share/vim-plugins
-
-    remove-references-to -t ${finalAttrs.deps} $out/bin/.ghostty-wrapped
+  preFixup = ''
+    remove-references-to -t ${finalAttrs.deps} $out/bin/ghostty
   '';
 
   nativeInstallCheckInputs = [

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -1,63 +1,55 @@
 {
-  stdenvNoCC,
-  callPackage,
   lib,
+  stdenv,
+  callPackage,
 }:
 
 let
-  pname = "ghostty";
-  version = "1.0.0";
-  outputs = [
-    "out"
-    "man"
-    "shell_integration"
-    "terminfo"
-    "vim"
-  ];
-  meta = {
-    description = "Fast, native, feature-rich terminal emulator pushing modern features";
-    longDescription = ''
-      Ghostty is a terminal emulator that differentiates itself by being
-      fast, feature-rich, and native. While there are many excellent terminal
-      emulators available, they all force you to choose between speed,
-      features, or native UIs. Ghostty provides all three.
-    '';
-    homepage = "https://ghostty.org/";
-    downloadPage = "https://ghostty.org/download";
+  package = callPackage (if stdenv.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix) { };
+in
 
-    license = lib.licenses.mit;
-    mainProgram = "ghostty";
-    maintainers = with lib.maintainers; [
-      jcollie
-      pluiedev
-      getchoo
-      DimitarNestorov
-    ];
-    outputsToInstall = [
+package.overrideAttrs (
+  finalAttrs: oldAttrs: {
+    pname = "ghostty";
+    version = "1.0.0";
+
+    outputs = [
       "out"
       "man"
       "shell_integration"
       "terminfo"
+      "vim"
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-  };
-in
 
-if stdenvNoCC.hostPlatform.isDarwin then
-  callPackage ./darwin.nix {
-    inherit
-      pname
-      version
-      outputs
-      meta
-      ;
+    # Point `nix edit`, etc. to the file that defines the attribute
+    pos = builtins.unsafeGetAttrPos "src" finalAttrs;
+
+    meta = lib.recursiveUpdate (oldAttrs.meta or { }) {
+      description = "Fast, native, feature-rich terminal emulator pushing modern features";
+      longDescription = ''
+        Ghostty is a terminal emulator that differentiates itself by being
+        fast, feature-rich, and native. While there are many excellent terminal
+        emulators available, they all force you to choose between speed,
+        features, or native UIs. Ghostty provides all three.
+      '';
+      homepage = "https://ghostty.org/";
+      downloadPage = "https://ghostty.org/download";
+
+      license = lib.licenses.mit;
+      mainProgram = "ghostty";
+      maintainers = with lib.maintainers; [
+        jcollie
+        pluiedev
+        getchoo
+        DimitarNestorov
+      ];
+      outputsToInstall = [
+        "out"
+        "man"
+        "shell_integration"
+        "terminfo"
+      ];
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
   }
-else
-  callPackage ./linux.nix {
-    inherit
-      pname
-      version
-      outputs
-      meta
-      ;
-  }
+)

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -21,6 +21,45 @@ package.overrideAttrs (
       "vim"
     ];
 
+    /**
+      Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
+
+      - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
+      - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
+      - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
+
+      terminfo and shell integration should also be installable on remote machines
+
+      ```nix
+      { pkgs, ... }: {
+        environment.systemPackages = [ pkgs.ghostty.terminfo ];
+
+        programs.bash = {
+          interactiveShellInit = ''
+            if [[ "$TERM" == "xterm-ghostty" ]]; then
+              builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
+            fi
+          '';
+        };
+      }
+      ```
+    */
+    postFixup = ''
+      ln -s $man/share/man $resourceDir/man
+
+      mkdir -p $terminfo/share
+      mv $resourceDir/terminfo $terminfo/share/terminfo
+      ln -s $terminfo/share/terminfo $resourceDir/terminfo
+
+      mv $resourceDir/ghostty/shell-integration $shell_integration
+      ln -s $shell_integration $resourceDir/ghostty/shell-integration
+
+      mv $resourceDir/vim/vimfiles $vim
+      rmdir $resourceDir/vim
+      mkdir -p $out/share
+      ln -s $vim $out/share/vim-plugins
+    '';
+
     # Point `nix edit`, etc. to the file that defines the attribute
     pos = builtins.unsafeGetAttrPos "src" finalAttrs;
 


### PR DESCRIPTION
Follow up on #369080

The initial PR came with a good number of issues, like broken split outputs (instead of linking the split output back to `$out`, subpaths of `$out` were linked to the separate output), exposing of internal implementation details (through `pname`, `version`, etc. being override args), and a bit of copied effort across both expressions

This fixes those, and cleans up a few other things
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
