### PR TITLE
nixos/osquery: fix database_path + logger_path opts per systemd docs

### DIFF
--- a/nixos/modules/services/monitoring/osquery.nix
+++ b/nixos/modules/services/monitoring/osquery.nix
@@ -63,16 +63,30 @@ in
           freeformType = attrsOf str;
           options = {
             database_path = lib.mkOption {
-              default = "osquery/osquery.db";
+              default = "/var/lib/osquery/osquery.db";
               readOnly = true;
-              description = "Path used for the database file, relative to /var/lib/.";
-              type = nonEmptyStr;
+              description = ''
+                Path used for the database file.
+
+                ::: {.note}
+                If left as the default value, this directory will be automatically created before the
+                service starts, otherwise you are responsible for ensuring the directory exists with
+                the appropriate ownership and permissions.
+              '';
+              type = path;
             };
             logger_path = lib.mkOption {
-              default = "osquery";
+              default = "/var/log/osquery";
               readOnly = true;
-              description = "Base directory used for logging, relative to /var/log/.";
-              type = nonEmptyStr;
+              description = ''
+                Base directory used for logging.
+
+                ::: {.note}
+                If left as the default value, this directory will be automatically created before the
+                service starts, otherwise you are responsible for ensuring the directory exists with
+                the appropriate ownership and permissions.
+              '';
+              type = path;
             };
             pidfile = lib.mkOption {
               default = "/run/osquery/osqueryd.pid";
@@ -96,8 +110,8 @@ in
       serviceConfig = {
         ExecStart = "${pkgs.osquery}/bin/osqueryd --flagfile ${flagfile}";
         PIDFile = cfg.flags.pidfile;
-        LogsDirectory = cfg.flags.logger_path;
-        StateDirectory = dirname cfg.flags.database_path;
+        LogsDirectory = lib.mkIf (cfg.flags.logger_path == "/var/log/osquery") [ "osquery" ];
+        StateDirectory = lib.mkIf (cfg.flags.database_path == "/var/lib/osquery/osquery.db") [ "osquery" ];
         Restart = "always";
       };
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/monitoring/osquery.nix
+++ b/nixos/modules/services/monitoring/osquery.nix
@@ -63,16 +63,16 @@ in
           freeformType = attrsOf str;
           options = {
             database_path = lib.mkOption {
-              default = "/var/lib/osquery/osquery.db";
+              default = "osquery/osquery.db";
               readOnly = true;
-              description = "Path used for the database file.";
-              type = path;
+              description = "Path used for the database file, relative to /var/lib/.";
+              type = nonEmptyStr;
             };
             logger_path = lib.mkOption {
-              default = "/var/log/osquery";
+              default = "osquery";
               readOnly = true;
-              description = "Base directory used for logging.";
-              type = path;
+              description = "Base directory used for logging, relative to /var/log/.";
+              type = nonEmptyStr;
             };
             pidfile = lib.mkOption {
               default = "/run/osquery/osqueryd.pid";

--- a/nixos/tests/osquery.nix
+++ b/nixos/tests/osquery.nix
@@ -53,7 +53,7 @@ import ./make-test-python.nix (
         machine.succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"nullvalue\";' | osqueryi | tee /dev/console | grep -q ${nullvalue}")
 
         # Module creates directories for default database_path and pidfile flag values.
-        machine.succeed("test -d $(dirname ${cfg.flags.database_path})")
+        machine.succeed("test -d $(dirname /var/lib/${cfg.flags.database_path})")
         machine.succeed("test -d $(dirname ${cfg.flags.pidfile})")
       '';
   }

--- a/nixos/tests/osquery.nix
+++ b/nixos/tests/osquery.nix
@@ -53,7 +53,7 @@ import ./make-test-python.nix (
         machine.succeed("echo 'SELECT value FROM osquery_flags WHERE name = \"nullvalue\";' | osqueryi | tee /dev/console | grep -q ${nullvalue}")
 
         # Module creates directories for default database_path and pidfile flag values.
-        machine.succeed("test -d $(dirname /var/lib/${cfg.flags.database_path})")
+        machine.succeed("test -d $(dirname ${cfg.flags.database_path})")
         machine.succeed("test -d $(dirname ${cfg.flags.pidfile})")
       '';
   }


### PR DESCRIPTION
Update the database_path and logger_path defaults, descriptions and types as the defaults cause the service to fail. The defaults were previously using exact paths but the systemd documentation requires relative paths:

https://www.freedesktop.org/software/systemd/man/247/systemd.exec.html#RuntimeDirectory=

> RuntimeDirectory=, StateDirectory=, CacheDirectory=, LogsDirectory=, ConfigurationDirectory=

> These options take a whitespace-separated list of directory names. The specified directory names must be relative, and may not include "..".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Fixes #369765

Maintainers:
@znewman01 
@nlewo 
@squalus 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
