### PR TITLE
gcc: use full pathnames in libraries

### DIFF
--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -235,13 +235,15 @@ pipe ((callFile ./common/builder.nix {}) ({
   # insert into default search paths.
   + optionalString hostPlatform.isDarwin ''
     substituteInPlace gcc/config/darwin-c.c${optionalString atLeast12 "c"} \
-      --replace 'if (stdinc)' 'if (0)'
+      --replace-fail 'if (stdinc)' 'if (0)'
 
-    substituteInPlace libgcc/config/t-slibgcc-darwin \
-      --replace "-install_name @shlib_slibdir@/\$(SHLIB_INSTALL_NAME)" "-install_name ''${!outputLib}/lib/\$(SHLIB_INSTALL_NAME)"
-
-    substituteInPlace libgfortran/configure \
-      --replace "-install_name \\\$rpath/\\\$soname" "-install_name ''${!outputLib}/lib/\\\$soname"
+    for c in $(find . -name '*.m4' | xargs grep -l "'@rpath/\\\\\$soname'" || true)
+    do
+      # see also pattern in preConfigure
+      substituteInPlace $c \
+        --replace-fail "'\\\$rpath/\\\$soname'" "''\'''${!outputLib}/lib/\\\$soname'" \
+        --replace-fail "'@rpath/\\\$soname'" "''\'''${!outputLib}/lib/\\\$soname'"
+    done
   ''
   + (
     optionalString (targetPlatform != hostPlatform || stdenv.cc.libc != null)
@@ -280,6 +282,18 @@ pipe ((callFile ./common/builder.nix {}) ({
 
   preConfigure = (callFile ./common/pre-configure.nix { }) + optionalString atLeast10 ''
     ln -sf ${libxcrypt}/include/crypt.h libsanitizer/sanitizer_common/crypt.h
+  ''
+  + optionalString hostPlatform.isDarwin ''
+    for c in $(find . -name configure | xargs grep -l "'@rpath/\\\\\$soname'" || true)
+    do
+      # see also pattern in postPatch
+      substituteInPlace $c \
+        --replace-fail "'\\\$rpath/\\\$soname'" "''\'''${!outputLib}/lib/\\\$soname'" \
+        --replace-fail "'@rpath/\\\$soname'" "''\'''${!outputLib}/lib/\\\$soname'"
+    done
+    substituteInPlace libgcc/config/t-darwin-rpath \
+      --replace-fail "@rpath" "''\'''${!outputLib}/lib'"
+
   '';
 
   dontDisableStatic = true;


### PR DESCRIPTION
NOTE -- nixfmt makes a complete mess of `pkgs/development/compilers/gcc/common/builder.nix` so opted not to apply it.
 

this is a Darwin-only change but due to the bash changes in  `builder.nix` the derivation changes for all platforms. I moved the darwin code into a conditional so future changes only effect darwin. 

gcc interlibrary dependancies are added using `@rpath`. this can break linking when these libs are in the dependency chain in certain conditions. Fix the configure scripts to pass the full path to `-install_name` when linking. Add some checks that verifies the the libs don't contain references to `@rpaths` and remove all `LC_RPATH` entries in the postInstall stage.

```
libgfortran.5.dylib:
	@rpath/libquadmath.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	@rpath/libgcc_s.1.1.dylib (compatibility version 1.0.0, current version 1.1.0)
libobjc-gnu.4.dylib:
	@rpath/libgcc_s.1.1.dylib (compatibility version 1.0.0, current version 1.1.0)
libstdc++.6.dylib:
	@rpath/libgcc_s.1.1.dylib (compatibility version 1.0.0, current version 1.1.0)
```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fixes link errors
https://hydra.nixos.org/build/283880696
```
ld: file not found: @rpath/libquadmath.0.dylib for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
