### PR TITLE
ci/request-reviews: limit to 10 review requests

### DIFF
--- a/ci/request-reviews/request-reviewers.sh
+++ b/ci/request-reviews/request-reviewers.sh
@@ -68,6 +68,11 @@ for user in "${!users[@]}"; do
     fi
 done
 
+if [[ "${#users[@]}" -gt 10 ]]; then
+    log "Too many reviewers (${!users[@]}), skipping review requests"
+    exit 1
+fi
+
 for user in "${!users[@]}"; do
     log "Requesting review from: $user"
 


### PR DESCRIPTION
This [mirrors old ofborg](https://github.com/NixOS/ofborg/blob/1ef14d9c5b570b110d045795b4e80a37db2e1f0a/ofborg/src/tasks/eval/nixpkgs.rs#L553-L582) for now and avoids pinging a huge number of reviewers, for example like in #370749 or even worse in #371100. The latter is similar to the old code-owners behavior after changing from master to staging. Both happened after #370857.

I'm thinking about alternatives based on my ideas in https://github.com/NixOS/nixpkgs/pull/366046#discussion_r1894610992, but to make those work well, we'd need to avoiding pinging maintainers in draft mode first as discussed in https://github.com/NixOS/nixpkgs/pull/370857#discussion_r1903127928. However, that's not trivial, because we don't want to run all of eval again on each "pull request edited" event.

This change here technically limits review requests to 10 reviewers max for **code owners**, too - not only maintainers. That's because both now used the same code path since #370857. I'm OK with this for now.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
