### PR TITLE
python3Packages.pyside6-qtads: init at 4.3.1.1

### DIFF
--- a/pkgs/development/python-modules/cmake-build-extension/default.nix
+++ b/pkgs/development/python-modules/cmake-build-extension/default.nix
@@ -1,0 +1,47 @@
+{
+  buildPythonPackage,
+  cmake,
+  fetchFromGitHub,
+  gitpython,
+  lib,
+  ninja,
+  setuptools,
+  setuptools-scm,
+}:
+
+buildPythonPackage rec {
+  pname = "cmake-build-extension";
+  version = "0.6.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "diegoferigo";
+    repo = "cmake-build-extension";
+    rev = "v${version}";
+    hash = "sha256-taAwxa7Sv+xc8xJRnNM6V7WPcL+TWZOkngwuqjAslzc=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    cmake
+    ninja
+    gitpython
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "cmake_build_extension" ];
+  doPythonRuntimeDepsCheck = false;
+
+  meta = {
+    description = "Setuptools extension to build and package CMake projects";
+    homepage = "https://github.com/diegoferigo/cmake-build-extension";
+    changelog = "https://github.com/diegoferigo/cmake-build-extension/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ scoder12 ];
+  };
+}

--- a/pkgs/development/python-modules/cmake-build-extension/default.nix
+++ b/pkgs/development/python-modules/cmake-build-extension/default.nix
@@ -1,9 +1,9 @@
 {
+  lib,
   buildPythonPackage,
   cmake,
   fetchFromGitHub,
   gitpython,
-  lib,
   ninja,
   setuptools,
   setuptools-scm,
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "diegoferigo";
     repo = "cmake-build-extension";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-taAwxa7Sv+xc8xJRnNM6V7WPcL+TWZOkngwuqjAslzc=";
   };
 
@@ -35,6 +35,7 @@ buildPythonPackage rec {
   dontUseCmakeConfigure = true;
 
   pythonImportsCheck = [ "cmake_build_extension" ];
+
   doPythonRuntimeDepsCheck = false;
 
   meta = {

--- a/pkgs/development/python-modules/pyside6-qtads/default.nix
+++ b/pkgs/development/python-modules/pyside6-qtads/default.nix
@@ -1,8 +1,8 @@
 {
+  lib,
   buildPythonPackage,
   cmake-build-extension,
   fetchFromGitHub,
-  lib,
   pythonRelaxDepsHook,
   pyside6,
   qt6,
@@ -13,19 +13,20 @@
 
 buildPythonPackage rec {
   pname = "pyside6-qtads";
-  version = "4.3.1.1";
+  version = "4.3.1.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mborgerson";
     repo = "pyside6_qtads";
-    rev = "v${version}";
-    hash = "sha256-WSthRtK9IaRDDFEtGMUsQwylD+iGdsZM2vkXBjt8+mI=";
+    tag = "v${version}";
+    hash = "sha256-02YUeD9PfcaYkvz9JX5FucsbG9Idk7OH24U+RXXEmvo=";
     fetchSubmodules = true;
   };
 
   # bypass the broken parts of their bespoke python script cmake plugin
   patches = [ ./find-nix-deps.patch ];
+
   postPatch = ''
     substituteInPlace setup.py \
       --replace-fail @shiboken6@ ${shiboken6} \
@@ -47,10 +48,6 @@ buildPythonPackage rec {
     qt6.qtquick3d
   ];
 
-  nativeBuildInputs = [
-    pythonRelaxDepsHook
-  ];
-
   build-system = [
     cmake-build-extension
     setuptools
@@ -61,6 +58,8 @@ buildPythonPackage rec {
     pyside6
     shiboken6
   ];
+
+  nativeBuildInputs = [ pythonRelaxDepsHook ];
 
   # cmake-build-extension will configure
   dontUseCmakeConfigure = true;
@@ -74,6 +73,7 @@ buildPythonPackage rec {
   meta = {
     description = "Python bindings to Qt Advanced Docking System for PySide6";
     homepage = "https://github.com/mborgerson/pyside6_qtads";
+    changelog = "https://github.com/mborgerson/pyside6_qtads/releases/tag/";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ scoder12 ];
   };

--- a/pkgs/development/python-modules/pyside6-qtads/default.nix
+++ b/pkgs/development/python-modules/pyside6-qtads/default.nix
@@ -1,0 +1,80 @@
+{
+  buildPythonPackage,
+  cmake-build-extension,
+  fetchFromGitHub,
+  lib,
+  pythonRelaxDepsHook,
+  pyside6,
+  qt6,
+  setuptools,
+  setuptools-scm,
+  shiboken6,
+}:
+
+buildPythonPackage rec {
+  pname = "pyside6-qtads";
+  version = "4.3.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mborgerson";
+    repo = "pyside6_qtads";
+    rev = "v${version}";
+    hash = "sha256-WSthRtK9IaRDDFEtGMUsQwylD+iGdsZM2vkXBjt8+mI=";
+    fetchSubmodules = true;
+  };
+
+  # bypass the broken parts of their bespoke python script cmake plugin
+  patches = [ ./find-nix-deps.patch ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail @shiboken6@ ${shiboken6} \
+      --replace-fail @pyside6@ ${pyside6}
+
+    # can't use pythonRelaxDepsHook because it runs postBuild but the dependency check
+    #  happens during build.
+    # -Essentials is a smaller version of PySide6, but the name mismatch breaks build
+    # _generator is also a virtual package with the same issue
+    substituteInPlace pyproject.toml \
+      --replace-warn 'PySide6-Essentials' "" \
+      --replace-warn 'shiboken6_generator' "" \
+      --replace-quiet '"",' "" \
+      --replace-quiet '""' ""
+  '';
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtquick3d
+  ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+
+  build-system = [
+    cmake-build-extension
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    pyside6
+    shiboken6
+  ];
+
+  # cmake-build-extension will configure
+  dontUseCmakeConfigure = true;
+
+  dontWrapQtApps = true;
+  # runtime deps check fails on the pyside6-essentials virtual package
+  dontCheckRuntimeDeps = true;
+
+  pythonImportsCheck = [ "PySide6QtAds" ];
+
+  meta = {
+    description = "Python bindings to Qt Advanced Docking System for PySide6";
+    homepage = "https://github.com/mborgerson/pyside6_qtads";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ scoder12 ];
+  };
+}

--- a/pkgs/development/python-modules/pyside6-qtads/find-nix-deps.patch
+++ b/pkgs/development/python-modules/pyside6-qtads/find-nix-deps.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0c0568a..f12d50e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -105,15 +105,17 @@ macro(pyside_config option output_var)
+ endmacro()
+ 
+ # Query for the shiboken generator path, Python path, include paths and linker flags.
++find_package(Shiboken6 REQUIRED)
++find_package(PySide6 REQUIRED)
+ pyside_config(--shiboken-module-path shiboken_module_path)
+-pyside_config(--shiboken-generator-path shiboken_generator_path)
+-pyside_config(--pyside-path pyside_path)
+-pyside_config(--pyside-include-path pyside_include_dir 1)
++set(shiboken_generator_path "" CACHE PATH "Path where shiboken6 executable can be found")
++set(pyside_path "" CACHE PATH "pyside share path, where typesystems dir can be found")
++get_target_property(pyside_include_dir PySide6::pyside6 INTERFACE_INCLUDE_DIRECTORIES)
+ pyside_config(--python-include-path python_include_dir)
+-pyside_config(--shiboken-generator-include-path shiboken_include_dir 1)
+-pyside_config(--shiboken-module-shared-libraries-cmake shiboken_shared_libraries 0)
++get_target_property(shiboken_include_dir Shiboken6::libshiboken INTERFACE_INCLUDE_DIRECTORIES)
++get_target_property(shiboken_shared_libraries Shiboken6::libshiboken IMPORTED_LOCATION_RELEASE)
+ pyside_config(--python-link-flags-cmake python_linking_data 0)
+-pyside_config(--pyside-shared-libraries-cmake pyside_shared_libraries 0)
++get_target_property(pyside_shared_libraries PySide6::pyside6 IMPORTED_LOCATION_RELEASE)
+ 
+ set(shiboken_path "${shiboken_generator_path}/shiboken6${CMAKE_EXECUTABLE_SUFFIX}")
+ if(NOT EXISTS ${shiboken_path})
+diff --git a/setup.py b/setup.py
+index 802821b..f522818 100644
+--- a/setup.py
++++ b/setup.py
+@@ -88,7 +88,9 @@ setuptools.setup(
+                 "-DBUILD_STATIC:BOOL=ON",
+                 "-DADS_VERSION=4.3.0",
+                 f"-DPython3_ROOT_DIR={Path(sys.prefix)}",
+-                f"-DPython_EXECUTABLE={Path(sys.executable)}"
++                f"-DPython_EXECUTABLE={Path(sys.executable)}",
++                "-Dshiboken_generator_path=@shiboken6@/bin",
++                "-Dpyside_path=@pyside6@/share/PySide6"
+             ],
+             py_limited_api=True
+         ),

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2522,6 +2522,8 @@ self: super: with self; {
 
   cmake = callPackage ../development/python-modules/cmake { inherit (pkgs) cmake; };
 
+  cmake-build-extension = callPackage ../development/python-modules/cmake-build-extension { };
+
   cmarkgfm = callPackage ../development/python-modules/cmarkgfm { };
 
   cmd2 = callPackage ../development/python-modules/cmd2 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -13011,6 +13011,8 @@ self: super: with self; {
     inherit (pkgs) cmake ninja;
   });
 
+  pyside6-qtads = callPackage ../development/python-modules/pyside6-qtads { };
+
   pysigma = callPackage ../development/python-modules/pysigma { };
 
   pysigma-backend-elasticsearch = callPackage ../development/python-modules/pysigma-backend-elasticsearch { };


### PR DESCRIPTION
Add the python library [pyside6-qtads](https://github.com/mborgerson/pyside6_qtads), pyside6 bindings for the Qt Advanced Docking System, and it build dependency. Motivation: pyside6-qtads is a dependency of [angr-management](https://github.com/angr/angr-management) and this PR is a spinoff from #360310.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
