### PR TITLE
binaryen: fix strictDeps build

### DIFF
--- a/pkgs/development/compilers/binaryen/default.nix
+++ b/pkgs/development/compilers/binaryen/default.nix
@@ -34,6 +34,8 @@ stdenv.mkDerivation rec {
     python3
   ];
 
+  strictDeps = true;
+
   preConfigure = ''
     if [ $doCheck -eq 1 ]; then
       sed -i '/googletest/d' third_party/CMakeLists.txt
@@ -45,10 +47,12 @@ stdenv.mkDerivation rec {
   '';
 
   nativeCheckInputs = [
-    gtest
     lit
     nodejs
     filecheck
+  ];
+  checkInputs = [
+    gtest
   ];
   checkPhase = ''
     LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/lib python3 ../check.py $tests


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).