### PR TITLE
libf2c: mark cross as broken

### DIFF
--- a/pkgs/by-name/li/libf2c/package.nix
+++ b/pkgs/by-name/li/libf2c/package.nix
@@ -20,9 +20,15 @@ stdenv.mkDerivation rec {
     unzip ${src}
   '';
 
+  postPatch = ''
+    substituteInPlace makefile.u \
+      --replace-fail "ld" "${stdenv.cc.targetPrefix}ld"
+  '';
+
   makeFlags = [
     "-f"
     "makefile.u"
+    "CC=${stdenv.cc.targetPrefix}cc"
   ];
 
   installPhase = ''
@@ -44,5 +50,9 @@ stdenv.mkDerivation rec {
     homepage = "http://www.netlib.org/f2c/";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
+    # Generates arith.h at build time. Uses non-standard fpu_control.h.
+    broken =
+      (!stdenv.buildPlatform.canExecute stdenv.hostPlatform)
+      || (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.libc != "glibc");
   };
 }


### PR DESCRIPTION
The makefile fixes still apply for static builds, I believe. (Though that also fails, for a different reason.)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).