### PR TITLE
ROCm 6: Refactor ROCm LLVM to standalone HIP compiler

### DIFF
--- a/pkgs/development/rocm-modules/6/clr/default.nix
+++ b/pkgs/development/rocm-modules/6/clr/default.nix
@@ -9,6 +9,7 @@
   makeWrapper,
   cmake,
   perl,
+  llvm,
   clang,
   hip-common,
   hipcc,
@@ -72,6 +73,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    llvm
     numactl
     libGL
     libxml2
@@ -84,6 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
     rocm-runtime
     rocminfo
   ];
+
+  hardeningDisable = [ "all" ];
 
   cmakeFlags = [
     "-DCMAKE_POLICY_DEFAULT_CMP0072=NEW" # Prefer newer OpenGL libraries
@@ -190,6 +194,8 @@ stdenv.mkDerivation (finalAttrs: {
       "1102"
     ] (target: "gfx${target}");
 
+    rocmClang = clang;
+
     updateScript = rocmUpdateScript {
       name = finalAttrs.pname;
       owner = finalAttrs.src.owner;
@@ -215,8 +221,8 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken =
-      versions.minor finalAttrs.version != versions.minor stdenv.cc.version
-      || versionAtLeast finalAttrs.version "7.0.0";
+    # broken =
+    #   versions.minor finalAttrs.version != versions.minor stdenv.cc.version
+    #   || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/default.nix
+++ b/pkgs/development/rocm-modules/6/default.nix
@@ -22,86 +22,85 @@ in rec {
 
   rocm-core = callPackage ./rocm-core {
     inherit rocmUpdateScript;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocm-cmake = callPackage ./rocm-cmake {
     inherit rocmUpdateScript;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocm-thunk = callPackage ./rocm-thunk {
     inherit rocmUpdateScript;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocm-smi = python3Packages.callPackage ./rocm-smi {
     inherit rocmUpdateScript;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   # Eventually will be in the LLVM repo
   rocm-device-libs = callPackage ./rocm-device-libs {
     inherit rocmUpdateScript rocm-cmake;
-    stdenv = llvm.rocmClangStdenv;
+    inherit (llvm) llvm clang;
   };
 
   rocm-runtime = callPackage ./rocm-runtime {
     inherit rocmUpdateScript rocm-device-libs rocm-thunk;
-    stdenv = llvm.rocmClangStdenv;
+    inherit (llvm) llvm;
   };
 
   # Eventually will be in the LLVM repo
   rocm-comgr = callPackage ./rocm-comgr {
     inherit rocmUpdateScript rocm-cmake rocm-device-libs;
-    stdenv = llvm.rocmClangStdenv;
+    inherit (llvm) llvm;
   };
 
   rocminfo = callPackage ./rocminfo {
     inherit rocmUpdateScript rocm-cmake rocm-runtime;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   clang-ocl = callPackage ./clang-ocl {
     inherit rocmUpdateScript rocm-cmake rocm-device-libs;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   # Unfree
   hsa-amd-aqlprofile-bin = callPackage ./hsa-amd-aqlprofile-bin {
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   # Broken, too many errors
   rdc = callPackage ./rdc {
     inherit rocmUpdateScript rocm-smi rocm-runtime stdenv;
-    # stdenv = llvm.rocmClangStdenv;
+    #
   };
 
   rocm-docs-core = python3Packages.callPackage ./rocm-docs-core { inherit stdenv; };
 
   hip-common = callPackage ./hip-common {
     inherit rocmUpdateScript;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   # Eventually will be in the LLVM repo
   hipcc = callPackage ./hipcc {
     inherit rocmUpdateScript;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   # Replaces hip, opencl-runtime, and rocclr
   clr = callPackage ./clr {
     inherit rocmUpdateScript hip-common hipcc rocm-device-libs rocm-comgr rocm-runtime roctracer rocminfo rocm-smi;
-    inherit (llvm) clang;
-    stdenv = llvm.rocmClangStdenv;
+    inherit (llvm) llvm clang;
   };
 
   hipify = callPackage ./hipify {
     inherit rocmUpdateScript;
     inherit (llvm) clang;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   # Needs GCC
@@ -117,108 +116,108 @@ in rec {
 
   rocgdb = callPackage ./rocgdb {
     inherit rocmUpdateScript rocdbgapi;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocdbgapi = callPackage ./rocdbgapi {
     inherit rocmUpdateScript rocm-cmake rocm-comgr rocm-runtime;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocr-debug-agent = callPackage ./rocr-debug-agent {
     inherit rocmUpdateScript clr rocdbgapi;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocprim = callPackage ./rocprim {
     inherit rocmUpdateScript rocm-cmake clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocsparse = callPackage ./rocsparse {
     inherit rocmUpdateScript rocm-cmake rocprim clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocthrust = callPackage ./rocthrust {
     inherit rocmUpdateScript rocm-cmake rocprim clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocrand = callPackage ./rocrand {
     inherit rocmUpdateScript rocm-cmake clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   hiprand = callPackage ./hiprand {
     inherit rocmUpdateScript rocm-cmake clr rocrand;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocfft = callPackage ./rocfft {
     inherit rocmUpdateScript rocm-cmake rocrand rocfft clr;
     inherit (llvm) openmp;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rccl = callPackage ./rccl {
     inherit rocmUpdateScript rocm-cmake rocm-smi clr hipify;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   hipcub = callPackage ./hipcub {
     inherit rocmUpdateScript rocm-cmake rocprim clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   hipsparse = callPackage ./hipsparse {
     inherit rocmUpdateScript rocm-cmake rocsparse clr;
     inherit (llvm) openmp;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   hipfort = callPackage ./hipfort {
     inherit rocmUpdateScript rocm-cmake;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   hipfft = callPackage ./hipfft {
     inherit rocmUpdateScript rocm-cmake rocfft clr;
     inherit (llvm) openmp;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   tensile = python3Packages.callPackage ./tensile {
     inherit rocmUpdateScript rocminfo;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocblas = callPackage ./rocblas {
     inherit rocmUpdateScript rocm-cmake clr tensile;
     inherit (llvm) openmp;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocsolver = callPackage ./rocsolver {
     inherit rocmUpdateScript rocm-cmake rocblas rocsparse clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocwmma = callPackage ./rocwmma {
     inherit rocmUpdateScript rocm-cmake rocm-smi rocblas clr;
     inherit (llvm) openmp;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocalution = callPackage ./rocalution {
     inherit rocmUpdateScript rocm-cmake rocprim rocsparse rocrand rocblas clr;
     inherit (llvm) openmp;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocmlir = callPackage ./rocmlir {
     inherit rocmUpdateScript rocm-cmake rocminfo clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rocmlir-rock = rocmlir.override {
@@ -227,12 +226,12 @@ in rec {
 
   hipsolver = callPackage ./hipsolver {
     inherit rocmUpdateScript rocm-cmake rocblas rocsolver clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   hipblas = callPackage ./hipblas {
     inherit rocmUpdateScript rocm-cmake rocblas rocsolver clr;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   # hipBlasLt - Very broken with Tensile at the moment, only supports GFX9
@@ -242,19 +241,19 @@ in rec {
     composable_kernel_build = callPackage ./composable_kernel {
       inherit rocmUpdateScript rocm-cmake clr;
       inherit (llvm) openmp clang-tools-extra;
-      stdenv = llvm.rocmClangStdenv;
+
     };
   };
 
   half = callPackage ./half {
     inherit rocmUpdateScript rocm-cmake;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   miopen = callPackage ./miopen {
     inherit rocmUpdateScript rocm-cmake rocblas clang-ocl composable_kernel rocm-comgr clr rocm-docs-core half roctracer;
     inherit (llvm) clang-tools-extra;
-    stdenv = llvm.rocmClangStdenv;
+
     rocmlir = rocmlir-rock;
     boost = boost179.override { enableStatic = true; };
   };
@@ -264,14 +263,14 @@ in rec {
   migraphx = callPackage ./migraphx {
     inherit rocmUpdateScript rocm-cmake rocblas composable_kernel miopen clr half rocm-device-libs;
     inherit (llvm) openmp clang-tools-extra;
-    stdenv = llvm.rocmClangStdenv;
+
     rocmlir = rocmlir-rock;
   };
 
   rpp = callPackage ./rpp {
     inherit rocmUpdateScript rocm-cmake rocm-docs-core clr half;
     inherit (llvm) openmp;
-    stdenv = llvm.rocmClangStdenv;
+
   };
 
   rpp-hip = rpp.override {
@@ -294,7 +293,7 @@ in rec {
     inherit (llvm) clang openmp;
     opencv = opencv.override { enablePython = true; };
     ffmpeg = ffmpeg_4;
-    stdenv = llvm.rocmClangStdenv;
+
 
     # Unfortunately, rocAL needs a custom libjpeg-turbo until further notice
     # See: https://github.com/ROCm/MIVisionX/issues/1051

--- a/pkgs/development/rocm-modules/6/hip-common/default.nix
+++ b/pkgs/development/rocm-modules/6/hip-common/default.nix
@@ -39,6 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version || versionAtLeast finalAttrs.version "7.0.0";
+    # broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/hipcc/default.nix
+++ b/pkgs/development/rocm-modules/6/hipcc/default.nix
@@ -42,8 +42,8 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken =
-      versions.minor finalAttrs.version != versions.minor stdenv.cc.version
-      || versionAtLeast finalAttrs.version "7.0.0";
+    # broken =
+    #   versions.minor finalAttrs.version != versions.minor stdenv.cc.version
+    #   || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/llvm/default.nix
+++ b/pkgs/development/rocm-modules/6/llvm/default.nix
@@ -1,142 +1,278 @@
 {
   # stdenv FIXME: Try changing back to this with a new ROCm release https://github.com/NixOS/nixpkgs/issues/271943
-  gcc12Stdenv,
+  stdenv,
+  lib,
+  gcc13Stdenv,
   callPackage,
+  fetchFromGitHub,
   rocmUpdateScript,
   wrapBintoolsWith,
   overrideCC,
+  wrapCCWith,
+  wrapCC,
+  fetchpatch,
+
+  pkg-config,
+  cmake,
+  ninja,
+  git,
+  makeBinaryWrapper,
+  python3Packages,
+  doxygen,
+  sphinx,
+  lit,
+  libxml2,
+  libxcrypt,
+  libffi,
+  mpfr,
+  libedit,
+  ncurses,
+  zlib,
+  zstd,
+
   rocm-device-libs,
   rocm-runtime,
   rocm-thunk,
   clr,
+  buildTests ? false,
+  buildMan ? false,
+  buildDocs ? false,
+
+  ccache,
 }:
 
-let
-  ## Stage 1 ##
-  # Projects
-  llvm = callPackage ./stage-1/llvm.nix {
-    inherit rocmUpdateScript;
-    stdenv = gcc12Stdenv;
-  };
-  clang-unwrapped = callPackage ./stage-1/clang-unwrapped.nix {
-    inherit rocmUpdateScript llvm;
-    stdenv = gcc12Stdenv;
-  };
-  lld = callPackage ./stage-1/lld.nix {
-    inherit rocmUpdateScript llvm;
-    stdenv = gcc12Stdenv;
-  };
-
-  # Runtimes
-  runtimes = callPackage ./stage-1/runtimes.nix {
-    inherit rocmUpdateScript llvm;
-    stdenv = gcc12Stdenv;
-  };
-
-  ## Stage 2 ##
-  # Helpers
-  bintools-unwrapped = callPackage ./stage-2/bintools-unwrapped.nix { inherit llvm lld; };
-  bintools = wrapBintoolsWith { bintools = bintools-unwrapped; };
-  rStdenv = callPackage ./stage-2/rstdenv.nix {
-    inherit
-      llvm
-      clang-unwrapped
-      lld
-      runtimes
-      bintools
-      ;
-    stdenv = gcc12Stdenv;
-  };
-in
 rec {
-  inherit
-    llvm
-    clang-unwrapped
-    lld
-    bintools
-    ;
+  llvm =
+    let
+      targetProjects = [ "llvm" "clang" "lld" "clang-tools-extra" "compiler-rt" ];
+      # targetRuntimes = [ "libc" "libunwind" "libcxxabi" "libcxx" "compiler-rt" ];
+      targetRuntimes = [ ];
+      llvmTargetsToBuild = [ "X86" "AMDGPU" ];
+      # stdenv = gcc13Stdenv;
+    in
+      stdenv.mkDerivation (finalAttrs: {
+        pname = "rocm-llvm";
+        version = "6.0.2";
 
-  # Runtimes
-  libc = callPackage ./stage-2/libc.nix {
-    inherit rocmUpdateScript;
-    stdenv = rStdenv;
-  };
-  libunwind = callPackage ./stage-2/libunwind.nix {
-    inherit rocmUpdateScript;
-    stdenv = rStdenv;
-  };
-  libcxxabi = callPackage ./stage-2/libcxxabi.nix {
-    inherit rocmUpdateScript;
-    stdenv = rStdenv;
-  };
-  libcxx = callPackage ./stage-2/libcxx.nix {
-    inherit rocmUpdateScript;
-    stdenv = rStdenv;
-  };
-  compiler-rt = callPackage ./stage-2/compiler-rt.nix {
-    inherit rocmUpdateScript llvm;
-    stdenv = rStdenv;
-  };
+        outputs =
+          [
+            "out"
+          ]
+          ++ lib.optionals buildDocs [
+            "doc"
+          ]
+          ++ lib.optionals buildMan [
+            "man"
+            "info" # Avoid `attribute 'info' missing` when using with wrapCC
+          ];
 
-  ## Stage 3 ##
-  # Helpers
-  clang = callPackage ./stage-3/clang.nix {
-    inherit
-      llvm
-      lld
-      clang-unwrapped
-      bintools
-      libc
-      libunwind
-      libcxxabi
-      libcxx
-      compiler-rt
-      ;
-    stdenv = gcc12Stdenv;
-  };
-  rocmClangStdenv = overrideCC gcc12Stdenv clang;
+        patches = [
+          # ./clang-bodge-ignore-systemwide-incls.diff
+          # ./clang-at-least-16-LLVMgold-path.patch
+          # ./clang-log-jobs.diff
+          # For LLVM 17 only!
+          (fetchpatch {
+            name = "fix-fzero-call-used-regs.patch";
+            url = "https://github.com/llvm/llvm-project/commit/f800c1f3b207e7bcdc8b4c7192928d9a078242a0.patch";
+            # stripLen = 1;
+            hash = "sha256-xwuHEKzAO88pcFN2/PzKGwz7gD1dAcfq2WShZ7TwDVo=";
+          })
+        ];
 
-  # Projects
-  clang-tools-extra = callPackage ./stage-3/clang-tools-extra.nix {
-    inherit rocmUpdateScript llvm clang-unwrapped;
-    stdenv = rocmClangStdenv;
-  };
-  libclc = callPackage ./stage-3/libclc.nix {
-    inherit rocmUpdateScript llvm clang;
-    stdenv = rocmClangStdenv;
-  };
-  lldb = callPackage ./stage-3/lldb.nix {
-    inherit rocmUpdateScript clang;
-    stdenv = rocmClangStdenv;
-  };
-  mlir = callPackage ./stage-3/mlir.nix {
-    inherit rocmUpdateScript clr;
-    stdenv = rocmClangStdenv;
-  };
-  polly = callPackage ./stage-3/polly.nix {
-    inherit rocmUpdateScript;
-    stdenv = rocmClangStdenv;
-  };
-  flang = callPackage ./stage-3/flang.nix {
-    inherit rocmUpdateScript clang-unwrapped mlir;
-    stdenv = rocmClangStdenv;
-  };
-  openmp = callPackage ./stage-3/openmp.nix {
-    inherit
-      rocmUpdateScript
-      llvm
-      clang-unwrapped
-      clang
-      rocm-device-libs
-      rocm-runtime
-      rocm-thunk
-      ;
-    stdenv = rocmClangStdenv;
-  };
+        src = fetchFromGitHub {
+          owner = "ROCm";
+          repo = "llvm-project";
+          rev = "rocm-${finalAttrs.version}";
+          hash = "sha256-uGxalrwMNCOSqSFVrYUBi3ijkMEFFTrzFImmvZKQf6I=";
+        };
 
-  # Runtimes
-  pstl = callPackage ./stage-3/pstl.nix {
-    inherit rocmUpdateScript;
-    stdenv = rocmClangStdenv;
-  };
+        nativeBuildInputs =
+          [
+            pkg-config
+            cmake
+            ninja
+            git
+            makeBinaryWrapper
+            (python3Packages.python.withPackages (p: [ p.setuptools ]))
+
+            ccache
+          ]
+          ++ lib.optionals (buildDocs || buildMan) [
+            doxygen
+            sphinx
+            python3Packages.recommonmark
+          ]
+          ++ lib.optionals (buildTests) [
+            lit
+          ];
+
+        buildInputs = [
+          libxml2
+          libxcrypt
+          libffi
+          mpfr
+        ];
+
+        propagatedBuildInputs = [
+          libedit
+          ncurses
+          zlib
+          zstd
+        ];
+
+        env = {
+          CMAKE_C_COMPILER_LAUNCHER = "${ccache}/bin/ccache";
+          CMAKE_CXX_COMPILER_LAUNCHER = "${ccache}/bin/ccache";
+          CCACHE_DIR = "/nix/var/cache/ccache";
+          CCACHE_COMPRESS = "1";
+          # CCACHE_NOCOMPRESS = "true";
+          CCACHE_UMASK = "007";
+        };
+
+        cmakeFlags =
+          [
+            "-DLLVM_TARGETS_TO_BUILD=${builtins.concatStringsSep ";" llvmTargetsToBuild}"
+            "-DLLVM_ENABLE_PROJECTS=${lib.concatStringsSep ";" targetProjects}"
+            "-DLLVM_ENABLE_RUNTIMES=${lib.concatStringsSep ";" targetRuntimes}"
+            # (lib.cmakeBool "COMPILER_RT_STANDALONE_BUILD" true)
+            # (lib.cmakeBool "LIBC_ENABLE_USE_BY_CLANG" false)
+            (lib.cmakeFeature "LLVM_BINUTILS_INCDIR" "${stdenv.cc.bintools.bintools.plugin-api-header}/include")
+            # (lib.cmakeBool "LLVM_BUILD_EXTERNAL_COMPILER_RT" false)
+            (lib.cmakeBool "LLVM_INCLUDE_TESTS" buildTests)
+            (lib.cmakeBool "LLVM_BUILD_TESTS" buildTests)
+            # (lib.cmakeBool "LLVM_LIBC_FULL_BUILD" true)
+            # (lib.cmakeFeature "DEFAULT_SYSROOT" "${stdenv.cc.libc}")
+            # (lib.cmakeFeature "GCC_INSTALL_PREFIX" "${bootstrapSysroot}")
+            # (lib.cmakeFeature "DEFAULT_SYSROOT" "${placeholder "out"}")
+            # (lib.cmakeBool "COMPILER_RT_BUILD_XRAY" false)
+            # (lib.cmakeFeature "DEFAULT_SYSROOT" "${stdenv.cc.targetPrefix}")
+            # (lib.cmakeFeature "CLANG_CONFIG_FILE_SYSTEM_DIR" "${placeholder "out"}/share/llvm-rocm6/config")
+          ]
+          ++ [
+            "-DLLVM_INSTALL_UTILS=ON"
+            "-DLLVM_INSTALL_GTEST=OFF"
+          ]
+          ++ lib.optionals (buildDocs || buildMan) [
+            "-DLLVM_INCLUDE_DOCS=ON"
+            "-DLLVM_BUILD_DOCS=ON"
+            # "-DLLVM_ENABLE_DOXYGEN=ON" Way too slow, only uses one core
+            "-DLLVM_ENABLE_SPHINX=ON"
+            "-DSPHINX_OUTPUT_HTML=ON"
+            "-DSPHINX_OUTPUT_MAN=ON"
+            "-DSPHINX_WARNINGS_AS_ERRORS=OFF"
+          ]
+          ++ lib.optionals buildTests [
+            "-DLLVM_EXTERNAL_LIT=${lit}/bin/.lit-wrapped"
+          ];
+
+        postPatch =
+          ''
+            cd llvm
+            patchShebangs lib/OffloadArch/make_generated_offload_arch_h.sh
+          '';
+
+        doCheck = buildTests;
+
+        # postInstall =
+        # let
+        #   gcc = stdenv.cc.cc;
+        #   libc = stdenv.cc.libc;
+        #   libc_dev = lib.getDev libc;
+        #   libc_lib = lib.getLib libc;
+        #   hostPlatform = stdenv.hostPlatform;
+        #   targetPlatform = stdenv.targetPlatform;
+        # in
+        # ''
+        #   # This is the config for the final compiler
+        #   mkdir -p $out/share/llvm-rocm6/config
+        #   gcc_ver=$(basename ${gcc}/lib/gcc/${targetPlatform.config}/*)
+        #   pushd $out/share/llvm-rocm6/config
+        #     # General
+        #     echo "--gcc-toolchain=${gcc}" | tee clang.cfg
+        #
+        #     # libc
+        #     echo "-B${libc_lib}/lib" | tee -a clang.cfg
+        #     echo "-B${gcc}/lib/gcc/${targetPlatform.config}/$gcc_ver" | tee -a clang.cfg
+        #     echo "-idirafter ${libc_dev}/include" | tee -a clang.cfg
+        #     echo "-L${gcc}/lib" | tee -a clang.cfg
+        #     echo "-L${gcc.libgcc}/lib" | tee -a clang.cfg
+        #
+        #     # libc++
+        #     for dir in ${gcc}/include/c++/*; do
+        #       echo "-isystem $dir" | tee -a clang.cfg
+        #     done
+        #     for dir in ${gcc}/include/c++/*/${hostPlatform.config}*; do
+        #       echo "-isystem $dir" | tee -a clang.cfg
+        #     done
+        #     # echo "-isystem $out/include/c++/v1" | tee -a clang.cfg
+        #     echo \
+        #       "${lib.optionalString profilableStdenv "-gz -gz -fno-omit-frame-pointer -momit-leaf-frame-pointer"}" \
+        #       | tee -a clang.cfg
+        #     # echo "" | tee clang.cfg
+        #
+        #     cp clang.cfg clang++.cfg
+        #     echo "--stdlib=libstdc++" | tee -a clang++.cfg
+        #
+        #     cp clang.cfg clang-cpp.cfg
+        #     cp clang.cfg clang-cl.cfg
+        #     cp clang.cfg flang.cfg
+        #     cp clang.cfg clang-dxc.cfg
+        #   popd
+        #
+        #   $out/bin/clang --version
+        #   $out/bin/clang -print-resource-dir
+        #
+        #   echo '#include <iostream>' >> test.cpp
+        #   echo '#include <cmath>' >> test.cpp
+        #   echo 'int main() { std::cout << "Hello World!" << std::max(2, 3); }' >> test.cpp
+        #   echo "Compiling as C++"
+        #   $out/bin/clang++ -v -std=c++17 -o test test.cpp
+        # ''
+        # + lib.optionalString buildMan ''
+        #   mkdir -p $info
+        # '';
+
+        passthru = {
+          updateScript = rocmUpdateScript {
+            name = finalAttrs.pname;
+            owner = finalAttrs.src.owner;
+            repo = finalAttrs.src.repo;
+          };
+          isClang = true;
+          isLLVM = true;
+        };
+
+        meta = with lib; {
+          description = "ROCm fork of the LLVM compiler infrastructure";
+          homepage = "https://github.com/ROCm/llvm-project";
+          license = with licenses; [ ncsa ];
+          maintainers =
+            with maintainers;
+            [
+              acowley
+              lovesegfault
+            ]
+            ++ teams.rocm.members;
+          platforms = platforms.linux;
+          broken = versionAtLeast finalAttrs.version "7.0.0";
+        };
+      });
+
+  clang = wrapCCWith ({
+    name = "rocm-clang";
+    cc = llvm;
+    # If C compilation breaks, check if cc-wrapper is adding some flags to
+    # `libcxx-cxxflags` that would cause problems for the C compiler.
+    extraBuildCommands = ''
+      # HIP will be invoked through C compiler (`clang`) even though it needs C++ headers
+      cat $out/nix-support/libcxx-cxxflags | tee -a $out/nix-support/cc-cflags
+
+      # Hardening is basically broken on HIP
+      echo "" | tee $out/nix-support/add-hardening.sh
+    '';
+  });
+
+  openmp = llvm;
+
+  clang-tools-extra = llvm;
 }

--- a/pkgs/development/rocm-modules/6/rocm-cmake/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-cmake/default.nix
@@ -30,6 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.mit;
     maintainers = teams.rocm.members;
     platforms = platforms.unix;
-    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version || versionAtLeast finalAttrs.version "7.0.0";
+    # broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-comgr/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   rocmUpdateScript,
   cmake,
+  llvm,
   rocm-cmake,
   rocm-device-libs,
   libxml2,
@@ -37,6 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    llvm
     rocm-device-libs
     libxml2
   ];
@@ -55,8 +57,8 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.ncsa;
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken =
-      versions.minor finalAttrs.version != versions.minor stdenv.cc.version
-      || versionAtLeast finalAttrs.version "7.0.0";
+    # broken =
+    #   versions.minor finalAttrs.version != versions.minor stdenv.cc.version
+    #   || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/rocm-device-libs/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-device-libs/default.nix
@@ -6,6 +6,8 @@
   cmake,
   rocm-cmake,
   libxml2,
+  llvm,
+  clang,
 }:
 
 let
@@ -35,8 +37,12 @@ stdenv.mkDerivation (finalAttrs: {
     rocm-cmake
   ];
 
-  buildInputs = [ libxml2 ];
-  cmakeFlags = [ "-DLLVM_TARGETS_TO_BUILD=AMDGPU;${llvmNativeTarget}" ];
+  buildInputs = [ libxml2 llvm ];
+  cmakeFlags = [
+    "-DLLVM_TARGETS_TO_BUILD=AMDGPU;${llvmNativeTarget}"
+    (lib.cmakeFeature "CMAKE_C_COMPILER" "${clang}/bin/clang")
+    (lib.cmakeFeature "CMAKE_CXX_COMPILER" "${clang}/bin/clang++")
+  ];
 
   passthru.updateScript = rocmUpdateScript {
     name = finalAttrs.pname;
@@ -50,8 +56,8 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.ncsa;
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken =
-      versions.minor finalAttrs.version != versions.minor stdenv.cc.version
-      || versionAtLeast finalAttrs.version "7.0.0";
+    # broken =
+    #   versions.minor finalAttrs.version != versions.minor stdenv.cc.version
+    #   || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-runtime/default.nix
@@ -7,6 +7,7 @@
   pkg-config,
   cmake,
   xxd,
+  llvm,
   rocm-device-libs,
   rocm-thunk,
   elfutils,
@@ -36,6 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    llvm
     rocm-thunk
     elfutils
     libdrm
@@ -80,8 +82,8 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ ncsa ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken =
-      versions.minor finalAttrs.version != versions.minor stdenv.cc.version
-      || versionAtLeast finalAttrs.version "7.0.0";
+    # broken =
+    #   versions.minor finalAttrs.version != versions.minor stdenv.cc.version
+    #   || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/rocm-thunk/default.nix
+++ b/pkgs/development/rocm-modules/6/rocm-thunk/default.nix
@@ -49,6 +49,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ bsd2 mit ];
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version || versionAtLeast finalAttrs.version "7.0.0";
+    # broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/rocminfo/default.nix
+++ b/pkgs/development/rocm-modules/6/rocminfo/default.nix
@@ -59,9 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
     license = licenses.ncsa;
     maintainers = with maintainers; [ lovesegfault ] ++ teams.rocm.members;
     platforms = platforms.linux;
-    broken =
-      stdenv.hostPlatform.isAarch64
-      || versions.minor finalAttrs.version != versions.minor stdenv.cc.version
-      || versionAtLeast finalAttrs.version "7.0.0";
+    # broken =
+    #   stdenv.hostPlatform.isAarch64
+    #   || versions.minor finalAttrs.version != versions.minor stdenv.cc.version
+    #   || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/rocprim/default.nix
+++ b/pkgs/development/rocm-modules/6/rocprim/default.nix
@@ -90,6 +90,6 @@ stdenv.mkDerivation (finalAttrs: {
     license = with licenses; [ mit ];
     maintainers = teams.rocm.members;
     platforms = platforms.linux;
-    broken = versions.minor finalAttrs.version != versions.minor stdenv.cc.version || versionAtLeast finalAttrs.version "7.0.0";
+    broken = versions.minor finalAttrs.version != versions.minor clr.rocmClang.version || versionAtLeast finalAttrs.version "7.0.0";
   };
 })

--- a/pkgs/development/rocm-modules/6/rocsparse/default.nix
+++ b/pkgs/development/rocm-modules/6/rocsparse/default.nix
@@ -15,7 +15,7 @@
   python3Packages,
   buildTests ? false,
   buildBenchmarks ? false, # Seems to depend on tests
-  gpuTargets ? [ ],
+  gpuTargets ? clr.gpuTargets,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -157,7 +157,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = teams.rocm.members;
     platforms = platforms.linux;
     broken =
-      versions.minor finalAttrs.version != versions.minor stdenv.cc.version
+      versions.minor finalAttrs.version != versions.minor clr.rocmClang.version
       || versionAtLeast finalAttrs.version "7.0.0";
   };
 })


### PR DESCRIPTION
Demonstration of a possible fix for #368672. Will work on commit messages later if we decide we want to merge this.

Currently, we build our own LLVM derivation because (as far as I have checked) it builds essentially out-of-the-box and runs fine.

I'm also aware of the existing code to build `llvmPackages_*` and I'm trying to reuse them.

Currently, this PR is planned to be merged after #367695 due to the large number of changes already planned in that PR.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
