### PR TITLE
qtox: 1.17.6 -> 1.18.0, switch to TokTok fork

### DIFF
--- a/pkgs/applications/networking/instant-messengers/qtox/default.nix
+++ b/pkgs/applications/networking/instant-messengers/qtox/default.nix
@@ -1,17 +1,14 @@
 { lib
 , stdenv
-, mkDerivation
 , fetchFromGitHub
 , cmake
 , pkg-config
 , perl
+, kdePackages
 , libtoxcore
 , libpthreadstubs
 , libXdmcp
 , libXScrnSaver
-, qtbase
-, qtsvg
-, qttools
 , ffmpeg
 , filter-audio
 , libexif
@@ -21,28 +18,27 @@
 , openal
 , pcre
 , qrencode
+, qt6
 , sqlcipher
-, AVFoundation
 }:
 
-mkDerivation rec {
+stdenv.mkDerivation rec {
   pname = "qtox";
-  version = "1.17.6";
+  version = "1.18.0";
 
   src = fetchFromGitHub {
-    owner = "qTox";
+    owner = "TokTok";
     repo = "qTox";
-    rev = "v${version}";
-    sha256 = "sha256-naKWoodSMw0AEtACvkASFmw9t0H0d2pcqOW79NNTYF0=";
+    tag = "v${version}";
+    hash = "sha256-UgUlWeFrNoNR1ZwobfNLmDBn9/Aw4LUMeSgIfrq/uqo=";
   };
 
   buildInputs = [
+    kdePackages.sonnet
     libtoxcore
     libpthreadstubs
     libXdmcp
     libXScrnSaver
-    qtbase
-    qtsvg
     ffmpeg
     filter-audio
     libexif
@@ -52,17 +48,16 @@ mkDerivation rec {
     openal
     pcre
     qrencode
+    qt6.qtbase
+    qt6.qtsvg
     sqlcipher
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ AVFoundation ];
+  ];
 
-  nativeBuildInputs = [ cmake pkg-config qttools ]
+  nativeBuildInputs = [ cmake pkg-config qt6.qttools qt6.wrapQtAppsHook ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ perl ];
 
   cmakeFlags = [
     "-DGIT_DESCRIBE=v${version}"
-    "-DENABLE_STATUSNOTIFIER=False"
-    "-DENABLE_GTK_SYSTRAY=False"
-    "-DENABLE_APPINDICATOR=False"
     "-DTIMESTAMP=1"
   ];
 

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15052,9 +15052,7 @@ with pkgs;
 
   qtemu = libsForQt5.callPackage ../applications/virtualization/qtemu { };
 
-  qtox = libsForQt5.callPackage ../applications/networking/instant-messengers/qtox {
-    inherit (darwin.apple_sdk.frameworks) AVFoundation;
-  };
+  qtox = callPackage ../applications/networking/instant-messengers/qtox { };
 
   qtpass = libsForQt5.callPackage ../applications/misc/qtpass { };
 


### PR DESCRIPTION
The original qTox is unmaintained, the repo is archived since Feb 2023.

Upstream warns about unofficial forks, however:

* TokTok are the maintainers of toxcore
* qtox.meta.homepage was set to tox.chat and the TokTok fork is listed in the tox.chat client list

This also unbreaks the package, which is also broken on stable, so I added the backport label.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
