### PR TITLE
python3Packages.taichi: init at 1.7.3

### DIFF
--- a/pkgs/development/python-modules/taichi/default.nix
+++ b/pkgs/development/python-modules/taichi/default.nix
@@ -1,0 +1,244 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildPythonPackage,
+  autoPatchelfHook,
+  versionCheckHook,
+  autoAddDriverRunpath,
+  llvmPackages_15,
+  cmake,
+  ninja,
+  setuptools,
+  wheel,
+  pybind11,
+  scikit-build,
+  git,
+  pythonImportsCheckHook,
+  pythonCatchConflictsHook,
+
+  colorama,
+  dill,
+  matplotlib,
+  numpy,
+  rich,
+
+  cudaPackages,
+  elfutils,
+  libbfd,
+  libdwarf,
+  libffi,
+  libGL,
+  libX11,
+  libXrandr,
+  libXinerama,
+  libXcursor,
+  libXi,
+  libxml2,
+  vulkan-headers,
+  vulkan-loader,
+
+  gtest,
+  pytest,
+
+  config,
+  cudaSupport ? config.cudaSupport,
+  rocmSupport ? config.rocmSupport,
+  stdenv,
+  enableMetal ? stdenv.isDarwin,
+  enableOpenGL ? stdenv.isLinux,
+  enableVulkan ? stdenv.isLinux,
+}:
+let
+  pname = "taichi";
+  version = "1.7.3";
+  src = fetchFromGitHub {
+    owner = "taichi-dev";
+    repo = pname;
+    tag = "v${version}";
+    hash = "sha256-QWtxPgR8RGnIEpbGO18Y8TFNhbKd4pOi9VLEkK2nhfk=";
+    fetchSubmodules = true;
+    # leaveDotGit = true;
+  };
+
+  llvmPackages = llvmPackages_15;
+  libllvm = llvmPackages.libllvm;
+  stdenv = llvmPackages.stdenv;
+
+  platformLibs =
+    lib.optionals cudaSupport [ cudaPackages.cudatoolkit ]
+    ++ lib.optionals enableMetal [ ]
+    ++ lib.optionals rocmSupport [ ]
+    ++ lib.optionals enableVulkan [
+      vulkan-loader
+      vulkan-headers
+    ]
+    ++ lib.optionals enableOpenGL [ libGL ];
+
+  # If the flag is a boolean, we'll pass "ON" or "OFF" to CMake.
+  # Otherwise, we'll pass the value of the flag.
+  cmakeFlag =
+    cflag: flag:
+    "-D" + cflag + "=" + (if (lib.typeOf flag == "bool") then (if flag then "ON" else "OFF") else flag);
+
+  cmakeFlags = lib.attrsets.mapAttrsToList (name: value: (cmakeFlag name value)) {
+    TI_BUILD_EXAMPLES = true;
+    TI_BUILD_RHI_EXAMPLES = true;
+    TI_BUILD_TESTS = true;
+    TI_WITH_BACKTRACE = stdenv.isLinux;
+    TI_WITH_C_API = true;
+    TI_WITH_GGUI = true;
+    TI_WITH_STATIC_C_API = with stdenv; (isDarwin && isAarch64);
+    TI_WITH_PYTHON = true;
+    TI_WITH_AMDGPU = rocmSupport;
+    TI_WITH_CUDA = cudaSupport;
+    TI_WITH_CUDA_TOOLKIT = false;
+    TI_WITH_LLVM = true;
+    TI_WITH_METAL = enableMetal;
+    TI_WITH_OPENGL = enableOpenGL;
+    TI_WITH_VULKAN = enableVulkan;
+
+    # Should be resolved with buildinputs, not as a flag!
+    LIBDWARF_INCLUDE_DIR = "${lib.getInclude libdwarf}/include";
+  };
+
+  # The echos are for debugging purposes
+  # Can be removed later
+  preConfigure = ''
+    echo "CUDA:   ${builtins.toString cudaSupport}"
+    echo "Metal:  ${builtins.toString enableMetal}"
+    echo "ROCm:   ${builtins.toString rocmSupport}"
+
+    echo "OpenGL: ${builtins.toString enableOpenGL}"
+    echo "Vulkan: ${builtins.toString enableVulkan}"
+
+    echo "Platform libs: ${builtins.toString platformLibs}"
+
+    git init
+    git config user.email "you@example.com"
+    git commit -m "initial commit" --allow-empty
+    git describe --match=DummyTagNotExisting --always --abbrev=40 --dirty
+    # echo "${src.gitRepoUrl}"
+    # git clone --no-checkout --depth 1 --branch ${src.tag} ${src.gitRepoUrl} ./tmp
+    # cp -t ./tmp/.git .
+    # rm -rf ./tmp
+  '';
+
+  taichi = stdenv.mkDerivation {
+    inherit
+      pname
+      version
+      src
+      cmakeFlags
+      preConfigure
+      ;
+
+    propagatedNativeBuildInputs = [
+      autoPatchelfHook
+      cmake
+      pybind11
+      git
+    ] ++ lib.optionals cudaSupport [ autoAddDriverRunpath ];
+
+    propagatedBuildInputs = [
+      elfutils
+      libbfd
+      libdwarf
+      libdwarf.dev
+      libffi.dev
+      libxml2.dev
+
+      libX11
+      libXrandr
+      libXinerama
+      libXcursor
+      libXi
+
+      libllvm
+    ] ++ platformLibs;
+
+    # See https://github.com/NixOS/nixpkgs/issues/144170
+    # Taken from original PR,
+    # maybe this is more future proof:
+    # https://github.com/NixOS/nixpkgs/issues/144170#issuecomment-1423195220
+    postPatch = ''
+      substituteInPlace \
+        external/SPIRV-Headers/SPIRV-Headers.pc.in \
+        external/SPIRV-Cross/pkg-config/spirv-cross-c-shared.pc.in \
+        external/SPIRV-Tools/cmake/SPIRV-Tools.pc.in \
+        external/SPIRV-Tools/cmake/SPIRV-Tools-shared.pc.in \
+        --replace-warn '$'{prefix}/@CMAKE_INSTALL_LIBDIR@ @CMAKE_INSTALL_FULL_LIBDIR@  \
+        --replace-warn '$'{prefix}/@CMAKE_INSTALL_INCLUDEDIR@ @CMAKE_INSTALL_FULL_INCLUDEDIR@
+    '';
+
+    doCheck = true;
+    nativeCheckInputs = [ gtest ];
+  };
+in
+buildPythonPackage {
+  inherit
+    pname
+    version
+    src
+    cmakeFlags
+    stdenv
+    preConfigure
+    ;
+
+  nativeBuildInputs =
+    [
+      ninja
+      numpy
+      scikit-build
+      setuptools
+      wheel
+    ]
+    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+      pythonImportsCheckHook
+      pythonCatchConflictsHook
+    ];
+
+  buildInputs = [
+    taichi
+  ];
+
+  dependencies = [
+    colorama
+    dill
+    matplotlib
+    numpy
+    rich
+  ];
+
+  postConfigure = ''
+    cd ..
+  '';
+
+  # This is needed for the libraries like opengl and vulkan to be found at runtime
+  preInstallCheck = ''
+    shopt -s globstar
+
+    for file in $out/**/*.so; do
+      patchelf --add-rpath "${lib.makeLibraryPath platformLibs}" "$file"
+    done
+  '';
+
+  dontUseNinjaCheck = true;
+
+  nativeCheckInputs = [ pytest ];
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  pythonImportsCheck = [ "taichi" ];
+
+  meta = {
+    description = "Productive & portable high-performance programming in Python";
+    homepage = "https://github.com/taichi-dev/taichi";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ arunoruto ];
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+    mainProgram = "ti";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15335,6 +15335,10 @@ self: super: with self; {
 
   tahoma-api = callPackage ../development/python-modules/tahoma-api { };
 
+  taichi = callPackage ../development/python-modules/taichi {
+    inherit (pkgs.config) cudaSupport rocmSupport;
+  };
+
   tailer = callPackage ../development/python-modules/tailer { };
 
   tailscale = callPackage ../development/python-modules/tailscale { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
closes: #143181

Continuation of #367617, but instead of building from PyPI, this one builds from source!
- [x] OpenGL support works
- [ ] Vulkan support is missing something, compared to #367617.
- [ ] CUDA support is broken with `[llvm_context.cpp:operator()@80] LLVM Fatal Error: Undefined external symbol "__stack_chk_fail"`.
- [ ] ROCm is still in beta, and while `rocmPackages` are not updated to `6.3.x`, I won't be testing it.

TODO:
- [x] The hash needs to be refetched from time to time. Maybe due to the submodules or that the `.git` directory is still present.
      **Solution**: faking a `.git` folder.

Submodules found under `external`:
- [ ] ~~DirectX-Headers~~ Not needed, now windows support
- [ ] FP16: doesn't seem hard to package [repo](https://github.com/Maratyszcza/FP16/tree/master)
- [ ] PicoSHA2: doesn't seem hard to package [repo](https://github.com/okdshin/PicoSHA2/tree/master)
- [x] [SPIRV-Cross](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/sp/spirv-cross/package.nix)
- [x] [SPIRV-Headers](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/sp/spirv-headers/package.nix)
- [ ] SPIRV-Reflect: could be added too! [repo](https://github.com/KhronosGroup/SPIRV-Reflect)
- [x] [SPIRV-Tools](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/sp/spirv-tools/package.nix)
- [x] [Vulkan-Headers](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/libraries/vulkan-headers/default.nix)
- [x] [VulkanMemoryAllocator](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/vu/vulkan-memory-allocator/package.nix)
- [ ] assets: maybe not needed? but can be fetched, not a huge burden
- [x] [backward_cpp](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ba/backward-cpp/package.nix)
- [x] [eigen](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/libraries/eigen/default.nix)
- [ ] [glad](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/glad/default.nix): it is packaged, but taichi uses [their own version](https://github.com/taichi-dev/taichi_glad_ready/tree/master)
- [ ] [glfw](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/gl/glfw3/package.nix): taichi uses [their own version](https://github.com/taichi-dev/glfw/tree/cf9263d56662ee7fcc18add84d91243167cc0328)
- [x] [glm](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/gl/glm/package.nix)
- [x] [googletest](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/gt/gtest/package.nix)
- [x] [imgui](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/libraries/imgui/default.nix)
- [x] [spdlog](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/sp/spdlog/package.nix)
- [x] [volk](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/vu/vulkan-volk/package.nix)
`amdgpu_libdevice`, `cuda_libdevice`, and `include` are local folders.

Some of the submodules are frozen to certain commits, so if we would move to building using the version from nixpkgs instead of those, one needs to check first if everything still works!
*Con*: does it still compile/work with newer versions? 📉 
*Pro*: easier dependency maintenance 📈 👀 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
