### PR TITLE
stdenv: refactor nix logging functions

### DIFF
--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -72,7 +72,7 @@ nixLog() {
 
 # Identical to nixLog, but additionally prefixed by the logLevel.
 # NOTE: This function is only every meant to be called from the nix*Log family of functions.
-nixLogWithLevel() {
+_nixLogWithLevel() {
   # Return a value explicitly instead of the implicit return of the last command (result of the test).
   [[ -z ${NIX_LOG_FD-} || ${NIX_DEBUG:-0} -lt ${1:?} ]] && return 0
 
@@ -87,7 +87,7 @@ nixLogWithLevel() {
   6) logLevel=DEBUG ;;
   7) logLevel=VOMIT ;;
   *)
-    echo "nixLogWithLevel: called with invalid log level: ${1:?}" >&"$NIX_LOG_FD"
+    echo "_nixLogWithLevel: called with invalid log level: ${1:?}" >&"$NIX_LOG_FD"
     return 1
     ;;
   esac
@@ -107,49 +107,49 @@ nixLogWithLevel() {
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlError` in the Nix source.
 nixErrorLog() {
-  nixLogWithLevel 0 "$*"
+  _nixLogWithLevel 0 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlWarn` in the Nix source.
 nixWarnLog() {
-  nixLogWithLevel 1 "$*"
+  _nixLogWithLevel 1 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlNotice` in the Nix source.
 nixNoticeLog() {
-  nixLogWithLevel 2 "$*"
+  _nixLogWithLevel 2 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlInfo` in the Nix source.
 nixInfoLog() {
-  nixLogWithLevel 3 "$*"
+  _nixLogWithLevel 3 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlTalkative` in the Nix source.
 nixTalkativeLog() {
-  nixLogWithLevel 4 "$*"
+  _nixLogWithLevel 4 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlChatty` in the Nix source.
 nixChattyLog() {
-  nixLogWithLevel 5 "$*"
+  _nixLogWithLevel 5 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlDebug` in the Nix source.
 nixDebugLog() {
-  nixLogWithLevel 6 "$*"
+  _nixLogWithLevel 6 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlVomit` in the Nix source.
 nixVomitLog() {
-  nixLogWithLevel 7 "$*"
+  _nixLogWithLevel 7 "$*"
 }
 
 # Log a hook, to be run before the hook is actually called.

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -60,6 +60,7 @@ getAllOutputNames() {
 # the hook name if the caller was an implicit hook), then directed to $NIX_LOG_FD, if it's set.
 nixLog() {
   # Return a value explicitly instead of the implicit return of the last command (result of the test).
+  # NOTE: By requiring NIX_LOG_FD be set, we avoid dumping logging inside of nix-shell.
   [[ -z ${NIX_LOG_FD-} ]] && return 0
 
   # Use the function name of the caller, unless it is _callImplicitHook, in which case use the name of the hook.
@@ -74,6 +75,7 @@ nixLog() {
 # NOTE: This function is only every meant to be called from the nix*Log family of functions.
 _nixLogWithLevel() {
   # Return a value explicitly instead of the implicit return of the last command (result of the test).
+  # NOTE: By requiring NIX_LOG_FD be set, we avoid dumping logging inside of nix-shell.
   [[ -z ${NIX_LOG_FD-} || ${NIX_DEBUG:-0} -lt ${1:?} ]] && return 0
 
   local logLevel

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -56,60 +56,100 @@ getAllOutputNames() {
     fi
 }
 
+# All provided arguments are joined with a space, then prefixed by the name of the function which invoked `nixLog` (or
+# the hook name if the caller was an implicit hook), then directed to $NIX_LOG_FD, if it's set.
+nixLog() {
+  # Return a value explicitly instead of the implicit return of the last command (result of the test).
+  [[ -z ${NIX_LOG_FD-} ]] && return 0
+
+  # Use the function name of the caller, unless it is _callImplicitHook, in which case use the name of the hook.
+  local callerName="${FUNCNAME[1]}"
+  if [[ $callerName == "_callImplicitHook" ]]; then
+    callerName="${hookName:?}"
+  fi
+  printf "%s: %s\n" "$callerName" "$*" >&"$NIX_LOG_FD"
+}
+
+# Identical to nixLog, but additionally prefixed by the logLevel.
+# NOTE: This function is only every meant to be called from the nix*Log family of functions.
+nixLogWithLevel() {
+  # Return a value explicitly instead of the implicit return of the last command (result of the test).
+  [[ -z ${NIX_LOG_FD-} || ${NIX_DEBUG:-0} -lt ${1:?} ]] && return 0
+
+  local logLevel
+  case "${1:?}" in
+  0) logLevel=ERROR ;;
+  1) logLevel=WARN ;;
+  2) logLevel=NOTICE ;;
+  3) logLevel=INFO ;;
+  4) logLevel=TALKATIVE ;;
+  5) logLevel=CHATTY ;;
+  6) logLevel=DEBUG ;;
+  7) logLevel=VOMIT ;;
+  *)
+    echo "nixLogWithLevel: called with invalid log level: ${1:?}" >&"$NIX_LOG_FD"
+    return 1
+    ;;
+  esac
+
+  # Use the function name of the caller, unless it is _callImplicitHook, in which case use the name of the hook.
+  # NOTE: Our index into FUNCNAME is 2, not 1, because we are only ever to be called from the nix*Log family of
+  # functions, never directly.
+  local callerName="${FUNCNAME[2]}"
+  if [[ $callerName == "_callImplicitHook" ]]; then
+    callerName="${hookName:?}"
+  fi
+
+  # Use the function name of the caller's caller, since we should only every be invoked by nix*Log functions.
+  printf "%s: %s: %s\n" "$logLevel" "$callerName" "${2:?}" >&"$NIX_LOG_FD"
+}
+
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlError` in the Nix source.
 nixErrorLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 0 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 0 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlWarn` in the Nix source.
 nixWarnLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 1 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 1 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlNotice` in the Nix source.
 nixNoticeLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 2 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 2 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlInfo` in the Nix source.
 nixInfoLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 3 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 3 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlTalkative` in the Nix source.
 nixTalkativeLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 4 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 4 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlChatty` in the Nix source.
 nixChattyLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 5 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 5 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlDebug` in the Nix source.
 nixDebugLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 6 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 6 "$*"
 }
 
 # All provided arguments are joined with a space then directed to $NIX_LOG_FD, if it's set.
 # Corresponds to `Verbosity::lvlVomit` in the Nix source.
 nixVomitLog() {
-    if [[ -z ${NIX_LOG_FD-} ]] || [[ ${NIX_DEBUG:-0} -lt 7 ]]; then return; fi
-    printf "%s\n" "$*" >&"$NIX_LOG_FD"
+  nixLogWithLevel 7 "$*"
 }
 
 # Log a hook, to be run before the hook is actually called.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Package maintainers frequently include `echo` commands in their phase expressions to provide breadcrumbs for debugging or information for troubleshooting. To try to standardize the logging format and avoid the need to remember to pipe the output from `echo` to stderr or `NIX_LOG_FD`, we have the log-level family of functions (`nix*Log`) and an unconditional log function, `nixLog`.

The `nix*Log` function family only prints to `NIX_LOG_FD` when the severity of the log message is at least the value of `NIX_DEBUG`. This should be the preferred logger.

The `nixLog` function logs unconditionally and is meant to be used to provide information about the status of some process or phase (e.g., log messages delimiting a series of `substituteInPlace` calls, or to notify about the progress of a setup hook). It should never be used by trivial builders or writers (see #328229).

These functions both make use of Bash's `FUNCNAME` shell variable to prefix the logged message with the caller (or the phase name, if the caller is an implicit hook), which is extremely useful when debugging failing phases.

I've been using this change to great success in an external repo containing a rewrite of our CUDA packaging: it is implemented here https://github.com/ConnorBaker/cuda-packages/tree/main/upstreamable-packages/nixLogWithLevelAndFunctionNameHook and an example of its use is here https://github.com/ConnorBaker/cuda-packages/blob/358e4a6a73f11042f4454e81918039e62ddfb261/cuda-packages/common/setupCudaHook/setup-cuda-hook.sh. I'm submitting it here because I believe it can help remove ad-hoc `echo` statements while also enriching our build logs.

Here's a snippet of the output I see when I build `nccl`:

<details>

```
cuda12.6-nccl> structuredAttrs is enabled
cuda12.6-nccl> source: installed nix loggers with level and function name functionality
cuda12.6-nccl> source: added noBrokenSymlinksInAllOutputs to postFixupHooks
cuda12.6-nccl> source: sourcing setup-cuda-hook.sh
cuda12.6-nccl> source: added setupCUDAPopulateArrays to preConfigureHooks
cuda12.6-nccl> source: added setupCUDAEnvironmentVariables to preConfigureHooks
cuda12.6-nccl> source: added setupCUDACmakeFlags to preConfigureHooks
cuda12.6-nccl> source: added propagateCudaLibraries to postFixupHooks
cuda12.6-nccl> source: added noBrokenSymlinksInAllOutputs to postFixupHooks
cuda12.6-nccl> Running phase: unpackPhase
cuda12.6-nccl> unpacking source archive /nix/store/p83r5nhn5i9fhrbprfpvdmbq1px99590-NVIDIA-nccl-v2.23.4-1
cuda12.6-nccl> source root is NVIDIA-nccl-v2.23.4-1
cuda12.6-nccl> Running phase: patchPhase
cuda12.6-nccl> patching script interpreter paths in ./src/device/generate.py
cuda12.6-nccl> ./src/device/generate.py: interpreter directive changed from "#!/usr/bin/env python3" to "/nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/python3"
cuda12.6-nccl> Running phase: updateAutotoolsGnuConfigScriptsPhase
cuda12.6-nccl> Running phase: configurePhase
cuda12.6-nccl> setupCUDAPopulateArrays: searching dependencies in pkgsBuildBuild for CUDA markers
cuda12.6-nccl> setupCUDAPopulateArrays: searching dependencies in pkgsBuildHost for CUDA markers
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/acs9ccnlgkx6wmvjjh5kjiw3rly4sjas-cuda12.6-cuda_nvcc-12.6.85-dev from pkgsBuildHost
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/91gl5axqklbh8hbcd9q8bpqq084r39s6-cuda12.6-cuda_nvcc-12.6.85-bin from pkgsBuildHost
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/gswsylmapc3f4fb4njs6gsxvn2p8vv9m-cuda12.6-cuda_nvcc-12.6.85-include from pkgsBuildHost
cuda12.6-nccl> setupCUDAPopulateArrays: searching dependencies in pkgsBuildTarget for CUDA markers
cuda12.6-nccl> setupCUDAPopulateArrays: searching dependencies in pkgsHostHost for CUDA markers
cuda12.6-nccl> setupCUDAPopulateArrays: searching dependencies in pkgsHostTarget for CUDA markers
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/9iyad3k0b1np3fslnbl6vh1blw1pzbqj-cuda12.6-cuda_cudart-12.6.77-dev from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/00gyy9yf6n8rcxbi36miay91p3xgw93l-cuda12.6-cuda_cudart-12.6.77-include from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/gswsylmapc3f4fb4njs6gsxvn2p8vv9m-cuda12.6-cuda_nvcc-12.6.85-include from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/xnfs0swsk9laa35hnlpfhfi8jddbiqdy-cuda12.6-cuda_cccl-12.6.77-include from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/hd7vskrjdi5kjmh2ir4ra6a34h5zzf1x-cuda12.6-cuda_cudart-12.6.77-lib from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/70fj8bbfrx7rx9hrzsbqqw3z9mxdxp2j-cuda12.6-cuda_cudart-12.6.77-static from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/gdrrsva6842fwgcq1sp1imknpsk2r1rg-cuda12.6-cuda_cudart-12.6.77-stubs from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/acs9ccnlgkx6wmvjjh5kjiw3rly4sjas-cuda12.6-cuda_nvcc-12.6.85-dev from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/91gl5axqklbh8hbcd9q8bpqq084r39s6-cuda12.6-cuda_nvcc-12.6.85-bin from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: found CUDA marker in /nix/store/vx0h02f8jm3hr728rg2cjjdv8had7kp6-cuda12.6-cuda_cccl-12.6.77-dev from pkgsHostTarget
cuda12.6-nccl> setupCUDAPopulateArrays: searching dependencies in pkgsTargetTarget for CUDA markers
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/00gyy9yf6n8rcxbi36miay91p3xgw93l-cuda12.6-cuda_cudart-12.6.77-include to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/00gyy9yf6n8rcxbi36miay91p3xgw93l-cuda12.6-cuda_cudart-12.6.77-include/include to CUDAToolkit_INCLUDE_DIRS
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/acs9ccnlgkx6wmvjjh5kjiw3rly4sjas-cuda12.6-cuda_nvcc-12.6.85-dev to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/70fj8bbfrx7rx9hrzsbqqw3z9mxdxp2j-cuda12.6-cuda_cudart-12.6.77-static to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/9iyad3k0b1np3fslnbl6vh1blw1pzbqj-cuda12.6-cuda_cudart-12.6.77-dev to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/gswsylmapc3f4fb4njs6gsxvn2p8vv9m-cuda12.6-cuda_nvcc-12.6.85-include to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/gswsylmapc3f4fb4njs6gsxvn2p8vv9m-cuda12.6-cuda_nvcc-12.6.85-include/include to CUDAToolkit_INCLUDE_DIRS
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/gdrrsva6842fwgcq1sp1imknpsk2r1rg-cuda12.6-cuda_cudart-12.6.77-stubs to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/hd7vskrjdi5kjmh2ir4ra6a34h5zzf1x-cuda12.6-cuda_cudart-12.6.77-lib to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/vx0h02f8jm3hr728rg2cjjdv8had7kp6-cuda12.6-cuda_cccl-12.6.77-dev to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/xnfs0swsk9laa35hnlpfhfi8jddbiqdy-cuda12.6-cuda_cccl-12.6.77-include to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/xnfs0swsk9laa35hnlpfhfi8jddbiqdy-cuda12.6-cuda_cccl-12.6.77-include/include to CUDAToolkit_INCLUDE_DIRS
cuda12.6-nccl> setupCUDAEnvironmentVariables: added /nix/store/91gl5axqklbh8hbcd9q8bpqq084r39s6-cuda12.6-cuda_nvcc-12.6.85-bin to CUDAToolkit_ROOT
cuda12.6-nccl> setupCUDAEnvironmentVariables: set CUDAHOSTCXX to /nix/store/cxv2d1nnxjaqmzg9kaf64806prdcwi9v-gcc-wrapper-13.3.0/bin/c++
cuda12.6-nccl> setupCUDAEnvironmentVariables: set CUDAARCHS to 89
cuda12.6-nccl> setupCUDAEnvironmentVariables: appended -ccbin /nix/store/cxv2d1nnxjaqmzg9kaf64806prdcwi9v-gcc-wrapper-13.3.0/bin/c++ to NVCC_PREPEND_FLAGS
cuda12.6-nccl> setupCUDAEnvironmentVariables: set NVCC_CCBIN to /nix/store/cxv2d1nnxjaqmzg9kaf64806prdcwi9v-gcc-wrapper-13.3.0/bin/c++
cuda12.6-nccl> setupCUDAEnvironmentVariables: appended -Xfatbin=-compress-all to NVCC_PREPEND_FLAGS
cuda12.6-nccl> no configure script, doing nothing
cuda12.6-nccl> Running phase: buildPhase
```

</details>

## Prior work

- https://github.com/NixOS/nixpkgs/issues/328229
- https://github.com/NixOS/nixpkgs/pull/331560
- https://github.com/NixOS/nixpkgs/pull/331794

## Future work

Ideally, we would have better integration with the Nix CLI such that using structured logging is enough for the CLI to filter messages.

Rebuilding derivations just to see logs with a higher level of verbosity is frustrating because it slows down development and introduces additional steps to get more visibility into failures. Instead, the Nix build log should be at full verbosity so that information is always available and the CLI should filter the output before display.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
