### PR TITLE
givaro: fix gcc-14 /clang-19 builds

### DIFF
--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -31,6 +31,13 @@ stdenv.mkDerivation rec {
       url = "https://github.com/linbox-team/givaro/commit/a81d44b3b57c275bcb04ab00db79be02561deaa2.patch";
       hash = "sha256-sSk+VWffoEjZRTJcHRISLHPyW6yuvI1u8knBOfxNUIE=";
     })
+    # https://github.com/linbox-team/givaro/issues/226
+    (fetchpatch {
+      name = "gcc-14.patch";
+      url = "https://github.com/linbox-team/givaro/commit/b0cf33e1d4437530c7e4b3db90b6c80057a7f2f3.patch";
+      includes = [ "src/kernel/integer/random-integer.h" ];
+      hash = "sha256-b2Q8apP9ueEqIUtibTeP47x6TlroRzLgAxuv5ZM1EUw=";
+    })
   ];
 
   enableParallelBuilding = true;

--- a/pkgs/development/libraries/givaro/default.nix
+++ b/pkgs/development/libraries/givaro/default.nix
@@ -38,6 +38,12 @@ stdenv.mkDerivation rec {
       includes = [ "src/kernel/integer/random-integer.h" ];
       hash = "sha256-b2Q8apP9ueEqIUtibTeP47x6TlroRzLgAxuv5ZM1EUw=";
     })
+    # https://github.com/linbox-team/givaro/issues/232
+    (fetchpatch {
+      name = "clang-19.patch";
+      url = "https://github.com/linbox-team/givaro/commit/a18baf5227d4f3e81a50850fe98e0d954eaa3ddb.patch";
+      hash = "sha256-IR0IHhCqbxgtsST30vxM9ak1nGtt0apxcLUQ1kS1DHw=";
+    })
   ];
 
   enableParallelBuilding = true;


### PR DESCRIPTION
https://github.com/linbox-team/givaro/commit/b0cf33e1d4437530c7e4b3db90b6c80057a7f2f3
https://github.com/linbox-team/givaro/commit/a18baf5227d4f3e81a50850fe98e0d954eaa3ddb
https://hydra.nixos.org/build/282637482
https://hydra.nixos.org/build/282709189

fixes: https://github.com/NixOS/nixpkgs/issues/369884

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
