### PR TITLE
dotnet: improve language coverage of passthru.tests for dotnet sdks

### DIFF
--- a/pkgs/development/compilers/dotnet/wrapper.nix
+++ b/pkgs/development/compilers/dotnet/wrapper.nix
@@ -104,7 +104,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           let
             sdk = finalAttrs.finalPackage;
             built = stdenv.mkDerivation {
-              name = "dotnet-test-${name}";
+              name = "${sdk.name}-test-${name}";
               buildInputs = [ sdk ] ++ buildInputs ++ lib.optional (usePackageSource) sdk.packages;
               # make sure ICU works in a sandbox
               propagatedSandboxProfile = toString sdk.__propagatedSandboxProfile;

--- a/pkgs/development/compilers/dotnet/wrapper.nix
+++ b/pkgs/development/compilers/dotnet/wrapper.nix
@@ -288,6 +288,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
           # yes, older SDKs omit the comma
           cs = mkConsoleTests "C#" "cs" "Hello,?\\ World!";
           fs = mkConsoleTests "F#" "fs" "Hello\\ from\\ F#";
+          vb = mkConsoleTests "VB" "vb" "Hello,?\\ World!";
         };
 
         web = lib.recurseIntoAttrs {

--- a/pkgs/development/compilers/dotnet/wrapper.nix
+++ b/pkgs/development/compilers/dotnet/wrapper.nix
@@ -82,6 +82,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   postFixup = lib.optionalString (unwrapped ? man) ''
     ln -s ${unwrapped.man} "$man"
   '';
+
   passthru = unwrapped.passthru // {
     inherit unwrapped;
     tests =
@@ -91,6 +92,7 @@ stdenvNoCC.mkDerivation (finalAttrs: {
             name,
             stdenv ? stdenvNoCC,
             template,
+            lang ? null,
             usePackageSource ? false,
             build,
             buildInputs ? [ ],
@@ -106,16 +108,28 @@ stdenvNoCC.mkDerivation (finalAttrs: {
               buildInputs = [ sdk ] ++ buildInputs ++ lib.optional (usePackageSource) sdk.packages;
               # make sure ICU works in a sandbox
               propagatedSandboxProfile = toString sdk.__propagatedSandboxProfile;
-              unpackPhase = ''
-                mkdir test
-                cd test
-                dotnet new ${template} -o . --no-restore
-              '';
+              unpackPhase =
+                let
+                  unpackArgs =
+                    [ template ]
+                    ++ lib.optionals (lang != null) [
+                      "-lang"
+                      lang
+                    ];
+                in
+                ''
+                  mkdir test
+                  cd test
+                  dotnet new ${lib.escapeShellArgs unpackArgs} -o . --no-restore
+                '';
               buildPhase = build;
               dontPatchELF = true;
             };
           in
-          if run == null then
+          # older SDKs don't include an embedded FSharp.Core package
+          if lang == "F#" && lib.versionOlder sdk.version "6.0.400" then
+            null
+          else if run == null then
             built
           else
             runCommand "${built.name}-run"
@@ -142,61 +156,90 @@ stdenvNoCC.mkDerivation (finalAttrs: {
                 + run
               );
 
-        # Setting LANG to something other than 'C' forces the runtime to search
-        # for ICU, which will be required in most user environments.
-        checkConsoleOutput = command: ''
-          output="$(LANG=C.UTF-8 ${command})"
-          # yes, older SDKs omit the comma
-          [[ "$output" =~ Hello,?\ World! ]] && touch "$out"
-        '';
-      in
-      unwrapped.passthru.tests or { }
-      // {
-        version = testers.testVersion (
-          {
-            package = finalAttrs.finalPackage;
+        mkConsoleTests =
+          lang: suffix: output:
+          let
+            # Setting LANG to something other than 'C' forces the runtime to search
+            # for ICU, which will be required in most user environments.
+            checkConsoleOutput = command: ''
+              output="$(LANG=C.UTF-8 ${command})"
+              [[ "$output" =~ ${output} ]] && touch "$out"
+            '';
+
+            mkConsoleTest =
+              { name, ... }@args:
+              mkDotnetTest (
+                args
+                // {
+                  name = "console-${name}-${suffix}";
+                  template = "console";
+                  inherit lang;
+                }
+              );
+          in
+          lib.recurseIntoAttrs {
+            run = mkConsoleTest {
+              name = "run";
+              build = checkConsoleOutput "dotnet run";
+            };
+
+            publish = mkConsoleTest {
+              name = "publish";
+              build = "dotnet publish -o $out/bin";
+              run = checkConsoleOutput "$src/bin/test";
+            };
+
+            self-contained = mkConsoleTest {
+              name = "self-contained";
+              usePackageSource = true;
+              build = "dotnet publish --use-current-runtime --sc -o $out";
+              runtime = null;
+              run = checkConsoleOutput "$src/test";
+            };
+
+            single-file = mkConsoleTest {
+              name = "single-file";
+              usePackageSource = true;
+              build = "dotnet publish --use-current-runtime -p:PublishSingleFile=true -o $out/bin";
+              runtime = null;
+              run = checkConsoleOutput "$src/bin/test";
+            };
           }
-          // lib.optionalAttrs (type != "sdk") {
-            command = "dotnet --info";
-          }
-        );
-      }
-      // lib.optionalAttrs (type == "sdk") (
-        {
-          console = mkDotnetTest {
-            name = "console";
-            template = "console";
-            build = checkConsoleOutput "dotnet run";
+          // lib.optionalAttrs finalAttrs.finalPackage.hasILCompiler {
+            aot = mkConsoleTest {
+              name = "aot";
+              stdenv = if stdenv.hostPlatform.isDarwin then swiftPackages.stdenv else stdenv;
+              usePackageSource = true;
+              buildInputs =
+                [
+                  zlib
+                ]
+                ++ lib.optional stdenv.hostPlatform.isDarwin (
+                  with darwin;
+                  with apple_sdk.frameworks;
+                  [
+                    swiftPackages.swift
+                    Foundation
+                    CryptoKit
+                    GSS
+                    ICU
+                  ]
+                );
+              build = ''
+                dotnet restore -p:PublishAot=true
+                dotnet publish -p:PublishAot=true -o $out/bin
+              '';
+              runtime = null;
+              run = checkConsoleOutput "$src/bin/test";
+            };
           };
 
-          publish = mkDotnetTest {
-            name = "publish";
-            template = "console";
-            build = "dotnet publish -o $out/bin";
-            run = checkConsoleOutput "$src/bin/test";
-          };
-
-          self-contained = mkDotnetTest {
-            name = "self-contained";
-            template = "console";
-            usePackageSource = true;
-            build = "dotnet publish --use-current-runtime --sc -o $out";
-            runtime = null;
-            run = checkConsoleOutput "$src/test";
-          };
-
-          single-file = mkDotnetTest {
-            name = "single-file";
-            template = "console";
-            usePackageSource = true;
-            build = "dotnet publish --use-current-runtime -p:PublishSingleFile=true -o $out/bin";
-            runtime = null;
-            run = checkConsoleOutput "$src/bin/test";
-          };
-
-          web = mkDotnetTest {
-            name = "web";
+        mkWebTest =
+          lang: suffix:
+          mkDotnetTest {
+            name = "web-${suffix}";
             template = "web";
+            inherit lang;
             build = "dotnet publish -o $out/bin";
             runtime = finalAttrs.finalPackage.aspnetcore;
             runInputs = [
@@ -228,36 +271,29 @@ stdenvNoCC.mkDerivation (finalAttrs: {
             '';
             runAllowNetworking = true;
           };
-        }
-        // lib.optionalAttrs finalAttrs.finalPackage.hasILCompiler {
-          aot = mkDotnetTest {
-            name = "aot";
-            stdenv = if stdenv.hostPlatform.isDarwin then swiftPackages.stdenv else stdenv;
-            template = "console";
-            usePackageSource = true;
-            buildInputs =
-              [
-                zlib
-              ]
-              ++ lib.optional stdenv.hostPlatform.isDarwin (
-                with darwin;
-                with apple_sdk.frameworks;
-                [
-                  swiftPackages.swift
-                  Foundation
-                  CryptoKit
-                  GSS
-                  ICU
-                ]
-              );
-            build = ''
-              dotnet restore -p:PublishAot=true
-              dotnet publish -p:PublishAot=true -o $out/bin
-            '';
-            runtime = null;
-            run = checkConsoleOutput "$src/bin/test";
-          };
-        }
-      );
+      in
+      unwrapped.passthru.tests or { }
+      // {
+        version = testers.testVersion (
+          {
+            package = finalAttrs.finalPackage;
+          }
+          // lib.optionalAttrs (type != "sdk") {
+            command = "dotnet --info";
+          }
+        );
+      }
+      // lib.optionalAttrs (type == "sdk") ({
+        console = lib.recurseIntoAttrs {
+          # yes, older SDKs omit the comma
+          cs = mkConsoleTests "C#" "cs" "Hello,?\\ World!";
+          fs = mkConsoleTests "F#" "fs" "Hello\\ from\\ F#";
+        };
+
+        web = lib.recurseIntoAttrs {
+          cs = mkWebTest "C#" "cs";
+          fs = mkWebTest "F#" "fs";
+        };
+      });
   };
 })


### PR DESCRIPTION
This adds console tests for F# and VB, and a aspnet test for F#.

Cc: @NixOS/dotnet

This is mostly just rearranging things in `passthru.tests`.  `tests.aot` will now be `tests.console.cs.aot`, etc.  It seems uncommon to nest tests more deeply using `recurseIntoAttrs`, but it works with `nix build`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
