### PR TITLE
protobuf: fix protoc used when cross-compiling

### DIFF
--- a/pkgs/applications/blockchains/monero-cli/default.nix
+++ b/pkgs/applications/blockchains/monero-cli/default.nix
@@ -23,7 +23,7 @@
   trezorSupport ? true,
   hidapi,
   libusb1,
-  protobuf_21,
+  protobuf,
   udev,
 }:
 
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
       python3
       hidapi
       libusb1
-      protobuf_21
+      protobuf
     ]
     ++ lib.optionals (trezorSupport && stdenv.hostPlatform.isLinux) [ udev ];
 
@@ -138,5 +138,7 @@ stdenv.mkDerivation rec {
       rnhmjoj
     ];
     mainProgram = "monero-wallet-cli";
+    # internal build tool generate_translations_header is tricky to compile for the build platform
+    broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
 }

--- a/pkgs/applications/blockchains/monero-gui/default.nix
+++ b/pkgs/applications/blockchains/monero-gui/default.nix
@@ -30,7 +30,7 @@
   trezorSupport ? true,
   hidapi,
   libusb1,
-  protobuf_21,
+  protobuf,
   python3,
   udev,
 }:
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals trezorSupport [
       hidapi
       libusb1
-      protobuf_21
+      protobuf
       python3
     ]
     ++ lib.optionals (trezorSupport && stdenv.hostPlatform.isLinux) [

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -12,7 +12,7 @@
 , glib
 , glog
 , gflags
-, protobuf_21
+, protobuf_29
 , config
 , ocl-icd
 , buildPackages
@@ -308,7 +308,7 @@ effectiveStdenv.mkDerivation {
     glib
     glog
     pcre2
-    protobuf_21
+    protobuf_29
     zlib
   ] ++ optionals enablePython [
     pythonPackages.python
@@ -419,7 +419,6 @@ effectiveStdenv.mkDerivation {
     (cmakeBool "OPENCV_GENERATE_PKGCONFIG" true)
     (cmakeBool "WITH_OPENMP" true)
     (cmakeBool "BUILD_PROTOBUF" false)
-    (cmakeOptionType "path" "Protobuf_PROTOC_EXECUTABLE" (getExe buildPackages.protobuf_21))
     (cmakeBool "PROTOBUF_UPDATE_FILES" true)
     (cmakeBool "OPENCV_ENABLE_NONFREE" enableUnfree)
     (cmakeBool "BUILD_TESTS" runAccuracyTests)

--- a/pkgs/development/libraries/protobuf/setup-hook.sh
+++ b/pkgs/development/libraries/protobuf/setup-hook.sh
@@ -1,0 +1,9 @@
+ProtobufCMakeFlags() {
+  cmakeFlagsArray+=(
+    -DPROTOC_EXE="@build_protobuf@/bin/protoc"
+    -DProtobuf_PROTOC_EXE="@build_protobuf@/bin/protoc"
+    -DProtobuf_PROTOC_EXECUTABLE="@build_protobuf@/bin/protoc"
+  )
+}
+
+preConfigureHooks+=(ProtobufCMakeFlags)


### PR DESCRIPTION
This basically inlines the fix applied in most consumers of protobuf.

OpenCV 4 derivation is simplified to automatically use the right protoc. (It didn't work before anyhow.)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux: `pkgsCross.aarch64-multiplatform.protobuf_{21,23,24,25,26,27,28}` `pkgsCross.aarch64-multiplatform.opencv4` builds
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc