### PR TITLE
workflows/eval: fix maintainer requests

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -293,7 +293,7 @@ jobs:
           # Request reviewers from maintainers of changed output paths
           GH_TOKEN=${{ steps.app-token.outputs.token }} gh api \
             --method POST \
-            /repos/${{ github.repository }}/pulls/${{ github.event.number }}/requested_reviewers \
+            /repos/"$REPOSITORY"/pulls/"$NUMBER"/requested_reviewers \
             --input reviewers.json
 
         env:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -219,7 +219,7 @@ jobs:
   tag:
     name: Tag
     runs-on: ubuntu-latest
-    needs: process
+    needs: [ attrs, process ]
     if: needs.process.outputs.baseRunId
     permissions:
       pull-requests: write
@@ -238,6 +238,21 @@ jobs:
         with:
           name: comparison
           path: comparison
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
+
+      # Important: This workflow job runs with extra permissions,
+      # so we need to make sure to not run untrusted code from PRs
+      - name: Check out Nixpkgs at the base commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.attrs.outputs.baseSha }}
+          path: base
+          sparse-checkout: ci
+
+      - name: Build the requestReviews derivation
+        run: nix-build base/ci -A requestReviews
 
       - name: Tagging pull request
         run: |
@@ -271,8 +286,8 @@ jobs:
           # maintainers.json contains GitHub IDs. Look up handles to request reviews from.
           # There appears to be no API to request reviews based on GitHub IDs
           jq -r 'keys[]' comparison/maintainers.json \
-            | while read -r id; do gh api /user/"$id"; done \
-            | jq -s '{ reviewers: map(.login) }' \
+            | while read -r id; do gh api /user/"$id" --jq .login; done \
+            | GH_TOKEN=${{ steps.app-token.outputs.token }} result/bin/process-reviewers.sh "$REPOSITORY" "$NUMBER" "$AUTHOR" \
             > reviewers.json
 
           # Request reviewers from maintainers of changed output paths
@@ -285,6 +300,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
 
       - name: Add eval summary to commit statuses
         if: ${{ github.event_name == 'pull_request_target' }}

--- a/ci/request-reviews/default.nix
+++ b/ci/request-reviews/default.nix
@@ -15,6 +15,7 @@ stdenvNoCC.mkDerivation {
     root = ./.;
     fileset = lib.fileset.unions [
       ./get-reviewers.sh
+      ./process-reviewers.sh
       ./request-reviews.sh
       ./verify-base-branch.sh
       ./dev-branches.txt

--- a/ci/request-reviews/process-reviewers.sh
+++ b/ci/request-reviews/process-reviewers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Process reviewers for a PR, reading line-separated usernames on stdin,
+# returning a JSON suitable to be consumed by the API endpoint to request reviews:
+# https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2022-11-28#request-reviewers-for-a-pull-request
+
+set -euo pipefail
+
+log() {
+    echo "$@" >&2
+}
+
+if (( "$#" < 3 )); then
+    log "Usage: $0 BASE_REPO PR_NUMBER PR_AUTHOR"
+    exit 1
+fi
+
+baseRepo=$1
+prNumber=$2
+prAuthor=$3
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' exit
+
+declare -A users=()
+while read -r handle && [[ -n "$handle" ]]; do
+    users[$handle]=
+done
+
+# Cannot request a review from the author
+if [[ -v users[${prAuthor,,}] ]]; then
+    log "One or more files are owned by the PR author, ignoring"
+    unset 'users[${prAuthor,,}]'
+fi
+
+gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$baseRepo/pulls/$prNumber/reviews" \
+    --jq '.[].user.login' > "$tmp/already-reviewed-by"
+
+# And we don't want to rerequest reviews from people who already reviewed
+while read -r user; do
+    if [[ -v users[${user,,}] ]]; then
+        log "User $user is a code owner but has already left a review, ignoring"
+        unset 'users[${user,,}]'
+    fi
+done < "$tmp/already-reviewed-by"
+
+# Turn it into a JSON for the GitHub API call to request PR reviewers
+jq -n \
+    --arg users "${!users[*]}" \
+    '{
+      reviewers: $users | split(" "),
+    }'

--- a/ci/request-reviews/process-reviewers.sh
+++ b/ci/request-reviews/process-reviewers.sh
@@ -47,6 +47,16 @@ while read -r user; do
     fi
 done < "$tmp/already-reviewed-by"
 
+for user in "${!users[@]}"; do
+    if ! gh api \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/repos/$baseRepo/collaborators/$user" >&2; then
+        log "User $user is not a repository collaborator, probably missed the automated invite to the maintainers team (see <https://github.com/NixOS/nixpkgs/issues/234293>), ignoring"
+        unset 'users[$user]'
+    fi
+done
+
 # Turn it into a JSON for the GitHub API call to request PR reviewers
 jq -n \
     --arg users "${!users[*]}" \

--- a/ci/request-reviews/request-reviews.sh
+++ b/ci/request-reviews/request-reviews.sh
@@ -78,7 +78,8 @@ if ! "$SCRIPT_DIR"/verify-base-branch.sh "$tmp/nixpkgs.git" "$headRef" "$baseRep
 fi
 
 log "Getting code owners to request reviews from"
-"$SCRIPT_DIR"/get-reviewers.sh "$tmp/nixpkgs.git" "$ownersFile" "$baseRepo" "$baseBranch" "$headRef" "$prNumber" "$prAuthor" > "$tmp/reviewers.json"
+"$SCRIPT_DIR"/get-reviewers.sh "$tmp/nixpkgs.git" "$ownersFile" "$baseBranch" "$headRef" | \
+    "$SCRIPT_DIR"/process-reviewers.sh "$baseRepo" "$prNumber" "$prAuthor" > "$tmp/reviewers.json"
 
 log "Requesting reviews from: $(<"$tmp/reviewers.json")"
 


### PR DESCRIPTION
Fixes the problems after https://github.com/NixOS/nixpkgs/pull/366046, including:
- Avoiding requests from PR authors (therefore superseding https://github.com/NixOS/nixpkgs/pull/370186)
- Avoiding requests from people that aren't repo collaborators (which happens if you didn't accept the automated maintainer team invite)
- Avoiding requests from people that already left a review

This reuses part of a script that deals with requests from code owners introduced in https://github.com/NixOS/nixpkgs/pull/336261

Best reviewed commit-by-commit

## Things done
- [x] Tested codeowner reviews: https://github.com/Infinisil-s-Test-Organization/nixpkgs/pull/39#issuecomment-2568634578
- [x] Tested maintainer reviews: https://github.com/Infinisil-s-Test-Organization/nixpkgs/pull/38#issuecomment-2568637395
- [x] Tested that org membership is not enough to be requested as reviewer: https://github.com/Infinisil-s-Test-Organization/nixpkgs/pull/40#issuecomment-2568654606

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
