### PR TITLE
lcalc: use libc++-compatible way of extending namespace std

### DIFF
--- a/pkgs/by-name/lc/lcalc/libcxx-compat.patch
+++ b/pkgs/by-name/lc/lcalc/libcxx-compat.patch
@@ -1,0 +1,30 @@
+diff --git a/src/libLfunction/Lcomplex.h b/src/libLfunction/Lcomplex.h
+index 363bbf4..ffecd70 100644
+--- a/src/libLfunction/Lcomplex.h
++++ b/src/libLfunction/Lcomplex.h
+@@ -56,8 +56,11 @@
+ #include <cmath>
+ #include <sstream>
+ 
+-namespace std
+-{
++#ifdef _LIBCPP_VERSION
++_LIBCPP_BEGIN_NAMESPACE_STD
++#else
++namespace std {
++#endif
+   // Forward declarations
+   template<typename _Tp> class complex;
+   template<> class complex<float>;
+@@ -1193,6 +1196,10 @@ namespace std
+   inline
+   complex<long double>::complex(const complex<double>& __z)
+   : _M_value(_ComplexT(__z._M_value)) { }
+-} // namespace std
++#ifdef _LIBCPP_VERSION
++_LIBCPP_END_NAMESPACE_STD
++#else
++}
++#endif
+ 
+ #endif	/* _CPP_COMPLEX */

--- a/pkgs/by-name/lc/lcalc/package.nix
+++ b/pkgs/by-name/lc/lcalc/package.nix
@@ -19,13 +19,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-RxWZ7T0I9zV7jUVnL6jV/PxEoU32KY7Q1UsOL5Lonuc=";
   };
 
-  # workaround for vendored GCC 3.5 <complex>
+  # workaround for vendored GCC <complex> on libc++
   # https://gitlab.com/sagemath/lcalc/-/issues/16
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-D_GLIBCXX_COMPLEX"
-    "-D_LIBCPP_COMPLEX"
-    "-D_LIBCPP___FWD_COMPLEX_H"
-  ];
+  patches = [ ./libcxx-compat.patch ];
 
   nativeBuildInputs = [
     autoreconfHook


### PR DESCRIPTION
I suggested something in #370176 and didn't test it properly on libc++, and it wasn't enough to fix the Sage build. Let's try an alternate fix. Another possible fix is available at #370547, along with discussion of the tradeoffs between the two.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
