### PR TITLE
ucc: CUDA fixups

### DIFF
--- a/pkgs/by-name/uc/ucc/package.nix
+++ b/pkgs/by-name/uc/ucc/package.nix
@@ -1,28 +1,45 @@
 {
-  stdenv,
-  lib,
-  fetchFromGitHub,
-  libtool,
-  automake,
   autoconf,
-  ucx,
+  automake,
   config,
-  enableCuda ? config.cudaSupport,
   cudaPackages,
+  fetchFromGitHub,
+  lib,
+  libtool,
+  stdenv,
+  ucx,
+  # Configuration options
   enableAvx ? stdenv.hostPlatform.avxSupport,
+  enableCuda ? config.cudaSupport,
   enableSse41 ? stdenv.hostPlatform.sse4_1Support,
   enableSse42 ? stdenv.hostPlatform.sse4_2Support,
 }:
+let
+  inherit (lib.lists) optionals;
+  inherit (lib.strings) concatStringsSep;
 
-stdenv.mkDerivation rec {
+  inherit (cudaPackages)
+    cuda_cccl
+    cuda_cudart
+    cuda_nvcc
+    cudaFlags
+    ;
+in
+stdenv.mkDerivation (finalAttrs: {
+  __structuredAttrs = true;
+  # TODO: When strictDeps is enabled, the CUDA build fails during configurePhase because it can't find all the CUDA
+  # dependencies. As such, we hold off on enabling strictDeps until CUDA compilation works.
+  # https://github.com/openucx/ucc/blob/0c0fc21559835044ab107199e334f7157d6a0d3d/config/m4/cuda.m4
+  strictDeps = false;
+
   pname = "ucc";
   version = "1.3.0";
 
   src = fetchFromGitHub {
     owner = "openucx";
     repo = "ucc";
-    rev = "v${version}";
-    sha256 = "sha256-xcJLYktkxNK2ewWRgm8zH/dMaIoI+9JexuswXi7MpAU=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-xcJLYktkxNK2ewWRgm8zH/dMaIoI+9JexuswXi7MpAU=";
   };
 
   outputs = [
@@ -32,44 +49,46 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  # NOTE: We use --replace-quiet because not all Makefile.am files contain /bin/bash.
   postPatch = ''
-
     for comp in $(find src/components -name Makefile.am); do
-      substituteInPlace $comp \
-        --replace "/bin/bash" "${stdenv.shell}"
+      substituteInPlace "$comp" \
+        --replace-quiet \
+          "/bin/bash" \
+          "${stdenv.shell}"
     done
   '';
 
   nativeBuildInputs = [
-    libtool
-    automake
     autoconf
-  ] ++ lib.optionals enableCuda [ cudaPackages.cuda_nvcc ];
+    automake
+    libtool
+  ] ++ optionals enableCuda [ cuda_nvcc ];
+
   buildInputs =
     [ ucx ]
-    ++ lib.optionals enableCuda [
-      cudaPackages.cuda_cccl
-      cudaPackages.cuda_cudart
+    ++ optionals enableCuda [
+      cuda_cccl
+      cuda_cudart
     ];
 
-  preConfigure =
-    ''
-      ./autogen.sh
-    ''
-    + lib.optionalString enableCuda ''
-      configureFlagsArray+=( "--with-nvcc-gencode=${builtins.concatStringsSep " " cudaPackages.cudaFlags.gencode}" )
-    '';
+  preConfigure = ''
+    ./autogen.sh
+  '';
+
   configureFlags =
-    [ ]
-    ++ lib.optional enableSse41 "--with-sse41"
-    ++ lib.optional enableSse42 "--with-sse42"
-    ++ lib.optional enableAvx "--with-avx"
-    ++ lib.optional enableCuda "--with-cuda=${cudaPackages.cuda_cudart}";
+    optionals enableSse41 [ "--with-sse41" ]
+    ++ optionals enableSse42 [ "--with-sse42" ]
+    ++ optionals enableAvx [ "--with-avx" ]
+    ++ optionals enableCuda [
+      "--with-cuda=${cuda_cudart}"
+      "--with-nvcc-gencode=${concatStringsSep " " cudaFlags.gencode}"
+    ];
 
   postInstall = ''
-    find $out/lib/ -name "*.la" -exec rm -f \{} \;
+    find "$out/lib/" -name "*.la" -exec rm -f \{} \;
 
-    moveToOutput bin/ucc_info $dev
+    moveToOutput bin/ucc_info "$dev"
   '';
 
   meta = with lib; {
@@ -79,4 +98,4 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.markuskowa ];
     platforms = platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/369226

- fix CUDA build (use cuda-compatible stdenv via `effectiveStdenv` "pattern")
- use `__structuredAttrs`
- use `strictDeps`
- switch to use of `fetchFromGitHub`'s `tag` argument
- build with `nccl`
- build with `nvml`
- remove deprecated use of `substituteInPlace`'s `--replace` flag
- remove `rec` keyword in favor of `finalAttrs` pattern

As future work, a number of these changes could be applied to UCX.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
