### PR TITLE
emacsPackages.copilot: bump and fix

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
@@ -4,9 +4,11 @@
   editorconfig,
   f,
   fetchFromGitHub,
+  replaceVars,
   nodejs,
   s,
   melpaBuild,
+  copilot-node-server,
 }:
 melpaBuild {
   pname = "copilot";
@@ -21,6 +23,11 @@ melpaBuild {
 
   files = ''(:defaults "dist")'';
 
+  patches = [
+    (replaceVars ./specify-copilot-install-dir.patch {
+      copilot-node-server = copilot-node-server;
+    })
+  ];
   packageRequires = [
     dash
     editorconfig

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
@@ -10,13 +10,13 @@
 }:
 melpaBuild {
   pname = "copilot";
-  version = "0-unstable-2024-05-01";
+  version = "0-unstable-2024-12-28";
 
   src = fetchFromGitHub {
     owner = "copilot-emacs";
     repo = "copilot.el";
-    rev = "733bff26450255e092c10873580e9abfed8a81b8";
-    sha256 = "sha256-Knp36PtgA73gtYO+W1clQfr570bKCxTFsGW3/iH86A0=";
+    rev = "c5dfa99f05878db5e6a6a378dc7ed09f11e803d4";
+    sha256 = "sha256-FzI08AW7a7AleEM7kSQ8LsWsDYID8SW1SmSN6/mIB/A=";
   };
 
   files = ''(:defaults "dist")'';

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/package.nix
@@ -10,6 +10,20 @@
   melpaBuild,
   copilot-node-server,
 }:
+let
+  # The Emacs package isn't compatible with the latest
+  # copilot-node-server so we have to set a specific revision
+  # https://github.com/copilot-emacs/copilot.el/issues/344
+  pinned-copilot-node-server = copilot-node-server.overrideAttrs (old: rec {
+    version = "1.27.0";
+    src = fetchFromGitHub {
+      owner = "jfcherng";
+      repo = "copilot-node-server";
+      rev = version;
+      hash = "sha256-Ds2agoO7LBXI2M1dwvifQyYJ3F9fm9eV2Kmm7WITgyo=";
+    };
+  });
+in
 melpaBuild {
   pname = "copilot";
   version = "0-unstable-2024-12-28";
@@ -25,7 +39,7 @@ melpaBuild {
 
   patches = [
     (replaceVars ./specify-copilot-install-dir.patch {
-      copilot-node-server = copilot-node-server;
+      copilot-node-server = pinned-copilot-node-server;
     })
   ];
   packageRequires = [

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/specify-copilot-install-dir.patch
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/copilot/specify-copilot-install-dir.patch
@@ -1,0 +1,14 @@
+diff --git a/copilot.el b/copilot.el
+index f1f5e51..ddf2b5b 100644
+--- a/copilot.el
++++ b/copilot.el
+@@ -132,8 +132,7 @@ (defcustom copilot-indentation-alist
+ (defconst copilot-server-package-name "copilot-node-server"
+   "The name of the package to install copilot server.")
+ 
+-(defcustom copilot-install-dir (expand-file-name
+-                                (locate-user-emacs-file (f-join ".cache" "copilot")))
++(defcustom copilot-install-dir "@copilot-node-server@"
+   "Directory in which the servers will be installed."
+   :risky t
+   :type 'directory


### PR DESCRIPTION
- Bump to the latest version
- Use fixed version of copilot-node-server from nix

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc