### PR TITLE
hyfetch: install man pages and add nullcube to maintainers

### DIFF
--- a/pkgs/by-name/hy/hyfetch/package.nix
+++ b/pkgs/by-name/hy/hyfetch/package.nix
@@ -53,6 +53,7 @@ python3Packages.buildPythonApplication rec {
     maintainers = with lib.maintainers; [
       yisuidenghua
       isabelroses
+      nullcube
     ];
   };
 }

--- a/pkgs/by-name/hy/hyfetch/package.nix
+++ b/pkgs/by-name/hy/hyfetch/package.nix
@@ -3,11 +3,17 @@
   fetchFromGitHub,
   python3Packages,
   pciutils,
+  installShellFiles,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "hyfetch";
   version = "1.99.0";
   pyproject = true;
+
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "hykilpikonna";
@@ -24,12 +30,25 @@ python3Packages.buildPythonApplication rec {
     python3Packages.typing-extensions
   ];
 
+  nativeBuildInputs = [
+    installShellFiles
+  ];
+
   # No test available
   doCheck = false;
 
   pythonImportsCheck = [
     "hyfetch"
   ];
+
+  # NOTE: The HyFetch project maintains an updated version of neofetch renamed
+  # to "neowofetch" which is included in this package. However, the man page
+  # included is still named "neofetch", so to prevent conflicts and confusion
+  # we rename the file to "neowofetch" before installing it:
+  postInstall = ''
+    mv ./docs/neofetch.1 ./docs/neowofetch.1
+    installManPage ./docs/hyfetch.1 ./docs/neowofetch.1
+  '';
 
   postFixup = ''
     wrapProgram $out/bin/neowofetch \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated the hyfetch package to install the man pages available in the upstream repo, and added myself as a maintainer.

A note, the HyFetch project maintains an updated version of neofetch renamed to "neowofetch" which is included in this package. However, the man page included is still named "neofetch", so to prevent any potential conflicts/confusion I have the script rename the man page file to "neowofetch" before installing it.

If you don't have the neofetch package installed, then running `man neofetch` (with man-db 2.13.0) still brings up the neowofetch man page, and if neofetch *is* installed then `man neofetch` goes to it's own man page instead. Regardless though, the neowofetch man page will still, of course, read "neofetch", but is now accessible via `man neowofetch` which is the same as the name of the binary/script.

If this wholly isn't necessary, or if we should just respect upstream's file name choice, then let me know, I just thought it was prudent and more intuitive to rename the man page file.

Tagging maintainers:
@YisuiDenghua 
@isabelroses 


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
