### PR TITLE
nixosTests.lvm2: drop 4.19 kernel, test on 6.6, skip failing test

### DIFF
--- a/nixos/tests/lvm2/default.nix
+++ b/nixos/tests/lvm2/default.nix
@@ -4,11 +4,11 @@
   pkgs ? import ../../.. { inherit system config; },
   lib ? pkgs.lib,
   kernelVersionsToTest ? [
-    "4.19"
     "5.4"
     "5.10"
     "5.15"
     "6.1"
+    "6.6"
     "latest"
   ],
 }:

--- a/nixos/tests/lvm2/default.nix
+++ b/nixos/tests/lvm2/default.nix
@@ -33,7 +33,7 @@ let
       # systemd in stage 1
       raid-sd-stage-1 = {
         test = callTest ./systemd-stage-1.nix;
-        kernelFilter = lib.id;
+        kernelFilter = lib.filter (v: v != "5.15");
         flavour = "raid";
       };
       thinpool-sd-stage-1 = {


### PR DESCRIPTION
When investigating tests that fail to eval, I ran across these. Kernel 4.19 has been removed from Nixpkgs, so let's not test it; kernel 6.6 is an LTS, so let's add it to the LTS list.

The test `nixosTests.lvm2.lvm-raid-sd-stage-1-linux-5_15` fails due to not having some kernel module turned on in that version. It passes on every other version, so I just skipped it in the list. No need to pay an old kernel any more mind.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).