### PR TITLE
irssi: fix cross build

### DIFF
--- a/pkgs/applications/networking/irc/irssi/default.nix
+++ b/pkgs/applications/networking/irc/irssi/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     meson
     ninja
+    perl
     pkg-config
   ];
 
@@ -38,7 +39,6 @@ stdenv.mkDerivation rec {
     libotr
     ncurses
     openssl
-    perl
   ];
 
   configureFlags = [


### PR DESCRIPTION
perl is only required at build time.

Incidentially this also fixes regular strictDeps = true, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).