### PR TITLE
satdump: init at 1.2.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22628,6 +22628,11 @@
     githubId = 1220572;
     name = "Christian Theune";
   };
+  theverygaming = {
+    name = "theverygaming";
+    github = "theverygaming";
+    githubId = 18639279;
+  };
   thiagokokada = {
     email = "thiagokokada@gmail.com";
     github = "thiagokokada";

--- a/pkgs/by-name/nn/nng/package.nix
+++ b/pkgs/by-name/nn/nng/package.nix
@@ -27,7 +27,10 @@ stdenv.mkDerivation rec {
   buildInputs = lib.optionals mbedtlsSupport [ mbedtls ];
 
   cmakeFlags =
-    [ "-G Ninja" ]
+    [
+      "-G Ninja"
+      (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    ]
     ++ lib.optionals mbedtlsSupport [
       "-DMBEDTLS_ROOT_DIR=${mbedtls}"
       "-DNNG_ENABLE_TLS=ON"

--- a/pkgs/by-name/sa/satdump/package.nix
+++ b/pkgs/by-name/sa/satdump/package.nix
@@ -1,0 +1,111 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nix-update-script,
+  cmake,
+  pkg-config,
+  # required dependencies
+  fftwFloat,
+  libpng,
+  libtiff,
+  jemalloc,
+  volk,
+  nng,
+  curl,
+  # Optional dependencies
+  withZIQRecordingCompression ? true,
+  zstd,
+  withGUI ? true,
+  glfw,
+  zenity,
+  withAudio ? true,
+  portaudio,
+  withOfficialProductSupport ? true,
+  hdf5,
+  withOpenCL ? true,
+  opencl-headers,
+  ocl-icd,
+  withSourceRtlsdr ? true,
+  rtl-sdr-librtlsdr,
+  withSourceHackRF ? true,
+  hackrf,
+  withSourceAirspy ? true,
+  airspy,
+  withSourceAirspyHF ? true,
+  airspyhf,
+  withSourceAD9361 ? true,
+  libad9361,
+  libiio,
+  withSourceBladeRF ? true,
+  libbladeRF,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "satdump";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "SatDump";
+    repo = "SatDump";
+    tag = finalAttrs.version;
+    hash = "sha256-+Sne+NMwnIAs3ff64fBHAIE4/iDExIC64sXtO0LJwI0=";
+  };
+
+  postPatch = ''
+    substituteInPlace src-core/CMakeLists.txt \
+      --replace-fail '$'{CMAKE_INSTALL_PREFIX}/'$'{CMAKE_INSTALL_LIBDIR} '$'{CMAKE_INSTALL_FULL_LIBDIR}
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      fftwFloat
+      libpng
+      libtiff
+      jemalloc
+      volk
+      nng
+      curl
+    ]
+    ++ lib.optionals withZIQRecordingCompression [ zstd ]
+    ++ lib.optionals withGUI [
+      glfw
+      zenity
+    ]
+    ++ lib.optionals withAudio [ portaudio ]
+    ++ lib.optionals withOfficialProductSupport [ hdf5 ]
+    ++ lib.optionals withOpenCL [
+      opencl-headers
+      ocl-icd
+    ]
+    ++ lib.optionals withSourceRtlsdr [ rtl-sdr-librtlsdr ]
+    ++ lib.optionals withSourceHackRF [ hackrf ]
+    ++ lib.optionals withSourceAirspy [ airspy ]
+    ++ lib.optionals withSourceAirspyHF [ airspyhf ]
+    ++ lib.optionals withSourceAD9361 [
+      libad9361
+      libiio
+    ]
+    ++ lib.optionals withSourceBladeRF [ libbladeRF ];
+
+  cmakeFlags = [ (lib.cmakeBool "BUILD_GUI" withGUI) ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A generic satellite data processing software";
+    homepage = "https://www.satdump.org/";
+    changelog = "https://github.com/SatDump/SatDump/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      theverygaming
+    ];
+    mainProgram = "satdump";
+  };
+})


### PR DESCRIPTION
Closes:  #314003

Packaged SatDump, a software to receive, decode and process data from satellites.

See https://www.satdump.org/about/ and https://github.com/SatDump/SatDump

Also https://repology.org/project/satdump/versions

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
