### PR TITLE
nixos/victoriametrics: Add ability to pass basicAuthPassword file

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -450,6 +450,8 @@ Alongside many enhancements to NixOS modules and general system improvements, th
 
 - [`hardware.xone`](#opt-hardware.xone.enable) will also enable [`hardware.xpad-noone`](#opt-hardware.xpad-noone.enable) to provide Xbox 360 driver by default.
 
+- `service.victoriametrics` now has optional parameters `basicAuthUser` `basicAuthPasswordFile` to enable basic auth functionality of `victoriametrics` package.  Those options can be used for authentication on `victoriametrics` level as a replacement of `vmauth` used for single-instances as auth frontend
+
 - `services.mysql` now supports easy cluster setup via [`services.mysql.galeraCluster`](#opt-services.mysql.galeraCluster.enable) option.
 
   Example:

--- a/nixos/modules/services/databases/victoriametrics.nix
+++ b/nixos/modules/services/databases/victoriametrics.nix
@@ -155,7 +155,9 @@ in
           startCLIList
           ++ lib.optionals (cfg.prometheusConfig != { }) [ "-promscrape.config=${prometheusConfigYml}" ]
           ++ lib.optional (cfg.basicAuthUsername != null) "-httpAuth.username=${cfg.basicAuthUsername}"
-          ++ lib.optional (cfg.basicAuthPasswordFile != null) "-httpAuth.password=file://\${CREDENTIALS_DIRECTORY}/basic_auth_password"
+          ++ lib.optional (
+            cfg.basicAuthPasswordFile != null
+          ) "-httpAuth.password=file://\${CREDENTIALS_DIRECTORY}/basic_auth_password"
         );
 
         DynamicUser = true;

--- a/nixos/modules/services/databases/victoriametrics.nix
+++ b/nixos/modules/services/databases/victoriametrics.nix
@@ -171,9 +171,9 @@ in
         );
 
         DynamicUser = true;
-        LoadCredential = lib.optionals (
-          cfg.basicAuthPasswordFile != null
-        ) "basic_auth_password:${cfg.basicAuthPasswordFile}";
+        LoadCredential = lib.optionals (cfg.basicAuthPasswordFile != null) [
+          "basic_auth_password:${cfg.basicAuthPasswordFile}"
+        ];
 
         RestartSec = 1;
         Restart = "on-failure";

--- a/nixos/modules/services/databases/victoriametrics.nix
+++ b/nixos/modules/services/databases/victoriametrics.nix
@@ -144,6 +144,16 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion =
+          (cfg.basicAuthUsername != null && cfg.basicAuthPasswordFile == null)
+          || (cfg.basicAuthUsername == null && cfg.basicAuthPasswordFile != null);
+        message = "Both basicAuthUsername and basicAuthPasswordFile must be set together to enable basicAuth functionality, or neither should be set.";
+      }
+    ];
+
     systemd.services.victoriametrics = {
       description = "VictoriaMetrics time series database";
       wantedBy = [ "multi-user.target" ];

--- a/nixos/modules/services/databases/victoriametrics.nix
+++ b/nixos/modules/services/databases/victoriametrics.nix
@@ -171,9 +171,9 @@ in
         );
 
         DynamicUser = true;
-        LoadCredential = lib.optional (cfg.basicAuthPasswordFile != null) [
-          "basic_auth_password:${cfg.basicAuthPasswordFile}"
-        ];
+        LoadCredential = lib.optionals (
+          cfg.basicAuthPasswordFile != null
+        ) "basic_auth_password:${cfg.basicAuthPasswordFile}";
 
         RestartSec = 1;
         Restart = "on-failure";

--- a/nixos/tests/victoriametrics/remote-write.nix
+++ b/nixos/tests/victoriametrics/remote-write.nix
@@ -31,10 +31,8 @@ import ../make-test-python.nix (
           networking.firewall.allowedTCPPorts = [ 8428 ];
           services.victoriametrics = {
             enable = true;
-            extraOptions = [
-              "-httpAuth.username=${username}"
-              "-httpAuth.password=file://${toString passwordFile}"
-            ];
+            basicAuthUsername = username;
+            basicAuthPasswordFile = toString passwordFile;
           };
         };
 


### PR DESCRIPTION
**Summary**:
Adds ability to pass `basicAuthPasswordFile` parameter via `LoadCredentials` option

**Use case:**
* Usage of `basicAuthPasswordFile` now possible in conjunction with sops-nix, agenix, etc

vmagent uses DynamicUser with `LoadCredentials` option to pass `basicAuthPasswordFile` option
https://github.com/NixOS/nixpkgs/blob/18536bf04cd71abd345f9579158841376fdd0c5a/nixos/modules/services/monitoring/vmagent.nix#L95 
To maintain code uniform (as modules are related) I backported this change
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
