### PR TITLE
python312Packages.blockdiag: fix missing runtime dependency

### DIFF
--- a/pkgs/development/python-modules/blockdiag/default.nix
+++ b/pkgs/development/python-modules/blockdiag/default.nix
@@ -58,6 +58,7 @@ buildPythonPackage rec {
     funcparserlib
     pillow
     reportlab
+    setuptools
     webcolors
   ];
 


### PR DESCRIPTION
The `blockdiag.imagedraw` module has a runtime dependency on [`pkg_resources`], which is part of the `setuptools` package.

[`pkg_resources`]: https://github.com/blockdiag/blockdiag/blob/3.0.0/src/blockdiag/imagedraw/__init__.py#L16

I stumbled on this when trying to `nix run nixpkgs#nwdiag` (on 24.11).

```console
$ nix run nixpkgs#nwdiag
Traceback (most recent call last):
  File "/nix/store/h547458m5jdswzwi8imxf8nfiv32rnwq-python3.12-nwdiag-3.0.0/bin/.rackdiag-wrapped", line 6, in <module>
    from rackdiag.command import main
  File "/nix/store/h547458m5jdswzwi8imxf8nfiv32rnwq-python3.12-nwdiag-3.0.0/lib/python3.12/site-packages/rackdiag/command.py", line 18, in <module>
    from blockdiag.utils.bootstrap import Application
  File "/nix/store/bw1a8s6mkihbf3lr17d2968960p24b8n-python3.12-blockdiag-3.0.0/lib/python3.12/site-packages/blockdiag/utils/bootstrap.py", line 23, in <module>
    from blockdiag import imagedraw, plugins
  File "/nix/store/bw1a8s6mkihbf3lr17d2968960p24b8n-python3.12-blockdiag-3.0.0/lib/python3.12/site-packages/blockdiag/imagedraw/__init__.py", line 16, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

After the PR, I can

```console
$ nix-build -A nwdiag
$ ./result/bin/nwdiag
...
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
