### PR TITLE
home-assistant-custom-components.frigidaire: Init at 0.1.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16578,6 +16578,13 @@
     githubId = 22592293;
     name = "Kartik Gokte";
   };
+  nullcube = {
+    email = "nullcub3@gmail.com";
+    name = "NullCube";
+    github = "nullcub3";
+    githubId = 51034487;
+    matrix = "@nullcube:matrix.org";
+  };
   nullishamy = {
     email = "spam@amyerskine.me";
     name = "nullishamy";

--- a/pkgs/servers/home-assistant/custom-components/frigidaire/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/frigidaire/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  frigidaire,
+}:
+buildHomeAssistantComponent rec {
+  owner = "bm1549";
+  domain = "frigidaire";
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = "home-assistant-frigidaire";
+    tag = version;
+    hash = "sha256-Jynm0e5y/mSgyd5Pyus+nIVV3XSjsm5z+oNuGIhCu9s=";
+  };
+
+  dependencies = [ frigidaire ];
+
+  # NOTE: The manifest.json specifies an exact version requirement for the
+  # frigidaire dependency
+  ignoreVersionRequirement = [ "frigidaire" ];
+
+  meta = {
+    description = "Custom component for the Frigidaire integration";
+    homepage = "https://github.com/bm1549/home-assistant-frigidaire";
+    maintainers = with lib.maintainers; [ nullcube ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added home-assistant-custom-components.frigidaire which allows Home Assistant to integrate and control Frigidaire smart home products, and added myself as maintainer of said package.

https://github.com/bm1549/home-assistant-frigidaire

I've tested this integration with my own Home Assistant instance using a version of this package slightly altered (a couple `let in`'s) to get the python dependencies correct when using this outside of nixpkgs, and the resulting derivations are identical.

The integration loads, connects to my frigidaire account, and adds the correct devices and entities, but I don't have my frigidaire air conditioner set up at the moment to fully test end to end. However, if it's getting this far, I could only assume any issues would be with the custom component itself, and not with the nix package?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
