### PR TITLE
rocmPackages.llvm.clang: remove -nostdlibinc flag

### DIFF
--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -639,7 +639,7 @@ stdenvNoCC.mkDerivation {
     # no `/usr/include`, there’s essentially no risk to dropping
     # the flag there. See discussion in NixOS/nixpkgs#191152.
     #
-    + optionalString ((cc.isClang or false) && !targetPlatform.isDarwin) ''
+    + optionalString ((cc.isClang or false) && !(cc.isROCm or false) && !targetPlatform.isDarwin) ''
       echo " -nostdlibinc" >> $out/nix-support/cc-cflags
     ''
 

--- a/pkgs/development/rocm-modules/5/llvm/base.nix
+++ b/pkgs/development/rocm-modules/5/llvm/base.nix
@@ -180,6 +180,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     isLLVM = targetDir == "llvm";
     isClang = targetDir == "clang" || builtins.elem "clang" targetProjects;
+    isROCm = true;
 
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;

--- a/pkgs/development/rocm-modules/5/llvm/stage-3/clang.nix
+++ b/pkgs/development/rocm-modules/5/llvm/stage-3/clang.nix
@@ -40,7 +40,10 @@ wrapCCWith rec {
     '';
 
     passthru.isClang = true;
+    passthru.isROCm = true;
   });
+
+  gccForLibs = stdenv.cc.cc;
 
   extraPackages = [
     llvm

--- a/pkgs/development/rocm-modules/6/llvm/base.nix
+++ b/pkgs/development/rocm-modules/6/llvm/base.nix
@@ -188,6 +188,7 @@ stdenv.mkDerivation (finalAttrs: {
   passthru = {
     isLLVM = targetDir == "llvm";
     isClang = targetDir == "clang" || builtins.elem "clang" targetProjects;
+    isROCm = true;
 
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;

--- a/pkgs/development/rocm-modules/6/llvm/stage-3/clang.nix
+++ b/pkgs/development/rocm-modules/6/llvm/stage-3/clang.nix
@@ -40,7 +40,10 @@ wrapCCWith rec {
     '';
 
     passthru.isClang = true;
+    passthru.isROCm = true;
   });
+
+  gccForLibs = stdenv.cc.cc;
 
   extraPackages = [
     llvm


### PR DESCRIPTION
As reported in #368672, `rocmPackages.llvm.libc` fails to build. The proximate cause is #356162, but I think it just revealed a problem with the rocm package. More specifically, there seems to be something fishy in

https://github.com/NixOS/nixpkgs/blob/4f0dadbf38ee4cf4cc38cbc232b7708fddf965bc/pkgs/development/rocm-modules/6/llvm/stage-2/rstdenv.nix#L14

I think `libcxx-cxxflags` only gets populated in the wrapper if `libcxx` is null or `lib.isLLVM` is true...

https://github.com/NixOS/nixpkgs/blob/4f0dadbf38ee4cf4cc38cbc232b7708fddf965bc/pkgs/build-support/cc-wrapper/default.nix#L588-L599

...but `runtimes` is neither:

https://github.com/NixOS/nixpkgs/blob/4f0dadbf38ee4cf4cc38cbc232b7708fddf965bc/pkgs/development/rocm-modules/6/llvm/stage-1/runtimes.nix#L1-L32

Since nothing ROCm-related builds at the moment, this PR adds a minimal workaround, namely hackily removing `-nostdlibinc` from `nix-support/cc-cflags`. Turns out the gcc 14 update also caused a different libstdc++ version to be used in ROCm's wrapped Clang, so we now also pass `gccForLibs` explicitly. 

cc @emilazy @LunNova (because of #367695) @NixOS/rocm-maintainers

Fixes #368672, fixes #369433

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
