### PR TITLE
perf: Fix eBPF skeletons for perf trace 6.11+

### DIFF
--- a/pkgs/os-specific/linux/kernel/perf/default.nix
+++ b/pkgs/os-specific/linux/kernel/perf/default.nix
@@ -39,6 +39,8 @@
   zstd,
   withLibcap ? true,
   libcap,
+  buildPackages,
+  writeShellScript,
 }:
 let
   d3-flame-graph-templates = stdenv.mkDerivation rec {
@@ -54,6 +56,15 @@ let
       install -D -m 0755 -t $out/share/d3-flame-graph/ ./dist/templates/*
     '';
   };
+  # The cc-wrapper adds `-fzero-call-used-regs` as part of the default
+  # hardening to the compiler command line, but clang aborts with an error when
+  # that is used together with a target arch that is not x86 or x86_64.
+  # This wrapper works around that issue by instructing the machinery to not
+  # add that flag for those particular invocations.
+  clang-bpf = writeShellScript "clang-bpf" ''
+    NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/zerocallusedregs/}
+    exec ${lib.getExe buildPackages.clang} "$@"
+  '';
 in
 
 stdenv.mkDerivation {
@@ -61,17 +72,22 @@ stdenv.mkDerivation {
   inherit (kernel) version src;
 
   patches =
-    lib.optionals (lib.versionAtLeast kernel.version "5.10" && lib.versionOlder kernel.version "6.13")
-      [
-        # fix wrong path to dmesg
-        ./fix-dmesg-path.diff
-      ];
+    lib.optionals (lib.versionAtLeast kernel.version "5.10" && lib.versionOlder kernel.version "6.13") [
+      # fix wrong path to dmesg
+      ./fix-dmesg-path.diff
+    ]
+    ++ lib.optionals (lib.versionAtLeast kernel.version "6.12") [
+      ./fix-augmented-raw-syscalls.bpf.diff # Loading this bpf object can fail with E2BIG in perf trace without the fix
+    ];
 
   postPatch =
     ''
       # Linux scripts
       patchShebangs scripts
       patchShebangs tools/perf/check-headers.sh
+
+      # Expose warnings and errors of feature detection
+      sed -i -e 's/2>\/dev\/null//g' tools/build/Makefile.feature
     ''
     + lib.optionalString (lib.versionAtLeast kernel.version "6.3") ''
       # perf-specific scripts
@@ -100,6 +116,7 @@ stdenv.mkDerivation {
       "prefix=$(out)"
       "WERROR=0"
       "ASCIIDOC8=1"
+      "CLANG=${clang-bpf}"
     ]
     ++ kernel.makeFlags
     ++ lib.optional (!withGtk) "NO_GTK2=1"

--- a/pkgs/os-specific/linux/kernel/perf/fix-augmented-raw-syscalls.bpf.diff
+++ b/pkgs/os-specific/linux/kernel/perf/fix-augmented-raw-syscalls.bpf.diff
@@ -1,0 +1,31 @@
+--- a/tools/perf/util/bpf_skel/augmented_raw_syscalls.bpf.c
++++ b/tools/perf/util/bpf_skel/augmented_raw_syscalls.bpf.c
+@@ -431,9 +431,9 @@ static bool pid_filter__has(struct pids_filtered *pids, pid_t pid)
+ static int augment_sys_enter(void *ctx, struct syscall_enter_args *args)
+ {
+ 	bool augmented, do_output = false;
+-	int zero = 0, size, aug_size, index,
+-	    value_size = sizeof(struct augmented_arg) - offsetof(struct augmented_arg, value);
++	int zero = 0, index, value_size = sizeof(struct augmented_arg) - offsetof(struct augmented_arg, value);
+ 	u64 output = 0; /* has to be u64, otherwise it won't pass the verifier */
++	s64 aug_size, size;
+ 	unsigned int nr, *beauty_map;
+ 	struct beauty_payload_enter *payload;
+ 	void *arg, *payload_offset;
+@@ -484,14 +484,11 @@ static int augment_sys_enter(void *ctx, struct syscall_enter_args *args)
+ 		} else if (size > 0 && size <= value_size) { /* struct */
+ 			if (!bpf_probe_read_user(((struct augmented_arg *)payload_offset)->value, size, arg))
+ 				augmented = true;
+-		} else if (size < 0 && size >= -6) { /* buffer */
++		} else if ((int)size < 0 && size >= -6) { /* buffer */
+ 			index = -(size + 1);
+ 			barrier_var(index); // Prevent clang (noticed with v18) from removing the &= 7 trick.
+ 			index &= 7;	    // Satisfy the bounds checking with the verifier in some kernels.
+-			aug_size = args->args[index];
+-
+-			if (aug_size > TRACE_AUG_MAX_BUF)
+-				aug_size = TRACE_AUG_MAX_BUF;
++			aug_size = args->args[index] > TRACE_AUG_MAX_BUF ? TRACE_AUG_MAX_BUF : args->args[index];
+ 
+ 			if (aug_size > 0) {
+ 				if (!bpf_probe_read_user(((struct augmented_arg *)payload_offset)->value, aug_size, arg))


### PR DESCRIPTION
This fixes only versions 6.11 and up.

Perf trace tries to make use of eBPF to trace and extract parameters of some syscalls (openat, connect, ...).
Take a look inside tools/perf/utils/bpf_skel/augmented_raw_syscalls.bpf.c

In order to build bpf skeletons clang is required. During build process make tries to compile an example bpf program to test if tools required work (clang-bpf-co-re).
Script responsible for that suppresses any warning and error that would show the issue. Enabling those and inspecting the logs we can learn that clang --target=bpf doesn't support zerocallusedregs hardening option.

In version 6.12
during execution perf trace fails to load bpf program. Patch provided by Howard Chu (howardchu95@gmail.com) in https://lore.kernel.org/all/20241213023047.541218-1-howardchu95@gmail.com/ fixes the issue.

Simple test to verify the fix:
```
sudo perf trace -e open* --max-events 4
```
should display filenames as text in syscalls instead of raw pointers.

Additionally this change fixes these tests for latest version:
 65: dlfilter C API
 77: build id cache operations
 86: perf list tests
 92: probe libc's inet_pton & backtrace it with ping
 96: perf record sample filtering (by BPF) tests
 98: perf record offcpu profiling tests
 99: perf record sideband tests
100: perf script tests
111: perf stat --bpf-counters test
119: Test data symbol
122: 'perf data convert --to-json' command test
125: test perf probe of function from different CU


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
