### PR TITLE
mkBinaryCache: improve performance by processing items in parallel

### DIFF
--- a/pkgs/build-support/binary-cache/make-binary-cache.py
+++ b/pkgs/build-support/binary-cache/make-binary-cache.py
@@ -1,43 +1,69 @@
-
+from functools import partial
 import json
+from multiprocessing import Pool
 import os
+from pathlib import Path
 import subprocess
 
-with open(os.environ["NIX_ATTRS_JSON_FILE"], "r") as f:
-  closures = json.load(f)["closure"]
 
-os.chdir(os.environ["out"])
+def dropPrefix(path, nixPrefix):
+    return path[len(nixPrefix + "/") :]
 
-nixPrefix = os.environ["NIX_STORE"] # Usually /nix/store
 
-with open("nix-cache-info", "w") as f:
-  f.write("StoreDir: " + nixPrefix + "\n")
+def processItem(item, nixPrefix, outDir):
+    narInfoHash = dropPrefix(item["path"], nixPrefix).split("-")[0]
 
-def dropPrefix(path):
-  return path[len(nixPrefix + "/"):]
+    xzFile = outDir / "nar" / f"{narInfoHash}.nar.xz"
+    with open(xzFile, "wb") as f:
+        subprocess.run(
+            f"nix-store --dump {item['path']} | xz -c",
+            stdout=f,
+            shell=True,
+            check=True,
+        )
 
-for item in closures:
-  narInfoHash = dropPrefix(item["path"]).split("-")[0]
+    fileHash = (
+        subprocess.run(
+            ["nix-hash", "--base32", "--type", "sha256", "--flat", xzFile],
+            capture_output=True,
+            check=True,
+        )
+        .stdout.decode()
+        .strip()
+    )
+    fileSize = os.path.getsize(xzFile)
 
-  xzFile = "nar/" + narInfoHash + ".nar.xz"
-  with open(xzFile, "w") as f:
-    subprocess.run("nix-store --dump %s | xz -c" % item["path"], stdout=f, shell=True)
+    finalXzFileName = Path("nar") / f"{fileHash}.nar.xz"
+    os.rename(xzFile, outDir / finalXzFileName)
 
-  fileHash = subprocess.run(["nix-hash", "--base32", "--type", "sha256", "--flat", xzFile], capture_output=True).stdout.decode().strip()
-  fileSize = os.path.getsize(xzFile)
+    with open(outDir / f"{narInfoHash}.narinfo", "wt") as f:
+        f.write(f"StorePath: {item['path']}\n")
+        f.write(f"URL: {finalXzFileName}\n")
+        f.write("Compression: xz\n")
+        f.write(f"FileHash: sha256:{fileHash}\n")
+        f.write(f"FileSize: {fileSize}\n")
+        f.write(f"NarHash: {item['narHash']}\n")
+        f.write(f"NarSize: {item['narSize']}\n")
+        f.write(f"References: {' '.join(dropPrefix(ref, nixPrefix) for ref in item['references'])}\n")
 
-  # Rename the .nar.xz file to its own hash to match "nix copy" behavior
-  finalXzFile = "nar/" + fileHash + ".nar.xz"
-  os.rename(xzFile, finalXzFile)
 
-  with open(narInfoHash + ".narinfo", "w") as f:
-    f.writelines((x + "\n" for x in [
-      "StorePath: " + item["path"],
-      "URL: " + finalXzFile,
-      "Compression: xz",
-      "FileHash: sha256:" + fileHash,
-      "FileSize: " + str(fileSize),
-      "NarHash: " + item["narHash"],
-      "NarSize: " + str(item["narSize"]),
-      "References: " + " ".join(dropPrefix(ref) for ref in item["references"]),
-    ]))
+def main():
+    outDir = Path(os.environ["out"])
+    nixPrefix = os.environ["NIX_STORE"]
+    numWorkers = int(os.environ.get("NIX_BUILD_CORES", "4"))
+
+    with open(os.environ["NIX_ATTRS_JSON_FILE"], "r") as f:
+        closures = json.load(f)["closure"]
+
+    os.makedirs(outDir / "nar", exist_ok=True)
+
+    with open(outDir / "nix-cache-info", "w") as f:
+        f.write(f"StoreDir: {nixPrefix}\n")
+
+    with Pool(processes=numWorkers) as pool:
+        worker = partial(processItem, nixPrefix=nixPrefix, outDir=outDir)
+        pool.map(worker, closures)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`mkBinaryCache` can become very slow while building a non-trivial cache, because it processes each item sequentially and because the `xz` compression it uses is somewhat slow.

This PR solves the first problem by using Python's `multiprocessing` library to do the processing in parallel. It gets the number of workers from the `NIX_BUILD_CORES` environment variable. 

This results in a substantial performance improvement: in my testing, the expression `mkBinaryCache { rootPaths = [hello curl emacs htop]; }` goes from **117.4s** to **22.6s** (a **5.2x** speedup).

I also verified that it works on macOS, where using `multiprocessing` can be a little trickier.

The tests pass for me if you rebase this on https://github.com/NixOS/nixpkgs/pull/370773; it might be good to land that one first.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
