### PR TITLE
treewide: drop `darwinMinVersionHook` for macOS < 11

### DIFF
--- a/pkgs/by-name/co/conduwuit/package.nix
+++ b/pkgs/by-name/co/conduwuit/package.nix
@@ -6,8 +6,6 @@
   bzip2,
   zstd,
   stdenv,
-  apple-sdk_15,
-  darwinMinVersionHook,
   rocksdb,
   nix-update-script,
   testers,
@@ -55,12 +53,7 @@ rustPlatform.buildRustPackage rec {
       zstd
     ]
     ++ lib.optional enableJemalloc rust-jemalloc-sys'
-    ++ lib.optional enableLiburing liburing
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      apple-sdk_15
-      # aws-lc-sys requires CryptoKit's CommonCrypto, which is available on macOS 10.15+
-      (darwinMinVersionHook "10.15")
-    ];
+    ++ lib.optional enableLiburing liburing;
 
   env = {
     ZSTD_SYS_USE_PKG_CONFIG = true;

--- a/pkgs/by-name/do/dosbox-staging/package.nix
+++ b/pkgs/by-name/do/dosbox-staging/package.nix
@@ -29,8 +29,6 @@
   stdenv,
   testers,
   zlib-ng,
-  apple-sdk_15,
-  darwinMinVersionHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -81,11 +79,7 @@ stdenv.mkDerivation (finalAttrs: {
       speexdsp
       zlib-ng
     ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      apple-sdk_15
-      (darwinMinVersionHook "10.15") # from https://www.dosbox-staging.org/releases/macos/
-    ];
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ alsa-lib ];
 
   outputs = [ "out" "man" ];
 

--- a/pkgs/by-name/go/golem/package.nix
+++ b/pkgs/by-name/go/golem/package.nix
@@ -11,8 +11,6 @@
   # buildInputs
   fontconfig,
   openssl,
-  apple-sdk_15,
-  darwinMinVersionHook,
 
   redis,
   versionCheckHook,
@@ -40,16 +38,10 @@ rustPlatform.buildRustPackage rec {
     rustPlatform.bindgenHook
   ];
 
-  buildInputs =
-    [
-      fontconfig
-      (lib.getDev openssl)
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      apple-sdk_15
-      # aws-lc-sys requires CryptoKit's CommonCrypto, which is available on macOS 10.15+
-      (darwinMinVersionHook "10.15")
-    ];
+  buildInputs = [
+    fontconfig
+    (lib.getDev openssl)
+  ];
 
   # Required for golem-wasm-rpc's build.rs to find the required protobuf files
   # https://github.com/golemcloud/wasm-rpc/blob/v1.0.6/wasm-rpc/build.rs#L7

--- a/pkgs/by-name/mo/moltenvk/package.nix
+++ b/pkgs/by-name/mo/moltenvk/package.nix
@@ -5,7 +5,6 @@
   fetchpatch2,
   gitUpdater,
   apple-sdk_15,
-  darwinMinVersionHook,
   cereal,
   libcxx,
   glslang,
@@ -31,7 +30,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     apple-sdk_15
     cereal
-    (darwinMinVersionHook "10.15")
     glslang
     spirv-cross
     spirv-headers

--- a/pkgs/by-name/vf/vfkit/package.nix
+++ b/pkgs/by-name/vf/vfkit/package.nix
@@ -3,7 +3,6 @@
   apple-sdk_14,
   buildGoModule,
   darwin,
-  darwinMinVersionHook,
   fetchFromGitHub,
   testers,
   vfkit,
@@ -36,7 +35,6 @@ buildGoModule rec {
 
   buildInputs = [
     apple-sdk_14
-    (darwinMinVersionHook "11")
   ];
 
   postFixup = ''

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -234,13 +234,11 @@ in stdenv.mkDerivation {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_swift
-      (darwinMinVersionHook deploymentVersion)
     ];
 
   # Will effectively be `buildInputs` when swift is put in `nativeBuildInputs`.
   depsTargetTargetPropagated = lib.optionals stdenv.targetPlatform.isDarwin [
     apple-sdk_swift
-    (darwinMinVersionHook deploymentVersion)
   ];
 
   # This is a partial reimplementation of our setup hook. Because we reuse

--- a/pkgs/development/compilers/swift/default.nix
+++ b/pkgs/development/compilers/swift/default.nix
@@ -77,7 +77,6 @@ let
 
     swiftpm = callPackage ./swiftpm {
       inherit (darwin) DarwinTools;
-      inherit (apple_sdk.frameworks) CryptoKit LocalAuthentication;
       swift = swiftNoSwiftDriver;
     };
 

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -19,8 +19,6 @@
   DarwinTools, # sw_vers
   cctools, # vtool
   xcbuild,
-  CryptoKit,
-  LocalAuthentication,
 }:
 
 let
@@ -412,16 +410,11 @@ stdenv.mkDerivation (
       swift
       swiftpm-bootstrap
     ];
-    buildInputs =
-      [
-        ncursesInput
-        sqlite
-        XCTest
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [
-        CryptoKit
-        LocalAuthentication
-      ];
+    buildInputs = [
+      ncursesInput
+      sqlite
+      XCTest
+    ];
 
     configurePhase =
       generated.configure

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -18,7 +18,6 @@
   makeWrapper,
   DarwinTools, # sw_vers
   cctools, # vtool
-  darwinMinVersionHook,
   xcbuild,
   CryptoKit,
   LocalAuthentication,
@@ -387,7 +386,7 @@ let
         swift-driver
         swift-system
         swift-tools-support-core
-      ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ (darwinMinVersionHook "10.15.4") ];
+      ];
 
       cmakeFlags = [
         "-DUSE_CMAKE_INSTALL=ON"
@@ -422,8 +421,7 @@ stdenv.mkDerivation (
       ++ lib.optionals stdenv.hostPlatform.isDarwin [
         CryptoKit
         LocalAuthentication
-      ]
-      ++ lib.optionals stdenv.hostPlatform.isDarwin [ (darwinMinVersionHook "10.15.4") ];
+      ];
 
     configurePhase =
       generated.configure

--- a/pkgs/development/python-modules/materialx/default.nix
+++ b/pkgs/development/python-modules/materialx/default.nix
@@ -11,7 +11,6 @@
   openimageio,
   imath,
   python,
-  darwinMinVersionHook,
   apple-sdk_14,
 }:
 
@@ -40,7 +39,6 @@ buildPythonPackage rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       apple-sdk_14
-      (darwinMinVersionHook "10.15")
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
       libX11


### PR DESCRIPTION
Following up on https://github.com/NixOS/nixpkgs/pull/370445 and friends. Time to resurrect my big old branch for a lot of the remaining stuff…

Running a `nixpkgs-review`, just in case. I think this is small enough for `master` but I can move the Qt change to `staging` if desired.

cc @ofalvai @niklaskorz @kmatasfp for the `apple-sdk_15` unpins; it didn’t seem like those packages actually used any functionality newer than macOS 11, but I could be wrong.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
