### PR TITLE
gromit-mpx: remove pcre

### DIFF
--- a/pkgs/by-name/gr/gromit-mpx/package.nix
+++ b/pkgs/by-name/gr/gromit-mpx/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitHub {
     owner = "bk138";
     repo = "gromit-mpx";
-    rev = finalAttrs.version;
+    tag = finalAttrs.version;
     hash = "sha256-jHw4V2ZvfpT3PUihe/O+9BPsv+udFg5seMbYmxOz8Yk=";
   };
 

--- a/pkgs/by-name/gr/gromit-mpx/package.nix
+++ b/pkgs/by-name/gr/gromit-mpx/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     lz4
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Desktop annotation tool";
     longDescription = ''
       Gromit-MPX (GRaphics Over MIscellaneous Things) is a small tool
@@ -59,12 +59,12 @@ stdenv.mkDerivation (finalAttrs: {
     '';
     homepage = "https://github.com/bk138/gromit-mpx";
     changelog = "https://github.com/bk138/gromit-mpx/blob/${finalAttrs.version}/NEWS.md";
-    maintainers = with maintainers; [
+    maintainers = with lib.maintainers; [
       pjones
       gepbird
     ];
-    platforms = platforms.linux;
-    license = licenses.gpl2Plus;
+    platforms = lib.platforms.linux;
+    license = lib.licenses.gpl2Plus;
     mainProgram = "gromit-mpx";
   };
 })

--- a/pkgs/by-name/gr/gromit-mpx/package.nix
+++ b/pkgs/by-name/gr/gromit-mpx/package.nix
@@ -17,6 +17,7 @@
   libdbusmenu,
   lz4,
   wrapGAppsHook3,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -50,6 +51,8 @@ stdenv.mkDerivation (finalAttrs: {
     libdbusmenu
     lz4
   ];
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Desktop annotation tool";

--- a/pkgs/by-name/gr/gromit-mpx/package.nix
+++ b/pkgs/by-name/gr/gromit-mpx/package.nix
@@ -6,7 +6,6 @@
   pkg-config,
   gtk3,
   glib,
-  pcre,
   libappindicator-gtk3,
   libpthreadstubs,
   xorg,
@@ -40,7 +39,6 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     gtk3
     glib
-    pcre
     libappindicator-gtk3
     libpthreadstubs
     xorg.libXdmcp


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Tracking: https://github.com/NixOS/nixpkgs/issues/356387

I'm not sure why PCRE was added in the first place in the package's first commit (cc @pjones), I couldn't find any references to it. Tested some CLI and graphics functionality of the app, works well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
