### PR TITLE
pimsync: init at 0.1.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18638,6 +18638,12 @@
     githubId = 40905037;
     name = "qwqawawow";
   };
+  qxrein = {
+    email = "mnv07@proton.me";
+    github = "qxrein";
+    githubId = 101001298;
+    name = "qxrein";
+  };
   qyliss = {
     email = "hi@alyssa.is";
     github = "alyssais";

--- a/pkgs/by-name/pi/pimsync/package.nix
+++ b/pkgs/by-name/pi/pimsync/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromSourcehut,
+  pkg-config,
+  sqlite,
+  scdoc,
+  makeWrapper,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "pimsync";
+  version = "0.1.0";
+
+  src = fetchFromSourcehut {
+    owner = "~whynothugo";
+    repo = "pimsync";
+    rev = "v${version}";
+    hash = "sha256-upOCrpbveSSFrhdHDkTOmja4MLmsgtuoDHMsgXyulWI=";
+  };
+
+  cargoHash = "sha256-QRgyHzIjdI8+OzvM+3sfuxTNMVCdGxrMvQpCnot9iUM=";
+
+  nativeBuildInputs = [
+    pkg-config
+    scdoc
+    makeWrapper
+  ];
+
+  buildInputs = [
+    sqlite
+  ];
+
+  makeFlags = [
+    "build"
+    "PREFIX=${placeholder "out"}"
+  ];
+
+  meta = {
+    description = "Synchronise calendars and contacts";
+    homepage = "https://git.sr.ht/~whynothugo/pimsync";
+    license = lib.licenses.eupl12;
+    platforms = lib.platforms.unix;
+    maintainers = [ lib.maintainers.qxrein ];
+    mainProgram = "pimsync";
+  };
+}


### PR DESCRIPTION
Add pimsync, a successor to vdirsyncer written in Rust. It provides calendar and contact synchronization via CalDAV and CardDAV protocols.

Key features:
- Calendar and contacts synchronization 
- CalDAV and CardDAV support
- SQLite-based storage
- Written in Rust for improved performance and safety
- Configurable via man pages (pimsync.conf)

The package includes:
- Main binary
- Man pages built with scdoc
- Required runtime dependencies (sqlite)

for #369924


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
