### PR TITLE
singular, gfan: fix the same clang-19 error 

### DIFF
--- a/pkgs/by-name/gf/gfan/package.nix
+++ b/pkgs/by-name/gf/gfan/package.nix
@@ -19,6 +19,14 @@ stdenv.mkDerivation rec {
   patches =
     [
       ./gfan-0.6.2-cddlib-prefix.patch
+      (fetchpatch {
+        # removes dead code with invalid member reference in gfanlib
+        name = "clang-19.patch";
+        url = "https://github.com/Singular/Singular/commit/d3f73432d73ac0dd041af83cb35301498e9b57d9.patch";
+        stripLen = 2;
+        extraPrefix = "src/";
+        hash = "sha256-jPGMYx/GOFV7Tk3CqaRWeX/UHkzjeL57eZj4r40s8/g=";
+      })
     ]
     ++ lib.optionals (stdenv.cc.isClang) [
       (fetchpatch {

--- a/pkgs/by-name/si/singular/package.nix
+++ b/pkgs/by-name/si/singular/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   gmp,
   bison,
   perl,
@@ -47,6 +48,15 @@ stdenv.mkDerivation rec {
     # not included in the tarball downloaded by fetchzip.
     forceFetchGit = true;
   };
+
+  patches = [
+    (fetchpatch {
+      # removes dead code with invalid member reference in gfanlib
+      name = "clang-19.patch";
+      url = "https://github.com/Singular/Singular/commit/d3f73432d73ac0dd041af83cb35301498e9b57d9.patch";
+      hash = "sha256-1KOk+yrTvHWY4aSK9QcByHIwKwe71QIYTMx8zo7XNos=";
+    })
+  ];
 
   configureFlags =
     [
@@ -173,6 +183,7 @@ stdenv.mkDerivation rec {
   '';
 
   enableParallelBuilding = true;
+  __darwinAllowLocalNetworking = true;
 
   meta = with lib; {
     description = "CAS for polynomial computations";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

applies https://github.com/Singular/Singular/commit/d3f73432d73ac0dd041af83cb35301498e9b57d9 to remove dead code that tries to access a non-existent member.

note: singular is still broken on darwin but will be fixed in an upcoming PR to remove `@rpath/libname.dylib` from the libs in gfortran. another workaround could probably be removing `-flat_namespace` from it's link step but I haven't full tested it.

https://hydra.nixos.org/build/282808358


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
