### PR TITLE
stdenv: add no-broken-symlinks hook

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1371,6 +1371,14 @@ This setup hook moves any systemd user units installed in the `lib/` subdirector
 
 This hook only runs when compiling for Linux.
 
+### `no-broken-symlinks.sh` {#no-broken-symlinks.sh}
+
+This setup hook checks for, reports, and (by default) fails builds when "broken" symlinks are found. A symlink is considered "broken" if it's dangling (the target doesn't exist) or reflexive (it refers to itself).
+
+By setting `allowDanglingSymlinks` or `allowReflexiveSymlinks` the hook can be configured to allow symlinks with non-existent targets or symlinks which are reflexive, respectively.
+
+This hook can be disabled entirely by setting `dontCheckForBrokenSymlinks`.
+
 ### `set-source-date-epoch-to-latest.sh` {#set-source-date-epoch-to-latest.sh}
 
 This sets `SOURCE_DATE_EPOCH` to the modification time of the most recent file.

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1375,9 +1375,11 @@ This hook only runs when compiling for Linux.
 
 This setup hook checks for, reports, and (by default) fails builds when "broken" symlinks are found. A symlink is considered "broken" if it's dangling (the target doesn't exist) or reflexive (it refers to itself).
 
-By setting `allowDanglingSymlinks` or `allowReflexiveSymlinks` the hook can be configured to allow symlinks with non-existent targets or symlinks which are reflexive, respectively.
+This hook can be disabled by setting `dontCheckForBrokenSymlinks`.
 
-This hook can be disabled entirely by setting `dontCheckForBrokenSymlinks`.
+::: {.note}
+The check for reflexivity is direct and does not account for transitivity, so this hook will not prevent cycles in symlinks.
+:::
 
 ### `set-source-date-epoch-to-latest.sh` {#set-source-date-epoch-to-latest.sh}
 

--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -40,14 +40,9 @@ noBrokenSymlinks() {
       nixInfoLog "symlink $path points to absolute target $symlinkTarget"
     else
       nixInfoLog "symlink $path points to relative target $symlinkTarget"
-      symlinkTarget="$pathParent/$symlinkTarget"
-
-      # Check to make sure the interpolated target doesn't escape the store path of `output`.
-      # If it does, Nix probably won't be able to resolve or track dependencies.
-      if [[ $symlinkTarget != "$output" && $symlinkTarget != "$output"/* ]]; then
-        nixErrorLog "symlink $path points to target $symlinkTarget, which escapes the current store path $output"
-        exit 1
-      fi
+      # Use --no-symlinks to avoid dereferencing again and --canonicalize-missing to avoid existence
+      # checks at this step (which can lead to infinite recursion).
+      symlinkTarget="$(realpath --no-symlinks --canonicalize-missing "$pathParent/$symlinkTarget")"
     fi
 
     if [[ $path == "$symlinkTarget" ]]; then

--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -1,4 +1,12 @@
 # shellcheck shell=bash
+
+# Guard against double inclusion.
+if (("${noBrokenSymlinksHookInstalled:-0}" > 0)); then
+  nixInfoLog "skipping because the hook has been propagated more than once"
+  return 0
+fi
+declare -ig noBrokenSymlinksHookInstalled=1
+
 # symlinks are often created in postFixup
 # don't use fixupOutputHooks, it is before postFixup
 postFixupHooks+=(noBrokenSymlinksInAllOutputs)

--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -51,22 +51,22 @@ noBrokenSymlinks() {
       fi
     fi
 
-    if [[ ! -e $symlinkTarget ]]; then
+    if [[ $path == "$symlinkTarget" ]]; then
+      # symlinkTarget is reflexive
+      errorMessage="the symlink $path is reflexive $symlinkTarget"
+      if [[ -z ${allowReflexiveSymlinks-} ]]; then
+        nixErrorLog "$errorMessage"
+        numReflexiveSymlinks+=1
+      else
+        nixInfoLog "$errorMessage"
+      fi
+
+    elif [[ ! -e $symlinkTarget ]]; then
       # symlinkTarget does not exist
       errorMessage="the symlink $path points to a missing target $symlinkTarget"
       if [[ -z ${allowDanglingSymlinks-} ]]; then
         nixErrorLog "$errorMessage"
         numDanglingSymlinks+=1
-      else
-        nixInfoLog "$errorMessage"
-      fi
-
-    elif [[ $path == "$symlinkTarget" ]]; then
-      # symlinkTarget is exists and is reflexive
-      errorMessage="the symlink $path is reflexive $symlinkTarget"
-      if [[ -z ${allowReflexiveSymlinks-} ]]; then
-        nixErrorLog "$errorMessage"
-        numReflexiveSymlinks+=1
       else
         nixInfoLog "$errorMessage"
       fi

--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -19,11 +19,10 @@ noBrokenSymlinks() {
   local path
   local pathParent
   local symlinkTarget
-  local errorMessage
   local -i numDanglingSymlinks=0
   local -i numReflexiveSymlinks=0
 
-  # TODO(@connorbaker): This hook doesn't check for cycles in symlinks.
+  # NOTE(@connorbaker): This hook doesn't check for cycles in symlinks.
 
   if [[ ! -e $output ]]; then
     nixWarnLog "skipping non-existent output $output"
@@ -52,28 +51,13 @@ noBrokenSymlinks() {
     fi
 
     if [[ $path == "$symlinkTarget" ]]; then
-      # symlinkTarget is reflexive
-      errorMessage="the symlink $path is reflexive $symlinkTarget"
-      if [[ -z ${allowReflexiveSymlinks-} ]]; then
-        nixErrorLog "$errorMessage"
-        numReflexiveSymlinks+=1
-      else
-        nixInfoLog "$errorMessage"
-      fi
-
+      nixErrorLog "the symlink $path is reflexive $symlinkTarget"
+      numReflexiveSymlinks+=1
     elif [[ ! -e $symlinkTarget ]]; then
-      # symlinkTarget does not exist
-      errorMessage="the symlink $path points to a missing target $symlinkTarget"
-      if [[ -z ${allowDanglingSymlinks-} ]]; then
-        nixErrorLog "$errorMessage"
-        numDanglingSymlinks+=1
-      else
-        nixInfoLog "$errorMessage"
-      fi
-
+      nixErrorLog "the symlink $path points to a missing target $symlinkTarget"
+      numDanglingSymlinks+=1
     else
-      # symlinkTarget exists and is irreflexive
-      nixInfoLog "the symlink $path is irreflexive and points to a target which exists"
+      nixDebugLog "the symlink $path is irreflexive and points to a target which exists"
     fi
   done < <(find "$output" -type l -print0)
 

--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -47,7 +47,7 @@ noBrokenSymlinks() {
       # If it does, Nix probably won't be able to resolve or track dependencies.
       if [[ $symlinkTarget != "$output" && $symlinkTarget != "$output"/* ]]; then
         nixErrorLog "symlink $path points to target $symlinkTarget, which escapes the current store path $output"
-        return 1
+        exit 1
       fi
     fi
 
@@ -79,7 +79,7 @@ noBrokenSymlinks() {
 
   if ((numDanglingSymlinks > 0 || numReflexiveSymlinks > 0)); then
     nixErrorLog "found $numDanglingSymlinks dangling symlinks and $numReflexiveSymlinks reflexive symlinks"
-    return 1
+    exit 1
   fi
   return 0
 }

--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -1,0 +1,85 @@
+# shellcheck shell=bash
+# symlinks are often created in postFixup
+# don't use fixupOutputHooks, it is before postFixup
+postFixupHooks+=(noBrokenSymlinksInAllOutputs)
+
+# A symlink is "dangling" if it points to a non-existent target.
+# A symlink is "reflexive" if it points to itself.
+# A symlink is considered "broken" if it is either dangling or reflexive.
+noBrokenSymlinks() {
+  local -r output="${1:?}"
+  local path
+  local pathParent
+  local symlinkTarget
+  local errorMessage
+  local -i numDanglingSymlinks=0
+  local -i numReflexiveSymlinks=0
+
+  # TODO(@connorbaker): This hook doesn't check for cycles in symlinks.
+
+  if [[ ! -e $output ]]; then
+    nixWarnLog "skipping non-existent output $output"
+    return 0
+  fi
+  nixInfoLog "running on $output"
+
+  # NOTE: path is absolute because we're running `find` against an absolute path (`output`).
+  while IFS= read -r -d $'\0' path; do
+    pathParent="$(dirname "$path")"
+    symlinkTarget="$(readlink "$path")"
+
+    # Canonicalize symlinkTarget to an absolute path.
+    if [[ $symlinkTarget == /* ]]; then
+      nixInfoLog "symlink $path points to absolute target $symlinkTarget"
+    else
+      nixInfoLog "symlink $path points to relative target $symlinkTarget"
+      symlinkTarget="$pathParent/$symlinkTarget"
+
+      # Check to make sure the interpolated target doesn't escape the store path of `output`.
+      # If it does, Nix probably won't be able to resolve or track dependencies.
+      if [[ $symlinkTarget != "$output" && $symlinkTarget != "$output"/* ]]; then
+        nixErrorLog "symlink $path points to target $symlinkTarget, which escapes the current store path $output"
+        return 1
+      fi
+    fi
+
+    if [[ ! -e $symlinkTarget ]]; then
+      # symlinkTarget does not exist
+      errorMessage="the symlink $path points to a missing target $symlinkTarget"
+      if [[ -z ${allowDanglingSymlinks-} ]]; then
+        nixErrorLog "$errorMessage"
+        numDanglingSymlinks+=1
+      else
+        nixInfoLog "$errorMessage"
+      fi
+
+    elif [[ $path == "$symlinkTarget" ]]; then
+      # symlinkTarget is exists and is reflexive
+      errorMessage="the symlink $path is reflexive $symlinkTarget"
+      if [[ -z ${allowReflexiveSymlinks-} ]]; then
+        nixErrorLog "$errorMessage"
+        numReflexiveSymlinks+=1
+      else
+        nixInfoLog "$errorMessage"
+      fi
+
+    else
+      # symlinkTarget exists and is irreflexive
+      nixInfoLog "the symlink $path is irreflexive and points to a target which exists"
+    fi
+  done < <(find "$output" -type l -print0)
+
+  if ((numDanglingSymlinks > 0 || numReflexiveSymlinks > 0)); then
+    nixErrorLog "found $numDanglingSymlinks dangling symlinks and $numReflexiveSymlinks reflexive symlinks"
+    return 1
+  fi
+  return 0
+}
+
+noBrokenSymlinksInAllOutputs() {
+  if [[ -z ${dontCheckForBrokenSymlinks-} ]]; then
+    for output in $(getAllOutputNames); do
+      noBrokenSymlinks "${!output}"
+    done
+  fi
+}

--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -77,6 +77,7 @@ let
           ../../build-support/setup-hooks/move-sbin.sh
           ../../build-support/setup-hooks/move-systemd-user-units.sh
           ../../build-support/setup-hooks/multiple-outputs.sh
+          ../../build-support/setup-hooks/no-broken-symlinks.sh
           ../../build-support/setup-hooks/patch-shebangs.sh
           ../../build-support/setup-hooks/prune-libtool-files.sh
           ../../build-support/setup-hooks/reproducible-builds.sh

--- a/pkgs/test/stdenv/hooks.nix
+++ b/pkgs/test/stdenv/hooks.nix
@@ -97,6 +97,7 @@
       [[ -e $out/bin/foo ]]
     '';
   };
+  no-broken-symlinks = import ./no-broken-symlinks.nix { inherit stdenv lib pkgs; };
   # TODO: add multiple-outputs
   patch-shebangs = import ./patch-shebangs.nix { inherit stdenv lib pkgs; };
   prune-libtool-files =

--- a/pkgs/test/stdenv/no-broken-symlinks.nix
+++ b/pkgs/test/stdenv/no-broken-symlinks.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  pkgs,
+  stdenv,
+}:
+
+let
+  inherit (lib.strings) concatStringsSep;
+  inherit (pkgs) runCommand;
+  inherit (pkgs.testers) testBuildFailure;
+
+  mkDanglingSymlink = ''
+    ln -sr "$out/dangling" "$out/dangling-symlink"
+  '';
+
+  mkReflexiveSymlink = ''
+    ln -sr "$out/reflexive-symlink" "$out/reflexive-symlink"
+  '';
+
+  mkValidSymlink = ''
+    touch "$out/valid"
+    ln -sr "$out/valid" "$out/valid-symlink"
+  '';
+
+  testBuilder =
+    {
+      name,
+      commands ? [ ],
+      derivationArgs ? { },
+    }:
+    stdenv.mkDerivation (
+      {
+        inherit name;
+        strictDeps = true;
+        dontUnpack = true;
+        dontPatch = true;
+        dontConfigure = true;
+        dontBuild = true;
+        installPhase =
+          ''
+            mkdir -p "$out"
+
+          ''
+          + concatStringsSep "\n" commands;
+      }
+      // derivationArgs
+    );
+in
+{
+  # Dangling symlinks (allowDanglingSymlinks)
+  fail-dangling-symlink =
+    runCommand "fail-dangling-symlink"
+      {
+        failed = testBuildFailure (testBuilder {
+          name = "fail-dangling-symlink-inner";
+          commands = [ mkDanglingSymlink ];
+        });
+      }
+      ''
+        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
+        grep -F 'found 1 dangling symlinks and 0 reflexive symlinks' "$failed/testBuildFailure.log"
+        touch $out
+      '';
+
+  pass-dangling-symlink-allowed = testBuilder {
+    name = "pass-symlink-dangling-allowed";
+    commands = [ mkDanglingSymlink ];
+    derivationArgs.allowDanglingSymlinks = true;
+  };
+
+  # Reflexive symlinks (allowReflexiveSymlinks)
+  fail-reflexive-symlink =
+    runCommand "fail-reflexive-symlink"
+      {
+        failed = testBuildFailure (testBuilder {
+          name = "fail-reflexive-symlink-inner";
+          commands = [ mkReflexiveSymlink ];
+        });
+      }
+      ''
+        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
+        grep -F 'found 0 dangling symlinks and 1 reflexive symlinks' "$failed/testBuildFailure.log"
+        touch $out
+      '';
+
+  pass-reflexive-symlink-allowed = testBuilder {
+    name = "pass-reflexive-symlink-allowed";
+    commands = [ mkReflexiveSymlink ];
+    derivationArgs.allowReflexiveSymlinks = true;
+  };
+
+  # Global (dontCheckForBrokenSymlinks)
+  fail-broken-symlinks =
+    runCommand "fail-broken-symlinks"
+      {
+        failed = testBuildFailure (testBuilder {
+          name = "fail-broken-symlinks-inner";
+          commands = [
+            mkDanglingSymlink
+            mkReflexiveSymlink
+          ];
+        });
+      }
+      ''
+        (( 1 == "$(cat "$failed/testBuildFailure.exit")" ))
+        grep -F 'found 1 dangling symlinks and 1 reflexive symlinks' "$failed/testBuildFailure.log"
+        touch $out
+      '';
+
+  pass-broken-symlinks-allowed = testBuilder {
+    name = "fail-broken-symlinks-allowed";
+    commands = [
+      mkDanglingSymlink
+      mkReflexiveSymlink
+    ];
+    derivationArgs.dontCheckForBrokenSymlinks = true;
+  };
+
+  pass-valid-symlink = testBuilder {
+    name = "pass-valid-symlink";
+    commands = [ mkValidSymlink ];
+  };
+}


### PR DESCRIPTION
Adds a setup hook which checks for broken symlinks; a symlink is considered broken if it's dangling (target doesn't exist) or reflexive (it refers to itself).

In my experience, outputs with broken symlinks are generally errors, and so we should provide a hook which can catch and report them.

The hook can be disabled by setting `dontCheckForBrokenSymlinks`.

## Future work

Fixup PRs:

- #376043
- #376202
- ~~#376210~~ (superseded by #376261)
- ~~#376218~~ (superseded by #376261)
- #376261

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
