### PR TITLE
WIP nixosTests: no aliases allowed

### DIFF
--- a/nixos/tests/kernel-generic.nix
+++ b/nixos/tests/kernel-generic.nix
@@ -4,8 +4,6 @@
   pkgs ? import ../.. { inherit system config; },
 }@args:
 
-with pkgs.lib;
-
 let
   testsForLinuxPackages =
     linuxPackages:
@@ -13,13 +11,7 @@ let
       { pkgs, ... }:
       {
         name = "kernel-${linuxPackages.kernel.version}";
-        meta = with pkgs.lib.maintainers; {
-          maintainers = [
-            nequissimus
-            atemu
-            ma27
-          ];
-        };
+        meta = { inherit maintainers; };
 
         nodes.machine =
           { ... }:
@@ -33,7 +25,11 @@ let
         '';
       }
     ) args);
-  kernels = pkgs.linuxKernel.vanillaPackages // {
+
+  # Skip kernels whose definition is `throw`.
+  kernelShallowlyEvals = name: kernel: (builtins.tryEval kernel).success;
+
+  kernels = (pkgs.lib.filterAttrs kernelShallowlyEvals pkgs.linuxKernel.vanillaPackages) // {
     inherit (pkgs.linuxKernel.packages)
       linux_5_4_hardened
       linux_5_10_hardened
@@ -48,19 +44,24 @@ let
       linux_rt_6_1
       linux_rt_6_6
       linux_libre
-
       linux_testing
       ;
   };
 
+  maintainers = with pkgs.lib.maintainers; [
+    nequissimus
+    atemu
+    ma27
+  ];
+
 in
-mapAttrs (_: lP: testsForLinuxPackages lP) kernels
+builtins.mapAttrs (_: lP: testsForLinuxPackages lP) kernels
 // {
   passthru = {
     inherit testsForLinuxPackages;
 
     # Useful for development testing of all Kernel configs without building full Kernel
-    configfiles = mapAttrs (_: lP: lP.kernel.configfile) kernels;
+    configfiles = builtins.mapAttrs (_: lP: lP.kernel.configfile) kernels;
 
     testsForKernel = kernel: testsForLinuxPackages (pkgs.linuxPackagesFor kernel);
   };


### PR DESCRIPTION
I discovered these searching for things under `nixosTests` that didn't evaluate.

It doesn't seem worth it to claim to have a test for kernels that aren't actually in `nixpkgs`.

Also, remove a top-level `with` statement and reshape the code to continue working.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).