### PR TITLE
python3Packages.manga-ocr: 0.1.13 -> 0.1.14

### DIFF
--- a/pkgs/development/python-modules/manga-ocr/default.nix
+++ b/pkgs/development/python-modules/manga-ocr/default.nix
@@ -8,15 +8,14 @@ with python3Packages;
 
 buildPythonPackage rec {
   pname = "manga-ocr";
-  version = "0.1.13";
-  disabled = pythonOlder "3.7";
+  version = "0.1.14";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "kha-white";
     repo = "manga-ocr";
     tag = "v${version}";
-    hash = "sha256-0EwXDMnA9SCmSsMVXnMenSFSzs74lorFNNym9y/NNsI=";
+    hash = "sha256-fCLgFeo6GYPSpCX229TK2MXTKt3p1tQV06phZYD6UeE=";
   };
 
   build-system = [
@@ -37,15 +36,11 @@ buildPythonPackage rec {
     unidic-lite
   ];
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace-fail "numpy<2" "numpy"
-  '';
-
   meta = with lib; {
+    mainProgram = "manga_ocr";
     description = "Optical character recognition for Japanese text, with the main focus being Japanese manga";
     homepage = "https://github.com/kha-white/manga-ocr";
-    changelog = "https://github.com/kha-white/manga-ocr/releases/tag/${version}";
+    changelog = "https://github.com/kha-white/manga-ocr/releases/tag/v${version}";
     license = licenses.asl20;
     maintainers = with maintainers; [ laurent-f1z1 ];
   };


### PR DESCRIPTION
The numpy -> numpy2 change we added at build-time got incorperated upstream and released as a new version already, so switch to that.

I'm doing this by hand rather than relying on the dependency bot because we want to remove the postPatch I just added as well.

That's the only change in this release: https://github.com/kha-white/manga-ocr/compare/v0.1.13...v0.1.14

xref https://github.com/NixOS/nixpkgs/pull/369936, since the change there is upstreamed, we can effectively undo that.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [  ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
