### PR TITLE
`nixos-render-docs`: Support explicit anchors in markdown for optional compatibility with the HTML renderer

### DIFF
--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -193,12 +193,16 @@ rec {
   optionsCommonMark =
     pkgs.runCommand "options.md"
       {
+        __structuredAttrs = true;
         nativeBuildInputs = [ pkgs.nixos-render-docs ];
+        # For overriding
+        extraArgs = [ ];
       }
       ''
         nixos-render-docs -j $NIX_BUILD_CORES options commonmark \
           --manpage-urls ${pkgs.path + "/doc/manpage-urls.json"} \
           --revision ${lib.escapeShellArg revision} \
+          ''${extraArgs[@]} \
           ${optionsJSON}/share/doc/nixos/options.json \
           $out
       '';

--- a/nixos/lib/make-options-doc/default.nix
+++ b/nixos/lib/make-options-doc/default.nix
@@ -1,3 +1,5 @@
+# Tests: ./tests.nix
+
 /**
   Generates documentation for [nix modules](https://nix.dev/tutorials/module-system/index.html).
 

--- a/nixos/lib/make-options-doc/tests.nix
+++ b/nixos/lib/make-options-doc/tests.nix
@@ -1,0 +1,59 @@
+# Run tests: nix-build -A tests.nixosOptionsDoc
+
+{
+  lib,
+  nixosOptionsDoc,
+  runCommand,
+}:
+let
+  inherit (lib) mkOption types;
+
+  eval = lib.evalModules {
+    modules = [
+      {
+        options.foo.bar.enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enable the foo bar feature.
+          '';
+        };
+      }
+    ];
+  };
+
+  doc = nixosOptionsDoc {
+    inherit (eval) options;
+  };
+in
+{
+  /**
+    Test that
+      - the `nixosOptionsDoc` function can be invoked
+      - integration of the module system and `nixosOptionsDoc` (limited coverage)
+
+    The more interesting tests happen in the `nixos-render-docs` package.
+  */
+  commonMark =
+    runCommand "test-nixosOptionsDoc-commonMark"
+      {
+        commonMarkDefault = doc.optionsCommonMark;
+        commonMarkAnchors = doc.optionsCommonMark.overrideAttrs {
+          extraArgs = [
+            "--anchor-prefix"
+            "my-opt-"
+            "--anchor-style"
+            "legacy"
+          ];
+        };
+      }
+      ''
+        env | grep ^commonMark | sed -e 's/=/ = /'
+        (
+          set -x
+          grep -F 'foo\.bar\.enable' $commonMarkDefault >/dev/null
+          grep -F '{#my-opt-foo.bar.enable}' $commonMarkAnchors >/dev/null
+        )
+        touch $out
+      '';
+}

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/types.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/types.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from enum import Enum
 from typing import Callable, Optional, NamedTuple
 
 from markdown_it.token import Token
@@ -12,3 +13,7 @@ class RenderedOption(NamedTuple):
     links: Optional[list[str]] = None
 
 RenderFn = Callable[[Token, Sequence[Token], int], str]
+
+class AnchorStyle(Enum):
+    NONE = "none"
+    LEGACY = "legacy"

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_simple.json
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_simple.json
@@ -1,0 +1,17 @@
+{
+  "services.frobnicator.types.<name>.enable": {
+    "declarations": [
+      "nixos/modules/services/frobnicator.nix"
+    ],
+    "description": "Whether to enable the frobnication of this (`<name>`) type.",
+    "loc": [
+      "services",
+      "frobnicator",
+      "types",
+      "<name>",
+      "enable"
+    ],
+    "readOnly": false,
+    "type": "boolean"
+  }
+}

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_simple_default.md
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_simple_default.md
@@ -1,0 +1,13 @@
+## services\.frobnicator\.types\.\<name>\.enable
+
+Whether to enable the frobnication of this (` <name> `) type\.
+
+
+
+*Type:*
+boolean
+
+*Declared by:*
+ - [\<nixpkgs/nixos/modules/services/frobnicator\.nix>](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/frobnicator.nix)
+
+

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_simple_legacy.md
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/sample_options_simple_legacy.md
@@ -1,0 +1,13 @@
+## services\.frobnicator\.types\.\<name>\.enable {#opt-services.frobnicator.types._name_.enable}
+
+Whether to enable the frobnication of this (` <name> `) type\.
+
+
+
+*Type:*
+boolean
+
+*Declared by:*
+ - [\<nixpkgs/nixos/modules/services/frobnicator\.nix>](https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/services/frobnicator.nix)
+
+

--- a/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/tests/test_options.py
@@ -1,6 +1,9 @@
 import nixos_render_docs
+from nixos_render_docs.options import AnchorStyle
 
+import json
 from markdown_it.token import Token
+from pathlib import Path
 import pytest
 
 def test_option_headings() -> None:
@@ -12,3 +15,27 @@ def test_option_headings() -> None:
         type='heading_open', tag='h1', nesting=1, attrs={}, map=[0, 1], level=0, children=None,
         content='', markup='#', info='', meta={}, block=True, hidden=False
     )
+
+def test_options_commonmark() -> None:
+    c = nixos_render_docs.options.CommonMarkConverter({}, 'local')
+    with Path('tests/sample_options_simple.json').open() as f:
+        opts = json.load(f)
+    assert opts is not None
+    with Path('tests/sample_options_simple_default.md').open() as f:
+        expected = f.read()
+
+    c.add_options(opts)
+    s = c.finalize()
+    assert s == expected
+
+def test_options_commonmark_legacy_anchors() -> None:
+    c = nixos_render_docs.options.CommonMarkConverter({}, 'local', anchor_style = AnchorStyle.LEGACY, anchor_prefix = 'opt-')
+    with Path('tests/sample_options_simple.json').open() as f:
+        opts = json.load(f)
+    assert opts is not None
+    with Path('tests/sample_options_simple_legacy.md').open() as f:
+        expected = f.read()
+
+    c.add_options(opts)
+    s = c.finalize()
+    assert s == expected

--- a/pkgs/test/default.nix
+++ b/pkgs/test/default.nix
@@ -155,6 +155,8 @@ with pkgs;
 
   nixos-functions = callPackage ./nixos-functions { };
 
+  nixosOptionsDoc = callPackage ../../nixos/lib/make-options-doc/tests.nix { };
+
   overriding = callPackage ./overriding.nix { };
 
   texlive = callPackage ./texlive { };


### PR DESCRIPTION

This adds `--anchor-style` and `--anchor-prefix` parameters to `nixos-render-docs options commonmark`, so that its output can be made compatible with the HTML renderer.

Usage example:

```nix
              nixosOptionsDocResult.optionsCommonMark.overrideAttrs {
                extraArgs = [
                  "--anchor-prefix"
                  "opt-"
                  "--anchor-style"
                  "legacy"
                ];
              };
```

- Incorporates feedback from https://github.com/NixOS/nixpkgs/pull/300309

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
