### PR TITLE
docs: init lib.stringsWithDeps.textClosureList

### DIFF
--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -124,7 +124,7 @@ rec {
     - Ordering the dependent phases of `system.activationScripts`
     - Ordering the dependent phases of `system.userActivationScripts`
 
-    For further examples see: [NixOS activation script)(https://nixos.org/manual/nixos/stable/#sec-activation-script)
+    For further examples see: [NixOS activation script](https://nixos.org/manual/nixos/stable/#sec-activation-script)
 
   */
   textClosureList = predefined: arg:

--- a/lib/strings-with-deps.nix
+++ b/lib/strings-with-deps.nix
@@ -52,10 +52,81 @@ let
 in
 rec {
 
-  /* !!! The interface of this function is kind of messed up, since
-     it's way too overloaded and almost but not quite computes a
-     topological sort of the depstrings. */
+  /**
+    Topologically sort a collection of dependent strings.
+    Only the values to keys listed in `arg` and their dependencies will be included in the result.
 
+    ::: {.note}
+    This function doesn't formally fulfill the definition of topological sorting, but it's good enough for our purposes in Nixpkgs.
+    :::
+
+    # Inputs
+
+    `predefined` (attribute set)
+
+    : strings with annotated dependencies (strings or attribute set)
+      A value can be a simple string if it has no dependencies.
+      Otherwise, is can be an attribute set with the following attributes:
+      - `deps` (list of strings)
+      - `text` (Any
+
+    `arg` (list of strings)
+
+    : Keys for which the values in the dependency closure will be included in the result
+
+    # Type
+
+    ```
+    textClosureList :: { ${phase} :: { deps :: [String]; text :: String; } | String; } -> [String] -> [String]
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.stringsWithDeps.textClosureList` usage example
+
+    ```nix
+    textClosureList {
+      a = {
+        deps = [ "b" "c" "e" ];
+        text = "a: depends on b, c and e";
+      };
+      b = {
+        deps = [ ];
+        text = "b: no dependencies";
+      };
+      c = {
+        deps = [ "b" ];
+        text = "c: depends on b";
+      };
+      d = {
+        deps = [ "c" ];
+        text = "d: not being depended on by anything in `arg`";
+      };
+      e = {
+        deps = [ "c" ];
+        text = "e: depends on c, depended on by a, not in `arg`";
+      };
+    } [
+      "a"
+      "b"
+      "c"
+    ]
+    => [
+      "b: no dependencies"
+      "c: depends on b"
+      "e: depends on c, depended on by a, not in `arg`"
+      "a: depends on b, c and e"
+    ]
+    ```
+    :::
+
+    Common real world usages are:
+    - Ordering the dependent phases of `system.activationScripts`
+    - Ordering the dependent phases of `system.userActivationScripts`
+
+    For further examples see: [NixOS activation script)(https://nixos.org/manual/nixos/stable/#sec-activation-script)
+
+  */
   textClosureList = predefined: arg:
     let
       f = done: todo:


### PR DESCRIPTION
Init doc-comment for `lib.stringsWithDeps.textClosureList` 



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
