### PR TITLE
mono: fix build on gcc 14

### DIFF
--- a/pkgs/development/compilers/mono/4.nix
+++ b/pkgs/development/compilers/mono/4.nix
@@ -12,4 +12,11 @@ callPackage ./generic.nix ({
   sha256 = "1vyvp2g28ihcgxgxr8nhzyzdmzicsh5djzk8dk1hj5p5f2k3ijqq";
   enableParallelBuilding = false; # #32386, https://hydra.nixos.org/build/65600645
   extraPatches = lib.optionals stdenv.hostPlatform.isLinux [ ./mono4-glibc.patch ];
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=implicit-function-declaration"
+    "-Wno-error=implicit-int"
+    "-Wno-error=incompatible-pointer-types"
+    "-Wno-error=int-conversion"
+    "-Wno-error=return-mismatch"
+  ];
 })

--- a/pkgs/development/compilers/mono/5.nix
+++ b/pkgs/development/compilers/mono/5.nix
@@ -9,4 +9,5 @@ callPackage ./generic.nix ({
   version = "5.20.1.34";
   sha256 = "12vw5dkhmp1vk9l658pil8jiqirkpdsc5z8dm5mpj595yr6d94fd";
   enableParallelBuilding = true;
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=incompatible-pointer-types -Wno-error=implicit-function-declaration";
 })

--- a/pkgs/development/compilers/mono/generic.nix
+++ b/pkgs/development/compilers/mono/generic.nix
@@ -29,6 +29,7 @@
   enableParallelBuilding ? true,
   srcArchiveSuffix ? "tar.bz2",
   extraPatches ? [ ],
+  env ? { },
 }:
 
 let
@@ -36,7 +37,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mono";
-  inherit version;
+  inherit version env;
 
   src = fetchurl {
     inherit sha256;

--- a/pkgs/development/libraries/gtk-sharp/2.0.nix
+++ b/pkgs/development/libraries/gtk-sharp/2.0.nix
@@ -64,11 +64,7 @@ stdenv.mkDerivation rec {
     ./bootstrap-${lib.versions.majorMinor version}
   '';
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals stdenv.cc.isClang [
-      "-Wno-error=int-conversion"
-    ]
-  );
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=int-conversion";
 
   dontStrip = true;
 

--- a/pkgs/development/libraries/gtk-sharp/3.0.nix
+++ b/pkgs/development/libraries/gtk-sharp/3.0.nix
@@ -31,6 +31,8 @@ stdenv.mkDerivation rec {
     libxml2
   ];
 
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+
   patches = [
     # Fixes MONO_PROFILE_ENTER_LEAVE undeclared when compiling against newer versions of mono.
     # @see https://github.com/mono/gtk-sharp/pull/266


### PR DESCRIPTION
This was broken in the last staging update via gcc 13 -> 14.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
