### PR TITLE
csound: 6.18.1 -> 6.18.1-unstable-2024-07-02

### DIFF
--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -29,15 +29,15 @@
 
 stdenv.mkDerivation rec {
   pname = "csound";
-  version = "6.18.1";
+  version = "6.18.1-unstable-2024-07-02";
 
   hardeningDisable = [ "format" ];
 
   src = fetchFromGitHub {
     owner = "csound";
     repo = "csound";
-    rev = version;
-    sha256 = "sha256-O7s92N54+zIl07eIdK/puoSve/qJ3O01fTh0TP+VdZA=";
+    rev = "2536da284dd70ec7272040cb0763f70ae57123c4";
+    sha256 = "sha256-NDYltwmjBsX1DWCjy8/4cXMSl3/mK+HaQHSKUmRR9TI=";
   };
 
   cmakeFlags =


### PR DESCRIPTION
https://github.com/csound/csound/issues/1988

ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).