### PR TITLE
beets: fix building in 2025

### DIFF
--- a/pkgs/tools/audio/beets/default.nix
+++ b/pkgs/tools/audio/beets/default.nix
@@ -3,6 +3,7 @@
   callPackage,
   fetchFromGitHub,
   python3Packages,
+  fetchpatch,
 }:
 /*
   ** To customize the enabled beets plugins, use the pluginOverrides input to the
@@ -17,11 +18,22 @@
   **   alternatives = { enable = true; propagatedBuildInputs = [ beetsPackages.alternatives ]; };
   ** }; }
 */
+let
+  extraPatches = [
+    # Bash completion fix for Nix
+    ./patches/bash-completion-always-print.patch
+    # Remove after next release.
+    (fetchpatch {
+      url = "https://github.com/beetbox/beets/commit/bcc79a5b09225050ce7c88f63dfa56f49f8782a8.patch?full_index=1";
+      hash = "sha256-Y2Q5Co3UlDGKuzfxUvdUY3rSMNpsBoDW03ZWZOfzp3Y=";
+    })
+  ];
+in
 lib.makeExtensible (self: {
   beets = self.beets-stable;
 
   beets-stable = callPackage ./common.nix rec {
-    inherit python3Packages;
+    inherit python3Packages extraPatches;
     version = "2.2.0";
     src = fetchFromGitHub {
       owner = "beetbox";
@@ -29,16 +41,12 @@ lib.makeExtensible (self: {
       rev = "v${version}";
       hash = "sha256-jhwXRgUUQJgQ/PLwvY1UfHCJ9UC8DcdBpE/janao0RM=";
     };
-    extraPatches = [
-      # Bash completion fix for Nix
-      ./patches/bash-completion-always-print.patch
-    ];
   };
 
   beets-minimal = self.beets.override { disableAllPlugins = true; };
 
   beets-unstable = callPackage ./common.nix {
-    inherit python3Packages;
+    inherit python3Packages extraPatches;
     version = "2.2.0-unstable-2024-12-02";
     src = fetchFromGitHub {
       owner = "beetbox";
@@ -46,10 +54,6 @@ lib.makeExtensible (self: {
       rev = "f92c0ec8b14fbd59e58374fd123563123aef197b";
       hash = "sha256-jhwXRgUUQJgQ/PLwvY1UfHCJ9UC8DcdBpE/janao0RM=";
     };
-    extraPatches = [
-      # Bash completion fix for Nix
-      ./patches/bash-completion-always-print.patch
-    ];
   };
 
   alternatives = callPackage ./plugins/alternatives.nix { beets = self.beets-minimal; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`BucketPluginTest.test_year_single_year_last_folder` assumed the next year is 2025, which is no longer true. https://github.com/beetbox/beets/pull/5566 fixes this but there hasn't been a release since.

Fixes #370204.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
