### PR TITLE
av1an: 0.4.3 -> 0.4.4

### DIFF
--- a/pkgs/by-name/av/av1an-unwrapped/package.nix
+++ b/pkgs/by-name/av/av1an-unwrapped/package.nix
@@ -1,29 +1,40 @@
 {
   lib,
   stdenv,
-  rustPlatform,
   fetchFromGitHub,
-  pkg-config,
+  fetchpatch,
   ffmpeg,
-  nasm,
-  vapoursynth,
   libaom,
-  rav1e,
+  nasm,
   nix-update-script,
+  pkg-config,
+  rav1e,
+  rustPlatform,
+  vapoursynth,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "av1an-unwrapped";
-  version = "0.4.3";
+  version = "0.4.4";
 
   src = fetchFromGitHub {
     owner = "master-of-zen";
     repo = "av1an";
     tag = version;
-    hash = "sha256-Mb5I+9IBwpfmK1w4LstNHI/qsJKlCuRxgSUiqpwUqF0=";
+    hash = "sha256-YF+j349777pE+evvXWTo42DQn1CE0jlfKBEXUFTfcb8=";
   };
 
-  cargoHash = "sha256-IWcSaJoakXSPIdycWIikGSmOk+D4A3aMnJwuiKn8XNY=";
+  cargoPatches = [
+    # TODO: Remove in next version
+    # Avoids https://github.com/shssoichiro/ffmpeg-the-third/issues/63
+    # https://github.com/master-of-zen/Av1an/pull/912
+    (fetchpatch {
+      url = "https://github.com/master-of-zen/Av1an/commit/e6b29a5a624434eb0dc95b7e8aa31ccf624ccb9d.patch";
+      hash = "sha256-nFE04hlTzApYafSzgl/XOUdchxEjKvxXy+SKr/d6+0Q=";
+    })
+  ];
+
+  cargoHash = "sha256-4+JyWymj0yFsXw+7im+ye4rJmkc8nyg+7d1U/MTOerk=";
 
   nativeBuildInputs = [
     nasm

--- a/pkgs/by-name/av/av1an-unwrapped/package.nix
+++ b/pkgs/by-name/av/av1an-unwrapped/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
@@ -60,5 +61,7 @@ rustPlatform.buildRustPackage rec {
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ getchoo ];
     mainProgram = "av1an";
+    # symbol index out of range file '/private/tmp/nix-build-av1an-unwrapped-0.4.4.drv-0/rustcz0anL2/librav1e-ca440893f9248a14.rlib' for architecture x86_64
+    broken = stdenv.hostPlatform.system == "x86_64-darwin";
   };
 }

--- a/pkgs/by-name/av/av1an/package.nix
+++ b/pkgs/by-name/av/av1an/package.nix
@@ -81,6 +81,7 @@ symlinkJoin {
       license
       maintainers
       mainProgram
+      broken
       ;
   };
 }

--- a/pkgs/by-name/av/av1an/package.nix
+++ b/pkgs/by-name/av/av1an/package.nix
@@ -1,19 +1,21 @@
 {
   lib,
-  symlinkJoin,
-  makeBinaryWrapper,
+  av1an,
   av1an-unwrapped,
   ffmpeg,
-  python3,
   libaom,
-  svt-av1,
-  rav1e,
+  libvmaf,
   libvpx,
+  makeBinaryWrapper,
+  mkvtoolnix-cli,
+  python3,
+  rav1e,
+  svt-av1,
+  symlinkJoin,
+  testers,
+  vapoursynth,
   x264,
   x265,
-  libvmaf,
-  vapoursynth,
-  mkvtoolnix-cli,
   withAom ? true, # AV1 reference encoder
   withSvtav1 ? false, # AV1 encoder/decoder (focused on speed and correctness)
   withRav1e ? false, # AV1 encoder (focused on speed and safety)
@@ -27,15 +29,16 @@
 # av1an requires at least one encoder
 assert lib.assertMsg (lib.elem true [
   withAom
-  withSvtav1
   withRav1e
+  withSvtav1
   withVpx
   withX264
   withX265
 ]) "At least one encoder is required!";
 
 symlinkJoin {
-  name = "av1an-${av1an-unwrapped.version}";
+  pname = "av1an";
+  inherit (av1an-unwrapped) version;
 
   paths = [ av1an-unwrapped ];
 
@@ -49,13 +52,13 @@ symlinkJoin {
           (ffmpeg.override { inherit withVmaf; })
         ]
         ++ lib.optional withAom libaom
-        ++ lib.optional withSvtav1 svt-av1
+        ++ lib.optional withMkvtoolnix mkvtoolnix-cli
         ++ lib.optional withRav1e rav1e
+        ++ lib.optional withSvtav1 svt-av1
+        ++ lib.optional withVmaf libvmaf
         ++ lib.optional withVpx libvpx
         ++ lib.optional withX264 x264
-        ++ lib.optional withX265 x265
-        ++ lib.optional withVmaf libvmaf
-        ++ lib.optional withMkvtoolnix mkvtoolnix-cli;
+        ++ lib.optional withX265 x265;
     in
     ''
       wrapProgram $out/bin/av1an \
@@ -65,11 +68,10 @@ symlinkJoin {
     '';
 
   passthru = {
-    # TODO: uncomment when upstream actually bumps CARGO_PKG_VERSION
-    #tests.version = testers.testVersion {
-    #  package = av1an;
-    #  inherit (av1an-unwrapped) version;
-    #};
+    tests.version = testers.testVersion {
+      package = av1an;
+      inherit (av1an-unwrapped) version;
+    };
   };
 
   meta = {


### PR DESCRIPTION
Diff: https://github.com/master-of-zen/av1an/compare/refs/tags/0.4.3...0.4.4

Changelog: https://github.com/master-of-zen/Av1an/releases/tag/0.4.4

```console
$ nix-build -A av1an -A av1an.passthru.tests
/nix/store/6zlw2qkjf9qgglvv5nmb581vdyk2c95s-av1an-0.4.4
/nix/store/ykw5h8w1m26f7mz3sms2p6y2hg7bmdra-av1an-0.4.4-test-version
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
