### PR TITLE
aegisub-arch1t3cht: init at feature_12

### DIFF
--- a/pkgs/by-name/ae/aegisub-arch1t3cht/package.nix
+++ b/pkgs/by-name/ae/aegisub-arch1t3cht/package.nix
@@ -1,0 +1,150 @@
+{
+  lib,
+  alsa-lib,
+  boost,
+  meson,
+  config,
+  expat,
+  fetchFromGitHub,
+  ffmpeg,
+  ffms,
+  fftw,
+  fontconfig,
+  freetype,
+  fribidi,
+  harfbuzz,
+  hunspell,
+  icu,
+  intltool,
+  libGL,
+  libass,
+  libpulseaudio,
+  libuchardet,
+  luajit,
+  ninja,
+  openal,
+  pkg-config,
+  portaudio,
+  python3,
+  stdenv,
+  vapoursynth-bestsource,
+  wrapGAppsHook3,
+  wxGTK32,
+  zlib,
+  # Boolean guard flags
+  alsaSupport ? stdenv.hostPlatform.isLinux,
+  openalSupport ? true,
+  portaudioSupport ? true,
+  pulseaudioSupport ? config.pulseaudio or stdenv.hostPlatform.isLinux,
+  spellcheckSupport ? true,
+  useBundledLuaJIT ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "aegisub";
+  version = "feature_12";
+
+  src = fetchFromGitHub {
+    owner = "arch1t3cht";
+    repo = "aegisub";
+    tag = finalAttrs.version;
+    hash = "sha256-P+0aUeFsjke3Jj/QtGJRdaS0negYSnhiuf5QCw2Of5Q=";
+  };
+
+  nativeBuildInputs = [
+    meson
+    intltool
+    ninja
+    pkg-config
+    python3
+    wxGTK32
+    wrapGAppsHook3
+  ];
+
+  buildInputs =
+    [
+      boost
+      expat
+      ffmpeg
+      ffms
+      fftw
+      fontconfig
+      freetype
+      fribidi
+      harfbuzz
+      icu
+      libGL
+      libass
+      libuchardet
+      vapoursynth-bestsource
+      wxGTK32
+      zlib
+    ]
+    ++ lib.optionals alsaSupport [ alsa-lib ]
+    ++ lib.optionals (openalSupport && !stdenv.hostPlatform.isDarwin) [ openal ]
+    ++ lib.optionals portaudioSupport [ portaudio ]
+    ++ lib.optionals pulseaudioSupport [ libpulseaudio ]
+    ++ lib.optionals spellcheckSupport [ hunspell ]
+    ++ lib.optionals (!useBundledLuaJIT) [ (luajit.override { enable52Compat = true; }) ];
+
+  mesonFlags = [
+    (lib.mesonEnable "alsa" alsaSupport)
+    (lib.mesonEnable "openal" openalSupport)
+    (lib.mesonEnable "libpulse" pulseaudioSupport)
+    (lib.mesonEnable "portaudio" portaudioSupport)
+
+    (lib.mesonEnable "avisynth" false)
+    # TODO: Requires upstream changes to allow using system VapourSynth.
+    (lib.mesonEnable "vapoursynth" false)
+
+    (lib.mesonEnable "hunspell" spellcheckSupport)
+
+    (lib.mesonBool "system_luajit" (!useBundledLuaJIT))
+  ];
+
+  hardeningDisable = [
+    "bindnow"
+    "relro"
+  ];
+
+  strictDeps = true;
+
+  postPatch = ''
+    patchShebangs tools/respack.py
+
+    # TODO: Tests require wrapped GoogleTest; upstream support for
+    # system version?
+    substituteInPlace meson.build \
+      --replace-fail "subdir('tests')" "# subdir('tests')"
+  '';
+
+  # Inject the version, per the AUR package:
+  # <https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=aegisub-arch1t3cht&id=bbbea73953858fc7bf2775a0fb92cec49afb586c>
+  preBuild = ''
+    cat > git_version.h <<EOF
+    #define BUILD_GIT_VERSION_NUMBER 0
+    #define BUILD_GIT_VERSION_STRING "${finalAttrs.version}"
+    EOF
+  '';
+
+  meta = {
+    homepage = "https://github.com/arch1t3cht/Aegisub";
+    description = "Advanced subtitle editor";
+    longDescription = ''
+      Aegisub is a free, cross-platform open source tool for creating and
+      modifying subtitles. Aegisub makes it quick and easy to time subtitles to
+      audio, and features many powerful tools for styling them, including a
+      built-in real-time video preview.
+    '';
+    # The Aegisub sources are itself BSD/ISC, but they are linked against GPL'd
+    # softwares - so the resulting program will be GPL
+    license = with lib.licenses; [
+      bsd3
+    ];
+    mainProgram = "aegisub";
+    maintainers = with lib.maintainers; [ wegank ];
+    platforms = lib.platforms.unix;
+    # https://github.com/arch1t3cht/Aegisub/issues/154
+    badPlatforms = lib.platforms.darwin;
+  };
+})


### PR DESCRIPTION
Reintroduction of arch1t3cht's fork from #359027, until Aegisub absorbs all its features.

I'll create another PR to bump Aegisub to 3.4.1, see https://github.com/TypesettingTools/Aegisub/releases/tag/v3.4.1.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
