### PR TITLE
formatjson5: fix missing_docs error

### DIFF
--- a/pkgs/by-name/fo/formatjson5/package.nix
+++ b/pkgs/by-name/fo/formatjson5/package.nix
@@ -5,6 +5,7 @@
   stdenv,
   darwin,
   nix-update-script,
+  fetchpatch,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -18,6 +19,13 @@ rustPlatform.buildRustPackage rec {
     rev = "056829990bab4ddc78c65a0b45215708c91b8628";
     hash = "sha256-Lredw/Fez+2U2++ShZcKTFCv8Qpai9YUvqvpGjG5W0o=";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/google/json5format/commit/32914546e7088b3d9173ae9a2f307effa87917bf.patch";
+      hash = "sha256-kAbRUL/FuhnxkC9Xo4J2bXt9nkMOLeJvgMmOoKnSxKc=";
+    })
+  ];
 
   cargoHash = "sha256-zPgaZPDyNVPmBXz6QwOYnmh/sbJ8aPST8znLMfIWejk=";
 


### PR DESCRIPTION
Rust 1.83 introduced changes to how `missing_docs` works. https://releases.rs/docs/1.83.0/

This commit introduces a patch from a PR made against the upstream source repository to fix the issue.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
