### PR TITLE
nixos/kmonad: add new option enableHardening

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -126,6 +126,9 @@
   to review the new defaults and description of
   [](#opt-services.nextcloud.poolSettings).
 
+- `kmonad` is now hardened by default using common `systemd` settings.
+  If KMonad is used to execute shell commands, hardening may make some of them fail.  In that case, you can disable hardening using {option}`services.kmonad.keyboards.<name>.enableHardening` option.
+
 - `asusd` has been upgraded to version 6 which supports multiple aura devices. To account for this, the single `auraConfig` configuration option has been replaced with `auraConfigs` which is an attribute set of config options per each device. The config files may also be now specified as either source files or text strings; to account for this you will need to specify that `text` is used for your existing configs, e.g.:
   ```diff
   -services.asusd.asusdConfig = '''file contents'''

--- a/nixos/modules/services/hardware/kmonad.nix
+++ b/nixos/modules/services/hardware/kmonad.nix
@@ -41,6 +41,19 @@ let
           '';
         };
 
+        enableHardening = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          example = false;
+          description = ''
+            Whether to enable systemd hardening.
+
+            ::: {.note}
+            If KMonad is used to execute shell commands, hardening may make some of them fail.
+            :::
+          '';
+        };
+
         defcfg = {
           enable = lib.mkEnableOption ''
             automatic generation of the defcfg block.
@@ -128,26 +141,60 @@ let
         StartLimitIntervalSec = 2;
         StartLimitBurst = 5;
       };
-      serviceConfig = {
-        ExecStart = ''
-          ${lib.getExe cfg.package} ${mkCfg keyboard} \
-            ${utils.escapeSystemdExecArgs cfg.extraArgs}
-        '';
-        Restart = "always";
-        # Restart at increasing intervals from 2s to 1m
-        RestartSec = 2;
-        RestartSteps = 30;
-        RestartMaxDelaySec = "1min";
-        Nice = -20;
-        DynamicUser = true;
-        User = "kmonad";
-        Group = "kmonad";
-        SupplementaryGroups = [
-          # These ensure that our dynamic user has access to the device node
-          config.users.groups.input.name
-          config.users.groups.uinput.name
-        ] ++ keyboard.extraGroups;
-      };
+      serviceConfig =
+        {
+          ExecStart = ''
+            ${lib.getExe cfg.package} ${mkCfg keyboard} \
+              ${utils.escapeSystemdExecArgs cfg.extraArgs}
+          '';
+          Restart = "always";
+          # Restart at increasing intervals from 2s to 1m
+          RestartSec = 2;
+          RestartSteps = 30;
+          RestartMaxDelaySec = "1min";
+          Nice = -20;
+          DynamicUser = true;
+          User = "kmonad";
+          Group = "kmonad";
+          SupplementaryGroups = [
+            # These ensure that our dynamic user has access to the device node
+            config.users.groups.input.name
+            config.users.groups.uinput.name
+          ] ++ keyboard.extraGroups;
+        }
+        // lib.optionalAttrs keyboard.enableHardening {
+          DeviceAllow = [
+            "/dev/uinput w"
+            "char-input r"
+          ];
+          CapabilityBoundingSet = [ "" ];
+          DevicePolicy = "closed";
+          IPAddressDeny = [ "any" ];
+          LockPersonality = true;
+          MemoryDenyWriteExecute = true;
+          PrivateNetwork = true;
+          PrivateUsers = true;
+          ProcSubset = "pid";
+          ProtectClock = true;
+          ProtectControlGroups = true;
+          ProtectHome = true;
+          ProtectHostname = true;
+          ProtectKernelLogs = true;
+          ProtectKernelModules = true;
+          ProtectKernelTunables = true;
+          ProtectProc = "invisible";
+          RestrictAddressFamilies = [ "none" ];
+          RestrictNamespaces = true;
+          RestrictRealtime = true;
+          SystemCallArchitectures = [ "native" ];
+          SystemCallErrorNumber = "EPERM";
+          SystemCallFilter = [
+            "@system-service"
+            "~@privileged"
+            "~@resources"
+          ];
+          UMask = "0077";
+        };
       # make sure the new config is used after nixos-rebuild switch
       # stopIfChanged controls[0] how a service is "restarted" during
       # nixos-rebuild switch.  By default, stopIfChanged is true, which stops


### PR DESCRIPTION
Before

```console
$ systemd-analyze security kmonad-foo.service | tail -n 1
→ Overall exposure level for kmonad-foo.service: 8.2 EXPOSED 🙁
```

After

```console
$ systemd-analyze security kmonad-foo.service | tail -n 1
→ Overall exposure level for kmonad-foo.service: 0.4 SAFE 😀
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
