### PR TITLE
treewide: replace `git` with `gitMinimal`

### DIFF
--- a/pkgs/applications/audio/lpd8editor/default.nix
+++ b/pkgs/applications/audio/lpd8editor/default.nix
@@ -2,7 +2,7 @@
   lib,
   qt5,
   stdenv,
-  git,
+  gitMinimal,
   fetchFromGitHub,
   cmake,
   alsa-lib,
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
-    git
+    gitMinimal
     qt5.wrapQtAppsHook
   ];
 

--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -7,7 +7,7 @@
   cxx-rs,
   db62,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   hexdump,
   lib,
   libevent,
@@ -48,7 +48,7 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
     autoreconfHook
     cargo
     cxx-rs
-    git
+    gitMinimal
     hexdump
     makeWrapper
     pkg-config

--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -7,7 +7,7 @@
   texinfo,
   writeScript,
   common-updater-scripts,
-  git,
+  gitMinimal,
   nix,
   nixfmt-classic,
   coreutils,
@@ -74,7 +74,7 @@ stdenv.mkDerivation rec {
       PATH=${
         lib.makeBinPath [
           common-updater-scripts
-          git
+          gitMinimal
           nixfmt-classic
           nix
           coreutils

--- a/pkgs/applications/misc/visidata/default.nix
+++ b/pkgs/applications/misc/visidata/default.nix
@@ -40,7 +40,7 @@
   zstandard,
   zulip,
   # other
-  git,
+  gitMinimal,
   withPcap ? true,
   dpkt,
   dnslib,
@@ -121,7 +121,7 @@ buildPythonApplication rec {
     ++ lib.optional withXclip xclip;
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   # check phase uses the output bin, which is not possible when cross-compiling

--- a/pkgs/applications/version-management/nbstripout/default.nix
+++ b/pkgs/applications/version-management/nbstripout/default.nix
@@ -3,7 +3,7 @@
   python3,
   fetchPypi,
   coreutils,
-  git,
+  gitMinimal,
   mercurial,
 }:
 
@@ -29,7 +29,7 @@ python3.pkgs.buildPythonApplication rec {
   nativeCheckInputs =
     [
       coreutils
-      git
+      gitMinimal
       mercurial
     ]
     ++ (with python3.pkgs; [

--- a/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
+++ b/pkgs/build-support/make-hardcode-gsettings-patch/default.nix
@@ -1,6 +1,6 @@
 {
   runCommand,
-  git,
+  gitMinimal,
   coccinelle,
   python3,
 }:
@@ -60,7 +60,7 @@ runCommand "hardcode-gsettings.patch"
   {
     inherit src patches;
     nativeBuildInputs = [
-      git
+      gitMinimal
       coccinelle
       python3 # For patch script
     ];

--- a/pkgs/by-name/bi/biome/package.nix
+++ b/pkgs/by-name/bi/biome/package.nix
@@ -6,7 +6,7 @@
   libgit2,
   rust-jemalloc-sys,
   zlib,
-  git,
+  gitMinimal,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "biome";
@@ -29,7 +29,7 @@ rustPlatform.buildRustPackage rec {
     zlib
   ];
 
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [ gitMinimal ];
 
   cargoBuildFlags = [ "-p=biome_cli" ];
   cargoTestFlags =

--- a/pkgs/by-name/ca/cargo-generate/package.nix
+++ b/pkgs/by-name/ca/cargo-generate/package.nix
@@ -7,7 +7,7 @@
   openssl,
   stdenv,
   darwin,
-  git,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -34,7 +34,7 @@ rustPlatform.buildRustPackage rec {
       darwin.apple_sdk.frameworks.Security
     ];
 
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [ gitMinimal ];
 
   # disable vendored libgit2 and openssl
   buildNoDefaultFeatures = true;

--- a/pkgs/by-name/ca/cargo-llvm-cov/package.nix
+++ b/pkgs/by-name/ca/cargo-llvm-cov/package.nix
@@ -20,7 +20,7 @@
   fetchFromGitHub,
   rustPlatform,
   llvmPackages_19,
-  git,
+  gitMinimal,
 }:
 
 let
@@ -70,7 +70,7 @@ rustPlatform.buildRustPackage {
   LLVM_PROFDATA = "${llvm}/bin/llvm-profdata";
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   # `cargo-llvm-cov` tests rely on `git ls-files.

--- a/pkgs/by-name/da/databricks-cli/package.nix
+++ b/pkgs/by-name/da/databricks-cli/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   python3,
 }:
 
@@ -37,7 +37,7 @@ buildGoModule rec {
     ]);
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     (python3.withPackages (
       ps: with ps; [
         setuptools

--- a/pkgs/by-name/gi/git-aggregator/package.nix
+++ b/pkgs/by-name/gi/git-aggregator/package.nix
@@ -2,7 +2,7 @@
   lib,
   python3Packages,
   fetchFromGitHub,
-  git,
+  gitMinimal,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -23,13 +23,13 @@ python3Packages.buildPythonApplication rec {
   propagatedBuildInputs = with python3Packages; [
     argcomplete
     colorama
-    git
+    gitMinimal
     kaptan
     requests
   ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   preCheck = ''

--- a/pkgs/by-name/gi/git-bug-migration/package.nix
+++ b/pkgs/by-name/gi/git-bug-migration/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  git,
+  gitMinimal,
 }:
 buildGoModule rec {
   pname = "git-bug-migration";
@@ -17,7 +17,7 @@ buildGoModule rec {
 
   vendorHash = "sha256-Hid9OK91LNjLmDHam0ZlrVQopVOsqbZ+BH2rfQi5lS0=";
 
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [ gitMinimal ];
 
   ldflags = [
     "-X main.GitExactTag=${version}"

--- a/pkgs/by-name/gi/git-dive/package.nix
+++ b/pkgs/by-name/gi/git-dive/package.nix
@@ -8,7 +8,7 @@
   zlib,
   stdenv,
   darwin,
-  git,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -39,7 +39,7 @@ rustPlatform.buildRustPackage rec {
     ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   # don't use vendored libgit2

--- a/pkgs/by-name/gi/github-runner/package.nix
+++ b/pkgs/by-name/gi/github-runner/package.nix
@@ -6,7 +6,7 @@
   dotnetCorePackages,
   fetchFromGitHub,
   fetchpatch,
-  git,
+  gitMinimal,
   glibc,
   glibcLocales,
   lib,
@@ -112,7 +112,7 @@ buildDotnetModule (finalAttrs: {
   nativeBuildInputs =
     [
       which
-      git
+      gitMinimal
       # needed for `uname`
       coreutils
     ]

--- a/pkgs/by-name/gi/gitstatus/package.nix
+++ b/pkgs/by-name/gi/gitstatus/package.nix
@@ -3,7 +3,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   zsh,
   zlib,
   runtimeShell,
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
   # command ran successfully. This tests the binary itself and the zsh
   # integration.
   nativeInstallCheckInputs = [
-    git
+    gitMinimal
     zsh
   ];
   doInstallCheck = true;

--- a/pkgs/by-name/gl/glitter/package.nix
+++ b/pkgs/by-name/gl/glitter/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  git,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -19,7 +19,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-7JQcY3HCG3UQ0Mfz/+ZZ0axGEpQoH410FT72tjHW7EE=";
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   # tests require it to be in a git repository

--- a/pkgs/by-name/gs/gst/package.nix
+++ b/pkgs/by-name/gs/gst/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   ghq,
 }:
 
@@ -22,7 +22,7 @@ buildGoModule rec {
   doCheck = false;
 
   nativeBuildInputs = [
-    git
+    gitMinimal
     ghq
   ];
 

--- a/pkgs/by-name/ko/ko/package.nix
+++ b/pkgs/by-name/ko/ko/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   installShellFiles,
 }:
 
@@ -35,7 +35,7 @@ buildGoModule rec {
     "-skip=TestNewPublisherCanPublish"
   ];
 
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [ gitMinimal ];
   preCheck = ''
     # Feed in all the tests for testing
     # This is because subPackages above limits what is built to just what we

--- a/pkgs/by-name/lo/log4j-sniffer/package.nix
+++ b/pkgs/by-name/lo/log4j-sniffer/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
-  git,
+  gitMinimal,
 }:
 
 buildGoModule rec {
@@ -19,7 +19,7 @@ buildGoModule rec {
   vendorHash = null;
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   preCheck = ''

--- a/pkgs/by-name/on/onefetch/package.nix
+++ b/pkgs/by-name/on/onefetch/package.nix
@@ -8,7 +8,7 @@
   zstd,
   stdenv,
   darwin,
-  git,
+  gitMinimal,
 }:
 
 let
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage rec {
     ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   preCheck = ''

--- a/pkgs/by-name/pr/pre-commit/package.nix
+++ b/pkgs/by-name/pr/pre-commit/package.nix
@@ -6,13 +6,12 @@
   cargo,
   coursier,
   dotnet-sdk,
-  git,
+  gitMinimal,
   glibcLocales,
   go,
   nodejs,
   perl,
   cabal-install,
-  testers,
   pre-commit,
 }:
 
@@ -50,7 +49,7 @@ buildPythonApplication rec {
     cargo
     coursier
     dotnet-sdk
-    git
+    gitMinimal
     glibcLocales
     go
     libiconv # For rust tests on Darwin

--- a/pkgs/by-name/pr/pre-commit/tests.nix
+++ b/pkgs/by-name/pr/pre-commit/tests.nix
@@ -1,5 +1,5 @@
 {
-  git,
+  gitMinimal,
   pre-commit,
   runCommand,
   testers,
@@ -9,7 +9,7 @@
     runCommand "check-meta-hooks"
       {
         nativeBuildInputs = [
-          git
+          gitMinimal
           pre-commit
         ];
       }

--- a/pkgs/by-name/st/stellar-core/package.nix
+++ b/pkgs/by-name/st/stellar-core/package.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchpatch,
   flex,
-  git,
+  gitMinimal,
   lib,
   libtool,
   libunwind,
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     automake
     autoconf
-    git
+    gitMinimal
     libtool
     pkg-config
     ripgrep

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -10,7 +10,7 @@
   nodejs,
   pnpm,
   python3,
-  git,
+  gitMinimal,
   jq,
   zip,
 }:
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
     customPython
     nodejs
     pnpm.configHook
-    git
+    gitMinimal
     jq
     zip
   ];

--- a/pkgs/by-name/zo/zoekt/package.nix
+++ b/pkgs/by-name/zo/zoekt/package.nix
@@ -1,8 +1,9 @@
-{ lib
-, buildGoModule
-, fetchFromGitHub
-, git
-, nix-update-script
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  gitMinimal,
+  nix-update-script,
 }:
 
 buildGoModule {
@@ -19,7 +20,7 @@ buildGoModule {
   vendorHash = "sha256-Dvs8XMOxZEE9moA8aCxuxg947+x/6C8cKtgdcByL4Eo=";
 
   nativeCheckInputs = [
-    git
+    gitMinimal
   ];
 
   preCheck = ''
@@ -28,7 +29,10 @@ buildGoModule {
   '';
 
   passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version" "branch" ];
+    extraArgs = [
+      "--version"
+      "branch"
+    ];
   };
 
   meta = {

--- a/pkgs/development/compilers/flutter/engine/package.nix
+++ b/pkgs/development/compilers/flutter/engine/package.nix
@@ -38,7 +38,7 @@
   ninja,
   python312,
   python39,
-  git,
+  gitMinimal,
   version,
   flutterVersion,
   dartSdkVersion,
@@ -176,7 +176,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       python3
       (tools.vpython python3)
-      git
+      gitMinimal
       pkg-config
       ninja
       dart

--- a/pkgs/development/compilers/flutter/flutter.nix
+++ b/pkgs/development/compilers/flutter/flutter.nix
@@ -22,7 +22,7 @@
   callPackage,
   makeWrapper,
   darwin,
-  git,
+  gitMinimal,
   which,
   jq,
   flutterTools ? null,
@@ -64,7 +64,7 @@ let
     nativeBuildInputs = [
       makeWrapper
       jq
-      git
+      gitMinimal
     ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwin.DarwinTools ];
     strictDeps = true;
 

--- a/pkgs/development/julia-modules/util.nix
+++ b/pkgs/development/julia-modules/util.nix
@@ -1,5 +1,5 @@
 {
-  git,
+  gitMinimal,
   runCommand,
 }:
 
@@ -20,7 +20,7 @@
   # Convert an ordinary source checkout into a repo with a single commit
   repoifySimple =
     name: path:
-    runCommand ''${name}-repoified'' { buildInputs = [ git ]; } ''
+    runCommand ''${name}-repoified'' { buildInputs = [ gitMinimal ]; } ''
       mkdir -p $out
       cp -r ${path}/. $out
       cd $out
@@ -36,7 +36,7 @@
   # Convert an dependency source info into a repo with a single commit
   repoifyInfo =
     uuid: info:
-    runCommand ''julia-${info.name}-${info.version}'' { buildInputs = [ git ]; } ''
+    runCommand ''julia-${info.name}-${info.version}'' { buildInputs = [ gitMinimal ]; } ''
       mkdir -p $out
       cp -r ${info.src}/. $out
       cd $out

--- a/pkgs/development/python-modules/commitizen/default.nix
+++ b/pkgs/development/python-modules/commitizen/default.nix
@@ -3,7 +3,7 @@
   commitizen,
   fetchFromGitHub,
   buildPythonPackage,
-  git,
+  gitMinimal,
   pythonOlder,
   stdenv,
   installShellFiles,
@@ -69,7 +69,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     argcomplete
     deprecated
-    git
+    gitMinimal
     py
     pytest-freezer
     pytest-mock

--- a/pkgs/development/python-modules/dunamai/default.nix
+++ b/pkgs/development/python-modules/dunamai/default.nix
@@ -7,7 +7,7 @@
   importlib-metadata,
   packaging,
   pytestCheckHook,
-  git,
+  gitMinimal,
 }:
 
 buildPythonPackage rec {
@@ -38,7 +38,7 @@ buildPythonPackage rec {
   '';
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/font-v/default.nix
+++ b/pkgs/development/python-modules/font-v/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fonttools,
-  git,
+  gitMinimal,
   gitpython,
   pytestCheckHook,
 }:
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     pytestCheckHook
   ];
   preCheck = ''

--- a/pkgs/development/python-modules/fontbakery/default.nix
+++ b/pkgs/development/python-modules/fontbakery/default.nix
@@ -16,7 +16,7 @@
   freetype-py,
   gflanguages,
   gfsubsets,
-  git,
+  gitMinimal,
   glyphsets,
   installShellFiles,
   jinja2,
@@ -110,7 +110,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     pytestCheckHook
     pytest-xdist
     requests-mock

--- a/pkgs/development/python-modules/gto/default.nix
+++ b/pkgs/development/python-modules/gto/default.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   freezegun,
   funcy,
-  git,
+  gitMinimal,
   pydantic,
   pytest-cov-stub,
   pytest-mock,
@@ -56,7 +56,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     freezegun
-    git
+    gitMinimal
     pytest-cov-stub
     pytest-mock
     pytest-test-utils

--- a/pkgs/development/python-modules/nbdime/default.nix
+++ b/pkgs/development/python-modules/nbdime/default.nix
@@ -15,7 +15,7 @@
   jupyter-server,
   jupyter-server-mathjax,
   jinja2,
-  git,
+  gitMinimal,
   pytest-tornado,
   pytestCheckHook,
 }:
@@ -51,7 +51,7 @@ buildPythonPackage rec {
   ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     pytest-tornado
     pytestCheckHook
   ];

--- a/pkgs/development/python-modules/pdm-backend/default.nix
+++ b/pkgs/development/python-modules/pdm-backend/default.nix
@@ -9,7 +9,7 @@
 
   # tests
   editables,
-  git,
+  gitMinimal,
   mercurial,
   pytestCheckHook,
   setuptools,
@@ -35,7 +35,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     editables
-    git
+    gitMinimal
     mercurial
     pytestCheckHook
     setuptools

--- a/pkgs/development/python-modules/pdm-pep517/default.nix
+++ b/pkgs/development/python-modules/pdm-pep517/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  git,
+  gitMinimal,
   pytestCheckHook,
   setuptools,
 }:
@@ -26,7 +26,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     pytestCheckHook
-    git
+    gitMinimal
     setuptools
   ];
 

--- a/pkgs/development/python-modules/playwright/default.nix
+++ b/pkgs/development/python-modules/playwright/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   auditwheel,
   buildPythonPackage,
-  git,
+  gitMinimal,
   greenlet,
   fetchFromGitHub,
   pyee,
@@ -71,7 +71,7 @@ buildPythonPackage rec {
   '';
 
   nativeBuildInputs = [
-    git
+    gitMinimal
     setuptools-scm
     setuptools
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [ auditwheel ];

--- a/pkgs/development/python-modules/pre-commit-hooks/default.nix
+++ b/pkgs/development/python-modules/pre-commit-hooks/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   pytestCheckHook,
   pythonOlder,
   ruamel-yaml,
@@ -27,7 +27,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ ruamel-yaml ] ++ lib.optionals (pythonOlder "3.11") [ tomli ];
 
   nativeCheckInputs = [
-    git
+    gitMinimal
     pytestCheckHook
   ];
 

--- a/pkgs/development/python-modules/pypass/default.nix
+++ b/pkgs/development/python-modules/pypass/default.nix
@@ -5,7 +5,7 @@
   click,
   colorama,
   fetchPypi,
-  git,
+  gitMinimal,
   gnugrep,
   gnupg,
   pbr,
@@ -34,7 +34,7 @@ buildPythonPackage rec {
   patches = [
     (substituteAll {
       src = ./mark-executables.patch;
-      git_exec = "${git}/bin/git";
+      git_exec = "${gitMinimal}/bin/git";
       grep_exec = "${gnugrep}/bin/grep";
       gpg_exec = "${gnupg}/bin/gpg2";
       tree_exec = "${tree}/bin/tree";
@@ -57,15 +57,18 @@ buildPythonPackage rec {
     pexpect
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    gitMinimal
+    pytestCheckHook
+  ];
 
   # Configuration so that the tests work
   preCheck = ''
     export HOME=$(mktemp -d)
     export GNUPGHOME=pypass/tests/gnupg
-    ${git}/bin/git config --global user.email "nix-builder@nixos.org"
-    ${git}/bin/git config --global user.name "Nix Builder"
-    ${git}/bin/git config --global pull.ff only
+    git config --global user.email "nix-builder@nixos.org"
+    git config --global user.name "Nix Builder"
+    git config --global pull.ff only
     make setup_gpg
   '';
 

--- a/pkgs/development/tools/ocaml/dune-release/default.nix
+++ b/pkgs/development/tools/ocaml/dune-release/default.nix
@@ -19,7 +19,7 @@
   yojson,
   astring,
   opam,
-  git,
+  gitMinimal,
   findlib,
   mercurial,
   bzip2,
@@ -34,7 +34,7 @@ let
   runtimeInputs = [
     opam
     findlib
-    git
+    gitMinimal
     mercurial
     bzip2
     gnutar
@@ -78,7 +78,10 @@ buildDunePackage rec {
     astring
     fpath
   ];
-  nativeCheckInputs = [ odoc ];
+  nativeCheckInputs = [
+    odoc
+    gitMinimal
+  ];
   checkInputs = [ alcotest ] ++ runtimeInputs;
   doCheck = true;
 

--- a/pkgs/development/tools/rust/cargo-crev/default.nix
+++ b/pkgs/development/tools/rust/cargo-crev/default.nix
@@ -1,15 +1,17 @@
-{ lib, stdenv
-, fetchFromGitHub
-, rustPlatform
-, perl
-, pkg-config
-, SystemConfiguration
-, Security
-, CoreFoundation
-, curl
-, libiconv
-, openssl
-, git
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  rustPlatform,
+  perl,
+  pkg-config,
+  SystemConfiguration,
+  Security,
+  CoreFoundation,
+  curl,
+  libiconv,
+  openssl,
+  gitMinimal,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -31,17 +33,35 @@ rustPlatform.buildRustPackage rec {
     git config --global user.email "nobody@example.com"
   '';
 
-  nativeBuildInputs = [ perl pkg-config ];
+  nativeBuildInputs = [
+    perl
+    pkg-config
+  ];
 
-  buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ SystemConfiguration Security CoreFoundation libiconv curl ];
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      SystemConfiguration
+      Security
+      CoreFoundation
+      libiconv
+      curl
+    ];
 
-  nativeCheckInputs = [ git ];
+  nativeCheckInputs = [ gitMinimal ];
 
   meta = with lib; {
     description = "Cryptographically verifiable code review system for the cargo (Rust) package manager";
     mainProgram = "cargo-crev";
     homepage = "https://github.com/crev-dev/cargo-crev";
-    license = with licenses; [ asl20 mit mpl20 ];
-    maintainers = with maintainers; [ b4dm4n matthiasbeyer ];
+    license = with licenses; [
+      asl20
+      mit
+      mpl20
+    ];
+    maintainers = with maintainers; [
+      b4dm4n
+      matthiasbeyer
+    ];
   };
 }

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -418,7 +418,7 @@ let
     dune-private-libs = callPackage ../development/ocaml-modules/dune-private-libs { };
 
     dune-release = callPackage ../development/tools/ocaml/dune-release {
-      inherit (pkgs) opam git mercurial coreutils gnutar bzip2;
+      inherit (pkgs) opam gitMinimal mercurial coreutils gnutar bzip2;
     };
 
     dune-rpc = callPackage ../development/ocaml-modules/dune-rpc { };


### PR DESCRIPTION
This PR:

- Replace `git` with `gitMinimal` when `git init` is used in the `checkPhases`

### Why?

The footprint of `git` is approximately 3 times bigger than `gitMinimal`. There's no need to download so much when we can do it with something smaller.

```
❯ nix build .#git
❯ nix path-info -Sh ./result
/nix/store/iwq58rpn6idjnxbnyjh351776qzvsd0r-git-2.47.0   317.3 MiB
❯ nix build .#gitMinimal
❯ nix path-info -Sh ./result
/nix/store/7998dljnnlk9yqpwnrrwwbhrikjkbai5-git-minimal-2.47.0   121.6 MiB
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
