### PR TITLE
ceph: fix python build

### DIFF
--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -240,13 +240,12 @@ let
         });
 
         # We pin the older `cryptography` 40 here;
-        # this also forces us to pin an older `pyopenssl` because the current one
-        # is not compatible with older `cryptography`, see:
-        #     https://github.com/pyca/pyopenssl/blob/d9752e44127ba36041b045417af8a0bf16ec4f1e/CHANGELOG.rst#2320-2023-05-30
+        # this also forces us to pin other packages, see below
         cryptography = self.callPackage ./old-python-packages/cryptography.nix { };
 
         # This is the most recent version of `pyopenssl` that's still compatible with `cryptography` 40.
         # See https://github.com/NixOS/nixpkgs/pull/281858#issuecomment-1899358602
+        # and https://github.com/pyca/pyopenssl/blob/d9752e44127ba36041b045417af8a0bf16ec4f1e/CHANGELOG.rst#2320-2023-05-30
         pyopenssl = super.pyopenssl.overridePythonAttrs (old: rec {
           version = "23.1.1";
           src = fetchPypi {
@@ -262,7 +261,12 @@ let
           ];
         });
 
-        fastapi = super.fastapi.overridePythonAttrs (old: rec {
+        # This is the most recent version of `trustme` that's still compatible with `cryptography` 40.
+        # See https://github.com/NixOS/nixpkgs/issues/359723
+        # and https://github.com/python-trio/trustme/commit/586f7759d5c27beb44da60615a71848eb2a5a490
+        trustme = self.callPackage ./old-python-packages/trustme.nix { };
+
+        fastapi = super.fastapi.overridePythonAttrs (old: {
           # Flaky test:
           #     ResourceWarning: Unclosed <MemoryObjectSendStream>
           # Unclear whether it's flaky in general or only in this overridden package set.

--- a/pkgs/tools/filesystems/ceph/old-python-packages/trustme.nix
+++ b/pkgs/tools/filesystems/ceph/old-python-packages/trustme.nix
@@ -1,0 +1,52 @@
+# This older version only exists because `ceph` needs it, see its package.
+{
+  lib,
+  buildPythonPackage,
+  cryptography,
+  fetchPypi,
+  idna,
+  pyopenssl,
+  pytestCheckHook,
+  pythonOlder,
+  service-identity,
+}:
+
+buildPythonPackage rec {
+  pname = "trustme";
+  version = "1.1.0";
+  format = "setuptools";
+
+  disabled = pythonOlder "3.8";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-U3Wtf7QnB0vslWWS4NTuKkz02miTThukvPQhcSa8ReY=";
+  };
+
+  propagatedBuildInputs = [
+    cryptography
+    idna
+  ];
+
+  nativeCheckInputs = [
+    pyopenssl
+    pytestCheckHook
+    service-identity
+  ];
+
+  # Some of the tests use localhost networking.
+  __darwinAllowLocalNetworking = true;
+
+  pythonImportsCheck = [ "trustme" ];
+
+  meta = with lib; {
+    description = "High quality TLS certs while you wait, for the discerning tester";
+    homepage = "https://github.com/python-trio/trustme";
+    changelog = "https://trustme.readthedocs.io/en/latest/#change-history";
+    license = with licenses; [
+      mit
+      asl20
+    ];
+    maintainers = with maintainers; [ jfly ];
+  };
+}


### PR DESCRIPTION
`trustme` 1.2+ doesn't work with the old pinned version of `cryptography` that `ceph` needs. This vendors the previous version of `trustme`, which does work. How I got this:

```shell
git show fd30f2796b08596646c9a43fd439c4177f53c0ac~:pkgs/development/python-modules/trustme/default.nix > pkgs/tools/filesystems/ceph/old-python-packages/trustme.nix
```

I then added a warning on the top of the file, and updated the maintiner to myself.

This fixes https://github.com/NixOS/nixpkgs/issues/359723.

Unfortunately, the build goes on to fail trying to compile ceph itself. I see a bunch of errors that look like this. Hopefully someone more familiar with C++ can help figure this out:

    /build/ceph-19.2.0/src/osd/osd_types.h: In lambda function:
    /build/ceph-19.2.0/src/common/dout.h:196:73: error: call to non-'constexpr' function 'virtual unsigned int DoutPrefixProvider::get_subsys() const'
      196 |     dout_impl(pdpp->get_cct(), ceph::dout::need_dynamic(pdpp->get_subsys()), v) \
          |                                                         ~~~~~~~~~~~~~~~~^~
    /build/ceph-19.2.0/src/common/dout.h:167:58: note: in definition of macro 'dout_impl'
      167 |       return (cctX->_conf->subsys.template should_gather<sub, v>());    \
          |                                                          ^~~
    /build/ceph-19.2.0/src/osd/osd_types.h:3704:3: note: in expansion of macro 'ldpp_dout'
     3704 |   ldpp_dout(dpp, 10) << "build_prior all_probe " << all_probe << dendl;
          |   ^~~~~~~~~
    /build/ceph-19.2.0/src/common/dout.h:63:20: note: 'virtual unsigned int DoutPrefixProvider::get_subsys() const' declared here
       63 |   virtual unsigned get_subsys() const = 0;
          |                    ^~~~~~~~~~

I've filed https://github.com/NixOS/nixpkgs/issues/369777 so we can fix this in a follow up PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
