### PR TITLE
flrig: fix cross / strictDeps build

### DIFF
--- a/pkgs/by-name/fl/flrig/package.nix
+++ b/pkgs/by-name/fl/flrig/package.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
+  env.FLTK_CONFIG = lib.getExe' (lib.getDev fltk13) "fltk-config";
+
   meta = {
     description = "Digital modem rig control program";
     homepage = "https://sourceforge.net/projects/fldigi/";


### PR DESCRIPTION
Incidentally also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).