### PR TITLE
python312Packages.meeko: 0.5.1 -> 0.6.1

### DIFF
--- a/pkgs/development/python-modules/meeko/default.nix
+++ b/pkgs/development/python-modules/meeko/default.nix
@@ -2,44 +2,35 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch,
+  gemmi,
   numpy,
   pytestCheckHook,
-  pythonOlder,
   rdkit,
   scipy,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "meeko";
-  version = "0.5.1";
-  format = "setuptools";
-
-  disabled = pythonOlder "3.5";
+  version = "0.6.1";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "forlilab";
     repo = "Meeko";
     tag = "v${version}";
-    hash = "sha256-I/kAO0a6DbDqmzjS36ETuoH/Z1gR2eNpyE3herHDKMs=";
+    hash = "sha256-ViIBiczwxTwraYn8UnFAZFCFT28v3WEYm04W2YpU/4g=";
   };
 
-  patches = [
-    # https://github.com/forlilab/Meeko/issues/60
-    (fetchpatch {
-      name = "fix-unknown-sidechains.patch";
-      url = "https://github.com/forlilab/Meeko/commit/28c9fbfe3b778aa1bd5e8d7e4f3e6edf44633a0c.patch";
-      hash = "sha256-EJbLnbKTTOsTxKtLiU7Af07yjfY63ungGUHbGvrm0AU=";
-    })
-    (fetchpatch {
-      name = "add-test-data.patch";
-      url = "https://github.com/forlilab/Meeko/commit/57b52e3afffb82685cdd1ef1bf6820d55924b97a.patch";
-      hash = "sha256-nLnyIjT68iaY3lAEbH9EJ5jZflhxABBwDqw8kaRKf3k=";
-    })
+  build-system = [ setuptools ];
+
+  pythonRemoveDeps = [
+    "gemmi"
+    "rdkit"
   ];
 
-  propagatedBuildInputs = [
-    # setup.py only requires numpy but others are needed at runtime
+  dependencies = [
+    gemmi
     numpy
     rdkit
     scipy
@@ -52,8 +43,8 @@ buildPythonPackage rec {
   meta = {
     description = "Python package for preparing small molecule for docking";
     homepage = "https://github.com/forlilab/Meeko";
-    changelog = "https://github.com/forlilab/Meeko/releases/tag/v${version}";
-    license = lib.licenses.lgpl21Only;
+    changelog = "https://github.com/forlilab/Meeko/releases/tag/${src.tag}";
+    license = lib.licenses.lgpl21Plus;
     maintainers = with lib.maintainers; [ natsukium ];
   };
 }

--- a/pkgs/development/python-modules/rdkit/default.nix
+++ b/pkgs/development/python-modules/rdkit/default.nix
@@ -117,6 +117,7 @@ buildPythonPackage rec {
     (lib.cmakeBool "RDK_BUILD_INCHI_SUPPORT" true)
     (lib.cmakeBool "RDK_BUILD_MAEPARSER_SUPPORT" true)
     (lib.cmakeBool "RDK_BUILD_THREADSAFE_SSS" true)
+    (lib.cmakeBool "RDK_BUILD_XYZ2MOL_SUPPORT" true)
     (lib.cmakeBool "RDK_BUILD_YAEHMOP_SUPPORT" true)
     (lib.cmakeBool "RDK_INSTALL_INTREE" false)
     (lib.cmakeBool "RDK_INSTALL_STATIC_LIBS" false)


### PR DESCRIPTION
Diff: https://github.com/forlilab/Meeko/compare/refs/tags/v0.5.1...v0.6.1

Changelog: https://github.com/forlilab/Meeko/releases/tag/v0.6.1
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
