### PR TITLE
gpu-screen-recorder-ui: init at 1.12.2

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -232,6 +232,7 @@
   ./programs/gnupg.nix
   ./programs/gpaste.nix
   ./programs/gphoto2.nix
+  ./programs/gpu-screen-recorder-ui.nix
   ./programs/gpu-screen-recorder.nix
   ./programs/haguichi.nix
   ./programs/hamster.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -234,6 +234,7 @@
   ./programs/gnupg.nix
   ./programs/gpaste.nix
   ./programs/gphoto2.nix
+  ./programs/gpu-screen-recorder-ui.nix
   ./programs/gpu-screen-recorder.nix
   ./programs/haguichi.nix
   ./programs/hamster.nix

--- a/nixos/modules/programs/gpu-screen-recorder-ui.nix
+++ b/nixos/modules/programs/gpu-screen-recorder-ui.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.programs.gpu-screen-recorder-ui;
+  package = cfg.package.override {
+    inherit (config.security) wrapperDir;
+  };
+in
+{
+  options = {
+    programs.gpu-screen-recorder-ui = {
+      package = lib.mkPackageOption pkgs "gpu-screen-recorder-ui" { };
+
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to install gpu-screen-recorder-ui and generate setcap
+          wrappers for global hotkeys.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.gpu-screen-recorder.enable = lib.mkDefault true;
+
+    environment.systemPackages = [ package ];
+
+    systemd.packages = [ package ];
+
+    security.wrappers."gsr-global-hotkeys" = {
+      owner = "root";
+      group = "root";
+      capabilities = "cap_setuid+ep";
+      source = lib.getExe' package "gsr-global-hotkeys";
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ js6pak ];
+}

--- a/pkgs/by-name/gp/gpu-screen-recorder-notification/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder-notification/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  pkg-config,
+  meson,
+  ninja,
+  libx11,
+  libxrender,
+  libxrandr,
+  libxext,
+  libglvnd,
+  wayland,
+  wayland-scanner,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpu-screen-recorder-notification";
+  version = "1.1.0";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-notification";
+    tag = finalAttrs.version;
+    hash = "sha256-ODifZ046DEBNiGT3+S6pQyF8ekrb6LIHWton8nv1MBo=";
+  };
+
+  postPatch = ''
+    substituteInPlace depends/mglpp/depends/mgl/src/gl.c \
+      --replace-fail "libGL.so.1" "${lib.getLib libglvnd}/lib/libGL.so.1" \
+      --replace-fail "libGLX.so.0" "${lib.getLib libglvnd}/lib/libGLX.so.0" \
+      --replace-fail "libEGL.so.1" "${lib.getLib libglvnd}/lib/libEGL.so.1"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    libx11
+    libxrender
+    libxrandr
+    libxext
+    libglvnd
+    wayland
+    wayland-scanner
+  ];
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Notification in the style of ShadowPlay";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder-notification/about/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gsr-notify";
+    maintainers = with lib.maintainers; [ js6pak ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gp/gpu-screen-recorder-notification/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder-notification/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  pkg-config,
+  meson,
+  ninja,
+  libx11,
+  libxrender,
+  libxrandr,
+  libxext,
+  libxkbcommon,
+  libglvnd,
+  wayland,
+  wayland-scanner,
+  pango,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpu-screen-recorder-notification";
+  version = "1.3.0";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-notification";
+    tag = finalAttrs.version;
+    hash = "sha256-32d6GlX00fStQOu9h/fgOoUjKsZd+/xp7O4nlAeEYII=";
+  };
+
+  postPatch = ''
+    substituteInPlace depends/mglpp/depends/mgl/src/gl.c \
+      --replace-fail "libGL.so.1" "${lib.getLib libglvnd}/lib/libGL.so.1" \
+      --replace-fail "libGLX.so.0" "${lib.getLib libglvnd}/lib/libGLX.so.0" \
+      --replace-fail "libEGL.so.1" "${lib.getLib libglvnd}/lib/libEGL.so.1"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+
+  buildInputs = [
+    libx11
+    libxrender
+    libxrandr
+    libxext
+    libxkbcommon
+    libglvnd
+    wayland
+    wayland-scanner
+    pango
+  ];
+
+  mesonBuildType = "release";
+
+  passthru.updateScript = gitUpdater { };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Notification in the style of ShadowPlay";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder-notification/about/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gsr-notify";
+    maintainers = with lib.maintainers; [ js6pak ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gp/gpu-screen-recorder-ui/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder-ui/package.nix
@@ -1,0 +1,108 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  pkg-config,
+  meson,
+  ninja,
+  makeWrapper,
+  gpu-screen-recorder,
+  gpu-screen-recorder-notification,
+  libx11,
+  libxrender,
+  libxrandr,
+  libxcomposite,
+  libxi,
+  libxcursor,
+  libglvnd,
+  libpulseaudio,
+  libdrm,
+  dbus,
+  wayland,
+  wayland-scanner,
+  wrapperDir ? "/run/wrappers/bin",
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpu-screen-recorder-ui";
+  version = "1.10.8";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-ui";
+    tag = finalAttrs.version;
+    hash = "sha256-x7MBTUWDKCzClq4ukgtFazOD/RLkX5lgmm9slN5BjVk=";
+  };
+
+  patches = [
+    ./remove-gnome-postinstall.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace depends/mglpp/depends/mgl/src/gl.c \
+      --replace-fail "libGL.so.1" "${lib.getLib libglvnd}/lib/libGL.so.1" \
+      --replace-fail "libGLX.so.0" "${lib.getLib libglvnd}/lib/libGLX.so.0" \
+      --replace-fail "libEGL.so.1" "${lib.getLib libglvnd}/lib/libEGL.so.1"
+
+    substituteInPlace extra/gpu-screen-recorder-ui.service \
+      --replace-fail "ExecStart=gsr-ui" "ExecStart=$out/bin/gsr-ui"
+
+    substituteInPlace gpu-screen-recorder.desktop \
+      --replace-fail "Exec=gsr-ui" "Exec=$out/bin/gsr-ui"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libx11
+    libxrender
+    libxrandr
+    libxcomposite
+    libxi
+    libxcursor
+    libglvnd
+    libpulseaudio
+    libdrm
+    dbus
+    wayland
+    wayland-scanner
+  ];
+
+  mesonFlags = [
+    # Handled by the module
+    (lib.mesonBool "capabilities" false)
+  ];
+
+  postInstall =
+    let
+      gpu-screen-recorder-wrapped = gpu-screen-recorder.override {
+        inherit wrapperDir;
+      };
+    in
+    ''
+      wrapProgram "$out/bin/gsr-ui" \
+        --prefix PATH : "${wrapperDir}" \
+        --suffix PATH : "${
+          lib.makeBinPath [
+            gpu-screen-recorder-wrapped
+            gpu-screen-recorder-notification
+          ]
+        }"
+    '';
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "Fullscreen overlay UI for GPU Screen Recorder in the style of ShadowPlay";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder-ui/about/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gsr-ui";
+    maintainers = with lib.maintainers; [ js6pak ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gp/gpu-screen-recorder-ui/package.nix
+++ b/pkgs/by-name/gp/gpu-screen-recorder-ui/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  pkg-config,
+  meson,
+  ninja,
+  makeWrapper,
+  gpu-screen-recorder,
+  gpu-screen-recorder-notification,
+  libx11,
+  libxrender,
+  libxrandr,
+  libxcomposite,
+  libxi,
+  libxcursor,
+  libxkbcommon,
+  libglvnd,
+  libpulseaudio,
+  libdrm,
+  dbus,
+  wayland,
+  wayland-scanner,
+  pango,
+  wrapperDir ? "/run/wrappers/bin",
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "gpu-screen-recorder-ui";
+  version = "1.12.2";
+
+  src = fetchgit {
+    url = "https://repo.dec05eba.com/gpu-screen-recorder-ui";
+    tag = finalAttrs.version;
+    hash = "sha256-9hm5Guv+C1++hVmJ43xw9SkyqDv8hJk3SNEImbulLOs=";
+  };
+
+  patches = [
+    ./remove-gnome-postinstall.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace depends/mglpp/depends/mgl/src/gl.c \
+      --replace-fail "libGL.so.1" "${lib.getLib libglvnd}/lib/libGL.so.1" \
+      --replace-fail "libGLX.so.0" "${lib.getLib libglvnd}/lib/libGLX.so.0" \
+      --replace-fail "libEGL.so.1" "${lib.getLib libglvnd}/lib/libEGL.so.1"
+
+    substituteInPlace gpu-screen-recorder.desktop \
+      --replace-fail "Exec=gsr-ui" "Exec=$out/bin/gsr-ui"
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+    makeWrapper
+  ];
+
+  buildInputs = [
+    libx11
+    libxrender
+    libxrandr
+    libxcomposite
+    libxi
+    libxcursor
+    libxkbcommon
+    libglvnd
+    libpulseaudio
+    libdrm
+    dbus
+    wayland
+    wayland-scanner
+    pango
+  ];
+
+  mesonBuildType = "release";
+
+  mesonFlags = [
+    # Handled by the module
+    (lib.mesonBool "capabilities" false)
+  ];
+
+  postInstall =
+    let
+      gpu-screen-recorder-wrapped = gpu-screen-recorder.override {
+        inherit wrapperDir;
+      };
+    in
+    ''
+      wrapProgram "$out/bin/gsr-ui" \
+        --prefix PATH : "${wrapperDir}" \
+        --suffix PATH : "${
+          lib.makeBinPath [
+            gpu-screen-recorder-wrapped
+            gpu-screen-recorder-notification
+          ]
+        }"
+    '';
+
+  passthru.updateScript = gitUpdater { };
+
+  strictDeps = true;
+  __structuredAttrs = true;
+
+  meta = {
+    description = "Fullscreen overlay UI for GPU Screen Recorder in the style of ShadowPlay";
+    homepage = "https://git.dec05eba.com/gpu-screen-recorder-ui/about/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "gsr-ui";
+    maintainers = with lib.maintainers; [ js6pak ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/gp/gpu-screen-recorder-ui/remove-gnome-postinstall.patch
+++ b/pkgs/by-name/gp/gpu-screen-recorder-ui/remove-gnome-postinstall.patch
@@ -1,0 +1,14 @@
+diff --git a/meson.build b/meson.build
+index cf16e81..7c3629d 100644
+--- a/meson.build
++++ b/meson.build
+@@ -147,9 +147,6 @@ install_subdir('translations', install_dir : gsr_ui_resources_path)
+ if get_option('desktop-files') == true
+     install_data(files('gpu-screen-recorder.desktop'), install_dir : join_paths(prefix, datadir, 'applications'))
+     install_subdir('icons/hicolor', install_dir : icons_path)
+-
+-    gnome = import('gnome')
+-    gnome.post_install(update_desktop_database : true)
+ endif
+ 
+ if get_option('systemd') == true


### PR DESCRIPTION
https://git.dec05eba.com/gpu-screen-recorder-ui/about/
Fullscreen overlay UI for GPU Screen Recorder in the style of ShadowPlay

Closes #369558
Depends on #367552

### Usage

1. Enable the module to add the setcap wrappers and systemd service
```nix
programs.gpu-screen-recorder-ui.enable = true;
```
2. Start the program using one of the following ways:
	1. Run `gsr-ui`
	2. Enable the service imperatively `systemctl enable --now --user gpu-screen-recorder-ui`
	3. Enable the service declaratively
		```nix
		systemd.user.services.gpu-screen-recorder-ui.wantedBy = [ "default.target" ];
		```
		Note: This will break the "Startup" setting in-app
		Question: Should this be a nixos module option?
3. Press `Alt+Z` (key binds are not configurable yet)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
