### PR TITLE
enpass-mac: init at 6.11.8.1861

### DIFF
--- a/pkgs/by-name/en/enpass-mac/package.nix
+++ b/pkgs/by-name/en/enpass-mac/package.nix
@@ -10,6 +10,10 @@
   cacert,
   gawk,
   common-updater-scripts,
+  versionCheckHook,
+  writeShellScript,
+  coreutils,
+  xcbuild,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -64,6 +68,16 @@ stdenvNoCC.mkDerivation (finalAttrs: {
       update-source-version enpass-mac "$version"
     '';
   });
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = writeShellScript "version-check" ''
+    marketing_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleShortVersionString" "$1" | ${coreutils}/bin/tr -d '"')
+    build_version=$(${xcbuild}/bin/PlistBuddy -c "Print :CFBundleVersion" "$1")
+
+    echo $marketing_version.$build_version
+  '';
+  versionCheckProgramArg = [ "${placeholder "out"}/Applications/Enpass.app/Contents/Info.plist" ];
+  doInstallCheck = true;
 
   meta = {
     description = "Choose your own safest place to store passwords";

--- a/pkgs/by-name/en/enpass-mac/package.nix
+++ b/pkgs/by-name/en/enpass-mac/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  gzip,
+  xar,
+  cpio,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "enpass-mac";
+  version = "6.11.8.1861";
+
+  src = fetchurl {
+    url = "https://dl.enpass.io/stable/mac/package/${finalAttrs.version}/Enpass.pkg";
+    hash = "sha256-n0ClsyGTS52ms161CJihIzBI5GjiMIF6HEJ59+jciq8=";
+  };
+
+  dontPatch = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  nativeBuildInputs = [
+    gzip
+    xar
+    cpio
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    xar -xf $src
+    gunzip -dc Enpass_temp.pkg/Payload | cpio -i
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/Applications
+    mv Enpass.app $out/Applications
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Choose your own safest place to store passwords";
+    homepage = "https://www.enpass.io";
+    changelog = "https://www.enpass.io/release-notes/macos-website-ver/";
+    license = [ lib.licenses.unfree ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ DimitarNestorov ];
+    platforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/en/enpass-mac/package.nix
+++ b/pkgs/by-name/en/enpass-mac/package.nix
@@ -5,6 +5,11 @@
   gzip,
   xar,
   cpio,
+  writeShellApplication,
+  curl,
+  cacert,
+  gawk,
+  common-updater-scripts,
 }:
 
 stdenvNoCC.mkDerivation (finalAttrs: {
@@ -44,6 +49,21 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = lib.getExe (writeShellApplication {
+    name = "enpass-mac-update-script";
+    runtimeInputs = [
+      curl
+      cacert
+      gawk
+      common-updater-scripts
+    ];
+    text = ''
+      url="https://www.enpass.io/download/macos/website/stable"
+      version=$(curl -Ls -o /dev/null -w "%{url_effective}" "$url" | awk -F'/' '{print $7}')
+      update-source-version enpass-mac "$version"
+    '';
+  });
 
   meta = {
     description = "Choose your own safest place to store passwords";


### PR DESCRIPTION
## Things done

Added Enpass for Mac

<img width="1087" alt="image" src="https://github.com/user-attachments/assets/07f76004-eb1f-49f9-ae31-7be50d5c66fc" />

### `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
#### `aarch64-darwin`
<details>
  <summary>:white_check_mark: 1 package built:</summary>
  <ul>
    <li>enpass-mac</li>
  </ul>
</details>

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
