### PR TITLE
[staging] treewide: remove obsolete aligned allocation workarounds

### DIFF
--- a/pkgs/by-name/ng/nghttp2/package.nix
+++ b/pkgs/by-name/ng/nghttp2/package.nix
@@ -88,14 +88,6 @@ stdenv.mkDerivation rec {
     (lib.enableFeature enableHttp3 "http3")
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals
-      (stdenv.hostPlatform.isDarwin && lib.versionOlder stdenv.hostPlatform.darwinMinVersion "10.13")
-      [
-        "-faligned-allocation"
-      ]
-  );
-
   # Unit tests require CUnit and setting TZDIR environment variable
   doCheck = enableTests;
   nativeCheckInputs = lib.optionals (enableTests) [

--- a/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
+++ b/pkgs/development/libraries/qt-6/modules/qtquick3dphysics.nix
@@ -12,8 +12,5 @@ qtModule {
     qtbase
     qtquick3d
   ];
-  env.NIX_CFLAGS_COMPILE = lib.optionalString (
-    stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64
-  ) "-faligned-allocation";
   meta.mainProgram = "cooker";
 }

--- a/pkgs/development/python-modules/pybind11/default.nix
+++ b/pkgs/development/python-modules/pybind11/default.nix
@@ -26,27 +26,6 @@ let
       pythonSitePackages = "${python}/${python.sitePackages}";
     };
   } ./setup-hook.sh;
-
-  # clang 16 defaults to C++17, which results in the use of aligned allocations by pybind11.
-  # libc++ supports aligned allocations via `posix_memalign`, which is available since 10.6,
-  # but clang has a check hard-coded requiring 10.13 because that’s when Apple first shipped a
-  # support for C++17 aligned allocations on macOS.
-  # Tell clang we’re targeting 10.13 on x86_64-darwin while continuing to use the default SDK.
-  stdenv' =
-    if stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64 then
-      python.stdenv.override (oldStdenv: {
-        buildPlatform = oldStdenv.buildPlatform // {
-          darwinMinVersion = "10.13";
-        };
-        targetPlatform = oldStdenv.targetPlatform // {
-          darwinMinVersion = "10.13";
-        };
-        hostPlatform = oldStdenv.hostPlatform // {
-          darwinMinVersion = "10.13";
-        };
-      })
-    else
-      python.stdenv;
 in
 buildPythonPackage rec {
   pname = "pybind11";
@@ -68,8 +47,6 @@ buildPythonPackage rec {
 
   buildInputs = lib.optionals (pythonOlder "3.9") [ libxcrypt ];
   propagatedNativeBuildInputs = [ setupHook ];
-
-  stdenv = stdenv';
 
   dontUseCmakeBuildDir = true;
 

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -148,10 +148,6 @@ let
       # Note: do not set TERM=dumb environment variable globally, it is used in
       # test-ci-js test suite to skip tests that otherwise run fine.
       NINJA = "TERM=dumb ninja";
-    } // lib.optionalAttrs (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) {
-      # Make sure libc++ uses `posix_memalign` instead of `aligned_alloc` on x86_64-darwin.
-      # Otherwise, nodejs would require the 11.0 SDK and macOS 10.15+.
-      NIX_CFLAGS_COMPILE = "-D__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__=101300 -Wno-macro-redefined";
     };
 
     # NB: technically, we do not need bash in build inputs since all scripts are


### PR DESCRIPTION
`staging` counterpart of https://github.com/NixOS/nixpkgs/pull/370749.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
