### PR TITLE
octoprint: use octoprint from final package set as plugin build input

### DIFF
--- a/pkgs/by-name/oc/octoprint/plugins.nix
+++ b/pkgs/by-name/oc/octoprint/plugins.nix
@@ -11,7 +11,7 @@ let
   buildPlugin = args: self.buildPythonPackage (args // {
     pname = "octoprint-plugin-${args.pname}";
     inherit (args) version;
-    propagatedBuildInputs = (args.propagatedBuildInputs or [ ]) ++ [ super.octoprint ];
+    propagatedBuildInputs = (args.propagatedBuildInputs or [ ]) ++ [ self.octoprint ];
     # none of the following have tests
     doCheck = false;
   });


### PR DESCRIPTION
OctoPrint and its plugins are packaged in the form of multiple overlays, each adding one or more packages built with `buildPythonPackage`. In the NixOS module, the core `octoprint` package is then combined with zero or more of the plugin packages into one `python.withPackages` environment that is referenced by the systemd service unit.

Since plugins have to use the OctoPrint modules at runtime, they receive the `octoprint` Python package as part of `propagatedBuildInputs`. However, the current implementation of the plugins overlay takes this dependency from the `super` package set, i.e., the stage preceding the plugins overlay.

The use of `super` packages for dependencies is problematic here, as there may be other subsequent overlays that modify the `octoprint` package, and the `octoprint` that ends up in the final package set may not be the same that the plugin was built against.

Things work out fine in the absence of any `octoprint` overrides, or if no plugins are used. Combining the two in a NixOS configuration, however, breaks the build with a collision of OctoPrint executables:

```plain
error: builder for '/nix/store/7sjbm51s4j5p02s76ncrb6arzb5nwph7-python3-3.12.8-env.drv' failed with exit code 255;
       last 1 log lines:
       > error: collision between `/nix/store/rg9mixyc0qpdgn3ynrlwlp2qk9l5gh6a-python3.12-OctoPrint-1.10.3/bin/octoprint' and `/nix/store/ws68951jy8gx7q9n09xgpykkwhia82mb-Overridden-OctoPrint-1.10.2/bin/octoprint'
       For full logs, run 'nix-store -l /nix/store/7sjbm51s4j5p02s76ncrb6arzb5nwph7-python3-3.12.8-env.drv'.
error: 1 dependencies of derivation '/nix/store/sgmn253inypq9hi722a9817w1ji8lkb8-unit-octoprint.service.drv' failed to build
error: 1 dependencies of derivation '/nix/store/aydjfz8xf8s87hxc60vpnkzbclj5knj5-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/97a3pr2v2b5yjw9g3za5rbc6blb2q808-etc.drv' failed to build
```

The collision is between the overridden `octoprint` from the final package set and the non-overridden version that the plugins depend on (and end up propagating to their consumers).

They all should be using one and the same `octoprint` package, which is the one from `self`, the final package set after applying all overrides. Modify the `buildPlugin` helper function accordingly.

Fixes: https://github.com/NixOS/nixpkgs/issues/370946


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (NixOS 24.11)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - [x] `nix build .#nixosTests.octoprint` completed successfully
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
