### PR TITLE
passage: fix `passage -c` on darwin

### DIFF
--- a/pkgs/by-name/pa/passage/package.nix
+++ b/pkgs/by-name/pa/passage/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./darwin-getopt-path.patch {
       inherit getopt;
     })
+    ./set-correct-program-name-for-sleep.patch
   ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];

--- a/pkgs/by-name/pa/passage/set-correct-program-name-for-sleep.patch
+++ b/pkgs/by-name/pa/passage/set-correct-program-name-for-sleep.patch
@@ -1,0 +1,50 @@
+From d11261c2ad184daf6e9edd777bc8a3372c277b4b Mon Sep 17 00:00:00 2001
+From: Johannes Frankenau <johannes@frankenau.net>
+Date: Fri, 10 Aug 2018 09:49:57 +0200
+Subject: [PATCH] Patch the clip() function to work even when using
+ single-binary coreutils
+
+---
+ src/platform/cygwin.sh | 4 ++--
+ src/platform/darwin.sh | 4 ++--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/platform/cygwin.sh b/src/platform/cygwin.sh
+index 5a8d5ea..423e0ce 100644
+--- a/src/platform/cygwin.sh
++++ b/src/platform/cygwin.sh
+@@ -3,11 +3,11 @@
+ 
+ clip() {
+ 	local sleep_argv0="password store sleep on display $DISPLAY"
+-	pkill -f "^$sleep_argv0" 2>/dev/null && sleep 0.5
++	pkill -P $(pgrep -f "^$sleep_argv0") 2>/dev/null && sleep 0.5
+ 	local before="$($BASE64 < /dev/clipboard)"
+ 	echo -n "$1" > /dev/clipboard
+ 	(
+-		( exec -a "$sleep_argv0" sleep "$CLIP_TIME" )
++		( exec -a "$sleep_argv0" bash <(echo sleep "$CLIP_TIME") )
+ 		local now="$($BASE64 < /dev/clipboard)"
+ 		[[ $now != $(echo -n "$1" | $BASE64) ]] && before="$now"
+ 		echo "$before" | $BASE64 -d > /dev/clipboard
+diff --git a/src/platform/darwin.sh b/src/platform/darwin.sh
+index 342ecce..9e12837 100644
+--- a/src/platform/darwin.sh
++++ b/src/platform/darwin.sh
+@@ -3,11 +3,11 @@
+ 
+ clip() {
+ 	local sleep_argv0="password store sleep for user $(id -u)"
+-	pkill -f "^$sleep_argv0" 2>/dev/null && sleep 0.5
++	pkill -P $(pgrep -f "^$sleep_argv0") 2>/dev/null && sleep 0.5
+ 	local before="$(pbpaste | $BASE64)"
+ 	echo -n "$1" | pbcopy
+ 	(
+-		( exec -a "$sleep_argv0" sleep "$CLIP_TIME" )
++		( exec -a "$sleep_argv0" bash <(echo sleep "$CLIP_TIME") )
+ 		local now="$(pbpaste | $BASE64)"
+ 		[[ $now != $(echo -n "$1" | $BASE64) ]] && before="$now"
+ 		echo "$before" | $BASE64 -d | pbcopy
+-- 
+2.16.4
+


### PR DESCRIPTION
Closes #369314

Same fix as in #24797, but applied to passage. The core issue is that the current bash code doesn't work properly with a single-binary coreutils.

cc @KAction 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
