### PR TITLE
alsa-utils: replace /usr/bin in udev rules

### DIFF
--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -16,6 +16,7 @@
   pipewire,
   withPipewireLib ? true,
   symlinkJoin,
+  coreutils,
 }:
 
 let
@@ -65,6 +66,9 @@ stdenv.mkDerivation rec {
       ]
     }"
     wrapProgram $out/bin/aplay --set-default ALSA_PLUGIN_DIR ${plugin-dir}
+
+    sed -i $out/lib/udev/rules.d/*.rules \
+      -e 's,/usr/bin/cat,${coreutils}/bin/cat,g'
   '';
 
   passthru.updateScript = directoryListingUpdater {

--- a/pkgs/by-name/al/alsa-utils/package.nix
+++ b/pkgs/by-name/al/alsa-utils/package.nix
@@ -17,6 +17,8 @@
   withPipewireLib ? true,
   symlinkJoin,
   coreutils,
+  testers,
+  alsa-utils,
 }:
 
 let
@@ -73,6 +75,15 @@ stdenv.mkDerivation rec {
 
   passthru.updateScript = directoryListingUpdater {
     url = "https://www.alsa-project.org/files/pub/utils/";
+  };
+
+  passthru.tests.udev-rules = testers.runNixOSTest {
+    name = pname + "-udev-rules";
+    nodes.machine = {
+      services.udev.packages = [ alsa-utils ];
+    };
+    # the udev rules are checked during generation the machine
+    testScript = "machine.start()";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Replace /usr/bin in udev rules. This PR should
fix #370915
but I did not test the udev rule checker.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
