### PR TITLE
python312Packages.mandown: 1.10.0 -> 1.10.1

### DIFF
--- a/pkgs/development/python-modules/comicon/default.nix
+++ b/pkgs/development/python-modules/comicon/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   poetry-core,
   pythonOlder,
   ebooklib,
@@ -13,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "comicon";
-  version = "1.2.1";
+  version = "1.3.0";
   pyproject = true;
   disabled = pythonOlder "3.10";
 
@@ -21,8 +22,18 @@ buildPythonPackage rec {
     owner = "potatoeggy";
     repo = "comicon";
     tag = "v${version}";
-    hash = "sha256-FvAgcpYvUTTE24jJB2ZxSNcNjAIyUBa3BaysjWXurtg=";
+    hash = "sha256-0AGCTnStyBVL7DVkrUFyD60xnuuO1dcl+Twdyy+uq1Y=";
   };
+
+  patches = [
+    # Upstream forgot to bump the version before tagging
+    # See https://github.com/potatoeggy/comicon/commit/d698f0f03b1a391f988176885686e9fca135676e
+    (fetchpatch2 {
+      name = "comicon-version-bump.patch";
+      url = "https://github.com/potatoeggy/comicon/commit/d698f0f03b1a391f988176885686e9fca135676e.diff";
+      hash = "sha256-ZHltw4OSYuHF8mH0kBZDsuozPy08Bm7nme+XSwfGNn8=";
+    })
+  ];
 
   nativeBuildInputs = [
     poetry-core

--- a/pkgs/development/python-modules/mandown/default.nix
+++ b/pkgs/development/python-modules/mandown/default.nix
@@ -19,14 +19,14 @@
 
 buildPythonPackage rec {
   pname = "mandown";
-  version = "1.10.0";
+  version = "1.10.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "potatoeggy";
     repo = "mandown";
     tag = "v${version}";
-    hash = "sha256-eMZXXOGe9jKf9bXEinIIu6w3i4SOkLnDWnxmT5G0RWA=";
+    hash = "sha256-6i0a2jEJy7aL6W801Xki7jmHhO5kkFL8rJI+y+MhWVo=";
   };
 
   nativeBuildInputs = [
@@ -34,7 +34,6 @@ buildPythonPackage rec {
   ];
 
   pythonRelaxDeps = [
-    "lxml"
     "pillow"
     "typer"
   ];


### PR DESCRIPTION
https://github.com/potatoeggy/mandown/releases/tag/v1.10.1

Closes #371206

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
