### PR TITLE
python3.pkgs.service-identity: 24.1.0 -> 24.2.0

### DIFF
--- a/pkgs/development/python-modules/service-identity/default.nix
+++ b/pkgs/development/python-modules/service-identity/default.nix
@@ -12,11 +12,12 @@
   pyasn1-modules,
   pytestCheckHook,
   pythonOlder,
+  pyopenssl,
 }:
 
 buildPythonPackage rec {
   pname = "service-identity";
-  version = "24.1.0";
+  version = "24.2.0";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
@@ -25,7 +26,7 @@ buildPythonPackage rec {
     owner = "pyca";
     repo = pname;
     tag = version;
-    hash = "sha256-ibi9hls/VnVePv4fF2CyxI22P1RX6QpCwyeENWVPkx4=";
+    hash = "sha256-onxCUWqGVeenLqB5lpUpj3jjxTM61ogXCQOGnDnClT4=";
   };
 
   nativeBuildInputs = [
@@ -41,6 +42,8 @@ buildPythonPackage rec {
     pyasn1
     pyasn1-modules
   ];
+
+  checkInputs = [ pyopenssl ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 

--- a/pkgs/development/tools/continuous-integration/buildbot/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildbot/default.nix
@@ -3,25 +3,10 @@
   newScope,
   python3,
   recurseIntoAttrs,
-  fetchFromGitHub,
 }:
 # Take packages from self first, then python.pkgs (and secondarily pkgs)
 lib.makeScope (self: newScope (self.python.pkgs // self)) (self: {
-  python = python3.override {
-    self = self.python;
-    packageOverrides = self: super: {
-      service-identity = super.service-identity.overridePythonAttrs (oldAttrs: {
-        version = "24.2.0";
-        src = fetchFromGitHub {
-          owner = "pyca";
-          repo = "service-identity";
-          tag = "24.2.0";
-          hash = "sha256-onxCUWqGVeenLqB5lpUpj3jjxTM61ogXCQOGnDnClT4=";
-        };
-        checkInputs = [ super.pyopenssl ];
-      });
-    };
-  };
+  python = python3;
 
   buildbot-pkg = self.callPackage ./pkg.nix { };
 


### PR DESCRIPTION
Changelog: https://github.com/pyca/service-identity/releases/tag/24.2.0

This one is required for pyopenssl to work e.g. in twisted/buildbot
cc @zowoq 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
