### PR TITLE
Add `lib.showOptionParent`

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -94,8 +94,9 @@ let
     inherit (self.lists) singleton forEach map foldr fold foldl foldl' imap0 imap1
       filter ifilter0 concatMap flatten remove findSingle findFirst any all count
       optional optionals toList range replicate partition zipListsWith zipLists
-      reverseList listDfs toposort sort sortOn naturalSort compareLists take
-      drop sublist last init crossLists unique allUnique intersectLists
+      reverseList listDfs toposort sort sortOn naturalSort compareLists
+      take drop dropEnd sublist last init
+      crossLists unique allUnique intersectLists
       subtractLists mutuallyExclusive groupBy groupBy' concatLists genList
       length head tail elem elemAt isList;
     inherit (self.strings) concatStrings concatMapStrings concatImapStrings

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -151,7 +151,7 @@ let
       getValues getFiles
       optionAttrSetToDocList optionAttrSetToDocList'
       scrubOptionValue literalExpression literalExample
-      showOption showOptionWithDefLocs showFiles
+      showOption showOptionParent showOptionWithDefLocs showFiles
       unknownModule mkOption mkPackageOption mkPackageOptionMD
       literalMD;
     inherit (self.types) isType setType defaultTypeMerge defaultFunctor

--- a/lib/lists.nix
+++ b/lib/lists.nix
@@ -6,6 +6,7 @@ let
   inherit (lib.strings) toInt;
   inherit (lib.trivial) compare min id warn pipe;
   inherit (lib.attrsets) mapAttrs;
+  inherit (lib) max;
 in
 rec {
 
@@ -1483,6 +1484,46 @@ rec {
   drop =
     count:
     list: sublist count (length list) list;
+
+  /**
+    Remove the last (at most) N elements of a list.
+
+
+    # Inputs
+
+    `count`
+
+    : Number of elements to drop
+
+    `list`
+
+    : Input list
+
+    # Type
+
+    ```
+    dropEnd :: Int -> [a] -> [a]
+    ```
+
+    # Examples
+
+    :::{.example}
+    ## `lib.lists.dropEnd` usage example
+
+    ```nix
+      dropEnd 2 [ "a" "b" "c" "d" ]
+      => [ "a" "b" ]
+      dropEnd 2 [ ]
+      => [ ]
+    ```
+    :::
+
+   */
+  dropEnd =
+    n: xs:
+      take
+        (max 0 (length xs - n))
+        xs;
 
   /**
     Whether the first list is a prefix of the second list.

--- a/lib/options.nix
+++ b/lib/options.nix
@@ -432,6 +432,40 @@ rec {
         then part
         else lib.strings.escapeNixIdentifier part;
     in (concatStringsSep ".") (map escapeOptionPart parts);
+
+  /**
+    Show the option path, except for the last `n` elements.
+
+    This can be used to refer to groups of options in documentation.
+
+    # Inputs
+
+    - `opt`: The option path.
+
+    - `n`: The number of elements to exclude from the end.
+
+    # Example
+
+    ```nix
+    showOptionParent config.services.foo.settings.bar 1
+    => "services.foo.settings"
+    ```
+
+    ```nix
+    mkOption {
+      type = types.str;
+      description = "The settings file for foo.";
+      default = tomlFormat.generate "foo.toml" opt.settings.value;
+      defaultText = lib.literalMD ''
+        Generated TOML file based on `${showOptionParent opt.settings.bar 1}`
+      '';
+    }
+    ```
+
+   */
+  showOptionParent = opt: n:
+    showOption (lib.dropEnd n opt);
+
   showFiles = files: concatStringsSep " and " (map (f: "`${f}'") files);
 
   showDefs = defs: concatMapStrings (def:

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -854,6 +854,18 @@ runTests {
     ([ 1 2 3 ] == (take 4 [  1 2 3 ]))
   ];
 
+  testDrop = let inherit (lib) drop; in testAllTrue [
+    # list index -1 is out of bounds
+    # ([ 1 2 3 ] == (drop (-1) [  1 2 3 ]))
+    (drop 0 [ 1 2 3 ] == [ 1 2 3 ])
+    (drop 1 [ 1 2 3 ] == [ 2 3 ])
+    (drop 2 [ 1 2 3 ] == [ 3 ])
+    (drop 3 [ 1 2 3 ] == [ ])
+    (drop 4 [ 1 2 3 ] == [ ])
+    (drop 0 [ ] == [ ])
+    (drop 1 [ ] == [ ])
+  ];
+
   testListHasPrefixExample1 = {
     expr = lists.hasPrefix [ 1 2 ] [ 1 2 3 4 ];
     expected = true;

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -866,6 +866,18 @@ runTests {
     (drop 1 [ ] == [ ])
   ];
 
+  testDropEnd = let inherit (lib) dropEnd; in testAllTrue [
+    (dropEnd 0 [ 1 2 3 ] == [ 1 2 3 ])
+    (dropEnd 1 [ 1 2 3 ] == [ 1 2 ])
+    (dropEnd 2 [ 1 2 3 ] == [ 1 ])
+    (dropEnd 3 [ 1 2 3 ] == [ ])
+    (dropEnd 4 [ 1 2 3 ] == [ ])
+    (dropEnd 0 [ ] == [ ])
+    (dropEnd 1 [ ] == [ ])
+    (dropEnd (-1) [ 1 2 3 ] == [ 1 2 3 ])
+    (dropEnd (-1) [ ] == [ ])
+  ];
+
   testListHasPrefixExample1 = {
     expr = lists.hasPrefix [ 1 2 ] [ 1 2 3 4 ];
     expected = true;

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -139,6 +139,8 @@ checkConfigOutput '^true$' config.assertion ./gvariant.nix
 
 checkConfigOutput '"ok"' config.result ./specialArgs-lib.nix
 
+checkConfigOutput '"ok"' config.result ./misc.nix
+
 # https://github.com/NixOS/nixpkgs/pull/131205
 # We currently throw this error already in `config`, but throwing in `config.wrong1` would be acceptable.
 checkConfigError 'It seems as if you.re trying to declare an option by placing it into .config. rather than .options.' config.wrong1 ./error-mkOption-in-config.nix

--- a/lib/tests/modules/misc.nix
+++ b/lib/tests/modules/misc.nix
@@ -1,0 +1,16 @@
+{ config, lib, options, ... }:
+
+{
+  options = {
+    result = lib.mkOption { };
+  };
+
+  config.result =
+    assert options._module.args.loc == [ "_module" "args" ];
+    assert lib.showOption options._module.args.loc == "_module.args";
+    assert lib.showOptionParent options._module.args.loc 1 == "_module";
+    assert lib.showOptionParent options._module.args.loc 2 == "";
+    assert lib.showOptionParent options._module.args.loc 3 == "";
+    "ok";
+
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Useful when referencing groups of options that aren't already grouped as a submodule, and therefore don't have an option that represents the group.

- Depends on https://github.com/NixOS/nixpkgs/pull/370558

This brushes against the [Fairbairn Threshold](https://wiki.haskell.org/Fairbairn_threshold), but

- doing this by hand requires knowledge of internals

- it's three steps, which I consider to be a medium amount
  - `.loc`
  - `dropEnd`
  - `showOption`
  
- this will be interpolated into documentation, so the call should be very easy to read  
  
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
