### PR TITLE
init airwin2rack-juce 2.13.0

### DIFF
--- a/pkgs/by-name/ai/airwin2rack-juce/0000-juce-clap-juce-extensions-src-juce-cmakelists.patch
+++ b/pkgs/by-name/ai/airwin2rack-juce/0000-juce-clap-juce-extensions-src-juce-cmakelists.patch
@@ -1,0 +1,36 @@
+diff --git a/src-juce/CMakeLists.txt b/src-juce/CMakeLists.txt
+index 1f41088..10bdbb4 100644
+--- a/src-juce/CMakeLists.txt
++++ b/src-juce/CMakeLists.txt
+@@ -1,28 +1,8 @@
+ # vi:set sw=2 et:
+ project(airwin-consolidated VERSION ${CMAKE_PROJECT_VERSION})
+ 
+-include ("../cmake/CPM.cmake")
+-
+-
+-if (DEFINED AWCO_ONJUCE7)
+-  set(AWCO_JUCETAG 7.0.12)
+-else()
+-  set(AWCO_JUCETAG 8.0.4)
+-endif()
+-
+-message(STATUS "Getting JUCE TAG ${AWCO_JUCETAG}")
+-CPMAddPackage(
+-        NAME JUCE
+-        GITHUB_REPOSITORY juce-framework/JUCE
+-        GIT_TAG ${AWCO_JUCETAG} # specify the tag to a version of your choice
+-)
+-
+-CPMAddPackage(
+-        NAME clap-juce-extensions
+-        GITHUB_REPOSITORY free-audio/clap-juce-extensions
+-        GIT_TAG main
+-        SUBMODULE_RECURSIVE ON
+-)
++add_subdirectory(juce)
++add_subdirectory(clap-juce-extensions)
+ 
+ if (NOT DEFINED AWCO_ARM64EC)
+   list(APPEND AWCO_FORMATS VST3)
+

--- a/pkgs/by-name/ai/airwin2rack-juce/package.nix
+++ b/pkgs/by-name/ai/airwin2rack-juce/package.nix
@@ -1,0 +1,121 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  pkg-config,
+  gcc12,
+  alsa-lib,
+  xorg,
+  freetype,
+  libGLU,
+  libjack2,
+  juce,
+  unzip,
+}:
+let
+  juce' = juce.overrideAttrs rec {
+    version = "8.0.4";
+  };
+  clap-juce-extensions = fetchFromGitHub {
+    owner = "free-audio";
+    repo = "clap-juce-extensions";
+    rev = "4f33b4930b6af806018c009f0f24b3a50808af99";
+    hash = "sha256-M+T7ll3Ap6VIP5ub+kfEKwT2RW2IxxY4wUPRQKFIotk=";
+    fetchSubmodules = true;
+  };
+in
+stdenv.mkDerivation {
+  pname = "airwin2rack-juce";
+  version = "2.13.0";
+
+  src = fetchFromGitHub {
+    owner = "baconpaul";
+    repo = "airwin2rack";
+    rev = "db56d13f853831ab94a5e1713282e4e518f50d5c";
+    hash = "sha256-utqDmQgnYUtUv0E0xhO5rGx+9RXTAn8kKhTzkyXjcbE=";
+    fetchSubmodules = true;
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    gcc12
+    unzip
+  ];
+
+  buildInputs = [
+    gcc12
+    alsa-lib
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXext
+    xorg.libXinerama
+    xorg.libXrandr
+    xorg.libXrender
+    libGLU
+    libjack2
+    freetype
+    juce'
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_JUCE_PLUGIN" true)
+    (lib.cmakeBool "USE_JUCE_PROGRAMS" true)
+  ];
+
+  cmakeBuildType = "Release";
+
+  patches = [
+    ./0000-juce-clap-juce-extensions-src-juce-cmakelists.patch
+  ];
+
+  preConfigure = ''
+    ln -s ${juce'.src} src-juce/juce
+    ln -s ${clap-juce-extensions} src-juce/clap-juce-extensions
+  '';
+
+  buildPhase = ''
+    cmake --build . --config Release --target awcons-installer --parallel $NIX_BUILD_CORES
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p temp
+    unzip installer/AirwindowsConsolidated-1980-01-01-unknownhash-Linux.zip -d temp
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2 $out/lib/clap $out/bin
+
+    cp -r "temp/awcons-products/Airwindows Consolidated.vst3" $out/lib/vst3
+    cp -r "temp/awcons-products/Airwindows Consolidated.lv2" $out/lib/lv2
+    install -Dm644 "temp/awcons-products/Airwindows Consolidated.clap" -t $out/lib/clap
+
+    install -Dm755 "temp/awcons-products/Airwindows Consolidated" $out/bin/Airwindows\ Consolidated
+    ln -s $out/bin/Airwindows\ Consolidated $out/bin/airwindows-consolidated
+
+    runHook postInstall
+  '';
+
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcomposite"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-lXrender"
+    ]
+  );
+
+  meta = {
+    description = "JUCE Plugin Version of Airwindows Consolidated";
+    homepage = "https://airwindows.com/";
+    platforms = [ "x86_64-linux" ];
+    license = lib.licenses.mit;
+    mainProgram = "airwindows-consolidated";
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds the Airwindows Consolidated package for DAW-Plugin/JUCE at 2.13.0. Please see [airwindows.com](https://www.airwindows.com/consolidated/) and the [git repo](https://github.com/baconpaul/airwin2rack)

Note that the VCV-Rack version is **not** included (as I don't have a use for VCV Rack)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
