### PR TITLE
lua: Don't flood stdout when included in `mkShell`

### DIFF
--- a/pkgs/development/interpreters/lua-5/utils.sh
+++ b/pkgs/development/interpreters/lua-5/utils.sh
@@ -66,7 +66,7 @@ addToLuaPath() {
 _addToLuaPath() {
   local dir="$1"
 
-  echo "_addToLuaPath called for dir $dir"
+  nix_debug "_addToLuaPath called for dir $dir"
 
   if [[ ! -d "$dir" ]]; then
     nix_debug "$dir not a directory abort"
@@ -77,7 +77,7 @@ _addToLuaPath() {
   # if [ -n "${pythonPathsSeen[$dir]}" ]; then return; fi
   if [[ -n "${luaPathsSeen[$dir]:-}" ]]; then
   # if [ -n "${luaPathsSeen[$dir]}" ]; then
-    echo "$dir already parsed"
+    nix_debug "$dir already parsed"
     return
   fi
 
@@ -103,7 +103,7 @@ _addToLuaPath() {
   if [ -e "$prop" ]; then
     local new_path
     for new_path in $(cat $prop); do
-        echo "newpath: $new_path"
+        nix_debug "newpath: $new_path"
         _addToLuaPath "$new_path"
     done
   fi
@@ -116,7 +116,7 @@ buildLuaPath() {
   local luaPath="$1"
   local path
 
-  echo "BUILD_LUA_PATH"
+  nix_debug "BUILD_LUA_PATH"
 
 #   # set -x
 #   # Create an empty table of paths (see doc on loadFromPropagatedInputs


### PR DESCRIPTION
per https://github.com/NixOS/nixpkgs/commit/665f3f694bfc6c2f3a95a98b1abf71d2961879bb#r149554096

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
