### PR TITLE
davinci-resolve and davinci-resolve-studio: fix panel support and add missing applications

### DIFF
--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -303,11 +303,14 @@ symlinkJoin {
 
     (makeDesktopItem {
       name = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-      desktopName = "Davinci Resolve${lib.optionalString studioVariant " Studio"}";
+      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"}";
       genericName = "Video Editor";
       exec = "${resolveWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}";
       icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
       comment = "Professional video editing, color, effects and audio post-processing";
+      mimeTypes = ["application/x-resolveproj"];
+      startupNotify = true;
+      terminal = false;
       categories = [
         "AudioVideo"
         "AudioVideoEditing"

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -195,22 +195,28 @@ fhs = buildFHSEnv {
       fontconfig
       freetype
       glib
+      krb5  # for DaVinci Control Panels Setup
       libGL
       libGLU
       libarchive
       libcap
+      libdrm
+      libpng12
       librsvg
       libtool
+      libusb1
       libuuid
-      libxcrypt # provides libcrypt.so.1
+      libxcrypt  # provides libcrypt.so.1
       libxkbcommon
       nspr
+      nss
       ocl-icd
       opencl-headers
       python3
       python3.pkgs.numpy
       udev
-      xdg-utils # xdg-open needed to open URLs
+      xcb-util-cursor
+      xdg-utils  # xdg-open needed to open URLs
       xorg.libICE
       xorg.libSM
       xorg.libX11
@@ -221,6 +227,7 @@ fhs = buildFHSEnv {
       xorg.libXfixes
       xorg.libXi
       xorg.libXinerama
+      xorg.libxkbfile
       xorg.libXrandr
       xorg.libXrender
       xorg.libXt
@@ -274,6 +281,7 @@ resolveUdev = runCommandLocal "davinci-resolve${lib.optionalString studioVariant
 resolveIcons = runCommandLocal "davinci-resolve${lib.optionalString studioVariant "-studio"}-icons" {} ''
   mkdir -p $out/share/icons/hicolor/128x128/apps
   ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
+  ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-panels.png
 '';
 
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
@@ -288,6 +296,8 @@ resolveWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-
 # in order to simplify running Resolve and related tools from the command line.
 resolveShellWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-shell" ["/usr/bin/env" "bash"];
 
+panelSetupWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
+
 in
 symlinkJoin {
 
@@ -297,6 +307,7 @@ symlinkJoin {
   paths = [
     resolveWrapper
     resolveShellWrapper
+    panelSetupWrapper
 
     resolveUdev
     resolveIcons
@@ -318,6 +329,19 @@ symlinkJoin {
         "Graphics"
       ];
       startupWMClass = "resolve";
+    })
+
+    (makeDesktopItem {
+      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
+      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"} Control Panels Setup";
+      exec = "${panelSetupWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
+      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
+      categories = [
+        "AudioVideo"
+        "AudioVideoEditing"
+        "Video"
+        "Graphics"
+      ];
     })
   ];
 

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -275,7 +275,8 @@ resolveUdev = runCommandLocal "${davinci.pname}-udev" {} ''
   echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="096e", MODE="0666"' > $SDX_RULES
 '';
 
-resolveIcons = runCommandLocal "${davinci.pname}-icons" {} ''
+resolveXdg = runCommandLocal "${davinci.pname}-xdg" {} ''
+  # icons for applications
   mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/apps
   ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}.png
   ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-panels.png
@@ -284,6 +285,33 @@ resolveIcons = runCommandLocal "${davinci.pname}-icons" {} ''
   ln -s ${davinci}/graphics/blackmagicraw-speedtest_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-speed-test.png
   ln -s ${davinci}/graphics/blackmagicraw-player_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-player.png
   ln -s ${davinci}/graphics/blackmagicraw-player_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-player.png
+
+  # icons for mime types
+  mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/mimetypes
+
+  ln -s ${davinci}/graphics/application-x-braw-clip_48x48_mimetypes.png $out/share/icons/hicolor/48x48/mimetypes/application-x-braw-clip.png
+  ln -s ${davinci}/graphics/application-x-braw-sidecar_48x48_mimetypes.png $out/share/icons/hicolor/48x48/mimetypes/application-x-braw-sidecar.png
+  ln -s ${davinci}/graphics/application-x-braw-clip_256x256_mimetypes.png $out/share/icons/hicolor/256x256/mimetypes/application-x-braw-clip.png
+  ln -s ${davinci}/graphics/application-x-braw-sidecar_256x256_mimetypes.png $out/share/icons/hicolor/256x256/mimetypes/application-x-braw-sidecar.png
+  ln -s ${davinci}/graphics/DV_ResolveBin.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvebin.png
+  ln -s ${davinci}/graphics/DV_ResolveProj.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolveproj.png
+  ln -s ${davinci}/graphics/DV_ResolveTimeline.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvetimeline.png
+  ln -s ${davinci}/graphics/DV_TemplateBundle.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvetemplatebundle.png
+
+  # mime types
+  mkdir -p $out/share/mime/packages
+  # without these patches, GNOME displays blank icons
+  cat ${davinci}/share/blackmagicraw.xml \
+    | sed '/<mime-type type="application\/x-braw-clip">/a <generic-icon name="application-x-braw-clip"/>' \
+    | sed '/<mime-type type="application\/x-braw-sidecar">/a <generic-icon name="application-x-braw-sidecar"/>' \
+    > $out/share/mime/packages/${davinci.pname}-raw.xml
+  cat ${davinci}/share/resolve.xml \
+    | sed '/<mime-type type="application\/x-resolveproj">/a <generic-icon name="application-x-resolveproj"/>' \
+    | sed '/<mime-type type="application\/x-resolvedbkey">/a <generic-icon name="application-x-resolvedbkey"/>' \
+    | sed '/<mime-type type="application\/x-resolvebin">/a <generic-icon name="application-x-resolvebin"/>' \
+    | sed '/<mime-type type="application\/x-resolvetimeline">/a <generic-icon name="application-x-resolvetimeline"/>' \
+    | sed '/<mime-type type="application\/x-resolvetemplatebundle">/a <generic-icon name="application-x-resolvetemplatebundle"/>' \
+    > $out/share/mime/packages/${davinci.pname}.xml
 '';
 
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
@@ -330,7 +358,7 @@ symlinkJoin {
     remoteMonitorWrapper
 
     resolveUdev
-    resolveIcons
+    resolveXdg
 
     (makeDesktopItem {
       name = "${davinci.pname}";

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -254,9 +254,6 @@ fhs = buildFHSEnv {
   ];
 
   runScript = "${bash}/bin/bash ${writeText "davinci-wrapper" ''
-    export QT_XKB_CONFIG_ROOT="${xkeyboard_config}/share/X11/xkb"
-    export QT_PLUGIN_PATH="${davinci}/libs/plugins:$QT_PLUGIN_PATH"
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib:/usr/lib32:${davinci}/libs
     exec "$@"
   ''}";
 
@@ -290,20 +287,27 @@ resolveIcons = runCommandLocal "${davinci.pname}-icons" {} ''
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
 
 # creates a derivation that wraps the "path" command with arguments in "args" list to run inside the FHS
-mkWrapper = path: args: writeShellScriptBin path ''${lib.strings.concatMapStringsSep " " lib.escapeShellArg ([wrapper] ++ args)} "$@"'';
+# the directories in "libs" and "plugins" are put into LD_LIBRARY_PATH and QT_PLUGIN_PATH
+mkWrapper = path: libs: plugins: args: writeShellScriptBin path ''
+    export QT_XKB_CONFIG_ROOT="${xkeyboard_config}/share/X11/xkb"
+    export QT_PLUGIN_PATH="${plugins}:$QT_PLUGIN_PATH"
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib:/usr/lib32:${libs}"
+
+    exec ${lib.strings.concatMapStringsSep " " lib.escapeShellArg ([wrapper] ++ args)} "$@"
+'';
 
 # wrap main executable
-resolveWrapper = mkWrapper "${davinci.pname}" ["${davinci}/bin/resolve"];
+resolveWrapper = mkWrapper "${davinci.pname}" "${davinci}/libs" "${davinci}/libs/plugins" ["${davinci}/bin/resolve"];
 
 # This provides the "davinci-resolve-shell"/"davinci-resolve-studio-shell" command to open a shell in the correct FHS
 # in order to simplify running Resolve and related tools from the command line.
-resolveShellWrapper = mkWrapper "${davinci.pname}-shell" ["/usr/bin/env" "bash"];
+resolveShellWrapper = mkWrapper "${davinci.pname}-shell" "${davinci}/libs" "${davinci}/libs/plugins" ["/usr/bin/env" "bash"];
 
-panelSetupWrapper = mkWrapper "${davinci.pname}-panels" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
+panelSetupWrapper = mkWrapper "${davinci.pname}-panels" "${davinci}/DaVinci Control Panels Setup" "${davinci}/DaVinci Control Panels Setup/plugins" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
 
-rawSpeedTestWrapper = mkWrapper "${davinci.pname}-raw-speed-test" ["${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest"];
+rawSpeedTestWrapper = mkWrapper "${davinci.pname}-raw-speed-test" "${davinci}/BlackmagicRAWSpeedTest/lib" "${davinci}/BlackmagicRAWSpeedTest/plugins" ["${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest"];
 
-remoteMonitorWrapper = mkWrapper "${davinci.pname}-monitor" ["${davinci}/bin/DaVinci Remote Monitor"];
+remoteMonitorWrapper = mkWrapper "${davinci.pname}-monitor" "${davinci}/libs" "${davinci}/libs/plugins" ["${davinci}/bin/DaVinci Remote Monitor"];
 
 product = "DaVinci Resolve${lib.optionalString studioVariant " Studio"}";
 
@@ -318,6 +322,7 @@ symlinkJoin {
     resolveShellWrapper
     panelSetupWrapper
     rawSpeedTestWrapper
+    remoteMonitorWrapper
 
     resolveUdev
     resolveIcons

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -177,24 +177,6 @@ let
         done
         ln -s $out/libs/libcrypto.so.1.1 $out/libs/libcrypt.so.1
       '';
-
-      desktopItems = [
-        (makeDesktopItem {
-          name = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-          desktopName = "Davinci Resolve${lib.optionalString studioVariant " Studio"}";
-          genericName = "Video Editor";
-          exec = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-          icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-          comment = "Professional video editing, color, effects and audio post-processing";
-          categories = [
-            "AudioVideo"
-            "AudioVideoEditing"
-            "Video"
-            "Graphics"
-          ];
-          startupWMClass = "resolve";
-        })
-      ];
     }
   );
 
@@ -272,9 +254,8 @@ fhs = buildFHSEnv {
   ''}";
 
   extraInstallCommands = ''
-    mkdir -p $out/share/applications $out/share/icons/hicolor/128x128/apps
+    mkdir -p $out/share/applications
     ln -s ${davinci}/share/applications/*.desktop $out/share/applications/
-    ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
   '';
 };
 
@@ -290,6 +271,10 @@ resolveUdev = runCommandLocal "davinci-resolve${lib.optionalString studioVariant
   echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="096e", MODE="0666"' > $SDX_RULES
 '';
 
+resolveIcons = runCommandLocal "davinci-resolve${lib.optionalString studioVariant "-studio"}-icons" {} ''
+  mkdir -p $out/share/icons/hicolor/128x128/apps
+  ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
+'';
 
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
 
@@ -314,6 +299,23 @@ symlinkJoin {
     resolveShellWrapper
 
     resolveUdev
+    resolveIcons
+
+    (makeDesktopItem {
+      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
+      desktopName = "Davinci Resolve${lib.optionalString studioVariant " Studio"}";
+      genericName = "Video Editor";
+      exec = "${resolveWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}";
+      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
+      comment = "Professional video editing, color, effects and audio post-processing";
+      categories = [
+        "AudioVideo"
+        "AudioVideoEditing"
+        "Video"
+        "Graphics"
+      ];
+      startupWMClass = "resolve";
+    })
   ];
 
   passthru = {

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -266,7 +266,7 @@ fhs = buildFHSEnv {
   '';
 };
 
-resolveUdev = runCommandLocal "davinci-resolve${lib.optionalString studioVariant "-studio"}-udev" {} ''
+resolveUdev = runCommandLocal "${davinci.pname}-udev" {} ''
   mkdir -p $out/etc/udev/rules.d
   # follows the resolve install script, see scripts/post_install.sh
   DVP_RULES=$out/etc/udev/rules.d/75-davincipanel.rules
@@ -278,13 +278,13 @@ resolveUdev = runCommandLocal "davinci-resolve${lib.optionalString studioVariant
   echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="096e", MODE="0666"' > $SDX_RULES
 '';
 
-resolveIcons = runCommandLocal "davinci-resolve${lib.optionalString studioVariant "-studio"}-icons" {} ''
+resolveIcons = runCommandLocal "${davinci.pname}-icons" {} ''
   mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/apps
-  ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
-  ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-panels.png
-  ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor.png
-  ln -s ${davinci}/graphics/blackmagicraw-speedtest_256x256_apps.png $out/share/icons/hicolor/256x256/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test.png
-  ln -s ${davinci}/graphics/blackmagicraw-speedtest_48x48_apps.png $out/share/icons/hicolor/48x48/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test.png
+  ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}.png
+  ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-panels.png
+  ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-monitor.png
+  ln -s ${davinci}/graphics/blackmagicraw-speedtest_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-speed-test.png
+  ln -s ${davinci}/graphics/blackmagicraw-speedtest_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-speed-test.png
 '';
 
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
@@ -293,23 +293,24 @@ wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
 mkWrapper = path: args: writeShellScriptBin path ''${lib.strings.concatMapStringsSep " " lib.escapeShellArg ([wrapper] ++ args)} "$@"'';
 
 # wrap main executable
-resolveWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}" ["${davinci}/bin/resolve"];
+resolveWrapper = mkWrapper "${davinci.pname}" ["${davinci}/bin/resolve"];
 
 # This provides the "davinci-resolve-shell"/"davinci-resolve-studio-shell" command to open a shell in the correct FHS
 # in order to simplify running Resolve and related tools from the command line.
-resolveShellWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-shell" ["/usr/bin/env" "bash"];
+resolveShellWrapper = mkWrapper "${davinci.pname}-shell" ["/usr/bin/env" "bash"];
 
-panelSetupWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
+panelSetupWrapper = mkWrapper "${davinci.pname}-panels" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
 
-rawSpeedTestWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test" ["${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest"];
+rawSpeedTestWrapper = mkWrapper "${davinci.pname}-raw-speed-test" ["${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest"];
 
-remoteMonitorWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor" ["${davinci}/bin/DaVinci Remote Monitor"];
+remoteMonitorWrapper = mkWrapper "${davinci.pname}-monitor" ["${davinci}/bin/DaVinci Remote Monitor"];
+
+product = "DaVinci Resolve${lib.optionalString studioVariant " Studio"}";
 
 in
 symlinkJoin {
 
-  pname = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-  inherit (davinci) version;
+  inherit (davinci) pname version;
 
   paths = [
 
@@ -322,11 +323,11 @@ symlinkJoin {
     resolveIcons
 
     (makeDesktopItem {
-      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
-      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"}";
+      name = "${davinci.pname}";
+      desktopName = "${product}";
       genericName = "Video Editor";
-      exec = "${resolveWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}";
-      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
+      exec = "${resolveWrapper}/bin/${davinci.pname}";
+      icon = "${davinci.pname}";
       comment = "Professional video editing, color, effects and audio post-processing";
       mimeTypes = ["application/x-resolveproj"];
       startupNotify = true;
@@ -341,10 +342,10 @@ symlinkJoin {
     })
 
     (makeDesktopItem {
-      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
-      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"} Control Panels Setup";
-      exec = "${panelSetupWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
-      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
+      name = "${davinci.pname}-panels";
+      desktopName = "${product} Control Panels Setup";
+      exec = "${panelSetupWrapper}/bin/${davinci.pname}-panels";
+      icon = "${davinci.pname}-panels";
       categories = [
         "AudioVideo"
         "AudioVideoEditing"
@@ -354,10 +355,10 @@ symlinkJoin {
     })
 
     (makeDesktopItem {
-      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test";
-      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"} Blackmagic RAW Speed Test";
-      exec = "${rawSpeedTestWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test";
-      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test";
+      name = "${davinci.pname}-raw-speed-test";
+      desktopName = "${product} Blackmagic RAW Speed Test";
+      exec = "${rawSpeedTestWrapper}/bin/${davinci.pname}-raw-speed-test";
+      icon = "${davinci.pname}-raw-speed-test";
       categories = [
         "AudioVideo"
         "AudioVideoEditing"
@@ -373,10 +374,10 @@ symlinkJoin {
     remoteMonitorWrapper
 
     (makeDesktopItem {
-      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor";
-      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"} Remote Monitor";
-      exec = "${remoteMonitorWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor";
-      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor";
+      name = "${davinci.pname}-monitor";
+      desktopName = "${product} Remote Monitor";
+      exec = "${remoteMonitorWrapper}/bin/${davinci.pname}-monitor";
+      icon = "${davinci.pname}-monitor";
       startupNotify = true;
       categories = [
         "AudioVideo"
@@ -420,16 +421,18 @@ symlinkJoin {
   meta = {
     description = "Professional video editing, color, effects and audio post-processing";
     longDescription = ''
-      DaVinci Resolve${lib.optionalString studioVariant " Studio"} includes a non-linear video editor, color grading tool, video effects
-      editor and track-based audio post-processing tool. The main executable davinci-resolve{lib.optionalString studioVariant "-studio"}
+      ${product} includes a non-linear video editor, color grading tool, video effects
+      editor and track-based audio post-processing tool. The main executable `${davinci.pname}`
       is wrapped in an FHS environment. For scripting and other purposes, the package provides the
-      davinci-resolve${lib.optionalString studioVariant "-studio"}-shell command, which opens a shell within the FHS environment.
+      `${davinci.pname}-shell` command, which opens a shell within the FHS environment.
 
       Using hardware hardware panels with Resolve requires a physical USB connection and setting `udev` rules via
-          services.udev.packages =
-            with pkgs; [
-              davinci-resolve${lib.optionalString studioVariant "-studio"}
-            ];
+      ```
+      services.udev.packages =
+        with pkgs; [
+          ${davinci.pname}
+        ];
+      ```
     '';
     homepage = "https://www.blackmagicdesign.com/products/davinciresolve";
     license = lib.licenses.unfree;
@@ -439,6 +442,6 @@ symlinkJoin {
     ];
     platforms = [ "x86_64-linux" ];
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    mainProgram = "davinci-resolve${lib.optionalString studioVariant "-studio"}";
+    mainProgram = "${davinci.pname}";
   };
 }

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -279,10 +279,12 @@ resolveUdev = runCommandLocal "davinci-resolve${lib.optionalString studioVariant
 '';
 
 resolveIcons = runCommandLocal "davinci-resolve${lib.optionalString studioVariant "-studio"}-icons" {} ''
-  mkdir -p $out/share/icons/hicolor/128x128/apps
+  mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/apps
   ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
   ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-panels.png
   ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor.png
+  ln -s ${davinci}/graphics/blackmagicraw-speedtest_256x256_apps.png $out/share/icons/hicolor/256x256/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test.png
+  ln -s ${davinci}/graphics/blackmagicraw-speedtest_48x48_apps.png $out/share/icons/hicolor/48x48/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test.png
 '';
 
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
@@ -299,6 +301,8 @@ resolveShellWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVaria
 
 panelSetupWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
 
+rawSpeedTestWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test" ["${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest"];
+
 remoteMonitorWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor" ["${davinci}/bin/DaVinci Remote Monitor"];
 
 in
@@ -312,6 +316,7 @@ symlinkJoin {
     resolveWrapper
     resolveShellWrapper
     panelSetupWrapper
+    rawSpeedTestWrapper
 
     resolveUdev
     resolveIcons
@@ -340,6 +345,19 @@ symlinkJoin {
       desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"} Control Panels Setup";
       exec = "${panelSetupWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
       icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels";
+      categories = [
+        "AudioVideo"
+        "AudioVideoEditing"
+        "Video"
+        "Graphics"
+      ];
+    })
+
+    (makeDesktopItem {
+      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test";
+      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"} Blackmagic RAW Speed Test";
+      exec = "${rawSpeedTestWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test";
+      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}-raw-speed-test";
       categories = [
         "AudioVideo"
         "AudioVideoEditing"

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -32,9 +32,13 @@
   writeShellApplication,
 
   # overriding pythonPackage allows customizing python in the FHS environment
-  pythonPackage ? (python3.withPackages (python-pkgs: with python-pkgs; [
-    numpy
-  ])),
+  pythonPackage ? (
+    python3.withPackages (
+      python-pkgs: with python-pkgs; [
+        numpy
+      ]
+    )
+  ),
 
 }:
 
@@ -186,174 +190,196 @@ let
     }
   );
 
-fhs = buildFHSEnv {
-  pname = "${davinci.pname}-fhs";
-  inherit (davinci) version;
+  fhs = buildFHSEnv {
+    pname = "${davinci.pname}-fhs";
+    inherit (davinci) version;
 
-  targetPkgs =
-    pkgs: with pkgs; [
-      alsa-lib
-      aprutil
-      bzip2
-      davinci
-      dbus
-      expat
-      fontconfig
-      freetype
-      glib
-      krb5  # for DaVinci Control Panels Setup
-      libGL
-      libGLU
-      libarchive
-      libcap
-      libdrm
-      libpng12
-      librsvg
-      libtool
-      libusb1
-      libuuid
-      libxcrypt  # provides libcrypt.so.1
-      libxkbcommon
-      nspr
-      nss
-      ocl-icd
-      opencl-headers
-      pythonPackage
-      udev
-      xcb-util-cursor
-      xdg-utils  # xdg-open needed to open URLs
-      xorg.libICE
-      xorg.libSM
-      xorg.libX11
-      xorg.libXcomposite
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXi
-      xorg.libXinerama
-      xorg.libxkbfile
-      xorg.libXrandr
-      xorg.libXrender
-      xorg.libXt
-      xorg.libXtst
-      xorg.libXxf86vm
-      xorg.libxcb
-      xorg.xcbutil
-      xorg.xcbutilimage
-      xorg.xcbutilkeysyms
-      xorg.xcbutilrenderutil
-      xorg.xcbutilwm
-      xorg.xkeyboardconfig
-      zlib
+    targetPkgs =
+      pkgs: with pkgs; [
+        alsa-lib
+        aprutil
+        bzip2
+        davinci
+        dbus
+        expat
+        fontconfig
+        freetype
+        glib
+        krb5 # for DaVinci Control Panels Setup
+        libGL
+        libGLU
+        libarchive
+        libcap
+        libdrm
+        libpng12
+        librsvg
+        libtool
+        libusb1
+        libuuid
+        libxcrypt # provides libcrypt.so.1
+        libxkbcommon
+        nspr
+        nss
+        ocl-icd
+        opencl-headers
+        pythonPackage
+        udev
+        xcb-util-cursor
+        xdg-utils # xdg-open needed to open URLs
+        xorg.libICE
+        xorg.libSM
+        xorg.libX11
+        xorg.libXcomposite
+        xorg.libXcursor
+        xorg.libXdamage
+        xorg.libXext
+        xorg.libXfixes
+        xorg.libXi
+        xorg.libXinerama
+        xorg.libxkbfile
+        xorg.libXrandr
+        xorg.libXrender
+        xorg.libXt
+        xorg.libXtst
+        xorg.libXxf86vm
+        xorg.libxcb
+        xorg.xcbutil
+        xorg.xcbutilimage
+        xorg.xcbutilkeysyms
+        xorg.xcbutilrenderutil
+        xorg.xcbutilwm
+        xorg.xkeyboardconfig
+        zlib
+      ];
+
+    extraPreBwrapCmds = lib.optionalString studioVariant ''
+      mkdir -p ~/.local/share/DaVinciResolve/license || exit 1
+      mkdir -p ~/.local/share/DaVinciResolve/Extras || exit 1
+    '';
+
+    extraBwrapArgs = lib.optionals studioVariant [
+      ''--bind "$HOME"/.local/share/DaVinciResolve/license ${davinci}/.license''
+      ''--bind "$HOME"/.local/share/DaVinciResolve/Extras ${davinci}/Extras''
     ];
 
-  extraPreBwrapCmds = lib.optionalString studioVariant ''
-    mkdir -p ~/.local/share/DaVinciResolve/license || exit 1
-    mkdir -p ~/.local/share/DaVinciResolve/Extras || exit 1
+    runScript = "${bash}/bin/bash ${writeText "davinci-wrapper" ''
+      exec "$@"
+    ''}";
+
+    extraInstallCommands = ''
+      mkdir -p $out/share/applications
+      ln -s ${davinci}/share/applications/*.desktop $out/share/applications/
+    '';
+  };
+
+  resolveUdev = runCommandLocal "${davinci.pname}-udev" { } ''
+    mkdir -p $out/etc/udev/rules.d
+    # follows the resolve install script, see scripts/post_install.sh
+    DVP_RULES=$out/etc/udev/rules.d/75-davincipanel.rules
+    DVK_RULES=$out/etc/udev/rules.d/75-davincikb.rules
+    SDX_RULES=$out/etc/udev/rules.d/75-sdx.rules
+    cat ${davinci}/share/etc/udev/rules.d/99-BlackmagicDevices.rules > $DVP_RULES
+    echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0777", GROUP="resolve"' >> $DVP_RULES
+    cat ${davinci}/share/etc/udev/rules.d/99-ResolveKeyboardHID.rules > $DVK_RULES
+    echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="096e", MODE="0666"' > $SDX_RULES
   '';
 
-  extraBwrapArgs = lib.optionals studioVariant [
-    ''--bind "$HOME"/.local/share/DaVinciResolve/license ${davinci}/.license''
-    ''--bind "$HOME"/.local/share/DaVinciResolve/Extras ${davinci}/Extras''
+  resolveXdg = runCommandLocal "${davinci.pname}-xdg" { } ''
+    # icons for applications
+    mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/apps
+    ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}.png
+    ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-panels.png
+    ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-monitor.png
+    ln -s ${davinci}/graphics/blackmagicraw-speedtest_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-speed-test.png
+    ln -s ${davinci}/graphics/blackmagicraw-speedtest_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-speed-test.png
+    ln -s ${davinci}/graphics/blackmagicraw-player_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-player.png
+    ln -s ${davinci}/graphics/blackmagicraw-player_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-player.png
+
+    # icons for mime types
+    mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/mimetypes
+
+    ln -s ${davinci}/graphics/application-x-braw-clip_48x48_mimetypes.png $out/share/icons/hicolor/48x48/mimetypes/application-x-braw-clip.png
+    ln -s ${davinci}/graphics/application-x-braw-sidecar_48x48_mimetypes.png $out/share/icons/hicolor/48x48/mimetypes/application-x-braw-sidecar.png
+    ln -s ${davinci}/graphics/application-x-braw-clip_256x256_mimetypes.png $out/share/icons/hicolor/256x256/mimetypes/application-x-braw-clip.png
+    ln -s ${davinci}/graphics/application-x-braw-sidecar_256x256_mimetypes.png $out/share/icons/hicolor/256x256/mimetypes/application-x-braw-sidecar.png
+    ln -s ${davinci}/graphics/DV_ResolveBin.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvebin.png
+    ln -s ${davinci}/graphics/DV_ResolveProj.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolveproj.png
+    ln -s ${davinci}/graphics/DV_ResolveTimeline.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvetimeline.png
+    ln -s ${davinci}/graphics/DV_TemplateBundle.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvetemplatebundle.png
+
+    # mime types
+    mkdir -p $out/share/mime/packages
+    # without these patches, GNOME displays blank icons
+    cat ${davinci}/share/blackmagicraw.xml \
+      | sed '/<mime-type type="application\/x-braw-clip">/a <generic-icon name="application-x-braw-clip"/>' \
+      | sed '/<mime-type type="application\/x-braw-sidecar">/a <generic-icon name="application-x-braw-sidecar"/>' \
+      > $out/share/mime/packages/${davinci.pname}-raw.xml
+    cat ${davinci}/share/resolve.xml \
+      | sed '/<mime-type type="application\/x-resolveproj">/a <generic-icon name="application-x-resolveproj"/>' \
+      | sed '/<mime-type type="application\/x-resolvedbkey">/a <generic-icon name="application-x-resolvedbkey"/>' \
+      | sed '/<mime-type type="application\/x-resolvebin">/a <generic-icon name="application-x-resolvebin"/>' \
+      | sed '/<mime-type type="application\/x-resolvetimeline">/a <generic-icon name="application-x-resolvetimeline"/>' \
+      | sed '/<mime-type type="application\/x-resolvetemplatebundle">/a <generic-icon name="application-x-resolvetemplatebundle"/>' \
+      > $out/share/mime/packages/${davinci.pname}.xml
+  '';
+
+  wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
+
+  # creates a derivation that wraps the "path" command with arguments in "args" list to run inside the FHS
+  # the directories in "libs" and "plugins" are put into LD_LIBRARY_PATH and QT_PLUGIN_PATH
+  mkWrapper =
+    path: libs: plugins: args:
+    writeShellScriptBin path ''
+      export QT_XKB_CONFIG_ROOT="${xkeyboard_config}/share/X11/xkb"
+      export QT_PLUGIN_PATH="${plugins}:$QT_PLUGIN_PATH"
+      export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib:/usr/lib32:${libs}"
+
+      # this allows Python to find the modules, see Developer/Scripting/README.txt
+      export RESOLVE_SCRIPT_API="${davinci}/Developer/Scripting"
+      export RESOLVE_SCRIPT_LIB="${davinci}/libs/Fusion/fusionscript.so"
+      export PYTHONPATH="$PYTHONPATH:${davinci}/Developer/Scripting/Modules"
+
+      exec ${lib.strings.concatMapStringsSep " " lib.escapeShellArg ([ wrapper ] ++ args)} "$@"
+    '';
+
+  # wrap main executable
+  resolveWrapper = mkWrapper "${davinci.pname}" "${davinci}/libs" "${davinci}/libs/plugins" [
+    "${davinci}/bin/resolve"
   ];
 
-  runScript = "${bash}/bin/bash ${writeText "davinci-wrapper" ''
-    exec "$@"
-  ''}";
+  # This provides the "davinci-resolve-shell"/"davinci-resolve-studio-shell" command to open a shell in the correct FHS
+  # in order to simplify running Resolve and related tools from the command line.
+  resolveShellWrapper =
+    mkWrapper "${davinci.pname}-shell" "${davinci}/libs" "${davinci}/libs/plugins"
+      [
+        "/usr/bin/env"
+        "bash"
+      ];
 
-  extraInstallCommands = ''
-    mkdir -p $out/share/applications
-    ln -s ${davinci}/share/applications/*.desktop $out/share/applications/
-  '';
-};
+  panelSetupWrapper =
+    mkWrapper "${davinci.pname}-panels" "${davinci}/DaVinci Control Panels Setup"
+      "${davinci}/DaVinci Control Panels Setup/plugins"
+      [ "${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup" ];
 
-resolveUdev = runCommandLocal "${davinci.pname}-udev" {} ''
-  mkdir -p $out/etc/udev/rules.d
-  # follows the resolve install script, see scripts/post_install.sh
-  DVP_RULES=$out/etc/udev/rules.d/75-davincipanel.rules
-  DVK_RULES=$out/etc/udev/rules.d/75-davincikb.rules
-  SDX_RULES=$out/etc/udev/rules.d/75-sdx.rules
-  cat ${davinci}/share/etc/udev/rules.d/99-BlackmagicDevices.rules > $DVP_RULES
-  echo 'KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0777", GROUP="resolve"' >> $DVP_RULES
-  cat ${davinci}/share/etc/udev/rules.d/99-ResolveKeyboardHID.rules > $DVK_RULES
-  echo 'SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="096e", MODE="0666"' > $SDX_RULES
-'';
+  rawSpeedTestWrapper =
+    mkWrapper "${davinci.pname}-raw-speed-test" "${davinci}/BlackmagicRAWSpeedTest/lib"
+      "${davinci}/BlackmagicRAWSpeedTest/plugins"
+      [ "${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest" ];
 
-resolveXdg = runCommandLocal "${davinci.pname}-xdg" {} ''
-  # icons for applications
-  mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/apps
-  ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}.png
-  ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-panels.png
-  ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-monitor.png
-  ln -s ${davinci}/graphics/blackmagicraw-speedtest_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-speed-test.png
-  ln -s ${davinci}/graphics/blackmagicraw-speedtest_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-speed-test.png
-  ln -s ${davinci}/graphics/blackmagicraw-player_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-player.png
-  ln -s ${davinci}/graphics/blackmagicraw-player_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-player.png
+  rawPlayerWrapper =
+    mkWrapper "${davinci.pname}-raw-player" "${davinci}/BlackmagicRAWPlayer/lib"
+      "${davinci}/BlackmagicRAWPlayer/plugins"
+      [ "${davinci}/BlackmagicRAWPlayer/BlackmagicRAWPlayer" ];
 
-  # icons for mime types
-  mkdir -p $out/share/icons/hicolor/{48x48,128x128,256x256}/mimetypes
+  remoteMonitorWrapper =
+    mkWrapper "${davinci.pname}-monitor" "${davinci}/libs" "${davinci}/libs/plugins"
+      [ "${davinci}/bin/DaVinci Remote Monitor" ];
 
-  ln -s ${davinci}/graphics/application-x-braw-clip_48x48_mimetypes.png $out/share/icons/hicolor/48x48/mimetypes/application-x-braw-clip.png
-  ln -s ${davinci}/graphics/application-x-braw-sidecar_48x48_mimetypes.png $out/share/icons/hicolor/48x48/mimetypes/application-x-braw-sidecar.png
-  ln -s ${davinci}/graphics/application-x-braw-clip_256x256_mimetypes.png $out/share/icons/hicolor/256x256/mimetypes/application-x-braw-clip.png
-  ln -s ${davinci}/graphics/application-x-braw-sidecar_256x256_mimetypes.png $out/share/icons/hicolor/256x256/mimetypes/application-x-braw-sidecar.png
-  ln -s ${davinci}/graphics/DV_ResolveBin.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvebin.png
-  ln -s ${davinci}/graphics/DV_ResolveProj.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolveproj.png
-  ln -s ${davinci}/graphics/DV_ResolveTimeline.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvetimeline.png
-  ln -s ${davinci}/graphics/DV_TemplateBundle.png $out/share/icons/hicolor/128x128/mimetypes/application-x-resolvetemplatebundle.png
+  pythonWrapper = mkWrapper "${davinci.pname}-python" "${davinci}/libs" "${davinci}/libs/plugins" [
+    "${pythonPackage}/bin/python"
+  ];
 
-  # mime types
-  mkdir -p $out/share/mime/packages
-  # without these patches, GNOME displays blank icons
-  cat ${davinci}/share/blackmagicraw.xml \
-    | sed '/<mime-type type="application\/x-braw-clip">/a <generic-icon name="application-x-braw-clip"/>' \
-    | sed '/<mime-type type="application\/x-braw-sidecar">/a <generic-icon name="application-x-braw-sidecar"/>' \
-    > $out/share/mime/packages/${davinci.pname}-raw.xml
-  cat ${davinci}/share/resolve.xml \
-    | sed '/<mime-type type="application\/x-resolveproj">/a <generic-icon name="application-x-resolveproj"/>' \
-    | sed '/<mime-type type="application\/x-resolvedbkey">/a <generic-icon name="application-x-resolvedbkey"/>' \
-    | sed '/<mime-type type="application\/x-resolvebin">/a <generic-icon name="application-x-resolvebin"/>' \
-    | sed '/<mime-type type="application\/x-resolvetimeline">/a <generic-icon name="application-x-resolvetimeline"/>' \
-    | sed '/<mime-type type="application\/x-resolvetemplatebundle">/a <generic-icon name="application-x-resolvetemplatebundle"/>' \
-    > $out/share/mime/packages/${davinci.pname}.xml
-'';
-
-wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
-
-# creates a derivation that wraps the "path" command with arguments in "args" list to run inside the FHS
-# the directories in "libs" and "plugins" are put into LD_LIBRARY_PATH and QT_PLUGIN_PATH
-mkWrapper = path: libs: plugins: args: writeShellScriptBin path ''
-    export QT_XKB_CONFIG_ROOT="${xkeyboard_config}/share/X11/xkb"
-    export QT_PLUGIN_PATH="${plugins}:$QT_PLUGIN_PATH"
-    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib:/usr/lib32:${libs}"
-
-    # this allows Python to find the modules, see Developer/Scripting/README.txt
-    export RESOLVE_SCRIPT_API="${davinci}/Developer/Scripting"
-    export RESOLVE_SCRIPT_LIB="${davinci}/libs/Fusion/fusionscript.so"
-    export PYTHONPATH="$PYTHONPATH:${davinci}/Developer/Scripting/Modules"
-
-    exec ${lib.strings.concatMapStringsSep " " lib.escapeShellArg ([wrapper] ++ args)} "$@"
-'';
-
-# wrap main executable
-resolveWrapper = mkWrapper "${davinci.pname}" "${davinci}/libs" "${davinci}/libs/plugins" ["${davinci}/bin/resolve"];
-
-# This provides the "davinci-resolve-shell"/"davinci-resolve-studio-shell" command to open a shell in the correct FHS
-# in order to simplify running Resolve and related tools from the command line.
-resolveShellWrapper = mkWrapper "${davinci.pname}-shell" "${davinci}/libs" "${davinci}/libs/plugins" ["/usr/bin/env" "bash"];
-
-panelSetupWrapper = mkWrapper "${davinci.pname}-panels" "${davinci}/DaVinci Control Panels Setup" "${davinci}/DaVinci Control Panels Setup/plugins" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
-
-rawSpeedTestWrapper = mkWrapper "${davinci.pname}-raw-speed-test" "${davinci}/BlackmagicRAWSpeedTest/lib" "${davinci}/BlackmagicRAWSpeedTest/plugins" ["${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest"];
-
-rawPlayerWrapper = mkWrapper "${davinci.pname}-raw-player" "${davinci}/BlackmagicRAWPlayer/lib" "${davinci}/BlackmagicRAWPlayer/plugins" ["${davinci}/BlackmagicRAWPlayer/BlackmagicRAWPlayer"];
-
-remoteMonitorWrapper = mkWrapper "${davinci.pname}-monitor" "${davinci}/libs" "${davinci}/libs/plugins" ["${davinci}/bin/DaVinci Remote Monitor"];
-
-pythonWrapper = mkWrapper "${davinci.pname}-python" "${davinci}/libs" "${davinci}/libs/plugins" [ "${pythonPackage}/bin/python" ];
-
-product = "DaVinci Resolve${lib.optionalString studioVariant " Studio"}";
+  product = "DaVinci Resolve${lib.optionalString studioVariant " Studio"}";
 
 in
 symlinkJoin {
@@ -380,7 +406,7 @@ symlinkJoin {
       exec = "${resolveWrapper}/bin/${davinci.pname}";
       icon = "${davinci.pname}";
       comment = "Professional video editing, color, effects and audio post-processing";
-      mimeTypes = ["application/x-resolveproj"];
+      mimeTypes = [ "application/x-resolveproj" ];
       startupNotify = true;
       terminal = false;
       categories = [
@@ -423,7 +449,10 @@ symlinkJoin {
       desktopName = "${product} Blackmagic RAW Player";
       exec = "${rawPlayerWrapper}/bin/${davinci.pname}-raw-player %f";
       icon = "${davinci.pname}-raw-player";
-      mimeTypes = ["application/x-braw-clip" "application/x-braw-sidecar"];
+      mimeTypes = [
+        "application/x-braw-clip"
+        "application/x-braw-sidecar"
+      ];
       terminal = false;
       categories = [
         "AudioVideo"
@@ -433,7 +462,8 @@ symlinkJoin {
       ];
     })
 
-  ] ++ lib.lists.optionals studioVariant [
+  ]
+  ++ lib.lists.optionals studioVariant [
 
     # remote monitor is not available in the non-studio version
 
@@ -513,7 +543,8 @@ symlinkJoin {
       ];
       ```
       Use `${davinci.pname}-python` to run Python inside the FHS environment.
-    '' + (lib.optionalString studioVariant ''
+    ''
+    + (lib.optionalString studioVariant ''
 
       DaVinci Resolve Studio additionally support remote scripting. Example:
       ```

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -282,6 +282,7 @@ resolveIcons = runCommandLocal "davinci-resolve${lib.optionalString studioVarian
   mkdir -p $out/share/icons/hicolor/128x128/apps
   ln -s ${davinci}/graphics/DV_Resolve.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}.png
   ln -s ${davinci}/graphics/DV_Panels.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-panels.png
+  ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor.png
 '';
 
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
@@ -298,6 +299,8 @@ resolveShellWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVaria
 
 panelSetupWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-panels" ["${davinci}/DaVinci Control Panels Setup/DaVinci Control Panels Setup"];
 
+remoteMonitorWrapper = mkWrapper "davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor" ["${davinci}/bin/DaVinci Remote Monitor"];
+
 in
 symlinkJoin {
 
@@ -305,6 +308,7 @@ symlinkJoin {
   inherit (davinci) version;
 
   paths = [
+
     resolveWrapper
     resolveShellWrapper
     panelSetupWrapper
@@ -343,6 +347,27 @@ symlinkJoin {
         "Graphics"
       ];
     })
+
+  ] ++ lib.lists.optionals studioVariant [
+
+    # remote monitor is not available in the non-studio version
+
+    remoteMonitorWrapper
+
+    (makeDesktopItem {
+      name = "davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor";
+      desktopName = "DaVinci Resolve${lib.optionalString studioVariant " Studio"} Remote Monitor";
+      exec = "${remoteMonitorWrapper}/bin/davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor";
+      icon = "davinci-resolve${lib.optionalString studioVariant "-studio"}-monitor";
+      startupNotify = true;
+      categories = [
+        "AudioVideo"
+        "AudioVideoEditing"
+        "Video"
+        "Graphics"
+      ];
+    })
+
   ];
 
   passthru = {

--- a/pkgs/by-name/da/davinci-resolve/package.nix
+++ b/pkgs/by-name/da/davinci-resolve/package.nix
@@ -282,6 +282,8 @@ resolveIcons = runCommandLocal "${davinci.pname}-icons" {} ''
   ln -s ${davinci}/graphics/Remote_Monitoring.png $out/share/icons/hicolor/128x128/apps/${davinci.pname}-monitor.png
   ln -s ${davinci}/graphics/blackmagicraw-speedtest_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-speed-test.png
   ln -s ${davinci}/graphics/blackmagicraw-speedtest_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-speed-test.png
+  ln -s ${davinci}/graphics/blackmagicraw-player_256x256_apps.png $out/share/icons/hicolor/256x256/apps/${davinci.pname}-raw-player.png
+  ln -s ${davinci}/graphics/blackmagicraw-player_48x48_apps.png $out/share/icons/hicolor/48x48/apps/${davinci.pname}-raw-player.png
 '';
 
 wrapper = ''${fhs}/bin/${davinci.pname}-fhs'';
@@ -307,6 +309,8 @@ panelSetupWrapper = mkWrapper "${davinci.pname}-panels" "${davinci}/DaVinci Cont
 
 rawSpeedTestWrapper = mkWrapper "${davinci.pname}-raw-speed-test" "${davinci}/BlackmagicRAWSpeedTest/lib" "${davinci}/BlackmagicRAWSpeedTest/plugins" ["${davinci}/BlackmagicRAWSpeedTest/BlackmagicRAWSpeedTest"];
 
+rawPlayerWrapper = mkWrapper "${davinci.pname}-raw-player" "${davinci}/BlackmagicRAWPlayer/lib" "${davinci}/BlackmagicRAWPlayer/plugins" ["${davinci}/BlackmagicRAWPlayer/BlackmagicRAWPlayer"];
+
 remoteMonitorWrapper = mkWrapper "${davinci.pname}-monitor" "${davinci}/libs" "${davinci}/libs/plugins" ["${davinci}/bin/DaVinci Remote Monitor"];
 
 product = "DaVinci Resolve${lib.optionalString studioVariant " Studio"}";
@@ -322,6 +326,7 @@ symlinkJoin {
     resolveShellWrapper
     panelSetupWrapper
     rawSpeedTestWrapper
+    rawPlayerWrapper
     remoteMonitorWrapper
 
     resolveUdev
@@ -364,6 +369,21 @@ symlinkJoin {
       desktopName = "${product} Blackmagic RAW Speed Test";
       exec = "${rawSpeedTestWrapper}/bin/${davinci.pname}-raw-speed-test";
       icon = "${davinci.pname}-raw-speed-test";
+      categories = [
+        "AudioVideo"
+        "AudioVideoEditing"
+        "Video"
+        "Graphics"
+      ];
+    })
+
+    (makeDesktopItem {
+      name = "${davinci.pname}-raw-player";
+      desktopName = "${product} Blackmagic RAW Player";
+      exec = "${rawPlayerWrapper}/bin/${davinci.pname}-raw-player %f";
+      icon = "${davinci.pname}-raw-player";
+      mimeTypes = ["application/x-braw-clip" "application/x-braw-sidecar"];
+      terminal = false;
       categories = [
         "AudioVideo"
         "AudioVideoEditing"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This commit fixes #366384, #364991, #364646, and possibly (untested) #168789.

It also adds several applications that are bundled with Resolve but were not supported yet:
- DaVinci Control Panels Setup
- DaVinci Remote Monitor
- Blackmagic RAW Player
- Blackmagic RAW Speed Test
- External Python scripting

This required some refactoring, so I am submitting this PR for discussion and expect that it would require some changes before accepting.

Changes:
 - Adds a number of missing dependencies required by the new applications.
 - The binary libraries required for the panels to work are now unpacked from `share/panels/dvpanel-framework-linux-x86_64.tgz` into `lib` so that they can be found from within the FHS environment.
 - The FHS environment formerly directly executed `bin/resolve` via `runScript` (discarding command line arguments). This did not allow to run the other supplied applications in the same FHS, therefore it now functions as a wrapper that can be called with the command+arguments to run. For debugging, the package also has a `bin/davinci-resolve-*-fhs` command, which starts a shell in the FHS environment.
 - The main package is now created using `symlinkJoin` to have better control of which files are linked where. The main package only includes the application links in `bin/`, udev rules in `etc/udev/rules.d/`, and desktop items in `share/applications/`.
 - The `udev` rules now follow the same naming and priority as when installing Resolve on Non-NixOS. These files were formerly only mapped from the unpacked archive (`99-*.rules`), but in the Resolve install script they are actually modified and a new file is added for the dongle, which results in `75-davincipanel.rules`, `75-davincikb.rules`, and `75-sdx.rules` (new).
 - Desktop items for the new applications are added and the main desktop item now has `mimeTypes` set.
 - MIME types XML and icons are installed into the XDG directory structure
 - A `longDescription` is added to hint to the fact that the package needs to be added to `services.udev.packages` in order for the panels to work, which was not documented, and includes comments about scripting.

I have tested using a DaVinci Resolve Micro Panel and DaVinci Resolve Speed Editor, which work including updating the firmware using the Control Panels Setup application. I do not have access to panels with a display, so I am not sure if they require the supplied daemon, which would require additional setup.

External scripting works with DaVinci Resolve Studio. Icons are correctly displayed on GNOME, Resolve project files (.drp) are correctly opened by Resolve, and RAW file (.braw) open the RAW player (see the three clips that can be downloaded on [this page](https://www.blackmagicdesign.com/products/blackmagicraw) for testing).

I have tested the automatic update script and it still works as far as I can tell.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
