### PR TITLE
foo2zjs: fix cross build

### DIFF
--- a/pkgs/by-name/fo/foo2zjs/package.nix
+++ b/pkgs/by-name/fo/foo2zjs/package.nix
@@ -19,12 +19,15 @@ stdenv.mkDerivation rec {
     sha256 = "14x3wizvncdy0xgvmcx541qanwb7bg76abygqy17bxycn1zh5r1x";
   };
 
-  buildInputs = [
-    foomatic-filters
+  nativeBuildInputs = [
     bc
+    foomatic-filters
     ghostscript
-    systemd
     vim
+  ];
+
+  buildInputs = [
+    systemd
   ];
 
   patches = [


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).