### PR TITLE
numbat: 1.14.0 -> 1.15.0

### DIFF
--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -1,30 +1,24 @@
 {
   lib,
-  stdenv,
   testers,
   fetchFromGitHub,
   rustPlatform,
-  darwin,
   numbat,
   tzdata,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "numbat";
-  version = "1.14.0";
+  version = "1.15.0";
 
   src = fetchFromGitHub {
     owner = "sharkdp";
     repo = "numbat";
-    rev = "v${version}";
-    hash = "sha256-TmzM541S2W5Cy8zHEWKRE2Zj2bSgrM4vbsWw3zbi3LQ=";
+    tag = "v${version}";
+    hash = "sha256-5XsrOAvBrmCG6k7YRwGZZtBP/o1jVVtBBTrwIT5CDX8=";
   };
 
-  cargoHash = "sha256-exvJJsGIj6KhmMcwhPjXMELvisuUtl17BAO6XEJSJmI=";
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.apple_sdk.frameworks.Security
-  ];
+  cargoHash = "sha256-RMON7JThY6Ad1QHQFiNbTb2PUsfviR2t+55k1ZtlOd8=";
 
   env.NUMBAT_SYSTEM_MODULE_PATH = "${placeholder "out"}/share/numbat/modules";
 

--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -1,10 +1,10 @@
 {
   lib,
-  testers,
   fetchFromGitHub,
   rustPlatform,
-  numbat,
   tzdata,
+  versionCheckHook,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -34,11 +34,12 @@ rustPlatform.buildRustPackage rec {
     export TZDIR=${tzdata}/share/zoneinfo
   '';
 
-  passthru.tests.version = testers.testVersion {
-    package = numbat;
-  };
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+  versionCheckProgramArg = [ "--version" ];
 
   meta = with lib; {
+  passthru.updateScript = nix-update-script { };
     description = "High precision scientific calculator with full support for physical units";
     longDescription = ''
       A statically typed programming language for scientific computations

--- a/pkgs/by-name/nu/numbat/package.nix
+++ b/pkgs/by-name/nu/numbat/package.nix
@@ -38,8 +38,9 @@ rustPlatform.buildRustPackage rec {
   doInstallCheck = true;
   versionCheckProgramArg = [ "--version" ];
 
-  meta = with lib; {
   passthru.updateScript = nix-update-script { };
+
+  meta = {
     description = "High precision scientific calculator with full support for physical units";
     longDescription = ''
       A statically typed programming language for scientific computations
@@ -47,14 +48,14 @@ rustPlatform.buildRustPackage rec {
     '';
     homepage = "https://numbat.dev";
     changelog = "https://github.com/sharkdp/numbat/releases/tag/v${version}";
-    license = with licenses; [
+    license = with lib.licenses; [
       asl20
       mit
     ];
-    mainProgram = "numbat";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       giomf
       atemu
     ];
+    mainProgram = "numbat";
   };
 }


### PR DESCRIPTION
- Update to [1.15.0](https://github.com/sharkdp/numbat/releases/tag/v1.15.0) ([diff](https://github.com/sharkdp/numbat/compare/v1.14.0...v1.15.0))
- Use `tag` instead of `rev`
- Use version check hook, remove `testers.testVersion`
- Remove old darwin sdk (now in stdenv by default)
- Add `nix-update-script`
- Refactor meta, remove `with lib;`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
