### PR TITLE
libdnet: fix cross build

### DIFF
--- a/pkgs/by-name/li/libdnet/package.nix
+++ b/pkgs/by-name/li/libdnet/package.nix
@@ -26,9 +26,11 @@ stdenv.mkDerivation (finalAttrs: {
     automake
     autoconf
     pkg-config
-    check
   ];
-  buildInputs = [ libtool ];
+  buildInputs = [
+    check
+    libtool
+  ];
 
   # .so endings are missing (quick and dirty fix)
   postInstall = ''


### PR DESCRIPTION
Also fixes regular `strictDeps = true` ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).