### PR TITLE
nixos/kmonad: misc improvements

### DIFF
--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -94,7 +94,7 @@ let
       '';
     in
     pkgs.writeTextFile {
-      name = "${mkName keyboard.name}.cfg";
+      name = "${mkName keyboard.name}.kbd";
       text = lib.optionalString keyboard.defcfg.enable (defcfg + "\n") + keyboard.config;
       checkPhase = "${cfg.package}/bin/kmonad -d $out";
     };

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -56,7 +56,7 @@ let
             };
 
             delay = lib.mkOption {
-              type = lib.types.int;
+              type = lib.types.ints.unsigned;
               default = 5;
               description = "The delay (in milliseconds) between compose key sequences.";
             };

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -15,6 +15,7 @@ let
       options = {
         name = lib.mkOption {
           type = lib.types.str;
+          default = name;
           example = "laptop-internal";
           description = "Keyboard name.";
         };
@@ -70,10 +71,6 @@ let
           type = lib.types.lines;
           description = "Keyboard configuration.";
         };
-      };
-
-      config = {
-        name = lib.mkDefault name;
       };
     };
 

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -96,7 +96,7 @@ let
     pkgs.writeTextFile {
       name = "${mkName keyboard.name}.kbd";
       text = lib.optionalString keyboard.defcfg.enable (defcfg + "\n") + keyboard.config;
-      checkPhase = "${cfg.package}/bin/kmonad -d $out";
+      checkPhase = "${lib.getExe cfg.package} -d $out";
     };
 
   # Build a systemd path config that starts the service below when a

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -35,16 +35,16 @@ let
             Since KMonad runs as an unprivileged user, it may sometimes
             need extra permissions in order to read the keyboard device
             file.  If your keyboard's device file isn't in the input
-            group you'll need to list its group in this option.
+            group, you'll need to list its group in this option.
           '';
         };
 
         defcfg = {
           enable = lib.mkEnableOption ''
-            Automatically generate the defcfg block.
+            automatic generation of the defcfg block.
 
-            When this is option is set to true the config option for
-            this keyboard should not include a defcfg block.
+            When this option is set to true, the config option for
+            this keyboard should not include a defcfg block
           '';
 
           compose = {
@@ -61,9 +61,9 @@ let
             };
           };
 
-          fallthrough = lib.mkEnableOption "Re-emit unhandled key events.";
+          fallthrough = lib.mkEnableOption "re-emitting unhandled key events";
 
-          allowCommands = lib.mkEnableOption "Allow keys to run shell commands.";
+          allowCommands = lib.mkEnableOption "keys to run shell commands";
         };
 
         config = lib.mkOption {
@@ -159,9 +159,9 @@ let
 in
 {
   options.services.kmonad = {
-    enable = lib.mkEnableOption "KMonad: An advanced keyboard manager.";
+    enable = lib.mkEnableOption "KMonad: an advanced keyboard manager";
 
-    package = lib.mkPackageOption pkgs "kmonad" { };
+    package = lib.mkPackageOption pkgs "KMonad" { default = "kmonad"; };
 
     keyboards = lib.mkOption {
       type = lib.types.attrsOf (lib.types.submodule keyboard);

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -188,4 +188,11 @@ in
       services = lib.mapAttrs' (_: mkService) cfg.keyboards;
     };
   };
+
+  meta = {
+    maintainers = with lib.maintainers; [
+      linj
+      rvdp
+    ];
+  };
 }

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -74,6 +74,8 @@ let
       };
     };
 
+  mkName = name: "kmonad-" + name;
+
   # Create a complete KMonad configuration file:
   mkCfg =
     keyboard:
@@ -81,7 +83,7 @@ let
       defcfg = ''
         (defcfg
           input  (device-file "${keyboard.device}")
-          output (uinput-sink "kmonad-${keyboard.name}")
+          output (uinput-sink "${mkName keyboard.name}")
           ${lib.optionalString (keyboard.defcfg.compose.key != null) ''
             cmp-seq ${keyboard.defcfg.compose.key}
             cmp-seq-delay ${toString keyboard.defcfg.compose.delay}
@@ -92,7 +94,7 @@ let
       '';
     in
     pkgs.writeTextFile {
-      name = "kmonad-${keyboard.name}.cfg";
+      name = "${mkName keyboard.name}.cfg";
       text = lib.optionalString keyboard.defcfg.enable (defcfg + "\n") + keyboard.config;
       checkPhase = "${cfg.package}/bin/kmonad -d $out";
     };
@@ -102,7 +104,7 @@ let
   mkPath =
     keyboard:
     let
-      name = "kmonad-${keyboard.name}";
+      name = mkName keyboard.name;
     in
     lib.nameValuePair name {
       description = "KMonad trigger for ${keyboard.device}";
@@ -126,7 +128,7 @@ let
         ++ cfg.extraArgs
         ++ [ "${mkCfg keyboard}" ];
     in
-    lib.nameValuePair "kmonad-${keyboard.name}" {
+    lib.nameValuePair (mkName keyboard.name) {
       description = "KMonad for ${keyboard.device}";
       script = lib.escapeShellArgs cmd;
       unitConfig = {

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -520,6 +520,7 @@ in {
   keyd = handleTest ./keyd.nix {};
   keymap = handleTest ./keymap.nix {};
   kimai = handleTest ./kimai.nix {};
+  kmonad = runTest ./kmonad.nix;
   knot = handleTest ./knot.nix {};
   komga = handleTest ./komga.nix {};
   krb5 = discoverTests (import ./krb5);

--- a/nixos/tests/kmonad.nix
+++ b/nixos/tests/kmonad.nix
@@ -1,0 +1,47 @@
+{ lib, ... }:
+
+{
+  name = "kmonad";
+
+  meta = {
+    maintainers = with lib.maintainers; [ linj ];
+  };
+
+  nodes = {
+    machine = {
+      services.kmonad = {
+        enable = true;
+        keyboards = {
+          defaultKbd = {
+            device = "/dev/input/by-id/vm-default-kbd";
+            defcfg = {
+              enable = true;
+              fallthrough = true;
+            };
+            config = ''
+              (defsrc :name default-src
+                1)
+              (deflayer default-layer :source default-src
+                @T2)
+              (defalias
+                T2 2)
+            '';
+          };
+        };
+      };
+
+      # make a determinate symlink to the default vm keyboard for kmonad to use
+      services.udev.extraRules = ''
+        ACTION=="add", KERNEL=="event*", SUBSYSTEM=="input", ATTRS{name}=="QEMU Virtio Keyboard", ATTRS{id/product}=="0001", ATTRS{id/vendor}=="0627", SYMLINK+="input/by-id/vm-default-kbd"
+      '';
+    };
+  };
+
+  testScript = ''
+    service_name = "kmonad-defaultKbd"
+    machine.wait_for_unit(f"{service_name}.service")
+
+    with subtest("kmonad is running"):
+         machine.succeed(f"systemctl status {service_name}")
+  '';
+}

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1478,7 +1478,14 @@ self: super: builtins.intersectAttrs super {
   # cause actual problems in dependent packages, see https://github.com/lehins/pvar/issues/4
   pvar = dontCheck super.pvar;
 
-  kmonad = enableSeparateBinOutput super.kmonad;
+  kmonad = lib.pipe super.kmonad [
+    enableSeparateBinOutput
+    (overrideCabal (drv: {
+      passthru = lib.recursiveUpdate
+        drv.passthru or { }
+        { tests.nixos = pkgs.nixosTests.kmonad; };
+    }))
+  ];
 
   xmobar = enableSeparateBinOutput super.xmobar;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It may be easier to review this PR commit by commit.

- add a basic nixos test
- improve nixos module

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
