### PR TITLE
nixos: fix various modules after `with lib` removal

### DIFF
--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -130,7 +130,7 @@ in
                 type = addCheck str (
                   x:
                   cfg.svcManager == "command"
-                  || elem x [
+                  || lib.elem x [
                     "restart"
                     "reload"
                     "nop"

--- a/nixos/modules/services/security/cfssl.nix
+++ b/nixos/modules/services/security/cfssl.nix
@@ -193,7 +193,7 @@ in
           ExecStart =
             with cfg;
             let
-              opt = n: v: optionalString (v != null) ''-${n}="${v}"'';
+              opt = n: v: lib.optionalString (v != null) ''-${n}="${v}"'';
             in
             lib.concatStringsSep " \\\n" [
               "${pkgs.cfssl}/bin/cfssl serve"

--- a/nixos/modules/services/security/endlessh-go.nix
+++ b/nixos/modules/services/security/endlessh-go.nix
@@ -94,14 +94,14 @@ in
           Restart = "always";
           ExecStart =
             with cfg;
-            concatStringsSep " " (
+            lib.concatStringsSep " " (
               [
                 (lib.getExe cfg.package)
                 "-logtostderr"
                 "-host=${listenAddress}"
                 "-port=${toString port}"
               ]
-              ++ optionals prometheus.enable [
+              ++ lib.optionals prometheus.enable [
                 "-enable_prometheus"
                 "-prometheus_host=${prometheus.listenAddress}"
                 "-prometheus_port=${toString prometheus.port}"
@@ -149,7 +149,7 @@ in
         };
     };
 
-    networking.firewall.allowedTCPPorts = with cfg; optionals openFirewall [ port ];
+    networking.firewall.allowedTCPPorts = with cfg; lib.optionals openFirewall [ port ];
   };
 
   meta.maintainers = with lib.maintainers; [ azahi ];

--- a/nixos/modules/services/security/endlessh.nix
+++ b/nixos/modules/services/security/endlessh.nix
@@ -60,7 +60,7 @@ in
           Restart = "always";
           ExecStart =
             with cfg;
-            concatStringsSep " " (
+            lib.concatStringsSep " " (
               [
                 "${pkgs.endlessh}/bin/endlessh"
                 "-p ${toString port}"
@@ -109,7 +109,7 @@ in
         };
     };
 
-    networking.firewall.allowedTCPPorts = with cfg; optionals openFirewall [ port ];
+    networking.firewall.allowedTCPPorts = with cfg; lib.optionals openFirewall [ port ];
   };
 
   meta.maintainers = with lib.maintainers; [ azahi ];

--- a/nixos/modules/services/system/cloud-init.nix
+++ b/nixos/modules/services/system/cloud-init.nix
@@ -17,9 +17,9 @@ let
       util-linux
       busybox
     ]
-    ++ optional cfg.btrfs.enable btrfs-progs
-    ++ optional cfg.ext4.enable e2fsprogs
-    ++ optional cfg.xfs.enable xfsprogs
+    ++ lib.optional cfg.btrfs.enable btrfs-progs
+    ++ lib.optional cfg.ext4.enable e2fsprogs
+    ++ lib.optional cfg.xfs.enable xfsprogs
     ++ cfg.extraPackages;
   hasFs = fsName: lib.any (fs: fs.fsType == fsName) (lib.attrValues config.fileSystems);
   settingsFormat = pkgs.formats.yaml { };

--- a/nixos/modules/services/torrent/magnetico.nix
+++ b/nixos/modules/services/torrent/magnetico.nix
@@ -15,7 +15,7 @@ let
       credentialsFile
     else
       pkgs.writeText "magnetico-credentials" (
-        concatStrings (mapAttrsToList (user: hash: "${user}:${hash}\n") cfg.web.credentials)
+        lib.concatStrings (lib.mapAttrsToList (user: hash: "${user}:${hash}\n") cfg.web.credentials)
       );
 
   # default options in magneticod/main.go
@@ -28,7 +28,7 @@ let
 
   crawlerArgs =
     with cfg.crawler;
-    escapeShellArgs (
+    lib.escapeShellArgs (
       [
         "--database=${dbURI}"
         "--indexer-addr=${address}:${toString port}"
@@ -40,7 +40,7 @@ let
 
   webArgs =
     with cfg.web;
-    escapeShellArgs (
+    lib.escapeShellArgs (
       [
         "--database=${dbURI}"
         (


### PR DESCRIPTION
I ran through `NIXPKGS_ALLOW_UNFREE=1 NIXPKGS_ALLOW_INSECURE=1 NIXPKGS_ALLOW_BROKEN=1 nix-eval-jobs --workers 20 --force-recurse --impure --flake .#legacyPackages.x86_64-linux.nixosTests` to look for eval errors due to `undefined variable`. These were introduced in recent `with lib` removals.

There may still be some errors due to modules not covered by a NixOS test.

Resolves #369847.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).