### PR TITLE
spotube: unify linux and darwin builder

### DIFF
--- a/pkgs/by-name/sp/spotube/package.nix
+++ b/pkgs/by-name/sp/spotube/package.nix
@@ -20,37 +20,73 @@
   webkitgtk_4_1,
 }:
 
-let
+stdenv.mkDerivation (finalAttrs: {
   pname = "spotube";
   version = "3.9.0";
 
-  meta = {
-    description = "Open source, cross-platform Spotify client compatible across multiple platforms";
-    longDescription = ''
-      Spotube is an open source, cross-platform Spotify client compatible across
-      multiple platforms utilizing Spotify's data API and YouTube (or Piped.video or JioSaavn)
-      as an audio source, eliminating the need for Spotify Premium
-    '';
-    downloadPage = "https://github.com/KRTirtho/spotube/releases";
-    homepage = "https://spotube.krtirtho.dev/";
-    license = lib.licenses.bsdOriginal;
-    mainProgram = "spotube";
-    maintainers = with lib.maintainers; [ tomasajt ];
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-      "aarch64-linux"
-    ];
-    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-  };
+  src = finalAttrs.passthru.sources.${stdenv.hostPlatform.system};
 
-  sources =
+  sourceRoot = lib.optionalString stdenv.hostPlatform.isDarwin ".";
+
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      autoPatchelfHook
+      dpkg
+      makeWrapper
+      wrapGAppsHook3
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      undmg
+      makeBinaryWrapper
+    ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    glib-networking
+    gtk3
+    libappindicator
+    libnotify
+    libsoup_3
+    mpv-unwrapped
+    webkitgtk_4_1
+  ];
+
+  dontWrapGApps = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    ${lib.optionalString stdenv.hostPlatform.isLinux ''
+      mkdir -p $out
+      cp -r usr/* $out
+    ''}
+
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      mkdir -p $out/Applications
+      cp -r Spotube.app $out/Applications
+      makeBinaryWrapper $out/Applications/Spotube.app/Contents/MacOS/Spotube $out/bin/spotube
+    ''}
+
+    runHook postInstall
+  '';
+
+  preFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf $out/share/spotube/lib/libmedia_kit_native_event_loop.so \
+        --replace-needed libmpv.so.1 libmpv.so
+  '';
+
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    makeWrapper $out/share/spotube/spotube $out/bin/spotube \
+        "''${gappsWrapperArgs[@]}" \
+        --prefix LD_LIBRARY_PATH : $out/share/spotube/lib:${lib.makeLibraryPath [ mpv-unwrapped ]} \
+        --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
+  '';
+
+  passthru.sources =
     let
       fetchArtifact =
         { filename, hash }:
         fetchurl {
-          url = "https://github.com/KRTirtho/spotube/releases/download/v${version}/${filename}";
+          url = "https://github.com/KRTirtho/spotube/releases/download/v${finalAttrs.version}/${filename}";
           inherit hash;
         };
     in
@@ -73,81 +109,19 @@ let
       };
     };
 
-  src = sources.${stdenv.hostPlatform.system};
-
-  darwin = stdenv.mkDerivation {
-    inherit
-      pname
-      version
-      meta
-      src
-      ;
-
-    passthru = { inherit sources; };
-
-    sourceRoot = ".";
-
-    nativeBuildInputs = [
-      undmg
-      makeBinaryWrapper
-    ];
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/Applications $out/bin
-      cp -r spotube.app $out/Applications
-      makeBinaryWrapper $out/Applications/spotube.app/Contents/MacOS/spotube $out/bin/spotube
-      runHook postInstall
+  meta = {
+    description = "Open source, cross-platform Spotify client compatible across multiple platforms";
+    longDescription = ''
+      Spotube is an open source, cross-platform Spotify client compatible across
+      multiple platforms utilizing Spotify's data API and YouTube (or Piped.video or JioSaavn)
+      as an audio source, eliminating the need for Spotify Premium
     '';
+    downloadPage = "https://github.com/KRTirtho/spotube/releases";
+    homepage = "https://spotube.krtirtho.dev/";
+    license = lib.licenses.bsdOriginal;
+    mainProgram = "spotube";
+    maintainers = with lib.maintainers; [ tomasajt ];
+    platforms = lib.attrNames finalAttrs.passthru.sources;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
   };
-
-  linux = stdenv.mkDerivation {
-    inherit
-      pname
-      version
-      meta
-      src
-      ;
-
-    passthru = { inherit sources; };
-
-    nativeBuildInputs = [
-      autoPatchelfHook
-      dpkg
-      makeWrapper
-      wrapGAppsHook3
-    ];
-
-    buildInputs = [
-      glib-networking
-      gtk3
-      libappindicator
-      libnotify
-      libsoup_3
-      mpv-unwrapped
-      webkitgtk_4_1
-    ];
-
-    dontWrapGApps = true;
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out
-      cp -r usr/* $out
-      runHook postInstall
-    '';
-
-    preFixup = ''
-      patchelf $out/share/spotube/lib/libmedia_kit_native_event_loop.so \
-          --replace-needed libmpv.so.1 libmpv.so
-    '';
-
-    postFixup = ''
-      makeWrapper $out/share/spotube/spotube $out/bin/spotube \
-          "''${gappsWrapperArgs[@]}" \
-          --prefix LD_LIBRARY_PATH : $out/share/spotube/lib:${lib.makeLibraryPath [ mpv-unwrapped ]} \
-          --prefix PATH : ${lib.makeBinPath [ xdg-user-dirs ]}
-    '';
-  };
-in
-if stdenv.hostPlatform.isDarwin then darwin else linux
+})


### PR DESCRIPTION
Luckily the github diff is not too horrible

Other then the combining of the two builders I did the following:
- use `finalAttrs`
- calculate `meta.platforms` from `passthru.sources`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
