### PR TITLE
nixos/ytdl-sub: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -47,6 +47,8 @@
 
 - [Zenoh](https://zenoh.io/), a pub/sub/query protocol with low overhead. The Zenoh router daemon is available as [services.zenohd](options.html#opt-services.zenohd.enable)
 
+- [ytdl-sub](https://github.com/jmbannon/ytdl-sub), a tool that downloads media via yt-dlp and prepares it for your favorite media player, including Kodi, Jellyfin, Plex, Emby, and modern music players. Available as [services.ytdl-sub](options.html#opt-services.ytdl-sub.instances).
+
 - [MaryTTS](https://github.com/marytts/marytts), an open-source, multilingual text-to-speech synthesis system written in pure Java. Available as [services.marytts](options.html#opt-services.marytts).
 
 - [networking.modemmanager](options.html#opt-networking.modemmanager) has been split out of [networking.networkmanager](options.html#opt-networking.networkmanager). NetworkManager still enables ModemManager by default, but options exist now to run NetworkManager without ModemManager.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -893,6 +893,7 @@
   ./services/misc/workout-tracker.nix
   ./services/misc/whisparr.nix
   ./services/misc/xmrig.nix
+  ./services/misc/ytdl-sub.nix
   ./services/misc/zoneminder.nix
   ./services/misc/zookeeper.nix
   ./services/monitoring/alerta.nix

--- a/nixos/modules/services/misc/ytdl-sub.nix
+++ b/nixos/modules/services/misc/ytdl-sub.nix
@@ -1,0 +1,155 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.ytdl-sub;
+
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  meta.maintainers = with lib.maintainers; [ defelo ];
+
+  options.services.ytdl-sub = {
+    package = lib.mkPackageOption pkgs "ytdl-sub" { };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "ytdl-sub";
+      description = "User account under which ytdl-sub runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "ytdl-sub";
+      description = "Group under which ytdl-sub runs.";
+    };
+
+    instances = lib.mkOption {
+      default = { };
+      description = "Configuration for ytdl-sub instances.";
+      type = lib.types.attrsOf (
+        lib.types.submodule (
+          { name, ... }:
+          {
+            options = {
+              enable = lib.mkEnableOption "ytdl-sub instance";
+
+              schedule = lib.mkOption {
+                type = lib.types.nullOr lib.types.str;
+                description = "How often to run ytdl-sub. See {manpage}`systemd.time(7)` for the format.";
+                default = null;
+                example = "0/6:0";
+              };
+
+              config = lib.mkOption {
+                type = settingsFormat.type;
+                description = "Configuration for ytdl-sub. See <https://ytdl-sub.readthedocs.io/en/latest/config_reference/config_yaml.html> for more information.";
+                default = { };
+                example = {
+                  presets."YouTube Playlist" = {
+                    download = "{subscription_value}";
+                    output_options = {
+                      output_directory = "YouTube";
+                      file_name = "{channel}/{playlist_title}/{playlist_index_padded}_{title}.{ext}";
+                      maintain_download_archive = true;
+                    };
+                  };
+                };
+              };
+
+              subscriptions = lib.mkOption {
+                type = settingsFormat.type;
+                description = "Subscriptions for ytdl-sub. See <https://ytdl-sub.readthedocs.io/en/latest/config_reference/subscription_yaml.html> for more information.";
+                default = { };
+                example = {
+                  "YouTube Playlist" = {
+                    "Some Playlist" = "https://www.youtube.com/playlist?list=...";
+                  };
+                };
+              };
+            };
+
+            config = {
+              config.configuration.working_directory = "/run/ytdl-sub/${utils.escapeSystemdPath name}";
+            };
+          }
+        )
+      );
+    };
+  };
+
+  config = lib.mkIf (cfg.instances != { }) {
+    systemd.services =
+      let
+        mkService =
+          name: instance:
+          let
+            configFile = settingsFormat.generate "config.yaml" instance.config;
+            subscriptionsFile = settingsFormat.generate "subscriptions.yaml" instance.subscriptions;
+          in
+          lib.nameValuePair "ytdl-sub-${utils.escapeSystemdPath name}" {
+            inherit (instance) enable;
+
+            wants = [ "network-online.target" ];
+            after = [ "network-online.target" ];
+
+            startAt = lib.optional (instance.schedule != null) instance.schedule;
+
+            serviceConfig = {
+              User = cfg.user;
+              Group = cfg.group;
+
+              RuntimeDirectory = "ytdl-sub/${utils.escapeSystemdPath name}";
+              StateDirectory = "ytdl-sub/${utils.escapeSystemdPath name}";
+              WorkingDirectory = "/var/lib/ytdl-sub/${utils.escapeSystemdPath name}";
+
+              ExecStart = "${lib.getExe cfg.package} --config ${configFile} sub ${subscriptionsFile}";
+
+              # Hardening
+              CapabilityBoundingSet = [ "" ];
+              DeviceAllow = [ "" ];
+              LockPersonality = true;
+              PrivateDevices = true;
+              PrivateTmp = true;
+              PrivateUsers = true;
+              ProcSubset = "pid";
+              ProtectClock = true;
+              ProtectControlGroups = true;
+              ProtectHome = true;
+              ProtectHostname = true;
+              ProtectKernelLogs = true;
+              ProtectKernelModules = true;
+              ProtectKernelTunables = true;
+              ProtectProc = "invisible";
+              ProtectSystem = "strict";
+              RestrictAddressFamilies = [
+                "AF_INET"
+                "AF_INET6"
+                "AF_UNIX"
+              ];
+              RestrictNamespaces = true;
+              RestrictRealtime = true;
+              RestrictSUIDSGID = true;
+              SystemCallArchitectures = "native";
+            };
+          };
+      in
+      lib.mapAttrs' mkService cfg.instances;
+
+    users.users = lib.mkIf (cfg.user == "ytdl-sub") {
+      ytdl-sub = {
+        isSystemUser = true;
+        group = cfg.group;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "ytdl-sub") {
+      ytdl-sub = { };
+    };
+  };
+}


### PR DESCRIPTION
Add a module which configures systemd timers to periodically invoke ytdl-sub and thus automate media downloads.

Since ytdl-sub heavily depends on external services such as YouTube, there are no tests for this module.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
