### PR TITLE
open-adventure: init at 1.20

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -6709,6 +6709,11 @@
     githubId = 934284;
     name = "Rouven Czerwinski";
   };
+  EmanuelM153 = {
+    name = "Emanuel";
+    github = "EmanuelM153";
+    githubId = 134736553;
+  };
   emattiza = {
     email = "nix@mattiza.dev";
     github = "emattiza";

--- a/pkgs/by-name/op/open-adventure/package.nix
+++ b/pkgs/by-name/op/open-adventure/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitLab,
+  python3Packages,
+  pkg-config,
+  libedit,
+  cppcheck,
+  coreutils,
+  asciidoctor,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "open-adventure";
+  version = "1.20";
+  src = fetchFromGitLab {
+    owner = "esr";
+    repo = "open-adventure";
+    tag = finalAttrs.version;
+    hash = "sha256-xbsMz99CNLhpM6BSJVcRzxPB6tUYfPy/3Z+8BKt8b1E=";
+  };
+
+  nativeBuildInputs = [
+    python3Packages.python
+    pkg-config
+    asciidoctor
+  ];
+
+  buildInputs = [
+    python3Packages.pyyaml
+    libedit
+  ];
+
+  doCheck = true;
+
+  nativeCheckInputs = [
+    python3Packages.pylint
+    cppcheck
+  ];
+
+  postPatch = ''
+    patchShebangs --build make_dungeon.py
+
+    # https://gitlab.com/esr/open-adventure/-/issues/70
+    substituteInPlace Makefile --replace-fail "--template " "--template="
+
+    substituteInPlace tests/tapview --replace-fail "/bin/echo" ${lib.getExe' coreutils "echo"}
+  '';
+
+  buildFlags = [
+    "advent.6"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -vp "$out/bin" "$out/share/man/man6" "$out/share/applications/" "$out/share/icons/hicolor/scalable/apps"
+    install -m 555 ./advent $out/bin
+    install -m 444 ./advent.6 $out/share/man/man6
+    install -m 444 ./advent.desktop $out/share/applications
+    install -m 444 ./advent.svg $out/share/icons/hicolor/scalable/apps
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Forward-port of the Crowther/Woods Adventure 2.5 game from 1995";
+    longDescription = ''
+      This code is a forward-port of the Crowther/Woods Adventure 2.5 game
+      from 1995, last version in the main line of Colossal Cave Adventure
+      development written by Crowther and Woods. The authors have given
+      permission and encouragement to this release.
+    '';
+    license = lib.licenses.bsd2;
+    mainProgram = "advent";
+    homepage = "http://www.catb.org/~esr/open-adventure/";
+    changelog = "https://gitlab.com/esr/open-adventure/-/blob/${finalAttrs.version}/NEWS.adoc";
+    maintainers = with lib.maintainers; [ EmanuelM153 ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
[open-adventure](http://www.catb.org/~esr/open-adventure/history.html) is a forward-port of the Crowther/Woods Adventure 2.5 game from 1995

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc