### PR TITLE
libtommath: fix cross build

### DIFF
--- a/pkgs/by-name/li/libtommath/package.nix
+++ b/pkgs/by-name/li/libtommath/package.nix
@@ -14,15 +14,17 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-KWJy2TQ1mRMI63NgdgDANLVYgHoH6CnnURQuZcz6nQg=";
   };
 
-  nativeBuildInputs = [ libtool ];
-
   postPatch = ''
-    substituteInPlace makefile.shared --replace glibtool libtool
-    substituteInPlace makefile_include.mk --replace "shell arch" "shell uname -m"
+    substituteInPlace makefile.shared \
+      --replace-fail glibtool libtool \
+      --replace-fail libtool "${lib.getExe (libtool.override { stdenv = stdenv; })}"
+    substituteInPlace makefile_include.mk \
+      --replace-fail "gcc" "${stdenv.cc.targetPrefix}cc"
   '';
 
   preBuild = ''
     makeFlagsArray=(PREFIX=$out \
+      CC=${stdenv.cc.targetPrefix}cc \
       INSTALL_GROUP=$(id -g) \
       INSTALL_USER=$(id -u))
   '';


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).