### PR TITLE
linbox: gcc-14 / clang-19 fixes

### DIFF
--- a/pkgs/by-name/li/linbox/package.nix
+++ b/pkgs/by-name/li/linbox/package.nix
@@ -30,6 +30,25 @@ stdenv.mkDerivation rec {
       url = "https://github.com/linbox-team/linbox/commit/4be26e9ef0eaf36a9909e5008940e8bf7dc625b6.patch";
       sha256 = "PX0Tik7blXOV2vHUq92xMxaADkNoNGiax4qrjQyGK6U=";
     })
+    (fetchpatch {
+      name = "gcc-14.patch";
+      url = "https://github.com/linbox-team/linbox/commit/b8f2d4ccdc0af4418d14f72caf6c4d01969092a3.patch";
+      includes = [
+        "linbox/matrix/sparsematrix/sparse-ell-matrix.h"
+        "linbox/matrix/sparsematrix/sparse-ellr-matrix.h"
+      ];
+      hash = "sha256-sqwgHkECexR2uX/SwYP7r9ZGHnGG+i4RXtfnvWsVQlk=";
+    })
+    (fetchpatch {
+      name = "clang-19.patch";
+      url = "https://github.com/linbox-team/linbox/commit/4f7a9bc830696b2f2c0219feaa74e85202700412.patch";
+      hash = "sha256-DoKh8/+2WPbMhN9MhpKmQ5sKmizD9iE81zS/XI0aM9Q=";
+    })
+    (fetchpatch {
+      name = "clang-19.patch";
+      url = "https://github.com/linbox-team/linbox/commit/4a1e1395804d4630ec556c61ba3f2cb67e140248.patch";
+      hash = "sha256-sCe/8hb27RuMxU1XXWsVU5gaGk2V+T6Ee7yrC5G5Hsc=";
+    })
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/linbox-team/linbox/commit/b8f2d4ccdc0af4418d14f72caf6c4d01969092a3
https://github.com/linbox-team/linbox/commit/4f7a9bc830696b2f2c0219feaa74e85202700412
https://github.com/linbox-team/linbox/commit/4a1e1395804d4630ec556c61ba3f2cb67e140248

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@collares