### PR TITLE
firebase-tools: enable building on node 22

### DIFF
--- a/pkgs/by-name/fi/firebase-tools/001-override-nan.patch
+++ b/pkgs/by-name/fi/firebase-tools/001-override-nan.patch
@@ -1,0 +1,54 @@
+diff --git a/npm-shrinkwrap.json b/npm-shrinkwrap.json
+index da429c128..9c69ec8cb 100644
+--- a/npm-shrinkwrap.json
++++ b/npm-shrinkwrap.json
+@@ -14637,9 +14637,10 @@
+       }
+     },
+     "node_modules/nan": {
+-      "version": "2.17.0",
+-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
++      "version": "2.22.0",
++      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
++      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
++      "license": "MIT",
+       "optional": true
+     },
+     "node_modules/nanoid": {
+@@ -31852,9 +31853,9 @@
+       }
+     },
+     "nan": {
+-      "version": "2.17.0",
+-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
++      "version": "2.22.0",
++      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
++      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+       "optional": true
+     },
+     "nanoid": {
+@@ -33672,7 +33673,7 @@
+       "optional": true,
+       "requires": {
+         "install-artifact-from-github": "^1.3.1",
+-        "nan": "^2.17.0",
++        "nan": "^2.22.0",
+         "node-gyp": "^9.3.0"
+       }
+     },
+diff --git a/package.json b/package.json
+index a4284d841..90a0524f2 100644
+--- a/package.json
++++ b/package.json
+@@ -98,6 +98,9 @@
+       "src/test/**/*"
+     ]
+   },
++  "overrides" : {
++    "nan": "^2.22.0"
++  },
+   "dependencies": {
+     "@electric-sql/pglite": "^0.2.0",
+     "@google-cloud/cloud-sql-connector": "^1.3.3",

--- a/pkgs/by-name/fi/firebase-tools/package.nix
+++ b/pkgs/by-name/fi/firebase-tools/package.nix
@@ -5,8 +5,8 @@
   fetchFromGitHub,
   python3,
   xcbuild,
+  fetchpatch,
 }:
-
 let
   version = "13.29.1";
   src = fetchFromGitHub {
@@ -20,7 +20,18 @@ buildNpmPackage {
   pname = "firebase-tools";
   inherit version src;
 
-  npmDepsHash = "sha256-3+XeXK3VGIs4Foi9iW9Kho/Y0JsTQZ7p+582MPgdH1A=";
+  npmDepsHash = "sha256-lQmoemIxzy2biu80UTR2eA+KJBeXWPh0xZRs/1of0eo=";
+
+  patches = [
+    # Use modern version of `ajv` instead of the four year old default in 13.29.1
+    (fetchpatch {
+      name = "bump-ajv.patch";
+      url = "https://github.com/firebase/firebase-tools/commit/b684155d827e7d1e8390e22511c0e1b5c46812ef.patch";
+      hash = "sha256-yv2AknT85Eyurc1ZFbbF5S9Sj/VEaVnHXBcXI10OWpw=";
+    })
+    # Fix embedded nan version to support node 22
+    ./001-override-nan.patch
+  ];
 
   postPatch = ''
     ln -s npm-shrinkwrap.json package-lock.json


### PR DESCRIPTION
1. Pulls in an upstream patch to replace the four-year old `ajv` JSON validator with a modern version. It was triggering compilation problems when built in the sandbox.
2. Adds a local patch to override `nan` -- the node native interfaces -- to a version supporting node 22 (and earlier).

Fixes #369813

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
