### PR TITLE
envoy: fix build, 1.32.0 -> 1.32.3

### DIFF
--- a/pkgs/by-name/en/envoy/0001-nixpkgs-use-system-Python.patch
+++ b/pkgs/by-name/en/envoy/0001-nixpkgs-use-system-Python.patch
@@ -1,4 +1,4 @@
-From 47406ebaf0260e5b66a92baac3717936c8386b69 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
 Date: Mon, 22 Apr 2024 11:52:59 +0200
 Subject: [PATCH] nixpkgs: use system Python
@@ -10,7 +10,7 @@ Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
  2 files changed, 5 insertions(+), 23 deletions(-)
 
 diff --git a/bazel/python_dependencies.bzl b/bazel/python_dependencies.bzl
-index 9f2b336b1a..53a2c93c59 100644
+index 9f2b336b1a36ca0d2f04a40ac1809b30ff21df27..53a2c93c59492a12ef4a6ecfc0c8a679f0df73f7 100644
 --- a/bazel/python_dependencies.bzl
 +++ b/bazel/python_dependencies.bzl
 @@ -1,28 +1,25 @@
@@ -47,7 +47,7 @@ index 9f2b336b1a..53a2c93c59 100644
          extra_pip_args = ["--require-hashes"],
      )
 diff --git a/bazel/repositories_extra.bzl b/bazel/repositories_extra.bzl
-index b92dd461ba..cef32b3140 100644
+index b92dd461ba7037d2f1c079f283ff2c466686f7a4..cef32b3140588cb7668d47d0c08528f131184fe4 100644
 --- a/bazel/repositories_extra.bzl
 +++ b/bazel/repositories_extra.bzl
 @@ -2,19 +2,11 @@ load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")

--- a/pkgs/by-name/en/envoy/0002-nixpkgs-use-system-Go.patch
+++ b/pkgs/by-name/en/envoy/0002-nixpkgs-use-system-Go.patch
@@ -1,4 +1,4 @@
-From 4be181e96199529a36e9a93c837af7173c827493 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
 Date: Mon, 22 Apr 2024 11:58:00 +0200
 Subject: [PATCH] nixpkgs: use system Go
@@ -9,7 +9,7 @@ Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/bazel/dependency_imports.bzl b/bazel/dependency_imports.bzl
-index c68eb4bf3e..addee4f6af 100644
+index c68eb4bf3ed2d39d46d38d7bd0eeab2c74a507fa..addee4f6af74ea78ae778b73384e01db83ac6694 100644
 --- a/bazel/dependency_imports.bzl
 +++ b/bazel/dependency_imports.bzl
 @@ -20,7 +20,7 @@ load("@rules_rust//rust:defs.bzl", "rust_common")

--- a/pkgs/by-name/en/envoy/0003-nixpkgs-use-system-C-C-toolchains.patch
+++ b/pkgs/by-name/en/envoy/0003-nixpkgs-use-system-C-C-toolchains.patch
@@ -1,4 +1,4 @@
-From 3ecb08a7603a07310d1a38c0f47bc54bbe1f11c8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Paul Meyer <49727155+katexochen@users.noreply.github.com>
 Date: Mon, 22 Apr 2024 11:59:22 +0200
 Subject: [PATCH] nixpkgs: use system C/C++ toolchains
@@ -9,7 +9,7 @@ Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/bazel/dependency_imports.bzl b/bazel/dependency_imports.bzl
-index addee4f6af..dc1967e43b 100644
+index addee4f6af74ea78ae778b73384e01db83ac6694..dc1967e43b2b71358d2767a3d83b52819987290d 100644
 --- a/bazel/dependency_imports.bzl
 +++ b/bazel/dependency_imports.bzl
 @@ -26,7 +26,11 @@ JQ_VERSION = "1.7"

--- a/pkgs/by-name/en/envoy/0004-nixpkgs-patch-boringssl-for-gcc14.patch
+++ b/pkgs/by-name/en/envoy/0004-nixpkgs-patch-boringssl-for-gcc14.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paul Meyer <katexochen0@gmail.com>
+Date: Thu, 2 Jan 2025 09:32:41 +0100
+Subject: [PATCH] nixpkgs: patch boringssl for gcc14
+
+Signed-off-by: Paul Meyer <katexochen0@gmail.com>
+---
+ bazel/boringssl-gcc14.patch | 25 +++++++++++++++++++++++++
+ bazel/repositories.bzl      |  1 +
+ 2 files changed, 26 insertions(+)
+ create mode 100644 bazel/boringssl-gcc14.patch
+
+diff --git a/bazel/boringssl-gcc14.patch b/bazel/boringssl-gcc14.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..8dcad4cc11f691eec93efa29075c1d356732e58b
+--- /dev/null
++++ b/bazel/boringssl-gcc14.patch
+@@ -0,0 +1,25 @@
++diff --git a/crypto/internal.h b/crypto/internal.h
++index a77102d..a45f97b 100644
++--- a/crypto/internal.h
+++++ b/crypto/internal.h
++@@ -1174,6 +1174,11 @@
++ 
++ // Arithmetic functions.
++ 
+++// The most efficient versions of these functions on GCC and Clang depend on C11
+++// |_Generic|. If we ever need to call these from C++, we'll need to add a
+++// variant that uses C++ overloads instead.
+++#if !defined(__cplusplus)
+++
++ // CRYPTO_addc_* returns |x + y + carry|, and sets |*out_carry| to the carry
++ // bit. |carry| must be zero or one.
++ #if OPENSSL_HAS_BUILTIN(__builtin_addc)
++@@ -1275,6 +1280,8 @@
++ #define CRYPTO_subc_w CRYPTO_subc_u32
++ #endif
++ 
+++#endif  // !__cplusplus
+++
++ 
++ // FIPS functions.
++ 
+diff --git a/bazel/repositories.bzl b/bazel/repositories.bzl
+index 5cb573770f0aeac7b42d803673c8c520b5e35131..e864ef24db4bf837ef50d90c8eca316eba939d74 100644
+--- a/bazel/repositories.bzl
++++ b/bazel/repositories.bzl
+@@ -264,6 +264,7 @@ def _boringssl():
+         patch_args = ["-p1"],
+         patches = [
+             "@envoy//bazel:boringssl_static.patch",
++            "@envoy//bazel:boringssl-gcc14.patch",
+         ],
+     )
+ 

--- a/pkgs/by-name/en/envoy/0005-deps-Bump-rules_rust-0.54.1-37056.patch
+++ b/pkgs/by-name/en/envoy/0005-deps-Bump-rules_rust-0.54.1-37056.patch
@@ -1,0 +1,128 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "dependency-envoy[bot]"
+ <148525496+dependency-envoy[bot]@users.noreply.github.com>
+Date: Fri, 8 Nov 2024 21:09:22 +0000
+Subject: [PATCH] deps: Bump `rules_rust` -> 0.54.1 (#37056)
+
+Fix #37054
+
+Signed-off-by: dependency-envoy[bot] <148525496+dependency-envoy[bot]@users.noreply.github.com>
+Signed-off-by: Ryan Northey <ryan@synca.io>
+---
+ bazel/repository_locations.bzl                | 10 ++++++---
+ .../dynamic_modules/sdk/rust/Cargo.Bazel.lock | 21 +++++++++++--------
+ 2 files changed, 19 insertions(+), 12 deletions(-)
+
+diff --git a/bazel/repository_locations.bzl b/bazel/repository_locations.bzl
+index 85a125d44ece6c655f94aab3d986d96ab837897f..cfe7d145b59b691f6455b58b1baaae48276b7e9f 100644
+--- a/bazel/repository_locations.bzl
++++ b/bazel/repository_locations.bzl
+@@ -1465,12 +1465,16 @@ REPOSITORY_LOCATIONS_SPEC = dict(
+         license = "Emscripten SDK",
+         license_url = "https://github.com/emscripten-core/emsdk/blob/{version}/LICENSE",
+     ),
++    # After updating you may need to run:
++    #
++    #     CARGO_BAZEL_REPIN=1 bazel sync --only=crate_index
++    #
+     rules_rust = dict(
+         project_name = "Bazel rust rules",
+         project_desc = "Bazel rust rules (used by Wasm)",
+         project_url = "https://github.com/bazelbuild/rules_rust",
+-        version = "0.51.0",
+-        sha256 = "042acfb73469b2d1848fe148d81c3422c61ea47a9e1900f1c9ec36f51e8e7193",
++        version = "0.54.1",
++        sha256 = "af4f56caae50a99a68bfce39b141b509dd68548c8204b98ab7a1cafc94d5bb02",
+         # Note: rules_rust should point to the releases, not archive to avoid the hassle of bootstrapping in crate_universe.
+         # This is described in https://bazelbuild.github.io/rules_rust/crate_universe.html#setup, otherwise bootstrap
+         # is required which in turn requires a system CC toolchains, not the bazel controlled ones.
+@@ -1482,7 +1486,7 @@ REPOSITORY_LOCATIONS_SPEC = dict(
+         ],
+         implied_untracked_deps = ["rules_cc"],
+         extensions = ["envoy.wasm.runtime.wasmtime"],
+-        release_date = "2024-09-19",
++        release_date = "2024-11-07",
+         cpe = "N/A",
+         license = "Apache-2.0",
+         license_url = "https://github.com/bazelbuild/rules_rust/blob/{version}/LICENSE.txt",
+diff --git a/source/extensions/dynamic_modules/sdk/rust/Cargo.Bazel.lock b/source/extensions/dynamic_modules/sdk/rust/Cargo.Bazel.lock
+index fa6012f406464428b37d548eecd6cec3fdaf901b..6af752304b65af39aa621fa201a8c0108931dad0 100644
+--- a/source/extensions/dynamic_modules/sdk/rust/Cargo.Bazel.lock
++++ b/source/extensions/dynamic_modules/sdk/rust/Cargo.Bazel.lock
+@@ -1,5 +1,5 @@
+ {
+-  "checksum": "96b309ddded40cf6f46a62829d15a02d7253b4cc94af2ac1890e492f9c07e93f",
++  "checksum": "b550022ca979d6b55c6dbee950bbf18368e4b8da16973c4e88e292b4d6f28e81",
+   "crates": {
+     "aho-corasick 1.1.3": {
+       "name": "aho-corasick",
+@@ -2149,9 +2149,6 @@
+     "aarch64-apple-ios-sim": [
+       "aarch64-apple-ios-sim"
+     ],
+-    "aarch64-fuchsia": [
+-      "aarch64-fuchsia"
+-    ],
+     "aarch64-linux-android": [
+       "aarch64-linux-android"
+     ],
+@@ -2159,6 +2156,9 @@
+     "aarch64-pc-windows-msvc": [
+       "aarch64-pc-windows-msvc"
+     ],
++    "aarch64-unknown-fuchsia": [
++      "aarch64-unknown-fuchsia"
++    ],
+     "aarch64-unknown-linux-gnu": [
+       "aarch64-unknown-linux-gnu"
+     ],
+@@ -2197,8 +2197,8 @@
+       "aarch64-apple-darwin",
+       "aarch64-apple-ios",
+       "aarch64-apple-ios-sim",
+-      "aarch64-fuchsia",
+       "aarch64-linux-android",
++      "aarch64-unknown-fuchsia",
+       "aarch64-unknown-linux-gnu",
+       "aarch64-unknown-nixos-gnu",
+       "aarch64-unknown-nto-qnx710",
+@@ -2213,9 +2213,9 @@
+       "s390x-unknown-linux-gnu",
+       "x86_64-apple-darwin",
+       "x86_64-apple-ios",
+-      "x86_64-fuchsia",
+       "x86_64-linux-android",
+       "x86_64-unknown-freebsd",
++      "x86_64-unknown-fuchsia",
+       "x86_64-unknown-linux-gnu",
+       "x86_64-unknown-nixos-gnu"
+     ],
+@@ -2264,15 +2264,15 @@
+     "wasm32-wasi": [
+       "wasm32-wasi"
+     ],
++    "wasm32-wasip1": [
++      "wasm32-wasip1"
++    ],
+     "x86_64-apple-darwin": [
+       "x86_64-apple-darwin"
+     ],
+     "x86_64-apple-ios": [
+       "x86_64-apple-ios"
+     ],
+-    "x86_64-fuchsia": [
+-      "x86_64-fuchsia"
+-    ],
+     "x86_64-linux-android": [
+       "x86_64-linux-android"
+     ],
+@@ -2283,6 +2283,9 @@
+     "x86_64-unknown-freebsd": [
+       "x86_64-unknown-freebsd"
+     ],
++    "x86_64-unknown-fuchsia": [
++      "x86_64-unknown-fuchsia"
++    ],
+     "x86_64-unknown-linux-gnu": [
+       "x86_64-unknown-linux-gnu"
+     ],

--- a/pkgs/by-name/en/envoy/0006-gcc-warnings.patch
+++ b/pkgs/by-name/en/envoy/0006-gcc-warnings.patch
@@ -1,0 +1,127 @@
+From 448e4e14f4f188687580362a861ae4a0dbb5b1fb Mon Sep 17 00:00:00 2001
+From: "Krinkin, Mike" <krinkin.m.u@gmail.com>
+Date: Sat, 16 Nov 2024 00:40:40 +0000
+Subject: [PATCH] [contrib] Disable GCC warnings and broken features (#37131)
+
+Currently contrib does not build with GCC because of various false
+positive compiler warnings turned to errors and a GCC compiler bug.
+
+Let's first start with the bug, in GCC apparently
+using -gsplit-dwarf (debug fission) and -fdebug-types-section (used to
+optimize the size of debug inforamtion), when used together, can result
+in a linker failure.
+
+Refer to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110885 for the GCC
+bug report of this issue. When it comes to Envoy, optimized builds with
+GCC are affected on at least GCC 11 (used by --config=docker-gcc) and
+GCC 12 (and I'm pretty sure the bug isn't fixed in any newer versions
+either, though I didn't check each version).
+
+Given that we cannot have both debug fission and a debug types section,
+we decided to abandon the debug types sections and keep the fission.
+
+That being said, apparently both of those options are unmaintained in
+GCC which poses a question of long term viability of using those or GCC.
+
+Other changes in this commit disable GCC compiler errors for various
+warnings that happen when building contrib. I checked those warnings and
+didn't find any true
+positive.
+
+And additionally, for warnings that exists in both Clang and GCC, Clang
+warnings don't trigger, so Clang also disagrees with GCC here.
+
+Additionally missing-requires warning is new and does not exist in GCC
+11, but exists in later versions of GCC, so to avoid breaking on this
+warning for future versions of GCC I disabled it, but also tell GCC to
+not complain if it sees a flag related to an unknwon diagnostic.
+
+This is the last change required to make GCC contrib builds work (you
+can find more context and discussions in
+https://github.com/envoyproxy/envoy/issues/31807)
+
+Risk Level: Low
+Testing: building with --config=gcc and --config=docker-gcc
+Docs Changes: N/A
+Release Notes: N/A
+Platform Specific Features: N/A
+Fixes #31807
+
+Signed-off-by: Mikhail Krinkin <krinkin.m.u@gmail.com>
+---
+ .bazelrc                 | 18 +++++++++++++++++-
+ bazel/envoy_internal.bzl | 16 +++++++++++++++-
+ 2 files changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/.bazelrc b/.bazelrc
+index e0e4899cecf1..7df94c77944c 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -57,9 +57,9 @@ test --experimental_ui_max_stdouterr_bytes=11712829 #default 1048576
+ # Allow tags to influence execution requirements
+ common --experimental_allow_tags_propagation
+ 
++build:linux --copt=-fdebug-types-section
+ # Enable position independent code (this is the default on macOS and Windows)
+ # (Workaround for https://github.com/bazelbuild/rules_foreign_cc/issues/421)
+-build:linux --copt=-fdebug-types-section
+ build:linux --copt=-fPIC
+ build:linux --copt=-Wno-deprecated-declarations
+ build:linux --cxxopt=-std=c++20 --host_cxxopt=-std=c++20
+@@ -95,6 +95,21 @@ build:gcc --linkopt=-fuse-ld=gold --host_linkopt=-fuse-ld=gold
+ build:gcc --test_env=HEAPCHECK=
+ build:gcc --action_env=BAZEL_COMPILER=gcc
+ build:gcc --action_env=CC=gcc --action_env=CXX=g++
++# This is to work around a bug in GCC that makes debug-types-section
++# option not play well with fission:
++# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110885
++build:gcc --copt=-fno-debug-types-section
++# These trigger errors in multiple places both in Envoy dependecies
++# and in Envoy code itself when using GCC.
++# And in all cases the reports appear to be clear false positives.
++build:gcc --copt=-Wno-error=restrict
++build:gcc --copt=-Wno-error=uninitialized
++build:gcc --cxxopt=-Wno-missing-requires
++# We need this because -Wno-missing-requires options is rather new
++# in GCC, so flags -Wno-missing-requires exists in GCC 12, but does
++# not in GCC 11 and GCC 11 is what is used in docker-gcc
++# configuration currently
++build:gcc --cxxopt=-Wno-unknown-warning
+ 
+ # Clang-tidy
+ # TODO(phlax): enable this, its throwing some errors as well as finding more issues
+@@ -375,6 +390,7 @@ build:docker-clang-libc++ --config=docker-sandbox
+ build:docker-clang-libc++ --config=rbe-toolchain-clang-libc++
+ 
+ build:docker-gcc --config=docker-sandbox
++build:docker-gcc --config=gcc
+ build:docker-gcc --config=rbe-toolchain-gcc
+ 
+ build:docker-asan --config=docker-sandbox
+diff --git a/bazel/envoy_internal.bzl b/bazel/envoy_internal.bzl
+index 015659851c1b..27ecaa0bbf47 100644
+--- a/bazel/envoy_internal.bzl
++++ b/bazel/envoy_internal.bzl
+@@ -68,7 +68,21 @@ def envoy_copts(repository, test = False):
+                    "-Wc++2a-extensions",
+                    "-Wrange-loop-analysis",
+                ],
+-               repository + "//bazel:gcc_build": ["-Wno-maybe-uninitialized"],
++               repository + "//bazel:gcc_build": [
++                   "-Wno-maybe-uninitialized",
++                   # GCC implementation of this warning is too noisy.
++                   #
++                   # It generates warnings even in cases where there is no ambiguity
++                   # between the overloaded version of a method and the hidden version
++                   # from the base class. E.g., when the two have different number of
++                   # arguments or incompatible types and therefore a wrong function
++                   # cannot be called by mistake without triggering a compiler error.
++                   #
++                   # As a safeguard, this warning is only disabled for GCC builds, so
++                   # if Clang catches a problem in the code we would get a warning
++                   # anyways.
++                   "-Wno-error=overloaded-virtual",
++               ],
+                # Allow 'nodiscard' function results values to be discarded for test code only
+                # TODO(envoyproxy/windows-dev): Replace /Zc:preprocessor with /experimental:preprocessor
+                # for msvc versions between 15.8 through 16.4.x. see

--- a/pkgs/by-name/en/envoy/0007-protobuf-remove-Werror.patch
+++ b/pkgs/by-name/en/envoy/0007-protobuf-remove-Werror.patch
@@ -1,0 +1,19 @@
+diff -Naur a/bazel/protobuf.patch b/bazel/protobuf.patch
+--- a/bazel/protobuf.patch	2025-01-06 23:00:26.683972526 +0100
++++ b/bazel/protobuf.patch	2025-01-07 00:53:33.997482569 +0100
+@@ -149,3 +149,15 @@
+  #if PROTOBUF_ENABLE_DEBUG_LOGGING_MAY_LEAK_PII
+  #define PROTOBUF_DEBUG true
+  #else
++diff -Naur a/build_defs/cpp_opts.bzl b/build_defs/cpp_opts.bzl
++--- a/build_defs/cpp_opts.bzl	2025-01-06 23:02:56.356552216 +0100
+++++ b/build_defs/cpp_opts.bzl	2025-01-07 00:23:30.534047300 +0100
++@@ -22,7 +22,7 @@
++         "-Woverloaded-virtual",
++         "-Wno-sign-compare",
++         "-Wno-nonnull",
++-        "-Werror",
+++        "-Wno-maybe-uninitialized",
++     ],
++ })
++ 

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -30,16 +30,16 @@ let
     # However, the version string is more useful for end-users.
     # These are contained in a attrset of their own to make it obvious that
     # people should update both.
-    version = "1.32.0";
-    rev = "86dc7ef91ca15fb4957a74bd599397413fc26a24";
-    hash = "sha256-Sb87yQXtNbKrqPVujPbfOE+Y8ARmW+HyqMmLLa5tPmA=";
+    version = "1.32.3";
+    rev = "58bd599ebd5918d4d005de60954fcd2cb00abd95";
+    hash = "sha256-5HpxcsAPoyVOJ3Aem+ZjSLa8Zu6s76iCMiWJbp8RjHc=";
   };
 
   # these need to be updated for any changes to fetchAttrs
   depsHash =
     {
-      x86_64-linux = "sha256-qny2l+gIoWCVRZIodd/Tzuj88f/+ajNXeZo/b9XEfVE=";
-      aarch64-linux = "sha256-DkibjmY1YND9Q2aQ41bhNdch0SKM5ghY2mjYSQfV31N=";
+      x86_64-linux = "sha256-YFXNatolLM9DdwkMnc9SWsa6Z6/aGzqLmo/zKE7OFy0=";
+      aarch64-linux = "sha256-AjG1OBjPjiSwWCmIJgHevSQHx8+rzRgmLsw3JwwD0hk=";
     }
     .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
 

--- a/pkgs/by-name/en/envoy/package.nix
+++ b/pkgs/by-name/en/envoy/package.nix
@@ -4,6 +4,7 @@
   bazel-gazelle,
   buildBazelPackage,
   fetchFromGitHub,
+  applyPatches,
   stdenv,
   cacert,
   cargo,
@@ -31,30 +32,52 @@ let
     # people should update both.
     version = "1.32.0";
     rev = "86dc7ef91ca15fb4957a74bd599397413fc26a24";
-    hash = "sha256-Wcbt62RfaNcTntmPjaAM0cP3LJangm4ht7Q0bzEpu5A=";
+    hash = "sha256-Sb87yQXtNbKrqPVujPbfOE+Y8ARmW+HyqMmLLa5tPmA=";
   };
 
   # these need to be updated for any changes to fetchAttrs
   depsHash =
     {
-      x86_64-linux = "sha256-LkDNPFT7UUCsGPG1dMnwzdIw0lzc5+3JYDoblF5oZVk=";
+      x86_64-linux = "sha256-KQ0ZxLC/ZLLcypmb1UlVXvLWErLmxuednjKRFaBgKuQ=";
       aarch64-linux = "sha256-DkibjmY1YND9Q2aQ41bhNdch0SKM5ghY2mjYSQfV30M=";
     }
     .${stdenv.system} or (throw "unsupported system ${stdenv.system}");
+
 in
 buildBazelPackage rec {
   pname = "envoy";
   inherit (srcVer) version;
   bazel = bazel_6;
-  src = fetchFromGitHub {
-    owner = "envoyproxy";
-    repo = "envoy";
-    inherit (srcVer) hash rev;
 
-    postFetch = ''
-      chmod -R +w $out
-      rm $out/.bazelversion
-      echo ${srcVer.rev} > $out/SOURCE_VERSION
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "envoyproxy";
+      repo = "envoy";
+      inherit (srcVer) hash rev;
+    };
+    patches = [
+      # use system Python, not bazel-fetched binary Python
+      ./0001-nixpkgs-use-system-Python.patch
+
+      # use system Go, not bazel-fetched binary Go
+      ./0002-nixpkgs-use-system-Go.patch
+
+      # use system C/C++ tools
+      ./0003-nixpkgs-use-system-C-C-toolchains.patch
+
+      # patch boringssl to work with GCC 14
+      # vendored patch from https://boringssl.googlesource.com/boringssl/+/c70190368c7040c37c1d655f0690bcde2b109a0d
+      ./0004-nixpkgs-patch-boringssl-for-gcc14.patch
+
+      # update rust rules to work with rustc v1.83
+      # cherry-pick of https://github.com/envoyproxy/envoy/commit/019f589da2cc8da7673edd077478a100b4d99436
+      # drop with v1.33.x
+      ./0005-deps-Bump-rules_rust-0.54.1-37056.patch
+    ];
+    postPatch = ''
+      chmod -R +w .
+      rm ./.bazelversion
+      echo ${srcVer.rev} > ./SOURCE_VERSION
     '';
   };
 
@@ -79,17 +102,6 @@ buildBazelPackage rec {
     cat bazel/nix/rules_rust_extra.patch bazel/rules_rust.patch > bazel/nix/rules_rust.patch
     mv bazel/nix/rules_rust.patch bazel/rules_rust.patch
   '';
-
-  patches = [
-    # use system Python, not bazel-fetched binary Python
-    ./0001-nixpkgs-use-system-Python.patch
-
-    # use system Go, not bazel-fetched binary Go
-    ./0002-nixpkgs-use-system-Go.patch
-
-    # use system C/C++ tools
-    ./0003-nixpkgs-use-system-C-C-toolchains.patch
-  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION


https://github.com/envoyproxy/envoy/releases/tag/v1.32.3

- [CVE-2024-53269](https://github.com/envoyproxy/envoy/security/advisories/GHSA-mfqp-7mmj-rm53): Happy Eyeballs: Validate that additional_address are IP addresses instead of crashing when sorting.
- [CVE-2024-53270](https://github.com/envoyproxy/envoy/security/advisories/GHSA-q9qv-8j52-77p3): HTTP/1: sending overload crashes when the request is reset beforehand
- [CVE-2024-53271](https://github.com/envoyproxy/envoy/security/advisories/GHSA-rmm5-h2wv-mg4f): HTTP/1.1 multiple issues with envoy.reloadable_features.http1_balsa_delay_reset

https://github.com/envoyproxy/envoy/releases/tag/v1.32.2
https://github.com/envoyproxy/envoy/releases/tag/v1.32.1


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
