### PR TITLE
qt6.qtwayland: backport fix for qtwayland compositor

### DIFF
--- a/pkgs/development/libraries/qt-6/modules/qtwayland.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtwayland.nix
@@ -35,13 +35,20 @@ qtModule {
       url = "https://invent.kde.org/qt/qt/qtwayland/-/commit/24002ac6cbd01dbde4944b63c1f7c87ed2bd72b5.patch";
       hash = "sha256-Lz4Gv6FLhFGv7dVpqqcss6/w5jsGA8SKaNeWMHT0A/A=";
     })
-  ];
 
-  # Replace vendored wayland.xml with our matching version
-  # FIXME: remove when upstream updates past 1.23
-  postPatch = ''
-    cp ${wayland-scanner}/share/wayland/wayland.xml src/3rdparty/protocol/wayland/wayland.xml
-  '';
+    # run waylandscanner with private-code to avoid conflict with symbols from libwayland
+    # better solution for https://github.com/NixOS/nixpkgs/pull/337913
+    (fetchpatch2 {
+      url = "https://invent.kde.org/qt/qt/qtwayland/-/commit/67f121cc4c3865aa3a93cf563caa1d9da3c92695.patch";
+      hash = "sha256-uh5lecHlHCWyO1/EU5kQ00VS7eti3PEvPA2HBCL9K0k=";
+    })
+
+    # fix crash when attach differ shellsurface to the same shellsurfaceitem
+    (fetchpatch2 {
+      url = "https://invent.kde.org/qt/qt/qtwayland/-/commit/070414dd4155e13583e5e8b16bed1a5b68d32910.patch";
+      hash = "sha256-JLTdSEbqM6OSijk0cgC419AdLE+PF5KbFh3ypgYUKz8=";
+    })
+  ];
 
   meta = {
     platforms = lib.platforms.unix;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

1. https://codereview.qt-project.org/c/qt/qtwayland/+/598596

>[PATCH] client: Run waylandscanner with private-code
This is the recommended mode, and failing to use private-code
makes libraries expose generated symbols like wl_shm_interface,
which may conflict with symbols from libwayland leading to
unexpected behavior or aborts.

This patch can replace https://github.com/NixOS/nixpkgs/pull/337913

2. https://codereview.qt-project.org/c/qt/qtwayland/+/599732

> Change shellSurface from a raw pointer to a QPointer to prevent
crash caused by accessing the wild pointer when shellSurface is destroyed

fix `use after free` in qtwayland compositor

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
