### PR TITLE
onefetch: 2.22.0 -> 2.23.1

### DIFF
--- a/pkgs/by-name/on/onefetch/package.nix
+++ b/pkgs/by-name/on/onefetch/package.nix
@@ -16,16 +16,16 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "onefetch";
-  version = "2.22.0";
+  version = "2.23.1";
 
   src = fetchFromGitHub {
     owner = "o2sh";
     repo = pname;
     rev = version;
-    hash = "sha256-Gk1hoC6qsLYm7DbbaRSur6GdC9yXQe+mYLUJklXIwZ4=";
+    hash = "sha256-lQxv2gwZOGtxJrXjxvjBnbl225ppSs3cVNCfePFeqEE=";
   };
 
-  cargoHash = "sha256-4YB10uj4ULhvhn+Yv0dRZO8fRxwm3lEAZ5v+MYHO7lI=";
+  cargoHash = "sha256-jDyEZaP1R1c5K+d9BQSVqy/rCEAXIrVA/68vQweSIF4=";
 
   cargoPatches = [
     # enable pkg-config feature of zstd

--- a/pkgs/by-name/on/onefetch/zstd-pkg-config.patch
+++ b/pkgs/by-name/on/onefetch/zstd-pkg-config.patch
@@ -1,8 +1,8 @@
 diff --git a/Cargo.lock b/Cargo.lock
-index dd0e3e1..5738ec1 100644
+index 839cdbc..9622d04 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -2829,6 +2829,7 @@ dependencies = [
+@@ -2819,6 +2819,7 @@ dependencies = [
   "tokei",
   "typetag",
   "winres",
@@ -11,11 +11,12 @@ index dd0e3e1..5738ec1 100644
  
  [[package]]
 diff --git a/Cargo.toml b/Cargo.toml
-index a0a2777..ad146cb 100644
+index 79cbb8c..410a969 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -65,6 +65,7 @@ time-humanize = { version = "0.1.3", features = ["time"] }
- tokei = "12.1.2"
+@@ -68,6 +68,7 @@ time = { version = "0.3.37", features = ["formatting"] }
+ time-humanize = { version = "0.1.3", features = ["time"] }
+ tokei = "13.0.0-alpha.7"
  typetag = "0.2"
 +zstd = { version = "*", features = ["pkg-config"] }
  


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
https://github.com/o2sh/onefetch/releases/tag/2.23.0
https://github.com/o2sh/onefetch/releases/tag/2.23.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
