### PR TITLE
fped: fix cross build

### DIFF
--- a/pkgs/by-name/fp/fped/package.nix
+++ b/pkgs/by-name/fp/fped/package.nix
@@ -21,6 +21,11 @@ stdenv.mkDerivation {
     sha256 = "0xv364a00zwxhd9kg1z9sch5y0cxnrhk546asspyb9bh58sdzfy7";
   };
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail 'pkg-config' '${stdenv.cc.targetPrefix}pkg-config'
+  '';
+
   # Workaround build failure on -fno-common toolchains:
   #   ld: postscript.o:postscript.h:29: multiple definition of
   #     `postscript_params'; fped.o:postscript.h:29: first defined here
@@ -43,6 +48,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
+    flex
     gtk2
   ];
 


### PR DESCRIPTION
Also fixes regular `strictDeps = true` build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).