### PR TITLE
pypy310Packages.{flake8,pyflakes}: disable failing tests

### DIFF
--- a/pkgs/development/python-modules/flake8/default.nix
+++ b/pkgs/development/python-modules/flake8/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  isPyPy,
   pythonOlder,
   fetchFromGitHub,
   setuptools,
@@ -34,6 +35,12 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
+
+  disabledTests = lib.optionals isPyPy [
+    # tests fail due to slightly different error position
+    "test_tokenization_error_is_a_syntax_error"
+    "test_tokenization_error_but_not_syntax_error"
+  ];
 
   meta = with lib; {
     changelog = "https://github.com/PyCQA/flake8/blob/${src.rev}/docs/source/release-notes/${version}.rst";

--- a/pkgs/development/python-modules/pyflakes/default.nix
+++ b/pkgs/development/python-modules/pyflakes/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   buildPythonPackage,
+  isPyPy,
   pythonAtLeast,
   pythonOlder,
   fetchFromGitHub,
@@ -27,10 +28,17 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  disabledTests = lib.optionals (pythonAtLeast "3.13") [
-    # https://github.com/PyCQA/pyflakes/issues/812
-    "test_errors_syntax"
-  ];
+  disabledTests =
+    lib.optionals (pythonAtLeast "3.13") [
+      # https://github.com/PyCQA/pyflakes/issues/812
+      "test_errors_syntax"
+    ]
+    ++ lib.optionals isPyPy [
+      # https://github.com/PyCQA/pyflakes/issues/779
+      "test_eofSyntaxError"
+      "test_misencodedFileUTF8"
+      "test_multilineSyntaxError"
+    ];
 
   pythonImportsCheck = [ "pyflakes" ];
 


### PR DESCRIPTION
Upstream does not test this Pypy version: https://github.com/PyCQA/pyflakes/issues/779

Since the only difference is in the text of the error messages, the tests seem safe to disable.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).