### PR TITLE
python3Packages.pdfposter: drop dependency on pypdf2

### DIFF
--- a/pkgs/by-name/pd/pdfposter/port-to-python-library-pypdf-version-3.patch
+++ b/pkgs/by-name/pd/pdfposter/port-to-python-library-pypdf-version-3.patch
@@ -1,0 +1,84 @@
+Patch based on upstream commit 066aeb918db7504f21ee9127b35603a06101a72a
+
+The PyPdf2 package changed a lot and was renamed to just `pypdf`.
+---
+
+diff --git a/docs/Installation.rst b/docs/Installation.rst
+index ec55082..ab18154 100644
+--- a/docs/Installation.rst
++++ b/docs/Installation.rst
+@@ -51,11 +51,11 @@ If this is not provided, please refer to the
+ `pip homepage <https://pip.pypa.io/en/stable/installing/>`_ for help.
+ 
+ 
+-Optionally you might want to install `PyPDF2`
++Optionally you might want to install `pypdf`
+ - which is a requirement for |pdfposter| -
+ provided by your distribution or vendor
+ so at least this package will be maintained by your distribution.
+-Check for a package named ``python-pypdf2`` or that like.
++Check for a package named ``python3-pypdf`` or that like.
+ 
+ Then continue with :ref:`installing pdfposter` below.
+ 
+@@ -65,7 +65,7 @@ Then continue with :ref:`installing pdfposter` below.
+ Installing |pdfposter| using :command:`pip`
+ ---------------------------------------------
+ 
+-After installing `Python` (and optionally `PyPDF2`), just run::
++After installing `Python` (and optionally `pypdf`), just run::
+ 
+   sudo pip install pdfposter
+ 
+diff --git a/pdftools/pdfposter/__init__.py b/pdftools/pdfposter/__init__.py
+index 838795e..6b4a36d 100644
+--- a/pdftools/pdfposter/__init__.py
++++ b/pdftools/pdfposter/__init__.py
+@@ -24,9 +24,9 @@ __copyright__ = "Copyright 2008-2022 by Hartmut Goebel <h.goebel@crazy-compilers
+ __license__ = "SPDX-License-Identifier: GPL-3.0-or-later"
+ __version__ = "0.8.1"
+ 
+-from PyPDF2 import PdfWriter, PdfReader, PageObject
+-from PyPDF2.types import NameObject
+-from PyPDF2.generic import ContentStream, RectangleObject, IndirectObject
++from pypdf import PdfWriter, PdfReader, PageObject
++from pypdf.types import NameObject
++from pypdf.generic import ContentStream, RectangleObject, IndirectObject
+ 
+ import logging
+ from logging import log
+diff --git a/pdftools/pdfposter/cmd.py b/pdftools/pdfposter/cmd.py
+index 51d87aa..9a20357 100644
+--- a/pdftools/pdfposter/cmd.py
++++ b/pdftools/pdfposter/cmd.py
+@@ -27,7 +27,7 @@ __license__ = "SPDX-License-Identifier: GPL-3.0-or-later"
+ from . import main, __version__, DEFAULT_MEDIASIZE, papersizes, DecryptionError
+ from .i18n import _
+ import re
+-import PyPDF2.errors
++import pypdf.errors
+ import argparse
+ 
+ # pattern for parsing user textual box spec
+@@ -192,7 +192,7 @@ try:
+         main(args, infilename=args.infilename, outfilename=args.outfilename)
+     except DecryptionError as e:
+         raise SystemExit(str(e))
+-    except PyPDF2.errors.PdfReadError as e:
++    except pypdf.errors.PdfReadError as e:
+         parser.error('The input-file is either currupt or no PDF at all: %s'
+                      % e)
+ 
+diff --git a/setup.cfg b/setup.cfg
+index 9616800..1e2f2d6 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -41,7 +41,7 @@ namespace_packages = pdftools
+ include_package_data = True
+ zip_safe = True
+ install_requires = 
+-	PyPDF2 >= 2.1.1, < 3
++ pypdf >= 3.0, < 5 
+ 
+ [options.entry_points]
+ console_scripts = 


### PR DESCRIPTION
We adopt the (not yet released) upstream patch to use pypdf (the successor pf pypdf2).

Includes a bit of refactoring of the derivation.

supersedes https://github.com/NixOS/nixpkgs/pull/370674

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
