### PR TITLE
libfishsound: fix build with gcc14

### DIFF
--- a/pkgs/by-name/li/libfishsound/fix-callbacks.patch
+++ b/pkgs/by-name/li/libfishsound/fix-callbacks.patch
@@ -1,0 +1,20 @@
+--- a/src/libfishsound/flac.c
++++ b/src/libfishsound/flac.c
+@@ -106,7 +106,7 @@ fs_flac_command (FishSound * fsound, int command, void * data, int datasize)
+ #if FS_DECODE
+ static FLAC__StreamDecoderReadStatus
+ fs_flac_read_callback(const FLAC__StreamDecoder *decoder,
+-                      FLAC__byte buffer[], unsigned int *bytes,
++                      FLAC__byte buffer[], size_t *bytes,
+                       void *client_data)
+ {
+   FishSound* fsound = (FishSound*)client_data;
+@@ -346,7 +346,7 @@ dec_err:
+ #if FS_ENCODE
+ static FLAC__StreamEncoderWriteStatus
+ fs_flac_enc_write_callback(const FLAC__StreamEncoder *encoder,
+-                           const FLAC__byte buffer[], unsigned bytes,
++                           const FLAC__byte buffer[], size_t bytes,
+                            unsigned samples, unsigned current_frame,
+                            void *client_data)
+ {

--- a/pkgs/by-name/li/libfishsound/package.nix
+++ b/pkgs/by-name/li/libfishsound/package.nix
@@ -17,6 +17,10 @@ stdenv.mkDerivation rec {
     sha256 = "1iz7mn6hw2wg8ljaw74f4g2zdj68ib88x4vjxxg3gjgc5z75f2rf";
   };
 
+  patches = [
+    ./fix-callbacks.patch
+  ];
+
   propagatedBuildInputs = [
     libvorbis
     speex


### PR DESCRIPTION
In gcc 14, the default compiler in stdenv, `-Wincompatible-pointer-types` is enabled by default. This causes a build failure for `libfishsound`.

This patch adds a patch to `libfishsound` to fix the declaration of two callbacks.

The problem has also been reported upstream in https://github.com/kfish/libfishsound/issues/2. However, there hasn't been much activity for the past 15 years, so I'm not sure how quick a response would be.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
