### PR TITLE
facetimehd-calibration: fix strictDeps build

### DIFF
--- a/pkgs/by-name/fa/facetimehd-calibration/package.nix
+++ b/pkgs/by-name/fa/facetimehd-calibration/package.nix
@@ -58,7 +58,7 @@ stdenvNoCC.mkDerivation {
   dontUnpack = true;
   dontInstall = true;
 
-  buildInputs = [ unrar-wrapper ];
+  nativeBuildInputs = [ unrar-wrapper ];
 
   buildPhase =
     ''


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).