### PR TITLE
libdwarf: 0.9.2 -> 0.11.1

### DIFF
--- a/pkgs/by-name/li/libdwarf/package.nix
+++ b/pkgs/by-name/li/libdwarf/package.nix
@@ -5,9 +5,9 @@
 }:
 
 callPackage ./common.nix rec {
-  version = "0.9.2";
+  version = "0.11.1";
   url = "https://www.prevanders.net/libdwarf-${version}.tar.xz";
-  hash = "sha512-9QK22kuW1ZYtoRl8SuUiv9soWElsSvGYEJ2ETgAhMYyypevJyM+fwuRDmZfKlUXGUMpPKPDZbLZrBcm4m5jy+A==";
+  hash = "sha512:d927b1d0e8dd1540c2f5da2a9d39b2914bb48225b2b9bdca94e7b36349358e1f537044eadc345f11d75de717fdda07ad99a8a7a5eb45e64fe4c79c37e165012f";
   buildInputs = [
     zlib
     zstd


### PR DESCRIPTION
Changes:
https://github.com/davea42/libdwarf-code/releases/tag/v0.11.1
https://github.com/davea42/libdwarf-code/releases/tag/v0.11.0
https://github.com/davea42/libdwarf-code/releases/tag/v0.10.1
https://github.com/davea42/libdwarf-code/releases/tag/v0.10.0



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

No new build failures.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 370814`

---
### `x86_64-linux`
<details>
  <summary>:x: 2 packages failed to build:</summary>
  <ul>
    <li>anbox</li>
    <li>ctypes_sh</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 9 packages built:</summary>
  <ul>
    <li>apitrace</li>
    <li>cpptrace</li>
    <li>dwarfdump (dwarfdump.bin ,dwarfdump.dev ,dwarfdump.lib ,libdwarf.bin)</li>
    <li>dwarfs</li>
    <li>elf-dissector</li>
    <li>libdwarf</li>
    <li>libdwarf.dev</li>
    <li>libdwarf.lib</li>
    <li>vengi-tools</li>
  </ul>
</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
