### PR TITLE
build-support: add new hooks

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -830,6 +830,9 @@
   "add-bin-to-path.sh": [
     "index.html#add-bin-to-path.sh"
   ],
+  "writable-tmpdir-as-home.sh": [
+    "index.html#writable-tmpdir-as-home.sh"
+  ],
   "bintools-wrapper": [
     "index.html#bintools-wrapper"
   ],

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -827,6 +827,9 @@
   "set-source-date-epoch-to-latest.sh": [
     "index.html#set-source-date-epoch-to-latest.sh"
   ],
+  "add-bin-to-path.sh": [
+    "index.html#add-bin-to-path.sh"
+  ],
   "bintools-wrapper": [
     "index.html#bintools-wrapper"
   ],

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1389,6 +1389,17 @@ work as intended in cases with multiple outputs or when binaries are located in
 directories like `sbin/`. These caveats should be considered when using this
 hook, as they might introduce unexpected behavior in some specific cases.
 
+### `writable-tmpdir-as-home.sh` {#writable-tmpdir-as-home.sh}
+
+This setup hook ensures that the directory specified by the `HOME` environment
+variable is writable. If it is not, the hook assigns `HOME` to a writable
+directory (in `.home` in `$NIX_BUILD_TOP`). This adjustment is necessary for
+certain packages that require write access to a home directory. This hook can
+be added to any phase.
+
+By setting `HOME` to a writable directory, this setup hook prevents failures in
+packages that attempt to write to the home directory.
+
 ### Bintools Wrapper and hook {#bintools-wrapper}
 
 The Bintools Wrapper wraps the binary utilities for a bunch of miscellaneous purposes. These are GNU Binutils when targeting Linux, and a mix of cctools and GNU binutils for Darwin. \[The “Bintools” name is supposed to be a compromise between “Binutils” and “cctools” not denoting any specific implementation.\] Specifically, the underlying bintools package, and a C standard library (glibc or Darwin’s libSystem, just for the dynamic loader) are all fed in, and dependency finding, hardening (see below), and purity checks for each are handled by the Bintools Wrapper. Packages typically depend on CC Wrapper, which in turn (at run time) depends on the Bintools Wrapper.

--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1375,6 +1375,20 @@ This hook only runs when compiling for Linux.
 
 This sets `SOURCE_DATE_EPOCH` to the modification time of the most recent file.
 
+### `add-bin-to-path.sh` {#add-bin-to-path.sh}
+
+This setup hook checks if the `bin/` directory exists in the `$out` output path
+and, if so, adds it to the `PATH` environment variable. This ensures that
+executables located in `$out/bin` are accessible.
+
+This hook is particularly useful during testing, as it allows packages to locate their executables without requiring manual modifications to the `PATH`.
+
+**Note**: This hook is specifically designed for the `$out/bin` directory only
+and does not handle and support other paths like `$sourceRoot/bin`. It may not
+work as intended in cases with multiple outputs or when binaries are located in
+directories like `sbin/`. These caveats should be considered when using this
+hook, as they might introduce unexpected behavior in some specific cases.
+
 ### Bintools Wrapper and hook {#bintools-wrapper}
 
 The Bintools Wrapper wraps the binary utilities for a bunch of miscellaneous purposes. These are GNU Binutils when targeting Linux, and a mix of cctools and GNU binutils for Darwin. \[The “Bintools” name is supposed to be a compromise between “Binutils” and “cctools” not denoting any specific implementation.\] Specifically, the underlying bintools package, and a C standard library (glibc or Darwin’s libSystem, just for the dynamic loader) are all fed in, and dependency finding, hardening (see below), and purity checks for each are handled by the Bintools Wrapper. Packages typically depend on CC Wrapper, which in turn (at run time) depends on the Bintools Wrapper.

--- a/pkgs/build-support/setup-hooks/add-bin-to-path.sh
+++ b/pkgs/build-support/setup-hooks/add-bin-to-path.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# This setup hook add $out/bin to the PATH environment variable.
+
+export PATH
+
+addBinToPath () {
+    # shellcheck disable=SC2154
+    if [ -d "$out/bin" ]; then
+        PATH="$out/bin:$PATH"
+        export PATH
+    fi
+}
+
+# shellcheck disable=SC2154
+addEnvHooks "$targetOffset" addBinToPath

--- a/pkgs/build-support/setup-hooks/writable-tmpdir-as-home.sh
+++ b/pkgs/build-support/setup-hooks/writable-tmpdir-as-home.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# This setup hook set the HOME environment variable to a writable directory.
+
+export HOME
+
+writableTmpDirAsHome () {
+    if [ ! -w "$HOME" ]; then
+        HOME="$NIX_BUILD_TOP/.home"
+        mkdir -p "$HOME"
+        export HOME
+    fi
+}
+
+# shellcheck disable=SC2154
+addEnvHooks "$targetOffset" writableTmpDirAsHome

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -163,6 +163,13 @@ with pkgs;
 
   __flattenIncludeHackHook = callPackage ../build-support/setup-hooks/flatten-include-hack { };
 
+  addBinToPathHook = callPackage (
+    { makeSetupHook }:
+    makeSetupHook {
+      name = "add-bin-to-path-hook";
+    } ../build-support/setup-hooks/add-bin-to-path.sh
+  ) { };
+
   autoreconfHook = callPackage (
     { makeSetupHook, autoconf, automake, gettext, libtool }:
     makeSetupHook {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -868,6 +868,13 @@ with pkgs;
     name = "setup-debug-info-dirs-hook";
   } ../build-support/setup-hooks/setup-debug-info-dirs.sh;
 
+  writableTmpDirAsHomeHook = callPackage (
+    { makeSetupHook }:
+    makeSetupHook {
+      name = "writable-tmpdir-as-home-hook";
+    } ../build-support/setup-hooks/writable-tmpdir-as-home.sh
+  ) { };
+
   useOldCXXAbi = makeSetupHook {
     name = "use-old-cxx-abi-hook";
   } ../build-support/setup-hooks/use-old-cxx-abi.sh;


### PR DESCRIPTION
Hello everyone,

During the holidays, I spent some time packaging Python packages and noticed that some of them require a valid and mutable home directory to build or function properly.

Currently, the default behavior of the Nix stdenv is to set the `HOME` environment variable to `/homeless-shelter`, a read-only directory. While this approach is consistent, it can cause issues for packages that expect a writable home directory.

After performing a treewide search in `nixpkgs`, I found approximately 500 instances where `export HOME` is used (`rg -c "export HOME" | wc -l`) and 300 where `export PATH` is used (`rg -c "export PATH" | wc -l`). These repetitive patterns inspired me to propose a solution adhering to the DRY principle.

I created custom hooks, `tmpdirAsHomeHook`, which sets up a mutable home directory automatically when added to `nativeBuildInputs` or another appropriate place. Additionally, `addBinToPath`, which modifies the `PATH` environment variable to include `bin/` if available.

I’d appreciate your feedback on this approach and have a few questions:

1. Do you think this would be a valuable addition to `nixpkgs`?
2. Regarding naming, I’m considering renaming `tmpdirAsHomeHook` to `mutableHomeDirHook` for better clarity. What do you think?
3. In the hooks, I use the line `addEnvHooks "$targetOffset" addBinToPath`. I’m not entirely confident about the best way to implement this. Could you provide some guidance?

Thanks for taking the time to review this. I look forward to hearing your thoughts and suggestions!

Best regards

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
