### PR TITLE
foxtrotgps: fix for GCC 14

### DIFF
--- a/pkgs/by-name/fo/foxtrotgps/package.nix
+++ b/pkgs/by-name/fo/foxtrotgps/package.nix
@@ -65,6 +65,8 @@ stdenv.mkDerivation rec {
     ))
   ];
 
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types";
+
   postUnpack = ''
     cp -R ${srcs.screenshots} $sourceRoot/doc/screenshots
     chmod -R u+w $sourceRoot/doc/screenshots


### PR DESCRIPTION
ref. #356812

Looks annoying to fix properly.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).