### PR TITLE
ovn: fix missing scripts and wrong paths

### DIFF
--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -52,7 +52,11 @@ stdenv.mkDerivation rec {
     popd
   '';
 
-  configureFlags = [ "--localstatedir=/var" ];
+  configureFlags = [
+    "--localstatedir=/var"
+    "--with-dbdir=/var/lib/ovn"
+    "--enable-ssl"
+  ];
 
   enableParallelBuilding = true;
 
@@ -66,7 +70,13 @@ stdenv.mkDerivation rec {
 
   postInstall = ''
     mkdir -vp $out/share/openvswitch/scripts
+    mkdir -vp $out/etc/ovn
+    cp ovs/utilities/ovs-appctl $out/share/openvswitch/scripts
+    cp ovs/utilities/ovs-vsctl $out/share/openvswitch/scripts
     cp ovs/utilities/ovs-lib $out/share/openvswitch/scripts
+    sed -i "s#/usr/local/bin#$out/share/openvswitch/scripts#g" $out/share/openvswitch/scripts/ovs-lib
+    sed -i "s#/usr/local/sbin#$out/share/openvswitch/scripts#g" $out/share/openvswitch/scripts/ovs-lib
+    sed -i '/chown -R $INSTALL_USER:$INSTALL_GROUP $ovn_etcdir/d' $out/share/ovn/scripts/ovn-ctl
   '';
 
   # https://docs.ovn.org/en/latest/topics/testing.html


### PR DESCRIPTION
Add missing ovs-appctl and ovs-vsctl scripts used by ovn-ctl.

ovs-ctl is looking for ${bindir}/ovs-appctl but I did not find a configure flag for bindir and sbindir in OVS, which default to /usr/local/{bin,sbin}, so I fixed it with sed.

We need to set the --with-dbdir configure flag so that ovn_dbdir does not default to ${ pkgs.ovn }/etc/ovn and is not in the Nix store, as ovn_dbdir contains stateful information.

"--enable-ssl" is the default if I did not misread the autoconf files, but it does not hurt to add it.

@adamcstephens This should be enough to have a working standalone ovn network

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
