### PR TITLE
caddy: 2.8.4 -> 2.9.0

### DIFF
--- a/pkgs/by-name/ca/caddy/package.nix
+++ b/pkgs/by-name/ca/caddy/package.nix
@@ -1,20 +1,21 @@
-{ lib
-, buildGoModule
-, callPackage
-, fetchFromGitHub
-, nixosTests
-, caddy
-, testers
-, installShellFiles
-, stdenv
+{
+  lib,
+  buildGoModule,
+  callPackage,
+  fetchFromGitHub,
+  nixosTests,
+  caddy,
+  testers,
+  installShellFiles,
+  stdenv,
 }:
 let
-  version = "2.8.4";
+  version = "2.9.0";
   dist = fetchFromGitHub {
     owner = "caddyserver";
     repo = "dist";
-    rev = "v${version}";
-    hash = "sha256-O4s7PhSUTXoNEIi+zYASx8AgClMC5rs7se863G6w+l0=";
+    tag = "v${version}";
+    hash = "sha256-3QcpmPUhZZ8oN/CUbCh/A1D0B59o1RxWPyMbA/WoRcU=";
   };
 in
 buildGoModule {
@@ -24,11 +25,11 @@ buildGoModule {
   src = fetchFromGitHub {
     owner = "caddyserver";
     repo = "caddy";
-    rev = "v${version}";
-    hash = "sha256-CBfyqtWp3gYsYwaIxbfXO3AYaBiM7LutLC7uZgYXfkQ=";
+    tag = "v${version}";
+    hash = "sha256-ea1Cch0LOGVGO9CVvS61EHVwJule4HZRizpQYP1QA2w=";
   };
 
-  vendorHash = "sha256-1Api8bBZJ1/oYk4ZGIiwWCSraLzK9L+hsKXkFtk6iVM=";
+  vendorHash = "sha256-HEQCNOv4vO5QsbmoT0acRoaJ4sB0dzF1zcR38778nBI=";
 
   subPackages = [ "cmd/caddy" ];
 
@@ -39,29 +40,35 @@ buildGoModule {
   ];
 
   # matches upstream since v2.8.0
-  tags = [ "nobadger" ];
+  tags = [
+    "nobadger"
+    "nomysql"
+    "nopgx"
+  ];
 
   nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
-    install -Dm644 ${dist}/init/caddy.service ${dist}/init/caddy-api.service -t $out/lib/systemd/system
+  postInstall =
+    ''
+      install -Dm644 ${dist}/init/caddy.service ${dist}/init/caddy-api.service -t $out/lib/systemd/system
 
-    substituteInPlace $out/lib/systemd/system/caddy.service \
-      --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
-    substituteInPlace $out/lib/systemd/system/caddy-api.service \
-      --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
-  '' + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-    # Generating man pages and completions fail on cross-compilation
-    # https://github.com/NixOS/nixpkgs/issues/308283
+      substituteInPlace $out/lib/systemd/system/caddy.service \
+        --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
+      substituteInPlace $out/lib/systemd/system/caddy-api.service \
+        --replace-fail "/usr/bin/caddy" "$out/bin/caddy"
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      # Generating man pages and completions fail on cross-compilation
+      # https://github.com/NixOS/nixpkgs/issues/308283
 
-    $out/bin/caddy manpage --directory manpages
-    installManPage manpages/*
+      $out/bin/caddy manpage --directory manpages
+      installManPage manpages/*
 
-    installShellCompletion --cmd caddy \
-      --bash <($out/bin/caddy completion bash) \
-      --fish <($out/bin/caddy completion fish) \
-      --zsh <($out/bin/caddy completion zsh)
-  '';
+      installShellCompletion --cmd caddy \
+        --bash <($out/bin/caddy completion bash) \
+        --fish <($out/bin/caddy completion fish) \
+        --zsh <($out/bin/caddy completion zsh)
+    '';
 
   passthru = {
     tests = {
@@ -74,11 +81,15 @@ buildGoModule {
     withPlugins = callPackage ./plugins.nix { inherit caddy; };
   };
 
-  meta = with lib; {
+  meta = {
     homepage = "https://caddyserver.com";
     description = "Fast and extensible multi-platform HTTP/1-2-3 web server with automatic HTTPS";
-    license = licenses.asl20;
+    license = lib.licenses.asl20;
     mainProgram = "caddy";
-    maintainers = with maintainers; [ Br1ght0ne techknowlogick ];
+    maintainers = with lib.maintainers; [
+      Br1ght0ne
+      stepbrobd
+      techknowlogick
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- update to 2.9.0 (release note: https://github.com/caddyserver/caddy/releases/tag/v2.9.0)
- add build tags `nomysql` and `nopgx` (see official docs)
- format with nixfmt-rfc-style
- add myself to maintainers

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
