### PR TITLE
syslinux: disable PIE hardening

### DIFF
--- a/pkgs/by-name/sy/syslinux/package.nix
+++ b/pkgs/by-name/sy/syslinux/package.nix
@@ -83,6 +83,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [
     "pic"
+    "pie" # MBR gets too big with PIE
     "stackprotector"
     "fortify"
   ];


### PR DESCRIPTION
In preparation for #205031

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).