### PR TITLE
piston-cli: 1.4.3 -> 1.5.0, tweak, fetchFromGitHub, versionCheckHook

### DIFF
--- a/pkgs/by-name/pi/piston-cli/package.nix
+++ b/pkgs/by-name/pi/piston-cli/package.nix
@@ -1,49 +1,66 @@
 {
-  stdenv,
   lib,
   python3Packages,
-  fetchPypi,
+  fetchFromGitHub,
+  versionCheckHook,
+  gitUpdater,
 }:
 
 python3Packages.buildPythonApplication rec {
   pname = "piston-cli";
-  version = "1.4.3";
-  format = "pyproject";
+  version = "1.5.0";
+  pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    sha256 = "qvDGVJcaMXUajdUQWl4W1dost8k0PsS9XX/o8uQrtfY=";
+  src = fetchFromGitHub {
+    owner = "Shivansh-007";
+    repo = "piston-cli";
+    tag = "v${version}";
+    hash = "sha256-5S+1YGoPMprWnlsTGGPHtlQT974TsFgct3jVPngTT1k=";
   };
 
-  propagatedBuildInputs = with python3Packages; [
-    rich
+  build-system = [
+    python3Packages.poetry-core
+  ];
+
+  dependencies = with python3Packages; [
+    appdirs
+    click
+    coloredlogs
+    more-itertools
     prompt-toolkit
-    requests
+    rich
+    requests-cache
     pygments
     pyyaml
     more-itertools
   ];
 
-  checkPhase = ''
-    $out/bin/piston --help > /dev/null
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'piston = "piston:main"' 'piston = "piston.cli:cli_app"'
   '';
-
-  nativeBuildInputs = with python3Packages; [
-    poetry-core
-  ];
 
   pythonRelaxDeps = [
     "rich"
     "more-itertools"
     "PyYAML"
+    "requests-cache"
   ];
 
-  meta = with lib; {
-    broken = stdenv.hostPlatform.isDarwin;
+  nativeCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = [ "--version" ];
+  versionCheckProgram = "${placeholder "out"}/bin/piston";
+
+  pythonImportsCheck = [ "piston" ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+
+  meta = {
     description = "Piston api tool";
     homepage = "https://github.com/Shivansh-007/piston-cli";
-    license = licenses.mit;
-    maintainers = with maintainers; [ ethancedwards8 ];
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ ethancedwards8 ];
     mainProgram = "piston";
   };
 }


### PR DESCRIPTION
piston-cli: 1.4.3 -> 1.5.0, tweak, fetchFromGitHub, versionCheckHook

Replaces: https://github.com/NixOS/nixpkgs/pull/370707

Tested and it works even though the upstream repo is archived.

nativeInstallCheckInputs is being a no-op for some reason so I put versionCheckHook in nativeCheckInputs.

Signed-off-by: lucasew <lucas59356@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
