### PR TITLE
python311Packages.nbmake: disable parallelism

### DIFF
--- a/pkgs/development/python-modules/nbmake/default.nix
+++ b/pkgs/development/python-modules/nbmake/default.nix
@@ -13,7 +13,6 @@
   pygments,
 
   # tests
-  pytest-xdist,
   pytestCheckHook,
   typing-extensions,
 }:
@@ -45,12 +44,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "nbmake" ];
 
-  # tests are prone to race conditions under high parallelism
-  # https://github.com/treebeardtech/nbmake/issues/129
-  pytestFlagsArray = [ "--maxprocesses=4" ];
-
   nativeCheckInputs = [
-    pytest-xdist
     pytestCheckHook
     typing-extensions
   ];
@@ -58,6 +52,13 @@ buildPythonPackage rec {
   preCheck = ''
     export HOME=$(mktemp -d)
   '';
+
+  disabledTests = [
+    # depends on pytest-xdist that is not added, as
+    # tests are prone to race conditions under parallelism, they sometimes hang indefinitely
+    # https://github.com/treebeardtech/nbmake/issues/129
+    "test_when_parallel_passing_nbs_then_ok"
+  ];
 
   __darwinAllowLocalNetworking = true;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes https://github.com/NixOS/nixpkgs/issues/369767
- tests sometimes (~1 in 10) hang indefinitely, @mweinelt improved it in https://github.com/NixOS/nixpkgs/pull/363255/commits/97efe32610530f74c852fc652f2f8971b324f6f9 which is probably fine for hydra if it builds it (last time I checked it only built for python 3.12 and 3.13, but not for 3.11), but on lower end devices this is more prone to failing
- *not fixed in this PR at the end*: tests rarely (~1 in 100) fail due to trying to use >32k ports which are already taken, this was observed in multiple tests, seems safer to ignore all tests for this package:
  - tests/test_pytest_plugin.py::test_when_parallel_passing_nbs_then_ok (https://github.com/NixOS/nixpkgs/issues/369767#issuecomment-2566952302)
  - tests/test_pytest_plugin.py::test_when_init_then_passes (https://github.com/treebeardtech/nbmake/issues/129#issue-2698013639)
  - tests/test_nb_run.py::TestNotebookRun::test_when_empty_then_succeeds (https://github.com/treebeardtech/nbmake/issues/129)

I intentionally kept the test related dependencies and workaround after disabling tests, in case we can enable them later.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
