### PR TITLE
vectorscan: fix cross-compile

### DIFF
--- a/pkgs/by-name/ve/vectorscan/package.nix
+++ b/pkgs/by-name/ve/vectorscan/package.nix
@@ -23,6 +23,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-wz2oIhau/vjnri3LOyPZSCFAWg694FTLVt7+SZYEsL4=";
   };
 
+  postPatch = ''
+    substituteInPlace cmake/build_wrapper.sh \
+      --replace-fail 'nm' '${stdenv.cc.targetPrefix}nm' \
+      --replace-fail 'objcopy' '${stdenv.cc.targetPrefix}objcopy'
+  '';
+
   nativeBuildInputs = [
     cmake
     pkg-config


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: regular and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).