### PR TITLE
boost: Split python module into separate derivation

### DIFF
--- a/pkgs/applications/science/misc/gplates/default.nix
+++ b/pkgs/applications/science/misc/gplates/default.nix
@@ -28,13 +28,6 @@ let
       numpy
     ]
   );
-  boost' = boost.override {
-    enablePython = true;
-    inherit python;
-  };
-  cgal' = cgal.override {
-    boost = boost';
-  };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gplates";
@@ -63,8 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost'
-    cgal'
+    (boost.withPython python3)
+    cgal
     gdal
     glew
     gmp

--- a/pkgs/by-name/an/antimony/package.nix
+++ b/pkgs/by-name/an/antimony/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation {
   buildInputs = [
     libpng
     python3
-    python3.pkgs.boost
+    python3.pkgs.boost-python
     libGLU
     libGL
     libsForQt5.qtbase

--- a/pkgs/by-name/ba/banana-vera/package.nix
+++ b/pkgs/by-name/ba/banana-vera/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [ cmake ];
   buildInputs = [
     python310
-    python310.pkgs.boost
+    python310.pkgs.boost-python
     tcl
   ];
 

--- a/pkgs/by-name/ba/banana-vera/package.nix
+++ b/pkgs/by-name/ba/banana-vera/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  python310,
+  python311,
   tcl,
 }:
 
@@ -20,8 +20,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [ cmake ];
   buildInputs = [
-    python310
-    python310.pkgs.boost-python
+    python311
+    python311.pkgs.boost-python
     tcl
   ];
 

--- a/pkgs/by-name/co/coal/package.nix
+++ b/pkgs/by-name/co/coal/package.nix
@@ -41,17 +41,15 @@ stdenv.mkDerivation (finalAttrs: {
   propagatedBuildInputs =
     [
       assimp
+      boost
+      eigen
       jrl-cmakemodules
       octomap
       qhull
       zlib
     ]
-    ++ lib.optionals (!pythonSupport) [
-      boost
-      eigen
-    ]
     ++ lib.optionals pythonSupport [
-      python3Packages.boost
+      python3Packages.boost-python
       python3Packages.eigenpy
     ];
 

--- a/pkgs/by-name/fr/freecad/package.nix
+++ b/pkgs/by-name/fr/freecad/package.nix
@@ -35,7 +35,7 @@
 }:
 let
   pythonDeps = with python3Packages; [
-    boost
+    boost-python
     gitpython # for addon manager
     ifcopenshell
     matplotlib

--- a/pkgs/by-name/fr/freeorion/package.nix
+++ b/pkgs/by-name/fr/freeorion/package.nix
@@ -37,11 +37,8 @@ stdenv.mkDerivation {
   };
 
   buildInputs = [
-    (boost.override {
-      enablePython = true;
-      python = python3;
-    })
     (python3.withPackages (p: with p; [ pycodestyle ]))
+    (boost.withPython python3)
     SDL2
     freetype
     glew

--- a/pkgs/by-name/ge/geant4/package.nix
+++ b/pkgs/by-name/ge/geant4/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchurl,
   callPackage,
-  boost,
   clhep,
   cmake,
   coin3d,
@@ -26,16 +25,9 @@
   enableQt ? false,
   enableXM ? false,
   enableOpenGLX11 ? !stdenv.hostPlatform.isDarwin,
-  enablePython ? false,
+  enablePython ? true,
   enableRaytracerX11 ? false,
 }:
-
-let
-  boost_python = boost.override {
-    enablePython = true;
-    python = python3;
-  };
-in
 
 stdenv.mkDerivation rec {
   version = "11.3.2";
@@ -98,8 +90,8 @@ stdenv.mkDerivation rec {
       motif
     ]
     ++ lib.optionals enablePython [
-      boost_python
       python3
+      python3.pkgs.boost-python
     ];
 
   propagatedBuildInputs =

--- a/pkgs/by-name/ge/gepetto-viewer-corba/package.nix
+++ b/pkgs/by-name/ge/gepetto-viewer-corba/package.nix
@@ -1,10 +1,8 @@
 {
-  boost,
   cmake,
   doxygen,
   fetchFromGitHub,
   fontconfig,
-  gepetto-viewer,
   lib,
   pkg-config,
   python3Packages,
@@ -39,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   propagatedBuildInputs = [
-    python3Packages.boost
+    python3Packages.boost-python
     python3Packages.gepetto-viewer
     python3Packages.omniorbpy
   ];

--- a/pkgs/by-name/ge/gepetto-viewer/package.nix
+++ b/pkgs/by-name/ge/gepetto-viewer/package.nix
@@ -1,5 +1,4 @@
 {
-  boost,
   cmake,
   darwin,
   doxygen,
@@ -42,7 +41,7 @@ let
     ];
 
     buildInputs = [
-      python3Packages.boost
+      python3Packages.boost-python
       python3Packages.python-qt
       libsForQt5.qtbase
     ];

--- a/pkgs/by-name/gl/glom/package.nix
+++ b/pkgs/by-name/gl/glom/package.nix
@@ -13,14 +13,12 @@
   graphviz,
   makeFontsConf,
   freefont_ttf,
-  boost,
   libxmlxx3,
   libxslt,
   libgdamm,
   libarchive,
   libepc,
   python311,
-  python3,
   ncurses,
   glibmm,
   gtk3,
@@ -66,8 +64,6 @@ stdenv.mkDerivation (finalAttrs: {
     ]
   );
 
-  python_boost = python311.withPackages (pkgs: with pkgs; [ pygobject3 ]);
-
   sphinx-build = python311.pkgs.sphinx.overrideAttrs (super: {
     postFixup =
       super.postFixup or ""
@@ -76,11 +72,6 @@ stdenv.mkDerivation (finalAttrs: {
         rm $out/nix-support/propagated-build-inputs
       '';
   });
-
-  boost_python = boost.override {
-    enablePython = true;
-    python = finalAttrs.python_boost;
-  };
 
   nativeBuildInputs = [
     pkg-config
@@ -101,12 +92,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    finalAttrs.boost_python
     glibmm
     gtk3
     openssl
     libxmlxx3
     libxslt
+    python311.pkgs.boost-python
     python311.pkgs.pygobject3
     finalAttrs.gda
     libarchive

--- a/pkgs/by-name/le/ledger/package.nix
+++ b/pkgs/by-name/le/ledger/package.nix
@@ -58,6 +58,7 @@ stdenv.mkDerivation rec {
 
   buildInputs =
     [
+      boost
       gmp
       mpfr
       libedit
@@ -66,18 +67,10 @@ stdenv.mkDerivation rec {
     ++ lib.optionals gpgmeSupport [
       gpgme
     ]
-    ++ (
-      if usePython then
-        [
-          python3
-          (boost.override {
-            enablePython = true;
-            python = python3;
-          })
-        ]
-      else
-        [ boost ]
-    );
+    ++ lib.optionals usePython [
+      python3
+      python3.pkgs.boost-python
+    ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/li/libtorrent-rasterbar-1_2_x/package.nix
+++ b/pkgs/by-name/li/libtorrent-rasterbar-1_2_x/package.nix
@@ -16,20 +16,6 @@
 let
   version = "1.2.19";
 
-  # Make sure we override python, so the correct version is chosen
-  # for the bindings, if overridden
-  boostPython = boost186.override (_: {
-    enablePython = true;
-    python = python311;
-    enableStatic = true;
-    enableShared = false;
-    enableSingleThreaded = false;
-    enableMultiThreaded = true;
-    # So that libraries will be named like 'libboost_system.a' instead
-    # of 'libboost_system-x64.a'.
-    taggedLayout = false;
-  });
-
   opensslStatic = openssl.override (_: {
     static = true;
   });
@@ -43,7 +29,7 @@ stdenv.mkDerivation {
     owner = "arvidn";
     repo = "libtorrent";
     rev = "v${version}";
-    hash = "sha256-HkpaOCBL+0Kc7M9DmnW2dUGC+b60a7n5n3i1SyRfkb4=";
+    hash = "sha256-KxyJmG7PdOjGPe18Dd3nzKI5X7B0MovWN8vq7llFFRc=";
   };
 
   enableParallelBuilding = true;
@@ -56,7 +42,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    boostPython
+    (boost186.withPython python311)
     opensslStatic
     zlib
     python311
@@ -87,8 +73,8 @@ stdenv.mkDerivation {
   configureFlags = [
     "--enable-python-binding"
     "--with-libiconv=yes"
-    "--with-boost=${boostPython.dev}"
-    "--with-boost-libdir=${boostPython.out}/lib"
+    "--with-boost=${lib.getDev boost186}"
+    "--with-boost-libdir=${boost186.withPython python311}/lib"
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
+++ b/pkgs/by-name/li/libtorrent-rasterbar-2_0_x/package.nix
@@ -10,24 +10,14 @@
   ncurses,
 }:
 
-let
-  version = "2.0.11";
-
-  # Make sure we override python, so the correct version is chosen
-  boostPython = boost.override {
-    enablePython = true;
-    python = python3;
-  };
-
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libtorrent-rasterbar";
-  inherit version;
+  version = "2.0.11";
 
   src = fetchFromGitHub {
     owner = "arvidn";
     repo = "libtorrent";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-iph42iFEwP+lCWNPiOJJOejISFF6iwkGLY9Qg8J4tyo=";
     fetchSubmodules = true;
   };
@@ -38,7 +28,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    boostPython
+    (boost.withPython python3)
     openssl
   ];
 
@@ -86,4 +76,4 @@ stdenv.mkDerivation {
     maintainers = [ ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ne/nextpnr/package.nix
+++ b/pkgs/by-name/ne/nextpnr/package.nix
@@ -6,7 +6,6 @@
   boost,
   python3,
   eigen,
-  python3Packages,
   icestorm,
   trellis,
   llvmPackages,
@@ -17,11 +16,6 @@
 }:
 
 let
-  boostPython = boost.override {
-    python = python3;
-    enablePython = true;
-  };
-
   pname = "nextpnr";
   version = "0.8";
 
@@ -57,9 +51,9 @@ stdenv.mkDerivation rec {
   ] ++ (lib.optional enableGui wrapQtAppsHook);
   buildInputs =
     [
-      boostPython
+      boost
       eigen
-      python3Packages.apycula
+      python3.pkgs.apycula
     ]
     ++ (lib.optional enableGui qtbase)
     ++ (lib.optional stdenv.cc.isClang llvmPackages.openmp);
@@ -78,7 +72,7 @@ stdenv.mkDerivation rec {
       "-DICESTORM_INSTALL_PREFIX=${icestorm}"
       "-DTRELLIS_INSTALL_PREFIX=${trellis}"
       "-DTRELLIS_LIBDIR=${trellis}/lib/trellis"
-      "-DGOWIN_BBA_EXECUTABLE=${python3Packages.apycula}/bin/gowin_bba"
+      "-DGOWIN_BBA_EXECUTABLE=${python3.pkgs.apycula}/bin/gowin_bba"
       "-DUSE_OPENMP=ON"
       "-DHIMBAECHEL_UARCH=all"
       "-DHIMBAECHEL_GOWIN_DEVICES=all"

--- a/pkgs/by-name/pi/pinocchio/package.nix
+++ b/pkgs/by-name/pi/pinocchio/package.nix
@@ -69,17 +69,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   propagatedBuildInputs =
     [
+      boost
       console-bridge
+      eigen
       jrl-cmakemodules
       urdfdom
     ]
-    ++ lib.optionals (!pythonSupport) [
-      boost
-      eigen
-    ]
     ++ lib.optionals (!pythonSupport && collisionSupport) [ coal ]
     ++ lib.optionals pythonSupport [
-      python3Packages.boost
+      python3Packages.boost-python
       python3Packages.eigenpy
     ]
     ++ lib.optionals (pythonSupport && collisionSupport) [ python3Packages.coal ]

--- a/pkgs/by-name/yo/yosys/package.nix
+++ b/pkgs/by-name/yo/yosys/package.nix
@@ -9,6 +9,7 @@
   pkg-config,
 
   # propagatedBuildInputs
+  boost,
   libffi,
   python3,
   readline,
@@ -126,9 +127,9 @@ stdenv.mkDerivation (finalAttrs: {
           click
         ]
       ))
-    ]
-    ++ lib.optionals enablePython [
-      python3.pkgs.boost
+    ] ++ lib.optionals enablePython  [
+      boost
+      (boost.pythonLib python3)
     ];
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -6,13 +6,14 @@
   bzip2,
   zstd,
   xz,
-  python ? null,
   fixDarwinDylibNames,
   libiconv,
-  libxcrypt,
   sanitiseHeaderPathsHook,
   makePkgconfigItem,
   copyPkgconfigItems,
+  callPackage,
+  runCommandLocal,
+  lndir,
   boost-build,
   fetchpatch,
   which,
@@ -52,7 +53,9 @@
 # We must build at least one type of libraries
 assert enableShared || enableStatic;
 
-assert enableNumpy -> enablePython;
+# Remove the enable* options after the NixOS 25.05 branch off.
+assert lib.asserts.assertMsg (!enablePython) "The `boost.enablePython` flag has been replaced by `boost.pythonLib pythonVer`";
+assert lib.asserts.assertMsg (!enableNumpy) "The `boost.enableNumpy` flag has been replaced by `boost.pythonLib pythonVer`";
 
 let
 
@@ -146,7 +149,7 @@ let
     ++ lib.optional (link != "static") "runtime-link=${runtime-link}"
     ++ lib.optional (variant == "release") "debug-symbols=off"
     ++ lib.optional (toolset != null) "toolset=${toolset}"
-    ++ lib.optional (!enablePython) "--without-python"
+    ++ [ "--without-python" ]
     ++ lib.optional needUserConfig "--user-config=user-config.jam"
     ++ lib.optional (stdenv.buildPlatform.isDarwin && stdenv.hostPlatform.isLinux) "pch=off"
     ++ lib.optionals stdenv.hostPlatform.isMinGW [
@@ -155,9 +158,7 @@ let
     ++ extraB2Args
   );
 
-in
-
-stdenv.mkDerivation {
+self = stdenv.mkDerivation {
   pname = "boost";
 
   inherit src version;
@@ -216,16 +217,6 @@ stdenv.mkDerivation {
     ++ lib.optional (
       lib.versionAtLeast version "1.81" && lib.versionOlder version "1.88" && stdenv.cc.isClang
     ) ./fix-clang-target.patch
-    ++ lib.optional (lib.versionAtLeast version "1.86" && lib.versionOlder version "1.87") [
-      # Backport fix for NumPy 2 support.
-      (fetchpatch {
-        name = "boost-numpy-2-compatibility.patch";
-        url = "https://github.com/boostorg/python/commit/0474de0f6cc9c6e7230aeb7164af2f7e4ccf74bf.patch";
-        stripLen = 1;
-        extraPrefix = "libs/python/";
-        hash = "sha256-0IHK55JSujYcwEVOuLkwOa/iPEkdAKQlwVWR42p/X2U=";
-      })
-    ]
     ++ lib.optional (version == "1.87.0") [
       # Fix operator<< for shared_ptr and intrusive_ptr
       # https://github.com/boostorg/smart_ptr/issues/115
@@ -253,12 +244,36 @@ stdenv.mkDerivation {
     # a very cryptic error message.
     badPlatforms = [ lib.systems.inspect.patterns.isMips64n32 ];
     maintainers = with maintainers; [ hjones2199 ];
-    broken =
-      enableNumpy && lib.versionOlder version "1.86" && lib.versionAtLeast python.pkgs.numpy.version "2";
   };
 
   passthru = {
     inherit boostBuildPatches;
+    pythonLib = python: callPackage ./python.nix {
+      inherit boost-build python;
+      boost = self;
+    };
+    withPython = python: let
+      pythonLib = self.pythonLib python;
+    in runCommandLocal "boost-combined" {
+      outputs = [
+        "out"
+        "dev"
+      ];
+      propagatedBuildInputs = [
+        self
+      ];
+    }
+      ''
+        mkdir -p $out
+        ${lib.getExe lndir} -silent ${self.out} $out
+        ${lib.getExe lndir} -silent ${lib.getLib pythonLib} $out
+        mkdir -p $dev/lib
+        ${lib.getExe lndir} -silent ${self.dev}/lib $dev/lib
+        ln -s ${lib.getDev pythonLib}/lib/cmake/boost_python-${version}* $dev/lib/cmake/
+        ln -s ${lib.getDev pythonLib}/lib/cmake/boost_numpy-${version}* $dev/lib/cmake/
+        ln -s ${lib.getInclude self}/include $dev/include
+        recordPropagatedDependencies
+      '';
   };
 
   preConfigure =
@@ -295,15 +310,6 @@ stdenv.mkDerivation {
       using clang : cross : ${stdenv.cc.targetPrefix}c++
         : <archiver>$AR
           <ranlib>$RANLIB
-        ;
-      EOF
-    ''
-    # b2 needs to be explicitly told how to find Python when cross-compiling
-    + lib.optionalString enablePython ''
-      cat << EOF >> user-config.jam
-      using python : : ${python.pythonOnBuildForHost.interpreter}
-        : ${python}/include/python${python.pythonVersion}
-        : ${python}/lib
         ;
       EOF
     '';
@@ -357,12 +363,7 @@ stdenv.mkDerivation {
     ]
     ++ lib.optional (lib.versionAtLeast version "1.69") zstd
     ++ [ xz ]
-    ++ lib.optional enableIcu icu
-    ++ lib.optionals enablePython [
-      libxcrypt
-      python
-    ]
-    ++ lib.optional enableNumpy python.pkgs.numpy;
+    ++ lib.optional enableIcu icu;
 
   configureScript = "./bootstrap.sh";
   configurePlatforms = [ ];
@@ -411,4 +412,6 @@ stdenv.mkDerivation {
     "dev"
   ];
   setOutputFlags = false;
-}
+};
+in
+  self

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -54,8 +54,12 @@
 assert enableShared || enableStatic;
 
 # Remove the enable* options after the NixOS 25.05 branch off.
-assert lib.asserts.assertMsg (!enablePython) "The `boost.enablePython` flag has been replaced by `boost.pythonLib pythonVer`";
-assert lib.asserts.assertMsg (!enableNumpy) "The `boost.enableNumpy` flag has been replaced by `boost.pythonLib pythonVer`";
+assert lib.asserts.assertMsg (
+  !enablePython
+) "The `boost.enablePython` flag has been replaced by `boost.pythonLib pythonVer`";
+assert lib.asserts.assertMsg (
+  !enableNumpy
+) "The `boost.enableNumpy` flag has been replaced by `boost.pythonLib pythonVer`";
 
 let
 
@@ -158,260 +162,265 @@ let
     ++ extraB2Args
   );
 
-self = stdenv.mkDerivation {
-  pname = "boost";
+  self = stdenv.mkDerivation {
+    pname = "boost";
 
-  inherit src version;
+    inherit src version;
 
-  patchFlags = [ ];
+    patchFlags = [ ];
 
-  patches =
-    patches
-    ++ lib.optional (
-      lib.versionOlder version "1.88" && stdenv.hostPlatform.isDarwin
-    ) ./darwin-no-system-python.patch
-    ++ lib.optional (lib.versionOlder version "1.88") ./cmake-paths-173.patch
-    ++ lib.optional (version == "1.77.0") (fetchpatch {
-      url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
-      relative = "include";
-      sha256 = "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
-    })
-    # Fixes ABI detection
-    ++ lib.optional (version == "1.83.0") (fetchpatch {
-      url = "https://github.com/boostorg/context/commit/6fa6d5c50d120e69b2d8a1c0d2256ee933e94b3b.patch";
-      stripLen = 1;
-      extraPrefix = "libs/context/";
-      sha256 = "sha256-bCfLL7bD1Rn4Ie/P3X+nIcgTkbXdCX6FW7B9lHsmVW8=";
-    })
-    # This fixes another issue regarding ill-formed constant expressions, which is a default error
-    # in clang 16 and will be a hard error in clang 17.
-    ++ lib.optional (lib.versionOlder version "1.80") (fetchpatch {
-      url = "https://github.com/boostorg/log/commit/77f1e20bd69c2e7a9e25e6a9818ae6105f7d070c.patch";
-      relative = "include";
-      hash = "sha256-6qOiGJASm33XzwoxVZfKJd7sTlQ5yd+MMFQzegXm5RI=";
-    })
-    ++ lib.optionals (lib.versionOlder version "1.81") [
-      # libc++ 15 dropped support for `std::unary_function` and `std::binary_function` in C++17+.
-      # C++17 is the default for clang 16, but clang 15 is also affected in that language mode.
-      # This patch is for Boost 1.80, but it also applies to earlier versions.
-      (fetchpatch {
-        url = "https://www.boost.org/patches/1_80_0/0005-config-libcpp15.patch";
-        hash = "sha256-ULFMzKphv70unvPZ3o4vSP/01/xbSM9a2TlIV67eXDQ=";
-      })
-      # This fixes another ill-formed contant expressions issue flagged by clang 16.
-      (fetchpatch {
-        url = "https://github.com/boostorg/numeric_conversion/commit/50a1eae942effb0a9b90724323ef8f2a67e7984a.patch";
+    patches =
+      patches
+      ++ lib.optional (
+        lib.versionOlder version "1.88" && stdenv.hostPlatform.isDarwin
+      ) ./darwin-no-system-python.patch
+      ++ lib.optional (lib.versionOlder version "1.88") ./cmake-paths-173.patch
+      ++ lib.optional (version == "1.77.0") (fetchpatch {
+        url = "https://github.com/boostorg/math/commit/7d482f6ebc356e6ec455ccb5f51a23971bf6ce5b.patch";
         relative = "include";
-        hash = "sha256-dq4SVgxkPJSC7Fvr59VGnXkM4Lb09kYDaBksCHo9C0s=";
+        sha256 = "sha256-KlmIbixcds6GyKYt1fx5BxDIrU7msrgDdYo9Va/KJR4=";
       })
-      # This fixes an issue in Python 3.11 about Py_TPFLAGS_HAVE_GC
-      (fetchpatch {
-        name = "python311-compatibility.patch";
-        url = "https://github.com/boostorg/python/commit/a218babc8daee904a83f550fb66e5cb3f1cb3013.patch";
-        hash = "sha256-IHxLtJBx0xSy7QEr8FbCPofsjcPuSYzgtPwDlx1JM+4=";
-        stripLen = 1;
-        extraPrefix = "libs/python/";
-      })
-    ]
-
-    ++ lib.optional (
-      lib.versionAtLeast version "1.81" && lib.versionOlder version "1.88" && stdenv.cc.isClang
-    ) ./fix-clang-target.patch
-    ++ lib.optional (version == "1.87.0") [
-      # Fix operator<< for shared_ptr and intrusive_ptr
-      # https://github.com/boostorg/smart_ptr/issues/115
-      (fetchpatch {
-        url = "https://github.com/boostorg/smart_ptr/commit/e7433ba54596da97cb7859455cd37ca140305a9c.patch";
-        relative = "include";
-        hash = "sha256-9JvKQOAB19wQpWLNAhuB9eL8qKqXWTQHAJIXdLYMNG8=";
-      })
-      # Fixes ABI detection on some platforms (like loongarch64)
-      (fetchpatch {
-        url = "https://github.com/boostorg/context/commit/63996e427b4470c7b99b0f4cafb94839ea3670b6.patch";
+      # Fixes ABI detection
+      ++ lib.optional (version == "1.83.0") (fetchpatch {
+        url = "https://github.com/boostorg/context/commit/6fa6d5c50d120e69b2d8a1c0d2256ee933e94b3b.patch";
         stripLen = 1;
         extraPrefix = "libs/context/";
-        hash = "sha256-Z8uw2+4IEybqVcU25i/0XJKS16hi/+3MXUxs53ghjL0=";
+        sha256 = "sha256-bCfLL7bD1Rn4Ie/P3X+nIcgTkbXdCX6FW7B9lHsmVW8=";
+      })
+      # This fixes another issue regarding ill-formed constant expressions, which is a default error
+      # in clang 16 and will be a hard error in clang 17.
+      ++ lib.optional (lib.versionOlder version "1.80") (fetchpatch {
+        url = "https://github.com/boostorg/log/commit/77f1e20bd69c2e7a9e25e6a9818ae6105f7d070c.patch";
+        relative = "include";
+        hash = "sha256-6qOiGJASm33XzwoxVZfKJd7sTlQ5yd+MMFQzegXm5RI=";
+      })
+      ++ lib.optionals (lib.versionOlder version "1.81") [
+        # libc++ 15 dropped support for `std::unary_function` and `std::binary_function` in C++17+.
+        # C++17 is the default for clang 16, but clang 15 is also affected in that language mode.
+        # This patch is for Boost 1.80, but it also applies to earlier versions.
+        (fetchpatch {
+          url = "https://www.boost.org/patches/1_80_0/0005-config-libcpp15.patch";
+          hash = "sha256-ULFMzKphv70unvPZ3o4vSP/01/xbSM9a2TlIV67eXDQ=";
+        })
+        # This fixes another ill-formed contant expressions issue flagged by clang 16.
+        (fetchpatch {
+          url = "https://github.com/boostorg/numeric_conversion/commit/50a1eae942effb0a9b90724323ef8f2a67e7984a.patch";
+          relative = "include";
+          hash = "sha256-dq4SVgxkPJSC7Fvr59VGnXkM4Lb09kYDaBksCHo9C0s=";
+        })
+        # This fixes an issue in Python 3.11 about Py_TPFLAGS_HAVE_GC
+        (fetchpatch {
+          name = "python311-compatibility.patch";
+          url = "https://github.com/boostorg/python/commit/a218babc8daee904a83f550fb66e5cb3f1cb3013.patch";
+          hash = "sha256-IHxLtJBx0xSy7QEr8FbCPofsjcPuSYzgtPwDlx1JM+4=";
+          stripLen = 1;
+          extraPrefix = "libs/python/";
+        })
+      ]
+
+      ++ lib.optional (
+        lib.versionAtLeast version "1.81" && lib.versionOlder version "1.88" && stdenv.cc.isClang
+      ) ./fix-clang-target.patch
+      ++ lib.optional (version == "1.87.0") [
+        # Fix operator<< for shared_ptr and intrusive_ptr
+        # https://github.com/boostorg/smart_ptr/issues/115
+        (fetchpatch {
+          url = "https://github.com/boostorg/smart_ptr/commit/e7433ba54596da97cb7859455cd37ca140305a9c.patch";
+          relative = "include";
+          hash = "sha256-9JvKQOAB19wQpWLNAhuB9eL8qKqXWTQHAJIXdLYMNG8=";
+        })
+        # Fixes ABI detection on some platforms (like loongarch64)
+        (fetchpatch {
+          url = "https://github.com/boostorg/context/commit/63996e427b4470c7b99b0f4cafb94839ea3670b6.patch";
+          stripLen = 1;
+          extraPrefix = "libs/context/";
+          hash = "sha256-Z8uw2+4IEybqVcU25i/0XJKS16hi/+3MXUxs53ghjL0=";
+        })
+      ];
+
+    meta = with lib; {
+      homepage = "http://boost.org/";
+      description = "Collection of C++ libraries";
+      license = licenses.boost;
+      platforms = platforms.unix ++ platforms.windows;
+      # boost-context lacks support for the N32 ABI on mips64.  The build
+      # will succeed, but packages depending on boost-context will fail with
+      # a very cryptic error message.
+      badPlatforms = [ lib.systems.inspect.patterns.isMips64n32 ];
+      maintainers = with maintainers; [ hjones2199 ];
+    };
+
+    passthru = {
+      inherit boostBuildPatches;
+      pythonLib =
+        python:
+        callPackage ./python.nix {
+          inherit boost-build python;
+          boost = self;
+        };
+      withPython =
+        python:
+        let
+          pythonLib = self.pythonLib python;
+        in
+        runCommandLocal "boost-combined"
+          {
+            outputs = [
+              "out"
+              "dev"
+            ];
+            propagatedBuildInputs = [
+              self
+            ];
+          }
+          ''
+            mkdir -p $out
+            ${lib.getExe lndir} -silent ${self.out} $out
+            ${lib.getExe lndir} -silent ${lib.getLib pythonLib} $out
+            mkdir -p $dev/lib
+            ${lib.getExe lndir} -silent ${self.dev}/lib $dev/lib
+            ln -s ${lib.getDev pythonLib}/lib/cmake/boost_python-${version}* $dev/lib/cmake/
+            ln -s ${lib.getDev pythonLib}/lib/cmake/boost_numpy-${version}* $dev/lib/cmake/
+            ln -s ${lib.getInclude self}/include $dev/include
+            recordPropagatedDependencies
+          '';
+    };
+
+    preConfigure =
+      lib.optionalString useMpi ''
+        cat << EOF >> user-config.jam
+        using mpi : ${lib.getDev mpi}/bin/mpiCC ;
+        EOF
+      ''
+      # On darwin we need to add the `$out/lib` to the libraries' rpath explicitly,
+      # otherwise the dynamic linker is unable to resolve the reference to @rpath
+      # when the boost libraries want to load each other at runtime.
+      + lib.optionalString (stdenv.hostPlatform.isDarwin && enableShared) ''
+        cat << EOF >> user-config.jam
+        using clang-darwin : : ${stdenv.cc.targetPrefix}c++
+          : <linkflags>"-rpath $out/lib/"
+            <archiver>$AR
+            <ranlib>$RANLIB
+          ;
+        EOF
+      ''
+      # b2 has trouble finding the correct compiler and tools for cross compilation
+      # since it apparently ignores $CC, $AR etc. Thus we need to set everything
+      # in user-config.jam. To keep things simple we just set everything in an
+      # uniform way for clang and gcc (which works thanks to our cc-wrapper).
+      # We pass toolset later which will make b2 invoke everything in the right
+      # way -- the other toolset in user-config.jam will be ignored.
+      + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+        cat << EOF >> user-config.jam
+        using gcc : cross : ${stdenv.cc.targetPrefix}c++
+          : <archiver>$AR
+            <ranlib>$RANLIB
+          ;
+
+        using clang : cross : ${stdenv.cc.targetPrefix}c++
+          : <archiver>$AR
+            <ranlib>$RANLIB
+          ;
+        EOF
+      '';
+
+    # Fix compilation to 32-bit ARM with clang in downstream packages
+    # https://github.com/ned14/outcome/pull/308
+    # https://github.com/boostorg/json/pull/1064
+    postPatch = lib.optionalString (version == "1.87.0") ''
+      substituteInPlace \
+        boost/outcome/outcome_gdb.h \
+        boost/outcome/experimental/status-code/status_code.hpp \
+        boost/json/detail/gdb_printers.hpp \
+        boost/unordered/unordered_printers.hpp \
+        boost/interprocess/interprocess_printers.hpp \
+        libs/json/pretty_printers/generate-gdb-header.py \
+        --replace-fail ",@progbits,1" ",%progbits,1"
+    '';
+
+    env = {
+      NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
+      # copyPkgconfigItems will substitute these in the pkg-config file
+      includedir = "${placeholder "dev"}/include";
+      libdir = "${placeholder "out"}/lib";
+    };
+
+    pkgconfigItems = [
+      (makePkgconfigItem {
+        name = "boost";
+        inherit version;
+        # Exclude other variables not needed by meson
+        variables = {
+          includedir = "@includedir@";
+          libdir = "@libdir@";
+        };
       })
     ];
 
-  meta = with lib; {
-    homepage = "http://boost.org/";
-    description = "Collection of C++ libraries";
-    license = licenses.boost;
-    platforms = platforms.unix ++ platforms.windows;
-    # boost-context lacks support for the N32 ABI on mips64.  The build
-    # will succeed, but packages depending on boost-context will fail with
-    # a very cryptic error message.
-    badPlatforms = [ lib.systems.inspect.patterns.isMips64n32 ];
-    maintainers = with maintainers; [ hjones2199 ];
-  };
+    enableParallelBuilding = true;
 
-  passthru = {
-    inherit boostBuildPatches;
-    pythonLib = python: callPackage ./python.nix {
-      inherit boost-build python;
-      boost = self;
-    };
-    withPython = python: let
-      pythonLib = self.pythonLib python;
-    in runCommandLocal "boost-combined" {
-      outputs = [
-        "out"
-        "dev"
-      ];
-      propagatedBuildInputs = [
-        self
-      ];
-    }
-      ''
-        mkdir -p $out
-        ${lib.getExe lndir} -silent ${self.out} $out
-        ${lib.getExe lndir} -silent ${lib.getLib pythonLib} $out
-        mkdir -p $dev/lib
-        ${lib.getExe lndir} -silent ${self.dev}/lib $dev/lib
-        ln -s ${lib.getDev pythonLib}/lib/cmake/boost_python-${version}* $dev/lib/cmake/
-        ln -s ${lib.getDev pythonLib}/lib/cmake/boost_numpy-${version}* $dev/lib/cmake/
-        ln -s ${lib.getInclude self}/include $dev/include
-        recordPropagatedDependencies
-      '';
-  };
+    nativeBuildInputs = [
+      which
+      boost-build
+      copyPkgconfigItems
+    ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+    buildInputs =
+      [
+        zlib
+        bzip2
+        libiconv
+      ]
+      ++ lib.optional (lib.versionAtLeast version "1.69") zstd
+      ++ [ xz ]
+      ++ lib.optional enableIcu icu;
 
-  preConfigure =
-    lib.optionalString useMpi ''
-      cat << EOF >> user-config.jam
-      using mpi : ${lib.getDev mpi}/bin/mpiCC ;
-      EOF
-    ''
-    # On darwin we need to add the `$out/lib` to the libraries' rpath explicitly,
-    # otherwise the dynamic linker is unable to resolve the reference to @rpath
-    # when the boost libraries want to load each other at runtime.
-    + lib.optionalString (stdenv.hostPlatform.isDarwin && enableShared) ''
-      cat << EOF >> user-config.jam
-      using clang-darwin : : ${stdenv.cc.targetPrefix}c++
-        : <linkflags>"-rpath $out/lib/"
-          <archiver>$AR
-          <ranlib>$RANLIB
-        ;
-      EOF
-    ''
-    # b2 has trouble finding the correct compiler and tools for cross compilation
-    # since it apparently ignores $CC, $AR etc. Thus we need to set everything
-    # in user-config.jam. To keep things simple we just set everything in an
-    # uniform way for clang and gcc (which works thanks to our cc-wrapper).
-    # We pass toolset later which will make b2 invoke everything in the right
-    # way -- the other toolset in user-config.jam will be ignored.
-    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
-      cat << EOF >> user-config.jam
-      using gcc : cross : ${stdenv.cc.targetPrefix}c++
-        : <archiver>$AR
-          <ranlib>$RANLIB
-        ;
+    configureScript = "./bootstrap.sh";
+    configurePlatforms = [ ];
+    dontDisableStatic = true;
+    dontAddStaticConfigureFlags = true;
+    configureFlags =
+      [
+        "--includedir=$(dev)/include"
+        "--libdir=$(out)/lib"
+        "--with-bjam=b2" # prevent bootstrapping b2 in configurePhase
+      ]
+      ++ lib.optional (toolset != null) "--with-toolset=${toolset}"
+      ++ [ (if enableIcu then "--with-icu=${icu.dev}" else "--without-icu") ];
 
-      using clang : cross : ${stdenv.cc.targetPrefix}c++
-        : <archiver>$AR
-          <ranlib>$RANLIB
-        ;
-      EOF
+    buildPhase = ''
+      runHook preBuild
+      b2 ${b2Args}
+      runHook postBuild
     '';
 
-  # Fix compilation to 32-bit ARM with clang in downstream packages
-  # https://github.com/ned14/outcome/pull/308
-  # https://github.com/boostorg/json/pull/1064
-  postPatch = lib.optionalString (version == "1.87.0") ''
-    substituteInPlace \
-      boost/outcome/outcome_gdb.h \
-      boost/outcome/experimental/status-code/status_code.hpp \
-      boost/json/detail/gdb_printers.hpp \
-      boost/unordered/unordered_printers.hpp \
-      boost/interprocess/interprocess_printers.hpp \
-      libs/json/pretty_printers/generate-gdb-header.py \
-      --replace-fail ",@progbits,1" ",%progbits,1"
-  '';
+    installPhase = ''
+      runHook preInstall
 
-  env = {
-    NIX_CFLAGS_LINK = lib.optionalString stdenv.hostPlatform.isDarwin "-headerpad_max_install_names";
-    # copyPkgconfigItems will substitute these in the pkg-config file
-    includedir = "${placeholder "dev"}/include";
-    libdir = "${placeholder "out"}/lib";
+      # boostbook is needed by some applications
+      mkdir -p $dev/share/boostbook
+      cp -a tools/boostbook/{xsl,dtd} $dev/share/boostbook/
+
+      # Let boost install everything else
+      b2 ${b2Args} install
+
+      runHook postInstall
+    '';
+
+    postFixup =
+      ''
+        # Make boost header paths relative so that they are not runtime dependencies
+        cd "$dev" && find include \( -name '*.hpp' -or -name '*.h' -or -name '*.ipp' \) \
+          -exec sed '1s/^\xef\xbb\xbf//;1i#line 1 "{}"' -i '{}' \;
+      ''
+      + lib.optionalString stdenv.hostPlatform.isMinGW ''
+        $RANLIB "$out/lib/"*.a
+      '';
+
+    outputs = [
+      "out"
+      "dev"
+    ];
+    setOutputFlags = false;
   };
-
-  pkgconfigItems = [
-    (makePkgconfigItem {
-      name = "boost";
-      inherit version;
-      # Exclude other variables not needed by meson
-      variables = {
-        includedir = "@includedir@";
-        libdir = "@libdir@";
-      };
-    })
-  ];
-
-  enableParallelBuilding = true;
-
-  nativeBuildInputs = [
-    which
-    boost-build
-    copyPkgconfigItems
-    sanitiseHeaderPathsHook
-  ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-  buildInputs =
-    [
-      zlib
-      bzip2
-      libiconv
-    ]
-    ++ lib.optional (lib.versionAtLeast version "1.69") zstd
-    ++ [ xz ]
-    ++ lib.optional enableIcu icu;
-
-  configureScript = "./bootstrap.sh";
-  configurePlatforms = [ ];
-  dontDisableStatic = true;
-  dontAddStaticConfigureFlags = true;
-  configureFlags =
-    [
-      "--includedir=$(dev)/include"
-      "--libdir=$(out)/lib"
-      "--with-bjam=b2" # prevent bootstrapping b2 in configurePhase
-    ]
-    ++ lib.optional (toolset != null) "--with-toolset=${toolset}"
-    ++ [ (if enableIcu then "--with-icu=${icu.dev}" else "--without-icu") ];
-
-  buildPhase = ''
-    runHook preBuild
-    b2 ${b2Args}
-    runHook postBuild
-  '';
-
-  installPhase = ''
-    runHook preInstall
-
-    # boostbook is needed by some applications
-    mkdir -p $dev/share/boostbook
-    cp -a tools/boostbook/{xsl,dtd} $dev/share/boostbook/
-
-    # Let boost install everything else
-    b2 ${b2Args} install
-
-    runHook postInstall
-  '';
-
-  preFixup = ''
-    # Strip UTF‐8 BOMs for `sanitiseHeaderPathsHook`.
-    cd "$dev" && find include \( -name '*.hpp' -or -name '*.h' -or -name '*.ipp' \) \
-      -exec sed '1s/^\xef\xbb\xbf//' -i '{}' \;
-  '';
-
-  postFixup = lib.optionalString stdenv.hostPlatform.isMinGW ''
-    $RANLIB "$out/lib/"*.a
-  '';
-
-  outputs = [
-    "out"
-    "dev"
-  ];
-  setOutputFlags = false;
-};
 in
-  self
+self

--- a/pkgs/development/libraries/boost/python.nix
+++ b/pkgs/development/libraries/boost/python.nix
@@ -1,0 +1,143 @@
+{
+  lib,
+  stdenv,
+  fetchpatch,
+  boost,
+  boost-build,
+  libxcrypt,
+  python,
+  fixDarwinDylibNames,
+  toolset ?
+    if stdenv.cc.isClang then
+      "clang"
+    else if stdenv.cc.isGNU then
+      "gcc"
+    else
+      null,
+}:
+let
+  b2Args = lib.concatStringsSep " " (
+    [
+      "--with-python"
+      "--user-config=user-config.jam"
+      "--includedir=${lib.getInclude boost}/include"
+      "--libdir=$out/lib"
+      "-j$NIX_BUILD_CORES"
+      "--layout=system"
+      "variant=release"
+      "debug-symbols=off"
+      "threading=multi"
+      "link=${if stdenv.hostPlatform.isStatic then "static" else "shared"}"
+      "runtime-link=${if stdenv.hostPlatform.isStatic then "static" else "shared"}"
+    ]
+    ++ lib.optional (toolset != null) "toolset=${toolset}"
+  );
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "boost.python";
+  inherit (boost) version src;
+  meta = {
+    inherit (boost.meta)
+      homepage
+      description
+      license
+      maintainers
+      platforms
+      ;
+  };
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  patches =
+    lib.optional stdenv.hostPlatform.isDarwin ./darwin-no-system-python.patch
+    ++ lib.optional (finalAttrs.version == "1.86.0") [
+      (fetchpatch {
+        name = "boost-python-numpy2-compat.patch";
+        url = "https://github.com/boostorg/python/commit/0474de0f6cc9c6e7230aeb7164af2f7e4ccf74bf.patch";
+        hash = "sha256-0IHK55JSujYcwEVOuLkwOa/iPEkdAKQlwVWR42p/X2U=";
+        stripLen = 1;
+        extraPrefix = "libs/python/";
+      })
+    ];
+
+  strictDeps = true;
+
+  nativeBuildInputs = [
+    boost-build
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
+
+  buildInputs = [
+    libxcrypt
+    python
+    python.pkgs.numpy
+  ];
+
+  propagatedBuildInputs = [ boost ];
+
+  enableParallelBuilding = true;
+
+  # b2 needs to be explicitly told how to find Python when cross-compiling
+  preConfigure = ''
+    cat << EOF >> user-config.jam
+    import toolset : using ;
+    using python : : ${python.pythonOnBuildForHost.interpreter}
+      : ${python}/include/python${python.pythonVersion}
+      : ${python}/lib
+      ;
+    EOF
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    b2 ${b2Args}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    b2 ${b2Args} install || true
+    moveToOutput "lib/${python.libPrefix}" "$numpy"
+
+    mkdir $TMPDIR/lib
+    mv $out/lib/libboost* $TMPDIR/lib/
+    mv $TMPDIR/lib/libboost_python* $out/lib
+    mv $TMPDIR/lib/libboost_numpy* $out/lib
+
+    runHook postInstall
+  '';
+
+  postFixup =
+    ''
+      mv $dev/lib/cmake $TMPDIR
+
+      for lib in python numpy; do
+        substituteInPlace $TMPDIR/cmake/boost_$lib-${finalAttrs.version}/boost_$lib-config.cmake \
+          --replace-fail "get_filename_component(_BOOST_LIBDIR \"\''${_BOOST_CMAKEDIR}/../\" ABSOLUTE)" \
+                         "get_filename_component(_BOOST_LIBDIR \"\''${_BOOST_CMAKEDIR}/../../../''${out#${builtins.storeDir}/}/lib/\" ABSOLUTE)" \
+          --replace-fail "include(\''${CMAKE_CURRENT_LIST_DIR}/../BoostDetectToolset-1.87.0.cmake)" \
+                         "include(\''${_BOOST_CMAKEDIR}/../../..${builtins.substring (builtins.stringLength builtins.storeDir) 99999 (lib.getDev boost)}/lib/cmake/BoostDetectToolset-1.87.0.cmake)"
+      done
+
+      mkdir $dev/lib/cmake
+      mv $TMPDIR/cmake/boost_python-${finalAttrs.version} $dev/lib/cmake/
+      mv $TMPDIR/cmake/boost_numpy-${finalAttrs.version} $dev/lib/cmake/
+
+      ln -s ${lib.getInclude boost}/include $dev/include
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      patchelf --add-rpath ${lib.getLib boost}/lib $out/lib/*.so.*
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      find $out/lib -type f -name '*.dylib' -exec install_name_tool -add_rpath $out/lib "{}" \;
+      find $out/lib -type f -name '*.dylib' -exec install_name_tool -add_rpath ${lib.getLib boost}/lib "{}" \;
+    ''
+    + lib.optionalString stdenv.hostPlatform.isMinGW ''
+      $RANLIB "$out/lib/"*.a
+    '';
+
+  setOutputFlags = false;
+})

--- a/pkgs/development/libraries/valhalla/default.nix
+++ b/pkgs/development/libraries/valhalla/default.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost
+    (boost.withPython python3)
     cxxopts
     lz4
     (python3.withPackages (ps: [ ps.pybind11 ]))

--- a/pkgs/development/python-modules/eigenpy/default.nix
+++ b/pkgs/development/python-modules/eigenpy/default.nix
@@ -12,7 +12,7 @@
   scipy,
 
   # buildInputs
-  boost,
+  boost-python,
 
   # propagatedBuildInputs
   eigen,
@@ -60,7 +60,7 @@ buildPythonPackage rec {
     scipy
   ];
 
-  buildInputs = [ boost ];
+  buildInputs = [ boost-python ];
 
   propagatedBuildInputs = [
     eigen

--- a/pkgs/development/python-modules/gattlib/default.nix
+++ b/pkgs/development/python-modules/gattlib/default.nix
@@ -11,7 +11,7 @@
   python,
   setuptools,
   bluez,
-  boost,
+  boost-python,
   glib,
 }:
 
@@ -51,7 +51,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     bluez
-    boost
+    boost-python
     glib
   ];
 

--- a/pkgs/development/python-modules/gfal2-python/default.nix
+++ b/pkgs/development/python-modules/gfal2-python/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   cmake,
   pkg-config,
-  boost,
+  boost-python,
   gfal2,
   glib,
   pythonAtLeast,
@@ -26,7 +26,7 @@ buildPythonPackage rec {
     pkg-config
   ];
   buildInputs = [
-    boost
+    boost-python
     gfal2
     glib
   ];

--- a/pkgs/development/python-modules/graph-tool/default.nix
+++ b/pkgs/development/python-modules/graph-tool/default.nix
@@ -23,12 +23,10 @@
   sparsehash,
   gitUpdater,
 }:
-
 let
-  boost' = boost.override {
-    enablePython = true;
-    inherit python;
-  };
+
+  boost' = boost.withPython python;
+
 in
 buildPythonPackage rec {
   pname = "graph-tool";

--- a/pkgs/development/python-modules/medpy/default.nix
+++ b/pkgs/development/python-modules/medpy/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   setuptools,
   unittestCheckHook,
-  boost,
+  boost-python,
   numpy,
   scipy,
   simpleitk,
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   build-system = [ setuptools ];
 
   dependencies = [
-    boost
+    boost-python
     numpy
     scipy
     simpleitk

--- a/pkgs/development/python-modules/metawear/default.nix
+++ b/pkgs/development/python-modules/metawear/default.nix
@@ -3,8 +3,8 @@
   buildPythonPackage,
   fetchPypi,
   cython,
-  boost,
   bluez,
+  distutils,
   nlohmann_json,
   pyserial,
   requests,
@@ -24,8 +24,8 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cython ];
 
   buildInputs = [
-    boost
     bluez
+    distutils
     nlohmann_json
   ];
 

--- a/pkgs/development/python-modules/opencamlib/default.nix
+++ b/pkgs/development/python-modules/opencamlib/default.nix
@@ -7,7 +7,7 @@
   ninja,
   stdenv,
   llvmPackages,
-  boost,
+  boost-python,
   python,
 }:
 
@@ -28,7 +28,7 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [
-    boost
+    boost-python
   ] ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/openusd/default.nix
+++ b/pkgs/development/python-modules/openusd/default.nix
@@ -1,7 +1,7 @@
 {
   alembic,
   bison,
-  boost,
+  boost-python,
   buildPythonPackage,
   cmake,
   distutils,
@@ -140,7 +140,7 @@ buildPythonPackage rec {
 
   propagatedBuildInputs =
     [
-      boost
+      boost-python
       jinja2
       numpy
       opensubdiv

--- a/pkgs/development/python-modules/py3exiv2/default.nix
+++ b/pkgs/development/python-modules/py3exiv2/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  boost,
+  boost-python,
   buildPythonPackage,
   exiv2,
   fetchPypi,
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   '';
 
   buildInputs = [
-    boost
+    boost-python
     exiv2
   ];
 

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -48,6 +48,8 @@ buildPythonPackage rec {
   buildInputs = lib.optionals (pythonOlder "3.9") [ libxcrypt ];
   propagatedNativeBuildInputs = [ setupHook ];
 
+  checkInputs = [ boost ];
+
   dontUseCmakeBuildDir = true;
 
   # Don't build tests if not needed, read the doInstallCheck value at runtime
@@ -58,7 +60,7 @@ buildPythonPackage rec {
   '';
 
   cmakeFlags = [
-    "-DBoost_INCLUDE_DIR=${lib.getDev boost}/include"
+    "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
     "-DEIGEN3_INCLUDE_DIR=${lib.getDev eigen}/include/eigen3"
   ] ++ lib.optionals (python.isPy3k && !stdenv.cc.isClang) [ "-DPYBIND11_CXX_STANDARD=-std=c++17" ];
 

--- a/pkgs/development/python-modules/pycuda/default.nix
+++ b/pkgs/development/python-modules/pycuda/default.nix
@@ -17,6 +17,8 @@
   lib,
 }:
 let
+  boostWithPython = boost.withPython python;
+
   compyte = import ./compyte.nix { inherit mkDerivation fetchFromGitHub; };
 
   inherit (cudaPackages) cudatoolkit;
@@ -32,8 +34,8 @@ buildPythonPackage rec {
   };
 
   preConfigure = with lib.versions; ''
-    ${python.pythonOnBuildForHost.interpreter} configure.py --boost-inc-dir=${boost.dev}/include \
-                          --boost-lib-dir=${boost}/lib \
+    ${python.pythonOnBuildForHost.interpreter} configure.py --boost-inc-dir=${lib.getInclude boostWithPython}/include \
+                          --boost-lib-dir=${lib.getLib boostWithPython}/lib \
                           --no-use-shipped-boost \
                           --boost-python-libname=boost_python${major python.version}${minor python.version} \
                           --cuda-root=${cudatoolkit}

--- a/pkgs/development/python-modules/pyftgl/default.nix
+++ b/pkgs/development/python-modules/pyftgl/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   stdenv,
   setuptools,
-  boost,
+  boost-python,
   freetype,
   ftgl,
   libGLU,
@@ -39,7 +39,7 @@ buildPythonPackage rec {
     '';
 
   buildInputs = [
-    boost
+    boost-python
     freetype
     ftgl
     libGLU

--- a/pkgs/development/python-modules/rdkit/default.nix
+++ b/pkgs/development/python-modules/rdkit/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   cmake,
   comic-neue,
-  boost,
+  boost-python,
   catch2_3,
   inchi,
   cairo,
@@ -45,7 +45,6 @@ let
       hash = "sha256-tQB4wqza9rlSoy4Uj9bA99ddawjxGyN9G7DYbcv/Qdo=";
     };
   };
-  boost' = boost.override { enableNumpy = true; };
 in
 buildPythonPackage rec {
   pname = "rdkit";
@@ -88,7 +87,7 @@ buildPythonPackage rec {
   nativeBuildInputs = [ cmake ];
 
   buildInputs = [
-    boost'
+    boost-python
     cairo
     catch2_3
     coordgenlibs

--- a/pkgs/development/python-modules/vowpalwabbit/fix-supplied-rapidjson.patch
+++ b/pkgs/development/python-modules/vowpalwabbit/fix-supplied-rapidjson.patch
@@ -1,0 +1,13 @@
+diff --git a/ext_libs/ext_libs.cmake b/ext_libs/ext_libs.cmake
+index e03de8690..f8acddd7e 100644
+--- a/ext_libs/ext_libs.cmake
++++ b/ext_libs/ext_libs.cmake
+@@ -37,8 +37,6 @@ endif()
+ if(RAPIDJSON_SYS_DEP)
+   # Since EXACT is not specified, any version compatible with 1.1.0 is accepted (>= 1.1.0)
+   find_package(RapidJSON 1.1.0 CONFIG REQUIRED)
+-  add_library(RapidJSON INTERFACE)
+-  target_include_directories(RapidJSON INTERFACE ${RapidJSON_INCLUDE_DIRS} ${RAPIDJSON_INCLUDE_DIRS})
+ else()
+   add_library(RapidJSON INTERFACE)
+   target_include_directories(RapidJSON SYSTEM INTERFACE "${CMAKE_CURRENT_LIST_DIR}/rapidjson/include")

--- a/pkgs/kde/gear/kopeninghours/default.nix
+++ b/pkgs/kde/gear/kopeninghours/default.nix
@@ -15,10 +15,7 @@ mkKdeDerivation {
   ];
   extraBuildInputs = [
     qtdeclarative
-    (boost.override {
-      enablePython = true;
-      python = python3;
-    })
+    (boost.withPython python3)
     python3
   ];
 }

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -310,11 +310,6 @@ let
       };
   };
 
-  boost' = boost183.override {
-    enablePython = true;
-    inherit python;
-  };
-
   # TODO: split this off in build and runtime environment
   ceph-python-env = python.withPackages (
     ps: with ps; [
@@ -428,7 +423,7 @@ rec {
       ++ [
         arrow-cpp
         babeltrace
-        boost'
+        (boost183.withPython python)
         bzip2
         # Adding `ceph-python-env` here adds the env's `site-packages` to `PYTHONPATH` during the build.
         # This is important, otherwise the build system may not find the Python deps and then

--- a/pkgs/tools/misc/calamares/default.nix
+++ b/pkgs/tools/misc/calamares/default.nix
@@ -62,7 +62,7 @@ mkDerivation rec {
     extra-cmake-modules
   ];
   buildInputs = [
-    boost
+    (boost.withPython python3)
     kparts.dev
     kpmcore.out
     kservice.dev

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1986,12 +1986,7 @@ with pkgs;
       '';
     });
 
-  calamares = libsForQt5.callPackage ../tools/misc/calamares {
-    boost = boost.override {
-      enablePython = true;
-      python = python3;
-    };
-  };
+  calamares = libsForQt5.callPackage ../tools/misc/calamares { };
   calamares-nixos = lowPrio (calamares.override { nixos-extensions = true; });
   candle = libsForQt5.callPackage ../applications/misc/candle { };
 
@@ -9603,10 +9598,6 @@ with pkgs;
   valeStyles = recurseIntoAttrs (callPackages ../by-name/va/vale/styles.nix { });
 
   valhalla = callPackage ../development/libraries/valhalla {
-    boost = boost.override {
-      enablePython = true;
-      python = python3;
-    };
     protobuf = protobuf_21.override {
       abseil-cpp = abseil-cpp_202103.override {
         cxxStandard = "17";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2025,18 +2025,9 @@ self: super: with self; {
 
   booleanoperations = callPackage ../development/python-modules/booleanoperations { };
 
-  # Build boost for this specific Python version
-  # TODO: use separate output for libboost_python.so
-  boost = toPythonModule (
-    pkgs.boost.override {
-      inherit (self) python numpy;
-      enablePython = true;
-    }
-  );
+  boost-histogram = callPackage ../development/python-modules/boost-histogram { };
 
-  boost-histogram = callPackage ../development/python-modules/boost-histogram {
-    inherit (pkgs) boost;
-  };
+  boost-python = toPythonModule (pkgs.boost.pythonLib python);
 
   borb = callPackage ../development/python-modules/borb { };
 
@@ -2225,7 +2216,7 @@ self: super: with self; {
   caffe = toPythonModule (
     pkgs.caffe.override {
       pythonSupport = true;
-      inherit (self) python numpy boost;
+      inherit (self) python numpy;
     }
   );
 
@@ -14561,12 +14552,8 @@ self: super: with self; {
       proj
       zlib
       ;
-    boost = pkgs.boost.override {
-      enablePython = true;
-      inherit python;
-    };
     harfbuzz = pkgs.harfbuzz.override { withIcu = true; };
-    mapnik = pkgs.mapnik.override { inherit boost harfbuzz; };
+    mapnik = pkgs.mapnik.override { inherit harfbuzz; };
   };
 
   python-markdown-math = callPackage ../development/python-modules/python-markdown-math { };
@@ -15302,12 +15289,7 @@ self: super: with self; {
 
   rdflib = callPackage ../development/python-modules/rdflib { };
 
-  rdkit = callPackage ../development/python-modules/rdkit {
-    boost = pkgs.boost.override {
-      enablePython = true;
-      inherit python;
-    };
-  };
+  rdkit = callPackage ../development/python-modules/rdkit { };
 
   re-assert = callPackage ../development/python-modules/re-assert { };
 


### PR DESCRIPTION
This change replaces the `enablePython` option from the boost package into a more granular structure where `boost-python` is a dedicated derivation. This is enabled by 2 new passthru functions from the `boost` attribute:
* `boost.pythonLib`: Takes a `python` derivation as a parameter and produces a `boost-python` itself.
* `boost.withPython`: Takes a `python` derivation as well and produces a `symlinkJoin`-style derivation containing a `boost-python` lib together with the rest of the boost libraries. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
