### PR TITLE
wallpaper-compat-hook: init

### DIFF
--- a/pkgs/by-name/co/cosmic-wallpapers/package.nix
+++ b/pkgs/by-name/co/cosmic-wallpapers/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  fetchpatch,
+  wallpaper-compat-hook,
   nix-update-script,
 }:
 
@@ -19,12 +19,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-Exrps3DicL/G/g0kbSsCvoFhiJn1k3v8I09GhW7EwNM=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://github.com/pop-os/cosmic-wallpapers/pull/2/commits/4d17ebe69335f8ffa80fd1c48baa7f3d3efa4dbe.patch";
-      hash = "sha256-4QRtX5dbN6C/ZKU3pvV7mTT7EDrMWvRCFB4004RMylM=";
-    })
-  ];
+  nativeBuildInputs = [ wallpaper-compat-hook ];
 
   makeFlags = [ "prefix=$(out)" ];
 

--- a/pkgs/by-name/wa/wallpaper-compat-hook/package.nix
+++ b/pkgs/by-name/wa/wallpaper-compat-hook/package.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  makeSetupHook,
+  imagemagick,
+  libsForQt5,
+}:
+
+makeSetupHook {
+  name = "wallpaper-compat-hook";
+
+  propagatedBuildInputs = [
+    imagemagick
+    libsForQt5.kcoreaddons
+  ];
+
+  meta = {
+    description = "Setup hook for ensuring wallpaper compatibility between desktop environments";
+    maintainers = with lib.maintainers; [ pandapip1 ];
+    platforms = lib.platforms.all;
+  };
+} ./setup-hook.sh

--- a/pkgs/by-name/wa/wallpaper-compat-hook/setup-hook.sh
+++ b/pkgs/by-name/wa/wallpaper-compat-hook/setup-hook.sh
@@ -1,0 +1,76 @@
+wallpaperCompatHook() {
+  echo "Running wallpaperCompatHook"
+
+  local backgrounds_dir="$out/share/backgrounds"
+  local wallpapers_dir="$out/share/wallpapers"
+
+  # Default name, if there isn't already one that we can use
+  local default_wallpaper_name=$(echo "$pname" | sed 's/wallpapers\?//i' | sed 's/^-//' | sed 's/-$//')
+  # Detect if there is an existing directory in $backgrounds_dir that we can co-opt. If there are multiple, keep the default name.
+  local existing_wallpaper_dirs=($(find "$backgrounds_dir" -mindepth 1 -maxdepth 1 -type d))
+  if [[ ${#existing_wallpaper_dirs[@]} -eq 1 ]]; then
+    default_wallpaper_name=$(basename "${existing_wallpaper_dirs[0]}")
+  fi
+  echo "wallpaperCompatHook: default_wallpaper_name=$default_wallpaper_name"
+
+  local added_wallpapers=()
+
+  for dir in "$backgrounds_dir"/*/; do
+    local wallpaper_name=$(basename "$dir")
+
+    for image_file in "$dir"/*; do
+      local image=$(basename "$image_file")
+      local image_no_ext="${image%.*}"
+      local image_ext="${image##*.}"
+
+      # Search wallpapers_dir for same image. If not found, create a wallpaper called $wallpaper_name-$image (without extension)
+      if [[ ! -f "$wallpapers_dir/$wallpaper_name/contents/images/$image" ]]; then
+        echo "wallpaperCompatHook: Creating wallpaper $wallpaper_name-$image"
+        mkdir -p "$wallpapers_dir/$wallpaper_name-$image_no_ext/contents/images"
+        ln -s "$image_file" "$wallpapers_dir/$wallpaper_name-$image_no_ext/contents/images/$(identify -format "%wx%h" "$image_file").$image_ext"
+        added_wallpapers+=($(basename "$wallpapers_dir/$wallpaper_name-$image_no_ext"))
+        cat >> $wallpapers_dir/$wallpaper_name-$image_no_ext/metadata.desktop <<_EOF
+[Desktop Entry]
+Name=$image_no_ext
+X-KDE-PluginInfo-Name=$wallpaper_name-$image_no_ext
+_EOF
+        cat >> $wallpapers_dir/$wallpaper_name-$image_no_ext/metadata.json <<_EOF
+{
+  "KPlugin": {
+    "Id": "$wallpaper_name-$image_no_ext",
+    "Name": "$image_no_ext",
+  }
+}
+_EOF
+      fi
+    done
+  done
+
+  for wallpaper_dir in "$wallpapers_dir"/*/; do
+    wallpaper_name=$(basename "$wallpaper_dir")
+    # If we added it ourselves, skip
+    if [[ " ${added_wallpapers[@]} " =~ "$wallpaper_name" ]]; then
+      echo "wallpaperCompatHook: Skipping $wallpaper_name as it was added by us"
+      continue
+    fi
+    # Else, create a symlink to the wallpaper in backgrounds_dir
+    echo "wallpaperCompatHook: Creating background $wallpaper_name with default directory $default_wallpaper_name"
+    local best_image=$(find "$wallpaper_dir/contents/images" -type f -name '*.jpg' -o -name '*.png' -o -name '*.jpeg' -o -name '*.svg' -o -name '*.webp' | xargs identify -format "%w %h %i\n" | awk '{print $1/$2, $1, $2, $3}' | sort -n | tail -n 1 | cut -d' ' -f4)
+    echo "wallpaperCompatHook: Best image for $wallpaper_name is $best_image with resolution $(identify -format "%wx%h" "$best_image")"
+    mkdir -p "$backgrounds_dir/$default_wallpaper_name"
+    ln -s "$best_image" "$backgrounds_dir/$default_wallpaper_name/$(basename "$best_image")"
+    echo "wallpaperCompatHook: Created symlink $backgrounds_dir/$default_wallpaper_name/$(basename "$best_image") -> $best_image"
+  done
+
+  # Run desktoptojson on every $wallpapers_dir/*/metadata.desktop that doesn't have a corresponding .json file
+  for metadata_file in "$wallpapers_dir"/*/metadata.desktop; do
+    local wallpaper_name=$(basename "$(dirname "$metadata_file")")
+    local json_file="$wallpapers_dir/$wallpaper_name/metadata.json"
+    if [[ ! -f "$json_file" ]]; then
+      echo "wallpaperCompatHook: Running desktoptojson on $metadata_file"
+      desktoptojson --input "$metadata_file" --output "$json_file"
+    fi
+  done
+}
+
+fixupOutputHooks+=('wallpaperCompatHook')


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
