### PR TITLE
nixos/rauthy: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1468,6 +1468,7 @@
   ./services/security/pass-secret-service.nix
   ./services/security/physlock.nix
   ./services/security/pocket-id.nix
+  ./services/security/rauthy.nix
   ./services/security/shibboleth-sp.nix
   ./services/security/sks.nix
   ./services/security/sshguard.nix

--- a/nixos/modules/services/security/rauthy.nix
+++ b/nixos/modules/services/security/rauthy.nix
@@ -1,0 +1,134 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+
+let
+  cfg = config.services.rauthy;
+  settingsFormat = pkgs.formats.toml { };
+  finalSettingsFile = "/var/lib/rauthy/config.toml";
+in
+{
+  meta.maintainers = with lib.maintainers; [
+    gepbird
+  ];
+
+  options.services.rauthy = {
+    enable = lib.mkEnableOption "Rauthy";
+
+    package = lib.mkPackageOption pkgs "rauthy" { };
+
+    settings = lib.mkOption {
+      type = settingsFormat.type;
+      default = { };
+      example = {
+        server = {
+          proxy_mode = true;
+          secret_api = {
+            _secret_path = "/run/secrets/rauthy/server_secret_api";
+          };
+        };
+      };
+      description = ''
+        TOML configuration options that will be writtern to config.toml
+        See https://sebadob.github.io/rauthy/config/config.html.
+
+        Settings containing secret data should be set to an
+        attribute set with this format: `{ _secret_path = "/path/to/secret"; }`.
+        For example settings `services.rauthy.settings.server.secret_api._secret_path`
+        to a file path containing "SuperSecureSecret1337" will set the
+        `server.secret_api = "SuperSecureSecret1337` TOML option securely.
+
+        Alternatively, you can use a single file with environment variables,
+        see `services.rauthy.environmentFile`.
+      '';
+    };
+
+    environmentFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = "/run/secrets/rauthy.cfg";
+      description = ''
+        Environment file to inject e.g. secrets into the configuration.
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.rauthy = {
+      description = "rauthy";
+      after = [
+        "postgresql.service"
+      ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        Type = "simple";
+
+        WorkingDirecotry = "/var/lib/rauthy";
+        StateDirectory = "rauthy";
+        StateDirectoryMode = 750;
+        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+
+        ExecStartPre =
+          let
+            checkSecretPath =
+              _secret_path:
+              lib.throwIf (
+                !lib.isPath _secret_path && !lib.isString _secret_path
+              ) "`_secret_path` must be a string or a path, but got: ${lib.typeOf _secret_path}" _secret_path;
+            renderSettings =
+              data:
+              if lib.isAttrs data then
+                if data ? _secret_path then
+                  checkSecretPath data._secret_path
+                else
+                  lib.mapAttrs (name: renderSettings) data
+              else if lib.isList data then
+                lib.map renderSettings data
+              else
+                data;
+            renderedSettingsFile = settingsFormat.generate "config.toml" (renderSettings cfg.settings);
+
+            findSecretPaths =
+              data:
+              if lib.isAttrs data then
+                if data ? _secret_path then data._secret_path else lib.map findSecretPaths (lib.attrValues data)
+              else if lib.isList data then
+                lib.map findSecretPaths data
+              else
+                [ ];
+            secretPaths = lib.flatten (findSecretPaths cfg.settings);
+
+            makeSecretReplacement = secretPath: ''
+              ${pkgs.replace-secret}/bin/replace-secret ${
+                lib.escapeShellArgs [
+                  secretPath
+                  secretPath
+                  finalSettingsFile
+                ]
+              }
+            '';
+
+            secretReplacements = lib.concatMapStrings makeSecretReplacement secretPaths;
+          in
+          # Use "+" to run as root because the secrets may not be accessible to the dynamic user
+          "+"
+          + pkgs.writeShellScript "rauthy-pre" ''
+            install -m 600 -o $USER ${renderedSettingsFile} ${finalSettingsFile}
+            ${secretReplacements}
+          '';
+        ExecStart = pkgs.writeShellScript "rauthy-start" ''
+          cd /var/lib/rauthy
+          ${cfg.package}/bin/rauthy
+        '';
+
+        User = "rauthy";
+        DynamicUser = true;
+      };
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1283,6 +1283,7 @@ in
   ragnarwm = runTestOn [ "x86_64-linux" "aarch64-linux" ] ./ragnarwm.nix;
   rasdaemon = runTest ./rasdaemon.nix;
   rathole = runTest ./rathole.nix;
+  rauthy = runTest ./rauthy.nix;
   readarr = runTest ./readarr.nix;
   realm = runTest ./realm.nix;
   readeck = runTest ./readeck.nix;

--- a/nixos/tests/rauthy.nix
+++ b/nixos/tests/rauthy.nix
@@ -1,0 +1,77 @@
+{ lib, ... }:
+{
+  name = "rauthy";
+  meta.maintainers = with lib.maintainers; [
+    gepbird
+  ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    let
+      # Do not use this in production. This will make the secret world-readable
+      # in the Nix store
+      secrets = {
+        rauthy-secret-api.path = builtins.toString (
+          pkgs.writeText "rauthy-secret-api" "SuperSecureSecret1337"
+        );
+        rauthy-secret-raft.path = builtins.toString (
+          pkgs.writeText "rauthy-secret-raft" "SuperSecureSecret1337"
+        );
+      };
+    in
+    {
+      services.rauthy = {
+        enable = true;
+        settings = {
+          bootstrap = {
+            admin_email = "admin@localhost";
+          };
+          cluster = {
+            node_id = 1;
+            nodes = [ "1 localhost:8100 localhost:8200" ];
+            secret_api._secret_path = secrets.rauthy-secret-api.path;
+            secret_raft._secret_path = secrets.rauthy-secret-raft.path;
+          };
+          email = {
+            smtp_from = "Rauthy <rauthy@localhost>";
+            smtp_password = "password";
+            smtp_url = "localhost";
+            smtp_username = "username";
+          };
+          encryption = {
+            key_active = "q6u26";
+            keys = [ "q6u26/M0NFQzhSSldCY01rckJNa1JYZ3g2NUFtSnNOVGdoU0E=" ];
+          };
+          events = {
+            email = "admin@localhost";
+          };
+          server = {
+            proxy_mode = false;
+            pub_url = "localhost:8080";
+            scheme = "http";
+          };
+          webauthn = {
+            rp_id = "localhost";
+            rp_origin = "http://localhost:5173";
+          };
+        };
+      };
+
+      services.postgresql = {
+        enable = true;
+        ensureDatabases = [ "rauthy" ];
+        ensureUsers = [
+          {
+            name = "rauthy";
+            ensureDBOwnership = true;
+          }
+        ];
+      };
+    };
+
+  # TODO: write asserts, maybe add a mail server so it doesnt crash?
+  testScript = ''
+    machine.wait_for_unit("rauthy.service")
+    machine.succeed("sleep 5")
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

[Rauthy](https://github.com/sebadob/rauthy) is a lightweight and easy to use OpenID Connect Identity Provider.

TODO:
- [ ] add mandatory options to the nixos module
- [ ] thorough nixos test
- [ ] fix and try to run cargo tests, preferably not while building the package (maybe nixos vm tests?)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
