### PR TITLE
chntpw: patch to build with gcc14

### DIFF
--- a/pkgs/by-name/ch/chntpw/package.nix
+++ b/pkgs/by-name/ch/chntpw/package.nix
@@ -58,6 +58,11 @@ stdenv.mkDerivation rec {
       url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/14_improve_description";
       sha256 = "11y5kc4dh4zv24nkb0jw2zwlifx6nzsd4jbizn63l6dbpqgb25rs";
     })
+    (fetchpatch {
+      name = "17_hexdump-pointer-type.patch";
+      url = "https://git.launchpad.net/ubuntu/+source/chntpw/plain/debian/patches/17_hexdump-pointer-type.patch?id=aed501c87499f403293e7b9f505277567c2f3b52";
+      sha256 = "sha256-ir9LFl8FJq141OwF5SbyVMtjQ1kTMH1NXlHl0XZq7m8=";
+    })
   ];
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

chntpw fails to build on gcc14 as follows.
There is a patch available for this on ubuntu that fixes it.
```
gcc -c -DUSEOPENSSL -g -I. -Wall libsam.c
libsam.c: In function 'sam_put_grp_members_sid':
libsam.c:514:28: error: passing argument 1 of 'hexdump' from incompatible pointer type [-Wincompatible-pointer-types]
  514 |      if (gverbose) hexdump(&c->data, 0, c->len, 1);
      |                            ^~~~~~~~
      |                            |
      |                            int *
In file included from libsam.c:47:
ntreg.h:394:20: note: expected 'char *' but argument is of type 'int *'
  394 | void hexdump(char *hbuf, int start, int stop, int ascii);
      |              ~~~~~~^~~~
libsam.c:531:56: warning: format '%x' expects argument of type 'unsigned int', but argument 4 has type 'void *' [-Wformat=]
  531 |       if (gverbose) printf("  copying : %d len %x, at %x\n",i,sarray[i].len, sidptr);
      |                                                       ~^                     ~~~~~~
      |                                                        |                     |
      |                                                        unsigned int          void *
      |                                                       %p
libsam.c:542:27: error: passing argument 1 of 'hexdump' from incompatible pointer type [-Wincompatible-pointer-types]
  542 |     if (gverbose) hexdump(&c->data, 0, c->len, 1);
      |                           ^~~~~~~~
      |                           |
      |                           int *
ntreg.h:394:20: note: expected 'char *' but argument is of type 'int *'
  394 | void hexdump(char *hbuf, int start, int stop, int ascii);
      |              ~~~~~~^~~~
make: *** [Makefile:55: libsam.o] Error 1
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] No release notes: Change is minor.

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
