### PR TITLE
libsigrokdecode: 0.5.3-unstable-2023-10-23 -> 0.5.3-unstable-2024-10-01

### DIFF
--- a/pkgs/by-name/li/libsigrokdecode/package.nix
+++ b/pkgs/by-name/li/libsigrokdecode/package.nix
@@ -12,12 +12,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libsigrokdecode";
-  version = "0.5.3-unstable-2023-10-23";
+  version = "0.5.3-unstable-2024-10-01";
 
   src = fetchgit {
     url = "git://sigrok.org/libsigrokdecode";
-    rev = "0c35c5c5845d05e5f624c99d58af992d2f004446";
-    hash = "sha256-1kQB7uk2c+6Uriw+1o6brThDcBLoCdPV0MVWAha7ohk=";
+    rev = "71f451443029322d57376214c330b518efd84f88";
+    hash = "sha256-aW0llB/rziJxLW3OZU1VhxeM3MDWsaMVVgvDKZzdiIY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/tools/libsigrok/default.nix
+++ b/pkgs/development/tools/libsigrok/default.nix
@@ -21,12 +21,12 @@
 
 stdenv.mkDerivation rec {
   pname = "libsigrok";
-  version = "0.5.2-unstable-2024-01-03";
+  version = "0.5.2-unstable-2024-10-20";
 
   src = fetchgit {
     url = "git://sigrok.org/libsigrok";
-    rev = "b503d24cdf56abf8c0d66d438ccac28969f01670";
-    hash = "sha256-9EW0UCzU6MqBX6rkT5CrBsDkAi6/CLyS9MZHsDV+1IQ=";
+    rev = "f06f788118191d19fdbbb37046d3bd5cec91adb1";
+    hash = "sha256-8aco5tymkCJ6ya1hyp2ODrz+dlXvZmcYoo4o9YC6D6o=";
   };
 
   enableParallelBuilding = true;


### PR DESCRIPTION
Update libsigrokdecode to the latest git version. I noticed that [this fix](http://sigrok.org/gitweb/?p=libsigrokdecode.git;a=commit;h=03dc5f85050301d31aa0803e85bdda1374109b49) would be useful for us, as running `pulseview` currently prints these messages:

```

/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/ds1307/pd.py:51: SyntaxWarning: invalid escape sequence '\/'
  l += [('bit_' + re.sub('\/| ', '_', b).lower(), b + ' bit') for b in bits]
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/ds1307/pd.py:55: SyntaxWarning: invalid escape sequence '\/'
  ['BIT_' + re.sub('\/| ', '_', b).upper() for b in bits] + \
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/arm_itm/pd.py:116: SyntaxWarning: invalid escape sequence '\s'
  instpat = re.compile('\s*([0-9a-fA-F]+):\t+([0-9a-fA-F ]+)\t+([a-zA-Z][^;]+)\s*;?.*')
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/arm_itm/pd.py:117: SyntaxWarning: invalid escape sequence '\s'
  filepat = re.compile('[^\s]+[/\\\\]([a-zA-Z0-9._-]+:[0-9]+)(?:\s.*)?')
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/arm_itm/pd.py:118: SyntaxWarning: invalid escape sequence '\s'
  funcpat = re.compile('[0-9a-fA-F]+\s*<([^>]+)>:.*')
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/arm_etmv3/pd.py:215: SyntaxWarning: invalid escape sequence '\s'
  instpat = re.compile('\s*([0-9a-fA-F]+):\t+([0-9a-fA-F ]+)\t+([a-zA-Z][^;]+)\s*;?.*')
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/arm_etmv3/pd.py:216: SyntaxWarning: invalid escape sequence '\.'
  branchpat = re.compile('(b|bl|b..|bl..|cbnz|cbz)(?:\.[wn])?\s+(?:r[0-9]+,\s*)?([0-9a-fA-F]+)')
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/arm_etmv3/pd.py:217: SyntaxWarning: invalid escape sequence '\s'
  filepat = re.compile('[^\s]+[/\\\\]([a-zA-Z0-9._-]+:[0-9]+)(?:\s.*)?')
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/arm_etmv3/pd.py:218: SyntaxWarning: invalid escape sequence '\s'
  funcpat = re.compile('[0-9a-fA-F]+\s*<([^>]+)>:.*')
/nix/store/6xwc3i333yij20dj0hpcrx04cdxa0fwk-libsigrokdecode-0.5.3-unstable-2023-10-23/share/libsigrokdecode/decoders/spiflash/pd.py:27: SyntaxWarning: invalid escape sequence '\/'
  a = [re.sub('\/', '_', c[0]).replace('2READ', 'READ2X') for c in cmds.values()] + ['BIT', 'FIELD', 'WARN']
```

After upgrading to the latest git version these messages are gone from the output of pulseview. I've compiled both pulseview and sigrok-cli with the updated library and they seem to work with a quick test.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
  - [x] I tested this manually for both pulseview and sigrok-cli, as nixpkgs-review crashes my host. 
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
