### PR TITLE
udev: substitute /usr/bin/cat in rules

### DIFF
--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -66,6 +66,7 @@ let
           --replace \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
           --replace \"/bin/mount \"${pkgs.util-linux}/bin/mount \
           --replace /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
+          --replace /usr/bin/cat ${pkgs.coreutils}/bin/cat \
           --replace /usr/bin/basename ${pkgs.coreutils}/bin/basename 2>/dev/null
       ${lib.optionalString (initrdBin != null) ''
         substituteInPlace $i --replace '/run/current-system/systemd' "${lib.removeSuffix "/bin" initrdBin}"

--- a/nixos/modules/services/hardware/udev.nix
+++ b/nixos/modules/services/hardware/udev.nix
@@ -61,15 +61,15 @@ let
       # Fix some paths in the standard udev rules.  Hacky.
       for i in $out/*.rules; do
         substituteInPlace $i \
-          --replace \"/sbin/modprobe \"${pkgs.kmod}/bin/modprobe \
-          --replace \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
-          --replace \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
-          --replace \"/bin/mount \"${pkgs.util-linux}/bin/mount \
-          --replace /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
-          --replace /usr/bin/cat ${pkgs.coreutils}/bin/cat \
-          --replace /usr/bin/basename ${pkgs.coreutils}/bin/basename 2>/dev/null
+          --replace-quiet \"/sbin/modprobe \"${pkgs.kmod}/bin/modprobe \
+          --replace-quiet \"/sbin/mdadm \"${pkgs.mdadm}/sbin/mdadm \
+          --replace-quiet \"/sbin/blkid \"${pkgs.util-linux}/sbin/blkid \
+          --replace-quiet \"/bin/mount \"${pkgs.util-linux}/bin/mount \
+          --replace-quiet /usr/bin/readlink ${pkgs.coreutils}/bin/readlink \
+          --replace-quiet /usr/bin/cat ${pkgs.coreutils}/bin/cat \
+          --replace-quiet /usr/bin/basename ${pkgs.coreutils}/bin/basename 2>/dev/null
       ${lib.optionalString (initrdBin != null) ''
-        substituteInPlace $i --replace '/run/current-system/systemd' "${lib.removeSuffix "/bin" initrdBin}"
+        substituteInPlace $i --replace-quiet '/run/current-system/systemd' "${lib.removeSuffix "/bin" initrdBin}"
       ''}
       done
 


### PR DESCRIPTION
alsa-utils 1.2.13 introduced a change to a udev rules file that references /usr/bin/cat, so let's substitute that too.

avoids NixOS build failure with "/usr/bin/cat is called in udev rules but is not executable or does not exist".