### PR TITLE
iverilog: set correct build compilers

### DIFF
--- a/pkgs/by-name/iv/iverilog/package.nix
+++ b/pkgs/by-name/iv/iverilog/package.nix
@@ -13,6 +13,7 @@
   python3,
   readline,
   zlib,
+  buildPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -33,8 +34,8 @@ stdenv.mkDerivation rec {
     gperf
   ];
 
-  CC_FOR_BUILD = "${stdenv.cc}/bin/cc";
-  CXX_FOR_BUILD = "${stdenv.cc}/bin/c++";
+  CC_FOR_BUILD = "${buildPackages.stdenv.cc}/bin/cc";
+  CXX_FOR_BUILD = "${buildPackages.stdenv.cc}/bin/c++";
 
   patches = [
     # NOTE(jleightcap): `-Werror=format-security` warning patched shortly after release, backport the upstream fix


### PR DESCRIPTION
As the name implies these should be build -> build compilers.
Incidentally this also fixes cross-compilation.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).