### PR TITLE
net-news-wire: fix update script

### DIFF
--- a/pkgs/by-name/ne/net-news-wire/package.nix
+++ b/pkgs/by-name/ne/net-news-wire/package.nix
@@ -28,7 +28,7 @@ stdenvNoCC.mkDerivation rec {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "RSS reader for macOS and iOS";
     longDescription = ''
       It's like podcasts — but for reading.
@@ -36,9 +36,9 @@ stdenvNoCC.mkDerivation rec {
     '';
     homepage = "https://github.com/Ranchero-Software/NetNewsWire";
     changelog = "https://github.com/Ranchero-Software/NetNewsWire/releases/tag/mac-${version}";
-    license = licenses.mit;
-    platforms = platforms.darwin;
-    maintainers = with maintainers; [
+    license = lib.licenses.mit;
+    platforms = lib.platforms.darwin;
+    maintainers = with lib.maintainers; [
       jakuzure
       DimitarNestorov
     ];

--- a/pkgs/by-name/ne/net-news-wire/package.nix
+++ b/pkgs/by-name/ne/net-news-wire/package.nix
@@ -39,5 +39,6 @@ stdenvNoCC.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.darwin;
     maintainers = with maintainers; [ jakuzure ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 }

--- a/pkgs/by-name/ne/net-news-wire/package.nix
+++ b/pkgs/by-name/ne/net-news-wire/package.nix
@@ -26,7 +26,12 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "^mac-(\\d+\\.\\d+\\.\\d+)$"
+    ];
+  };
 
   meta = {
     description = "RSS reader for macOS and iOS";

--- a/pkgs/by-name/ne/net-news-wire/package.nix
+++ b/pkgs/by-name/ne/net-news-wire/package.nix
@@ -38,7 +38,10 @@ stdenvNoCC.mkDerivation rec {
     changelog = "https://github.com/Ranchero-Software/NetNewsWire/releases/tag/mac-${version}";
     license = licenses.mit;
     platforms = platforms.darwin;
-    maintainers = with maintainers; [ jakuzure ];
+    maintainers = with maintainers; [
+      jakuzure
+      DimitarNestorov
+    ];
     sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 }


### PR DESCRIPTION
## Things done

Fix NetNewsWire update script

|Before|After|
|-|-|
|<img width="1250" alt="image" src="https://github.com/user-attachments/assets/22df7264-0ba2-43fd-b4b0-fd85edb767d9" />|<img width="1274" alt="image" src="https://github.com/user-attachments/assets/3b0f33ae-793f-44f2-bf25-c2bc462e8cd1" />|

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
