### PR TITLE
lcalc: fix consumers clang-19 build

### DIFF
--- a/pkgs/by-name/lc/lcalc/complex-fixes.diff
+++ b/pkgs/by-name/lc/lcalc/complex-fixes.diff
@@ -1,0 +1,73 @@
+diff --git a/src/libLfunction/Lcommon.h b/src/libLfunction/Lcommon.h
+index 873778c..d361b91 100644
+--- a/src/libLfunction/Lcommon.h
++++ b/src/libLfunction/Lcommon.h
+@@ -6,7 +6,7 @@
+ #define precise(T) typename precise<T>::precise_type
+ template<class T> struct precise { typedef T precise_type; };
+ template<> struct precise<double> { typedef Double precise_type; };
+-template<> struct precise<complex<double> > { typedef Complex precise_type; };
++template<> struct precise<lcalc::complex<double> > { typedef Complex precise_type; };
+ template<> struct precise<long long> { typedef long long precise_type; };
+ typedef long long Long;
+ 
+diff --git a/src/libLfunction/Lcomplex.h b/src/libLfunction/Lcomplex.h
+index 363bbf4..6e38186 100644
+--- a/src/libLfunction/Lcomplex.h
++++ b/src/libLfunction/Lcomplex.h
+@@ -40,10 +40,8 @@
+  *  in your programs, rather than any of the "st[dl]_*.h" implementation files.
+  */
+ 
+-#ifndef _CPP_COMPLEX
+-#define _CPP_COMPLEX	1
+-
+-#pragma GCC system_header
++#ifndef Lcomplex_H
++#define Lcomplex_H
+ 
+ //no longer include:
+ //#include <bits/cpp_type_traits.h>  only thing used was is_floating... 
+@@ -56,8 +54,19 @@
+ #include <cmath>
+ #include <sstream>
+ 
+-namespace std
++namespace lcalc
+ {
++  using std::abs;
++  using std::atan2;
++  using std::cos;
++  using std::cosh;
++  using std::sin;
++  using std::sinh;
++  using std::sqrt;
++  using std::exp;
++  using std::log;
++  using std::max;
++
+   // Forward declarations
+   template<typename _Tp> class complex;
+   template<> class complex<float>;
+@@ -1193,6 +1202,6 @@ namespace std
+   inline
+   complex<long double>::complex(const complex<double>& __z)
+   : _M_value(_ComplexT(__z._M_value)) { }
+-} // namespace std
++} // namespace lc
+ 
+-#endif	/* _CPP_COMPLEX */
++#endif
+diff --git a/src/libLfunction/Lglobals.h b/src/libLfunction/Lglobals.h
+index 8c6300b..21ba62c 100644
+--- a/src/libLfunction/Lglobals.h
++++ b/src/libLfunction/Lglobals.h
+@@ -53,7 +53,7 @@ using namespace std;
+ 
+ 
+ #include "Lcomplex.h"     //for complex numbers
+-typedef complex<Double> Complex;
++typedef lcalc::complex<Double> Complex;
+ 
+ #include "Lcommon.h"
+ 

--- a/pkgs/by-name/lc/lcalc/package.nix
+++ b/pkgs/by-name/lc/lcalc/package.nix
@@ -19,12 +19,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-RxWZ7T0I9zV7jUVnL6jV/PxEoU32KY7Q1UsOL5Lonuc=";
   };
 
-  # workaround for vendored GCC 3.5 <complex>
-  # https://gitlab.com/sagemath/lcalc/-/issues/16
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-D_GLIBCXX_COMPLEX"
-    "-D_LIBCPP_COMPLEX"
-    "-D_LIBCPP___FWD_COMPLEX_H"
+  patches = [
+    # workaround for vendored GCC 3.5 <complex>
+    # https://gitlab.com/sagemath/lcalc/-/issues/16
+    ./complex-fixes.diff
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/commit/6e95ad3b2b49d5da92feb3c310286a650c349dd6 fixed the standalone lcalc build by preventing stl <complex> from getting parsed consumers would still break.  This change moves the vendored <complex> into it's own namespace which fixes the build for consumers.

https://gitlab.com/sagemath/lcalc/-/issues/16
https://github.com/NixOS/nixpkgs/pull/370176

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

built sage on aarch64-darwin (with patches) and x64 linux

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
