### PR TITLE
virtualbox: fix X11 shared clipboard

### DIFF
--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -14,6 +14,7 @@
   xorgproto,
   libXext,
   libXcursor,
+  libXfixes,
   libXmu,
   libIDL,
   SDL2,
@@ -203,6 +204,9 @@ stdenv.mkDerivation (finalAttrs: {
 
     grep 'libdbus-1\.so\.3'     src include -rI --files-with-match | xargs sed -i -e '
       s@"libdbus-1\.so\.3"@"${dbus.lib}/lib/libdbus-1.so.3"@g'
+
+    grep 'libXfixes\.so\.3'     src include -rI --files-with-match | xargs sed -i -e '
+      s@"libXfixes\.so\.3"@"${libXfixes.out}/lib/libXfixes.so.3"@g'
 
     grep 'libasound\.so\.2'     src include -rI --files-with-match | xargs sed -i -e '
       s@"libasound\.so\.2"@"${alsa-lib.out}/lib/libasound.so.2"@g'


### PR DESCRIPTION
The [recent update](https://github.com/NixOS/nixpkgs/pull/353857) of virtualbox broke clipboard sharing, at least if the host runs in X11 and plasma5.  The commit introduced here fixes clipboard sharing by patching a dlopen call for `libXfixes.so`, like it is already done for other libraries.  More information is in the commit message.

Note: This problem is independent of https://github.com/NixOS/nixpkgs/pull/366080 : The pull request at hand fixes a missing library in the virtualbox host program, while https://github.com/NixOS/nixpkgs/pull/366080 fixed missing libraries in the guest additions.

Please consider backporting this pull request to stable NixOS 24.11, as the [update there](https://github.com/NixOS/nixpkgs/pull/368266) broken clipboard integration, too.  I tested the patch also with NixOS 24.11, and it fixes the problem there as well.

Notifying maintainers @blitz @svanderburg @FriedrichAltheide
Notifying author of update pull request @Mrmaxmeier

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:fast_forward: 1 package marked as broken and skipped:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_4_hardened.virtualbox</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 28 packages built:</summary>
  <ul>
    <li>linuxKernel.packages.linux_5_10.virtualbox</li>
    <li>linuxKernel.packages.linux_5_10_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_15.virtualbox</li>
    <li>linuxKernel.packages.linux_5_15_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_5_4.virtualbox</li>
    <li>linuxKernel.packages.linux_6_1.virtualbox</li>
    <li>linuxKernel.packages.linux_6_11.virtualbox</li>
    <li>linuxKernel.packages.linux_6_11_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_6_12.virtualbox</li>
    <li>linuxKernel.packages.linux_6_12_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_6_1_hardened.virtualbox</li>
    <li>linuxKernel.packages.linux_6_6.virtualbox</li>
    <li>linuxKernel.packages.linux_hardened.virtualbox (linuxKernel.packages.linux_6_6_hardened.virtualbox)</li>
    <li>linuxKernel.packages.linux_latest_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_libre.virtualbox</li>
    <li>linuxKernel.packages.linux_lqx.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod.virtualbox</li>
    <li>linuxKernel.packages.linux_xanmod_latest.virtualbox (linuxKernel.packages.linux_xanmod_stable.virtualbox)</li>
    <li>linuxKernel.packages.linux_zen.virtualbox</li>
    <li>virtualbox</li>
    <li>virtualbox.modsrc</li>
    <li>virtualboxHardened</li>
    <li>virtualboxHardened.modsrc</li>
    <li>virtualboxHeadless</li>
    <li>virtualboxHeadless.modsrc</li>
    <li>virtualboxKvm</li>
    <li>virtualboxWithExtpack</li>
    <li>virtualboxWithExtpack.modsrc</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
