### PR TITLE
lilypond: fix strictDeps build

### DIFF
--- a/pkgs/misc/lilypond/default.nix
+++ b/pkgs/misc/lilypond/default.nix
@@ -83,33 +83,36 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     bison
+    dblatex
     flex
+    fontforge
+    ghostscript
+    imagemagick
     makeWrapper
     pkg-config
+    python3
+    t1utils
+    tex
+    texi2html
+    texinfo
+    perl
+    rsync
   ];
 
   buildInputs = [
-    ghostscript
-    texinfo
-    imagemagick
-    texi2html
+    flex # FlexLexer.h
     guile
     dblatex
     tex
     zip
     netpbm
-    python3
     gettext
-    perl
     fontconfig
     freetype
     pango
-    fontforge
     help2man
     groff
-    t1utils
     boehmgc
-    rsync
   ];
 
   autoreconfPhase = "NOCONFIGURE=1 sh autogen.sh";


### PR DESCRIPTION
I am not sure this covers everything, so I didn't set `strictDeps = true`. This is sufficient to build the package.

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).