### PR TITLE
facetimehd-firmware: fix strictDeps build

### DIFF
--- a/pkgs/by-name/fa/facetimehd-firmware/package.nix
+++ b/pkgs/by-name/fa/facetimehd-firmware/package.nix
@@ -51,7 +51,7 @@ stdenvNoCC.mkDerivation {
   dontUnpack = true;
   dontInstall = true;
 
-  buildInputs = [
+  nativeBuildInputs = [
     cpio
     xz
   ];


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).