### PR TITLE
fbvnc: fix build with GCC 14

### DIFF
--- a/pkgs/by-name/fb/fbvnc/gcc14-fix.patch
+++ b/pkgs/by-name/fb/fbvnc/gcc14-fix.patch
@@ -1,0 +1,25 @@
+diff --git a/vncauth.c b/vncauth.c
+index 79c4448..6348007 100644
+--- a/vncauth.c
++++ b/vncauth.c
+@@ -26,6 +26,7 @@
+ #include <string.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
++#include <time.h>
+ #include <unistd.h>
+ 
+ #include "vncauth.h"
+diff --git a/vncauth.h b/vncauth.h
+index 86dc455..7fdb8d4 100644
+--- a/vncauth.h
++++ b/vncauth.h
+@@ -25,6 +25,8 @@
+ #define CHALLENGESIZE 16
+ 
+ extern int vncEncryptAndStorePasswd(char *passwd, char *fname);
++extern int vncEncryptAndStorePasswd2(char *passwd, char *passwdViewOnly, char *fname);
+ extern char *vncDecryptPasswdFromFile(char *fname);
++extern int vncDecryptPasswdFromFile2(char *fname, char *passwdFullControl, char *passwdViewOnly);
+ extern void vncRandomBytes(unsigned char *bytes);
+ extern void vncEncryptBytes(unsigned char *bytes, char *passwd);

--- a/pkgs/by-name/fb/fbvnc/package.nix
+++ b/pkgs/by-name/fb/fbvnc/package.nix
@@ -15,6 +15,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-oT7+6kIeFDgU6GbcHYQ6k0jCU84p8fTEVgUozYMkeVI=";
   };
 
+  patches = [
+    # GCC 14 errors on missing function definitions
+    # https://github.com/zohead/fbvnc/pull/3
+    ./gcc14-fix.patch
+  ];
+
   makeFlags = [
     "CC:=$(CC)"
   ];


### PR DESCRIPTION
Alternative would be to drop the package. It has seen no code changes in 13 years.

ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).