### PR TITLE
nixos/strongswan: improve testing of both swanctl and base strongswan module

### DIFF
--- a/nixos/modules/services/networking/strongswan.nix
+++ b/nixos/modules/services/networking/strongswan.nix
@@ -15,6 +15,7 @@ let
     mkIf
     mkEnableOption
     mkOption
+    mkPackageOption
     types
     literalExpression
     optionalString
@@ -80,6 +81,8 @@ in
 {
   options.services.strongswan = {
     enable = mkEnableOption "strongSwan";
+
+    package = mkPackageOption pkgs "strongswan" { };
 
     secrets = mkOption {
       type = types.listOf types.str;
@@ -200,7 +203,7 @@ in
           };
         };
         serviceConfig = {
-          ExecStart = "${pkgs.strongswan}/sbin/ipsec start --nofork";
+          ExecStart = "${cfg.package}/sbin/ipsec start --nofork";
         };
         preStart = ''
           # with 'nopeerdns' setting, ppp writes into this folder

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -972,7 +972,7 @@ in {
   static-web-server = handleTest ./web-servers/static-web-server.nix {};
   step-ca = handleTestOn ["x86_64-linux"] ./step-ca.nix {};
   stratis = handleTest ./stratis {};
-  strongswan-swanctl = handleTest ./strongswan-swanctl.nix {};
+  strongswan = discoverTests (import ./strongswan {});
   stub-ld = handleTestOn [ "x86_64-linux" "aarch64-linux" ] ./stub-ld.nix {};
   stunnel = handleTest ./stunnel.nix {};
   sudo = handleTest ./sudo.nix {};

--- a/nixos/tests/strongswan/default.nix
+++ b/nixos/tests/strongswan/default.nix
@@ -9,6 +9,7 @@ let
   ];
   tests = {
     swanctl = import ./swanctl.nix;
+    strongswan = import ./strongswan.nix;
   };
 in
 lib.mergeAttrsList (

--- a/nixos/tests/strongswan/default.nix
+++ b/nixos/tests/strongswan/default.nix
@@ -1,0 +1,22 @@
+{
+  system ? builtins.currentSystem,
+  pkgs ? import ../../.. { inherit system; },
+  lib ? pkgs.lib,
+}:
+let
+  withPackages = with pkgs; [
+    strongswan
+  ];
+  tests = {
+    swanctl = import ./swanctl.nix;
+  };
+in
+lib.mergeAttrsList (
+  map (
+    package:
+    lib.mapAttrs' (testName: test: {
+      name = "${package.pname}-${testName}";
+      value = test { inherit package; };
+    }) tests
+  ) withPackages
+)

--- a/nixos/tests/strongswan/strongswan.nix
+++ b/nixos/tests/strongswan/strongswan.nix
@@ -1,0 +1,109 @@
+{ package }:
+import ../make-test-python.nix (
+  { pkgs, lib, ... }:
+  let
+    hosts = {
+      a = {
+        ip = "192.168.1.1";
+        subnet = "192.168.11.0/24";
+        tunnelIp = "192.168.11.1";
+      };
+      b = {
+        ip = "192.168.1.2";
+        subnet = "192.168.12.0/24";
+        tunnelIp = "192.168.12.1";
+      };
+    };
+
+    ipUpDownScript = host: rec {
+      storePath = pkgs.writeShellScript "strongswan-updown.sh" ''
+        set +e
+
+        case "$PLUTO_VERB" in
+            up-client)
+                ip link add test type dummy
+                ip addr add ${host.tunnelIp}/32 dev test
+                ip link set up dev test
+                ;;
+        esac
+      '';
+      shortEtcPath = "strongswan/strongswan-updown.sh";
+      fullEtcPath = "/etc/${shortEtcPath}";
+    };
+
+    conn = left: right: {
+      auto = "start";
+      leftupdown = (ipUpDownScript left).fullEtcPath;
+      left = left.ip;
+      leftsubnet = left.subnet;
+      right = right.ip;
+      rightsubnet = right.subnet;
+      authby = "secret";
+      type = "tunnel";
+      keyexchange = "ikev2";
+      dpdaction = "restart";
+    };
+
+    mkNode =
+      name:
+      { pkgs, ... }:
+      let
+        me = hosts.${name};
+        other = if name == "a" then hosts.b else hosts.a;
+        myIfUpDownScript = ipUpDownScript me;
+        allowESP = "iptables --insert INPUT --protocol ESP --jump ACCEPT";
+      in
+      {
+        environment.systemPackages = with pkgs; [
+          iproute2
+        ];
+
+        networking.firewall = {
+          allowedUDPPorts = [
+            4500
+            500
+          ];
+          extraCommands = allowESP;
+        };
+
+        networking.useDHCP = false;
+        networking.interfaces.eth0.useDHCP = true;
+        networking.interfaces.eth1.ipv4.addresses = lib.mkForce [
+          {
+            address = me.ip;
+            prefixLength = 24;
+          }
+        ];
+
+        environment.etc.${myIfUpDownScript.shortEtcPath} = {
+          source = myIfUpDownScript.storePath;
+          mode = "0755";
+        };
+
+        services.strongswan = {
+          enable = true;
+          inherit package;
+          connections.test = conn me other;
+          secrets = [
+            (toString (pkgs.writeText "test.secrets" "${other.ip} : PSK NixpZAZqEN6Ti9sqt4ZP5EWcqx"))
+          ];
+        };
+      };
+  in
+  {
+    name = "strongswan";
+    meta.maintainers = [ lib.maintainers.johanot ];
+
+    nodes = {
+      nodeA = mkNode "a";
+      nodeB = mkNode "b";
+    };
+
+    testScript = ''
+      start_all()
+
+      nodeA.wait_until_succeeds("ping -c 1 ${hosts.b.tunnelIp}")
+      nodeB.wait_until_succeeds("ping -c 1 ${hosts.a.tunnelIp}")
+    '';
+  }
+)

--- a/nixos/tests/strongswan/swanctl.nix
+++ b/nixos/tests/strongswan/swanctl.nix
@@ -15,8 +15,8 @@
 #
 # See the NixOS manual for how to run this test:
 # https://nixos.org/nixos/manual/index.html#sec-running-nixos-tests-interactively
-
-import ./make-test-python.nix (
+{ package }:
+import ../make-test-python.nix (
   { pkgs, ... }:
 
   let
@@ -76,6 +76,7 @@ import ./make-test-python.nix (
           environment.systemPackages = [ strongswan ];
           services.strongswan-swanctl = {
             enable = true;
+            inherit package;
             swanctl = {
               connections = {
                 rw = {
@@ -121,6 +122,7 @@ import ./make-test-python.nix (
           environment.systemPackages = [ strongswan ];
           services.strongswan-swanctl = {
             enable = true;
+            inherit package;
             swanctl = {
               connections = {
                 home = {


### PR DESCRIPTION
Would like to see #362302 and #370067 merged. But I would also like to improve testing before approving.

This PR:

- Adds a new test case for the strongswan module
- Prepares the new test as well as the existing swanctl test for testing with multiple packages

cc @NickCao 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
