### PR TITLE
nixos/automx2: multi-domain support, service improvements, configurability

### DIFF
--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -93,6 +93,7 @@ in
         }/bin/flask run --host=127.0.0.1 --port=${toString cfg.port}";
         Restart = "always";
         StateDirectory = "automx2";
+        DynamicUser = true;
         User = "automx2";
         WorkingDirectory = "/var/lib/automx2";
       };
@@ -101,14 +102,6 @@ in
         Documentation = "https://rseichter.github.io/automx2/";
       };
       wantedBy = [ "multi-user.target" ];
-    };
-
-    users = {
-      groups.automx2 = { };
-      users.automx2 = {
-        group = "automx2";
-        isSystemUser = true;
-      };
     };
   };
 

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -185,10 +185,8 @@ in
           pkgs.python3.buildEnv.override { extraLibs = [ cfg.package ]; }
         }/bin/flask run --host=127.0.0.1 --port=${toString cfg.port}";
         Restart = "always";
-        StateDirectory = "automx2";
         DynamicUser = true;
         User = "automx2";
-        WorkingDirectory = "/var/lib/automx2";
       };
       unitConfig = {
         Description = "Service to automatically configure mail clients";

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -98,7 +98,7 @@ in
         WorkingDirectory = "/var/lib/automx2";
       };
       unitConfig = {
-        Description = "MUA configuration service";
+        Description = "Service to automatically configure mail clients";
         Documentation = "https://rseichter.github.io/automx2/";
       };
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -166,10 +166,7 @@ in
 
     systemd.services.automx2 = {
       after = [ "network.target" ];
-      postStart = ''
-        sleep 3
-        ${lib.getExe pkgs.curl} -X POST --json @${format.generate "automx2.json" cfg.settings} http://127.0.0.1:${toString cfg.port}/initdb/
-      '';
+      postStart = "${lib.getExe pkgs.curl} -X POST --json @${format.generate "automx2.json" cfg.settings} http://127.0.0.1:${toString cfg.port}/initdb/";
       serviceConfig = {
         Environment = [
           "AUTOMX2_CONF=${pkgs.writeText "automx2-conf" ''
@@ -187,6 +184,7 @@ in
         Restart = "always";
         DynamicUser = true;
         User = "automx2";
+        Type = "notify";
       };
       unitConfig = {
         Description = "Service to automatically configure mail clients";

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -138,6 +138,20 @@ in
           };
         };
       };
+
+      logLevel = lib.mkOption {
+        type = lib.types.enum [
+          "INFO"
+          "WARNING"
+          "DEBUG"
+          "ERROR"
+          "CRITICAL"
+        ];
+        default = "WARNING";
+        description = "Log level used for automx2 service.";
+        example = "DEBUG";
+      };
+
     };
   };
 
@@ -171,7 +185,7 @@ in
         Environment = [
           "AUTOMX2_CONF=${pkgs.writeText "automx2-conf" ''
             [automx2]
-            loglevel = WARNING
+            loglevel = ${cfg.logLevel}
             db_uri = sqlite:///:memory:
             proxy_count = 1
           ''}"

--- a/nixos/modules/services/mail/automx2.nix
+++ b/nixos/modules/services/mail/automx2.nix
@@ -152,61 +152,108 @@ in
         example = "DEBUG";
       };
 
-    };
-  };
-
-  config = lib.mkIf cfg.enable {
-    services.nginx = {
-      enable = true;
-      virtualHosts = builtins.listToAttrs (
-        map (domain: {
-          name = "autoconfig.${domain}";
-          value = {
-            enableACME = true;
-            forceSSL = true;
-            serverAliases = [ "autodiscover.${domain}" ];
-            locations = {
-              "/".proxyPass = "http://127.0.0.1:${toString cfg.port}/";
-              "/initdb".extraConfig = ''
-                # Limit access to clients connecting from localhost
-                allow 127.0.0.1;
-                deny all;
-              '';
-            };
-          };
-        }) cfg.domains
-      );
-    };
-
-    systemd.services.automx2 = {
-      after = [ "network.target" ];
-      postStart = "${lib.getExe pkgs.curl} -X POST --json @${format.generate "automx2.json" cfg.settings} http://127.0.0.1:${toString cfg.port}/initdb/";
-      serviceConfig = {
-        Environment = [
-          "AUTOMX2_CONF=${pkgs.writeText "automx2-conf" ''
-            [automx2]
-            loglevel = ${cfg.logLevel}
-            db_uri = sqlite:///:memory:
-            proxy_count = 1
-          ''}"
-          "FLASK_APP=automx2.server:app"
-          "FLASK_CONFIG=production"
+      webserver = lib.mkOption {
+        type = lib.types.enum [
+          "nginx"
+          "caddy"
         ];
-        ExecStart = "${
-          pkgs.python3.buildEnv.override { extraLibs = [ cfg.package ]; }
-        }/bin/flask run --host=127.0.0.1 --port=${toString cfg.port}";
-        Restart = "always";
-        DynamicUser = true;
-        User = "automx2";
-        Type = "notify";
+        default = "nginx";
+        description = ''
+          Whether to use nginx or caddy for virtual host management.
+
+          Further nginx configuration can be done by adapting `services.nginx.virtualHosts.<name>`.
+          See [](#opt-services.nginx.virtualHosts) for further information.
+
+          Further caddy configuration can be done by adapting `services.caddy.virtualHosts.<name>`.
+          See [](#opt-services.caddy.virtualHosts) for further information.
+        '';
       };
-      unitConfig = {
-        Description = "Service to automatically configure mail clients";
-        Documentation = "https://rseichter.github.io/automx2/";
-      };
-      wantedBy = [ "multi-user.target" ];
+
     };
   };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        systemd.services.automx2 = {
+          after = [ "network.target" ];
+          postStart = "${lib.getExe pkgs.curl} -X POST --json @${format.generate "automx2.json" cfg.settings} http://127.0.0.1:${toString cfg.port}/initdb/";
+          serviceConfig = {
+            Environment = [
+              "AUTOMX2_CONF=${pkgs.writeText "automx2-conf" ''
+                [automx2]
+                loglevel = ${cfg.logLevel}
+                db_uri = sqlite:///:memory:
+                proxy_count = 1
+              ''}"
+              "FLASK_APP=automx2.server:app"
+              "FLASK_CONFIG=production"
+            ];
+            ExecStart = "${
+              pkgs.python3.buildEnv.override { extraLibs = [ cfg.package ]; }
+            }/bin/flask run --host=127.0.0.1 --port=${toString cfg.port}";
+            Restart = "always";
+            DynamicUser = true;
+            User = "automx2";
+            Type = "notify";
+          };
+          unitConfig = {
+            Description = "Service to automatically configure mail clients";
+            Documentation = "https://rseichter.github.io/automx2/";
+          };
+          wantedBy = [ "multi-user.target" ];
+        };
+      }
+      (lib.mkIf (cfg.webserver == "nginx") {
+        services.nginx = {
+          enable = true;
+          virtualHosts = builtins.listToAttrs (
+            map (domain: {
+              name = "autoconfig.${domain}";
+              value = {
+                enableACME = true;
+                forceSSL = true;
+                serverAliases = [ "autodiscover.${domain}" ];
+                locations = {
+                  "/".proxyPass = "http://127.0.0.1:${toString cfg.port}/";
+                  # TODO: verify this actually blocks external requests due to the current IP/proxy issue?
+                  "/initdb".extraConfig = ''
+                    # Limit access to clients connecting from localhost
+                    allow 127.0.0.1;
+                    deny all;
+                  '';
+                };
+              };
+            }) cfg.domains
+          );
+        };
+      })
+      (lib.mkIf (cfg.webserver == "caddy") {
+        services.caddy = {
+          enable = true;
+          virtualHosts = builtins.listToAttrs (
+            map (domain: {
+              name = "autoconfig.${domain}";
+              value = {
+                serverAliases = [ "autodiscover.${domain}" ];
+                extraConfig = ''
+                  route /initdb* {
+                    respond 403 {
+                      body "Access Denied"
+                    }
+                  }
+
+                  route * {
+                    reverse_proxy http://127.0.0.1:${toString cfg.port}
+                  }
+                '';
+              };
+            }) cfg.domains
+          );
+        };
+      })
+    ]
+  );
 
   imports = [
     (lib.mkChangedOptionModule [ "services" "automx2" "domain" ] [ "services" "automx2" "domains" ]

--- a/pkgs/development/python-modules/automx2/default.nix
+++ b/pkgs/development/python-modules/automx2/default.nix
@@ -7,12 +7,13 @@
   ldap3,
   pytestCheckHook,
   pythonOlder,
+  pythonPackages,
   setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "automx2";
-  version = "2024.2";
+  version = "2025.1";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -21,7 +22,7 @@ buildPythonPackage rec {
     owner = "rseichter";
     repo = "automx2";
     tag = version;
-    hash = "sha256-7SbSKSjDHTppdqfPPKvuWbdoksHa6BMIOXOq0jDggTE=";
+    hash = "sha256-EG0S8Ie9U1nV96th7NdGsbAWXLVoqddHbGdHt/FUlqE=";
   };
 
   nativeBuildInputs = [ setuptools ];


### PR DESCRIPTION
This PR adds multiple improvements to the `automx2` service, such as:
- support for more than 1 domain
- configuration of the log level
- configuring `settings` as proper validated option instead of a plain JSON string
- improve the systemd service:
  - use `DynamicUser=` and get rid of extra service user
  - use sdnotify for a faster, more deterministic/race-free service startup
  - get rid of the service state, since it doesn't have any
- support for Caddy as webserver instead of only nginx

Since this is still WIP and only a draft PR so far, pinging @SuperSandro2000 as the original committer of this module for early input.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
