### PR TITLE
gimpPlugins.bimp: fix gcc-14 build; gimpPlugins.gap: drop; gimpPlugins.gimplensfun: fix clang build

### DIFF
--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -306,10 +306,14 @@ lib.makeScope pkgs.newScope (
         sha256 = "1jj3n7spkjc63aipwdqsvq9gi07w13bb1v8iqzvxwzld2kxa3c8w";
       };
 
-      buildInputs = with pkgs; [
-        lensfun
-        gexiv2
-      ];
+      buildInputs = (
+        with pkgs;
+        [
+          lensfun
+          gexiv2
+        ]
+        ++ lib.optional stdenv.cc.isClang llvmPackages.openmp
+      );
 
       installPhase = "
       installPlugin gimp-lensfun
@@ -322,7 +326,6 @@ lib.makeScope pkgs.newScope (
 
         license = lib.licenses.gpl3Plus;
         maintainers = [ ];
-        platforms = lib.platforms.gnu ++ lib.platforms.linux;
       };
     };
 

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -137,69 +137,6 @@ lib.makeScope pkgs.newScope (
       };
     };
 
-    gap = pluginDerivation {
-      /*
-        menu:
-        Video
-      */
-      pname = "gap";
-      version = "2.6.0-unstable-2023-05-20";
-
-      src = fetchFromGitLab {
-        domain = "gitlab.gnome.org";
-        owner = "Archive";
-        repo = "gimp-gap";
-        rev = "b2aa06cc7ee4ae1938f14640fe46b75ef5b15982";
-        hash = "sha256-q5TgCy0+iIfxyqJRXsKxiFrWMFSzBqC0SA9MBGTHXcA=";
-      };
-
-      nativeBuildInputs = with pkgs; [ autoreconfHook ];
-
-      postUnpack = ''
-        tar -xf $sourceRoot/extern_libs/ffmpeg.tar.gz -C $sourceRoot/extern_libs
-      '';
-
-      postPatch =
-        let
-          ffmpegPatch = fetchpatch2 {
-            name = "fix-ffmpeg-binutil-2.41.patch";
-            url = "https://git.ffmpeg.org/gitweb/ffmpeg.git/patch/effadce6c756247ea8bae32dc13bb3e6f464f0eb";
-            hash = "sha256-vLSltvZVMcQ0CnkU0A29x6fJSywE8/aU+Mp9os8DZYY=";
-          };
-        in
-        ''
-          patch -Np1 -i ${ffmpegPatch} -d extern_libs/ffmpeg
-          ffmpegSrc=$(realpath extern_libs/ffmpeg)
-        '';
-
-      configureFlags =
-        [
-          "--with-ffmpegsrcdir=${placeholder "ffmpegSrc"}"
-        ]
-        ++ lib.optionals (!stdenv.hostPlatform.isx86) [
-          "--disable-libavformat"
-        ];
-
-      hardeningDisable = [ "format" ];
-
-      env = {
-        NIX_LDFLAGS = "-lm";
-      };
-
-      meta = with lib; {
-        description = "GIMP Animation Package";
-        homepage = "https://www.gimp.org";
-        # The main code is given in GPLv3, but it has ffmpeg in it, and I think ffmpeg license
-        # falls inside "free".
-        license = with licenses; [
-          gpl3
-          free
-        ];
-        # Depends on linux/soundcard.h
-        platforms = platforms.linux;
-      };
-    };
-
     farbfeld = pluginDerivation {
       pname = "farbfeld";
       version = "unstable-2019-08-12";

--- a/pkgs/applications/graphics/gimp/plugins/default.nix
+++ b/pkgs/applications/graphics/gimp/plugins/default.nix
@@ -119,11 +119,9 @@ lib.makeScope pkgs.newScope (
 
       nativeBuildInputs = with pkgs; [ which ];
 
-      env.NIX_CFLAGS_COMPILE = toString (
-        lib.optionals stdenv.cc.isClang [
-          "-Wno-error=incompatible-function-pointer-types"
-        ]
-      );
+      # workaround for issue:
+      # https://github.com/alessandrofrancesconi/gimp-plugin-bimp/issues/411
+      env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
 
       installFlags = [
         "SYSTEM_INSTALL_DIR=${placeholder "out"}/${gimp.targetPluginDir}/bimp"


### PR DESCRIPTION
bimp:
workaround for https://github.com/alessandrofrancesconi/gimp-plugin-bimp/issues/411

fixes: https://github.com/NixOS/nixpkgs/issues/369212

gap:

gimpPlugins.gap is unmaintained and broken. also removed by Debian and fedora
https://bugzilla.redhat.com/show_bug.cgi?id=1674967
https://gitlab.gnome.org/Archive/gimp-gap


gimplensfun: add openmp when compiling with clang. this allows `gimp-with-plugins` to build on darwin.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
