### PR TITLE
nixos/luksroot: Implement keyFileTimeout (for non-systemd initrd)

### DIFF
--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -260,7 +260,8 @@ let
           ${
             if (dev.keyFile != null) then
               ''
-                if wait_target "key file" ${dev.keyFile}; then
+                local timeout=${optionalString (dev.keyFileTimeout != null) (toString dev.keyFileTimeout)}
+                if wait_target "key file" ${dev.keyFile} "$timeout"; then
                     ${csopen} --key-file=${dev.keyFile} \
                       ${optionalString (dev.keyFileSize != null) "--keyfile-size=${toString dev.keyFileSize}"} \
                       ${optionalString (dev.keyFileOffset != null) "--keyfile-offset=${toString dev.keyFileOffset}"}
@@ -1075,12 +1076,6 @@ in
           any (dev: dev.bypassWorkqueues) (attrValues luks.devices)
           -> versionAtLeast kernelPackages.kernel.version "5.9";
         message = "boot.initrd.luks.devices.<name>.bypassWorkqueues is not supported for kernels older than 5.9";
-      }
-
-      {
-        assertion =
-          !config.boot.initrd.systemd.enable -> all (x: x.keyFileTimeout == null) (attrValues luks.devices);
-        message = "boot.initrd.luks.devices.<name>.keyFileTimeout is only supported for systemd initrd";
       }
 
       {

--- a/nixos/modules/system/boot/luksroot.nix
+++ b/nixos/modules/system/boot/luksroot.nix
@@ -42,9 +42,11 @@ let
         if ! dev_exist $target; then
             echo -n "Waiting $secs seconds for $desc..."
             local success=false;
-            for try in $(seq $secs); do
+            local try=0
+            while [ $try -lt $secs ] ; do
                 echo -n "."
                 sleep 1
+                try=$((try+1))
                 if dev_exist $target; then
                     success=true
                     break
@@ -68,9 +70,11 @@ let
         if [ $? != 0 ]; then
             echo -n "Waiting $secs seconds for YubiKey to appear..."
             local success=false
-            for try in $(seq $secs); do
-                echo -n .
+            local try=0
+            while [ $try -lt $secs ] ; do
+                echo -n "."
                 sleep 1
+                try=$((try+1))
                 ykinfo -v 1>/dev/null 2>&1
                 if [ $? == 0 ]; then
                     success=true
@@ -95,9 +99,11 @@ let
         if [ $? != 0 ]; then
             echo -n "Waiting $secs seconds for GPG Card to appear"
             local success=false
-            for try in $(seq $secs); do
-                echo -n .
+            local try=0
+            while [ $try -lt $secs ] ; do
+                echo -n "."
                 sleep 1
+                try=$((try+1))
                 gpg --card-status > /dev/null 2> /dev/null
                 if [ $? == 0 ]; then
                     success=true


### PR DESCRIPTION
The user can then specify a very large timeout if they want to e.g. use remote unlocking to provision the key to the machine.

Also change the `for try in $(seq $secs)` loops to while loops to avoid very large string expansions when passing in a large number.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
