### PR TITLE
[Backport release-24.11] broot: 1.44.1 -> 1.44.4

### DIFF
--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -1,16 +1,17 @@
-{ lib
-, stdenv
-, rustPlatform
-, fetchFromGitHub
-, installShellFiles
-, makeWrapper
-, pkg-config
-, libgit2
-, oniguruma
-, zlib
-, buildPackages
-, withClipboard ? true
-, withTrash ? !stdenv.hostPlatform.isDarwin
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+  installShellFiles,
+  makeWrapper,
+  pkg-config,
+  libgit2,
+  oniguruma,
+  zlib,
+  buildPackages,
+  withClipboard ? true,
+  withTrash ? !stdenv.hostPlatform.isDarwin,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -33,9 +34,14 @@ rustPlatform.buildRustPackage rec {
   ];
 
   # TODO: once https://github.com/Canop/broot/issues/956 is released, oniguruma can be removed.
-  buildInputs = [ libgit2 oniguruma ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    zlib
-  ];
+  buildInputs =
+    [
+      libgit2
+      oniguruma
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      zlib
+    ];
 
   buildFeatures = lib.optionals withTrash [ "trash" ] ++ lib.optionals withClipboard [ "clipboard" ];
 
@@ -48,34 +54,36 @@ rustPlatform.buildRustPackage rec {
       --replace "#version" "${version}"
   '';
 
-  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
-    # Install shell function for bash.
-    ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function bash > br.bash
-    install -Dm0444 -t $out/etc/profile.d br.bash
+  postInstall =
+    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+      # Install shell function for bash.
+      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function bash > br.bash
+      install -Dm0444 -t $out/etc/profile.d br.bash
 
-    # Install shell function for zsh.
-    ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function zsh > br.zsh
-    install -Dm0444 br.zsh $out/share/zsh/site-functions/br
+      # Install shell function for zsh.
+      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function zsh > br.zsh
+      install -Dm0444 br.zsh $out/share/zsh/site-functions/br
 
-    # Install shell function for fish
-    ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function fish > br.fish
-    install -Dm0444 -t $out/share/fish/vendor_functions.d br.fish
+      # Install shell function for fish
+      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function fish > br.fish
+      install -Dm0444 -t $out/share/fish/vendor_functions.d br.fish
 
-  '' + ''
-    # install shell completion files
-    OUT_DIR=$releaseDir/build/broot-*/out
+    ''
+    + ''
+      # install shell completion files
+      OUT_DIR=$releaseDir/build/broot-*/out
 
-    installShellCompletion --bash $OUT_DIR/{br,broot}.bash
-    installShellCompletion --fish $OUT_DIR/{br,broot}.fish
-    installShellCompletion --zsh $OUT_DIR/{_br,_broot}
+      installShellCompletion --bash $OUT_DIR/{br,broot}.bash
+      installShellCompletion --fish $OUT_DIR/{br,broot}.fish
+      installShellCompletion --zsh $OUT_DIR/{_br,_broot}
 
-    installManPage man/broot.1
+      installManPage man/broot.1
 
-    # Do not nag users about installing shell integration, since
-    # it is impure.
-    wrapProgram $out/bin/broot \
-      --set BR_INSTALL no
-  '';
+      # Do not nag users about installing shell integration, since
+      # it is impure.
+      wrapProgram $out/bin/broot \
+        --set BR_INSTALL no
+    '';
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -7,13 +7,9 @@
 , pkg-config
 , libgit2
 , oniguruma
-, libiconv
-, Foundation
-, Security
-, xorg
 , zlib
 , buildPackages
-, withClipboard ? !stdenv.hostPlatform.isDarwin
+, withClipboard ? true
 , withTrash ? !stdenv.hostPlatform.isDarwin
 }:
 
@@ -36,10 +32,8 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs = [ libgit2 oniguruma xorg.libxcb ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    Foundation
-    libiconv
-    Security
+  # TODO: once https://github.com/Canop/broot/issues/956 is released, oniguruma can be removed.
+  buildInputs = [ libgit2 oniguruma ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     zlib
   ];
 

--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -16,16 +16,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "broot";
-  version = "1.44.2";
+  version = "1.44.3";
 
   src = fetchFromGitHub {
     owner = "Canop";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-rMAGnC1CcHYPLh199a+aKgVdm/xheUQIRSvF+HqeZQE=";
+    hash = "sha256-45QNcnx9sEjm02woIpxxLuir4Kep8SPlSZDdiifZNL8=";
   };
 
-  cargoHash = "sha256-DVH7dKJEkyBnjNtLK/xfO+Hlw+rr3wTKqyooj5JM2is=";
+  cargoHash = "sha256-2hqpltfKE8fIFlvXMQfXVT41jPILL/INXQRUHfi1EhY=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/br/broot/package.nix
+++ b/pkgs/by-name/br/broot/package.nix
@@ -16,16 +16,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "broot";
-  version = "1.44.3";
+  version = "1.44.4";
 
   src = fetchFromGitHub {
     owner = "Canop";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-45QNcnx9sEjm02woIpxxLuir4Kep8SPlSZDdiifZNL8=";
+    hash = "sha256-tNmhLEB2L+2KFzsVk8hjh6gB6pxAeHqssr3e/9FFAOA=";
   };
 
-  cargoHash = "sha256-2hqpltfKE8fIFlvXMQfXVT41jPILL/INXQRUHfi1EhY=";
+  cargoHash = "sha256-sQX282C4rYtkbk7koO3ep9O0hPDpYHNYhVKBlYyXqZw=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -19,16 +19,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "broot";
-  version = "1.44.1";
+  version = "1.44.2";
 
   src = fetchFromGitHub {
     owner = "Canop";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-Qyc4R5hvSal82/qywriH7agluu6miAC4Y7UUM3VATCo=";
+    hash = "sha256-rMAGnC1CcHYPLh199a+aKgVdm/xheUQIRSvF+HqeZQE=";
   };
 
-  cargoHash = "sha256-fsmwjr7EpzR/KKrGWoTeCOI7jmrlTYtjIksc205kRs8=";
+  cargoHash = "sha256-DVH7dKJEkyBnjNtLK/xfO+Hlw+rr3wTKqyooj5JM2is=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/tools/misc/broot/default.nix
+++ b/pkgs/tools/misc/broot/default.nix
@@ -1,21 +1,20 @@
-{
-  lib,
-  stdenv,
-  rustPlatform,
-  fetchFromGitHub,
-  installShellFiles,
-  makeWrapper,
-  pkg-config,
-  libgit2,
-  oniguruma,
-  libiconv,
-  Foundation,
-  Security,
-  xorg,
-  zlib,
-  buildPackages,
-  withClipboard ? !stdenv.hostPlatform.isDarwin,
-  withTrash ? !stdenv.hostPlatform.isDarwin,
+{ lib
+, stdenv
+, rustPlatform
+, fetchFromGitHub
+, installShellFiles
+, makeWrapper
+, pkg-config
+, libgit2
+, oniguruma
+, libiconv
+, Foundation
+, Security
+, xorg
+, zlib
+, buildPackages
+, withClipboard ? !stdenv.hostPlatform.isDarwin
+, withTrash ? !stdenv.hostPlatform.isDarwin
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -37,18 +36,12 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  buildInputs =
-    [
-      libgit2
-      oniguruma
-      xorg.libxcb
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      Foundation
-      libiconv
-      Security
-      zlib
-    ];
+  buildInputs = [ libgit2 oniguruma xorg.libxcb ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Foundation
+    libiconv
+    Security
+    zlib
+  ];
 
   buildFeatures = lib.optionals withTrash [ "trash" ] ++ lib.optionals withClipboard [ "clipboard" ];
 
@@ -61,36 +54,34 @@ rustPlatform.buildRustPackage rec {
       --replace "#version" "${version}"
   '';
 
-  postInstall =
-    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
-      # Install shell function for bash.
-      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function bash > br.bash
-      install -Dm0444 -t $out/etc/profile.d br.bash
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+    # Install shell function for bash.
+    ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function bash > br.bash
+    install -Dm0444 -t $out/etc/profile.d br.bash
 
-      # Install shell function for zsh.
-      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function zsh > br.zsh
-      install -Dm0444 br.zsh $out/share/zsh/site-functions/br
+    # Install shell function for zsh.
+    ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function zsh > br.zsh
+    install -Dm0444 br.zsh $out/share/zsh/site-functions/br
 
-      # Install shell function for fish
-      ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function fish > br.fish
-      install -Dm0444 -t $out/share/fish/vendor_functions.d br.fish
+    # Install shell function for fish
+    ${stdenv.hostPlatform.emulator buildPackages} $out/bin/broot --print-shell-function fish > br.fish
+    install -Dm0444 -t $out/share/fish/vendor_functions.d br.fish
 
-    ''
-    + ''
-      # install shell completion files
-      OUT_DIR=$releaseDir/build/broot-*/out
+  '' + ''
+    # install shell completion files
+    OUT_DIR=$releaseDir/build/broot-*/out
 
-      installShellCompletion --bash $OUT_DIR/{br,broot}.bash
-      installShellCompletion --fish $OUT_DIR/{br,broot}.fish
-      installShellCompletion --zsh $OUT_DIR/{_br,_broot}
+    installShellCompletion --bash $OUT_DIR/{br,broot}.bash
+    installShellCompletion --fish $OUT_DIR/{br,broot}.fish
+    installShellCompletion --zsh $OUT_DIR/{_br,_broot}
 
-      installManPage man/broot.1
+    installManPage man/broot.1
 
-      # Do not nag users about installing shell integration, since
-      # it is impure.
-      wrapProgram $out/bin/broot \
-        --set BR_INSTALL no
-    '';
+    # Do not nag users about installing shell integration, since
+    # it is impure.
+    wrapProgram $out/bin/broot \
+      --set BR_INSTALL no
+  '';
 
   doInstallCheck = true;
   installCheckPhase = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -2094,10 +2094,6 @@ with pkgs;
 
   brasero = callPackage ../tools/cd-dvd/brasero/wrapper.nix { };
 
-  broot = callPackage ../tools/misc/broot {
-    inherit (darwin.apple_sdk.frameworks) Foundation Security;
-  };
-
   ssdfs-utils = callPackage ../tools/filesystems/ssdfs-utils { };
 
   btlejack = python3Packages.callPackage ../applications/radio/btlejack { };


### PR DESCRIPTION
## Things done

Bot failed to backport broot: https://github.com/NixOS/nixpkgs/pull/369992#issuecomment-2569787503

### `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 370796`

---
#### `x86_64-linux`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>broot</li>
  </ul>
</details>

---
#### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>broot</li>
  </ul>
</details>

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
(cherry picked from commit c231b53)