### PR TITLE
harlequin: 1.25.2 -> 1.25.2-unstable-2024-12-30

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -1,28 +1,30 @@
 {
   lib,
+  stdenv,
   python3Packages,
   fetchFromGitHub,
-  harlequin,
-  testers,
   nix-update-script,
-  versionCheckHook,
   glibcLocales,
   withPostgresAdapter ? true,
   withBigQueryAdapter ? true,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "harlequin";
-  version = "1.25.2";
+  version = "1.25.2-unstable-2024-12-30";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tconbeer";
     repo = "harlequin";
-    tag = "v${version}";
-    hash = "sha256-ov9pMvFzJAMfOM7JeSgnp6dZ424GiRaH7W5OCKin9Jk=";
+    rev = "7ef5327157c7617c1032c9128b487b32d1c91fea";
+    hash = "sha256-QoIjEfQgN6YWDDor4PxfeFkkFGAidUC0ZvHy+PqgnWs=";
   };
 
-  pythonRelaxDeps = [ "textual" ];
+  pythonRelaxDeps = [
+    "numpy"
+    "pyarrow"
+    "textual"
+  ];
 
   build-system = with python3Packages; [ poetry-core ];
 
@@ -65,18 +67,24 @@ python3Packages.buildPythonApplication rec {
 
   nativeCheckInputs =
     [
-      versionCheckHook
+      # FIX: restore on next release
+      # versionCheckHook
     ]
     ++ (with python3Packages; [
       pytest-asyncio
       pytestCheckHook
     ]);
 
-  disabledTests = [
-    # Tests require network access
-    "test_connect_extensions"
-    "test_connect_prql"
-  ];
+  disabledTests =
+    [
+      # Tests require network access
+      "test_connect_extensions"
+      "test_connect_prql"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.system == "aarch64-darwin") [
+      # Test incorrectly tries to load a dylib compiled for x86_64
+      "test_load_extension"
+    ];
 
   disabledTestPaths = [
     # Tests requires more setup


### PR DESCRIPTION
Fixing runtime issue with latest textual version (1.0.0) by switching to latest master commit of Harlequin.

Fixes https://github.com/NixOS/nixpkgs/issues/370797
Fixes https://github.com/NixOS/nixpkgs/issues/364867

Original PR: https://github.com/NixOS/nixpkgs/pull/365766

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

