### PR TITLE
nerd-fonts: fix and improve pname, version and license handling

### DIFF
--- a/pkgs/data/fonts/nerd-fonts/default.nix
+++ b/pkgs/data/fonts/nerd-fonts/default.nix
@@ -14,10 +14,10 @@ let
     let
       lowerName = lib.strings.toLower name;
     in
-    if builtins.match "[[:digit:]].*" lowerName != null then "_" + lowerName else lowerName;
+    if builtins.match "^[[:digit:]].*" lowerName != null then "_" + lowerName else lowerName;
 
   convertVersion =
-    version: if builtins.match "[[:digit:]].*" version != null then "+" + version else "";
+    version: if builtins.match "^[[:digit:]].*" version != null then "+" + version else "";
 
   convertLicense = import ./convert-license.nix lib;
 

--- a/pkgs/data/fonts/nerd-fonts/default.nix
+++ b/pkgs/data/fonts/nerd-fonts/default.nix
@@ -9,6 +9,8 @@ let
   fontsInfo = lib.trivial.importJSON ./manifests/fonts.json;
   checksums = lib.trivial.importJSON ./manifests/checksums.json;
 
+  releaseVersion = lib.removePrefix "v" releaseInfo.tag_name;
+
   convertAttrName =
     name:
     let
@@ -33,7 +35,7 @@ let
     }:
     stdenvNoCC.mkDerivation {
       pname = "nerd-fonts-" + lib.strings.toLower caskName;
-      version = (lib.removePrefix "v" releaseInfo.tag_name) + convertVersion version;
+      version = releaseVersion + convertVersion version;
 
       src =
         let
@@ -63,9 +65,12 @@ let
           runHook postInstall
         '';
 
-      passthru.updateScript = {
-        command = ./update.py;
-        supportedFeatures = [ "commit" ];
+      passthru = {
+        inherit releaseVersion;
+        updateScript = {
+          command = ./update.py;
+          supportedFeatures = [ "commit" ];
+        };
       };
 
       meta = {

--- a/pkgs/data/fonts/nerd-fonts/manifests/release.json
+++ b/pkgs/data/fonts/nerd-fonts/manifests/release.json
@@ -1,4 +1,3 @@
 {
-  "tag_name": "v3.3.0",
-  "published_at": "2024-11-18T12:43:12Z"
+  "tag_name": "v3.3.0"
 }

--- a/pkgs/data/fonts/nerd-fonts/update.py
+++ b/pkgs/data/fonts/nerd-fonts/update.py
@@ -40,7 +40,7 @@ os.chdir(os.path.join(os.path.dirname(os.path.abspath(__file__)), "manifests"))
 
 release_info = slicedict(
     fetchjson(RELEASE_INFO_URL),
-    ["tag_name", "published_at"]
+    ["tag_name"]
 )
 
 tag_name = release_info["tag_name"]


### PR DESCRIPTION
Fix #370117.

- package name: prepend "nerd-fonts-".
- version: prepend the version of Nerd Fonts release, and discard the release-date version when the version of the font itself is absent.
- license: prepend the licenses of Nerd Fonts to those of the original fonts.
- `passthru`: add `releaseVersion`, the version of Nerd Fonts release.

Also fix the bug in attribute name and version handling.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@doronbehar