### PR TITLE
mobilizon: fix internal version

### DIFF
--- a/pkgs/servers/mobilizon/0001-fix-version.patch
+++ b/pkgs/servers/mobilizon/0001-fix-version.patch
@@ -1,0 +1,13 @@
+diff --git a/mix.exs b/mix.exs
+index 8338abf8..883e6987 100644
+--- a/mix.exs
++++ b/mix.exs
+@@ -1,7 +1,7 @@
+ defmodule Mobilizon.Mixfile do
+   use Mix.Project
+ 
+-  @version "5.1.0"
++  @version "5.1.1"
+ 
+   def project do
+     [

--- a/pkgs/servers/mobilizon/default.nix
+++ b/pkgs/servers/mobilizon/default.nix
@@ -19,6 +19,11 @@ in
 mixRelease rec {
   inherit (common) pname version src;
 
+  # Version 5.1.1 failed to bump their internal package version,
+  # which causes issues with static file serving in the NixOS module.
+  # See https://github.com/NixOS/nixpkgs/pull/370277
+  patches = [ ./0001-fix-version.patch ];
+
   nativeBuildInputs = [
     git
     cmake


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

It looks like Mobilizon 5.1.1 forgot to bump their internal version, which causes issues with static file serving in the Mobilizon NixOS module as it relies on Nix and internal package versions being the same:

https://github.com/NixOS/nixpkgs/blob/88195a94f390381c6afcdaa933c2f6ff93959cb4/nixos/modules/services/web-apps/mobilizon.nix#L439-L440

This PR temporarily replaces the version in the hopes that the next version of Mobilizon does not repeat this. If this becomes a recurring issue, we might want to consider always setting the version in `mix.exs` to the Nix package version.

I didn't catch this in the 5.1.1 update PR unfortunately because all static files were cached already when I was testing the update on rheinneckar.events.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
