### PR TITLE
criticality-score: migrate from python3Packages; 1.0.8 -> 2.0.4

### DIFF
--- a/pkgs/by-name/cr/criticality-score/package.nix
+++ b/pkgs/by-name/cr/criticality-score/package.nix
@@ -1,12 +1,10 @@
 {
   lib,
-  buildPythonPackage,
+  python3Packages,
   fetchPypi,
-  pygithub,
-  python-gitlab,
 }:
 
-buildPythonPackage rec {
+python3Packages.buildPythonApplication rec {
   pname = "criticality_score";
   version = "1.0.8";
 
@@ -15,7 +13,7 @@ buildPythonPackage rec {
     hash = "sha256-5XkVT0blnLG158a01jDfQl1Rx9U1LMsqaMjTdN7Q4QQ=";
   };
 
-  propagatedBuildInputs = [
+  propagatedBuildInputs = with python3Packages; [
     pygithub
     python-gitlab
   ];

--- a/pkgs/by-name/cr/criticality-score/package.nix
+++ b/pkgs/by-name/cr/criticality-score/package.nix
@@ -1,33 +1,54 @@
 {
   lib,
-  python3Packages,
-  fetchPypi,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
 }:
 
-python3Packages.buildPythonApplication rec {
-  pname = "criticality_score";
-  version = "1.0.8";
+buildGoModule rec {
+  pname = "criticality-score";
+  version = "2.0.4";
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-5XkVT0blnLG158a01jDfQl1Rx9U1LMsqaMjTdN7Q4QQ=";
+  src = fetchFromGitHub {
+    owner = "ossf";
+    repo = "criticality_score";
+    tag = "v${version}";
+    hash = "sha256-p2ZXNpPFwIKPWDKCdEUZQvt/hvLQS9xjZaaquNTaUB0=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    pygithub
-    python-gitlab
+  proxyVendor = true;
+
+  vendorHash = "sha256-mKCwyAE/fI9ateKcrTLDAdULbT6pUpV0cMZ0X5bqT1M=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X=main.version=${version}"
+    "-X=main.commit=${src.tag}"
+    "-X=main.date=1970-01-01T00:00:00Z"
   ];
 
-  doCheck = false;
+  subPackages = [
+    "cmd/collect_signals"
+    "cmd/criticality_score"
+    "cmd/csv_transfer"
+    "cmd/enumerate_github"
+    "cmd/scorer"
+  ];
 
-  pythonImportsCheck = [ "criticality_score" ];
+  doInstallCheck = true;
 
-  meta = with lib; {
-    description = "Python tool for computing the Open Source Project Criticality Score";
-    mainProgram = "criticality_score";
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgramArg = [ "--version" ];
+
+  meta = {
+    description = "Gives criticality score for an open source project";
     homepage = "https://github.com/ossf/criticality_score";
     changelog = "https://github.com/ossf/criticality_score/releases/tag/v${version}";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ wamserma ];
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ wamserma ];
+    mainProgram = "criticality_score";
   };
 }

--- a/pkgs/top-level/python-aliases.nix
+++ b/pkgs/top-level/python-aliases.nix
@@ -130,6 +130,7 @@ mapAliases ({
   covCore = throw "covCore was renamed to cov-core and subsequently removed since it has ben unmaintained since 2014"; # added 2024-05-20
   cov-core = throw "cov-core has been removed, it was archived and unmaintained since 2014"; # added 2024-05-21
   cozy = throw "cozy was removed because it was not actually https://pypi.org/project/Cozy/."; # added 2022-01-14
+  criticality-score = throw "use pkgs.criticality-score instead"; # added 2024-12-31
   cryptacular = throw "cryptacular was removed, because it was disabled on all python version since 3.6 and last updated in 2021"; # Added 2024-05-13
   cryptography_vectors = "cryptography_vectors is no longer exposed in python*Packages because it is used for testing cryptography only."; # Added 2022-03-23
   cx_Freeze = cx-freeze; # added 2023-08-02

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2720,8 +2720,6 @@ self: super: with self; {
 
   credstash = callPackage ../development/python-modules/credstash { };
 
-  criticality-score = callPackage ../development/python-modules/criticality-score { };
-
   crocoddyl = toPythonModule (pkgs.crocoddyl.override {
     pythonSupport = true;
     python3Packages = self;


### PR DESCRIPTION
Diff: https://github.com/ossf/criticality_score/compare/v1.0.8...v2.0.4

Changelog: https://github.com/ossf/criticality_score/releases/tag/v2.0.4

closes https://github.com/NixOS/nixpkgs/pull/271236
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
