### PR TITLE
elfutils: rebase cxx-header-collision.patch

### DIFF
--- a/pkgs/by-name/el/elfutils/cxx-header-collision.patch
+++ b/pkgs/by-name/el/elfutils/cxx-header-collision.patch
@@ -26,7 +26,7 @@ Signed-off-by: Tristan Ross <tristan.ross@midstall.com>
 
 diff --git a/config/eu-common.am b/config/eu-common.am
 new file mode 100644
-index 000000000..9cc7f6969
+index 00000000..9cc7f696
 --- /dev/null
 +++ b/config/eu-common.am
 @@ -0,0 +1,148 @@
@@ -179,7 +179,7 @@ index 000000000..9cc7f6969
 +print-%:
 +	@echo $*=$($*)
 diff --git a/config/eu.am b/config/eu.am
-index e6c241f9d..3aa6048aa 100644
+index 0b7dab5b..3aa6048a 100644
 --- a/config/eu.am
 +++ b/config/eu.am
 @@ -1,4 +1,5 @@
@@ -194,7 +194,7 @@ index e6c241f9d..3aa6048aa 100644
  ##
  
 -DEFS = -D_GNU_SOURCE -DHAVE_CONFIG_H -DLOCALEDIR='"${localedir}"'
- AM_CPPFLAGS = -I. -I$(srcdir) -I$(top_srcdir)/lib -I..
+-AM_CPPFLAGS = -iquote . -I$(srcdir) -I$(top_srcdir)/lib -I..
 -
 -# Drop the 'u' flag that automake adds by default. It is incompatible
 -# with deterministic archives.
@@ -310,12 +310,13 @@ index e6c241f9d..3aa6048aa 100644
 -
 -print-%:
 -	@echo $*=$($*)
++AM_CPPFLAGS = -I. -I$(srcdir) -I$(top_srcdir)/lib -I..
 +include $(top_srcdir)/config/eu-common.am
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 1d592d4de..5fcebc21d 100644
+index 97a0c61a..5bb8c078 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -16,10 +16,12 @@
+@@ -16,14 +16,15 @@
  ## You should have received a copy of the GNU General Public License
  ## along with this program.  If not, see <http://www.gnu.org/licenses/>.
  ##
@@ -323,9 +324,15 @@ index 1d592d4de..5fcebc21d 100644
 +include $(top_srcdir)/config/eu-common.am
  DEFS += $(YYDEBUG) -DDEBUGPRED=@DEBUGPRED@ \
  	-DSRCDIR=\"$(shell cd $(srcdir);pwd)\" -DOBJDIR=\"$(shell pwd)\"
+ 
+-DEFAULT_INCLUDES =
 -AM_CPPFLAGS += -I$(srcdir)/../libelf -I$(srcdir)/../libebl \
+-	    -I$(srcdir)/../libdw -I$(srcdir)/../libdwelf \
+-	    -I$(srcdir)/../libdwfl -I$(srcdir)/../libasm -I../debuginfod
 +DEFAULT_INCLUDES = -I$(top_builddir)
 +AM_CPPFLAGS = -I$(top_srcdir)/lib -I.. \
 +	    -I$(srcdir)/../libelf -I$(srcdir)/../libebl \
- 	    -I$(srcdir)/../libdw -I$(srcdir)/../libdwelf \
- 	    -I$(srcdir)/../libdwfl -I$(srcdir)/../libasm -I../debuginfod
++ 	    -I$(srcdir)/../libdw -I$(srcdir)/../libdwelf \
++ 	    -I$(srcdir)/../libdwfl -I$(srcdir)/../libasm -I../debuginfod
+ 
+ AM_LDFLAGS = -Wl,-rpath-link,../libelf:../libdw $(STACK_USAGE_NO_ERROR)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix `cxx-header-collision.patch` for LLVM.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
