### PR TITLE
nixos/geoclue2: add agentWhitelist option

### DIFF
--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -8,11 +8,6 @@
 let
   cfg = config.services.geoclue2;
 
-  defaultWhitelist = [
-    "gnome-shell"
-    "io.elementary.desktop.agent-geoclue2"
-  ];
-
   appConfigModule = lib.types.submodule (
     { name, ... }:
     {
@@ -198,6 +193,18 @@ in
         '';
       };
 
+      agentWhitelist = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "geoclue-demo-agent"
+          "gnome-shell"
+          "io.elementary.desktop.agent-geoclue2"
+        ];
+        description = ''
+          Whitelist of desktop IDs (without .desktop part) of all agents geoclue will recognise
+        '';
+      };
+
     };
 
   };
@@ -269,7 +276,7 @@ in
       {
         agent = {
           whitelist = lib.concatStringsSep ";" (
-            lib.optional cfg.enableDemoAgent "geoclue-demo-agent" ++ defaultWhitelist
+            cfg.agentWhitelist
           );
         };
         network-nmea = {

--- a/nixos/modules/services/desktops/geoclue2.nix
+++ b/nixos/modules/services/desktops/geoclue2.nix
@@ -199,6 +199,8 @@ in
           "geoclue-demo-agent"
           "gnome-shell"
           "io.elementary.desktop.agent-geoclue2"
+          "sm.puri.Phosh"
+          "lipstick"
         ];
         description = ''
           Whitelist of desktop IDs (without .desktop part) of all agents geoclue will recognise
@@ -262,6 +264,15 @@ in
       };
     };
 
+    # Gnome appConfig in gnome.nix:368
+
+    # Elementary appConfig in pantheon.nix:163
+
+    services.geoclue2.appConfig."sm.puri.Phosh" = {
+      isAllowed = true;
+      isSystem = true;
+    };
+
     services.geoclue2.appConfig.epiphany = {
       isAllowed = true;
       isSystem = false;
@@ -270,6 +281,11 @@ in
     services.geoclue2.appConfig.firefox = {
       isAllowed = true;
       isSystem = false;
+    };
+
+    services.geoclue2.appConfig.lipstick = {
+      isAllowed = true;
+      isSystem = true;
     };
 
     environment.etc."geoclue/geoclue.conf".text = lib.generators.toINI { } (


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While trying to use phosh I noticed that the location services, provided by the shell (phosh) weren't working because phosh wasn't included in the `geoclue.conf` generated by NixOS but was in the [upstream configuration](https://gitlab.freedesktop.org/geoclue/geoclue/-/blob/master/data/geoclue.conf.in). This PR adds a new `agentWhitelist` option replacing the statically defined `defaultWhitelist` and adds `"sm.puri.Phosh"` to the agentWhitelist and appConfig to allow phosh to correctly serve location services to applications. Also listed in the [upstream config](https://gitlab.freedesktop.org/geoclue/geoclue/-/merge_requests/90) was `lipstick` which [now seams abandoned](https://web.archive.org/web/20180812115424/https://git.merproject.org/mer-core/lipstick) and isn't listed in nixpkg, but I've added it anyway, if the nixpkgs maintainers think it shouldn't be listed I'll amend my commit and force push.

It's also possible, that, rather than including all the upstream agents in the default list, that the nix module of each agent, e.g. `gnome.nix` and `phosh.nix` add their own agent to the list when enabled. I'm not familiar with the style of nixpkgs to know if this is better than just listing everything as default, but if this would be a better way of doing this, then I'll amend my commit with the `agentWhitelist` being added to by the agent nix modules.

This PR is tangentially related to #329654, so I'll mention it here.

This is the first time I've submitted a PR to nixpkgs, so any feed back or help would be appreciated.

### Changes

1. Add an `agentWhitelist` option replacing the statically defined `defaultWhitelist`
2. Add `"sm.puri.Phosh"` to the agentWhitelist and appConfig
3. Add `lipstick` to the agentWhitelist and appConfig

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
