### PR TITLE
mattermost-desktop: 5.9.0 -> 5.10.2; build from source

### DIFF
--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -71,6 +71,9 @@ stdenv.mkDerivation {
       "x86_64-linux"
       "aarch64-linux"
     ];
-    maintainers = [ maintainers.joko ];
+    maintainers = with lib.maintainers; [
+      joko
+      liff
+    ];
   };
 }

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -9,17 +9,17 @@
 let
 
   pname = "mattermost-desktop";
-  version = "5.9.0";
+  version = "5.10.2";
 
   srcs = {
     "x86_64-linux" = {
       url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
-      hash = "sha256-zLKdfu5p7TyJOw8vJX7i/uu4j0PrUf2/BDmb1kdqqMc=";
+      hash = "sha256-MSV5ias643eYKmJlJInCuNA2hnaDRv+3c7x4xxZI7Z4=";
     };
 
     "aarch64-linux" = {
       url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-arm64.tar.gz";
-      hash = "sha256-JljK7d4KLAn1+NwF+VcedL/7hEsp/9LzLdzROa1fgJA=";
+      hash = "sha256-vuUn7LWs970o1S1CmW3uMiE0Y8XpP0eVtoC2NP13R8w=";
     };
   };
 

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -65,6 +65,7 @@ stdenv.mkDerivation {
     description = "Mattermost Desktop client";
     mainProgram = "mattermost-desktop";
     homepage = "https://about.mattermost.com/";
+    changelog = "https://github.com/mattermost/desktop/releases/tag/${src.tag}";
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
     license = licenses.asl20;
     platforms = [

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -4,6 +4,8 @@
   fetchurl,
   electron,
   makeWrapper,
+  testers,
+  mattermost-desktop,
 }:
 
 let
@@ -60,6 +62,14 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  passthru = {
+    tests.version = testers.testVersion {
+      package = mattermost-desktop;
+      # Invoking with `--version` insists on being able to write to a log file.
+      command = "env HOME=/tmp ${mattermost-desktop.meta.mainProgram} --version";
+    };
+  };
 
   meta = with lib; {
     description = "Mattermost Desktop client";

--- a/pkgs/by-name/ma/mattermost-desktop/package.nix
+++ b/pkgs/by-name/ma/mattermost-desktop/package.nix
@@ -1,59 +1,72 @@
 {
   lib,
-  stdenv,
-  fetchurl,
+  fetchFromGitHub,
+  buildNpmPackage,
   electron,
   makeWrapper,
   testers,
   mattermost-desktop,
+  nix-update-script,
 }:
 
-let
-
+buildNpmPackage rec {
   pname = "mattermost-desktop";
   version = "5.10.2";
 
-  srcs = {
-    "x86_64-linux" = {
-      url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-x64.tar.gz";
-      hash = "sha256-MSV5ias643eYKmJlJInCuNA2hnaDRv+3c7x4xxZI7Z4=";
-    };
-
-    "aarch64-linux" = {
-      url = "https://releases.mattermost.com/desktop/${version}/${pname}-${version}-linux-arm64.tar.gz";
-      hash = "sha256-vuUn7LWs970o1S1CmW3uMiE0Y8XpP0eVtoC2NP13R8w=";
-    };
+  src = fetchFromGitHub {
+    owner = "mattermost";
+    repo = "desktop";
+    tag = "v${version}";
+    hash = "sha256-LHjVmrsOdk8vfsqvNEWkzpusm6jbz3SOb3bEaIb7rb4=";
   };
 
-  inherit (stdenv.hostPlatform) system;
-
-in
-
-stdenv.mkDerivation {
-  inherit pname version;
-
-  src = fetchurl (srcs."${system}" or (throw "Unsupported system ${system}"));
+  npmDepsHash = "sha256-LAbqsMdMmmHGgvg2ilz6neQxMOK3jtCKt8K0M8BWifs=";
+  npmBuildScript = "build-prod";
+  makeCacheWritable = true;
 
   nativeBuildInputs = [ makeWrapper ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  postPatch = ''
+    substituteInPlace webpack.config.base.js \
+      --replace-fail \
+        "const VERSION = childProcess.execSync('git rev-parse --short HEAD', {cwd: __dirname}).toString();" \
+        "const VERSION = process.env.version;"
+  '';
+
+  postBuild = ''
+    # electronDist needs to be writable
+    cp -r ${electron.dist} electron-dist
+    chmod -R u+w electron-dist
+
+    npm exec electron-builder -- \
+        --config electron-builder.json \
+        --dir \
+        -c.electronDist=electron-dist \
+        -c.electronVersion=${electron.version}
+  '';
 
   installPhase = ''
     runHook preInstall
 
-    # Mattermost tarball comes with executable bit set for everything.
-    # We’ll apply it only to files that need it.
-    find . -type f -print0 | xargs -0 chmod -x
-    find . -type f \( -name '*.so.*' -o -name '*.s[oh]' \) -print0 | xargs -0 chmod +x
-    chmod +x mattermost-desktop chrome-sandbox
+    mkdir --parents \
+      $out/bin \
+      $out/share/applications \
+      $out/share/icons/hicolor/512x512/apps
 
-    mkdir -p $out/bin $out/share/applications $out/share/${pname}/
-    cp -r app_icon.png create_desktop_file.sh locales/ resources/* $out/share/${pname}/
+    readonly dist=release/linux-unpacked
 
-    patchShebangs $out/share/${pname}/create_desktop_file.sh
-    $out/share/${pname}/create_desktop_file.sh
-    rm $out/share/${pname}/create_desktop_file.sh
-    mv Mattermost.desktop $out/share/applications/Mattermost.desktop
+    cp -a $dist/resources $out/share/${pname}
+
+    patchShebangs $dist/create_desktop_file.sh
+    $dist/create_desktop_file.sh
+    mv Mattermost.desktop $out/share/applications/
     substituteInPlace $out/share/applications/Mattermost.desktop \
-      --replace /share/mattermost-desktop/mattermost-desktop /bin/mattermost-desktop
+      --replace-fail /build/source/$dist/app_icon.png ${pname} \
+      --replace-fail /build/source/$dist/ $out/bin/
+
+    cp src/assets/linux/app_icon.png $out/share/icons/hicolor/512x512/apps/${pname}.png
 
     makeWrapper '${lib.getExe electron}' $out/bin/${pname} \
       --set-default ELECTRON_IS_DEV 0 \
@@ -67,21 +80,18 @@ stdenv.mkDerivation {
     tests.version = testers.testVersion {
       package = mattermost-desktop;
       # Invoking with `--version` insists on being able to write to a log file.
-      command = "env HOME=/tmp ${mattermost-desktop.meta.mainProgram} --version";
+      command = "env HOME=/tmp ${meta.mainProgram} --version";
     };
+    updateScript = nix-update-script { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "Mattermost Desktop client";
     mainProgram = "mattermost-desktop";
     homepage = "https://about.mattermost.com/";
     changelog = "https://github.com/mattermost/desktop/releases/tag/${src.tag}";
-    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
-    license = licenses.asl20;
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+    license = lib.licenses.asl20;
+    platforms = electron.meta.platforms;
     maintainers = with lib.maintainers; [
       joko
       liff


### PR DESCRIPTION
Change the mattermost-desktop package to build from upstream sources.

Uses electron from nixpkgs, like some other electron-based applications.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
