### PR TITLE
libppd: fix cross build

### DIFF
--- a/pkgs/by-name/li/libppd/package.nix
+++ b/pkgs/by-name/li/libppd/package.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation rec {
     cups
   ];
   buildInputs = [
+    cups
     ghostscript
     libcupsfilters
     mupdf


### PR DESCRIPTION
Incidentally also fixes regular `strictDeps = true` build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: regular and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).