### PR TITLE
Revert "libportal: 0.8.1 -> 0.9.0"

### DIFF
--- a/pkgs/by-name/li/libportal/package.nix
+++ b/pkgs/by-name/li/libportal/package.nix
@@ -21,7 +21,7 @@ assert
 
 stdenv.mkDerivation rec {
   pname = "libportal" + lib.optionalString (variant != null) "-${variant}";
-  version = "0.9.0";
+  version = "0.8.1";
 
   outputs = [
     "out"
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
     owner = "flatpak";
     repo = "libportal";
     rev = version;
-    sha256 = "sha256-uKblVaJB3s01En/T3ofT8uZHHarPKAO1qyLidLZ/b/g=";
+    sha256 = "sha256-NAkD5pAQpmAtVxsFZt74PwURv+RbGBfqENIwyxEEUSc=";
   };
 
   depsBuildBuild = [


### PR DESCRIPTION
Reverts NixOS/nixpkgs#367114

Breaks xdg-desktop-portal.