### PR TITLE
antora-ui-default: update hash

### DIFF
--- a/pkgs/by-name/an/antora-lunr-extension/package.nix
+++ b/pkgs/by-name/an/antora-lunr-extension/package.nix
@@ -10,10 +10,10 @@ buildNpmPackage rec {
   version = "1.0.0-alpha.8";
 
   src = fetchFromGitLab {
-    hash = "sha256-GplCwhUl8jurD4FfO6/T3Vo1WFjg+rtAjWeIh35unk4=";
     owner = "antora";
     repo = pname;
     rev = "v${version}";
+    hash = "sha256-GplCwhUl8jurD4FfO6/T3Vo1WFjg+rtAjWeIh35unk4=";
   };
 
   npmDepsHash = "sha256-EtjZL6U/uSGSYSqtuatCkdWP0NHxRuht13D9OaM4x00=";

--- a/pkgs/by-name/an/antora-ui-default/package.nix
+++ b/pkgs/by-name/an/antora-ui-default/package.nix
@@ -5,7 +5,7 @@
 }:
 let
   srcFetchFromGitLab = {
-    hash = "sha256-q2FwkwzjanxTIxjMpCyMpzPt782uYZiWVdZ7Eev79oM=";
+    hash = "sha256-gUQLLjnWZ1OsAe005IOPIfoM0qmjoevcUuGBRD3oHXA=";
     owner = "trueNAHO";
     repo = "antora-ui-default";
     rev = "11f563294248e9b64124b9289d639e349f2e9f5f";

--- a/pkgs/by-name/an/antora-ui-default/package.nix
+++ b/pkgs/by-name/an/antora-ui-default/package.nix
@@ -5,10 +5,10 @@
 }:
 let
   srcFetchFromGitLab = {
-    hash = "sha256-gUQLLjnWZ1OsAe005IOPIfoM0qmjoevcUuGBRD3oHXA=";
     owner = "trueNAHO";
     repo = "antora-ui-default";
     rev = "11f563294248e9b64124b9289d639e349f2e9f5f";
+    hash = "sha256-gUQLLjnWZ1OsAe005IOPIfoM0qmjoevcUuGBRD3oHXA=";
   };
 in
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION
This patch updates the hash that was forgotten in commit 518ba1789aa2 ("antora-ui-default: 0-unstable-2024-09-20 -> 0-unstable-2024-12-26").

I have successfully tested this patch on my documentation that relies on this package and successfully built the following packages:

```console
nix build .#antora-ui-default &&
  nix build .#antora.tests.run &&
  nix build .#antora-lunr-extension.tests.run
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
