### PR TITLE
looking-glass-client: use nanosvg from nixpkgs

### DIFF
--- a/pkgs/by-name/lo/looking-glass-client/nanosvg-unvendor.diff
+++ b/pkgs/by-name/lo/looking-glass-client/nanosvg-unvendor.diff
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3755adc..55e1eb3 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -25,6 +25,7 @@ include(OptimizeForNative) # option(OPTIMIZE_FOR_NATIVE)
+ include(UninstallTarget)
+
+ find_package(PkgConfig)
++find_package(NanoSVG REQUIRED)
+ pkg_check_modules(FONTCONFIG REQUIRED IMPORTED_TARGET fontconfig)
+
+ option(ENABLE_OPENGL "Enable the OpenGL renderer"       ON)
+@@ -106,7 +107,6 @@ include_directories(
+   ${PROJECT_SOURCE_DIR}/include
+   ${CMAKE_BINARY_DIR}
+   ${CMAKE_BINARY_DIR}/include
+-  ${PROJECT_TOP}/repos/nanosvg/src
+ )
+
+ link_libraries(
+@@ -161,6 +161,7 @@ target_compile_definitions(looking-glass-client PRIVATE CIMGUI_DEFINE_ENUMS_AND_
+ target_link_libraries(looking-glass-client
+   ${EXE_FLAGS}
+   PkgConfig::FONTCONFIG
++  NanoSVG::nanosvg
+   lg_resources
+   lg_common
+   displayservers

--- a/pkgs/by-name/lo/looking-glass-client/package.nix
+++ b/pkgs/by-name/lo/looking-glass-client/package.nix
@@ -14,6 +14,7 @@
   libffi,
   expat,
   libGL,
+  nanosvg,
 
   libX11,
   libxkbcommon,
@@ -69,6 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
       hash = "sha256-CqB8AmOZ4YxnEsQkyu/ZEaun6ywpSh4B7PM+MFJF0qU=";
       stripLen = 1;
     })
+    ./nanosvg-unvendor.diff
   ];
 
   nativeBuildInputs = [
@@ -88,6 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
       nettle
       fontconfig
       libffi
+      nanosvg
     ]
     ++ lib.optionals xorgSupport [
       libxkbcommon


### PR DESCRIPTION
Issue building vendored nanosvg, just using the version we have.

Resolves https://github.com/NixOS/nixpkgs/issues/368827

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
