### PR TITLE
dotnet: fix linux build of dotnetCorePackages.dotnet_8

### DIFF
--- a/pkgs/development/compilers/dotnet/fix-clang19-build.patch
+++ b/pkgs/development/compilers/dotnet/fix-clang19-build.patch
@@ -1,0 +1,48 @@
+From 36354a7aca58753893148d62a889ca9e27381ac0 Mon Sep 17 00:00:00 2001
+From: David McFarland <corngood@gmail.com>
+Date: Thu, 2 Jan 2025 15:30:16 -0400
+Subject: [PATCH] fix clang19 build
+
+---
+ src/runtime/src/coreclr/vm/comreflectioncache.hpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/runtime/src/coreclr/vm/comreflectioncache.hpp b/src/runtime/src/coreclr/vm/comreflectioncache.hpp
+index 08d173e616..12db55251d 100644
+--- a/src/runtime/src/coreclr/vm/comreflectioncache.hpp
++++ b/src/runtime/src/coreclr/vm/comreflectioncache.hpp
+@@ -26,6 +26,7 @@ public:
+ 
+     void Init();
+ 
++#ifndef DACCESS_COMPILE
+     BOOL GetFromCache(Element *pElement, CacheType& rv)
+     {
+         CONTRACTL
+@@ -102,6 +103,7 @@ public:
+         AdjustStamp(TRUE);
+         this->LeaveWrite();
+     }
++#endif // !DACCESS_COMPILE
+ 
+ private:
+     // Lock must have been taken before calling this.
+@@ -141,6 +143,7 @@ private:
+         return CacheSize;
+     }
+ 
++#ifndef DACCESS_COMPILE
+     void AdjustStamp(BOOL hasWriterLock)
+     {
+         CONTRACTL
+@@ -170,6 +173,7 @@ private:
+         if (!hasWriterLock)
+             this->LeaveWrite();
+     }
++#endif // !DACCESS_COMPILE
+ 
+     void UpdateHashTable(SIZE_T hash, int slot)
+     {
+-- 
+2.47.0
+

--- a/pkgs/development/compilers/dotnet/vmr.nix
+++ b/pkgs/development/compilers/dotnet/vmr.nix
@@ -148,6 +148,7 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals (lib.versionOlder version "9") [
       ./fix-aspnetcore-portable-build.patch
+      ./fix-clang19-build.patch
     ];
 
   postPatch =


### PR DESCRIPTION
dotnetCorePackages.dotnet_8.stage0.vmr fails to build on llvm 19, e.g.:

> comreflectioncache.hpp:40:15: error: no member named 'EnterRead' in 'ReflectionCache<Element, CacheType, CacheSize>'; did you mean 'TryEnterRead'?

Cc: @NixOS/dotnet 

See https://hydra.nixos.org/build/282859783

It looks like dotnet 9 doesn't have this problem.

~Q. Should pin only as an exception on dotnet 8?  Is it a good idea to use latest llvm in general?~

~A. This now only pins dotnet 8.~

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
