### PR TITLE
pypy{27,310}: 7.3.12 -> 7.3.17

### DIFF
--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -149,25 +149,19 @@ in {
     inherit passthruFun;
   };
 
-  pypy39 = callPackage ./pypy {
-    self = __splicedPackages.pypy39;
+  pypy310 = callPackage ./pypy {
+    self = __splicedPackages.pypy310;
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "12";
+      patch = "17";
     };
 
-    hash = "sha256-56IEbH5sJfw4aru1Ey6Sp8wkkeOTVpmpRstdy7NCwqo=";
-    pythonVersion = "3.9";
+    hash = "sha256-atdLxXjpxtOoocUVAzEwWOPFjDXfhvdIVFPEvmqyS/c=";
+    pythonVersion = "3.10";
     db = db.override { dbmSupport = !stdenv.hostPlatform.isDarwin; };
     python = __splicedPackages.pypy27;
     inherit passthruFun;
-  };
-
-  pypy310 = __splicedPackages.pypy39.override {
-    self = __splicedPackages.pythonInterpreters.pypy310;
-    pythonVersion = "3.10";
-    hash = "sha256-huTk6sw2BGxhgvQwGHllN/4zpg4dKizGuOf5Gl3LPkI=";
   };
 
   pypy27_prebuilt = callPackage ./pypy/prebuilt_2_7.nix {
@@ -189,21 +183,23 @@ in {
     inherit passthruFun;
   };
 
-  pypy39_prebuilt = callPackage ./pypy/prebuilt.nix {
+  pypy39_prebuilt = throw "pypy 3.9 has been removed, use pypy 3.10 instead"; # Added 2025-01-03
+
+  pypy310_prebuilt = callPackage ./pypy/prebuilt.nix {
     # Not included at top-level
-    self = __splicedPackages.pythonInterpreters.pypy39_prebuilt;
+    self = __splicedPackages.pythonInterpreters.pypy310_prebuilt;
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "12";
+      patch = "17";
     };
     hash = {
-      aarch64-linux = "sha256-6TJ/ue2vKtkZNdW4Vj7F/yQZO92xdcGsqvdywCWvGCQ=";
-      x86_64-linux = "sha256-hMiblm+rK1j0UaSC7jDKf+wzUENb0LlhRhXGHcbaI5A=";
-      aarch64-darwin = "sha256-DooaNGi5eQxzSsaY9bAMwD/BaJnMxs6HZGX6wLg5gOM=";
-      x86_64-darwin = "sha256-ZPAI/6BwxAfl70bIJWsuAU3nGW6l2Fg4WGElTnlZ9Os=";
+      aarch64-linux = "sha256-v79JVJirwv53G2C/ZOXDwHLgr7z8pprHKCxP9Dd/9BY=";
+      x86_64-linux = "sha256-NA2kGWYGsiRQmhuLMa/SAYE/CCYB3xicE46QXB1g4K8=";
+      aarch64-darwin = "sha256-KPKf/JxcyQbo6QgT/BRPA34js4TwUuGE4kIzL3tgqwY=";
+      x86_64-darwin = "sha256-I/8mS3PlvFt8OhufrHdosj35bH1mDLZBLxxSNSGjNL8=";
     }.${stdenv.system};
-    pythonVersion = "3.9";
+    pythonVersion = "3.10";
     inherit passthruFun;
   };
 })

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -139,10 +139,10 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "12";
+      patch = "17";
     };
 
-    hash = "sha256-3WHYjaJ0ws4s7HdmfUo9+aZSvMUOJvkJkdTdCvZrzPQ=";
+    hash = "sha256-UOBoQPS73pFEgICkEYBoqJuPvK4l/42h4rsUAtyaA0Y=";
     pythonVersion = "2.7";
     db = db.override { dbmSupport = !stdenv.hostPlatform.isDarwin; };
     python = __splicedPackages.pythonInterpreters.pypy27_prebuilt;
@@ -176,14 +176,14 @@ in {
     sourceVersion = {
       major = "7";
       minor = "3";
-      patch = "12";
+      patch = "17";
     };
 
     hash = {
-      aarch64-linux = "sha256-4E3LYoantHJOw/DlDTzBuoWDMB3RZYwG1/N1meQgHFk=";
-      x86_64-linux = "sha256-GmGiV0t5Rm9gYBDymZormVvZbNCF+Rp46909XCxA6B0=";
-      aarch64-darwin = "sha256-a3R6oHauhZfklgPF3sTKWTWhoKEy10BKVZvpaiYNm/c=";
-      x86_64-darwin = "sha256-bon/3RVTfOT/zjFFtl7lfC6clSiSvZW5NAEtLwCfUDs=";
+      aarch64-linux = "sha256-DUzvpmBoUk4qyyxPn1EQSqcnIc0YvPRi7HyLo5Ekqa4=";
+      x86_64-linux = "sha256-nzSX+HszctF+RHNp4AFqS+yZprTSpZq6d0olv+Q1NHQ=";
+      aarch64-darwin = "sha256-gCJIc5sqzIwb5tlH8Zsy/A44wI4xKzXAXMf7IvEHCeQ=";
+      x86_64-darwin = "sha256-gtRgQhRmyBraSh2Z3y3xuLNTQbOXyF///lGkwwItCDM=";
     }.${stdenv.system};
     pythonVersion = "2.7";
     inherit passthruFun;

--- a/pkgs/development/interpreters/tcl/8.5.nix
+++ b/pkgs/development/interpreters/tcl/8.5.nix
@@ -12,5 +12,9 @@ callPackage ./generic.nix (
       url = "mirror://sourceforge/tcl/tcl${version}-src.tar.gz";
       sha256 = "066vlr9k5f44w9gl9382hlxnryq00d5p6c7w5vq1fgc7v9b49w6k";
     };
+
+    extraPatch = ''
+      substituteInPlace 'generic/tclInt.h' --replace-fail 'typedef int ptrdiff_t;' ""
+    '';
   }
 )

--- a/pkgs/development/interpreters/tcl/generic.nix
+++ b/pkgs/development/interpreters/tcl/generic.nix
@@ -12,6 +12,7 @@
   release,
   version,
   src,
+  extraPatch ? "",
   ...
 }:
 
@@ -27,13 +28,15 @@ let
 
     setOutputFlags = false;
 
-    postPatch = ''
-      substituteInPlace library/clock.tcl \
-        --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
-        --replace "/usr/share/lib/zoneinfo" "" \
-        --replace "/usr/lib/zoneinfo" "" \
-        --replace "/usr/local/etc/zoneinfo" ""
-    '';
+    postPatch =
+      ''
+        substituteInPlace library/clock.tcl \
+          --replace "/usr/share/zoneinfo" "${tzdata}/share/zoneinfo" \
+          --replace "/usr/share/lib/zoneinfo" "" \
+          --replace "/usr/lib/zoneinfo" "" \
+          --replace "/usr/local/etc/zoneinfo" ""
+      ''
+      + extraPatch;
 
     nativeBuildInputs = lib.optionals (lib.versionAtLeast version "9.0") [
       # Only used to detect the presence of zlib. Could be replaced with a stub.

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1113,6 +1113,7 @@ mapAliases {
   python-swiftclient = throw "'python-swiftclient' has been renamed to/replaced by 'swiftclient'"; # Converted to throw 2024-10-17
   pythonFull = python2Full; # Added 2022-01-11
   pythonPackages = python.pkgs; # Added 2022-01-11
+  pypy39 = throw "pypy 3.9 has been removed, use pypy 3.10 instead"; # Added 2025-01-03
 
   ### Q ###
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7327,7 +7327,7 @@ with pkgs;
 
   pypy = pypy2;
   pypy2 = pypy27;
-  pypy3 = pypy39;
+  pypy3 = pypy310;
 
   # Python interpreter that is build with all modules, including tkinter.
   # These are for compatibility and should not be used inside Nixpkgs.
@@ -7395,7 +7395,7 @@ with pkgs;
   };
 
   pythonInterpreters = callPackage ./../development/interpreters/python { };
-  inherit (pythonInterpreters) python27 python39 python310 python311 python312 python313 python314 python3Minimal pypy27 pypy310 pypy39;
+  inherit (pythonInterpreters) python27 python39 python310 python311 python312 python313 python314 python3Minimal pypy27 pypy310;
 
   # List of extensions with overrides to apply to all Python package sets.
   pythonPackagesExtensions = [ ];
@@ -7412,7 +7412,6 @@ with pkgs;
   pypy2Packages = pypy2.pkgs;
   pypy27Packages = pypy27.pkgs;
   pypy3Packages = pypy3.pkgs;
-  pypy39Packages = pypy39.pkgs;
   pypy310Packages = pypy310.pkgs;
 
   pythonManylinuxPackages = callPackage ./../development/interpreters/python/manylinux { };


### PR DESCRIPTION
Regular update. I checked, tcl-8_5 for prebuilt pypy can't be updated.

Fixes #280855

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).