### PR TITLE
storcli2: init at 8.11

### DIFF
--- a/pkgs/by-name/st/storcli2/package.nix
+++ b/pkgs/by-name/st/storcli2/package.nix
@@ -1,0 +1,73 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  rpmextract,
+  testers,
+}:
+stdenvNoCC.mkDerivation (
+  finalAttrs:
+  let
+    majVer = "8";
+    minVer = "11";
+    relPhs = "14";
+    verCode = "00" + majVer + ".00" + minVer + ".0000.00" + relPhs;
+  in
+  {
+    pname = "storcli";
+    version = majVer + "." + minVer;
+
+    src = fetchzip {
+      url = "https://docs.broadcom.com/docs-and-downloads/host-bus-adapters/host-bus-adapters-common-files/sas_sata_nvme_24g_p${finalAttrs.version}/StorCLI_Avenger_${finalAttrs.version}-${verCode}.zip";
+      hash = "sha256-vztV+Jp+p6nU4q7q8QQIkuL30QsoGj2tyIZp87luhH8=";
+    };
+
+    nativeBuildInputs = [ rpmextract ];
+
+    unpackPhase =
+      let
+        inherit (stdenvNoCC.hostPlatform) system;
+        platforms = {
+          x86_64-linux = "Linux";
+          aarch64-linux = "ARM/Linux";
+        };
+        platform = platforms.${system} or (throw "unsupported system: ${system}");
+      in
+      ''
+        rpmextract $src/Avenger_StorCLI/${platform}/storcli2-${verCode}-1.*.rpm
+      '';
+
+    dontPatch = true;
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      install -D ./opt/MegaRAID/storcli2/storcli2 $out/bin/storcli2
+    '';
+
+    # Not needed because the binary is statically linked
+    dontFixup = false;
+
+    passthru.tests = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "${finalAttrs.meta.mainProgram} v";
+      version = verCode;
+    };
+
+    meta = with lib; {
+      # Unfortunately there is no better page for this.
+      # Filter for downloads, set 100 items per page. Sort by newest does not work.
+      # Then search manually for the latest version.
+      homepage = "https://www.broadcom.com/support/download-search?pg=&pf=Host+Bus+Adapters&pn=&pa=&po=&dk=storcli2&pl=&l=false";
+      description = "Storage Command Line Tool";
+      sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+      license = licenses.unfree;
+      maintainers = with maintainers; [ edwtjo ];
+      mainProgram = "storcli2";
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    };
+  }
+)


### PR DESCRIPTION
This is a vendor package from BroadCom. Note that; StorCLI2 is for SAS4 instrumentation, whereas StorCLI is for SAS3.5 controllers.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
