### PR TITLE
nixos/kmonad: avoid running an unnecessary bash

### DIFF
--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -122,8 +122,6 @@ let
       cmd =
         [
           (lib.getExe cfg.package)
-          "--input"
-          ''device-file "${keyboard.device}"''
         ]
         ++ cfg.extraArgs
         ++ [ "${mkCfg keyboard}" ];

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 
@@ -118,17 +119,8 @@ let
   # Build a systemd service that starts KMonad:
   mkService =
     keyboard:
-    let
-      cmd =
-        [
-          (lib.getExe cfg.package)
-        ]
-        ++ cfg.extraArgs
-        ++ [ "${mkCfg keyboard}" ];
-    in
     lib.nameValuePair (mkName keyboard.name) {
       description = "KMonad for ${keyboard.device}";
-      script = lib.escapeShellArgs cmd;
       unitConfig = {
         # Control rate limiting.
         # Stop the restart logic if we restart more than
@@ -137,6 +129,10 @@ let
         StartLimitBurst = 5;
       };
       serviceConfig = {
+        ExecStart = ''
+          ${lib.getExe cfg.package} ${mkCfg keyboard} \
+            ${utils.escapeSystemdExecArgs cfg.extraArgs}
+        '';
         Restart = "always";
         # Restart at increasing intervals from 2s to 1m
         RestartSec = 2;

--- a/nixos/tests/kmonad.nix
+++ b/nixos/tests/kmonad.nix
@@ -11,6 +11,9 @@
     machine = {
       services.kmonad = {
         enable = true;
+        extraArgs = [
+          "--log-level=debug"
+        ];
         keyboards = {
           defaultKbd = {
             device = "/dev/input/by-id/vm-default-kbd";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
