### PR TITLE
python3Packages.fastjet: re-init at 3.4.2.1

### DIFF
--- a/pkgs/development/python-modules/awkward/default.nix
+++ b/pkgs/development/python-modules/awkward/default.nix
@@ -24,8 +24,6 @@
   pyarrow,
   pytest-xdist,
   pytestCheckHook,
-  jax,
-  jaxlib,
 
   stdenv,
 }:
@@ -61,28 +59,23 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "awkward" ];
 
-  nativeCheckInputs =
-    [
-      fsspec
-      numba
-      setuptools
-      numexpr
-      pandas
-      pyarrow
-      pytest-xdist
-      pytestCheckHook
-    ]
-    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-      # no support for darwin
-      jax
-      jaxlib
-    ];
+  nativeCheckInputs = [
+    fsspec
+    numba
+    setuptools
+    numexpr
+    pandas
+    pyarrow
+    pytest-xdist
+    pytestCheckHook
+  ];
 
-  # The following tests have been disabled because they need to be run on a GPU platform.
   disabledTestPaths = [
+    # Need to be run on a GPU platform.
     "tests-cuda"
-    # Disable tests dependending on jax on darwin
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ "tests/test_2603_custom_behaviors_with_jax.py" ];
+    # JAX is broken
+    "tests/test_2603_custom_behaviors_with_jax.py"
+  ];
 
   disabledTests = [
     # AssertionError: Regex pattern did not match.

--- a/pkgs/development/python-modules/correctionlib/default.nix
+++ b/pkgs/development/python-modules/correctionlib/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch,
 
   # build-system
   cmake,
@@ -36,6 +37,16 @@ buildPythonPackage rec {
     hash = "sha256-l+JjW/giGzU00z0jBN3D4KB/LjTIxeJb3CS+Ge0gbiA=";
     fetchSubmodules = true;
   };
+
+  patches = [
+    # fix https://github.com/Tencent/rapidjson/issues/2277
+    (fetchpatch {
+      url = "https://github.com/Tencent/rapidjson/pull/719.diff";
+      hash = "sha256-xarSfi9o73KoJo0ijT0G8fyTSYVuY0+9rLEtfUwas0Q=";
+      extraPrefix = "rapidjson/";
+      stripLen = 1;
+    })
+  ];
 
   build-system = [
     cmake

--- a/pkgs/development/python-modules/fastjet/default.nix
+++ b/pkgs/development/python-modules/fastjet/default.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  fetchPypi,
+  fetchurl,
+  buildPythonPackage,
+  pytestCheckHook,
+  pkgs,
+  awkward,
+  numpy,
+  pybind11,
+  python,
+  setuptools,
+  setuptools-scm,
+  vector,
+}:
+
+let
+  fastjet =
+    (pkgs.fastjet.override {
+      inherit python;
+      withPython = true;
+    }).overrideAttrs
+      (prev: {
+        postInstall =
+          (prev.postInstall or "")
+          + ''
+            mv "$out/${python.sitePackages}/"{fastjet.py,_fastjet_swig.py}
+          '';
+      });
+  fastjet-contrib = pkgs.fastjet-contrib.override {
+    inherit fastjet;
+  };
+in
+
+buildPythonPackage rec {
+  pname = "fastjet";
+  version = "3.4.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "fastjet";
+    inherit version;
+    hash = "sha256-YlYJWCdwEBiG+koh1X2app1HinvktryisxP/C024g1k=";
+  };
+
+  # unvendor fastjet/fastjet-contrib
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'cmdclass={"build_ext": FastJetBuild, "install": FastJetInstall},' "" \
+      --replace-fail 'str(OUTPUT / "include")' "" \
+      --replace-fail 'str(OUTPUT / "lib")' ""
+    for file in src/fastjet/*.py; do
+      substituteInPlace "$file" \
+        --replace-warn "fastjet._swig" "_fastjet_swig"
+    done
+    sed -i src/fastjet/_pyjet.py -e '1iimport _fastjet_swig'
+  '';
+
+  strictDeps = true;
+
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  dependencies = [
+    fastjet
+  ];
+
+  buildInputs = [
+    pybind11
+    fastjet-contrib
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    awkward
+    numpy
+    vector
+  ];
+
+  env.SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+  meta = {
+    description = "Jet-finding in the Scikit-HEP ecosystem";
+    homepage = "https://github.com/scikit-hep/fastjet";
+    changelog = "https://github.com/scikit-hep/fastjet/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ veprbl ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4492,10 +4492,7 @@ self: super: with self; {
 
   fastimport = callPackage ../development/python-modules/fastimport { };
 
-  fastjet = toPythonModule (pkgs.fastjet.override {
-    withPython = true;
-    inherit (self) python;
-  });
+  fastjet = callPackage ../development/python-modules/fastjet { };
 
   fastjsonschema = callPackage ../development/python-modules/fastjsonschema { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The fastjet package in pypi namespace is an "official" python package that vendors FastJet with its SWIG bindings. That vendoring is broken wrt macOS install_name, so this package implements unvendoring. The package is replaces the SWIG bindings, as it should provide a compatible API.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
