### PR TITLE
nchat: enable whatsapp module

### DIFF
--- a/pkgs/by-name/nc/nchat/package.nix
+++ b/pkgs/by-name/nc/nchat/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  buildGoModule,
   fetchFromGitHub,
   file, # for libmagic
   ncurses,
@@ -13,8 +14,7 @@
   darwin,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "nchat";
+let
   version = "5.4.2";
 
   src = fetchFromGitHub {
@@ -24,16 +24,55 @@ stdenv.mkDerivation rec {
     hash = "sha256-NrAU47GA7ZASJ7vCo1S8nyGBpfsZn4EBBqx2c4HKx7k=";
   };
 
+  libcgowm = buildGoModule {
+    pname = "nchat-wmchat-libcgowm";
+    inherit version src;
+
+    sourceRoot = "${src.name}/lib/wmchat/go";
+    vendorHash = "sha256-EdbOO5cCDT1CcPlCBgMoPDg65FcoOYvBwZa4bz0hfGE=";
+
+    buildPhase = ''
+      mkdir -p $out/
+      go build -o $out/ -buildmode=c-archive
+      mv $out/go.a $out/libcgowm.a
+      ln -s $out/libcgowm.a $out/libref-cgowm.a
+      mv $out/go.h $out/libcgowm.h
+    '';
+  };
+in
+stdenv.mkDerivation rec {
+  pname = "nchat";
+  inherit version src;
+
+  nl = "\n";
   postPatch = ''
     substituteInPlace lib/tgchat/ext/td/CMakeLists.txt \
       --replace "get_git_head_revision" "#get_git_head_revision"
     substituteInPlace lib/tgchat/CMakeLists.txt \
       --replace-fail "list(APPEND OPENSSL_ROOT_DIR" "#list(APPEND OPENSSL_ROOT_DIR"
+
+    # specific mangling to handle whatsapp go module:
+
+    substituteInPlace CMakeLists.txt \
+      --replace "if(HAS_WHATSAPP AND (NOT GO_VERSION VERSION_GREATER_EQUAL GO_VERSION_MIN))" \
+      "if(FALSE AND (NOT GO_VERSION VERSION_GREATER_EQUAL GO_VERSION_MIN))"
+
+    substituteInPlace lib/wmchat/CMakeLists.txt \
+      --replace-fail "add_subdirectory(go)" \
+    "set(GO_LIBRARIES ${libcgowm}/libcgowm.a)${nl}target_include_directories(wmchat PRIVATE ${libcgowm})"
+
+    substituteInPlace lib/wmchat/CMakeLists.txt \
+      --replace-fail "target_link_libraries(wmchat PUBLIC ref-cgowm ncutil \''${GO_LIBRARIES})" \
+      "target_link_libraries(wmchat PUBLIC ${libcgowm}/libcgowm.a ncutil \''${GO_LIBRARIES})"
+
+    substituteInPlace lib/wmchat/CMakeLists.txt \
+      --replace-fail "add_dependencies(wmchat ref-cgowm)" "#add_dependencies(wmchat ref-cgowm)"
   '';
 
   nativeBuildInputs = [
     cmake
     gperf
+    libcgowm
   ];
 
   buildInputs =
@@ -56,7 +95,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR=lib"
-    "-DHAS_WHATSAPP=OFF" # go module build required
   ];
 
   meta = {


### PR DESCRIPTION
This enables nchat's whatsapp module, which requires building go module 'whatsmeow' and arranging for it to be linked in. As this should statically link all external dependencies, and therefore not increase the runtime closure size, I haven't created an option for this.

I don't consider myself to be a nix/nixpkgs or golang expert, and have virtually no experience of cmake, so I'm very open to tidy-up etc suggestions from those who are! Similarly not familiar with requirements for nixpkgs PRs, so please do nudge me for housekeeping type issues.

Closes: #345884

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
