### PR TITLE
polymc-unwrapped: init at 7.0, polymc: init at 7.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17577,6 +17577,12 @@
     githubId = 7820716;
     name = "orthros";
   };
+  orvitpng = {
+    name = "Carter Davis";
+    email = "carterd1016@gmail.com";
+    githubId = 55005263;
+    keys = [ { fingerprint = "8745 5F03 93C6 45FA 5E22  8CCE 8885 4F72 6DDF 8373"; } ];
+  };
   orzklv = {
     email = "sakhib@orzklv.uz";
     github = "orzklv";

--- a/pkgs/by-name/po/polymc-unwrapped/package.nix
+++ b/pkgs/by-name/po/polymc-unwrapped/package.nix
@@ -1,0 +1,103 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  cmark,
+  extra-cmake-modules,
+  gamemode,
+  ghc_filesystem,
+  jdk8,
+  kdePackages,
+  ninja,
+  nix-update-script,
+  stripJavaArchivesHook,
+  tomlplusplus,
+  zlib,
+
+  msaClientID ? null,
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+}:
+
+let
+  libnbtplusplus = fetchFromGitHub {
+    owner = "PolyMC";
+    repo = "libnbtplusplus";
+    rev = "2203af7eeb48c45398139b583615134efd8d407f";
+    hash = "sha256-TvVOjkUobYJD9itQYueELJX3wmecvEdCbJ0FinW2mL4=";
+  };
+in
+
+assert lib.assertMsg (
+  gamemodeSupport -> stdenv.hostPlatform.isLinux
+) "gamemodeSupport is only available on Linux.";
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "polymc-unwrapped";
+  version = "7.0";
+
+  src = fetchFromGitHub {
+    owner = "PolyMC";
+    repo = "PolyMC";
+    tag = finalAttrs.version;
+    hash = "sha256-d6Npu21iC5JUhWOM2DMn7gtzOj/Oo+ZoB36birHxzyA=";
+  };
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    extra-cmake-modules
+    jdk8
+    stripJavaArchivesHook
+  ];
+
+  buildInputs = [
+    cmark
+    ghc_filesystem
+    kdePackages.qtbase
+    kdePackages.qtcharts
+    kdePackages.quazip
+    tomlplusplus
+    zlib
+  ] ++ lib.optional gamemodeSupport gamemode;
+
+  hardeningEnable = lib.optionals stdenv.hostPlatform.isLinux [ "pie" ];
+
+  cmakeFlags =
+    [
+      (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+      (lib.cmakeFeature "Launcher_QT_VERSION_MAJOR" (lib.versions.major kdePackages.qtbase.version))
+    ]
+    ++ lib.optionals (msaClientID != null) [
+      (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" (toString msaClientID))
+    ];
+
+  doCheck = true;
+
+  dontWrapQtApps = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    homepage = "https://polymc.org/";
+    downloadPage = "https://polymc.org/download/";
+    changelog = "https://github.com/PolyMC/PolyMC/releases/tag/${finalAttrs.version}";
+    description = "A free, open source launcher for Minecraft";
+    longDescription = ''
+      Allows you to have multiple, separate instances of Minecraft (each with
+      their own mods, texture packs, saves, etc) and helps you manage them and
+      their associated options with a simple interface.
+    '';
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl3Only;
+    mainProgram = "polymc";
+    maintainers = [ lib.maintainers.orvitpng ];
+  };
+})

--- a/pkgs/by-name/po/polymc/package.nix
+++ b/pkgs/by-name/po/polymc/package.nix
@@ -1,0 +1,129 @@
+{
+  addDriverRunpath,
+  alsa-lib,
+  flite,
+  gamemode,
+  glfw3-minecraft,
+  jdk17,
+  jdk21,
+  jdk8,
+  kdePackages,
+  lib,
+  libGL,
+  libX11,
+  libXcursor,
+  libXext,
+  libXrandr,
+  libXxf86vm,
+  libjack2,
+  libpulseaudio,
+  libusb1,
+  mangohud,
+  mesa-demos,
+  openal,
+  pciutils,
+  pipewire,
+  polymc-unwrapped,
+  stdenv,
+  symlinkJoin,
+  udev,
+  vulkan-loader,
+  wayland,
+  xrandr,
+
+  jdks ? [
+    jdk21
+    jdk17
+    jdk8
+  ],
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
+  mangohudSupport ? stdenv.hostPlatform.isLinux,
+  additionalLibs ? [ ],
+  additionalPrograms ? [ ],
+  msaClientID ? null,
+}:
+
+assert lib.assertMsg (
+  gamemodeSupport -> stdenv.hostPlatform.isLinux
+) "gamemodeSupport is only available on Linux.";
+
+assert lib.assertMsg (
+  mangohudSupport -> stdenv.hostPlatform.isLinux
+) "mangohudSupport is only available on Linux.";
+
+let
+  polymc' = polymc-unwrapped.override {
+    inherit gamemodeSupport msaClientID;
+  };
+  mangohud-lib = symlinkJoin {
+    name = "mangohud-lib";
+    paths = [ mangohud ];
+    postBuild = ''
+      mv $out/lib/mangohud/* $out/lib
+      rmdir $out/lib/mangohud
+    '';
+  };
+in
+
+symlinkJoin {
+  pname = "polymc";
+  inherit (polymc') version;
+
+  paths = [ polymc' ];
+
+  nativeBuildInputs = [ kdePackages.wrapQtAppsHook ];
+
+  buildInputs =
+    [ kdePackages.qtbase ]
+    ++ lib.optional (
+      lib.versionAtLeast kdePackages.qtbase.version "6" && stdenv.hostPlatform.isLinux
+    ) kdePackages.qtwayland;
+
+  postBuild = "wrapQtAppsHook";
+
+  qtWrapperArgs =
+    let
+      runtimeLibs =
+        [
+          (lib.getLib stdenv.cc.cc)
+          glfw3-minecraft
+          openal
+          libpulseaudio
+          alsa-lib
+          libjack2
+          pipewire
+
+          # glfw
+          libGL
+          libX11
+          libXcursor
+          libXext
+          libXrandr
+          libXxf86vm
+
+          udev # oshi
+
+          vulkan-loader # VulkanMod's lwjgl
+        ]
+        ++ lib.optionals stdenv.hostPlatform.isLinux [
+          flite
+          libusb1
+        ]
+        ++ lib.optional gamemodeSupport gamemode.lib
+        ++ lib.optional mangohudSupport mangohud-lib
+        ++ additionalLibs;
+
+      runtimePrograms = [
+        xrandr
+        mesa-demos # glxinfo
+        pciutils # lspci
+      ] ++ additionalPrograms;
+    in
+    [
+      "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
+      "--prefix POLYMC_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
+      "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
+    ];
+
+  inherit (polymc') meta;
+}


### PR DESCRIPTION
Adds myself as a maintainer and initializes polymc-unwrapped and polymc as packages. I tried to roughly follow what the prismlauncher derivation looked like while still sticking to what PolyMC itself uses in its own derivation, so hopefully it is kind of the best of both worlds.

Closes #365781.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
