### PR TITLE
PyKMS maintenance: unstable-2021-01-25 -> 0-unstable-2024-07-06

### DIFF
--- a/nixos/modules/services/misc/pykms.nix
+++ b/nixos/modules/services/misc/pykms.nix
@@ -24,6 +24,8 @@ in
         description = "Whether to enable the PyKMS service.";
       };
 
+      package = lib.mkPackageOption pkgs "pykms" { };
+
       listenAddress = lib.mkOption {
         type = lib.types.str;
         default = "0.0.0.0";
@@ -78,13 +80,13 @@ in
       wantedBy = [ "multi-user.target" ];
       # python programs with DynamicUser = true require HOME to be set
       environment.HOME = libDir;
-      serviceConfig = with pkgs; {
+      serviceConfig = {
         DynamicUser = true;
         StateDirectory = baseNameOf libDir;
-        ExecStartPre = "${lib.getBin pykms}/libexec/create_pykms_db.sh ${libDir}/clients.db";
+        ExecStartPre = "${lib.getBin cfg.package}/libexec/create_pykms_db.sh ${libDir}/clients.db";
         ExecStart = lib.concatStringsSep " " (
           [
-            "${lib.getBin pykms}/bin/server"
+            "${lib.getBin cfg.package}/bin/server"
             "--logfile=STDOUT"
             "--loglevel=${cfg.logLevel}"
             "--sqlite=${libDir}/clients.db"

--- a/nixos/modules/services/misc/pykms.nix
+++ b/nixos/modules/services/misc/pykms.nix
@@ -29,6 +29,7 @@ in
       listenAddress = lib.mkOption {
         type = lib.types.str;
         default = "0.0.0.0";
+        example = "::";
         description = "The IP address on which to listen.";
       };
 

--- a/pkgs/by-name/py/pykms/package.nix
+++ b/pkgs/by-name/py/pykms/package.nix
@@ -36,13 +36,13 @@ let
 in
 pypkgs.buildPythonApplication rec {
   pname = "pykms";
-  version = "unstable-2021-01-25";
+  version = "0-unstable-2024-07-06";
 
   src = fetchFromGitHub {
     owner = "Py-KMS-Organization";
     repo = "py-kms";
-    rev = "1435c86fe4f11aa7fd42d77fa61715ca3015eeab";
-    hash = "sha256-9KiMbS0uKTbWSZVIv5ziIeR9c8+EKfKd20yPmjCX7GQ=";
+    rev = "465f4d14c728819d4eb00e3419bd1cb98af7f81c";
+    hash = "sha256-/XbMbcBcZPO7joHyaprJ29Cq4gNpuuzTzj2x1XDIyj8=";
   };
 
   sourceRoot = "${src.name}/py-kms";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

We are currently using Python 3.12 by default, which [breaks the current version of PyKMS](https://github.com/Py-KMS-Organization/py-kms/issues/117#issuecomment-2479095069). Update with the HEAD of `next` branch since the fix is only available there.

Also added a trivial `package` option to allow overriding default pykms package, and provided a dual stack binding example.

[Dogfooding](https://github.com/MakiseKurisu/nixos-config/commit/5e034ce0c500cf0a9d6b2fa2b714b6e804a3d130)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
