### PR TITLE
libbraiding: 1.2 -> 1.3.1, import sage update patch

### DIFF
--- a/pkgs/by-name/li/libbraiding/package.nix
+++ b/pkgs/by-name/li/libbraiding/package.nix
@@ -3,21 +3,25 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  pkg-config,
 }:
 
 stdenv.mkDerivation rec {
-  version = "1.2";
+  version = "1.3.1";
   pname = "libbraiding";
 
   src = fetchFromGitHub {
     owner = "miguelmarco";
     repo = "libbraiding";
-    rev = version;
-    sha256 = "sha256-cgg6rvlOvFqGjgbw6i7QXS+tqvfFd1MkPCEjnW/FyFs=";
+    # version 1.3.1 contains a typo in configure.ac, fixed in the next commit.
+    # TODO: remove if on upgrade
+    rev = if version == "1.3.1" then "b174832026c2412baec83277c461e4df71d8525c" else version;
+    hash = "sha256-ar/EiaMZuQRa1lr0sZPLRuk5K00j63TqNf0q0iuiKjw=";
   };
 
   nativeBuildInputs = [
     autoreconfHook
+    pkg-config
   ];
 
   # no tests included for now (2018-08-05), but can't hurt to activate

--- a/pkgs/by-name/sa/sage/sage-src.nix
+++ b/pkgs/by-name/sa/sage/sage-src.nix
@@ -61,7 +61,7 @@ stdenv.mkDerivation rec {
     # a more conservative version of https://github.com/sagemath/sage/pull/37951
     ./patches/gap-element-crash.patch
 
-    # https://github.com/sagemath/sage/pull/38940, positively reviewed, to land in 10.6.beta0
+    # https://github.com/sagemath/sage/pull/38940, landed in 10.6.beta0
     (fetchpatch {
       name = "simplicial-sets-flaky-test.patch";
       url = "https://github.com/sagemath/sage/commit/1830861c5130d30b891e8c643308e1ceb91ce2b5.diff";
@@ -76,6 +76,12 @@ stdenv.mkDerivation rec {
   # should come from or be proposed to upstream. This list will probably never
   # be empty since dependencies update all the time.
   packageUpgradePatches = [
+    # https://github.com/sagemath/sage/pull/38887, landed in 10.6.beta0
+    (fetchpatch {
+      name = "libbraiding-1.3-update.patch";
+      url = "https://github.com/sagemath/sage/commit/f10a6d04599795732c1d99e2da0a4839ccdcb4f5.diff";
+      hash = "sha256-xB0xg8dGLnSMdFK3/B5hkI9yzI5N3lUMhPZ89lDsp3s=";
+    })
   ];
 
   patches = nixPatches ++ bugfixPatches ++ packageUpgradePatches;


### PR DESCRIPTION
Reviving #352269. Still need to run Sage tests.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
