### PR TITLE
fetchutils: fix cross build

### DIFF
--- a/pkgs/by-name/fe/fetchutils/package.nix
+++ b/pkgs/by-name/fe/fetchutils/package.nix
@@ -17,9 +17,12 @@ stdenvNoCC.mkDerivation rec {
     sha256 = "sha256-ONrVZC6GBV5v3TeBekW9ybZjDHF3FNyXw1rYknqKRbk=";
   };
 
+  nativeBuildInputs = [
+    scdoc
+  ];
+
   buildInputs = [
     bash
-    scdoc
   ];
 
   installFlags = [ "PREFIX=$(out)/" ];


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).