### PR TITLE
python312Packages.shiboken2: fix strictDeps build

### DIFF
--- a/pkgs/development/python-modules/shiboken2/default.nix
+++ b/pkgs/development/python-modules/shiboken2/default.nix
@@ -28,6 +28,7 @@ stdenv.mkDerivation {
         setuptools
       ]
     ))
+    qt5.qmake
   ];
 
   buildInputs =


### PR DESCRIPTION
qmake wasn't properly propagated.

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).