### PR TITLE
python312Packages.rigour: init at 0.8.2

### DIFF
--- a/pkgs/development/python-modules/rigour/default.nix
+++ b/pkgs/development/python-modules/rigour/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatchling,
+  babel,
+  banal,
+  fingerprints,
+  jellyfish,
+  jinja2,
+  normality,
+  python-stdnum,
+  pytz,
+  pyyaml,
+  rapidfuzz,
+  typing-extensions,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "rigour";
+  version = "0.8.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "opensanctions";
+    repo = "rigour";
+    tag = "v${version}";
+    hash = "sha256-endggriOj+DBWfcYDQ034OvzxVCaHV9QUMAk0qtSYPg=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  dependencies = [
+    babel
+    banal
+    fingerprints
+    jellyfish
+    jinja2
+    normality
+    python-stdnum
+    pytz
+    pyyaml
+    rapidfuzz
+    typing-extensions
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [
+    "rigour"
+    "rigour.names"
+    "rigour.ids"
+    "rigour.langs"
+    "rigour.mime"
+    "rigour.addresses"
+  ];
+
+  meta = {
+    description = "Data cleaning and validation functions for names, languages, identifiers, etc";
+    homepage = "https://opensanctions.github.io/rigour";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14126,6 +14126,8 @@ self: super: with self; {
 
   riden = callPackage ../development/python-modules/riden { };
 
+  rigour = callPackage ../development/python-modules/rigour { };
+
   ring-doorbell = callPackage ../development/python-modules/ring-doorbell { };
 
   rio-tiler = callPackage ../development/python-modules/rio-tiler { };


### PR DESCRIPTION
Init python312Packages.rigour, a [Python package](https://opensanctions.github.io/rigour) for cleaning of business/legal data (names, addresses, languages, MIME types, etc.).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
