### PR TITLE
python312Packages.textual: 0.86.1 -> 1.0.0

### DIFF
--- a/pkgs/by-name/me/memray/package.nix
+++ b/pkgs/by-name/me/memray/package.nix
@@ -10,14 +10,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "memray";
-  version = "1.14.0";
+  version = "1.15.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "bloomberg";
     repo = "memray";
     tag = "v${version}";
-    hash = "sha256-U9JR60rSxPYXbZaKR7vVNhGT78AXnqcoqvVC6/1OW/E=";
+    hash = "sha256-SgkJm+vtIid8RR1Qy98PkpvIQX4LxyAPlS+4UlYlZws=";
   };
 
   build-system = with python3Packages; [
@@ -48,7 +48,7 @@ python3Packages.buildPythonApplication rec {
       pytest-textual-snapshot
       pytestCheckHook
     ]
-    ++ lib.optionals (pythonOlder "3.12") [ greenlet ];
+    ++ lib.optionals (pythonOlder "3.14") [ greenlet ];
 
   pythonImportsCheck = [ "memray" ];
 
@@ -58,15 +58,6 @@ python3Packages.buildPythonApplication rec {
     # Import issue
     "test_header_allocator"
     "test_hybrid_stack_of_allocations_inside_ceval"
-
-    # snapshot-based tests are too fragile
-    # see https://github.com/bloomberg/memray/issues/654
-    "TestTUILooks"
-    "test_tui_basic"
-    "test_tui_pause"
-    "test_tui_gradient"
-    "test_merge_threads"
-    "test_unmerge_threads"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/textual-fastdatatable/default.nix
+++ b/pkgs/development/python-modules/textual-fastdatatable/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "textual-fastdatatable";
-  version = "0.10.0";
+  version = "0.11.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "tconbeer";
     repo = "textual-fastdatatable";
     tag = "v${version}";
-    hash = "sha256-r1evN69etFn21TkXPLuAh1OxIsurDDyPyYOKQR5uUos=";
+    hash = "sha256-Jz0ujO/nAnn15t8/OFOzZTpVBXNYsfVhxmYdGC39PpM=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/textual-textarea/default.nix
+++ b/pkgs/development/python-modules/textual-textarea/default.nix
@@ -12,7 +12,7 @@
 
 buildPythonPackage rec {
   pname = "textual-textarea";
-  version = "0.14.4";
+  version = "0.15.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "tconbeer";
     repo = "textual-textarea";
     tag = "v${version}";
-    hash = "sha256-tmbSCU1VgxR9aXG22UVpweD71dVmhKSRBTDm1Gf33jM=";
+    hash = "sha256-aaeXgD6RMQ3tlK5H/2lk3ueTyA3yYjHrYL51w/1tvSI=";
   };
 
   build-system = [ poetry-core ];

--- a/pkgs/development/python-modules/textual/default.nix
+++ b/pkgs/development/python-modules/textual/default.nix
@@ -9,6 +9,7 @@
   pytest-aiohttp,
   pytest-xdist,
   pytestCheckHook,
+  pythonAtLeast,
   pythonOlder,
   rich,
   syrupy,
@@ -20,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "textual";
-  version = "0.86.1";
+  version = "1.0.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -29,7 +30,7 @@ buildPythonPackage rec {
     owner = "Textualize";
     repo = "textual";
     tag = "v${version}";
-    hash = "sha256-5msCFv79nAmoaP9gZxV3DXMLTyVlSFb+qyA5jHWwc50=";
+    hash = "sha256-3pNUDkkq9X3W9DdWp4M4h4ddHN+GzUxLCFNJJdAtRJM=";
   };
 
   build-system = [ poetry-core ];
@@ -65,14 +66,24 @@ buildPythonPackage rec {
     "tests/snapshot_tests/test_snapshots.py"
   ];
 
-  disabledTests = [
-    # Assertion issues
-    "test_textual_env_var"
+  disabledTests =
+    [
+      # Assertion issues
+      "test_textual_env_var"
 
-    # Requirements for tests are not quite ready
-    "test_register_language"
-    "test_language_binary_missing"
-  ];
+      # Requirements for tests are not quite ready
+      "test_register_language"
+
+      # Requires python bindings for tree-sitter languages
+      # https://github.com/Textualize/textual/issues/5449
+      "test_setting_unknown_language"
+      "test_update_highlight_query"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      # https://github.com/Textualize/textual/issues/5327
+      "test_cursor_page_up"
+      "test_cursor_page_down"
+    ];
 
   # Some tests in groups require state from previous tests
   # See https://github.com/Textualize/textual/issues/4924#issuecomment-2304889067


### PR DESCRIPTION
Upgrading textual to latest version 1.0.0

Related: https://github.com/NixOS/nixpkgs/pull/365766

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

