### PR TITLE
gitlab: update prometheus-client-mmap gem to fix aarch64

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -99,7 +99,7 @@ rec {
 
         (onFullSupported "nixos.tests.firewall")
         (onFullSupported "nixos.tests.fontconfig-default-fonts")
-        (onSystems [ "x86_64-linux" ] "nixos.tests.gitlab") # we lack energy to really debug aarch64 here
+        (onFullSupported "nixos.tests.gitlab")
         (onFullSupported "nixos.tests.gnome")
         (onFullSupported "nixos.tests.gnome-xorg")
         (onSystems [ "x86_64-linux" ] "nixos.tests.hibernate")

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile
@@ -424,7 +424,7 @@ gem 'snowplow-tracker', '~> 0.8.0' # rubocop:todo Gemfile/MissingFeatureCategory
 
 # Metrics
 gem 'webrick', '~> 1.8.1', require: false # rubocop:todo Gemfile/MissingFeatureCategory
-gem 'prometheus-client-mmap', '~> 1.1', '>= 1.1.1', require: 'prometheus/client' # rubocop:todo Gemfile/MissingFeatureCategory
+gem 'prometheus-client-mmap', '1.1.2', require: 'prometheus/client' # rubocop:todo Gemfile/MissingFeatureCategory
 
 # Event-driven reactor for Ruby
 # Required manually in config/initializers/require_async_gem

--- a/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/Gemfile.lock
@@ -1436,7 +1436,8 @@ GEM
       coderay
       parser
       unparser
-    prometheus-client-mmap (1.1.1)
+    prometheus-client-mmap (1.1.2)
+      base64
       rb_sys (~> 0.9.86)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -2226,7 +2227,7 @@ DEPENDENCIES
   pg_query (~> 5.1.0)
   png_quantizator (~> 0.2.1)
   premailer-rails (~> 1.12.0)
-  prometheus-client-mmap (~> 1.1, >= 1.1.1)
+  prometheus-client-mmap (= 1.1.2)
   pry-byebug
   pry-rails (~> 0.3.9)
   pry-shell (~> 0.6.4)
@@ -2329,4 +2330,4 @@ DEPENDENCIES
   yajl-ruby (~> 1.4.3)
 
 BUNDLED WITH
-   2.5.11
+   2.5.22

--- a/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
+++ b/pkgs/applications/version-management/gitlab/rubyEnv/gemset.nix
@@ -5063,15 +5063,15 @@ src:
     version = "0.1.0";
   };
   prometheus-client-mmap = {
-    dependencies = ["rb_sys"];
+    dependencies = ["base64" "rb_sys"];
     groups = ["default"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0vg47xx3wgg24snqc6ychb08mbcyrjmvxym9fg69cpa4xvj133fx";
+      sha256 = "1dwvpxqj652c8r61q88s336vzf2h2akcijk9hmjp9jzlnhil44n4";
       type = "gem";
     };
-    version = "1.1.1";
+    version = "1.1.2";
   };
   pry = {
     dependencies = ["coderay" "method_source"];

--- a/pkgs/applications/version-management/gitlab/update.py
+++ b/pkgs/applications/version-management/gitlab/update.py
@@ -180,6 +180,12 @@ def update_rubyenv():
         cwd=rubyenv_dir,
     )
 
+    # update to 1.1.2 to fix https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap/-/issues/68
+    subprocess.check_output(
+        ["sed", "-i", "s:'prometheus-client-mmap', '~> 1.1', '>= 1.1.1':'prometheus-client-mmap', '1.1.2':g", "Gemfile"],
+        cwd=rubyenv_dir,
+    )
+
     # Un-vendor sidekiq
     #
     # The sidekiq dependency was vendored to maintain compatibility with Redis 6.0 (as

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -321,9 +321,12 @@ in
           cp -R ext/fast_mmaped_file_rs $out
         '';
       };
-      hash = if lib.versionAtLeast attrs.version "1.1.1"
-        then "sha256-RsN5XWX7Mj2ORccM0eczY+44WXsbXNTnJVcCMvnOATk="
-        else "sha256-XuQZPbFWqPHlrJvllkvLl1FjKeoAUbi8oKDrS2rY1KM=";
+      hash = if lib.versionAtLeast attrs.version "1.1.2"
+        then "sha256-pNzW2fQZDcuqu8apv3GU7lUC/H1cX5WRifBBQlbE8+s="
+        else
+          if lib.versionAtLeast attrs.version "1.1.1"
+          then "sha256-RsN5XWX7Mj2ORccM0eczY+44WXsbXNTnJVcCMvnOATk="
+          else "sha256-XuQZPbFWqPHlrJvllkvLl1FjKeoAUbi8oKDrS2rY1KM=";
     };
     nativeBuildInputs = [
       cargo


### PR DESCRIPTION
Currently the nixosTests for gitlab are failing on aarch64-linux do to an error within prometheus-client-mmap ("failed with weakmap value was not a string"), the update to 1.1.2 should fix this accouring to upstream. 

https://gitlab.com/gitlab-org/ruby/gems/prometheus-client-mmap/-/issues/68#top

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
