### PR TITLE
denemo: 2.6.0 -> 2.6.43 (fix for GCC 14)

### DIFF
--- a/pkgs/by-name/de/denemo/package.nix
+++ b/pkgs/by-name/de/denemo/package.nix
@@ -1,8 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
-  fetchpatch,
+  fetchgit,
   pkg-config,
   libjack2,
   gettext,
@@ -29,25 +28,13 @@
 
 stdenv.mkDerivation rec {
   pname = "denemo";
-  version = "2.6.0";
+  version = "2.6.43";
 
-  src = fetchurl {
-    url = "https://ftp.gnu.org/gnu/denemo/denemo-${version}.tar.gz";
-    sha256 = "sha256-S+WXDGmEf5fx+HYnXJdE5QNOfJg7EqEEX7IMI2SUtV0=";
+  src = fetchgit {
+    url = "https://git.savannah.gnu.org/git/denemo.git";
+    rev = "b04ead1d3efeee036357cf36898b838a96ec5332";
+    hash = "sha256-XMFbPk70JqUHWBPEK8rjr70iMs49RNyaaCUGnYlLf2E=";
   };
-
-  patches = [
-    (fetchpatch {
-      name = "allow-guile-3.patch";
-      url = "https://git.savannah.gnu.org/cgit/denemo.git/patch/?id=9de1c65e56a021925af532bb55336b0ce86d3084";
-      postFetch = ''
-        substituteInPlace $out \
-          --replace "2.6.8" "2.6.0" \
-          --replace "2.6.9" "2.6.0"
-      '';
-      hash = "sha256-Jj33k/KgvZgKG43MuLgjb4A2KNkm/z9ytzGKcXMAOI4=";
-    })
-  ];
 
   buildInputs = [
     libjack2
@@ -67,6 +54,9 @@ stdenv.mkDerivation rec {
     fftw
     portmidi
   ];
+
+  # error by default in GCC 14
+  NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
 
   preFixup = ''
     gappsWrapperArgs+=(
@@ -89,8 +79,5 @@ stdenv.mkDerivation rec {
     license = lib.licenses.gpl3;
     platforms = lib.platforms.linux;
     maintainers = [ lib.maintainers.olynch ];
-    # sffile.c:38:10: error: implicit declaration of function 'isprint' [-Wimplicit-function-declaration]
-    # sffile.c:54:10: error: type defaults to 'int' in declaration of 'initialized' [-Wimplicit-int]
-    broken = true;
   };
 }


### PR DESCRIPTION
Not entirely sure if this is a "stable" release.

ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).