### PR TITLE
nixos/wakapi: fix running under sqlite3; add stateDir; add sqlite test case

### DIFF
--- a/nixos/modules/services/web-apps/wakapi.nix
+++ b/nixos/modules/services/web-apps/wakapi.nix
@@ -26,6 +26,14 @@ in
   options.services.wakapi = {
     enable = mkEnableOption "Wakapi";
     package = mkPackageOption pkgs "wakapi" { };
+    stateDir = mkOption {
+      type = types.path;
+      default = "/var/lib/wakapi";
+      description = ''
+        The state directory where data is stored. Will also be used as the
+        working directory for the wakapi service.
+      '';
+    };
 
     settings = mkOption {
       inherit (settingsFormat) type;
@@ -166,6 +174,8 @@ in
         RestrictNamespaces = true;
         RestrictRealtime = true;
         RestrictSUIDSGID = true;
+        WorkingDirectory = cfg.stateDir;
+        RuntimeDirectory = "wakapi";
         StateDirectory = "wakapi";
         StateDirectoryMode = "0700";
         Restart = "always";

--- a/nixos/tests/wakapi.nix
+++ b/nixos/tests/wakapi.nix
@@ -3,36 +3,63 @@ import ./make-test-python.nix (
   {
     name = "Wakapi";
 
-    nodes.machine = {
-      services.wakapi = {
-        enable = true;
-        settings = {
-          server.port = 3000; # upstream default, set explicitly in case upstream changes it
-
-          db = {
-            dialect = "postgres"; # `createLocally` only supports postgres
-            host = "/run/postgresql";
-            port = 5432; # service will fail if port is not set
-            name = "wakapi";
-            user = "wakapi";
+    nodes = {
+      wakapiPsql = {
+        services.wakapi = {
+          enable = true;
+          settings = {
+            server.port = 3000; # upstream default, set explicitly in case upstream changes it
+            db = {
+              dialect = "postgres"; # `createLocally` only supports postgres
+              host = "/run/postgresql";
+              port = 5432; # service will fail if port is not set
+              name = "wakapi";
+              user = "wakapi";
+            };
           };
+
+          # Automatically create our database
+          database.createLocally = true; # only works with Postgresql for now
+
+          # Created with `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1`
+          # Prefer passwordSaltFile in production.
+          passwordSalt = "NpqCY7eY7fMoIWYmPx5mAgr6YoSlXSuI";
         };
+      };
 
-        database.createLocally = true;
+      wakapiSqlite = {
+        services.wakapi = {
+          enable = true;
+          settings = {
+            server.port = 3001;
+            db = {
+              dialect = "sqlite3";
+              name = "wakapi";
+              user = "wakapi";
+            };
+          };
 
-        # Created with `cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1`
-        # Prefer passwordSaltFile in production.
-        passwordSalt = "NpqCY7eY7fMoIWYmPx5mAgr6YoSlXSuI";
+          passwordSalt = "NpqCY7eY7fMoIWYmPx5mAgr6YoSlXSuI";
+        };
       };
     };
 
-    # Test that the service is running and that it is reachable.
+    # Test that service works under both postgresql and sqlite3
+    # by starting all machines, and curling the default address.
     # This is not very comprehensive for a test, but it should
     # catch very basic mistakes in the module.
     testScript = ''
-      machine.wait_for_unit("wakapi.service")
-      machine.wait_for_open_port(3000)
-      machine.succeed("curl --fail http://localhost:3000")
+      with subtest("Test Wakapi with postgresql backend"):
+        wakapiPsql.start()
+        wakapiPsql.wait_for_unit("wakapi.service")
+        wakapiPsql.wait_for_open_port(3000)
+        wakapiPsql.succeed("curl --fail http://localhost:3000")
+
+      with subtest("Test Wakapi with sqlite3 backend"):
+        wakapiSqlite.start()
+        wakapiSqlite.wait_for_unit("wakapi.service")
+        wakapiSqlite.wait_for_open_port(3001)
+        wakapiSqlite.succeed("curl --fail http://localhost:3001")
     '';
 
     meta.maintainers = [ lib.maintainers.NotAShelf ];


### PR DESCRIPTION
- **nixos/wakapi: add `stateDir` and set service WorkingDirectory**
- **tests/wakapi: switch to subest; add sqlite3 case**

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
