### PR TITLE
usbutils: 017 -> 018; add darwin support

### DIFF
--- a/pkgs/by-name/us/usbutils/fix-paths.patch
+++ b/pkgs/by-name/us/usbutils/fix-paths.patch
@@ -1,11 +1,14 @@
---- a/Makefile.am
-+++ b/Makefile.am
-@@ -61,7 +61,7 @@ EXTRA_DIST = \
- 	LICENSES/GPL-3.0-only.txt
+diff --git a/lsusb.py b/lsusb.py
+index bbc4dbb..8af1b1f 100755
+--- a/lsusb.py
++++ b/lsusb.py
+@@ -27,8 +27,7 @@ showwakeup = False
  
- lsusb.py: $(srcdir)/lsusb.py.in
--	sed 's|VERSION|$(VERSION)|g;s|@usbids@|$(datadir)/usb.ids|g' $< >$@
-+	sed 's|VERSION|$(VERSION)|g;s|@usbids@|@hwdata@/share/hwdata/usb.ids|g' $< >$@
- 	chmod 755 $@
+ prefix = "/sys/bus/usb/devices/"
+ usbids = [
+-	"/usr/share/hwdata/usb.ids",
+-	"/usr/share/usb.ids",
++	"@hwdata@/share/hwdata/usb.ids",
+ ]
+ cols = ("", "", "", "", "", "")
  
- lsusb.8: $(srcdir)/lsusb.8.in

--- a/pkgs/by-name/us/usbutils/package.nix
+++ b/pkgs/by-name/us/usbutils/package.nix
@@ -3,7 +3,8 @@
   stdenv,
   fetchurl,
   substituteAll,
-  autoreconfHook,
+  meson,
+  ninja,
   pkg-config,
   libusb1,
   hwdata,
@@ -12,11 +13,11 @@
 
 stdenv.mkDerivation rec {
   pname = "usbutils";
-  version = "017";
+  version = "018";
 
   src = fetchurl {
     url = "mirror://kernel/linux/utils/usb/usbutils/usbutils-${version}.tar.xz";
-    hash = "sha256-pqJf/c+RA+ONekRzKsoXBz9OYCuS5K5VYlIxqCcC4Fs=";
+    hash = "sha256-g/aLWbWFR1icACZugmcYZGJ1k6tDYtjIB/UO6pI8rZM=";
   };
 
   patches = [
@@ -27,7 +28,8 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    autoreconfHook
+    meson
+    ninja
     pkg-config
   ];
   buildInputs = [
@@ -40,10 +42,6 @@ stdenv.mkDerivation rec {
     "man"
     "python"
   ];
-
-  postBuild = ''
-    $CC $NIX_CFLAGS -o usbreset usbreset.c
-  '';
 
   postInstall = ''
     moveToOutput "bin/lsusb.py" "$python"

--- a/pkgs/by-name/us/usbutils/package.nix
+++ b/pkgs/by-name/us/usbutils/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   substituteAll,
+  fetchpatch,
   meson,
   ninja,
   pkg-config,
@@ -20,12 +21,19 @@ stdenv.mkDerivation rec {
     hash = "sha256-g/aLWbWFR1icACZugmcYZGJ1k6tDYtjIB/UO6pI8rZM=";
   };
 
-  patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      inherit hwdata;
-    })
-  ];
+  patches =
+    [
+      (substituteAll {
+        src = ./fix-paths.patch;
+        inherit hwdata;
+      })
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      (fetchpatch {
+        url = "https://raw.githubusercontent.com/Homebrew/formula-patches/24a6945778381a62ecdcc1d78bcc16b9f86778c1/usbutils/portable.patch";
+        hash = "sha256-spTkWURij4sPLoWtDaWVMIk81AS5W+qUUOQL1pAZEvs=";
+      })
+    ];
 
   nativeBuildInputs = [
     meson
@@ -37,13 +45,16 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  outputs = [
-    "out"
-    "man"
-    "python"
-  ];
+  outputs =
+    [
+      "out"
+      "man"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "python" # uses sysfs
+    ];
 
-  postInstall = ''
+  postInstall = lib.optionalString stdenv.hostPlatform.isLinux ''
     moveToOutput "bin/lsusb.py" "$python"
     install -Dm555 usbreset -t $out/bin
   '';
@@ -51,12 +62,15 @@ stdenv.mkDerivation rec {
   meta = {
     homepage = "http://www.linux-usb.org/";
     description = "Tools for working with USB devices, such as lsusb";
-    maintainers = with lib.maintainers; [ cafkafk ];
+    maintainers = with lib.maintainers; [
+      cafkafk
+      chuangzhu
+    ];
     license = with lib.licenses; [
       gpl2Only # manpages, usbreset
       gpl2Plus # most of the code
     ];
-    platforms = lib.platforms.linux;
+    platforms = with lib.platforms; linux ++ darwin;
     mainProgram = "lsusb";
   };
 }


### PR DESCRIPTION
v018 migrated from Autoconf and Makefile to to Meson, and lsusb.py is no longer a `.in`

Changelog: https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/usbutils.git/tree/NEWS?h=v018

(Fun fact: upstream metioned Nix in [`008e330`](https://git.kernel.org/pub/scm/linux/kernel/git/gregkh/usbutils.git/commit/?id=008e3307592965c88862d79591da2a8e3f434c15))

The patch to make it build on Darwin is pulled from Homebrew. Added myself as a maintainer to assist maintaining on Darwin.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
