### PR TITLE
seabios: disable PIE hardening

### DIFF
--- a/pkgs/by-name/se/seabios/package.nix
+++ b/pkgs/by-name/se/seabios/package.nix
@@ -61,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [
     "fortify"
     "pic"
+    "pie" # ld: warning: creating DT_TEXTREL in a PIE (and more)
     "stackprotector"
   ];
 


### PR DESCRIPTION
In preparation for #205031

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).