### PR TITLE
Add Module System error contexts for `imports` and module argument infinite recursions

### DIFF
--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -500,6 +500,30 @@ let
 
   applyModuleArgs = key: f: args@{ config, ... }:
     let
+      # Should we add this context to the selection of `_module.args` too?
+      # Triggering at that point seems much less common, and accomodating that
+      # scenario complicates the already long error message. That said, I wonder
+      # if `config` isn't already strict in `_module` defs and decls...
+      # Let's keep it simple for now.
+      config' =
+        name:
+          builtins.addErrorContext
+            ''
+              *risky* while evaluating the module fixpoint, `config`
+
+              Note that the module structure and `imports` fundamentally can not depend on the module fixpoint!
+              An argument `${name}` was not provided externally through .specialArgs., so we try to load it from the module fixpoint...
+              If the following message is "infinite recursion", this was the cause, and possible solutions include:
+              - Perhaps ${name /* unquoted for simplicity */} was misspelled.
+              - Make sure that the module was loaded into the right context.
+              - Provide the argument externally through `specialArgs`.
+              - Structure the module such that the top level attribute set and special attributes like `config`, `imports` and `config._module.args` do not refer to `${name}`.
+                (Except perhaps in a deeper structure, like a more deeply nested attribute, or a `mkIf` condition.)${
+                  # Remove after 25.11.
+                  optionalString (! lib.oldestSupportedReleaseIsAtLeast 2505) "\n\nThe above explanation is new. If it is inaccurate or out of place, please report a minimal example in a Nixpkgs issue and ping the Module System maintainers." }
+            ''
+            config;
+
       # Module arguments are resolved in a strict manner when attribute set
       # deconstruction is used.  As the arguments are now defined with the
       # config._module.args option, the strictness used on the attribute
@@ -515,7 +539,7 @@ let
       context = name: ''while evaluating the module argument `${name}' in "${key}":'';
       extraArgs = mapAttrs (name: _:
         addErrorContext (context name)
-          (args.${name} or config._module.args.${name})
+          (args.${name} or (config' name)._module.args.${name})
       ) (functionArgs f);
 
       # Note: we append in the opposite order such that we can add an error

--- a/lib/modules.nix
+++ b/lib/modules.nix
@@ -404,7 +404,10 @@ let
           };
         in parentFile: parentKey: initialModules: args: collectResults (imap1 (n: x:
           let
-            module = checkModule (loadModule args parentFile "${parentKey}:anon-${toString n}" x);
+            module =
+              builtins.addErrorContext
+                "while loading imports of module `${parentFile}`"
+                (checkModule (loadModule args parentFile "${parentKey}:anon-${toString n}" x));
             collectedImports = collectStructuredModules module._file module.key module.imports args;
           in {
             key = module.key;

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -323,6 +323,9 @@ checkConfigOutput '^true$' "$@" ./define-_module-args-custom.nix
 set -- "$@" ./define-_module-args-custom.nix ./import-custom-arg.nix
 checkConfigError 'while evaluating the module argument .*custom.* in .*import-custom-arg.nix.*:' "$@"
 checkConfigError 'infinite recursion encountered' "$@"
+# Make sure the error context for the `config` fixpoint is not triggered
+checkConfigNotError '\*risky\* while evaluating the module fixpoint.*custom. was not provided externally through .specialArgs., so I will now attempt to load it from the module fixpoint' config.result ./error-context-module-argument-failing.nix
+checkConfigError 'while evaluating the module argument .custom.' config.result ./error-context-module-argument-failing.nix
 
 # Check _module.check.
 set -- config.enable ./declare-enable.nix ./define-enable.nix ./define-attrsOfSub-foo.nix

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -8,6 +8,9 @@
 # [nixpkgs]$ lib/tests/modules.sh
 # or:
 # [nixpkgs]$ nix-build lib/tests/release.nix
+#
+# You may show all error traces, even for successful tests, by setting DUMP_TRACES=1
+# This can answer some questions about the occurrence of certain addErrorContext traces.
 
 set -o errexit -o noclobber -o nounset -o pipefail
 shopt -s failglob inherit_errexit
@@ -19,6 +22,14 @@ cd "$DIR"/modules
 
 pass=0
 fail=0
+
+if [[ -z "${DUMP_TRACES:-}" ]]; then
+    dump_traces() { :; }
+else
+    dump_traces() {
+        echo "$@"
+    }
+fi
 
 # loc
 #   prints the location of the call of to the function that calls it
@@ -96,6 +107,7 @@ checkConfigError() {
     else
         if echo "$err" | grep -zP --silent "$errorContains" ; then
             ((++pass))
+            dump_traces "$err"
         else
             logStartFailure
             echo "ACTUAL:"
@@ -128,6 +140,7 @@ checkConfigNotError() {
             logEndFailure
         else
             ((++pass))
+            dump_traces "$err"
         fi
     fi
 }

--- a/lib/tests/modules/error-context-imports-anonymous.nix
+++ b/lib/tests/modules/error-context-imports-anonymous.nix
@@ -1,0 +1,13 @@
+let
+  b =
+    abort "bad file or whatever";
+  a =
+    {
+      # anonymous module
+      imports = [ b ];
+    };
+in
+{
+  _file = "a-parent";
+  imports = [ a ];
+}

--- a/lib/tests/modules/error-context-imports-fail-in-body-infinite-recursion.nix
+++ b/lib/tests/modules/error-context-imports-fail-in-body-infinite-recursion.nix
@@ -1,0 +1,8 @@
+let
+  b =
+    { someUnknownArg, ... }: someUnknownArg;
+in
+{
+  _file = "a";
+  imports = [ b ];
+}

--- a/lib/tests/modules/error-context-imports-fail-in-body-structure.nix
+++ b/lib/tests/modules/error-context-imports-fail-in-body-structure.nix
@@ -1,0 +1,15 @@
+let
+  b =
+    { ... }: {
+      _file = "b";
+      options = { };
+      config = { };
+
+      # This will be rejected, because this is not a shorthand module syntax.
+      dummyBadAttr = { };
+    };
+in
+{
+  _file = "a";
+  imports = [ b ];
+}

--- a/lib/tests/modules/error-context-imports-fail-in-body.nix
+++ b/lib/tests/modules/error-context-imports-fail-in-body.nix
@@ -1,0 +1,8 @@
+let
+  b =
+    { ... }: abort "bad module";
+in
+{
+  _file = "a";
+  imports = [ b ];
+}

--- a/lib/tests/modules/error-context-imports.nix
+++ b/lib/tests/modules/error-context-imports.nix
@@ -1,0 +1,14 @@
+let
+  b =
+    abort "bad file or whatever";
+  a =
+    {
+      _file = "a";
+      imports = [ b ];
+    };
+in
+{
+  # This _file will not be reported.
+  _file = "not-this-file";
+  imports = [ a ];
+}

--- a/lib/tests/modules/error-context-module-argument-failing.nix
+++ b/lib/tests/modules/error-context-module-argument-failing.nix
@@ -1,0 +1,5 @@
+{ lib, custom, ... }: {
+  options.result = lib.mkOption {};
+  config._module.args.custom = throw "gotcha123";
+  config.result = custom;
+}


### PR DESCRIPTION
Apologies for the combined PR. They intersect at `checkConfigNotError`. Can split if desired nonetheless.

This adds two new error contexts, and a little addition to the test runner.

# Loading imports of module

```
       … while loading imports of module `/home/user/nixpkgs/lib/tests/modules/import-configuration.nix`
```

- only for the latest ok-ish module, not the whole chain
- see commit message

# Infinite recursion through module argument

```
       … while calling 'config''
         at /home/user/h/nixpkgs/lib/modules.nix:509:9:
          508|       config' =
          509|         name:
             |         ^
          510|           builtins.addErrorContext

       … *risky* while evaluating the module fixpoint, `config`

       Note that the module structure and `imports` fundamentally can not depend on the module fixpoint!
       An argument `someUnknownArg` was not provided externally through .specialArgs., so we try to load it from the module fixpoint...
       If the following message is "infinite recursion", this was the cause, and possible solutions include:
       - Perhaps someUnknownArg was misspelled.
       - Make sure that the module was loaded into the right context.
       - Provide the argument externally through `specialArgs`.
       - Structure the module such that the top level attribute set and special attributes like `config`, `imports` and `config._module.args` do not refer to `someUnknownArg`.
         (Except perhaps in a deeper structure, like a more deeply nested attribute, or a `mkIf` condition.)

       The above explanation is new. If it is inaccurate or out of place, please report a minimal example in a Nixpkgs issue and ping the Module System maintainers.


       error: infinite recursion encountered
```

for an example like

```nix
let
  b =
    { someUnknownArg, ... }: {
      imports = [ someUnknownArg ];
    };
in
{
  _file = "a";
  imports = [ b ];
}
```

This has to be the fanciest error message. I am pretty confident about this error message, but I don't have proof, hence the question to report back, which self-destructs in about a year.

Everyone with an up to date Nix will see these traces, even without `--show-trace`.

# Dump traces

`DUMP_TRACES=1` now lets us see all error traces in the test suite, including successful ones.

-----


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
