### PR TITLE
nixos/test-driver: don't crash interactive driver for failed subtests

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/__init__.py
+++ b/nixos/lib/test-driver/src/test_driver/__init__.py
@@ -113,7 +113,7 @@ def main() -> None:
     args = arg_parser.parse_args()
 
     output_directory = args.output_directory.resolve()
-    logger = CompositeLogger([TerminalLogger()])
+    logger = CompositeLogger([TerminalLogger()], exit_on_error=not args.interactive)
 
     if "LOGFILE" in os.environ.keys():
         logger.add_logger(XMLLogger(os.environ["LOGFILE"]))
@@ -154,7 +154,7 @@ def generate_driver_symbols() -> None:
     in user's test scripts. That list is then used by pyflakes to lint those
     scripts.
     """
-    d = Driver([], [], "", Path(), CompositeLogger([]))
+    d = Driver([], [], "", Path(), CompositeLogger([], exit_on_error=True))
     test_symbols = d.test_symbols()
     with open("driver-symbols", "w") as fp:
         fp.write(",".join(test_symbols.keys()))

--- a/nixos/lib/test-driver/src/test_driver/logger.py
+++ b/nixos/lib/test-driver/src/test_driver/logger.py
@@ -124,8 +124,11 @@ class JunitXMLLogger(AbstractLogger):
 
 
 class CompositeLogger(AbstractLogger):
-    def __init__(self, logger_list: list[AbstractLogger]) -> None:
+    def __init__(
+        self, logger_list: list[AbstractLogger], *, exit_on_error: bool
+    ) -> None:
         self.logger_list = logger_list
+        self.exit_on_error = exit_on_error
 
     def add_logger(self, logger: AbstractLogger) -> None:
         self.logger_list.append(logger)
@@ -159,7 +162,8 @@ class CompositeLogger(AbstractLogger):
     def error(self, *args, **kwargs) -> None:  # type: ignore
         for logger in self.logger_list:
             logger.error(*args, **kwargs)
-        sys.exit(1)
+        if self.exit_on_error:
+            sys.exit(1)
 
     def print_serial_logs(self, enable: bool) -> None:
         for logger in self.logger_list:


### PR DESCRIPTION
Before the test driver in interactive mode annoyingly crashed when an exception occurred within a subtest:

    $ $(nix-build -A driverInteractive nixos/tests/gnupg.nix)/bin/nixos-test-driver
    ...
    >>> with subtest("foo"):
    ...     assert False
    subtest: foo
    Test "foo" failed with error: ""
    cleanup
    kill vlan (pid 222342)
    (finished: cleanup, in 0.00 seconds)

Fixes #180089.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
