### PR TITLE
libajantv2: fix build for musl

### DIFF
--- a/pkgs/by-name/li/libajantv2/musl.patch
+++ b/pkgs/by-name/li/libajantv2/musl.patch
@@ -1,0 +1,32 @@
+From 6b27c75125f2b2c66d5d6dd8d35569260ac72f17 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Fri, 3 Jan 2025 12:21:28 +0100
+Subject: [PATCH] Don't use non-standard ACCESSPERMS macro
+
+This macro is non-standard, and is not defined by e.g. musl libc.
+It's just a define for 0777, so just use that instead.
+
+Link: https://github.com/aja-video/libajantv2/pull/42
+---
+ ajabase/test/main.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ajabase/test/main.cpp b/ajabase/test/main.cpp
+index 78196446..e18b10a3 100644
+--- a/ajabase/test/main.cpp
++++ b/ajabase/test/main.cpp
+@@ -1951,9 +1951,9 @@ TEST_SUITE("file" * doctest::description("functions in ajabase/system/file_io.h"
+ 				_mkdir(tempDir.c_str());
+ 				_getcwd(cwdBuf, AJA_MAX_PATH);
+ 	#else
+-				if (mkdir(tempDir.c_str(), ACCESSPERMS) == 0)
++				if (mkdir(tempDir.c_str(), 0777) == 0)
+ 				{
+-					chmod(tempDir.c_str(), ACCESSPERMS);
++					chmod(tempDir.c_str(), 0777);
+ 				}
+ 				char* result = getcwd(cwdBuf, AJA_MAX_PATH);
+ 				AJA_UNUSED(result);
+-- 
+2.47.0
+

--- a/pkgs/by-name/li/libajantv2/package.nix
+++ b/pkgs/by-name/li/libajantv2/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./use-system-mbedtls.patch
     ./device-info-list.patch
+    ./musl.patch
   ];
 
   outputs = [


### PR DESCRIPTION
Submitted upstream in https://github.com/aja-video/libajantv2/pull/42, but looking at past PRs, I don't expect upstream to respond before we start the next staging cycle.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
