### PR TITLE
inkscape: fix cross build

### DIFF
--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -113,6 +113,13 @@ stdenv.mkDerivation (finalAttrs: {
     # double-conversion is a dependency of 2geom
     substituteInPlace CMakeScripts/DefineDependsandFlags.cmake \
       --replace-fail 'find_package(DoubleConversion REQUIRED)' ""
+    # use native Python when cross-compiling
+    shopt -s globstar
+    for f in **/CMakeLists.txt; do
+      substituteInPlace $f \
+        --replace-quiet "COMMAND python3" "COMMAND ${lib.getExe python3Env.pythonOnBuildForHost}"
+    done
+    shopt -u globstar
   '';
 
   nativeBuildInputs = [


### PR DESCRIPTION
Obvious fix really. Though I am not sure why it tried to use the wrong Python in the first place.

Cross builds of some dependencies may be fixed by my other PRs, if they fail on this branch

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).