### PR TITLE
alphafold3: init at 3.0.0-unstable-2024-12-20

### DIFF
--- a/pkgs/by-name/al/alphafold3/add-shebang.patch
+++ b/pkgs/by-name/al/alphafold3/add-shebang.patch
@@ -1,0 +1,9 @@
+diff --git a/run_alphafold.py b/run_alphafold.py
+index 5e76b03..50eeda2 100644
+--- a/run_alphafold.py
++++ b/run_alphafold.py
+@@ -1,3 +1,4 @@
++#!/usr/bin/env python
+ # Copyright 2024 DeepMind Technologies Limited
+ #
+ # AlphaFold 3 source code is licensed under CC BY-NC-SA 4.0. To view a copy of

--- a/pkgs/by-name/al/alphafold3/libcifpp.patch
+++ b/pkgs/by-name/al/alphafold3/libcifpp.patch
@@ -1,0 +1,27 @@
+diff --git a/src/alphafold3/build_data.py b/src/alphafold3/build_data.py
+index 0c33338..f3b6ab9 100644
+--- a/src/alphafold3/build_data.py
++++ b/src/alphafold3/build_data.py
+@@ -22,7 +22,7 @@ from alphafold3.constants.converters import chemical_component_sets_gen
+ def build_data():
+   """Builds intermediate data."""
+   for site_path in site.getsitepackages():
+-    path = pathlib.Path(site_path) / 'share/libcifpp/components.cif'
++    path = pathlib.Path('@libcifpp@/share/libcifpp/components.cif')
+     if path.exists():
+       cif_path = path
+       break
+diff --git a/src/alphafold3/model/mkdssp_pybind.cc b/src/alphafold3/model/mkdssp_pybind.cc
+index 27ca7b5..7909456 100644
+--- a/src/alphafold3/model/mkdssp_pybind.cc
++++ b/src/alphafold3/model/mkdssp_pybind.cc
+@@ -31,8 +31,7 @@ void RegisterModuleMkdssp(pybind11::module m) {
+   bool found = false;
+   for (const auto& py_path : paths) {
+     auto path_str =
+-        std::filesystem::path(py::cast<absl::string_view>(py_path)) /
+-        "share/libcifpp/components.cif";
++        std::filesystem::path("@libcifpp@/share/libcifpp/components.cif");
+     if (std::filesystem::exists(path_str)) {
+       setenv("LIBCIFPP_DATA_DIR", path_str.parent_path().c_str(), 0);
+       found = true;

--- a/pkgs/by-name/al/alphafold3/package.nix
+++ b/pkgs/by-name/al/alphafold3/package.nix
@@ -1,0 +1,118 @@
+{
+  lib,
+  fetchFromGitHub,
+  replaceVars,
+  python3,
+  abseil-cpp,
+  dssp,
+  libcifpp,
+  pybind11-abseil,
+  zlib,
+  hmmer,
+}:
+
+let
+  python = python3.override {
+    self = python;
+    packageOverrides = final: prev: {
+      typeguard = prev.typeguard.overridePythonAttrs (oldAttrs: rec {
+        version = "2.13.3";
+        src = oldAttrs.src.override {
+          inherit version;
+          hash = "sha256-AO2qjaOhM2dHls9eqH2fS0w2fXdHbhhegCUcwT37uMQ=";
+        };
+        doCheck = false;
+      });
+    };
+  };
+  libcifpp' = libcifpp.override { downloadCCDFile = true; };
+in
+python.pkgs.buildPythonApplication {
+  pname = "alphafold3";
+  version = "3.0.0-unstable-2024-12-20";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "google-deepmind";
+    repo = "alphafold3";
+    rev = "b380a7c085a5eeea5117d2bd43c121e9a6e0df64";
+    hash = "sha256-jgI7nCPlieNWShvFOfNVVjVh6eHj7J6cla2hV1apmm4=";
+  };
+
+  patches = [
+    (replaceVars ./libcifpp.patch { libcifpp = libcifpp'; })
+    ./add-shebang.patch
+  ];
+
+  build-system = with python.pkgs; [
+    cmake
+    ninja
+    numpy
+    pybind11
+    scikit-build-core
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildInputs = [
+    dssp
+    libcifpp'
+    zlib
+  ];
+
+  pypaBuildFlags = [
+    "--config-setting=cmake.define.FETCHCONTENT_FULLY_DISCONNECTED=ON"
+    "--config-setting=cmake.define.FETCHCONTENT_TRY_FIND_PACKAGE_MODE=ALWAYS"
+    "--config-setting=cmake.define.FETCHCONTENT_SOURCE_DIR_ABSEIL-CPP=${abseil-cpp.src}"
+    "--config-setting=cmake.define.FETCHCONTENT_SOURCE_DIR_PYBIND11_ABSEIL=${pybind11-abseil.src}"
+  ];
+
+  pythonRelaxDeps = true;
+
+  # rdkit has no metadata
+  pythonRemoveDeps = [ "rdkit" ];
+
+  dependencies =
+    with python.pkgs;
+    [
+      absl-py
+      chex
+      dm-haiku
+      dm-tree
+      jax
+      jax-triton
+      jaxtyping
+      numpy
+      rdkit
+      tqdm
+      triton
+      typeguard
+      zstandard
+    ]
+    ++ jax.optional-dependencies.cuda12;
+
+  makeWrapperArgs = [ "--prefix PATH : ${lib.makeBinPath [ hmmer ]}" ];
+
+  postInstall = ''
+    install -Dm755 run_alphafold.py -t $out/bin
+  '';
+
+  postFixup = ''
+    $out/bin/build_data
+  '';
+
+  pythonImportsCheck = [ "alphafold3" ];
+
+  # there are some tests, but they are difficult to run
+  doCheck = false;
+
+  meta = {
+    description = "AlphaFold 3 inference pipeline";
+    homepage = "https://github.com/google-deepmind/alphafold3";
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = with lib.maintainers; [ natsukium ];
+    mainProgram = "run_alphafold.py";
+    # package size is too huge (> 900 MB) due to data
+    hydraPlatforms = [ ];
+  };
+}

--- a/pkgs/by-name/py/pybind11-abseil/package.nix
+++ b/pkgs/by-name/py/pybind11-abseil/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  abseil-cpp,
+  python3,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pybind11-abseil";
+  version = "202402.0";
+
+  src = fetchFromGitHub {
+    owner = "pybind";
+    repo = "pybind11_abseil";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hFVuGzEFqAEm2p2RmfhFtLB6qOqNuVNcwcLh8dIWi0k=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [ python3.pkgs.pybind11 ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "FETCHCONTENT_FULLY_DISCONNECTED" true)
+    (lib.cmakeFeature "FETCHCONTENT_TRY_FIND_PACKAGE_MODE" "ALWAYS")
+    (lib.cmakeFeature "FETCHCONTENT_SOURCE_DIR_ABSEIL-CPP" "${abseil-cpp.src}")
+    (lib.cmakeFeature "CMAKE_INSTALL_PYDIR" "${placeholder "out"}/${python3.sitePackages}")
+  ];
+
+  meta = {
+    description = "Pybind11 bindings for the Abseil C++ Common Libraries";
+    homepage = "https://github.com/pybind/pybind11_abseil";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+})

--- a/pkgs/development/python-modules/jax-triton/default.nix
+++ b/pkgs/development/python-modules/jax-triton/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  config,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  setuptools-scm,
+  absl-py,
+  jax,
+  triton,
+  cudaSupport ? config.cudaSupport,
+}:
+
+buildPythonPackage rec {
+  pname = "jax-triton";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jax-ml";
+    repo = "jax-triton";
+    tag = "v${version}";
+    hash = "sha256-1zqCYA/iGKt2GQvGywwT+56GnGgvxh8RR99RRpDjvYg=";
+  };
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    absl-py
+    jax
+    triton
+  ];
+
+  # require CUDA supported jax
+  dontUsePythonImportsCheck = !cudaSupport;
+
+  pythonImportsCheck = [ "jax_triton" ];
+
+  # require GPU access
+  doCheck = false;
+
+  meta = {
+    description = "Jax-triton contains integrations between JAX and OpenAI Triton";
+    homepage = "https://github.com/jax-ml/jax-triton";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ natsukium ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -6576,6 +6576,8 @@ self: super: with self; {
 
   jaxlib-bin = callPackage ../development/python-modules/jaxlib/bin.nix { };
 
+  jax-triton = callPackage ../development/python-modules/jax-triton { };
+
   jaxlib-build = callPackage ../development/python-modules/jaxlib rec {
     # Some platforms don't have `cudaSupport` defined, hence the need for 'or false'.
     inherit (pkgs.config) cudaSupport;


### PR DESCRIPTION
AlphaFold 3 inference pipeline.
source code: https://github.com/google-deepmind/alphafold3
paper: https://www.nature.com/articles/s41586-024-07487-w

new dependencies
- python312Packages.jax-triton: init at 0.2.0
  - https://github.com/jax-ml/jax-triton
- pybind11-abseil: init at 202402.0
  - https://github.com/pybind/pybind11_abseil

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
