### PR TITLE
nixos/klipper: preserve SAVE_CONFIG for nixos-managed config

### DIFF
--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -18,6 +18,13 @@ let
   };
 in
 {
+  imports = [
+    (lib.mkRenamedOptionModule
+      [ "services" "klipper" "mutableConfigFolder" ]
+      [ "services" "klipper" "configDir" ]
+    )
+  ];
+
   ##### interface
   options = {
     services.klipper = {
@@ -52,23 +59,22 @@ in
         default = false;
         example = true;
         description = ''
-          Whether to copy the config to a mutable directory instead of using the one directly from the nix store.
-          This will only copy the config if the file at `services.klipper.mutableConfigPath` doesn't exist.
+          Whether to manage the config outside of NixOS.
+
+          It will still be initialized with the defined NixOS config if the file doesn't already exist.
         '';
       };
 
-      mutableConfigFolder = lib.mkOption {
+      configDir = lib.mkOption {
         type = lib.types.path;
         default = "/var/lib/klipper";
-        description = "Path to mutable Klipper config file.";
+        description = "Path to Klipper config file.";
       };
 
       configFile = lib.mkOption {
         type = lib.types.nullOr lib.types.path;
         default = null;
-        description = ''
-          Path to default Klipper config.
-        '';
+        description = "Path to default Klipper config.";
       };
 
       octoprintIntegration = lib.mkOption {
@@ -162,11 +168,6 @@ in
       }
     ];
 
-    environment.etc = lib.mkIf (!cfg.mutableConfig) {
-      "klipper.cfg".source =
-        if cfg.settings != null then format.generate "klipper.cfg" cfg.settings else cfg.configFile;
-    };
-
     services.klipper = lib.mkIf cfg.octoprintIntegration {
       user = config.services.octoprint.user;
       group = config.services.octoprint.group;
@@ -178,9 +179,7 @@ in
           "--input-tty=${cfg.inputTTY}"
           + lib.optionalString (cfg.apiSocket != null) " --api-server=${cfg.apiSocket}"
           + lib.optionalString (cfg.logFile != null) " --logfile=${cfg.logFile}";
-        printerConfigPath =
-          if cfg.mutableConfig then cfg.mutableConfigFolder + "/printer.cfg" else "/etc/klipper.cfg";
-        printerConfigFile =
+        printerConfig =
           if cfg.settings != null then format.generate "klipper.cfg" cfg.settings else cfg.configFile;
       in
       {
@@ -188,19 +187,31 @@ in
         wantedBy = [ "multi-user.target" ];
         after = [ "network.target" ];
         preStart = ''
-          mkdir -p ${cfg.mutableConfigFolder}
-          ${lib.optionalString (cfg.mutableConfig) ''
-            [ -e ${printerConfigPath} ] || {
-              cp ${printerConfigFile} ${printerConfigPath}
-              chmod +w ${printerConfigPath}
+          mkdir -p ${cfg.configDir}
+          pushd ${cfg.configDir}
+          if [ -e printer.cfg ]; then
+            ${
+              if cfg.mutableConfig then
+                ":"
+              else
+                ''
+                  # Backup existing config using the same date format klipper uses for SAVE_CONFIG
+                  old_config="printer-$(date +"%Y%m%d_%H%M%S").cfg"
+                  mv printer.cfg "$old_config"
+                  # Preserve SAVE_CONFIG section from the existing config
+                  cat ${printerConfig} <(printf "\n") <(sed -n '/#*# <---------------------- SAVE_CONFIG ---------------------->/,$p' "$old_config") > printer.cfg
+                  ${pkgs.diffutils}/bin/cmp printer.cfg "$old_config" && rm "$old_config"
+                ''
             }
-          ''}
-          mkdir -p ${cfg.mutableConfigFolder}/gcodes
+          else
+            cat ${printerConfig} > printer.cfg
+          fi
+          popd
         '';
 
         serviceConfig =
           {
-            ExecStart = "${cfg.package}/bin/klippy ${klippyArgs} ${printerConfigPath}";
+            ExecStart = "${cfg.package}/bin/klippy ${klippyArgs} ${cfg.configDir}/printer.cfg";
             RuntimeDirectory = "klipper";
             StateDirectory = "klipper";
             SupplementaryGroups = [ "dialout" ];

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -209,6 +209,8 @@ in
           popd
         '';
 
+        restartTriggers = lib.optional (!cfg.mutableConfig) [ printerConfig ];
+
         serviceConfig =
           {
             ExecStart = "${cfg.package}/bin/klippy ${klippyArgs} ${cfg.configDir}/printer.cfg";


### PR DESCRIPTION
Klipper macros that use `SAVE_CONFIG` (eg. bed mesh calibration, PID tuning, ...) don't currently work with a nixos-managed config.

This can be worked around by using `services.klipper.mutableConfig = true`, but then you lose out on being able to configure klipper from NixOS.

This changes the default behaviour so that:

1. The config is stored in `services.klipper.configDir` instead of `/etc`
2. The config is copied instead of symlinked (keeping a timestamped backup of the existing config)
3. The `SAVE_CONFIG` section from the backup is copied over into the new config
4. The backup is deleted if the final config is identical

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
