### PR TITLE
fityk,xylib: fix cross / strictDeps build

### DIFF
--- a/pkgs/by-name/fi/fityk/package.nix
+++ b/pkgs/by-name/fi/fityk/package.nix
@@ -25,7 +25,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-m2RaZMYT6JGwa3sOUVsBIzCdZetTbiygaInQWoJ4m1o=";
   };
 
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    lua
+    swig
+  ];
   buildInputs = [
     wxGTK32
     boost
@@ -35,7 +39,10 @@ stdenv.mkDerivation rec {
     xylib
     readline
     gnuplot
-    swig
+  ];
+
+  configureFlags = [
+    "--with-wx-config=${lib.getExe' (lib.getDev wxGTK32) "wx-config"}"
   ];
 
   env.NIX_CFLAGS_COMPILE = toString [

--- a/pkgs/by-name/xy/xylib/package.nix
+++ b/pkgs/by-name/xy/xylib/package.nix
@@ -24,6 +24,10 @@ stdenv.mkDerivation rec {
     wxGTK32
   ];
 
+  configureFlags = [
+    "--with-wx-config=${lib.getExe' (lib.getDev wxGTK32) "wx-config"}"
+  ];
+
   meta = with lib; {
     description = "Portable library for reading files that contain x-y data from powder diffraction, spectroscopy and other experimental methods";
     license = licenses.lgpl21;


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).