### PR TITLE
chafa: support avif, jxl and svg image formats; add zsh completion; split outputs

### DIFF
--- a/pkgs/tools/misc/chafa/default.nix
+++ b/pkgs/tools/misc/chafa/default.nix
@@ -7,12 +7,14 @@
   libtool,
   pkg-config,
   which,
+  libavif,
+  libjxl,
+  librsvg,
   libxslt,
   libxml2,
   docbook_xml_dtd_412,
   docbook_xsl,
   glib,
-  imagemagick,
   Foundation,
 }:
 
@@ -41,8 +43,10 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     glib
-    imagemagick
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin Foundation;
+    libavif
+    libjxl
+    librsvg
+  ];
 
   patches = [ ./xmlcatalog_patch.patch ];
 
@@ -55,9 +59,6 @@ stdenv.mkDerivation rec {
     "--enable-man"
     "--with-xml-catalog=${docbook_xml_dtd_412}/xml/dtd/docbook/catalog.xml"
   ];
-
-  # https://github.com/NixOS/nixpkgs/pull/240893#issuecomment-1635347507
-  NIX_LDFLAGS = [ "-lwebp" ];
 
   meta = with lib; {
     description = "Terminal graphics for the 21st century";

--- a/pkgs/tools/misc/chafa/default.nix
+++ b/pkgs/tools/misc/chafa/default.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  installShellFiles,
   autoconf,
   automake,
   libtool,
@@ -39,6 +40,7 @@ stdenv.mkDerivation rec {
     libxml2
     docbook_xml_dtd_412
     docbook_xsl
+    installShellFiles
   ];
 
   buildInputs = [
@@ -59,6 +61,10 @@ stdenv.mkDerivation rec {
     "--enable-man"
     "--with-xml-catalog=${docbook_xml_dtd_412}/xml/dtd/docbook/catalog.xml"
   ];
+
+  postInstall = ''
+    installShellCompletion --cmd chafa tools/completions/zsh-completion.zsh
+  '';
 
   meta = with lib; {
     description = "Terminal graphics for the 21st century";

--- a/pkgs/tools/misc/chafa/default.nix
+++ b/pkgs/tools/misc/chafa/default.nix
@@ -30,6 +30,13 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-9RkN0yZnHf5cx6tsp3P6jsi0/xtplWxMm3hYCPjWj0M=";
   };
 
+  outputs = [
+    "bin"
+    "dev"
+    "man"
+    "out"
+  ];
+
   nativeBuildInputs = [
     autoconf
     automake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The new package can be verified by running:

```bash
$ ./result-bin/bin/chafa --version
Chafa version 1.14.5

Loaders:  AVIF GIF JPEG JXL PNG QOI SVG TIFF WebP XWD
Features: mmx sse4.1 popcnt avx2
Applying: mmx sse4.1 popcnt avx2

Copyright (C) 2018-2024 Hans Petter Jansson et al.
Incl. libnsgif copyright (C) 2004 Richard Wilson, copyright (C) 2008 Sean Fox
Incl. LodePNG copyright (C) 2005-2018 Lode Vandevenne
Incl. QOI decoder copyright (C) 2021 Dominic Szablewski

This is free software; see the source for copying conditions. There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
