### PR TITLE
python3Packages.sphinxext-rediraffe: init at 0.2.7

### DIFF
--- a/pkgs/development/python-modules/sphinxext-rediraffe/default.nix
+++ b/pkgs/development/python-modules/sphinxext-rediraffe/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  sphinx,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "sphinxext-rediraffe";
+  version = "0.2.7";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "wpilibsuite";
+    repo = "sphinxext-rediraffe";
+    tag = "v${version}";
+    hash = "sha256-g+GD1ApD26g6PwPOH/ir7aaEgH+n1QQYSr9QizYrmug=";
+  };
+
+  postPatch = ''
+    # Fixes "packaging.version.InvalidVersion: Invalid version: 'main'"
+    substituteInPlace setup.py \
+      --replace-fail 'version = "main"' 'version = "${version}"'
+  '';
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    sphinx
+  ];
+
+  # tests require seleniumbase which is not currently in nixpkgs
+  doCheck = false;
+
+  pythonImportsCheck = [ "sphinxext.rediraffe" ];
+
+  pythonNamespaces = [ "sphinxext" ];
+
+  meta = {
+    description = "Sphinx extension to redirect files";
+    homepage = "https://github.com/wpilibsuite/sphinxext-rediraffe";
+    changelog = "https://github.com/wpilibsuite/sphinxext-rediraffe/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.newam ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -15766,6 +15766,8 @@ self: super: with self; {
 
   sphinxext-opengraph = callPackage ../development/python-modules/sphinxext-opengraph { };
 
+  sphinxext-rediraffe = callPackage ../development/python-modules/sphinxext-rediraffe { };
+
   spidev = callPackage ../development/python-modules/spidev { };
 
   splinter = callPackage ../development/python-modules/splinter { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Add [sphinxext-rediraffe](https://github.com/wpilibsuite/sphinxext-rediraffe), a Sphinx extension to redirect moved files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
