### PR TITLE
dfcldd: 1.3.4-1 -> 1.9.2

### DIFF
--- a/pkgs/by-name/dc/dcfldd/package.nix
+++ b/pkgs/by-name/dc/dcfldd/package.nix
@@ -1,27 +1,38 @@
 {
+  autoreconfHook,
+  fetchFromGitHub,
   lib,
+  pkg-config,
   stdenv,
-  fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "dcfldd";
-  version = "1.3.4-1";
+  version = "1.9.2";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/dcfldd/dcfldd-${version}.tar.gz";
-    sha256 = "1y6mwsvm75f5jzxsjjk0yhf8xnpmz6y8qvcxfandavx59lc3l57m";
+  src = fetchFromGitHub {
+    owner = "resurrecting-open-source-projects";
+    repo = "dcfldd";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-IRyc57UBsUgW8WALRhYSvT1rKIt27PBiT7MWCPJL0mY=";
   };
 
-  meta = with lib; {
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  meta = {
     description = "Enhanced version of GNU dd";
 
-    homepage = "https://dcfldd.sourceforge.net/";
+    homepage = "https://github.com/resurrecting-open-source-projects/dcfldd";
 
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
 
-    platforms = platforms.all;
-    maintainers = with maintainers; [ qknight ];
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ qknight ];
     mainProgram = "dcfldd";
   };
-}
+})


### PR DESCRIPTION
Hi,

Since we updated to GCC 14, dcfldd 1.3.4-1 does not build:
```
       > In file included from dcfldd.c:63:
       > util.h:44:8: error: type defaults to 'int' in declaration of 'pclose2' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-int-Wimplicit-int8;;]
       >    44 | extern pclose2(FILE *);
       >       |        ^~~~~~~
       > dcfldd.c: In function 'scanargs':
       > dcfldd.c:687:9: error: implicit declaration of function 'init_hashlist' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
       >   687 |         init_hashlist(&ihashlist, hashops[VERIFY_HASH].flag);
       >       |         ^~~~~~~~~~~~~
       > make[1]: *** [Makefile:303: dcfldd.o] Error 1
```

Here is an update to fix this. upstream changed, according to https://salsa.debian.org/debian/dcfldd and https://www.kali.org/tools/dcfldd/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
