### PR TITLE
[WIP] mlibc: init at 5.0.0

### DIFF
--- a/pkgs/by-name/ml/mlibc/0001-rtld-improve-unexpected-dynamic-entry-logging.patch
+++ b/pkgs/by-name/ml/mlibc/0001-rtld-improve-unexpected-dynamic-entry-logging.patch
@@ -1,0 +1,23 @@
+From cf78339c7ba5ad5571d4c66cbd8788ecaccf3bae Mon Sep 17 00:00:00 2001
+From: no92 <leo@managarm.org>
+Date: Wed, 25 Sep 2024 01:42:54 +0200
+Subject: [PATCH] options/rtdl: improve logging for unexpected interpreter
+ dynamic entries
+
+---
+ options/rtld/generic/main.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/options/rtld/generic/main.cpp b/options/rtld/generic/main.cpp
+index 3edd15ff90..9219ef0ffd 100644
+--- a/options/rtld/generic/main.cpp
++++ b/options/rtld/generic/main.cpp
+@@ -305,7 +305,7 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
+ 		case DT_PLTGOT:
+ 			continue;
+ 		default:
+-			__ensure(!"Unexpected dynamic entry in program interpreter");
++			mlibc::panicLogger() << "rtld: unexpected dynamic entry " << ent->d_tag << " in program interpreter" << frg::endlog;
+ 		}
+ 	}
+ 	__ensure(strtab_offset);

--- a/pkgs/by-name/ml/mlibc/0002-rtld-ignore-supported-dt_flags.patch
+++ b/pkgs/by-name/ml/mlibc/0002-rtld-ignore-supported-dt_flags.patch
@@ -1,0 +1,46 @@
+From 50894ac109aa6ddb283e1b42ce5d64948542c8d0 Mon Sep 17 00:00:00 2001
+From: mintsuki <mintsuki@protonmail.com>
+Date: Thu, 17 Oct 2024 05:27:48 +0200
+Subject: [PATCH] rtld: Add list of supported DT_FLAGS{,_1} to ignore
+
+---
+ options/rtld/generic/main.cpp | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/options/rtld/generic/main.cpp b/options/rtld/generic/main.cpp
+index cfa2a6012f..68b447c22b 100644
+--- a/options/rtld/generic/main.cpp
++++ b/options/rtld/generic/main.cpp
+@@ -271,6 +271,11 @@ static frg::vector<frg::string_view, MemoryAllocator> parseList(frg::string_view
+ 	return list;
+ }
+ 
++#ifndef MLIBC_STATIC_BUILD
++static constexpr uint64_t supportedDtFlags = DF_BIND_NOW;
++static constexpr uint64_t supportedDtFlags1 = DF_1_NOW;
++#endif
++
+ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
+ 	if(logEntryExit)
+ 		mlibc::infoLogger() << "Entering ld.so" << frg::endlog;
+@@ -337,6 +342,20 @@ extern "C" void *interpreterMain(uintptr_t *entry_stack) {
+ 		case DT_RELRENT:
+ 		case DT_PLTGOT:
+ 			continue;
++		case DT_FLAGS: {
++			if((ent->d_un.d_val & ~supportedDtFlags) == 0) {
++				continue;
++			}
++			mlibc::panicLogger() << "rtld: unexpected DT_FLAGS value of " << frg::hex_fmt(ent->d_un.d_val) << " in program interpreter" << frg::endlog;
++			break;
++		}
++		case DT_FLAGS_1: {
++			if((ent->d_un.d_val & ~supportedDtFlags1) == 0) {
++				continue;
++			}
++			mlibc::panicLogger() << "rtld: unexpected DT_FLAGS_1 value of " << frg::hex_fmt(ent->d_un.d_val) << " in program interpreter" << frg::endlog;
++			break;
++		}
+ 		default:
+ 			mlibc::panicLogger() << "rtld: unexpected dynamic entry " << ent->d_tag << " in program interpreter" << frg::endlog;
+ 		}

--- a/pkgs/by-name/ml/mlibc/package.nix
+++ b/pkgs/by-name/ml/mlibc/package.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  gtest,
+  linuxHeaders,
+}:
+
+let
+  cshim = fetchFromGitHub {
+    owner = "managarm";
+    repo = "cshim";
+    rev = "2ec3cf90aac9207ce54eee70aa013910f5a6d243";
+    sha256 = "sha256-uub+Yj4N7C6KZwPpBw87h3niWu2YiIFk13Cs8ozu1KY=";
+  };
+  cxxshim = fetchFromGitHub {
+    owner = "managarm";
+    repo = "cxxshim";
+    rev = "6f146a41dda736572879fc524cf729eb193dc0a6";
+    sha256 = "sha256-SSsS+WFR1Z8wT3fPxMpByWSc1WPnXAsyWHPyAH+86yA=";
+  };
+  frigg = fetchFromGitHub {
+    owner = "managarm";
+    repo = "frigg";
+    rev = "1a415d6bef3aecabe5a4663f569ed71fa91bd603";
+    sha256 = "sha256-KkffTJGBSI+bfGgyA8zrlsQo9GoA1s0p1YckgmvqYpE=";
+  };
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mlibc";
+  version = "5.0.0";
+
+  src = fetchFromGitHub {
+    owner = "managarm";
+    repo = "mlibc";
+    rev = "5.0.0";
+    sha256 = "sha256-r9AqtsgV3ESApyX4WrwnCn1uj3ncTQ8tU9eZGEV8zSY=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    gtest
+  ];
+
+  # patchelf adds entries it shouldn't to ld.so
+  dontPatchELF = true;
+
+  patches = [
+    # These patches are cherry-picked commits from master to build with -z,now
+    ./0001-rtld-improve-unexpected-dynamic-entry-logging.patch
+    ./0002-rtld-ignore-supported-dt_flags.patch
+  ];
+
+  mesonBuildType = "release";
+  mesonFlags = [
+    "-Ddefault_library=both"
+    "-Dlinux_kernel_headers=${linuxHeaders}/include"
+  ];
+
+  # Vendor-in required subprojects.
+  # Shims are not required when building with a linux-mlibc compiler, but we
+  # don't have one in nixpkgs yet and we need the shims to bootstrap mlibc.
+  # Alternatively, we can install headers only and bootstrap a linux-mlibc
+  # compiler with those headers, then compile with the linux-mlibc compiler.
+  preConfigure = ''
+    ln -sf ${cshim} $(pwd)/subprojects/cshim
+    ln -sf ${cxxshim} $(pwd)/subprojects/cxxshim
+    ln -sf ${frigg} $(pwd)/subprojects/frigg
+  '';
+
+  # This mlibc-gcc uses a specs file to wrap the host's one. It's a hack,
+  # we don't use it.
+  postInstall = ''
+    rm $out/bin/mlibc-gcc $out/lib/mlibc-gcc.specs
+  '';
+
+  # The dynamic loader should never have a RPATH entry, no idea what keeps
+  # adding it, but this hack should fix it.
+  postFixup = ''
+    patchelf --remove-rpath $out/lib/ld.so
+  '';
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  meta = with lib; {
+    description = "Portable C standard library";
+    platforms = [
+      # These are the only platforms supported by both mlibc and nixpkgs
+      "aarch64-linux"
+      "i686-linux"
+      "m68k-linux"
+      "riscv64-linux"
+      "x86_64-linux"
+    ];
+    license = [
+      licenses.bsd0 # cshim
+      licenses.mit # mlibc, cxxshim, frigg, parts of musl
+    ];
+    maintainers = [
+      maintainers.sanana
+    ];
+  };
+})


### PR DESCRIPTION
Please do not merge yet.

[mlibc](https://github.com/managarm/mlibc) is a portable C standard library. This is the first step towards adding mlibc as a platform in nixpkgs. mlibc developers are interested in running a full linux distro on top of mlibc and in my opinion NixOS is a prime candidate. Having it in nixpkgs would also help developers using mlibc.

I've picked 2 commits from master as patches to enable building the dynamic loader with -z,now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
