### PR TITLE
lua-language-server: fix cross compiling

### DIFF
--- a/pkgs/by-name/lu/lua-language-server/package.nix
+++ b/pkgs/by-name/lu/lua-language-server/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  buildPackages,
 
   # nativeBuildInputs
   ninja,
@@ -14,7 +15,9 @@
   versionCheckHook,
   nix-update-script,
 }:
-
+let
+  target = if stdenv.hostPlatform.isDarwin then "macos" else "linux";
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "lua-language-server";
   version = "3.13.4";
@@ -32,15 +35,16 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
   ];
 
-  buildInputs =
-    [
-      fmt
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      rsync
-    ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    rsync
+  ];
 
-  env.NIX_LDFLAGS = "-lfmt";
+  depsBuildBuild = [
+    buildPackages.stdenv.cc
+    buildPackages.fmt
+  ];
+
+  env.NIX_LDFLAGS_FOR_BUILD = "-lfmt";
 
   postPatch =
     ''
@@ -64,38 +68,32 @@ stdenv.mkDerivation (finalAttrs: {
         --replace-fail "require 'tclient.tests.load-relative-library'" ""
 
       pushd 3rd/luamake
+
+      sed -i compile/ninja/${target}.ninja \
+        -e '/c++/s,$cc,${buildPackages.stdenv.cc.targetPrefix}cc,' \
+        -e '/test.lua/s,= .*,= true,' \
+        -e '/ldl/s,$cc,${buildPackages.stdenv.cc.targetPrefix}cc,' \
+        -e 's/cc = .*/cc = ${buildPackages.stdenv.cc.targetPrefix}cc/g'
+      sed -i scripts/compiler/gcc.lua \
+        -e '/cxx_/s,$cc,${buildPackages.stdenv.cc.targetPrefix}cc,'
     ''
     + lib.optionalString stdenv.hostPlatform.isDarwin (
-      # This package uses the program clang for C and C++ files. The language
-      # is selected via the command line argument -std, but this do not work
-      # in combination with the nixpkgs clang wrapper. Therefor we have to
-      # find all c++ compiler statements and replace $cc (which expands to
-      # clang) with clang++.
-      ''
-        sed -i compile/ninja/macos.ninja \
-          -e '/c++/s,$cc,clang++,' \
-          -e '/test.lua/s,= .*,= true,' \
-          -e '/ldl/s,$cc,clang++,'
-        sed -i scripts/compiler/gcc.lua \
-          -e '/cxx_/s,$cc,clang++,'
-      ''
       # Avoid relying on ditto (impure)
-      + ''
+      ''
         substituteInPlace compile/ninja/macos.ninja \
           --replace-fail "ditto" "rsync -a"
 
         substituteInPlace scripts/writer.lua \
           --replace-fail "ditto" "rsync -a"
-      ''
-    );
+      '');
 
   ninjaFlags = [
-    "-fcompile/ninja/${if stdenv.hostPlatform.isDarwin then "macos" else "linux"}.ninja"
+    "-fcompile/ninja/${target}.ninja"
   ];
 
   postBuild = ''
     popd
-    ./3rd/luamake/luamake rebuild
+    ./3rd/luamake/luamake rebuild -cc ${stdenv.cc.targetPrefix}cc
   '';
 
   installPhase = ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Makes `pkgsCross.riscv64.lua-language-server` work on `aarch64-linux`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
