### PR TITLE
sage.lib, sage.test: clang-19 / darwin fixes

### DIFF
--- a/pkgs/by-name/sa/sage/sage-tests.nix
+++ b/pkgs/by-name/sa/sage/sage-tests.nix
@@ -49,6 +49,14 @@ stdenv.mkDerivation {
     makeWrapper "${sage-with-env}/bin/sage" "$out/bin/sage"
   '';
 
+  env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+    # prevent warnings about assigning LC_* to "C" resulting in broken tests
+    # when run in darwin sandbox
+    LC_ALL = "en_US.UTF-8";
+  };
+
+  # allow singular tests to pass in darwin sandbox
+  __darwinAllowLocalNetworking = true;
   doInstallCheck = true;
   installCheckPhase = ''
     export HOME="$TMPDIR/sage-home"

--- a/pkgs/by-name/sa/sage/sagelib.nix
+++ b/pkgs/by-name/sa/sage/sagelib.nix
@@ -1,4 +1,6 @@
 {
+  lib,
+  stdenv,
   sage-src,
   env-locations,
   python,
@@ -117,6 +119,13 @@ buildPythonPackage rec {
     libpng
     readline
   ];
+
+  env = lib.optionalAttrs stdenv.cc.isClang {
+    # code tries to assign a unsigned long to an int in an initialized list
+    # leading to this error.
+    # https://github.com/sagemath/sage/pull/39249
+    NIX_CFLAGS_COMPILE = "-Wno-error=c++11-narrowing-const-reference";
+  };
 
   propagatedBuildInputs = [
     # native dependencies (TODO: determine which ones need to be propagated)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

adds `NIX_CFLAGS_COMPILE = "-Wno-error=c++11-narrowing-const-reference";`  to workaround https://github.com/sagemath/sage/pull/39249

and some changes in `sage.test` to allow tests to succeed in sandbox.

once https://github.com/NixOS/nixpkgs/pull/370545 is merged sage should compile on darwin again (running now, have build with this change and a different lcalc fix).

given sage builds singular with a `flint3` without blas the link error in that is seen in standalone singular https://hydra.nixos.org/build/283880696 does not exist. (I have various fixes for it but no need to hold off fixing sage for them)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
