### PR TITLE
nixos/tor: fix eval take three

### DIFF
--- a/nixos/modules/services/security/tor.nix
+++ b/nixos/modules/services/security/tor.nix
@@ -126,7 +126,7 @@ let
             );
           config = {
             flags =
-              filter (name: config.${name} == true) isolateFlags
+              lib.filter (name: config.${name} == true) isolateFlags
               ++ lib.optional (config.SessionGroup != null) "SessionGroup=${toString config.SessionGroup}";
           };
         }
@@ -244,7 +244,7 @@ let
                     }
                   );
                 config = {
-                  flags = filter (name: config.${name} == true) flags;
+                  flags = lib.filter (name: config.${name} == true) flags;
                 };
               }
             ))
@@ -928,7 +928,7 @@ in
                           }
                         );
                       config = {
-                        flags = filter (name: config.${name} == true) flags;
+                        flags = lib.filter (name: config.${name} == true) flags;
                       };
                     }
                   ))


### PR DESCRIPTION
This time I looked through all the symbols in `lib`, and verified that each instance in `nixos/modules/services/security/tor.nix` had a `lib.` before it for each one of those symbols. `filter` was the missing one.

The `nixosTests.tor` continues to pass. It doesn't cover all the cases, sadly.

Previously:

- https://github.com/NixOS/nixpkgs/pull/369233
- https://github.com/NixOS/nixpkgs/pull/369869
- https://github.com/NixOS/nixpkgs/pull/370042

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
