### PR TITLE
celestegame: init at 1.4.0.0{,+everest.5806}

### DIFF
--- a/pkgs/by-name/ce/celestegame/celeste/default.nix
+++ b/pkgs/by-name/ce/celestegame/celeste/default.nix
@@ -1,0 +1,171 @@
+{
+  lib,
+  stdenvNoCC,
+  requireFile,
+  makeWrapper,
+  copyDesktopItems,
+  makeDesktopItem,
+  unzip,
+  yq,
+  dotnet-runtime_8,
+
+  executableName ? "Celeste",
+  desktopItems ? null,
+  everest ? null,
+  overrideSrc ? null,
+  writableDir ? null,
+  launchFlags ? "",
+  launchEnv ? "",
+  # If we leave it to be the default (log.txt),
+  # Everest will try to delete log.txt when it starts,
+  # which doesn't work because the file system is read-only.
+  # https://github.com/EverestAPI/Everest/blob/050b4a1b4a7918b22d3d5140224f9c0472e1655a/Celeste.Mod.mm/Patches/Celeste.cs#L140-L155
+  everestLogFilename ? "everest-log.txt",
+}:
+
+# TODO: It appears that it is possible to package Celeste for aarch devices:
+# https://github.com/pixelomer/Celeste-ARM64
+# However, I don't have an aarch device to do that.
+# The ARM support doesn't seem promising because the builder needs to fetch fmod libraries somehow, which requires an account.
+# Though this whole process of registration and downloading can possibly be automated, this is probably against the TOS.
+let
+  pname = "celeste-unwrapped";
+  version = "1.4.0.0";
+  downloadPage = "https://maddymakesgamesinc.itch.io/celeste";
+  description = "2D platformer game about climing a mountain";
+  phome = "$out/lib/Celeste";
+
+  launchFlags' =
+    if launchFlags != "" && everest == null then
+      lib.warn "launchFlags is useless without Everest." ""
+    else
+      launchFlags;
+  launchEnv' =
+    if launchEnv != "" && everest == null then
+      lib.warn "launchEnv is useless without Everest." ""
+    else
+      ''
+        EVEREST_LOG_FILENAME=${everestLogFilename}
+        EVEREST_TMPDIR=${writableDir}
+        ${launchEnv}
+      '';
+in
+stdenvNoCC.mkDerivation {
+  pname = "celeste-unwrapped";
+  version = version;
+
+  src =
+    if overrideSrc == null then
+      requireFile {
+        name = "celeste-linux.zip";
+        hash = "sha256-phNDBBHb7zwMRaBHT5D0hFEilkx9F31p6IllvLhHQb8=";
+        url = downloadPage;
+      }
+    else
+      overrideSrc;
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    unzip
+    yq
+    makeWrapper
+    copyDesktopItems
+  ];
+  desktopItems =
+    if desktopItems != null then
+      desktopItems
+    else
+      [
+        (makeDesktopItem {
+          name = "Celeste";
+          desktopName = "Celeste";
+          genericName = "Celeste";
+          comment = description;
+          exec = "${executableName}";
+          icon = "Celeste";
+          categories = [ "Game" ];
+        })
+      ];
+
+  postInstall = ''
+    mkdir -p ${phome}
+    unzip -q $src -d ${phome}
+  ''
+  + lib.optionalString (everest != null) ''
+    cp -r ${everest}/* $out
+    chmod -R +w ${phome} # Files copied from other derivations are not writable by default
+
+    # There will still be a runtime error saying chmod failed for the splash,
+    # but it doesn't matter because we make it executable here.
+    # https://github.com/EverestAPI/Everest/blob/050b4a1b4a7918b22d3d5140224f9c0472e1655a/Celeste.Mod.mm/Mod/Everest/EverestSplashHandler.cs#L73-L81
+    chmod +x ${phome}/EverestSplash/EverestSplash-linux
+
+    # Everest determines whether it is FNA or XNA by the existence of the file.
+    # Creating this now prevents it from creating it in the future
+    # when the file system is read-only.
+    # https://github.com/EverestAPI/Everest/blob/050b4a1b4a7918b22d3d5140224f9c0472e1655a/Celeste.Mod.mm/Patches/Celeste.cs#L41-L47
+    touch ${phome}/BuildIsFNA.txt
+
+    # Please Piton by having the runtime.
+    # Otherwise it will try to download it.
+    # https://github.com/Popax21/Piton/blob/21c7868d06007f0c5e7d9030a0109fe892df1bf3/apphost/src/runtime.rs#L82-L89
+    mkdir ${phome}/piton-runtime
+    ln -s ${dotnet-runtime_8}/share/dotnet/* -t ${phome}/piton-runtime
+    platform=linux-x86_64
+    echo -n "$platform $(yq -r .\"$platform\".version ${phome}/piton-runtime.yaml)" > ${phome}/piton-runtime/piton-runtime-id.txt
+
+    chmod +x ${phome}/MiniInstaller-linux
+    ${phome}/MiniInstaller-linux
+
+    echo "${launchFlags'}" > ${phome}/everest-launch.txt
+    echo "${launchEnv'}" > ${phome}/everest-env.txt
+  ''
+  + (
+    if writableDir != null then
+      ''
+        mv ${phome}/Celeste ${phome}/Celeste-unwrapped
+        ln -s ${writableDir}/Celeste ${phome}/Celeste
+      ''
+    else
+      ''
+        ln -s ${phome}/Celeste ${phome}/Celeste-unwrapped
+      ''
+  )
+  + ''
+    makeWrapper ${phome}/Celeste-unwrapped $out/bin/${executableName} ${
+      # If ${phome}/lib64-linux is not present in LD_LIBRARY_PATH, Everest will try to restart:
+      # https://github.com/EverestAPI/Everest/blob/7bd41c26850bbdfef937e2ed929174e864101c4c/Celeste.Mod.mm/Mod/Everest/BOOT.cs#L188-L201
+      # It is hardcoded that it launches Celeste instead of Celeste-unwrapped.
+      # Therefore, we need to prevent it from restarting.
+      lib.optionalString (everest != null) "--prefix LD_LIBRARY_PATH : ${phome}/lib64-linux"
+    } --chdir ${phome}
+
+    icon=$out/share/icons/hicolor/512x512/apps/Celeste.png
+    mkdir -p $(dirname $icon)
+    ln -s ${phome}/Celeste.png $icon
+  '';
+
+  dontPatchELF = true;
+  dontStrip = true;
+  dontPatchShebangs = true;
+  postFixup =
+    lib.optionalString (everest != null) ''
+      rm -r ${phome}/Mods # Currently it is empty.
+      ln -s "${writableDir}"/{Mods,LogHistory,CrashLogs,${everestLogFilename}} -t ${phome}
+    ''
+    + lib.optionalString (writableDir != null) ''
+      ln -s "${writableDir}/log.txt" -t ${phome}
+    '';
+
+  meta = {
+    inherit downloadPage description;
+    homepage = "https://www.celestegame.com";
+    license = with lib.licenses; [ unfree ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+  };
+}

--- a/pkgs/by-name/ce/celestegame/everest-bin/default.nix
+++ b/pkgs/by-name/ce/celestegame/everest-bin/default.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchzip,
+  icu,
+  autoPatchelfHook,
+}:
+
+let
+  pname = "everest";
+  version = "5806";
+  phome = "$out/lib/Celeste";
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+  src = fetchzip {
+    url = "https://github.com/EverestAPI/Everest/releases/download/stable-1.5806.0/main.zip";
+    extension = "zip";
+    hash = "sha256-Hw/BNvWfhdO7bvYrY/Px12BRG1SYcCBeAXBH4QnKyeY=";
+  };
+  buildInputs = [
+    icu
+  ];
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+  postInstall = ''
+    mkdir -p ${phome}
+    cp -r * ${phome}
+  '';
+  dontAutoPatchelf = true;
+  dontPatchELF = true;
+  dontStrip = true;
+  dontPatchShebangs = true;
+  postFixup = ''
+    autoPatchelf ${phome}/MiniInstaller-linux
+  '';
+  meta = {
+    description = "Celeste mod loader";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    homepage = "https://everestapi.github.io";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+
+}

--- a/pkgs/by-name/ce/celestegame/everest/default.nix
+++ b/pkgs/by-name/ce/celestegame/everest/default.nix
@@ -1,0 +1,107 @@
+{
+  lib,
+  fetchurl,
+  fetchFromGitHub,
+  buildDotnetModule,
+  dotnetCorePackages,
+  autoPatchelfHook,
+  mono,
+  git,
+  icu,
+}:
+
+let
+  pname = "everest";
+  version = "5806";
+  phome = "$out/lib/Celeste";
+in
+buildDotnetModule {
+  inherit pname version;
+
+  src = fetchFromGitHub {
+    owner = "EverestAPI";
+    repo = "Everest";
+    rev = "e47f67fc8c4b0b60b0a75112c5c90704ed371040";
+    fetchSubmodules = true;
+    leaveDotGit = true; # MonoMod.SourceGen.Internal needs .git
+    hash = "sha256-uxb9LwCDGJIc+JN2EqNqHdLLwULnG7Bd/Az3H1zKf3E=";
+  };
+
+  nativeBuildInputs = [
+    git
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    icu # For autoPatchelf
+    mono # See upstream README
+  ];
+
+  postPatch = ''
+    # MonoMod.ILHelpers.Patcher complains at build phase: You must install .NET to run this application.
+    sed -i 's|<Exec Command="&quot;|<Exec Command="DOTNET_ROOT=${dotnetCorePackages.runtime_8_0}/share/dotnet \&quot;|' external/MonoMod/tools/Common.IL.targets
+
+    # Moving files after publishing somehow doesn't work. Will do this manually in postInstall.
+    sed -i 's|<Move.*/>||' Celeste.Mod.mm/Celeste.Mod.mm.csproj
+
+    autoPatchelf lib-ext/piton/piton-linux_x64
+  '';
+
+  dotnet-sdk = dotnetCorePackages.sdk_9_0;
+
+  preConfigure = ''
+    # Microsoft.SourceLink.GitHub complains: Unable to determine repository url, the source code won't be available via source link.
+    cd external/MonoMod
+    git -c safe.directory='*' remote add origin https://github.com/MonoMod/MonoMod.git
+    cd ../..
+  '';
+
+  nugetDeps = ./deps.json;
+
+  # Needed for ILAsm projects: https://github.com/NixOS/nixpkgs/issues/370754#issuecomment-2571475814
+  linkNugetPackages = true;
+
+  # Microsoft.NET.Sdk complains: The process cannot access the file xxx because it is being used by another process.
+  enableParallelBuilding = false;
+
+  preBuild = ''
+    # See .azure-pipelines/prebuild.ps1
+    sed -i 's|0\.0\.0-dev|1.${version}.0-nixos-'$(git rev-parse --short=5 HEAD)'|' Celeste.Mod.mm/Mod/Everest/Everest.cs
+    cat Celeste.Mod.mm/Mod/Everest/Everest.cs
+    cat <<-EOF > Celeste.Mod.mm/Mod/Helpers/EverestVersion.cs
+      namespace Celeste.Mod.Helpers {
+        internal static class EverestBuild${version} {
+          public static string EverestBuild = "EverestBuild${version}";
+        }
+      }
+    EOF
+  '';
+
+  installPath = builtins.replaceStrings [ "$out" ] [ (placeholder "out") ] phome;
+
+  postInstall = ''
+    mkdir tmp-EverestSplash
+    mv ${phome}/EverestSplash* tmp-EverestSplash
+    mv tmp-EverestSplash ${phome}/EverestSplash
+    cp ${phome}/piton-runtime.yaml ${phome}/EverestSplash
+  '';
+
+  executables = [ ];
+
+  dontPatchELF = true;
+  dontStrip = true;
+  dontPatchShebangs = true;
+  dontAutoPatchelf = true;
+
+  meta = {
+    description = "Celeste mod loader";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+    homepage = "https://everestapi.github.io";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+      fromSource
+    ];
+  };
+}

--- a/pkgs/by-name/ce/celestegame/everest/deps.json
+++ b/pkgs/by-name/ce/celestegame/everest/deps.json
@@ -1,0 +1,1037 @@
+[
+  {
+    "pname": "DotNetZip",
+    "version": "1.16.0",
+    "hash": "sha256-RlzHkO7DxCvRkr+gpM8Abs34XbovmBTmXfO7LtnE75E="
+  },
+  {
+    "pname": "IsExternalInit",
+    "version": "1.0.3",
+    "hash": "sha256-UfyGrj+hAfsvS/R7tlugTToD//ax9Fy0CameinRn1AU="
+  },
+  {
+    "pname": "Jdenticon-net",
+    "version": "3.1.2",
+    "hash": "sha256-tee3C3lYVDiic/8zZkNSuz8fNx7DXQFReIdrlQWRmww="
+  },
+  {
+    "pname": "KeraLua",
+    "version": "1.3.2",
+    "hash": "sha256-15C9K/S9L3yzB4wmDRNWQoWNskUVcm6qZjCbQQFGMPI="
+  },
+  {
+    "pname": "MAB.DotIgnore",
+    "version": "3.0.2",
+    "hash": "sha256-iAX3oCX2092oKXEASUhMkh2A1kh1cBRSkkMJ6BmszRA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Ref",
+    "version": "3.0.1",
+    "hash": "sha256-y4VQ8teCZOnCJyg0rh3s1SbbqfoEclB5T6lCfMrxWUw="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Ref",
+    "version": "3.1.10",
+    "hash": "sha256-51D1XkqFMPHJzOmt1HQ0Bf1n9K0auwEyxTJuqA/8xHY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Ref",
+    "version": "5.0.0",
+    "hash": "sha256-z22ZDldoIlDUYeF9Rje0aVPlYAGKIpdj5wDzn1CW+jQ="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Ref",
+    "version": "6.0.36",
+    "hash": "sha256-9jDkWbjw/nd8yqdzVTagCuqr6owJ/DUMi4BlUZT4hWU="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Ref",
+    "version": "7.0.20",
+    "hash": "sha256-OEDXXjQ1HDRPiA4Y1zPr1xUeH6wlzTCJpts+DZL61wI="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Ref",
+    "version": "8.0.19",
+    "hash": "sha256-QySX2bih1UvwmLcn9cy1j+RuvZZwbcFKggL5Y/WcTnw="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "3.0.3",
+    "hash": "sha256-CbtnZSF+lvyeIfEUC8a0Jf4EMvYAxa9mvWF9lyLymMk="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "3.1.32",
+    "hash": "sha256-OV3Ie8JGTEwNI4Y6DJFh+ZUrBTwrSdFjEbfljfAwn3s="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "5.0.17",
+    "hash": "sha256-iHn2yGpaL5EM8L7nJJ2aRCIZ+kE98NS+KWUvrWnjzhg="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "6.0.36",
+    "hash": "sha256-zUsVIpV481vMLAXaLEEUpEMA9/f1HGOnvaQnaWdzlyY="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "7.0.20",
+    "hash": "sha256-vq59xMfrET8InzUhkAsbs2xp3ML+SO9POsbwAiYKzkA="
+  },
+  {
+    "pname": "Microsoft.AspNetCore.App.Runtime.linux-x64",
+    "version": "8.0.19",
+    "hash": "sha256-u50rdLuoADSDCthx2Fg+AnT192TalHhFrzFCfMgmTn4="
+  },
+  {
+    "pname": "Microsoft.Build.Tasks.Git",
+    "version": "1.1.0",
+    "hash": "sha256-cwZU5VeF6aRZJqoIevJtF9hdYC1rKEf1GuqgCmoVAzE="
+  },
+  {
+    "pname": "Microsoft.Build.Tasks.Git",
+    "version": "8.0.0",
+    "hash": "sha256-vX6/kPij8vNAu8f7rrvHHhPrNph20IcufmrBgZNxpQA="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Analyzers",
+    "version": "3.3.4",
+    "hash": "sha256-qDzTfZBSCvAUu9gzq2k+LOvh6/eRvJ9++VCNck/ZpnE="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.BannedApiAnalyzers",
+    "version": "3.3.4",
+    "hash": "sha256-YPTHTZ8xRPMLADdcVYRO/eq3O9uZjsD+OsGRZE+0+e8="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.Common",
+    "version": "4.12.0",
+    "hash": "sha256-mm/OKG3zPLAeTVGZtuLxSG+jpQDOchn1oyHqBBJW2Ho="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp",
+    "version": "4.12.0",
+    "hash": "sha256-m1i1Q5pyEq4lAoYjNE9baEjTplH8+bXx5wSA+eMmehk="
+  },
+  {
+    "pname": "Microsoft.CodeAnalysis.CSharp.CodeStyle",
+    "version": "4.12.0",
+    "hash": "sha256-c9JyQNTMTr8WoNGzk3KDyaQuZjpkyBnM5I3P5oJwIkU="
+  },
+  {
+    "pname": "Microsoft.Net.Compilers.Toolset",
+    "version": "4.12.0",
+    "hash": "sha256-/iTvMab/y3xJOD0v02J2Pe4pGtm52YzAwZ74AgO5nrw="
+  },
+  {
+    "pname": "Microsoft.NET.HostModel",
+    "version": "3.1.16",
+    "hash": "sha256-42cFtaZFzM93I0gZjuDbcEYWM5Pld+kx2MkWu0J66ww="
+  },
+  {
+    "pname": "Microsoft.NET.Sdk.IL",
+    "version": "8.0.0",
+    "hash": "sha256-guQcVwSaVwJ0uJvUYZqk1bZ9ATLBk3zWHZmTW7EV1KM="
+  },
+  {
+    "pname": "Microsoft.NETCore.App",
+    "version": "2.1.0",
+    "hash": "sha256-RJksv5W7LhWJYGmkwYHfiU0s9XLCvT05KxSMz6U1/OE="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.linux-x64",
+    "version": "3.0.3",
+    "hash": "sha256-hIdA8ncOXoDM6/ryKCTVz/vZrqFLffxAgpN/qfl2L6Y="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.linux-x64",
+    "version": "3.1.32",
+    "hash": "sha256-ajR6pZv0zuzWDyxEnWtAuhasV5biV5lvweEbefTISiM="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.linux-x64",
+    "version": "5.0.17",
+    "hash": "sha256-exMpVamk8ZzfCQDQcDmQDYJplDcOOU99ic7NSDKUgtE="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.linux-x64",
+    "version": "6.0.36",
+    "hash": "sha256-VFRDzx7LJuvI5yzKdGmw/31NYVbwHWPKQvueQt5xc10="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.linux-x64",
+    "version": "7.0.20",
+    "hash": "sha256-Y1Dg8Sqhya86xD+9aJOuznT4mJUyFmoF/YZc0+5LBdc="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Host.linux-x64",
+    "version": "8.0.19",
+    "hash": "sha256-a9t/bX+WIKOu9q2R52b/hPGwOpkAgpYuP42SW2QXTak="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Ref",
+    "version": "3.0.0",
+    "hash": "sha256-PHovvd+mPN9HoCF0rFEnS015p7Yj76+e9cfSU4JAI+I="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Ref",
+    "version": "3.1.0",
+    "hash": "sha256-nuAvHwmJ2s3Ob1qNDH1+uV3awOZaWlaV3FenTmPUWyM="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Ref",
+    "version": "5.0.0",
+    "hash": "sha256-kQ8wpR4crWoqy/jrskat34Y3Nr3nbxoSpEPMnxycwtw="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Ref",
+    "version": "6.0.36",
+    "hash": "sha256-9LZgVoIFF8qNyUu8kdJrYGLutMF/cL2K82HN2ywwlx8="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Ref",
+    "version": "7.0.20",
+    "hash": "sha256-W9RU3bja4BQLAbsaIhANQPJJh6DycDiBR+WZ3mK6Zrs="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Ref",
+    "version": "8.0.19",
+    "hash": "sha256-4ymel0R1c0HrX0plAWubJPzev52y0Fsx1esyQ1R7bXc="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "3.0.3",
+    "hash": "sha256-mxA9JF2WyEDV8yahdwhe4qfCTbIFroUfmMzPBa91b/o="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "3.1.32",
+    "hash": "sha256-h4HjfRnvH81dW84S3TCPcCfxeQLiLN7b1ZleRNsprFY="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "5.0.17",
+    "hash": "sha256-2NpVvrbqct3M1fKiSe/zyt41mf1aV6WUdxIlJod27Ek="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "6.0.36",
+    "hash": "sha256-U8wJ2snSDFqeAgDVLXjnniidC7Cr5aJ1/h/BMSlyu0c="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "7.0.20",
+    "hash": "sha256-L+WaGvoXVMT3tZ7R5xFE06zaLcC3SI7LEf4ATBkUAGQ="
+  },
+  {
+    "pname": "Microsoft.NETCore.App.Runtime.linux-x64",
+    "version": "8.0.19",
+    "hash": "sha256-Ou51zUFTPESAAzP/z0+sLDAAXC54+oDlESBBT12M2lM="
+  },
+  {
+    "pname": "Microsoft.NETCore.DotNetAppHost",
+    "version": "2.1.0",
+    "hash": "sha256-LV8pnNFsKGFONyCTGsd8qB5A+EUIiyvbYWAr0eOEFoI="
+  },
+  {
+    "pname": "Microsoft.NETCore.DotNetHostPolicy",
+    "version": "2.1.0",
+    "hash": "sha256-FqQm4BLznzRmF1nhk3nEwrdeAdCY35eBmHk6/4+MCPY="
+  },
+  {
+    "pname": "Microsoft.NETCore.DotNetHostResolver",
+    "version": "2.1.0",
+    "hash": "sha256-5nQTmMhaEvbuT+1f7u0t0tEK3SCVUeXhsExq8tiYBI0="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "1.1.0",
+    "hash": "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "2.1.0",
+    "hash": "sha256-v09ltBAKTX8iAKuU2nCl+Op/ilVJQ0POZUh2z+u0rVo="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "3.1.0",
+    "hash": "sha256-cnygditsEaU86bnYtIthNMymAHqaT/sf9Gjykhzqgb0="
+  },
+  {
+    "pname": "Microsoft.NETCore.Platforms",
+    "version": "3.1.1",
+    "hash": "sha256-ByV7aEFjGR4L4Tudg4KaJ96lnzr7RhOxzWGE0p5XFRY="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "1.1.0",
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
+  },
+  {
+    "pname": "Microsoft.NETCore.Targets",
+    "version": "2.1.0",
+    "hash": "sha256-+KdWdA9I392SRqMb9KaiiRZatfvJ9RcdbtyGUkpHW7U="
+  },
+  {
+    "pname": "Microsoft.NETFramework.ReferenceAssemblies",
+    "version": "1.0.3",
+    "hash": "sha256-FBoJP5DHZF0QHM0xLm9yd4HJZVQOuSpSKA+VQRpphEE="
+  },
+  {
+    "pname": "Microsoft.NETFramework.ReferenceAssemblies.net35",
+    "version": "1.0.3",
+    "hash": "sha256-sWFWERqIZw2Rp1f71GX8tIVuA0saTVI64sQaRw81ePk="
+  },
+  {
+    "pname": "Microsoft.NETFramework.ReferenceAssemblies.net452",
+    "version": "1.0.3",
+    "hash": "sha256-RTPuFG8D7gnwINEoEtAqmVm4oTW8K4Z87v1o4DDeLMI="
+  },
+  {
+    "pname": "Microsoft.NETFramework.ReferenceAssemblies.net461",
+    "version": "1.0.3",
+    "hash": "sha256-vVIonl+4dlCQuxibOZoGR3o1DAhjAYpFW15dnkUpjMk="
+  },
+  {
+    "pname": "Microsoft.SourceLink.Common",
+    "version": "1.1.0",
+    "hash": "sha256-bVbHHr6Mo1NUdaaQgfj1GvGPzrobRlYb2pI7f4VDslk="
+  },
+  {
+    "pname": "Microsoft.SourceLink.Common",
+    "version": "8.0.0",
+    "hash": "sha256-AfUqleVEqWuHE7z2hNiwOLnquBJ3tuYtbkdGMppHOXc="
+  },
+  {
+    "pname": "Microsoft.SourceLink.GitHub",
+    "version": "1.1.0",
+    "hash": "sha256-Y5zUGJfiSj8/rQ1lK0t5Zje8rjoUhgbWrR8IpwtzB34="
+  },
+  {
+    "pname": "Microsoft.SourceLink.GitHub",
+    "version": "8.0.0",
+    "hash": "sha256-hNTkpKdCLY5kIuOmznD1mY+pRdJ0PKu2HypyXog9vb0="
+  },
+  {
+    "pname": "Microsoft.Win32.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg="
+  },
+  {
+    "pname": "Microsoft.Win32.SystemEvents",
+    "version": "8.0.0",
+    "hash": "sha256-UcxurEamYD+Bua0PbPNMYAZaRulMrov8CfbJGIgTaRQ="
+  },
+  {
+    "pname": "Mono.Cecil",
+    "version": "0.10.4",
+    "hash": "sha256-NFGkoRKoG+C/drjcK8o5as3wRV2AyJYeeQPOH7NcKpo="
+  },
+  {
+    "pname": "Mono.Cecil",
+    "version": "0.11.5",
+    "hash": "sha256-nPFwbzW08gnCjadBdgi+16MHYhsPAXnFIliveLxGaNA="
+  },
+  {
+    "pname": "MonoMod.Backports",
+    "version": "1.1.0",
+    "hash": "sha256-ruRX10/u+lRfMKr0UMbCVYS/nUK5fzV4+8ujJXBnles="
+  },
+  {
+    "pname": "MonoMod.Core",
+    "version": "1.0.0",
+    "hash": "sha256-Y55fgMd0d35qztqqC0drzn3NdSMYLiWie8IL9LbmFnc="
+  },
+  {
+    "pname": "MonoMod.ILHelpers",
+    "version": "1.0.0",
+    "hash": "sha256-N6ybnOMkEtxXy/PdJAEkqHggHYSLETbCMF+mgNGXAvo="
+  },
+  {
+    "pname": "MonoMod.Patcher",
+    "version": "25.0.0-prerelease.1",
+    "hash": "sha256-+5kddzc3FheDIRNoTPWQREc1ufVFjfPFiiKrXTPCTWQ="
+  },
+  {
+    "pname": "MonoMod.RuntimeDetour",
+    "version": "25.0.0",
+    "hash": "sha256-yyP3kTN+OcOoO8xmHZfebKB/EtWNi7V6aJnXUTjVU/8="
+  },
+  {
+    "pname": "MonoMod.RuntimeDetour.HookGen",
+    "version": "22.7.31.1",
+    "hash": "sha256-kjxLqU4/DprV1vyPfvC7nTTa6ShLS3HBFGiDXmHAEJw="
+  },
+  {
+    "pname": "MonoMod.Utils",
+    "version": "25.0.0",
+    "hash": "sha256-PL7/F0zXnLRb5icD5zl/QCeMyTEsJZKOvSBvM1t8BEY="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "1.6.1",
+    "hash": "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw="
+  },
+  {
+    "pname": "NETStandard.Library",
+    "version": "2.0.3",
+    "hash": "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo="
+  },
+  {
+    "pname": "Newtonsoft.Json",
+    "version": "13.0.3",
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
+  },
+  {
+    "pname": "NuGetizer",
+    "version": "1.2.3",
+    "hash": "sha256-KxvcV650WNBqpSn3S6xVjH95PT5mnUb3pPYBPleWHRM="
+  },
+  {
+    "pname": "Nullable",
+    "version": "1.3.1",
+    "hash": "sha256-5x5+l+7YhKjlBR9GEFKrZ8uewyB7eNxMAREwITDJmUM="
+  },
+  {
+    "pname": "PolySharp",
+    "version": "1.14.1",
+    "hash": "sha256-l6hz+SG+cEO817xTMq4DbJSJVnRe6Ffr+uJGVj/t170="
+  },
+  {
+    "pname": "runtime.any.System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-4PGZqyWhZ6/HCTF2KddDsbmTTjxs2oW79YfkberDZS8="
+  },
+  {
+    "pname": "runtime.any.System.Diagnostics.Tools",
+    "version": "4.3.0",
+    "hash": "sha256-8yLKFt2wQxkEf7fNfzB+cPUCjYn2qbqNgQ1+EeY2h/I="
+  },
+  {
+    "pname": "runtime.any.System.Diagnostics.Tracing",
+    "version": "4.3.0",
+    "hash": "sha256-dsmTLGvt8HqRkDWP8iKVXJCS+akAzENGXKPV18W2RgI="
+  },
+  {
+    "pname": "runtime.any.System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
+  },
+  {
+    "pname": "runtime.any.System.Globalization.Calendars",
+    "version": "4.3.0",
+    "hash": "sha256-AYh39tgXJVFu8aLi9Y/4rK8yWMaza4S4eaxjfcuEEL4="
+  },
+  {
+    "pname": "runtime.any.System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE="
+  },
+  {
+    "pname": "runtime.any.System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-Y2AnhOcJwJVYv7Rp6Jz6ma0fpITFqJW+8rsw106K2X8="
+  },
+  {
+    "pname": "runtime.any.System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ="
+  },
+  {
+    "pname": "runtime.any.System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-9EvnmZslLgLLhJ00o5MWaPuJQlbUFcUF8itGQNVkcQ4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-PQRACwnSUuxgVySO1840KvqCC9F8iI9iTzxNW0RcBS4="
+  },
+  {
+    "pname": "runtime.any.System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-Kaw5PnLYIiqWbsoF3VKJhy7pkpoGsUwn4ZDCKscbbzA="
+  },
+  {
+    "pname": "runtime.any.System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs="
+  },
+  {
+    "pname": "runtime.any.System.Text.Encoding.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-6MYj0RmLh4EVqMtO/MRqBi0HOn5iG4x9JimgCCJ+EFM="
+  },
+  {
+    "pname": "runtime.any.System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4="
+  },
+  {
+    "pname": "runtime.any.System.Threading.Timer",
+    "version": "4.3.0",
+    "hash": "sha256-BgHxXCIbicVZtpgMimSXixhFC3V+p5ODqeljDjO8hCs="
+  },
+  {
+    "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps="
+  },
+  {
+    "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I="
+  },
+  {
+    "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA="
+  },
+  {
+    "pname": "runtime.linux-x64.Microsoft.NETCore.App",
+    "version": "2.1.0",
+    "hash": "sha256-qFtPLe3t/V9DZTaYhAO6MbVsyzH4hcQQUvyIJ6ywbEw="
+  },
+  {
+    "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost",
+    "version": "2.1.0",
+    "hash": "sha256-NMuEFKc68Vn4bVoX6kdGSQeyDpktUYliUg6Lbj4E8FU="
+  },
+  {
+    "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy",
+    "version": "2.1.0",
+    "hash": "sha256-U/WlbUpImqPjZf075WgBOb1o1i1H3VOL4QbzHfQ9Itk="
+  },
+  {
+    "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver",
+    "version": "2.1.0",
+    "hash": "sha256-vcB6FY1GDP+kTsmp9OXpPg50sXKqOSJzWUSuNlN1+rs="
+  },
+  {
+    "pname": "runtime.linux-x64.Microsoft.NETCore.ILAsm",
+    "version": "6.0.0",
+    "hash": "sha256-i/UcSf9HhYBtscSZKsaPReL/ntN8EQhmEpFIkEfoGhQ="
+  },
+  {
+    "pname": "runtime.linux-x64.Microsoft.NETCore.ILDAsm",
+    "version": "6.0.0",
+    "hash": "sha256-flN7eEFoqIUmbuGHgVu/R1F7trwjOXwxmBVw/+Jv2Hg="
+  },
+  {
+    "pname": "runtime.native.System",
+    "version": "4.3.0",
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
+  },
+  {
+    "pname": "runtime.native.System.IO.Compression",
+    "version": "4.3.0",
+    "hash": "sha256-DWnXs4vlKoU6WxxvCArTJupV6sX3iBbZh8SbqfHace8="
+  },
+  {
+    "pname": "runtime.native.System.Net.Http",
+    "version": "4.3.0",
+    "hash": "sha256-c556PyheRwpYhweBjSfIwEyZHnAUB8jWioyKEcp/2dg="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.Apple",
+    "version": "4.3.0",
+    "hash": "sha256-2IhBv0i6pTcOyr8FFIyfPEaaCHUmJZ8DYwLUwJ+5waw="
+  },
+  {
+    "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I="
+  },
+  {
+    "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM="
+  },
+  {
+    "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
+    "version": "4.3.0",
+    "hash": "sha256-serkd4A7F6eciPiPJtUyJyxzdAtupEcWIZQ9nptEzIM="
+  },
+  {
+    "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0="
+  },
+  {
+    "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4="
+  },
+  {
+    "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g="
+  },
+  {
+    "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc="
+  },
+  {
+    "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw="
+  },
+  {
+    "pname": "runtime.unix.Microsoft.Win32.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LZb23lRXzr26tRS5aA0xyB08JxiblPDoA7HBvn6awXg="
+  },
+  {
+    "pname": "runtime.unix.System.Console",
+    "version": "4.3.0",
+    "hash": "sha256-AHkdKShTRHttqfMjmi+lPpTuCrM5vd/WRy6Kbtie190="
+  },
+  {
+    "pname": "runtime.unix.System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-ReoazscfbGH+R6s6jkg5sIEHWNEvjEoHtIsMbpc7+tI="
+  },
+  {
+    "pname": "runtime.unix.System.IO.FileSystem",
+    "version": "4.3.0",
+    "hash": "sha256-Pf4mRl6YDK2x2KMh0WdyNgv0VUNdSKVDLlHqozecy5I="
+  },
+  {
+    "pname": "runtime.unix.System.Net.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-pHJ+I6i16MV6m77uhTC6GPY6jWGReE3SSP3fVB59ti0="
+  },
+  {
+    "pname": "runtime.unix.System.Net.Sockets",
+    "version": "4.3.0",
+    "hash": "sha256-IvgOeA2JuBjKl5yAVGjPYMPDzs9phb3KANs95H9v1w4="
+  },
+  {
+    "pname": "runtime.unix.System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
+  },
+  {
+    "pname": "runtime.unix.System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-l8S9gt6dk3qYG6HYonHtdlYtBKyPb29uQ6NDjmrt3V4="
+  },
+  {
+    "pname": "System.AppContext",
+    "version": "4.3.0",
+    "hash": "sha256-yg95LNQOwFlA1tWxXdQkVyJqT4AnoDc+ACmrNvzGiZg="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.3.0",
+    "hash": "sha256-XqZWb4Kd04960h4U9seivjKseGA/YEIpdplfHYHQ9jk="
+  },
+  {
+    "pname": "System.Buffers",
+    "version": "4.5.1",
+    "hash": "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI="
+  },
+  {
+    "pname": "System.Collections",
+    "version": "4.3.0",
+    "hash": "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc="
+  },
+  {
+    "pname": "System.Collections.Concurrent",
+    "version": "4.3.0",
+    "hash": "sha256-KMY5DfJnDeIsa13DpqvyN8NkReZEMAFnlmNglVoFIXI="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "6.0.0",
+    "hash": "sha256-DKEbpFqXCIEfqp9p3ezqadn5b/S1YTk32/EQK+tEScs="
+  },
+  {
+    "pname": "System.Collections.Immutable",
+    "version": "8.0.0",
+    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
+  },
+  {
+    "pname": "System.Console",
+    "version": "4.3.0",
+    "hash": "sha256-Xh3PPBZr0pDbDaK8AEHbdGz7ePK6Yi1ZyRWI1JM6mbo="
+  },
+  {
+    "pname": "System.Diagnostics.Debug",
+    "version": "4.3.0",
+    "hash": "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM="
+  },
+  {
+    "pname": "System.Diagnostics.DiagnosticSource",
+    "version": "4.3.0",
+    "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
+  },
+  {
+    "pname": "System.Diagnostics.Tools",
+    "version": "4.3.0",
+    "hash": "sha256-gVOv1SK6Ape0FQhCVlNOd9cvQKBvMxRX9K0JPVi8w0Y="
+  },
+  {
+    "pname": "System.Diagnostics.Tracing",
+    "version": "4.3.0",
+    "hash": "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q="
+  },
+  {
+    "pname": "System.Drawing.Common",
+    "version": "8.0.0",
+    "hash": "sha256-xPNnKUTcZiqnTtRgI2YazMoZgay/prwKrJjbZUbVmcg="
+  },
+  {
+    "pname": "System.Globalization",
+    "version": "4.3.0",
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
+  },
+  {
+    "pname": "System.Globalization.Calendars",
+    "version": "4.3.0",
+    "hash": "sha256-uNOD0EOVFgnS2fMKvMiEtI9aOw00+Pfy/H+qucAQlPc="
+  },
+  {
+    "pname": "System.Globalization.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mmJWA27T0GRVuFP9/sj+4TrR4GJWrzNIk2PDrbr7RQk="
+  },
+  {
+    "pname": "System.IO",
+    "version": "4.3.0",
+    "hash": "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY="
+  },
+  {
+    "pname": "System.IO.Compression",
+    "version": "4.3.0",
+    "hash": "sha256-f5PrQlQgj5Xj2ZnHxXW8XiOivaBvfqDao9Sb6AVinyA="
+  },
+  {
+    "pname": "System.IO.Compression.ZipFile",
+    "version": "4.3.0",
+    "hash": "sha256-WQl+JgWs+GaRMeiahTFUbrhlXIHapzcpTFXbRvAtvvs="
+  },
+  {
+    "pname": "System.IO.FileSystem",
+    "version": "4.3.0",
+    "hash": "sha256-vNIYnvlayuVj0WfRfYKpDrhDptlhp1pN8CYmlVd2TXw="
+  },
+  {
+    "pname": "System.IO.FileSystem.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
+  },
+  {
+    "pname": "System.Linq",
+    "version": "4.3.0",
+    "hash": "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A="
+  },
+  {
+    "pname": "System.Linq.Expressions",
+    "version": "4.3.0",
+    "hash": "sha256-+3pvhZY7rip8HCbfdULzjlC9FPZFpYoQxhkcuFm2wk8="
+  },
+  {
+    "pname": "System.Memory",
+    "version": "4.5.5",
+    "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
+  },
+  {
+    "pname": "System.Net.Http",
+    "version": "4.3.0",
+    "hash": "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q="
+  },
+  {
+    "pname": "System.Net.NameResolution",
+    "version": "4.3.0",
+    "hash": "sha256-eGZwCBExWsnirWBHyp2sSSSXp6g7I6v53qNmwPgtJ5c="
+  },
+  {
+    "pname": "System.Net.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE="
+  },
+  {
+    "pname": "System.Net.Sockets",
+    "version": "4.3.0",
+    "hash": "sha256-il7dr5VT/QWDg/0cuh+4Es2u8LY//+qqiY9BZmYxSus="
+  },
+  {
+    "pname": "System.Numerics.Vectors",
+    "version": "4.4.0",
+    "hash": "sha256-auXQK2flL/JpnB/rEcAcUm4vYMCYMEMiWOCAlIaqu2U="
+  },
+  {
+    "pname": "System.Numerics.Vectors",
+    "version": "4.5.0",
+    "hash": "sha256-qdSTIFgf2htPS+YhLGjAGiLN8igCYJnCCo6r78+Q+c8="
+  },
+  {
+    "pname": "System.ObjectModel",
+    "version": "4.3.0",
+    "hash": "sha256-gtmRkWP2Kwr3nHtDh0yYtce38z1wrGzb6fjm4v8wN6Q="
+  },
+  {
+    "pname": "System.Private.Uri",
+    "version": "4.3.0",
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
+  },
+  {
+    "pname": "System.Reflection",
+    "version": "4.3.0",
+    "hash": "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.3.0",
+    "hash": "sha256-5LhkDmhy2FkSxulXR+bsTtMzdU3VyyuZzsxp7/DwyIU="
+  },
+  {
+    "pname": "System.Reflection.Emit",
+    "version": "4.7.0",
+    "hash": "sha256-Fw/CSRD+wajH1MqfKS3Q/sIrUH7GN4K+F+Dx68UPNIg="
+  },
+  {
+    "pname": "System.Reflection.Emit.ILGeneration",
+    "version": "4.3.0",
+    "hash": "sha256-mKRknEHNls4gkRwrEgi39B+vSaAz/Gt3IALtS98xNnA="
+  },
+  {
+    "pname": "System.Reflection.Emit.ILGeneration",
+    "version": "4.7.0",
+    "hash": "sha256-GUnQeGo/DtvZVQpFnESGq7lJcjB30/KnDY7Kd2G/ElE="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.3.0",
+    "hash": "sha256-rKx4a9yZKcajloSZHr4CKTVJ6Vjh95ni+zszPxWjh2I="
+  },
+  {
+    "pname": "System.Reflection.Emit.Lightweight",
+    "version": "4.7.0",
+    "hash": "sha256-V0Wz/UUoNIHdTGS9e1TR89u58zJjo/wPUWw6VaVyclU="
+  },
+  {
+    "pname": "System.Reflection.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-mMOCYzUenjd4rWIfq7zIX9PFYk/daUyF0A8l1hbydAk="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "1.5.0",
+    "hash": "sha256-wM75ACJUeypeOdaBUj4oTYiSWmg7A1usMpwRQXjSGK8="
+  },
+  {
+    "pname": "System.Reflection.Metadata",
+    "version": "8.0.0",
+    "hash": "sha256-dQGC30JauIDWNWXMrSNOJncVa1umR1sijazYwUDdSIE="
+  },
+  {
+    "pname": "System.Reflection.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM="
+  },
+  {
+    "pname": "System.Reflection.TypeExtensions",
+    "version": "4.3.0",
+    "hash": "sha256-4U4/XNQAnddgQIHIJq3P2T80hN0oPdU2uCeghsDTWng="
+  },
+  {
+    "pname": "System.Resources.ResourceManager",
+    "version": "4.3.0",
+    "hash": "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo="
+  },
+  {
+    "pname": "System.Runtime",
+    "version": "4.3.0",
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "4.5.3",
+    "hash": "sha256-lnZMUqRO4RYRUeSO8HSJ9yBHqFHLVbmenwHWkIU20ak="
+  },
+  {
+    "pname": "System.Runtime.CompilerServices.Unsafe",
+    "version": "6.0.0",
+    "hash": "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I="
+  },
+  {
+    "pname": "System.Runtime.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o="
+  },
+  {
+    "pname": "System.Runtime.Handles",
+    "version": "4.3.0",
+    "hash": "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms="
+  },
+  {
+    "pname": "System.Runtime.InteropServices",
+    "version": "4.3.0",
+    "hash": "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI="
+  },
+  {
+    "pname": "System.Runtime.InteropServices.RuntimeInformation",
+    "version": "4.3.0",
+    "hash": "sha256-MYpl6/ZyC6hjmzWRIe+iDoldOMW1mfbwXsduAnXIKGA="
+  },
+  {
+    "pname": "System.Runtime.Numerics",
+    "version": "4.3.0",
+    "hash": "sha256-P5jHCgMbgFMYiONvzmaKFeOqcAIDPu/U8bOVrNPYKqc="
+  },
+  {
+    "pname": "System.Security.AccessControl",
+    "version": "4.7.0",
+    "hash": "sha256-/9ZCPIHLdhzq7OW4UKqTsR0O93jjHd6BRG1SRwgHE1g="
+  },
+  {
+    "pname": "System.Security.Cryptography.Algorithms",
+    "version": "4.3.0",
+    "hash": "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8="
+  },
+  {
+    "pname": "System.Security.Cryptography.Cng",
+    "version": "4.3.0",
+    "hash": "sha256-u17vy6wNhqok91SrVLno2M1EzLHZm6VMca85xbVChsw="
+  },
+  {
+    "pname": "System.Security.Cryptography.Csp",
+    "version": "4.3.0",
+    "hash": "sha256-oefdTU/Z2PWU9nlat8uiRDGq/PGZoSPRgkML11pmvPQ="
+  },
+  {
+    "pname": "System.Security.Cryptography.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-Yuge89N6M+NcblcvXMeyHZ6kZDfwBv3LPMDiF8HhJss="
+  },
+  {
+    "pname": "System.Security.Cryptography.OpenSsl",
+    "version": "4.3.0",
+    "hash": "sha256-DL+D2sc2JrQiB4oAcUggTFyD8w3aLEjJfod5JPe+Oz4="
+  },
+  {
+    "pname": "System.Security.Cryptography.Primitives",
+    "version": "4.3.0",
+    "hash": "sha256-fnFi7B3SnVj5a+BbgXnbjnGNvWrCEU6Hp/wjsjWz318="
+  },
+  {
+    "pname": "System.Security.Cryptography.X509Certificates",
+    "version": "4.3.0",
+    "hash": "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0="
+  },
+  {
+    "pname": "System.Security.Permissions",
+    "version": "4.7.0",
+    "hash": "sha256-BGgXMLUi5rxVmmChjIhcXUxisJjvlNToXlyaIbUxw40="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "4.3.0",
+    "hash": "sha256-mbdLVUcEwe78p3ZnB6jYsizNEqxMaCAWI3tEQNhRQAE="
+  },
+  {
+    "pname": "System.Security.Principal.Windows",
+    "version": "4.7.0",
+    "hash": "sha256-rWBM2U8Kq3rEdaa1MPZSYOOkbtMGgWyB8iPrpIqmpqg="
+  },
+  {
+    "pname": "System.Text.Encoding",
+    "version": "4.3.0",
+    "hash": "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg="
+  },
+  {
+    "pname": "System.Text.Encoding.CodePages",
+    "version": "4.7.1",
+    "hash": "sha256-OUA8ttAKGgqD5KUwtnO2OewBF/tJI0nO3YcunK5qMPg="
+  },
+  {
+    "pname": "System.Text.Encoding.CodePages",
+    "version": "7.0.0",
+    "hash": "sha256-eCKTVwumD051ZEcoJcDVRGnIGAsEvKpfH3ydKluHxmo="
+  },
+  {
+    "pname": "System.Text.Encoding.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc="
+  },
+  {
+    "pname": "System.Text.RegularExpressions",
+    "version": "4.3.0",
+    "hash": "sha256-VLCk1D1kcN2wbAe3d0YQM/PqCsPHOuqlBY1yd2Yo+K0="
+  },
+  {
+    "pname": "System.Threading",
+    "version": "4.3.0",
+    "hash": "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc="
+  },
+  {
+    "pname": "System.Threading.Tasks",
+    "version": "4.3.0",
+    "hash": "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.3.0",
+    "hash": "sha256-X2hQ5j+fxcmnm88Le/kSavjiGOmkcumBGTZKBLvorPc="
+  },
+  {
+    "pname": "System.Threading.Tasks.Extensions",
+    "version": "4.5.4",
+    "hash": "sha256-owSpY8wHlsUXn5xrfYAiu847L6fAKethlvYx97Ri1ng="
+  },
+  {
+    "pname": "System.Threading.ThreadPool",
+    "version": "4.3.0",
+    "hash": "sha256-wW0QdvssRoaOfQLazTGSnwYTurE4R8FxDx70pYkL+gg="
+  },
+  {
+    "pname": "System.Threading.Timer",
+    "version": "4.3.0",
+    "hash": "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s="
+  },
+  {
+    "pname": "System.ValueTuple",
+    "version": "4.5.0",
+    "hash": "sha256-niH6l2fU52vAzuBlwdQMw0OEoRS/7E1w5smBFoqSaAI="
+  },
+  {
+    "pname": "System.Windows.Extensions",
+    "version": "4.7.0",
+    "hash": "sha256-yW+GvQranReaqPw5ZFv+mSjByQ5y1pRLl05JIEf3tYU="
+  },
+  {
+    "pname": "System.Xml.ReaderWriter",
+    "version": "4.3.0",
+    "hash": "sha256-QQ8KgU0lu4F5Unh+TbechO//zaAGZ4MfgvW72Cn1hzA="
+  },
+  {
+    "pname": "System.Xml.XDocument",
+    "version": "4.3.0",
+    "hash": "sha256-rWtdcmcuElNOSzCehflyKwHkDRpiOhJJs8CeQ0l1CCI="
+  },
+  {
+    "pname": "YamlDotNet",
+    "version": "16.1.3",
+    "hash": "sha256-xsti5h1ZUCS9Jvb4UGKdHrEudJIQXrbOe0USxSjWqjc="
+  }
+]

--- a/pkgs/by-name/ce/celestegame/package.nix
+++ b/pkgs/by-name/ce/celestegame/package.nix
@@ -1,0 +1,222 @@
+{
+  lib,
+  callPackage,
+  buildFHSEnv,
+  fetchzip,
+  makeDesktopItem,
+  writeShellScript,
+  autoPatchelfHook,
+  runtimeShell,
+
+  overrideSrc ? null,
+  # A package. Omit to build without Everest.
+  everest ? null,
+  # If build with Everest, must set writableDir to the path of a writable dir
+  # so that the mods can be installed there.
+  # It must be an absolute path.
+  # Example: "/home/kat/.local/share/Everest"
+  writableDir ? null,
+  # Optionally set paths of symlinks to the installation dir of Celeste.
+  # You can use this in Olympus so that you don't have to change installation dir path
+  # every time the nix store path changes.
+  # The links are updated every time the command `Celeste` is run.
+  gameDir ? [ ],
+  # This will be appended to everest-launch.txt.
+  launchFlags ? "",
+  # This will be appended to everest-env.txt.
+  launchEnv ? "",
+}:
+
+# For those who would like to use steam-run or alike to launch Celeste
+# (useful when using the `olympus` package with its `celesteWrapper` argument overridden),
+# install `celestegame.passthru.celeste-unwrapped` instead of `celestegame`, and if you want Everest,
+# override `everest` to `celestegame.passthru.everest-bin` instead of `celestegame.passthru.everest`
+# (steam-run cannot launch the latter for some currently unclear reason).
+# For those who would like to launch Celeste without the need of any additional wrapper like steam-run,
+# install `celestegame` with the `writableDir` argument overridden.
+
+let
+  pname = "celeste";
+  phome = "$out/${celesteHomeRelative}";
+  executableName = "Celeste";
+
+  writableDir' =
+    if writableDir == null && everest != null then
+      lib.warn "writableDir is not set, so mods will not work." "/tmp"
+    else
+      writableDir;
+  gameDir' = lib.toList gameDir;
+
+  everestLogFilename = "everest-log.txt";
+
+  celeste = callPackage ./celeste {
+    inherit
+      executableName
+      everest
+      overrideSrc
+      launchFlags
+      launchEnv
+      everestLogFilename
+      ;
+    desktopItems = [ desktopItem ];
+    writableDir = writableDir';
+  };
+  celesteHomeRelative = "lib/Celeste";
+  celesteHome = "${celeste}/${celesteHomeRelative}";
+
+  desktopItem = makeDesktopItem {
+    name = "Celeste";
+    desktopName = "Celeste";
+    genericName = "Celeste";
+    comment = celeste.meta.description;
+    exec = executableName;
+    icon = "Celeste";
+    categories = [ "Game" ];
+  };
+
+in
+buildFHSEnv {
+  inherit pname executableName;
+  version = celeste.version + (lib.optionalString (everest != null) "+everest.${everest.version}");
+
+  multiPkgs =
+    pkgs:
+    with pkgs;
+    [
+      glib
+      glibc_multi
+      kdePackages.wayland
+      libxkbcommon
+      libgcc
+      mesa
+      libdrm
+      expat
+      alsa-lib
+      at-spi2-atk
+      libGL
+      pcre2
+      libffi
+      zlib
+      util-linux.lib
+      libselinux
+      nspr
+      systemd
+      gtk3
+      pango
+      harfbuzz
+      fontconfig
+      fribidi
+      cairo
+      libepoxy
+      tinysparql
+      libthai
+      libpng
+      freetype
+      pixman
+      libcap
+      graphite2
+      bzip2
+      brotli
+      libjpeg
+      json-glib
+      libxml2
+      sqlite
+      libdatrie
+      ffmpeg
+      nss
+      dbus.lib
+      acl
+      attr
+      gmp
+      readline
+      libpulseaudio
+      pipewire
+      vulkan-loader
+    ]
+    ++ (with xorg; [
+      libX11
+      libXcomposite
+      libXdamage
+      libXfixes
+      libXext
+      libxcb
+      libXcursor
+      libXinerama
+      libXi
+      libXrandr
+      libXScrnSaver
+      libXxf86vm
+      libXau
+      libXdmcp
+    ]);
+
+  targetPkgs = pkgs: [ celeste ];
+
+  extraInstallCommands = ''
+    icon=$out/share/icons/hicolor/512x512/apps/Celeste.png
+    mkdir -p $(dirname $icon)
+    ln -s ${celesteHome}/Celeste.png $icon
+    cp -r ${desktopItem}/* $out
+  '';
+
+  extraPreBwrapCmds = ''
+    export NIX_CELESTE_LAUNCHER=$(realpath --no-symlinks $0)
+  '';
+
+  runScript = writeShellScript executableName (
+    lib.optionalString (writableDir' != null) ''
+      mkdir -p "${writableDir'}"
+      touch "${writableDir'}/log.txt"
+
+      # This script is symlinked to gameDir/Celeste, which gets launched by Olympus
+      # (if the user set up Olympus to use gameDir as the location of Celeste).
+      # Writing the script like this makes Olympus able to launch Celeste wihout any wrapper without any problems.
+      echo "#! ${runtimeShell}
+      exec $NIX_CELESTE_LAUNCHER"' "$@"' > "${writableDir'}/Celeste"
+      chmod +x "${writableDir'}/Celeste"
+    ''
+    + lib.optionalString (everest != null) ''
+      mkdir -p "${writableDir'}"/{LogHistory,Mods,CrashLogs}
+      touch "${writableDir'}/${everestLogFilename}"
+
+      # Needed to prevent restarting; see comments in postInstall of ./celeste/default.nix.
+      export LD_LIBRARY_PATH="${celesteHome}/lib64-linux:$LD_LIBRARY_PATH"
+    ''
+    + lib.optionalString (gameDir' != [ ]) (
+      lib.concatMapStrings (link: ''
+        mkdir -p "$(dirname "${link}")"
+        if [ -L "${link}" ]; then
+          if [ ${celesteHome} != "$(readlink "${link}")" ]; then
+            rm "${link}"
+            ln -s ${celesteHome} "${link}"
+          fi
+        else
+          rm -r "${link}"
+          ln -s ${celesteHome} "${link}"
+        fi
+      '') gameDir'
+    )
+    + ''
+      cd /${celesteHomeRelative}
+      exec ./Celeste-unwrapped "$@"
+    ''
+  );
+
+  passthru.celeste-unwrapped = celeste;
+  passthru.everest = callPackage ./everest { };
+  passthru.everest-bin = callPackage ./everest-bin { };
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    inherit (celeste.meta)
+      homepage
+      downloadPage
+      description
+      license
+      sourceProvenance
+      platforms
+      ;
+    maintainers = with lib.maintainers; [ ulysseszhan ];
+  };
+}

--- a/pkgs/by-name/ce/celestegame/update.sh
+++ b/pkgs/by-name/ce/celestegame/update.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl jq common-updater-scripts
+
+set -eu -o pipefail
+
+branch=stable # set to one of dev, beta, stable
+case $branch in
+  dev) branches='"dev", "beta", "stable"' ;;
+  beta) branches='"beta", "stable"' ;;
+  stable) branches='"stable"' ;;
+esac
+
+endpoint=$(curl -s https://everestapi.github.io/everestupdater.txt)
+endpoint="$endpoint$([[ "$endpoint" == *"?"* ]] && echo '&' || echo '?')supportsNativeBuilds=true"
+
+latest=$(curl -s "$endpoint" | jq -r "map(select(.branch | IN($branches))) | max_by(.date)")
+commit=$(echo "$latest" | jq -r .commit)
+version=$(echo "$latest" | jq -r .version)
+url=$(echo "$latest" | jq -r .mainDownload)
+
+update-source-version celestegame.passthru.everest $version --rev=$commit
+"$(nix-build --attr celestegame.passthru.everest.fetch-deps --no-out-link)"
+update-source-version celestegame.passthru.everest-bin $version "" $url


### PR DESCRIPTION
Celeste, a 2D platformer game about climing a mountain.

One needs to obtain the source by purchasing and downloading from itch.io, which is a zip file that contains the installation dir structure at top level. Alternatively, you can use `overrideSrc` to override it, in case the source you got is different from that from itch.io in terms of hash but can just work fine anyway (e.g. ripped from CD, removing DRM from the Steam version, pirated copy, etc).

Install with Everest (the mod loader) by overriding `everest`, which is expected to be a derivation. You can use `celestegame.passthru.everest` or `celestegame.passthru.everest-bin`. The bin package is there because I failed to package from source at first. It will be deleted if there is no good reason to keep it. ~~Currently the source of the bin package is from the Azure pipeline build of my PR to the upstream, which is only kept for 10 days.~~ I can use the build of the main branch now because EverestAPI/Everest#871 was merged.

Installing mods requires putting them (zip files) in the `Mods` dir in the game installation dir, which is read-only. To work around this, one needs to override the `writableDir` argument to provide a writable path. All things in the game installation dir that needs writability are symlinked to the path provided by `writableDir`.

One can manage mods using Olympus by adding the game installation path as a game installation in Olympus. If Olympus is installed by using the one packaged in #309327, it can launch manage mods just fine with this installation. However, because the install path is in nix store and subject to frequent change, one has to often update the path in Olympus. For convenience, one can override the `gameDir` argument to make it automatically symlinked to the new installation when the new one launches.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
