### PR TITLE
git: reorder and tidy build process

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -282,10 +282,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall =
     ''
-      notSupported() {
-        unlink $1 || true
-      }
-
       # Set up the flags array for make in the same way as for the main install
       # phase from stdenv.
       local flagsArray=(
@@ -381,8 +377,7 @@ stdenv.mkDerivation (finalAttrs: {
         ''
       else
         ''
-          # replace git-svn by notification script
-          notSupported $out/libexec/git-core/git-svn
+          rm $out/libexec/git-core/git-svn
         ''
     )
 
@@ -395,8 +390,7 @@ stdenv.mkDerivation (finalAttrs: {
         ''
       else
         ''
-          # replace git-send-email by notification script
-          notSupported $out/libexec/git-core/git-send-email
+          rm $out/libexec/git-core/git-send-email
         ''
     )
 
@@ -419,9 +413,8 @@ stdenv.mkDerivation (finalAttrs: {
         ''
       else
         ''
-          # Don't wrap Tcl/Tk, replace them by notification scripts
           for prog in bin/gitk libexec/git-core/git-gui; do
-            notSupported "$out/$prog"
+            rm "$out/$prog"
           done
         ''
     )

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -402,7 +402,7 @@ stdenv.mkDerivation (finalAttrs: {
 
     + lib.optionalString withManual ''
       # Install man pages
-      make "''${flagsArray[@]}" cmd-list.made install install-html \
+      make "''${flagsArray[@]}" install install-html \
         -C Documentation
     ''
 

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -116,7 +116,8 @@ stdenv.mkDerivation (finalAttrs: {
       # Fix references to gettext introduced by ./git-sh-i18n.patch
       substituteInPlace git-sh-i18n.sh \
           --subst-var-by gettext ${gettext}
-
+    ''
+    + lib.optionalString doInstallCheck ''
       # ensure we are using the correct shell when executing the test scripts
       patchShebangs t/*.sh
     ''


### PR DESCRIPTION
I've been testing Git builds against the v2.48.0 release candidates, hit some problems, and made some fixes.

The key fix is to build the Documentation directory before building documentation for `contrib/subtree`. This is partly just good practice -- without this fix, the documentation doesn't get built until the install stage -- but it's also necessary as of v2.48.0, when `Documentation/asciidoc.conf` is required for the `contrib/subtree` documentation to build successfully, and that file is only built in the main documentation build stage.

*Edit*: The part of this PR that was critical to Git building from v2.48.0 onwards was merged as part of #372784, but the rest of the tidying is – I think – still useful. I've also now added myself as a package maintainer.

This is a big collection of small enhancements and maintainability fixes to the Git packaging code; I've lumped several commits into a single PR for ease of reviewing and merging, but I'm happy to split it into multiple PRs if that's preferable.

## Things done

- Built at commit 0d8d106434a35ed03198428f107a0819f2a146bc:
  - x86_64-linux
    - [x] `git`
    - [x] `git.passthru.tests.withInstallCheck`
    - [x] `gitMinimal`
    - [x] `gitMinimal.passthru.tests.withInstallCheck`
    - [x] `gitFull`
    - [x] `gitFull.passthru.tests.withInstallCheck`
    - [x] `gitSVN`
    - [x] `gitSVN.passthru.tests.withInstallCheck`
    - [x] `git-doc`
    - [x] `nixosTests.gitdaemon`
    - [x] `nixosTests.buildbot`
    - [x] `tests.fetchgit`
  - aarch64-linux
    - [x] `git`
    - [x] `git.passthru.tests.withInstallCheck`
    - [x] `gitMinimal`
    - [x] `gitMinimal.passthru.tests.withInstallCheck`
    - [x] `gitFull`
    - [x] `gitFull.passthru.tests.withInstallCheck`
    - [x] `gitSVN`
    - [x] `gitSVN.passthru.tests.withInstallCheck`
    - [x] `git-doc`
    - [x] `nixosTests.gitdaemon`
    - [ ] `nixosTests.buildbot` (appears to be broken prior to my fix)
    - [x] `tests.fetchgit`
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
