### PR TITLE
openroad: 2.0-unstable-2024-12-22 -> 2.0-unstable-2024-12-31

### DIFF
--- a/pkgs/applications/science/electronics/openroad/swig43-compat.patch
+++ b/pkgs/applications/science/electronics/openroad/swig43-compat.patch
@@ -1,0 +1,30 @@
+diff --git a/src/odb/src/swig/python/dbtypes.i b/src/odb/src/swig/python/dbtypes.i
+index 37305d55e..d85f2915e 100644
+--- a/src/odb/src/swig/python/dbtypes.i
++++ b/src/odb/src/swig/python/dbtypes.i
+@@ -271,7 +271,7 @@ WRAP_OBJECT_RETURN_REF(odb::dbViaParams, params_return)
+   swig_type_info *tf = SWIG_TypeQuery("odb::dbShape" "*");
+   for(std::vector<odb::dbShape>::iterator it = $1->begin(); it != $1->end(); it++) {
+     PyObject *o = SWIG_NewInstanceObj(&(*it), tf, 0);
+-    $result = SWIG_Python_AppendOutput($result, o);
++    $result = SWIG_Python_AppendOutput($result, o, 0);
+   }
+ }
+ 
+@@ -283,14 +283,14 @@ WRAP_OBJECT_RETURN_REF(odb::dbViaParams, params_return)
+     auto layer = it->second;
+     PyObject *layer_swig = SWIG_NewInstanceObj(layer, tf, 0);
+     PyObject *tuple = PyTuple_Pack(2, PyFloat_FromDouble(value), layer_swig);
+-    $result = SWIG_Python_AppendOutput($result, tuple);
++    $result = SWIG_Python_AppendOutput($result, tuple, 0);
+   }
+ }
+ 
+ %typemap(argout) std::vector<int> &OUTPUT {
+   for(auto it = $1->begin(); it != $1->end(); it++) {
+     PyObject *obj = PyInt_FromLong((long)*it);
+-    $result = SWIG_Python_AppendOutput($result, obj);
++    $result = SWIG_Python_AppendOutput($result, obj, 0);
+   }
+ }
+ 


### PR DESCRIPTION
Update to head.
Also, unbreak nixpkgs build -- fix compile with swig 4.3.
Enable unit tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
