### PR TITLE
nixos/tests: manualy start networkd-wait-online

### DIFF
--- a/nixos/tests/kea.nix
+++ b/nixos/tests/kea.nix
@@ -223,6 +223,7 @@ import ./make-test-python.nix (
       ''
         start_all()
         router.wait_for_unit("kea-dhcp4-server.service")
+        client.systemctl("start systemd-networkd-wait-online.service")
         client.wait_for_unit("systemd-networkd-wait-online.service")
         client.wait_until_succeeds("ping -c 5 10.0.0.1")
         router.wait_until_succeeds("ping -c 5 10.0.0.3")

--- a/nixos/tests/systemd-bpf.nix
+++ b/nixos/tests/systemd-bpf.nix
@@ -39,7 +39,9 @@ import ./make-test-python.nix (
 
     testScript = ''
       start_all()
+      node1.systemctl("start systemd-networkd-wait-online.service")
       node1.wait_for_unit("systemd-networkd-wait-online.service")
+      node2.systemctl("start systemd-networkd-wait-online.service")
       node2.wait_for_unit("systemd-networkd-wait-online.service")
 
       with subtest("test RestrictNetworkInterfaces= works"):

--- a/nixos/tests/systemd-networkd-bridge.nix
+++ b/nixos/tests/systemd-networkd-bridge.nix
@@ -131,6 +131,7 @@ import ./make-test-python.nix (
       start_all()
 
       for n in network_nodes + network_switches:
+          n.systemctl("start systemd-networkd-wait-online.service")
           n.wait_for_unit("systemd-networkd-wait-online.service")
 
       node1.succeed("ping 10.0.0.2 -w 10 -c 1")

--- a/nixos/tests/systemd-networkd-dhcpserver-static-leases.nix
+++ b/nixos/tests/systemd-networkd-dhcpserver-static-leases.nix
@@ -73,6 +73,7 @@ import ./make-test-python.nix (
       start_all()
 
       with subtest("check router network configuration"):
+        router.systemctl("start systemd-networkd-wait-online.service")
         router.wait_for_unit("systemd-networkd-wait-online.service")
         eth1_status = router.succeed("networkctl status eth1")
         assert "Network File: /etc/systemd/network/01-eth1.network" in eth1_status, \
@@ -80,6 +81,7 @@ import ./make-test-python.nix (
         assert "10.0.0.1" in eth1_status, "Did not find expected router IPv4"
 
       with subtest("check client network configuration"):
+        client.systemctl("start systemd-networkd-wait-online.service")
         client.wait_for_unit("systemd-networkd-wait-online.service")
         eth1_status = client.succeed("networkctl status eth1")
         assert "Network File: /etc/systemd/network/40-eth1.network" in eth1_status, \

--- a/nixos/tests/systemd-networkd.nix
+++ b/nixos/tests/systemd-networkd.nix
@@ -96,10 +96,12 @@ in import ./make-test-python.nix ({pkgs, ... }: {
   };
 testScript = ''
     start_all()
-    node1.succeed("systemctl start systemd-networkd-wait-online@eth1.service")
+    node1.systemctl("start systemd-networkd-wait-online@eth1.service")
+    node1.systemctl("start systemd-networkd-wait-online.service")
     node1.wait_for_unit("systemd-networkd-wait-online@eth1.service")
     node1.wait_for_unit("systemd-networkd-wait-online.service")
-    node2.succeed("systemctl start systemd-networkd-wait-online@eth1.service")
+    node2.systemctl("start systemd-networkd-wait-online@eth1.service")
+    node2.systemctl("start systemd-networkd-wait-online.service")
     node2.wait_for_unit("systemd-networkd-wait-online@eth1.service")
     node2.wait_for_unit("systemd-networkd-wait-online.service")
 


### PR DESCRIPTION
Fix some tests that broke after 2370696d.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
