### PR TITLE
opentofu: move the plugin patch from `plugins` to `withPlugins`

### DIFF
--- a/pkgs/by-name/op/opentofu/package.nix
+++ b/pkgs/by-name/op/opentofu/package.nix
@@ -99,10 +99,17 @@ let
     in
     test;
 
-  plugins =
-    lib.mapAttrs
-      (
-        _: provider:
+  plugins = removeAttrs terraform-providers [
+    "override"
+    "overrideDerivation"
+    "recurseForDerivations"
+  ];
+
+  withPlugins =
+    plugins:
+    let
+      actualPlugins = lib.lists.map (
+        provider:
         if provider ? override then
           # use opentofu plugin registry over terraform's
           provider.override (oldArgs: {
@@ -116,19 +123,7 @@ let
           })
         else
           provider
-      )
-      (
-        removeAttrs terraform-providers [
-          "override"
-          "overrideDerivation"
-          "recurseForDerivations"
-        ]
-      );
-
-  withPlugins =
-    plugins:
-    let
-      actualPlugins = plugins package.plugins;
+      ) (plugins package.plugins);
 
       # Wrap PATH of plugins propagatedBuildInputs, plugins may have runtime dependencies on external binaries
       wrapperInputs = lib.unique (


### PR DESCRIPTION
moves the plugin patch in the `opentofu` package from `plugins` to `withPlugins`, making it easier to transparently swap out terraform/opentofu.

/cc @nickcao @zowoq @yannham

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- ~~[ ] Tested basic functionality of all binary files (usually in `./result/bin/`)~~
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - ~~[ ] (Package updates) Added a release notes entry if the change is major or breaking~~
  - ~~[ ] (Module updates) Added a release notes entry if the change is significant~~
  - ~~[ ] (Module addition) Added a release notes entry if adding a new NixOS module~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
