### PR TITLE
fileshare: fix build with GCC 14, misc. cleanup

### DIFF
--- a/pkgs/by-name/fi/fileshare/package.nix
+++ b/pkgs/by-name/fi/fileshare/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  fetchgit,
+  fetchFromGitea,
   pkg-config,
   git,
   libmicrohttpd,
@@ -11,15 +11,22 @@ stdenv.mkDerivation rec {
   pname = "fileshare";
   version = "0.2.4";
 
-  src = fetchgit {
-    url = "https://git.tkolb.de/Public/fileshare.git";
+  src = fetchFromGitea {
+    domain = "git.tkolb.de";
+    owner = "Public";
+    repo = "fileshare";
     rev = "v${version}";
-    sha256 = "03jrhk4vj6bc2w3lsrfjpfflb4laihysgs5i4cv097nr5cz32hyk";
+    sha256 = "sha256-00MxPivZngQ2I7Hopz2MipJFnbvSZU0HF2wZucmEWQ4=";
   };
 
   postPatch = ''
     sed -i 's,$(shell git rev-parse --short HEAD),/${version},g' Makefile
+    substituteInPlace Makefile \
+      --replace-fail pkg-config "${stdenv.cc.targetPrefix}pkg-config" \
+      --replace-fail gcc "${stdenv.cc.targetPrefix}cc"
   '';
+
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64, I think
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).