### PR TITLE
xsane: fix build failure

### DIFF
--- a/pkgs/applications/graphics/sane/xsane.nix
+++ b/pkgs/applications/graphics/sane/xsane.nix
@@ -27,12 +27,87 @@ stdenv.mkDerivation rec {
     hash = "sha256-oOg94nUsT9LLKnHocY0S5g02Y9a1UazzZAjpEI/s+yM=";
   };
 
-  patches = [
-    (fetchpatch {
-      url = "https://src.fedoraproject.org/rpms/xsane/raw/rawhide/f/xsane-0.998-libpng.patch";
-      hash = "sha256-0z292+Waa2g0PCQpUebdWprl9VDyBOY0XgqMJaIcRb8=";
-    })
-  ];
+  # add all fedora patchs. fix gcc-14 build among other things
+  # https://src.fedoraproject.org/rpms/xsane/tree/main
+  patches =
+    let
+      fetchFedoraPatch =
+        { name, hash }:
+        fetchpatch {
+          inherit name hash;
+          url = "https://src.fedoraproject.org/rpms/xsane/raw/846ace0a29063335c708b01e9696eda062d7459c/f/${name}";
+        };
+    in
+    map fetchFedoraPatch [
+      {
+        name = "0001-Follow-new-convention-for-registering-gimp-plugin.patch";
+        hash = "sha256-yOY7URyc8HEHHynvdcZAV1Pri31N/rJ0ddPavOF5zLw=";
+      }
+      {
+        name = "xsane-0.995-close-fds.patch";
+        hash = "sha256-qE7larHpBEikz6OaOQmmi9jl6iQxy/QM7iDg9QrVV1o=";
+      }
+      {
+        name = "xsane-0.995-xdg-open.patch";
+        hash = "sha256-/kHwwuDC2naGEp4NALfaJ0pJe+9kYhV4TX1eGeARvq8=";
+      }
+      {
+        name = "xsane-0.996-no-eula.patch";
+        hash = "sha256-CYmp1zFg11PUPz9um2W7XF6pzCzafKSEn2nvPiUSxNo=";
+      }
+      {
+        name = "xsane-0.997-ipv6.patch";
+        hash = "sha256-D3xH++DHxyTKMxgatU+PNCVN1u5ajPc3gQxvzhMYIdM=";
+      }
+      {
+        name = "xsane-0.997-off-root-build.patch";
+        hash = "sha256-2LXQfMbvqP+TAhAmxRe6pBqNlSX4tVjhDkBHIfX9HcA=";
+      }
+      {
+        name = "xsane-0.998-desktop-file.patch";
+        hash = "sha256-3xEj6IaOk/FS8pv+/yaNjZpIoB+0Oei0QB9mD4/owkM=";
+      }
+      {
+        name = "xsane-0.998-libpng.patch";
+        hash = "sha256-0z292+Waa2g0PCQpUebdWprl9VDyBOY0XgqMJaIcRb8=";
+      }
+      {
+        name = "xsane-0.998-preview-selection.patch";
+        hash = "sha256-TZ8vRA+0qPY2Rqz0VNHjgkj3YPob/BW+zBoVqxnUhb8=";
+      }
+      {
+        name = "xsane-0.998-wmclass.patch";
+        hash = "sha256-RubFOs+hsZS+GdxF0yvLSy4v+Fi6vb9G6zfwWZcUlkY=";
+      }
+      {
+        name = "xsane-0.999-lcms2.patch";
+        hash = "sha256-eiAxa1lhFrinqBvlIhH+NP7WBKk0Plf2S+OVTcpxXac=";
+      }
+      {
+        name = "xsane-0.999-man-page.patch";
+        hash = "sha256-4g0w4x9boAIOA6s5eTzKMh2mkkRKtF1TZ9KgHNTDaAg=";
+      }
+      {
+        name = "xsane-0.999-no-file-selected.patch";
+        hash = "sha256-e/QKtvsIwU5yy0SJKAEAmhmCoxWqV6FHmAW41SbW/eI=";
+      }
+      {
+        name = "xsane-0.999-pdf-no-high-bpp.patch";
+        hash = "sha256-o3LmOvgERuB9CQ8RL2Nd40h1ePuuuGMSK1GN68QlJ6s=";
+      }
+      {
+        name = "xsane-0.999-signal-handling.patch";
+        hash = "sha256-JU9BJ6UIDa1FsuPaQKsxcjxvsJkwgmuopIqCVWY3LQ0=";
+      }
+      {
+        name = "xsane-0.999-snprintf-update.patch";
+        hash = "sha256-bSTeoIOLeJ4PEsBHR+ZUQLPmrc0D6aQzyJGlLVhXt8o=";
+      }
+      {
+        name = "xsane-configure-c99.patch";
+        hash = "sha256-ukaNGgzCGiQwbOzSguAqBIKOUzXofSC3lct812U/8gY=";
+      }
+    ];
 
   preConfigure = ''
     sed -e '/SANE_CAP_ALWAYS_SETTABLE/d' -i src/xsane-back-gtk.c


### PR DESCRIPTION
simply applying all patches from fedora fixes #370011 the coverity patch doesn't apply any more..

ref. #356812

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
