### PR TITLE
fix cross build for various python packages

### DIFF
--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -5,7 +5,7 @@
   rustPlatform,
   rustc,
   setuptools,
-  setuptools-rust,
+  setuptoolsRustBuildHook,
   fetchPypi,
   pythonOlder,
   pytestCheckHook,
@@ -41,7 +41,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     setuptools
-    setuptools-rust
+    setuptoolsRustBuildHook
     rustPlatform.cargoSetupHook
     cargo
     rustc

--- a/pkgs/development/python-modules/contourpy/default.nix
+++ b/pkgs/development/python-modules/contourpy/default.nix
@@ -1,13 +1,16 @@
 {
   lib,
+  buildPackages,
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
+  python3,
 
   # build
   meson,
   meson-python,
   ninja,
+  nukeReferences,
   pybind11,
 
   # propagates
@@ -21,7 +24,9 @@
   # tests
   matplotlib,
   pillow,
+  pytest-xdist,
   pytestCheckHook,
+  wurlitzer,
 }:
 
 let
@@ -42,6 +47,7 @@ let
     nativeBuildInputs = [
       meson
       ninja
+      nukeReferences
       pybind11
     ];
 
@@ -63,6 +69,8 @@ let
       matplotlib
       pillow
       pytestCheckHook
+      pytest-xdist
+      wurlitzer
     ];
 
     passthru.tests = {
@@ -72,6 +80,12 @@ let
     };
 
     pythonImportsCheck = [ "contourpy" ];
+
+    # remove references to buildPackages.python3, which is not allowed for cross builds.
+    preFixup = ''
+      nuke-refs -e "${buildPackages.python3}" \
+        $out/${python3.sitePackages}/contourpy/util/{_build_config.py,__pycache__/_build_config.*}
+    '';
 
     meta = with lib; {
       changelog = "https://github.com/contourpy/contourpy/releases/tag/v${version}";

--- a/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
+++ b/pkgs/development/python-modules/home-assistant-chip-wheels/default.nix
@@ -32,6 +32,7 @@
   parameterized,
   pip-tools,
   pkg-config,
+  pkgconfig,
   prompt-toolkit,
   protobuf,
   psutil,
@@ -105,6 +106,7 @@ stdenv.mkDerivation rec {
     zap-chip
     # gdbus-codegen
     glib
+    pkgconfig
     python3
     # dependencies of build scripts
     click
@@ -193,6 +195,7 @@ stdenv.mkDerivation rec {
         packaging
         parameterized
         pip-tools
+        pkgconfig
         prompt-toolkit
         protobuf
         psutil


### PR DESCRIPTION
- **python3Packages.contourpy: fix cross build**
- **python3Packages.home-assistant-chip-wheels: simplify dependency closure generation**
- **python3Packages.home-assistant-chip-wheels: fix cross build**
- **python3Packages.bcrypt: fix cross build**

Apart from the cross fixes, this contains an optimization for the dependency closure computation in `home-assistant-chip-wheels`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
