### PR TITLE
hspell: Add zlib

### DIFF
--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
   patches = [ ./remove-shared-library-checks.patch ];
   postPatch = "patchShebangs .";
   preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-    make CC=${buildPackages.stdenv.cc}/bin/cc find_sizes
+    make CC='${buildPackages.stdenv.cc}/bin/cc -I${lib.getDev buildPackages.zlib}/include -L${buildPackages.zlib}/lib' find_sizes
     mv find_sizes find_sizes_build
     make clean
 
@@ -41,7 +41,10 @@ stdenv.mkDerivation rec {
     perl
     zlib
   ];
-  buildInputs = [ perl ];
+  buildInputs = [
+    perl
+    zlib
+  ];
 
   strictDeps = true;
 


### PR DESCRIPTION
As mentioned by the configure script output, hspell will fall back
on using `gzip` program when not linked against `zlib`:

    No Zlib library, defaulting to using pipes

It has been removed in 67f0a216e5c8cec5a1d1787c57dbf8b4fb56ccf9 for some reason.

Without this patch, Geary is stuck loading messages, even though I can interact
with the rest of its UI. I am also getting the following in the log so broken
piping might be breaking webkitgtk for some reason:

    Hspell: can't run gzip -dc '/nix/store/14qk9r9ywvpqn0a24fvw1iwjv302d04j-hspell-1.4/share/hspell/hebrew.wgz.prefixes'.
    Could not create GBM EGL display: EGL_NOT_INITIALIZED. Aborting...

And after quitting Geary:

    *[wrn] 18:29:13.0226 geary:application-client.vala:464: Forcing shutdown of Geary, 7s passed...
    gzip:
    gzip: stdout: Broken pipe
    stdout: Broken pipe

cc @kampka @uninsane 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
