### PR TITLE
faust2: fix cross / strictDeps build

### DIFF
--- a/pkgs/applications/audio/faust/faust2jaqt.nix
+++ b/pkgs/applications/audio/faust/faust2jaqt.nix
@@ -1,4 +1,5 @@
 {
+  bash,
   faust,
   jack2,
   qtbase,
@@ -30,6 +31,10 @@ faust.wrapWithBuildEnv {
   scripts = [
     "faust2jaqt"
     "faust2jackserver"
+  ];
+
+  buildInputs = [
+    bash
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/applications/audio/faust/faust2lv2.nix
+++ b/pkgs/applications/audio/faust/faust2lv2.nix
@@ -1,4 +1,5 @@
 {
+  bash,
   boost,
   faust,
   lv2,
@@ -8,6 +9,10 @@
 faust.wrapWithBuildEnv {
 
   baseName = "faust2lv2";
+
+  buildInputs = [
+    bash
+  ];
 
   propagatedBuildInputs = [
     boost

--- a/pkgs/by-name/fa/faustPhysicalModeling/package.nix
+++ b/pkgs/by-name/fa/faustPhysicalModeling/package.nix
@@ -1,6 +1,7 @@
 {
   stdenv,
   lib,
+  bash,
   fetchFromGitHub,
   faust2jaqt,
   faust2lv2,
@@ -16,28 +17,45 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-j5Qg/H7aMBZ6A8gh6v6+ICxmCZ7ya2tVF2FjueVtvHo=";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     faust2jaqt
     faust2lv2
   ];
 
+  buildInputs = [
+    bash
+  ];
+
+  # ld: /nix/store/*-gcc-14-20241116/lib/gcc/x86_64-unknown-linux-gnu/14.2.1/crtbegin.o:
+  #  relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a PIE object
+  hardeningDisable = [ "pie" ];
+
   dontWrapQtApps = true;
 
   buildPhase = ''
+    runHook preBuild
+
     cd examples/physicalModeling
 
     for f in *MIDI.dsp; do
       faust2jaqt -time -vec -double -midi -nvoices 16 -t 99999 $f
       faust2lv2  -time -vec -double -gui -nvoices 16 -t 99999 $f
     done
+
+    runHook postBuild
   '';
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/lib/lv2 $out/bin
     mv *.lv2/ $out/lib/lv2
     for f in $(find . -executable -type f); do
       cp $f $out/bin/
     done
+    patchShebangs --host $out/bin
+
+    runHook postInstall
   '';
 
   meta = with lib; {
@@ -46,5 +64,7 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = with maintainers; [ magnetophon ];
+    # compiles stuff for the build platform, difficult to do properly
+    broken = stdenv.hostPlatform != stdenv.buildPlatform;
   };
 }


### PR DESCRIPTION
Fix cross build by moving build-time dependencies to native inputs.

Also fixes regular `strictDeps = true` build, ref. #178468.

Disable PIE in faustPhysicalModeling due to link error, ref. #205031.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).