### PR TITLE
libossp_uuid: remove invalid ac_cv_va_copy value; fix darwin

### DIFF
--- a/pkgs/by-name/li/libossp_uuid/package.nix
+++ b/pkgs/by-name/li/libossp_uuid/package.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   };
 
   configureFlags = [
-    "ac_cv_va_copy=yes"
+    "ac_cv_va_copy=C99"
   ] ++ lib.optional stdenv.hostPlatform.isFreeBSD "--with-pic";
 
   patches = [ ./shtool.patch ];


### PR DESCRIPTION
fix https://hydra.nixos.org/build/282886856

Use `configure`'s va_copy detection when not cross compiling and when cross compiling pass in `ac_cv_va_copy=C99` which is a valid option for ac_cv_va_copy, unlike `ac_cv_va_copy=yes` which is invalid.

Change 5c7cfbc0f11e360f50467b20a407c675c976d3a0 set ac_cv_va_copy=yes which results in
```
uuid_str.c:699:5: error: call to undeclared function '__VA_COPY_USE_yes'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  699 |     va_copy(ap_tmp, ap);
      |     ^
./config.h:212:23: note: expanded from macro 'va_copy'
  212 | #define va_copy(d, s) __VA_COPY_USE(d, s)
      |                       ^
./config.h:217:23: note: expanded from macro '__VA_COPY_USE'
  217 | #define __VA_COPY_USE __VA_COPY_USE_yes
      |                       ^
uuid_str.c:738:9: error: call to undeclared function '__VA_COPY_USE_yes'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  738 |         va_copy(ap_tmp, ap);
      |         ^
./config.h:212:23: note: expanded from macro 'va_copy'
  212 | #define va_copy(d, s) __VA_COPY_USE(d, s)
      |                       ^
./config.h:217:23: note: expanded from macro '__VA_COPY_USE'
  217 | #define __VA_COPY_USE __VA_COPY_USE_yes
      |                       ^
2 errors generated.
```
and there is no definition for `__VA_COPY_USE_yes`, it needs to be `__VA_COPY_USE_{ASP,...,C99,...,GCM}`.

While __VA_COPY_USE_yes is wrong it didn't cause issues previously because stdarg.h is included after the macro which just redefines va_copy.

However, the headers with clang-19 do not redefine va_copy and the compile fails.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
