### PR TITLE
home-assistant-custom-components.homematicip_local: 1.75.0 -> 1.76.1

### DIFF
--- a/pkgs/development/python-modules/hahomematic/default.nix
+++ b/pkgs/development/python-modules/hahomematic/default.nix
@@ -7,6 +7,7 @@
   orjson,
   pydevccu,
   pytest-aiohttp,
+  pytest-socket,
   pytestCheckHook,
   python-slugify,
   pythonOlder,
@@ -16,16 +17,16 @@
 
 buildPythonPackage rec {
   pname = "hahomematic";
-  version = "2024.12.5";
+  version = "2024.12.13";
   pyproject = true;
 
   disabled = pythonOlder "3.12";
 
   src = fetchFromGitHub {
-    owner = "danielperna84";
+    owner = "SukramJ";
     repo = "hahomematic";
-    rev = "refs/tags/${version}";
-    hash = "sha256-jC9IXkl80pspqc9m0U6mspp5QSGG6u9Y6ANMK8WAG5s=";
+    tag = version;
+    hash = "sha256-qHB47S5bU+353deoq4B8XwPYfUoU940Y3hl8u3gGrNs=";
   };
 
   __darwinAllowLocalNetworking = true;
@@ -48,6 +49,7 @@ buildPythonPackage rec {
     freezegun
     pydevccu
     pytest-aiohttp
+    pytest-socket
     pytestCheckHook
   ];
 
@@ -55,8 +57,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Python module to interact with HomeMatic devices";
-    homepage = "https://github.com/danielperna84/hahomematic";
-    changelog = "https://github.com/danielperna84/hahomematic/blob/${src.rev}/changelog.md";
+    homepage = "https://github.com/SukramJ/hahomematic";
+    changelog = "https://github.com/SukramJ/hahomematic/blob/${src.tag}/changelog.md";
     license = licenses.mit;
     maintainers = with maintainers; [
       dotlambda

--- a/pkgs/development/python-modules/pydevccu/default.nix
+++ b/pkgs/development/python-modules/pydevccu/default.nix
@@ -8,17 +8,22 @@
 
 buildPythonPackage rec {
   pname = "pydevccu";
-  version = "0.1.8";
+  version = "0.1.9";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.12";
 
   src = fetchFromGitHub {
-    owner = "danielperna84";
+    owner = "SukramJ";
     repo = "pydevccu";
-    rev = "refs/tags/${version}";
-    hash = "sha256-WguSTtWxkiDs5nK5eiaarfD0CBxzIxQR9fxjuW3wMGc=";
+    tag = version;
+    hash = "sha256-s1u9+w0sPpXuqAET4k5VPWP+VoPqB08dZa9oY4UFXc8=";
   };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools==75.6.0" setuptools
+  '';
 
   build-system = [ setuptools ];
 
@@ -29,8 +34,8 @@ buildPythonPackage rec {
 
   meta = {
     description = "HomeMatic CCU XML-RPC Server with fake devices";
-    homepage = "https://github.com/danielperna84/pydevccu";
-    changelog = "https://github.com/danielperna84/pydevccu/releases/tag/${version}";
+    homepage = "https://github.com/SukramJ/pydevccu";
+    changelog = "https://github.com/SukramJ/pydevccu/releases/tag/${src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ fab ];
   };

--- a/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/homematicip_local/package.nix
@@ -7,15 +7,15 @@
 }:
 
 buildHomeAssistantComponent rec {
-  owner = "danielperna84";
+  owner = "SukramJ";
   domain = "homematicip_local";
-  version = "1.75.0";
+  version = "1.76.1";
 
   src = fetchFromGitHub {
-    owner = "danielperna84";
+    owner = "SukramJ";
     repo = "custom_homematic";
-    rev = "refs/tags/${version}";
-    hash = "sha256-H5Gf09C9/s2JYVTjgiYNe28mV18mqTiJ0ZDR6rnuojo=";
+    tag = version;
+    hash = "sha256-dBNZFYoi6tA9waV/yPCkgLu+ADxq09UKsOBHWOOBRJY=";
   };
 
   postPatch = ''
@@ -30,9 +30,9 @@ buildHomeAssistantComponent rec {
   ];
 
   meta = {
-    changelog = "https://github.com/danielperna84/custom_homematic/blob/${version}/changelog.md";
+    changelog = "https://github.com/SukramJ/custom_homematic/blob/${src.tag}/changelog.md";
     description = "Custom Home Assistant Component for HomeMatic";
-    homepage = "https://github.com/danielperna84/custom_homematic";
+    homepage = "https://github.com/SukramJ/custom_homematic";
     maintainers = with lib.maintainers; [ dotlambda ];
     license = lib.licenses.mit;
   };


### PR DESCRIPTION
Diff: https://github.com/SukramJ/custom_homematic/compare/refs/tags/1.75.0...1.76.1

Changelog: https://github.com/SukramJ/custom_homematic/blob/1.76.1/changelog.md
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
