### PR TITLE
emacs: elisp packages update

### DIFF
--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-devel-generated.nix
@@ -53,10 +53,10 @@
     elpaBuild {
       pname = "activities";
       ename = "activities";
-      version = "0.8pre0.20240727.5721";
+      version = "0.8pre0.20241225.10347";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20240727.5721.tar";
-        sha256 = "0f4p39vgi7fv3bh97267ys6rfy0ak0b4c15p57xfbybc47f8iwi1";
+        url = "https://elpa.gnu.org/devel/activities-0.8pre0.20241225.10347.tar";
+        sha256 = "0c6rivd7qvrd02pvryffr2h6y0lyp9z0zrvdk2rygxz6l5pq0g9x";
       };
       packageRequires = [ persist ];
       meta = {
@@ -440,10 +440,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.7.0.20241129.84113";
+      version = "14.0.8.0.20250101.100039";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/auctex-14.0.7.0.20241129.84113.tar";
-        sha256 = "0z7a9zsbljwzrn3xzn9hcl1zlqczafvcbx62cbmlrib0cknlxqp8";
+        url = "https://elpa.gnu.org/devel/auctex-14.0.8.0.20250101.100039.tar";
+        sha256 = "0nslxh8ai5rjpzg46ihirz4igq178f7lpybih47is7wlkj0vn68i";
       };
       packageRequires = [ ];
       meta = {
@@ -718,10 +718,10 @@
     elpaBuild {
       pname = "bind-key";
       ename = "bind-key";
-      version = "2.4.1.0.20240321.194020";
+      version = "2.4.1.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20240321.194020.tar";
-        sha256 = "02v2pc830b9vp0rmdxwcxjj36y5x2p8sy381h3c8hsi61pwyqy93";
+        url = "https://elpa.gnu.org/devel/bind-key-2.4.1.0.20250101.73917.tar";
+        sha256 = "0a1q6lwkky92f2fhmzlsj58cf9ywhzi2c0lhf2f6zk0ka4nz4yjz";
       };
       packageRequires = [ ];
       meta = {
@@ -811,10 +811,10 @@
     elpaBuild {
       pname = "boxy";
       ename = "boxy";
-      version = "1.1.4.0.20240505.204058";
+      version = "2.0.0.0.20250104.25705";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/boxy-1.1.4.0.20240505.204058.tar";
-        sha256 = "18sgxarymy65vjzb94jjd0npxfd7920xlw49py5lc2y8d508p3rf";
+        url = "https://elpa.gnu.org/devel/boxy-2.0.0.0.20250104.25705.tar";
+        sha256 = "1zy4vwlzm5gqhw2slg6j760b3hd1x989wx5p9xi9gqi2gaa43a1m";
       };
       packageRequires = [ ];
       meta = {
@@ -834,10 +834,10 @@
     elpaBuild {
       pname = "boxy-headings";
       ename = "boxy-headings";
-      version = "2.1.6.0.20240505.204122";
+      version = "2.1.8.0.20250104.93059";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/boxy-headings-2.1.6.0.20240505.204122.tar";
-        sha256 = "1m3k25j5z7q1gz2bbmyjkh79rq2b4350zz6csb2l0l8s4g1yddph";
+        url = "https://elpa.gnu.org/devel/boxy-headings-2.1.8.0.20250104.93059.tar";
+        sha256 = "1r4afw9m9sgk041vfrjzcz0in45wx8vc0bgl3wxr64yb64nydhx6";
       };
       packageRequires = [
         boxy
@@ -1041,10 +1041,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "1.7.0.20241123.92531";
+      version = "1.8.0.20250103.174415";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/cape-1.7.0.20241123.92531.tar";
-        sha256 = "0f1l510lzhd2p6003mnp4bvrhjqpqfvvz30lrj1ic9x453z80fpq";
+        url = "https://elpa.gnu.org/devel/cape-1.8.0.20250103.174415.tar";
+        sha256 = "18dw6zdnppncjik06mslc0wwp65lj32x123iidb3vbk84j6qwjai";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1322,10 +1322,10 @@
     elpaBuild {
       pname = "company";
       ename = "company";
-      version = "1.0.2.0.20241106.200056";
+      version = "1.0.2.0.20241227.162935";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20241106.200056.tar";
-        sha256 = "10pn52y3pgi2cbqi96sr3gghashsqvinc7lbylwg7mrhjgj0jdnv";
+        url = "https://elpa.gnu.org/devel/company-1.0.2.0.20241227.162935.tar";
+        sha256 = "17xpm50a1hvc77brwsb9kwvqxywzzz7xxjlai7rjh4nyaz0lgjr3";
       };
       packageRequires = [ ];
       meta = {
@@ -1418,10 +1418,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.0.0.0.0.20241120.163841";
+      version = "30.0.2.0.0.20250104.123009";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/compat-30.0.0.0.0.20241120.163841.tar";
-        sha256 = "0a67xpvjfzzbhwflldqhs8gd6cb38m6gqlv6il33d4w7wsnch4p2";
+        url = "https://elpa.gnu.org/devel/compat-30.0.2.0.0.20250104.123009.tar";
+        sha256 = "03inp9yr3nq1cfxby76ksg1qyr6y151wf5qx60mmfa9and8azn0r";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1461,10 +1461,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "1.8.0.20241201.134410";
+      version = "1.9.0.20250104.182417";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/consult-1.8.0.20241201.134410.tar";
-        sha256 = "11ndnrjfk9s99kyyygyip8bwx0icb2n8bfxk05g3ll43scblpnpx";
+        url = "https://elpa.gnu.org/devel/consult-1.9.0.20250104.182417.tar";
+        sha256 = "0xi7l7s1scrdy2ayrbqa8fjnjpjcrlnsw6l8avpk0xpq1gacbldj";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1574,10 +1574,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "1.5.0.20241127.155437";
+      version = "1.6.0.20250103.202938";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/corfu-1.5.0.20241127.155437.tar";
-        sha256 = "15xs0mdbw5h84m5msviw6vp73yxjxkh6hynzaa011a8xwaz7r5v1";
+        url = "https://elpa.gnu.org/devel/corfu-1.6.0.20250103.202938.tar";
+        sha256 = "06kw1kj4aqr85swi35291zsv2l37fz03502qvhsqbn912kcjdaxg";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1834,10 +1834,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.17.0.0.20241203.221759";
+      version = "0.19.0.0.20241229.225058";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dape-0.17.0.0.20241203.221759.tar";
-        sha256 = "1clhs99fh4d15mn2r5rpj9ag63nk8dksnr99zb81ywnvhf1934i0";
+        url = "https://elpa.gnu.org/devel/dape-0.19.0.0.20241229.225058.tar";
+        sha256 = "0v0995d4046ywwi60kcapis25nq51qdmx56i3248290nxhvd70iy";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1921,10 +1921,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.42.0.20241107.85529";
+      version = "0.43.0.20250102.111202";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/debbugs-0.42.0.20241107.85529.tar";
-        sha256 = "0vmd0qmfp05xbq504mh2xh98l0h48vn3ki8c1sl26i2y2pjvy6bf";
+        url = "https://elpa.gnu.org/devel/debbugs-0.43.0.20250102.111202.tar";
+        sha256 = "1jy1k6sggsg84zypvy7smz1jzixz5bq08zqxs626amg29lhg3j4l";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -1968,10 +1968,10 @@
     elpaBuild {
       pname = "denote";
       ename = "denote";
-      version = "3.1.0.0.20241203.81843";
+      version = "3.1.0.0.20250104.165535";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/denote-3.1.0.0.20241203.81843.tar";
-        sha256 = "1irr0z942qdjypaxx6q1scndzzkby0kcsa18jqsxnrc5np4f8p3i";
+        url = "https://elpa.gnu.org/devel/denote-3.1.0.0.20250104.165535.tar";
+        sha256 = "0jb98qgz4hd8ix3m9ijn9prjrnc6f772kj4kxbnjjz4hk1dz1cdx";
       };
       packageRequires = [ ];
       meta = {
@@ -2070,6 +2070,28 @@
       };
     }
   ) { };
+  dicom = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "dicom";
+      ename = "dicom";
+      version = "0.5.0.20250101.91536";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/dicom-0.5.0.20250101.91536.tar";
+        sha256 = "14d3vrk06nwzaiz26dbxx3qifiqayb6l1jd88aaa9njyxf417f01";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/dicom.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   dict-tree = callPackage (
     {
       elpaBuild,
@@ -2108,10 +2130,10 @@
     elpaBuild {
       pname = "diff-hl";
       ename = "diff-hl";
-      version = "1.10.0.0.20241128.233206";
+      version = "1.10.0.0.20241205.233841";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20241128.233206.tar";
-        sha256 = "1728i37sz52hf2bsbr5msvzciqdcn98xlnv812sd7mc7zz6j2q27";
+        url = "https://elpa.gnu.org/devel/diff-hl-1.10.0.0.20241205.233841.tar";
+        sha256 = "1a1ndnf6w7j0k85k1rzdi8r0m4fj78lafzsf9dl4s3dj11lqrphh";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -2235,10 +2257,10 @@
     elpaBuild {
       pname = "dired-preview";
       ename = "dired-preview";
-      version = "0.3.0.0.20241025.80757";
+      version = "0.3.0.0.20241226.143555";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/dired-preview-0.3.0.0.20241025.80757.tar";
-        sha256 = "0xw629nhbcbk5sndgxgwl6nwf5rva7nj2h87fx73dy1fb89jz827";
+        url = "https://elpa.gnu.org/devel/dired-preview-0.3.0.0.20241226.143555.tar";
+        sha256 = "1hz6lfm12rn45n4gc3kbfsab15rzyyc71qgg1pawaxryzxp9r4fy";
       };
       packageRequires = [ ];
       meta = {
@@ -2320,10 +2342,10 @@
     elpaBuild {
       pname = "do-at-point";
       ename = "do-at-point";
-      version = "0.1.2.0.20240625.155102";
+      version = "0.1.2.0.20241220.111054";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/do-at-point-0.1.2.0.20240625.155102.tar";
-        sha256 = "035f0gqywlrr8cwwk9b04nczcv8slf76f2ixvam949fphhc0zkrb";
+        url = "https://elpa.gnu.org/devel/do-at-point-0.1.2.0.20241220.111054.tar";
+        sha256 = "0y9rgxnrar6gwqj3w622xdavi5gnb748kbym25q19a4vsjdazvi1";
       };
       packageRequires = [ ];
       meta = {
@@ -2564,10 +2586,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20241123.0.20241202.94858";
+      version = "20241223.0.20241231.215609";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eev-20241123.0.20241202.94858.tar";
-        sha256 = "0id1rqva96hpn6hfn3iiprwh5k99g3cs6bn368263m2h6xvrgzsh";
+        url = "https://elpa.gnu.org/devel/eev-20241223.0.20241231.215609.tar";
+        sha256 = "15iivvlwkz3zigqzh4z0rp8y24p8p88l996dp9hr9kghlbsljw00";
       };
       packageRequires = [ ];
       meta = {
@@ -2585,10 +2607,10 @@
     elpaBuild {
       pname = "ef-themes";
       ename = "ef-themes";
-      version = "1.9.0.0.20241116.183040";
+      version = "1.9.0.0.20241228.104947";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ef-themes-1.9.0.0.20241116.183040.tar";
-        sha256 = "1xyw2pq4mv5pmssngqbvqbzqkirxm4xwg4xfbninwrk5474kmhip";
+        url = "https://elpa.gnu.org/devel/ef-themes-1.9.0.0.20241228.104947.tar";
+        sha256 = "0rzxfbw49knad8bn2xrlwwq7apmdphyg3qpry4w3d6c5rnmgarzi";
       };
       packageRequires = [ ];
       meta = {
@@ -2615,10 +2637,10 @@
     elpaBuild {
       pname = "eglot";
       ename = "eglot";
-      version = "1.17.0.20241024.85007";
+      version = "1.17.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eglot-1.17.0.20241024.85007.tar";
-        sha256 = "158022p4711xymcnkgck2bnv6w2bxj78kd7zgnxh7wp5424h4zd0";
+        url = "https://elpa.gnu.org/devel/eglot-1.17.0.20250101.73917.tar";
+        sha256 = "1jbkjiyvv6x79gppl1cb705hlp0hp541cn8y5lav8mcy5nfhgzcl";
       };
       packageRequires = [
         compat
@@ -2672,10 +2694,10 @@
     elpaBuild {
       pname = "eldoc";
       ename = "eldoc";
-      version = "1.15.0.0.20240708.123037";
+      version = "1.15.0.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/eldoc-1.15.0.0.20240708.123037.tar";
-        sha256 = "1ngi7zfg0l261myhnyifbvywak2clagiqmjdqbnwwnvs8gmj02in";
+        url = "https://elpa.gnu.org/devel/eldoc-1.15.0.0.20250101.73917.tar";
+        sha256 = "0pwicn9r2v85hpkxk7dibmxzy7iaj41r16lrybhm0kcw74lwhkkd";
       };
       packageRequires = [ ];
       meta = {
@@ -2718,10 +2740,10 @@
     elpaBuild {
       pname = "elisa";
       ename = "elisa";
-      version = "1.1.3.0.20241123.220535";
+      version = "1.1.4.0.20250102.163931";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/elisa-1.1.3.0.20241123.220535.tar";
-        sha256 = "0zvjnz4qxaxm2akg0hppyn8vn77zvmbgnw85mms2cq4148w7br2z";
+        url = "https://elpa.gnu.org/devel/elisa-1.1.4.0.20250102.163931.tar";
+        sha256 = "0cfxg4ipz6k3dkap1d2clsr18nl5fi26ybkaw8fipb9z3k6hkj0h";
       };
       packageRequires = [
         async
@@ -2769,10 +2791,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "0.13.0.0.20241129.214739";
+      version = "0.13.1.0.20250102.151353";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ellama-0.13.0.0.20241129.214739.tar";
-        sha256 = "1242ra8fbyq5lci44myvl62k76c234kxa0lsim1rmnbpsa3w3h0p";
+        url = "https://elpa.gnu.org/devel/ellama-0.13.1.0.20250102.151353.tar";
+        sha256 = "17pgzzanz4fcwrbirwa6pgiqv0cgsiknn9vzb0j1zd6slbbapy0h";
       };
       packageRequires = [
         compat
@@ -2905,10 +2927,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "20.2.0.20241129.151319";
+      version = "21.0.20241227.75423";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/emms-20.2.0.20241129.151319.tar";
-        sha256 = "17rqxmrcr3p150nhi2yyn21g7hg68yjpxdg7bjdpif5086h8snff";
+        url = "https://elpa.gnu.org/devel/emms-21.0.20241227.75423.tar";
+        sha256 = "1h5hzn9va97jn4kvkd42hrrr76hh70dr19h17ikbilqn3lf2c0hl";
       };
       packageRequires = [
         cl-lib
@@ -2994,10 +3016,10 @@
     elpaBuild {
       pname = "erc";
       ename = "erc";
-      version = "5.6.1snapshot0.20241201.105608";
+      version = "5.6.1snapshot0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20241201.105608.tar";
-        sha256 = "080ppzpc7r1myl2xig9jlzns9j8sbyd7qdmmijiwcfwgl6dsjg3b";
+        url = "https://elpa.gnu.org/devel/erc-5.6.1snapshot0.20250101.73917.tar";
+        sha256 = "18xjba35kccr9rsgnpsqrh1cixnfala72lykl4mgl21a0jf8vmh8";
       };
       packageRequires = [ compat ];
       meta = {
@@ -3041,10 +3063,10 @@
     elpaBuild {
       pname = "ess";
       ename = "ess";
-      version = "24.1.1.0.20241127.102031";
+      version = "24.1.1.0.20241230.154327";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ess-24.1.1.0.20241127.102031.tar";
-        sha256 = "19gkxkslg9y84fc9shc655fqgcr27rbjnn4rsnhkpqvwbzn54kkq";
+        url = "https://elpa.gnu.org/devel/ess-24.1.1.0.20241230.154327.tar";
+        sha256 = "0sdqrzsii4sgyppkw6zzmci4fivhma5wap9m8wsz5g2d2qbbag2s";
       };
       packageRequires = [ ];
       meta = {
@@ -3096,10 +3118,10 @@
     elpaBuild {
       pname = "expand-region";
       ename = "expand-region";
-      version = "1.0.0.0.20240919.142744";
+      version = "1.0.0.0.20241217.184034";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/expand-region-1.0.0.0.20240919.142744.tar";
-        sha256 = "01mr4aqzl8cb8jhap6pz6y561dv2hj5mykc5gdjnnfaqhypipwnq";
+        url = "https://elpa.gnu.org/devel/expand-region-1.0.0.0.20241217.184034.tar";
+        sha256 = "1bh8109irsh2hpk70fg38d0rf8as32a39677gz1m7k7v4fvs3nv5";
       };
       packageRequires = [ ];
       meta = {
@@ -3138,10 +3160,10 @@
     elpaBuild {
       pname = "external-completion";
       ename = "external-completion";
-      version = "0.1.0.20240725.13518";
+      version = "0.1.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20240725.13518.tar";
-        sha256 = "0xhpmayv23iiysi5smk0sq9r8rp3vr5sq12p6584128pss75viqh";
+        url = "https://elpa.gnu.org/devel/external-completion-0.1.0.20250101.73917.tar";
+        sha256 = "1z3an1r72sxw4l5xlrshxcdmyv3slzqfk42wwg7zi25lq2wf60pg";
       };
       packageRequires = [ ];
       meta = {
@@ -3161,10 +3183,10 @@
     elpaBuild {
       pname = "exwm";
       ename = "exwm";
-      version = "0.32.0.20241118.90416";
+      version = "0.32.0.20250103.173706";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/exwm-0.32.0.20241118.90416.tar";
-        sha256 = "1ssryfd1x9cidch3w0xq8750c1ifg58b672grw8x70spy2mrvqr1";
+        url = "https://elpa.gnu.org/devel/exwm-0.32.0.20250103.173706.tar";
+        sha256 = "0j5lvxm09vqfpggk3i1nipjmrjqbipnw9dn6gjb1xwxb7lclk62z";
       };
       packageRequires = [
         compat
@@ -3316,10 +3338,10 @@
     elpaBuild {
       pname = "flymake";
       ename = "flymake";
-      version = "1.3.7.0.20241024.85007";
+      version = "1.3.7.0.20250102.142949";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/flymake-1.3.7.0.20241024.85007.tar";
-        sha256 = "0vhfxvml2s678pxivss1nmm0ym62nxc4ab221jm6x8jpd6j1lff5";
+        url = "https://elpa.gnu.org/devel/flymake-1.3.7.0.20250102.142949.tar";
+        sha256 = "1z23l2vh10qxkfk4dp32xzdxvsc5xvzgh7w98s3fyidmmgiwv55s";
       };
       packageRequires = [
         eldoc
@@ -3383,10 +3405,10 @@
     elpaBuild {
       pname = "fontaine";
       ename = "fontaine";
-      version = "2.1.0.0.20240913.71012";
+      version = "2.1.0.0.20241229.72347";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/fontaine-2.1.0.0.20240913.71012.tar";
-        sha256 = "16wsmqkm9n0hz4s50m5janni7lzvvwgrcbnp17ngyqlzkld656yk";
+        url = "https://elpa.gnu.org/devel/fontaine-2.1.0.0.20241229.72347.tar";
+        sha256 = "1k4vjdx0ckpwjh8w57vx6dqnwly5rx9pvir1v892gv845sr5y9ln";
       };
       packageRequires = [ ];
       meta = {
@@ -3832,10 +3854,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.11.18.0.20241025.123748";
+      version = "0.12.6.0.20241231.233142";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/greader-0.11.18.0.20241025.123748.tar";
-        sha256 = "17sh65y476zd5lwmvialk399g5gl11d52p4jmhgjv7kpb4xl3jly";
+        url = "https://elpa.gnu.org/devel/greader-0.12.6.0.20241231.233142.tar";
+        sha256 = "0gn0dbqb0lmmq5s9h5hgr2qrw229c7hgip5lpjv3lrkm1aanm72f";
       };
       packageRequires = [
         compat
@@ -4072,10 +4094,10 @@
     elpaBuild {
       pname = "hyperbole";
       ename = "hyperbole";
-      version = "9.0.2pre0.20241126.91748";
+      version = "9.0.2pre0.20241230.225211";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20241126.91748.tar";
-        sha256 = "136xbqhm4gwfw7cyd1p45hx6pnc6wbqc7dmv6q620vall1r9s7nb";
+        url = "https://elpa.gnu.org/devel/hyperbole-9.0.2pre0.20241230.225211.tar";
+        sha256 = "0r9q9qpyc6h2320xsd5m821djii9ghpfh3wsgxkldcsb6li2qcl8";
       };
       packageRequires = [ ];
       meta = {
@@ -4449,10 +4471,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "1.10.0.20241201.134324";
+      version = "1.11.0.20250101.92006";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jinx-1.10.0.20241201.134324.tar";
-        sha256 = "19clhxy5p41ri0b2fsdk2rc9wf37nn90ya5mkhpn8mccfcs9kh7y";
+        url = "https://elpa.gnu.org/devel/jinx-1.11.0.20250101.92006.tar";
+        sha256 = "1sqnp3hk9dzcr983xbgy4ysi5c7hpzhnv7mg7fjfissg3fmc96s9";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4493,10 +4515,10 @@
     elpaBuild {
       pname = "js2-mode";
       ename = "js2-mode";
-      version = "20231224.0.20240908.123607";
+      version = "20231224.0.20241205.14012";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/js2-mode-20231224.0.20240908.123607.tar";
-        sha256 = "03zp9nsl06z1v2f3a78rbr8b7ng4dfhn3ar0rim30r99dyvf21kw";
+        url = "https://elpa.gnu.org/devel/js2-mode-20231224.0.20241205.14012.tar";
+        sha256 = "0kcxgkib56fjgv9c2ancr046ag3nwr6zw5x2dzw9gbnlma5w3x66";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -4535,10 +4557,10 @@
     elpaBuild {
       pname = "jsonrpc";
       ename = "jsonrpc";
-      version = "1.0.25.0.20241130.63516";
+      version = "1.0.25.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20241130.63516.tar";
-        sha256 = "1z2vwqj213bpygq5lp8b7inxjki9kzha6ymz315ls5w06kccvw3v";
+        url = "https://elpa.gnu.org/devel/jsonrpc-1.0.25.0.20250101.73917.tar";
+        sha256 = "127q6g4gdzilxws7r72ff3wqgx80d2wz1cpvfnd0fivldmjx64j2";
       };
       packageRequires = [ ];
       meta = {
@@ -4642,10 +4664,10 @@
     elpaBuild {
       pname = "kubed";
       ename = "kubed";
-      version = "0.4.2.0.20241022.131056";
+      version = "0.4.2.0.20250104.163324";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/kubed-0.4.2.0.20241022.131056.tar";
-        sha256 = "02sg5h2iv9zb2i1prxab9xcm682j8y5c3h10cqd66gcvpiwb790f";
+        url = "https://elpa.gnu.org/devel/kubed-0.4.2.0.20250104.163324.tar";
+        sha256 = "184b41x5y06vhggvzjbyvhz8024aq68ra3mz6xwk1wbfhjhb3396";
       };
       packageRequires = [ ];
       meta = {
@@ -4783,10 +4805,10 @@
     elpaBuild {
       pname = "let-alist";
       ename = "let-alist";
-      version = "1.0.6.0.20240919.15459";
+      version = "1.0.6.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/let-alist-1.0.6.0.20240919.15459.tar";
-        sha256 = "1h82ar9izb3a16w35qcvfv7k5s8rzjlkk6g3d3x7wk3rfivp8brl";
+        url = "https://elpa.gnu.org/devel/let-alist-1.0.6.0.20250101.73917.tar";
+        sha256 = "0lr22q8crlk160j38y5dyla1i3h882yv5zjh7f9rbfaqqs6w5xqm";
       };
       packageRequires = [ ];
       meta = {
@@ -4900,10 +4922,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.19.1.0.20241129.152751";
+      version = "0.20.0.0.20250102.194115";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/llm-0.19.1.0.20241129.152751.tar";
-        sha256 = "07jcm718wivagwnr53rriwa7gp3zkxgybff5wivi1n6xdfhm9b1y";
+        url = "https://elpa.gnu.org/devel/llm-0.20.0.0.20250102.194115.tar";
+        sha256 = "1gcrks096fawiygknbny683l8m8rqiw6z29wgmal3h67z6dssvlz";
       };
       packageRequires = [
         plz
@@ -5096,10 +5118,10 @@
     elpaBuild {
       pname = "m-buffer";
       ename = "m-buffer";
-      version = "0.16.0.20240302.175529";
+      version = "0.16.1.0.20241215.171432";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/m-buffer-0.16.0.20240302.175529.tar";
-        sha256 = "18lj0gb56xhwrbihijy4p5lyxqvdfcwyabcd30qy1dn4k715v614";
+        url = "https://elpa.gnu.org/devel/m-buffer-0.16.1.0.20241215.171432.tar";
+        sha256 = "1cvygjcnhlicbjxchgc45yzmw1v07qyzhf4qbf6xgrkwv06clrd6";
       };
       packageRequires = [ seq ];
       meta = {
@@ -5117,10 +5139,10 @@
     elpaBuild {
       pname = "map";
       ename = "map";
-      version = "3.3.1.0.20240221.84915";
+      version = "3.3.1.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20240221.84915.tar";
-        sha256 = "0cmxxgxi7nsgbx4a94pxhn4y6qddp14crfl2250nk6a1h17zvsnn";
+        url = "https://elpa.gnu.org/devel/map-3.3.1.0.20250101.73917.tar";
+        sha256 = "00qm9s79y4p0z9g9yc25jiy6xk29h6ddxglm3cpwgz0cwwzx426k";
       };
       packageRequires = [ ];
       meta = {
@@ -5139,10 +5161,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "1.7.0.20241124.113844";
+      version = "1.8.0.20250101.92029";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/marginalia-1.7.0.20241124.113844.tar";
-        sha256 = "19b1xc3q4mdzlipjn47drhg4k818iigf95jy2cj4hcmg6d6k37r7";
+        url = "https://elpa.gnu.org/devel/marginalia-1.8.0.20250101.92029.tar";
+        sha256 = "18pcby3547wrq2mc8ra85p69w16lm2gghxayzn609930zr3ndvk3";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5210,6 +5232,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/mathjax.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  matlab-mode = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "matlab-mode";
+      ename = "matlab-mode";
+      version = "6.3.0.20241224.134640";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/matlab-mode-6.3.0.20241224.134640.tar";
+        sha256 = "02y2ii89safyfj74221rlri99gr7382ir62zq2iqwvy6668srn4r";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/matlab-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -5415,10 +5458,10 @@
     elpaBuild {
       pname = "modus-themes";
       ename = "modus-themes";
-      version = "4.6.0.0.20241120.54202";
+      version = "4.6.0.0.20241228.105002";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/modus-themes-4.6.0.0.20241120.54202.tar";
-        sha256 = "189vcdd2895x3smydr84s8ldjvi92bkh4samk4qi1gxdj9r397hg";
+        url = "https://elpa.gnu.org/devel/modus-themes-4.6.0.0.20241228.105002.tar";
+        sha256 = "174v9cxi60hng57ky2a5cssk5xjdck4sjnjhg7qlq57cbp6arj96";
       };
       packageRequires = [ ];
       meta = {
@@ -5542,10 +5585,10 @@
     elpaBuild {
       pname = "nadvice";
       ename = "nadvice";
-      version = "0.4.0.20230111.104526";
+      version = "0.4.0.20241227.124457";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/nadvice-0.4.0.20230111.104526.tar";
-        sha256 = "0855x3vgp0i6kmi5kf8365xqnj92k9lwqyfn40i59fp4jj3c00kr";
+        url = "https://elpa.gnu.org/devel/nadvice-0.4.0.20241227.124457.tar";
+        sha256 = "1bhv1111iyypw01jpsy9p3lci2gi1bkpgfz7447f6w7rr2s9rbdr";
       };
       packageRequires = [ ];
       meta = {
@@ -5778,10 +5821,10 @@
     elpaBuild {
       pname = "ntlm";
       ename = "ntlm";
-      version = "2.1.0.0.20240102.22814";
+      version = "2.1.0.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/ntlm-2.1.0.0.20240102.22814.tar";
-        sha256 = "0wr9bhxxdkpfvwla97xrd77dv3321apq1gmcpqadyjvxl44c0km7";
+        url = "https://elpa.gnu.org/devel/ntlm-2.1.0.0.20250101.73917.tar";
+        sha256 = "0ld0xc1a237yah9ng723kd3ywmy4d5jly8rs2hjzc9f3bjd2sl6q";
       };
       packageRequires = [ ];
       meta = {
@@ -5975,10 +6018,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.2.0.20240926.92100";
+      version = "1.3.0.20250101.92243";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/orderless-1.2.0.20240926.92100.tar";
-        sha256 = "1clbmlfrr4dq30q0yh6mrrk8i8rc49yljs83hh77z000vxzmc8qk";
+        url = "https://elpa.gnu.org/devel/orderless-1.3.0.20250101.92243.tar";
+        sha256 = "1n28izngnqs2xy2iw7s0mw78mx7b4ahwf8yirr1jlv00vc51qiab";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5996,10 +6039,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.8pre0.20241127.183434";
+      version = "9.8pre0.20250104.140343";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-9.8pre0.20241127.183434.tar";
-        sha256 = "1v7inlp4mm2c9395jw814krg2yp5h70h0cj0q86m26zgg9f2wicy";
+        url = "https://elpa.gnu.org/devel/org-9.8pre0.20250104.140343.tar";
+        sha256 = "033zb7izh6mc458kwi2iz3sbs47mrcx6v1km3z2dg39f8x87037n";
       };
       packageRequires = [ ];
       meta = {
@@ -6088,10 +6131,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.5.0.20241022.103450";
+      version = "1.6.0.20250101.92312";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-modern-1.5.0.20241022.103450.tar";
-        sha256 = "1hbgf2yggrp2jfcgi1d9wk2fg3f7f082g8xn60znkyaa7zfsn5nb";
+        url = "https://elpa.gnu.org/devel/org-modern-1.6.0.20250101.92312.tar";
+        sha256 = "18v29i2svvymdz3434fkpi8qljliif0q1nmczvj28rvzgli3c7jl";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6132,10 +6175,10 @@
     elpaBuild {
       pname = "org-real";
       ename = "org-real";
-      version = "1.0.9.0.20240505.204156";
+      version = "1.0.11.0.20250104.92914";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-real-1.0.9.0.20240505.204156.tar";
-        sha256 = "05z8kycyqcfj0w18mnqys54wnlwa9yijlb5c0h86fqbhr7shbjmp";
+        url = "https://elpa.gnu.org/devel/org-real-1.0.11.0.20250104.92914.tar";
+        sha256 = "11my7ygxgin8gjhmaqj3q8c3llyjgac6x5rd7mcx9qb3llpfxhmm";
       };
       packageRequires = [
         boxy
@@ -6179,10 +6222,10 @@
     elpaBuild {
       pname = "org-transclusion";
       ename = "org-transclusion";
-      version = "1.4.0.0.20240922.152934";
+      version = "1.4.0.0.20250102.171949";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/org-transclusion-1.4.0.0.20240922.152934.tar";
-        sha256 = "1p391rjvzp9im2fas8vih3mpvd9w176ykashyy5g94i0pmjfazfi";
+        url = "https://elpa.gnu.org/devel/org-transclusion-1.4.0.0.20250102.171949.tar";
+        sha256 = "1zh67ssxkkfhr459iapl50j04826fx20s7xkwjs40rs0ng8mxrw5";
       };
       packageRequires = [ org ];
       meta = {
@@ -6265,10 +6308,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.4.0.20241122.13029";
+      version = "1.5.0.20250101.92420";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/osm-1.4.0.20241122.13029.tar";
-        sha256 = "0c4b0ddb5l2pipnnwcqqfjj08v9ppr93ailxq000hd683mw48kaz";
+        url = "https://elpa.gnu.org/devel/osm-1.5.0.20250101.92420.tar";
+        sha256 = "0cdx068pziprbsqz99p3383qlgk0v2q6q56ywrph1rnal7k19m5g";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6372,10 +6415,10 @@
     elpaBuild {
       pname = "parser-generator";
       ename = "parser-generator";
-      version = "0.2.1.0.20240220.204114";
+      version = "0.2.4.0.20241220.142732";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/parser-generator-0.2.1.0.20240220.204114.tar";
-        sha256 = "1yb3wv183xii4rvj7asccg9cgkv061vprakcpdq99fgc9zdx0maq";
+        url = "https://elpa.gnu.org/devel/parser-generator-0.2.4.0.20241220.142732.tar";
+        sha256 = "0q46ywjv4ymjal0jfmrm4i1ck6nkcil06xgzhncqp6j8fbn4mvj5";
       };
       packageRequires = [ ];
       meta = {
@@ -6563,10 +6606,10 @@
     elpaBuild {
       pname = "plz-event-source";
       ename = "plz-event-source";
-      version = "0.1.2pre0.20241106.190958";
+      version = "0.1.2pre0.20241227.143348";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.2pre0.20241106.190958.tar";
-        sha256 = "1kpwrc4c48dspyk1zm0b2wp7xmr7h1wm1j7ppqi0wrl350wjzh6f";
+        url = "https://elpa.gnu.org/devel/plz-event-source-0.1.2pre0.20241227.143348.tar";
+        sha256 = "010s4kfx3apdhh9z4r9d2c44arf90nbn8r1j9j3gjhpimsdjhbgq";
       };
       packageRequires = [ plz-media-type ];
       meta = {
@@ -6691,10 +6734,10 @@
     elpaBuild {
       pname = "polymode";
       ename = "polymode";
-      version = "0.2.2.0.20241129.123411";
+      version = "0.2.2.0.20241204.120252";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20241129.123411.tar";
-        sha256 = "0mrs7a8kp2mlidps76h5w0xgnilhpka7qi5pq2xc0i0lk09jd9gv";
+        url = "https://elpa.gnu.org/devel/polymode-0.2.2.0.20241204.120252.tar";
+        sha256 = "1ipdg4byc58gc4jncak5p6w7iyw0y173y4aky2fz88h1ccag2s2g";
       };
       packageRequires = [ ];
       meta = {
@@ -6841,10 +6884,10 @@
     elpaBuild {
       pname = "project";
       ename = "project";
-      version = "0.11.1.0.20241204.74033";
+      version = "0.11.1.0.20250104.95952";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20241204.74033.tar";
-        sha256 = "15npdg1cm3c1h6isq2j87djvslv4c4wan4qni09pra5hqyjmd767";
+        url = "https://elpa.gnu.org/devel/project-0.11.1.0.20250104.95952.tar";
+        sha256 = "1qdffp243idkgmswqyhz0fyq120f0xx5ay31y65zfgwxbrcb35cf";
       };
       packageRequires = [ xref ];
       meta = {
@@ -6904,10 +6947,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.1.0.0.20241126.85951";
+      version = "1.2.0.0.20241228.104712";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/pulsar-1.1.0.0.20241126.85951.tar";
-        sha256 = "01mqy0yl72kzydqq250a2vzyyk0w1q7fpf6bb1a49yh2hkd1g5s3";
+        url = "https://elpa.gnu.org/devel/pulsar-1.2.0.0.20241228.104712.tar";
+        sha256 = "02625fbs1l0c1lr0gy2v3rjmb65bmvil6svx1bf9wx4l1aqhfyjz";
       };
       packageRequires = [ ];
       meta = {
@@ -6975,10 +7018,10 @@
     elpaBuild {
       pname = "python";
       ename = "python";
-      version = "0.28.0.20241123.154630";
+      version = "0.28.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/python-0.28.0.20241123.154630.tar";
-        sha256 = "09ir2jxjk7jvzv7mz5iir3wzx0zas4ikhhh3ig9kbrsj7bsdz6dd";
+        url = "https://elpa.gnu.org/devel/python-0.28.0.20250101.73917.tar";
+        sha256 = "1s3dmqdpymvnvaafjza5pi1y9rf931byk4xqk3x91sjg3bdriqka";
       };
       packageRequires = [
         compat
@@ -7404,10 +7447,10 @@
     elpaBuild {
       pname = "relint";
       ename = "relint";
-      version = "2.0.0.20240802.81954";
+      version = "2.1.0.20241229.210640";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/relint-2.0.0.20240802.81954.tar";
-        sha256 = "1ncai8nbswxgx18kc8qvm47am4n6qbhs38gjbx1ps6xxbipbks1z";
+        url = "https://elpa.gnu.org/devel/relint-2.1.0.20241229.210640.tar";
+        sha256 = "1gx1rq17qvq73cl8921mx6w24nq9nvaa1w1blhl4r3n4wb7j96cw";
       };
       packageRequires = [ xr ];
       meta = {
@@ -7666,10 +7709,10 @@
     elpaBuild {
       pname = "setup";
       ename = "setup";
-      version = "1.4.0.0.20241123.145918";
+      version = "1.4.0.0.20241224.124645";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/setup-1.4.0.0.20241123.145918.tar";
-        sha256 = "01s4dv75r850nq1g84ccjqzlr2xhvd1f6d3zyvdni98qm0vg9si5";
+        url = "https://elpa.gnu.org/devel/setup-1.4.0.0.20241224.124645.tar";
+        sha256 = "00qyav0lrskbm9jryqlbyk4nlh9bv2191l0bjqhqhryj2hzm26rm";
       };
       packageRequires = [ ];
       meta = {
@@ -7962,10 +8005,10 @@
     elpaBuild {
       pname = "so-long";
       ename = "so-long";
-      version = "1.1.2.0.20240102.22814";
+      version = "1.1.2.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/so-long-1.1.2.0.20240102.22814.tar";
-        sha256 = "0fq1c34jlp9jc3zz4rrf9zz6mww0ydm3lh0zrfy3qgssj248ghmy";
+        url = "https://elpa.gnu.org/devel/so-long-1.1.2.0.20250101.73917.tar";
+        sha256 = "1z9mf5kac7bsqq0kkd2alcx9vvz87vsgbw753shd23y9m7ayapvx";
       };
       packageRequires = [ ];
       meta = {
@@ -7984,10 +8027,10 @@
     elpaBuild {
       pname = "soap-client";
       ename = "soap-client";
-      version = "3.2.3.0.20240102.22814";
+      version = "3.2.3.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/soap-client-3.2.3.0.20240102.22814.tar";
-        sha256 = "084svzsb2rrqxvb76qxnwdj64kn364dqgbgdpymqngihngyr88fb";
+        url = "https://elpa.gnu.org/devel/soap-client-3.2.3.0.20250101.73917.tar";
+        sha256 = "0y2zzf5c1yfxx2wrr2ixymk2brp3x73qlxsnjkbmlb6hvjzqp704";
       };
       packageRequires = [ cl-lib ];
       meta = {
@@ -8048,14 +8091,36 @@
     elpaBuild {
       pname = "spacious-padding";
       ename = "spacious-padding";
-      version = "0.5.0.0.20241114.85358";
+      version = "0.5.0.0.20241214.72200";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/spacious-padding-0.5.0.0.20241114.85358.tar";
-        sha256 = "1xs9mac6mrhk6519g13rf8s7q9iivd021bnwmxn54pal904x6q83";
+        url = "https://elpa.gnu.org/devel/spacious-padding-0.5.0.0.20241214.72200.tar";
+        sha256 = "1fm0r7w81cszb2az3xkazd15sfh4593myci6kqsaivnqakyvgj46";
       };
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/devel/spacious-padding.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  speedrect = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "speedrect";
+      ename = "speedrect";
+      version = "0.7.0.20241220.133155";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/devel/speedrect-0.7.0.20241220.133155.tar";
+        sha256 = "10bcmxy5pcni1789fa67awv03q17d5b3ls47vxkn1p6diiha95jw";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.gnu.org/devel/speedrect.html";
         license = lib.licenses.free;
       };
     }
@@ -8222,10 +8287,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.1.0.0.20241025.81655";
+      version = "2.2.0.0.20241229.165414";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/standard-themes-2.1.0.0.20241025.81655.tar";
-        sha256 = "0bba7mwilxhzjxcvqhgmj1gw8iw46wv6s6frx12cczfjdigjjxl4";
+        url = "https://elpa.gnu.org/devel/standard-themes-2.2.0.0.20241229.165414.tar";
+        sha256 = "04bw89j09fsvj69k0jn87mhb3fka4x3mjcxmalfmki263d6qmg5f";
       };
       packageRequires = [ ];
       meta = {
@@ -8243,10 +8308,10 @@
     elpaBuild {
       pname = "stream";
       ename = "stream";
-      version = "2.3.0.0.20241117.211530";
+      version = "2.4.0.0.20250102.122330";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/stream-2.3.0.0.20241117.211530.tar";
-        sha256 = "1hhvp3rikl1dv2ca090cy5jh61nq3mvxznjwz8p39y0gn6ym3x7x";
+        url = "https://elpa.gnu.org/devel/stream-2.4.0.0.20250102.122330.tar";
+        sha256 = "0p1cl4xl0yh3qw0r5zy37rapbzi0xav8wzhcrvm0scgsr7il5jm8";
       };
       packageRequires = [ ];
       meta = {
@@ -8285,10 +8350,10 @@
     elpaBuild {
       pname = "svg";
       ename = "svg";
-      version = "1.1.0.20240804.74716";
+      version = "1.1.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/svg-1.1.0.20240804.74716.tar";
-        sha256 = "1jgcs5x5rq4bd1ac2kyh9ylid9wp9c4sijxd1zch0yi2z67x8z62";
+        url = "https://elpa.gnu.org/devel/svg-1.1.0.20250101.73917.tar";
+        sha256 = "1sacdwkqh5vb9bnd1vmxjk35nl9rzakh5v9mpzslh2mjysx61bmm";
       };
       packageRequires = [ ];
       meta = {
@@ -8415,10 +8480,10 @@
     elpaBuild {
       pname = "sxhkdrc-mode";
       ename = "sxhkdrc-mode";
-      version = "1.0.0.0.20240913.71503";
+      version = "1.1.0.0.20241224.141418";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.0.0.0.20240913.71503.tar";
-        sha256 = "02qgyk2f1jglwkk34sph8j1ab1rq8r6pad7ixvi9idq7ya6wzfdb";
+        url = "https://elpa.gnu.org/devel/sxhkdrc-mode-1.1.0.0.20241224.141418.tar";
+        sha256 = "0z1q837vpjhhbr8gi5fiwnc25bvyfgsfxa4rlq2l527d8vrn1mpl";
       };
       packageRequires = [ ];
       meta = {
@@ -8595,10 +8660,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.2.0.20241116.82753";
+      version = "1.3.0.20250101.92736";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tempel-1.2.0.20241116.82753.tar";
-        sha256 = "13qakkcx260iscxa8w6160bzdxg7n0mr3dfa44jnb9l7dc5cs6vh";
+        url = "https://elpa.gnu.org/devel/tempel-1.3.0.20250101.92736.tar";
+        sha256 = "1jqg7k6pr088jmbvyzqwm5xyzpjlz0a4fk4z5qmrcr6hdzyjlhgi";
       };
       packageRequires = [ compat ];
       meta = {
@@ -8812,10 +8877,10 @@
     elpaBuild {
       pname = "track-changes";
       ename = "track-changes";
-      version = "1.2.0.20241018.155615";
+      version = "1.2.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/track-changes-1.2.0.20241018.155615.tar";
-        sha256 = "02m70rh2qzv3nnrs8ykwmpn6fsd2v9lvspiwx1q0yndgvhxwg5d4";
+        url = "https://elpa.gnu.org/devel/track-changes-1.2.0.20250101.73917.tar";
+        sha256 = "0w93lrbnpv567j9zn1vbw5h63d331ddi6n7cnhqi4c25kx55dzpw";
       };
       packageRequires = [ ];
       meta = {
@@ -8833,10 +8898,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.1.5.0.20241130.82948";
+      version = "2.7.2.0.20250101.91903";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-2.7.1.5.0.20241130.82948.tar";
-        sha256 = "0ypb44lhdv6hnx2rzpn8746sqa0wafknkf4bjxsvlh402xfjbypq";
+        url = "https://elpa.gnu.org/devel/tramp-2.7.2.0.20250101.91903.tar";
+        sha256 = "04wh0g7wym62j6bdddads1j9n4kmpb1l4zc8krb47va14avbvgmx";
       };
       packageRequires = [ ];
       meta = {
@@ -8875,10 +8940,10 @@
     elpaBuild {
       pname = "tramp-theme";
       ename = "tramp-theme";
-      version = "0.2.0.20221221.82451";
+      version = "0.3.0.20241214.144045";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/tramp-theme-0.2.0.20221221.82451.tar";
-        sha256 = "0x7wa17f2pnhd6nv7p2m5pafqqgpfp9n773qcmyxkawi4l5bp5d3";
+        url = "https://elpa.gnu.org/devel/tramp-theme-0.3.0.20241214.144045.tar";
+        sha256 = "1fhd8pag716h7x71bz059wd6vqn4mz058yg0apfz68dlchma4zhk";
       };
       packageRequires = [ ];
       meta = {
@@ -8919,10 +8984,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.7.9.0.20241203.214158";
+      version = "0.8.3.0.20250103.173148";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/transient-0.7.9.0.20241203.214158.tar";
-        sha256 = "0yrc8y035yxrirjnbq3hl4jb3mj5xdnv0sy6aji4pdln2ywv122d";
+        url = "https://elpa.gnu.org/devel/transient-0.8.3.0.20250103.173148.tar";
+        sha256 = "1fd867jcq8jh60p9y5bk06visx5hpjik78d31ayipvf1y2ijmjq2";
       };
       packageRequires = [
         compat
@@ -9237,10 +9302,10 @@
     elpaBuild {
       pname = "use-package";
       ename = "use-package";
-      version = "2.4.6.0.20241109.73512";
+      version = "2.4.6.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20241109.73512.tar";
-        sha256 = "1qxcl0nsry3in6n301240fg8n2bvxs58fxr8cf83vbwcfkp8n7sj";
+        url = "https://elpa.gnu.org/devel/use-package-2.4.6.0.20250101.73917.tar";
+        sha256 = "1c9rq2ija4a24ff0rysp1znnrlpch92v3qd35y49mjn0x4bn7sm8";
       };
       packageRequires = [ bind-key ];
       meta = {
@@ -9433,10 +9498,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2024.10.9.140346409.0.20241009.223438";
+      version = "2025.1.1.100165202.0.20250101.82250";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/verilog-mode-2024.10.9.140346409.0.20241009.223438.tar";
-        sha256 = "1zkdlq5ly9phjmg4ga1blbr184a7l3jldfpw58qx5njvyq5b3jq8";
+        url = "https://elpa.gnu.org/devel/verilog-mode-2025.1.1.100165202.0.20250101.82250.tar";
+        sha256 = "17q3d1nyw0szishffh0i44sm2yzfycvy6196dlwnfrbpkna9wmps";
       };
       packageRequires = [ ];
       meta = {
@@ -9455,10 +9520,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "1.9.0.20241130.70347";
+      version = "1.10.0.20250101.92843";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-1.9.0.20241130.70347.tar";
-        sha256 = "0xqyzmsyxrqvr1r25qyw59r5997f5ldj0c7nl8l821855dnm2c2y";
+        url = "https://elpa.gnu.org/devel/vertico-1.10.0.20250101.92843.tar";
+        sha256 = "1868m8ss9d9hyk55an6vmn6hb19qvvdadxn3jmngmbvxvgcsh4gm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9478,10 +9543,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.7.7.0.20241023.25940";
+      version = "0.7.8.0.20241225.125045";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vertico-posframe-0.7.7.0.20241023.25940.tar";
-        sha256 = "0gvi8z5jhgy5jqp4q80ax01djzswp2ygq9rfryy8p3m3pgf36g4n";
+        url = "https://elpa.gnu.org/devel/vertico-posframe-0.7.8.0.20241225.125045.tar";
+        sha256 = "11yhjx8hk5j04wagzwxm2rsb124q0s25m5bfr2a5qpalhj7dxhzq";
       };
       packageRequires = [
         posframe
@@ -9586,10 +9651,10 @@
     elpaBuild {
       pname = "vundo";
       ename = "vundo";
-      version = "2.3.0.0.20240425.211317";
+      version = "2.3.0.0.20241225.170413";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/vundo-2.3.0.0.20240425.211317.tar";
-        sha256 = "0dif9f3s3igpfi0r4dgzy14g8m6xf1g6lqyc0gfzf40n301iw4kz";
+        url = "https://elpa.gnu.org/devel/vundo-2.3.0.0.20241225.170413.tar";
+        sha256 = "0cl9ysfh9jkdk602183lbqb4xfb3z0y85ybs8ql6fl2n483n934a";
       };
       packageRequires = [ ];
       meta = {
@@ -9714,10 +9779,10 @@
     elpaBuild {
       pname = "which-key";
       ename = "which-key";
-      version = "3.6.1.0.20241123.44609";
+      version = "3.6.1.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/which-key-3.6.1.0.20241123.44609.tar";
-        sha256 = "0gn2z7l4fj5cff44k6xbqfbksbafm90i0wssak7c4ghai57wqqa2";
+        url = "https://elpa.gnu.org/devel/which-key-3.6.1.0.20250101.73917.tar";
+        sha256 = "05d6dbh0l7lb70rqqgqlwp1q32i4kr4lqkdgg4ngimyqnmm2xy5h";
       };
       packageRequires = [ ];
       meta = {
@@ -9757,10 +9822,10 @@
     elpaBuild {
       pname = "window-tool-bar";
       ename = "window-tool-bar";
-      version = "0.2.1.0.20241024.85007";
+      version = "0.2.1.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/window-tool-bar-0.2.1.0.20241024.85007.tar";
-        sha256 = "16226fm8hq862s9f4ja8wpkar4yp8v86pkq9kdv3mpbmw9lywq54";
+        url = "https://elpa.gnu.org/devel/window-tool-bar-0.2.1.0.20250101.73917.tar";
+        sha256 = "0cc1s4jrz9zy9986v27hlm6aj9iq11vd7xc4i2wymy47fkmqfbhl";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9953,10 +10018,10 @@
     elpaBuild {
       pname = "xelb";
       ename = "xelb";
-      version = "0.20.0.20240708.212415";
+      version = "0.20.0.20250101.94850";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xelb-0.20.0.20240708.212415.tar";
-        sha256 = "0sv3p1q3gc9jpjvnl9pjr98kzl3i969hmqbznpby1fgdrlbinvik";
+        url = "https://elpa.gnu.org/devel/xelb-0.20.0.20250101.94850.tar";
+        sha256 = "03lma8c203j736kl2pg1vmjd4iw52qg67qlb0617pr6dd7p7jr8j";
       };
       packageRequires = [ compat ];
       meta = {
@@ -10000,10 +10065,10 @@
     elpaBuild {
       pname = "xr";
       ename = "xr";
-      version = "2.0.0.20240802.81742";
+      version = "2.1.0.20241229.210720";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xr-2.0.0.20240802.81742.tar";
-        sha256 = "1x93v2x8zkr3s55c8r8lpimavqzcq0zjxshg5kif84gir10jgcdn";
+        url = "https://elpa.gnu.org/devel/xr-2.1.0.20241229.210720.tar";
+        sha256 = "0p7v5pl1rynhki6rx0fsxm3jnch3lspw59v9mxz86ir1w03913mm";
       };
       packageRequires = [ ];
       meta = {
@@ -10021,10 +10086,10 @@
     elpaBuild {
       pname = "xref";
       ename = "xref";
-      version = "1.7.0.0.20241127.14322";
+      version = "1.7.0.0.20250101.73917";
       src = fetchurl {
-        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20241127.14322.tar";
-        sha256 = "12983qax1jwbbcbd8zs1spi3z1hnnnmqih75dx0wy281zv1vwzp4";
+        url = "https://elpa.gnu.org/devel/xref-1.7.0.0.20250101.73917.tar";
+        sha256 = "057s32ps07cnzny7zv1zp794nhwvi11zfwjbbzql38pryqrjijp4";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/elpa-generated.nix
@@ -53,10 +53,10 @@
     elpaBuild {
       pname = "activities";
       ename = "activities";
-      version = "0.7.1";
+      version = "0.7.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/activities-0.7.1.tar";
-        sha256 = "1khhkfyy251mag5zqybsvfg3sak0aac1qlsdl1wyiin7f6sq9563";
+        url = "https://elpa.gnu.org/packages/activities-0.7.2.tar";
+        sha256 = "1b6d77b5h2vikfxqjlb1jx5pnij5bif788nysvvn3wlzpwdi88s0";
       };
       packageRequires = [ persist ];
       meta = {
@@ -419,10 +419,10 @@
     elpaBuild {
       pname = "auctex";
       ename = "auctex";
-      version = "14.0.7";
+      version = "14.0.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/auctex-14.0.7.tar";
-        sha256 = "1m71jr853b4d713z1k4jj73c8ba4753hv8nighx62razgmpn4ci8";
+        url = "https://elpa.gnu.org/packages/auctex-14.0.8.tar";
+        sha256 = "0bcjkbwhbkmm0r7pbh44j7vw9b39g2iw1jgw4sq54qp7387j6lmy";
       };
       packageRequires = [ ];
       meta = {
@@ -790,10 +790,10 @@
     elpaBuild {
       pname = "boxy";
       ename = "boxy";
-      version = "1.1.4";
+      version = "2.0.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/boxy-1.1.4.tar";
-        sha256 = "0mwj1qc626f1iaq5iaqm1f4iwyz91hzqhzfk5f53gsqka7yz2fnf";
+        url = "https://elpa.gnu.org/packages/boxy-2.0.0.tar";
+        sha256 = "1vfgwgk3vzzp2cy7n0qwhn7hzjxbp9vzxp1al1pkynv9hfs503gb";
       };
       packageRequires = [ ];
       meta = {
@@ -813,10 +813,10 @@
     elpaBuild {
       pname = "boxy-headings";
       ename = "boxy-headings";
-      version = "2.1.6";
+      version = "2.1.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/boxy-headings-2.1.6.tar";
-        sha256 = "0wnks9a4agvqjivp9myl8zcdq6rj7hh5ig73f8qv5imar0i76izc";
+        url = "https://elpa.gnu.org/packages/boxy-headings-2.1.8.tar";
+        sha256 = "1r356z090dkgc7wb5qq35pkq3932rr6zy90d85jb9frxf7w1zmd7";
       };
       packageRequires = [
         boxy
@@ -1020,10 +1020,10 @@
     elpaBuild {
       pname = "cape";
       ename = "cape";
-      version = "1.7";
+      version = "1.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/cape-1.7.tar";
-        sha256 = "03npj4a8g73dgrivjgc27w0c957naqhxq0hfzshdqci6mrq1gph3";
+        url = "https://elpa.gnu.org/packages/cape-1.8.tar";
+        sha256 = "18z3c3d1wbf2j40rym74918hxccmi84rbqkzc2g73jbigp78kyq4";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1398,10 +1398,10 @@
     elpaBuild {
       pname = "compat";
       ename = "compat";
-      version = "30.0.0.0";
+      version = "30.0.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/compat-30.0.0.0.tar";
-        sha256 = "0z7049xkdyx22ywq821d19lp73ywaz6brxj461h0h2a73y7999cl";
+        url = "https://elpa.gnu.org/packages/compat-30.0.2.0.tar";
+        sha256 = "0pizq8vwfqls04in95rpnfwv4xc1r2qjpf41g6bjy826i53cfdx0";
       };
       packageRequires = [ seq ];
       meta = {
@@ -1441,10 +1441,10 @@
     elpaBuild {
       pname = "consult";
       ename = "consult";
-      version = "1.8";
+      version = "1.9";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/consult-1.8.tar";
-        sha256 = "0k3k1jmwdw4w8rr5z2030ba37mcia2zghh6p4c36ck51hwvfkb8w";
+        url = "https://elpa.gnu.org/packages/consult-1.9.tar";
+        sha256 = "0qz8l962995znf9lhgy8hdd9z78bdhb8m95dxj1g3266jsgjf8sv";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1554,10 +1554,10 @@
     elpaBuild {
       pname = "corfu";
       ename = "corfu";
-      version = "1.5";
+      version = "1.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/corfu-1.5.tar";
-        sha256 = "0m80slhpr9xd57b3nvrqgfxm44851v9gfcy8ky3d3v2g5i2mrm6x";
+        url = "https://elpa.gnu.org/packages/corfu-1.6.tar";
+        sha256 = "1wx7hjvccb2jss4k0vcmmdxkyivs2qnzai6xw2l1fgdan9ngg89n";
       };
       packageRequires = [ compat ];
       meta = {
@@ -1814,10 +1814,10 @@
     elpaBuild {
       pname = "dape";
       ename = "dape";
-      version = "0.17.0";
+      version = "0.19.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/dape-0.17.0.tar";
-        sha256 = "113lmy0q1yk81cfi9dbig8p9bmhyqy6w1bvhn91m79my05ny2rxd";
+        url = "https://elpa.gnu.org/packages/dape-0.19.0.tar";
+        sha256 = "11hs0cnzyp75gmz32mqplaknf4lq0zf9zp07h1rhlvz31aacvrqh";
       };
       packageRequires = [ jsonrpc ];
       meta = {
@@ -1901,10 +1901,10 @@
     elpaBuild {
       pname = "debbugs";
       ename = "debbugs";
-      version = "0.42";
+      version = "0.43";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/debbugs-0.42.tar";
-        sha256 = "0n0kvkyzggn8q72dpy6c7rsjwn1rjx0r33y5jc080j7sw85xpigg";
+        url = "https://elpa.gnu.org/packages/debbugs-0.43.tar";
+        sha256 = "1jzdr7bp48incg1bdnq4s1ldnyp6hncz0mydy0bizk3c68chsls5";
       };
       packageRequires = [ soap-client ];
       meta = {
@@ -2041,6 +2041,28 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/devicetree-ts-mode.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  dicom = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "dicom";
+      ename = "dicom";
+      version = "0.5";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/dicom-0.5.tar";
+        sha256 = "1qz4zhq0fcfl7l42qib60j2dzm1vp2vmwfhm48s0ia6dgdkvad3x";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/dicom.html";
         license = lib.licenses.free;
       };
     }
@@ -2539,10 +2561,10 @@
     elpaBuild {
       pname = "eev";
       ename = "eev";
-      version = "20241123";
+      version = "20241223";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/eev-20241123.tar";
-        sha256 = "1bb2134jggj4xg49cwy8ivfb12yafxyy2p5k4rca9an3cr4s8ci7";
+        url = "https://elpa.gnu.org/packages/eev-20241223.tar";
+        sha256 = "0rp7b3sfh94zyah303sk43mfdbzcz6p20dqarkzbsgin3n77ara8";
       };
       packageRequires = [ ];
       meta = {
@@ -2689,10 +2711,10 @@
     elpaBuild {
       pname = "elisa";
       ename = "elisa";
-      version = "1.1.3";
+      version = "1.1.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/elisa-1.1.3.tar";
-        sha256 = "0370gvj3r701i2acp3wq705a9n534g719nzz8bg9a4lry76f2crv";
+        url = "https://elpa.gnu.org/packages/elisa-1.1.4.tar";
+        sha256 = "1v5y0piqz31dx38mv217l5z4xn6hnggznmrcxd2ffs0xdvr9iv3s";
       };
       packageRequires = [
         async
@@ -2740,10 +2762,10 @@
     elpaBuild {
       pname = "ellama";
       ename = "ellama";
-      version = "0.13.0";
+      version = "0.13.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/ellama-0.13.0.tar";
-        sha256 = "0wfn8fv124qxf9yxl4lsa3hwlicmaiv2zzn8w4vhmlni1kf37nlw";
+        url = "https://elpa.gnu.org/packages/ellama-0.13.1.tar";
+        sha256 = "1hf9lqjcg33xahz8i5ng123z6yljmwm3zw15n96x83x0szxi1wl1";
       };
       packageRequires = [
         compat
@@ -2876,10 +2898,10 @@
     elpaBuild {
       pname = "emms";
       ename = "emms";
-      version = "20.2";
+      version = "21";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/emms-20.2.tar";
-        sha256 = "0amc956amyfsjlq5aqc7nk2cs2ph2zcpci5wkms6w973wx67z2j6";
+        url = "https://elpa.gnu.org/packages/emms-21.tar";
+        sha256 = "188rij39qqaya7hk0p05ygcw5vlha7qd6pm4ws6nfw7g0nv1rbcc";
       };
       packageRequires = [
         cl-lib
@@ -3801,10 +3823,10 @@
     elpaBuild {
       pname = "greader";
       ename = "greader";
-      version = "0.11.18";
+      version = "0.12.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/greader-0.11.18.tar";
-        sha256 = "122mvjcbvi7dzggx1dl02iw9jl0h33l8ka4mzvlr6sl0wwwzfpr8";
+        url = "https://elpa.gnu.org/packages/greader-0.12.6.tar";
+        sha256 = "0xv814p7cdf2wj7qdj9cpz3blnkcd8b6sjk2jajym5hilmr9a9b5";
       };
       packageRequires = [
         compat
@@ -4422,10 +4444,10 @@
     elpaBuild {
       pname = "jinx";
       ename = "jinx";
-      version = "1.10";
+      version = "1.11";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/jinx-1.10.tar";
-        sha256 = "19l1wcrv610l6alb9xzyfmdkmnzgcf60z3557q4dkgvz35959p4y";
+        url = "https://elpa.gnu.org/packages/jinx-1.11.tar";
+        sha256 = "0g0iys02k488lbkd7a8qn3hwcmfhmyfp8v3mm07z3zsjhlqw0m57";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4873,10 +4895,10 @@
     elpaBuild {
       pname = "llm";
       ename = "llm";
-      version = "0.19.1";
+      version = "0.20.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/llm-0.19.1.tar";
-        sha256 = "03f8yvnq1n2pns62iji2iz50f30wxw50n9a6cxgd9p2vkd4pjb0g";
+        url = "https://elpa.gnu.org/packages/llm-0.20.0.tar";
+        sha256 = "12a6z2knsxp8jy0v9hsfsb7kdzyj6pnq5h58vnkrizd95zp6zf91";
       };
       packageRequires = [
         plz
@@ -5067,10 +5089,10 @@
     elpaBuild {
       pname = "m-buffer";
       ename = "m-buffer";
-      version = "0.16";
+      version = "0.16.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/m-buffer-0.16.tar";
-        sha256 = "16drbgamp7yd1ndw2qrycrgmnknv5k7h4d7svcdhv9az6fg1vzn4";
+        url = "https://elpa.gnu.org/packages/m-buffer-0.16.1.tar";
+        sha256 = "1iq7nld1i8v0da1ajhvfdarx4bx3wnwgz5lhb78fcnsq8zb6cp5y";
       };
       packageRequires = [ seq ];
       meta = {
@@ -5110,10 +5132,10 @@
     elpaBuild {
       pname = "marginalia";
       ename = "marginalia";
-      version = "1.7";
+      version = "1.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/marginalia-1.7.tar";
-        sha256 = "1bwbkz71w81zcqsydvqic2xri52pm1h9nac8i7i04nl5b98pszkk";
+        url = "https://elpa.gnu.org/packages/marginalia-1.8.tar";
+        sha256 = "0q8mflfsl4vj2r2m47jgm5hrg3a4k5pildb53vlgm5k9wb4sd7md";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5181,6 +5203,27 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.gnu.org/packages/mathjax.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  matlab-mode = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "matlab-mode";
+      ename = "matlab-mode";
+      version = "6.3";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/matlab-mode-6.3.tar";
+        sha256 = "0m3h60629p9rv8k2fk23iwfdgzsdmlk78y1j83xz5m53z7vl3a7m";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/matlab-mode.html";
         license = lib.licenses.free;
       };
     }
@@ -5943,10 +5986,10 @@
     elpaBuild {
       pname = "orderless";
       ename = "orderless";
-      version = "1.2";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/orderless-1.2.tar";
-        sha256 = "1iyfnvwqwn8y4bkv25zw15y8yy5dm89kyk7wlxw0al22bhfc2cm7";
+        url = "https://elpa.gnu.org/packages/orderless-1.3.tar";
+        sha256 = "1gh2xw34adk5q6v9sz42j5mwyjjp1yix70jvjylnapwsjjsjm5qk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -5964,10 +6007,10 @@
     elpaBuild {
       pname = "org";
       ename = "org";
-      version = "9.7.16";
+      version = "9.7.19";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-9.7.16.tar";
-        sha256 = "1d6vxd7ssfb1v00a37dr723v9cg8i8v78lcymqndqhy6f2ji1f06";
+        url = "https://elpa.gnu.org/packages/org-9.7.19.tar";
+        sha256 = "0v7ridhsz12iwznk8165ll61i1w1avhxfrq3p82p9r6ir2xdan1g";
       };
       packageRequires = [ ];
       meta = {
@@ -6056,10 +6099,10 @@
     elpaBuild {
       pname = "org-modern";
       ename = "org-modern";
-      version = "1.5";
+      version = "1.6";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-modern-1.5.tar";
-        sha256 = "08s253r3z5r37swlsgrp97ls7p3bdr4hr2xvyb1pm57j7livv74b";
+        url = "https://elpa.gnu.org/packages/org-modern-1.6.tar";
+        sha256 = "1fmmblqs6v52690fvky3xq48m5a3xh8xrl7j8pqw6hc06igm4m5q";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6100,10 +6143,10 @@
     elpaBuild {
       pname = "org-real";
       ename = "org-real";
-      version = "1.0.9";
+      version = "1.0.11";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/org-real-1.0.9.tar";
-        sha256 = "0g19pgg7rqijb6q1vpifvpzl2gyc13a42q1n23x3kawl2srhcjp2";
+        url = "https://elpa.gnu.org/packages/org-real-1.0.11.tar";
+        sha256 = "1mm2p6487m4sr8zvj7xqryvicvj0qbv7as39hxh1ad7yhfdhgpvw";
       };
       packageRequires = [
         boxy
@@ -6233,10 +6276,10 @@
     elpaBuild {
       pname = "osm";
       ename = "osm";
-      version = "1.4";
+      version = "1.5";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/osm-1.4.tar";
-        sha256 = "0cix4jn3919xnlsj85l4m83znkqf4m2988zzqwcsvvvjrmgccanh";
+        url = "https://elpa.gnu.org/packages/osm-1.5.tar";
+        sha256 = "1hgr1gfkii75nmfsz3nvn5hv9x9jg09as7k12rr7vr9k0fs0j4hk";
       };
       packageRequires = [ compat ];
       meta = {
@@ -6340,10 +6383,10 @@
     elpaBuild {
       pname = "parser-generator";
       ename = "parser-generator";
-      version = "0.2.1";
+      version = "0.2.4";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/parser-generator-0.2.1.tar";
-        sha256 = "1vrgkvcj16550frq2jivw31cmq6rhwrifmdk4rf0266br3jdarpf";
+        url = "https://elpa.gnu.org/packages/parser-generator-0.2.4.tar";
+        sha256 = "01b5bwh484fpicv0g2z64694pjkhrcqz9f8jpq6hk41kzhvr23m1";
       };
       packageRequires = [ ];
       meta = {
@@ -6830,10 +6873,10 @@
     elpaBuild {
       pname = "pulsar";
       ename = "pulsar";
-      version = "1.1.0";
+      version = "1.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/pulsar-1.1.0.tar";
-        sha256 = "0hs65y2avl8w5g4zd68sdg4rl4q15ac53xlbc4qrfjynlajma6mm";
+        url = "https://elpa.gnu.org/packages/pulsar-1.2.0.tar";
+        sha256 = "03bx06fa7md78xrn10kigrf3p8pm07lxpw70wbhfqgq1b3zr46rl";
       };
       packageRequires = [ ];
       meta = {
@@ -7325,10 +7368,10 @@
     elpaBuild {
       pname = "relint";
       ename = "relint";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/relint-2.0.tar";
-        sha256 = "0r89b5yk5lp92k4gnr0sx6ccilqzpv6kd5csqhxydk0xmqh8rsff";
+        url = "https://elpa.gnu.org/packages/relint-2.1.tar";
+        sha256 = "0ikml87y0k85qd92m3l1gkzjd9ng3mhjfk19w15ln0w801351cq0";
       };
       packageRequires = [ xr ];
       meta = {
@@ -7960,6 +8003,28 @@
       };
     }
   ) { };
+  speedrect = callPackage (
+    {
+      compat,
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "speedrect";
+      ename = "speedrect";
+      version = "0.7";
+      src = fetchurl {
+        url = "https://elpa.gnu.org/packages/speedrect-0.7.tar";
+        sha256 = "0nxwwd12qqyxq1fg8n6miyx63fp29cvpfp8w33zmf9dhkcjwyfd1";
+      };
+      packageRequires = [ compat ];
+      meta = {
+        homepage = "https://elpa.gnu.org/packages/speedrect.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
   spinner = callPackage (
     {
       elpaBuild,
@@ -8101,10 +8166,10 @@
     elpaBuild {
       pname = "standard-themes";
       ename = "standard-themes";
-      version = "2.1.0";
+      version = "2.2.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/standard-themes-2.1.0.tar";
-        sha256 = "0x7fphd36kwg4vfwix5rq7260xl6x6cjfwsq11rj4af30sm4hlfn";
+        url = "https://elpa.gnu.org/packages/standard-themes-2.2.0.tar";
+        sha256 = "0qdld75vcfhsn2l0xips52vrlp5q7ss3973hd722h2gp1wddn5f7";
       };
       packageRequires = [ ];
       meta = {
@@ -8122,10 +8187,10 @@
     elpaBuild {
       pname = "stream";
       ename = "stream";
-      version = "2.3.0";
+      version = "2.4.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/stream-2.3.0.tar";
-        sha256 = "0224hjcxvy3cxv1c3pz9j2laxld2cxqbs5sigr02fcdcb9qn7hay";
+        url = "https://elpa.gnu.org/packages/stream-2.4.0.tar";
+        sha256 = "16wl1q7wikk0wyzfwjz16azq025dx4wdh1j9q0nadi68ygxi172b";
       };
       packageRequires = [ ];
       meta = {
@@ -8294,10 +8359,10 @@
     elpaBuild {
       pname = "sxhkdrc-mode";
       ename = "sxhkdrc-mode";
-      version = "1.0.0";
+      version = "1.1.0";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/sxhkdrc-mode-1.0.0.tar";
-        sha256 = "0gfv5l71md2ica9jfa8ynwfag3zvayc435pl91lzcz92qy5n0hlj";
+        url = "https://elpa.gnu.org/packages/sxhkdrc-mode-1.1.0.tar";
+        sha256 = "00mzhxrlcbswsv3jysgqniq02inakz7j5a2hx2w83is5rbmb9bhc";
       };
       packageRequires = [ ];
       meta = {
@@ -8449,10 +8514,10 @@
     elpaBuild {
       pname = "tempel";
       ename = "tempel";
-      version = "1.2";
+      version = "1.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tempel-1.2.tar";
-        sha256 = "0lvdd7lvdx4yf0zhrv380y5q3zvvk7gsxjgxj2c40np86c4q2q7m";
+        url = "https://elpa.gnu.org/packages/tempel-1.3.tar";
+        sha256 = "0fivsldisk17a1vbzx91kmvsd85vl0dnih77pqnzriyqs8dl1wdm";
       };
       packageRequires = [ compat ];
       meta = {
@@ -8688,10 +8753,10 @@
     elpaBuild {
       pname = "tramp";
       ename = "tramp";
-      version = "2.7.1.5";
+      version = "2.7.2";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-2.7.1.5.tar";
-        sha256 = "11a2zyk0d1y9bxhdqfzcx4ynazfs6hb3mdgpz5kp9p3lk8l6bz5g";
+        url = "https://elpa.gnu.org/packages/tramp-2.7.2.tar";
+        sha256 = "1m1ar9k5f4yx98m8v0y8rm7hq5dwjafb096gmdg6mz57k1k3y6vl";
       };
       packageRequires = [ ];
       meta = {
@@ -8730,10 +8795,10 @@
     elpaBuild {
       pname = "tramp-theme";
       ename = "tramp-theme";
-      version = "0.2";
+      version = "0.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/tramp-theme-0.2.tar";
-        sha256 = "0dz8ndnmwc38g1gy30f3jcjqg5nzdi6721x921r4s5a8i1mx2kpm";
+        url = "https://elpa.gnu.org/packages/tramp-theme-0.3.tar";
+        sha256 = "1v9265cnk858jl522zcnqf2cv3f3g93f0mk52plz3n4a8k5nlfa7";
       };
       packageRequires = [ ];
       meta = {
@@ -8774,10 +8839,10 @@
     elpaBuild {
       pname = "transient";
       ename = "transient";
-      version = "0.7.9";
+      version = "0.8.3";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/transient-0.7.9.tar";
-        sha256 = "07d5pzd7nalnjxn6wpj6vpfg8pldnwh69l85immmiww03vl8ngrf";
+        url = "https://elpa.gnu.org/packages/transient-0.8.3.tar";
+        sha256 = "0cx9h7knkyzalkyvbvl762mnl2mslcfxh899mf5wgqfavwkzgqp7";
       };
       packageRequires = [
         compat
@@ -9287,10 +9352,10 @@
     elpaBuild {
       pname = "verilog-mode";
       ename = "verilog-mode";
-      version = "2024.10.9.140346409";
+      version = "2025.1.1.100165202";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/verilog-mode-2024.10.9.140346409.tar";
-        sha256 = "1hm0id8sivb7znvw1f63asbs4sf4v6hkimr0j8bqqda3h9sz197l";
+        url = "https://elpa.gnu.org/packages/verilog-mode-2025.1.1.100165202.tar";
+        sha256 = "1cgv081dlarc0b4s6rjkqbvs4fa9npyq9pjxj7173vmgkfdwmkp5";
       };
       packageRequires = [ ];
       meta = {
@@ -9309,10 +9374,10 @@
     elpaBuild {
       pname = "vertico";
       ename = "vertico";
-      version = "1.9";
+      version = "1.10";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-1.9.tar";
-        sha256 = "12aiqxsar86xlmsfzvilza10wf184nwhg218bv6bip7v51ikh37y";
+        url = "https://elpa.gnu.org/packages/vertico-1.10.tar";
+        sha256 = "1mka141i5dmdw8c8dsxgxwqfr78s3gjy4rrra8qd5b8qrhv797dx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -9332,10 +9397,10 @@
     elpaBuild {
       pname = "vertico-posframe";
       ename = "vertico-posframe";
-      version = "0.7.7";
+      version = "0.7.8";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/vertico-posframe-0.7.7.tar";
-        sha256 = "0ahn0b5v9xw6f1zvgv27c82kxdh4rx7n9dbp17rkkkg3dvvkdzxy";
+        url = "https://elpa.gnu.org/packages/vertico-posframe-0.7.8.tar";
+        sha256 = "08f1fmr0s9kx3f7ivh1isdik04cq87j69wgl5ir0gppa39ip0dqw";
       };
       packageRequires = [
         posframe
@@ -9853,10 +9918,10 @@
     elpaBuild {
       pname = "xr";
       ename = "xr";
-      version = "2.0";
+      version = "2.1";
       src = fetchurl {
-        url = "https://elpa.gnu.org/packages/xr-2.0.tar";
-        sha256 = "1y5pcrph6v8q06mipv3l49qhw55yvvb1nnq0817bzm25k0s3z70v";
+        url = "https://elpa.gnu.org/packages/xr-2.1.tar";
+        sha256 = "1yssl7av2rpanzmm93iw74acnb3pbrnh0b51kr64wcj6hwb26cy2";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-devel-generated.nix
@@ -177,10 +177,10 @@
     elpaBuild {
       pname = "apropospriate-theme";
       ename = "apropospriate-theme";
-      version = "0.2.0.0.20241118.190153";
+      version = "0.2.0.0.20241215.141144";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20241118.190153.tar";
-        sha256 = "0nqnf57bf21wg2vlw85msg927618hhsn4qfwd60vrx70260432kf";
+        url = "https://elpa.nongnu.org/nongnu-devel/apropospriate-theme-0.2.0.0.20241215.141144.tar";
+        sha256 = "0hr961s3s9n9an63yxkxkryas0vr0cw9g07ir8igyan6b8b2didb";
       };
       packageRequires = [ ];
       meta = {
@@ -220,10 +220,10 @@
     elpaBuild {
       pname = "auto-dim-other-buffers";
       ename = "auto-dim-other-buffers";
-      version = "2.1.1.0.20240515.131159";
+      version = "2.2.1.0.20241219.184527";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/auto-dim-other-buffers-2.1.1.0.20240515.131159.tar";
-        sha256 = "1dp3q1hrdcvi82pcj5hxha9yyy9lkdqs8kxfq6v7lq716wxkwxfl";
+        url = "https://elpa.nongnu.org/nongnu-devel/auto-dim-other-buffers-2.2.1.0.20241219.184527.tar";
+        sha256 = "0596jw2qxk79z26blq7vlch7wszv39f84kpi7gwrbad0jyjcryfw";
       };
       packageRequires = [ ];
       meta = {
@@ -284,10 +284,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.1.1.0.20241118.194353";
+      version = "3.2.1snapshot0.20250101.145820";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.1.1.0.20241118.194353.tar";
-        sha256 = "10cirfnwz34yc7glf1xzshq3926jdwdf3s7bdarykrkxmsrha4f7";
+        url = "https://elpa.nongnu.org/nongnu-devel/bash-completion-3.2.1snapshot0.20250101.145820.tar";
+        sha256 = "11a2fijxi102mnm63vbxgrrw2rr9nf5rhlfal3766m8rv2drwhd7";
       };
       packageRequires = [ ];
       meta = {
@@ -544,10 +544,10 @@
     elpaBuild {
       pname = "cider";
       ename = "cider";
-      version = "1.16.1.0.20241203.160720";
+      version = "1.16.1.0.20250103.102622";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.16.1.0.20241203.160720.tar";
-        sha256 = "0b6nqhg5c0ny8ilm4653c7pd34aj02bh6ya9bzc9swdpyq7pwnqr";
+        url = "https://elpa.nongnu.org/nongnu-devel/cider-1.16.1.0.20250103.102622.tar";
+        sha256 = "0xxmarmq2mja45yb4a4aqddbcnhi91dcdlw0xq5j5ab3k9grmmpa";
       };
       packageRequires = [
         clojure-mode
@@ -573,10 +573,10 @@
     elpaBuild {
       pname = "clojure-mode";
       ename = "clojure-mode";
-      version = "5.20.0snapshot0.20241125.112305";
+      version = "5.20.0snapshot0.20241211.152233";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0snapshot0.20241125.112305.tar";
-        sha256 = "0hh17w63j5x4687kbd2vmlj9qs468ivq54mwwcm6p43wr7rvk2cj";
+        url = "https://elpa.nongnu.org/nongnu-devel/clojure-mode-5.20.0snapshot0.20241211.152233.tar";
+        sha256 = "0m6bafwl3687ccl815q70bw4q8k3w12vkfl24g5x9rn6dn44ppxx";
       };
       packageRequires = [ ];
       meta = {
@@ -638,10 +638,10 @@
     elpaBuild {
       pname = "consult-flycheck";
       ename = "consult-flycheck";
-      version = "1.0.0.20241114.112007";
+      version = "1.0.0.20250101.91433";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20241114.112007.tar";
-        sha256 = "1jzli50sjr8pv2j9qg7glxdgm54sx2yw6xr7ka738gisa1r0iscl";
+        url = "https://elpa.nongnu.org/nongnu-devel/consult-flycheck-1.0.0.20250101.91433.tar";
+        sha256 = "05ms0zhswsdlvvrz71md4nsqisshar284xn7idw7z01ddd05rjmb";
       };
       packageRequires = [
         consult
@@ -774,10 +774,10 @@
     elpaBuild {
       pname = "d-mode";
       ename = "d-mode";
-      version = "202408131340.0.20241126.105644";
+      version = "202408131340.0.20241225.185152";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/d-mode-202408131340.0.20241126.105644.tar";
-        sha256 = "11hc3dyxyr1pcq25jvw9x3ys4v73rbqw9p19s4i59p9mdb0bnxpy";
+        url = "https://elpa.nongnu.org/nongnu-devel/d-mode-202408131340.0.20241225.185152.tar";
+        sha256 = "08wlsp1mzsn0xprslwmnhxzj58yy35vjy09l70dxz5pyxk3vg2vd";
       };
       packageRequires = [ ];
       meta = {
@@ -880,10 +880,10 @@
     elpaBuild {
       pname = "diff-ansi";
       ename = "diff-ansi";
-      version = "0.2.0.20240818.235912";
+      version = "0.2.0.20241208.51148";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20240818.235912.tar";
-        sha256 = "085h7xb75dkdmsnc572rmqgzw1pp4jmxcfrr3nnpbvirgjij8pma";
+        url = "https://elpa.nongnu.org/nongnu-devel/diff-ansi-0.2.0.20241208.51148.tar";
+        sha256 = "08fvdzs2qmd4mbcz52bhmng2wz2pxn9x06w5sg9fjq744005p7dd";
       };
       packageRequires = [ ];
       meta = {
@@ -902,10 +902,10 @@
     elpaBuild {
       pname = "dirvish";
       ename = "dirvish";
-      version = "2.0.53.0.20230519.150010";
+      version = "2.0.53.0.20250101.212150";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.0.53.0.20230519.150010.tar";
-        sha256 = "0n73giyvg244s0cxfrkc3j0jrq20bs1zili6liab0s3ks02kvqdg";
+        url = "https://elpa.nongnu.org/nongnu-devel/dirvish-2.0.53.0.20250101.212150.tar";
+        sha256 = "0q4lh8xz2922lsgjb58c116sndcvy2fc0clws6bp1418fsyjxa9l";
       };
       packageRequires = [ transient ];
       meta = {
@@ -923,10 +923,10 @@
     elpaBuild {
       pname = "doc-show-inline";
       ename = "doc-show-inline";
-      version = "0.1.0.20240616.234552";
+      version = "0.1.0.20241208.50508";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20240616.234552.tar";
-        sha256 = "0p39glahjqm2fv8xcnwyhcnzsf53g15013jbnj1lh7610bdgfk6g";
+        url = "https://elpa.nongnu.org/nongnu-devel/doc-show-inline-0.1.0.20241208.50508.tar";
+        sha256 = "1k98b8d0bxiz7i4n4r46zxy14jszskfmvxavwriig59p2g5gx1yb";
       };
       packageRequires = [ ];
       meta = {
@@ -965,10 +965,10 @@
     elpaBuild {
       pname = "dracula-theme";
       ename = "dracula-theme";
-      version = "1.8.2.0.20241102.130126";
+      version = "1.8.2.0.20241217.214522";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.2.0.20241102.130126.tar";
-        sha256 = "01f3g7cy9snm4f2b2rx7zd82kwxzlf9g0wapwa83k3i60p23rf5s";
+        url = "https://elpa.nongnu.org/nongnu-devel/dracula-theme-1.8.2.0.20241217.214522.tar";
+        sha256 = "0dizqwzgygkim66lxkxpwcidhhi7ppwazi57nqkahyd3n03ka2f9";
       };
       packageRequires = [ ];
       meta = {
@@ -1008,10 +1008,10 @@
     elpaBuild {
       pname = "dslide";
       ename = "dslide";
-      version = "0.5.5.0.20241128.111432";
+      version = "0.6.2.0.20250102.81901";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/dslide-0.5.5.0.20241128.111432.tar";
-        sha256 = "1d2rsqzn8w6w3qvsfsgpmjwn53nsj30jivli02d7n24q30pxzpv6";
+        url = "https://elpa.nongnu.org/nongnu-devel/dslide-0.6.2.0.20250102.81901.tar";
+        sha256 = "18ggnfj9adlrhni2mb6f1ygc0mf7q8xm99729cbvp2k6l7yidxxc";
       };
       packageRequires = [ ];
       meta = {
@@ -1080,6 +1080,48 @@
       packageRequires = [ ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/editorconfig.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  eglot-inactive-regions = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "eglot-inactive-regions";
+      ename = "eglot-inactive-regions";
+      version = "0.6.3.0.20241217.45248";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/eglot-inactive-regions-0.6.3.0.20241217.45248.tar";
+        sha256 = "1kf84wzfdysskmxjv45c1vdp5vpg7issk92gvcvrw59afsv25cza";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/eglot-inactive-regions.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  eldoc-diffstat = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "eldoc-diffstat";
+      ename = "eldoc-diffstat";
+      version = "1.0.0.20241214.213403";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu-devel/eldoc-diffstat-1.0.0.20241214.213403.tar";
+        sha256 = "10rjz33lhsp61pjdj64k0y9wh9nlfnz1w89xck0gfp2p42kya87n";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu-devel/eldoc-diffstat.html";
         license = lib.licenses.free;
       };
     }
@@ -1180,10 +1222,10 @@
     elpaBuild {
       pname = "evil";
       ename = "evil";
-      version = "1.15.0.0.20241006.175409";
+      version = "1.15.0.0.20241229.162330";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20241006.175409.tar";
-        sha256 = "0w752hhnpkfa5wqm1rk6nzq6n9y8c8mjzjhzri91l06jngpl6ckd";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-1.15.0.0.20241229.162330.tar";
+        sha256 = "03l1cg2d4zdh59cf93cvc3i5daq2pw7j8hw7kbdxjy5cl7136d32";
       };
       packageRequires = [
         cl-lib
@@ -1255,10 +1297,10 @@
     elpaBuild {
       pname = "evil-escape";
       ename = "evil-escape";
-      version = "3.16.0.20231122.211452";
+      version = "3.16.0.20241212.131839";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-escape-3.16.0.20231122.211452.tar";
-        sha256 = "1yv77vxvyl41795h7ixl6fhm43n7q6xqkqp1yaqgv5g9iymdj1s0";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-escape-3.16.0.20241212.131839.tar";
+        sha256 = "18j653kymcvxdr0n0vibl091p2zwdzgqymw3g778visshxgk11mb";
       };
       packageRequires = [
         cl-lib
@@ -1407,10 +1449,10 @@
     elpaBuild {
       pname = "evil-matchit";
       ename = "evil-matchit";
-      version = "3.0.4.0.20241111.120111";
+      version = "4.0.1.0.20241205.72440";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-matchit-3.0.4.0.20241111.120111.tar";
-        sha256 = "1jv7rs102i00kwdkj1n3l0j9as0kbrylhkkn2rrgwv9b97lmlirs";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-matchit-4.0.1.0.20241205.72440.tar";
+        sha256 = "0hi6p25pbn2xh7jzglmpvs5nvrlzi7b4gjm37q1vbyiji9k5xfci";
       };
       packageRequires = [ ];
       meta = {
@@ -1450,10 +1492,10 @@
     elpaBuild {
       pname = "evil-numbers";
       ename = "evil-numbers";
-      version = "0.7.0.20241204.12906";
+      version = "0.7.0.20241208.52322";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20241204.12906.tar";
-        sha256 = "1r4ic5db8vl3mslp48w8lqx904raxi8lzp512jcjv21vs36gjl97";
+        url = "https://elpa.nongnu.org/nongnu-devel/evil-numbers-0.7.0.20241208.52322.tar";
+        sha256 = "1a5lw59lfavfqnaxay4c4j7246q4i3w53ra9gc44qr94432nd1q9";
       };
       packageRequires = [ evil ];
       meta = {
@@ -1610,10 +1652,10 @@
     elpaBuild {
       pname = "flycheck";
       ename = "flycheck";
-      version = "35.0snapshot0.20241130.150233";
+      version = "35.0snapshot0.20250104.70510";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0snapshot0.20241130.150233.tar";
-        sha256 = "08viqbba50alfj3783ykymjqwpi08si6bi411sm29gagga1cjxr6";
+        url = "https://elpa.nongnu.org/nongnu-devel/flycheck-35.0snapshot0.20250104.70510.tar";
+        sha256 = "1p186zsjjhaz99776zgys9zxx9fk01mllv9g6bsmzd6srmcf9bc5";
       };
       packageRequires = [ ];
       meta = {
@@ -1856,10 +1898,10 @@
     elpaBuild {
       pname = "geiser-chicken";
       ename = "geiser-chicken";
-      version = "0.17.0.20241204.11932";
+      version = "0.17.0.20241204.144210";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chicken-0.17.0.20241204.11932.tar";
-        sha256 = "1l95d72wl74mlfa50m9m999skj993vqdmm13qm42n0lp0y9ndvyf";
+        url = "https://elpa.nongnu.org/nongnu-devel/geiser-chicken-0.17.0.20241204.144210.tar";
+        sha256 = "0lss1nz7kdbpmky96r10gvsbnjxxnqlymz0d0579ggvf9hi1cj66";
       };
       packageRequires = [ geiser ];
       meta = {
@@ -2090,10 +2132,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.4.8.0.20241115.104152";
+      version = "0.4.10.0.20241211.105407";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.4.8.0.20241115.104152.tar";
-        sha256 = "143pmwp5g2wzmmhmbwc1q6hhf86j1cywi8x2hzvlq0p5mhkkilr1";
+        url = "https://elpa.nongnu.org/nongnu-devel/gnosis-0.4.10.0.20241211.105407.tar";
+        sha256 = "0wvqk279qfdvwk7k27lzw9063x7w6jypprlh1rgj6xlhnn3kv9y8";
       };
       packageRequires = [
         compat
@@ -2264,10 +2306,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.6.0.20241202.163036";
+      version = "0.9.7.0.20250103.103741";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.6.0.20241202.163036.tar";
-        sha256 = "0zlfrnp01hb6syrkgkwfi1hjxm9l4j9sqrwn7a8nmk5wlw4bi6xm";
+        url = "https://elpa.nongnu.org/nongnu-devel/gptel-0.9.7.0.20250103.103741.tar";
+        sha256 = "00d22c6hgm8cr2wfqk4s2xcqblljzcv4iyrvbcjbgipr2nynb6iw";
       };
       packageRequires = [
         compat
@@ -2288,10 +2330,10 @@
     elpaBuild {
       pname = "graphql-mode";
       ename = "graphql-mode";
-      version = "1.0.0.0.20241020.75405";
+      version = "1.0.0.0.20241206.72535";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20241020.75405.tar";
-        sha256 = "0bds1zv0syg1jfdak2hk3kank4c532r6ki095wamxy06rwdbm2il";
+        url = "https://elpa.nongnu.org/nongnu-devel/graphql-mode-1.0.0.0.20241206.72535.tar";
+        sha256 = "06pn5rk0mkswrx2sd589hbqir1wkczjwy453ssk0az4z49g85ks9";
       };
       packageRequires = [ ];
       meta = {
@@ -2438,10 +2480,10 @@
     elpaBuild {
       pname = "haskell-ts-mode";
       ename = "haskell-ts-mode";
-      version = "1.0.20241108.150811";
+      version = "1.0.20250101.102728";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.0.20241108.150811.tar";
-        sha256 = "1ycbcwhj9j77jgpb3ag7hy8474qdj4rzzg7z5z79f0fqvlnv94m7";
+        url = "https://elpa.nongnu.org/nongnu-devel/haskell-ts-mode-1.0.20250101.102728.tar";
+        sha256 = "15m1qdcb899wmdx7ih53c5ndlvv3q5fny885l287sf17f6p563k7";
       };
       packageRequires = [ ];
       meta = {
@@ -2461,10 +2503,10 @@
     elpaBuild {
       pname = "helm";
       ename = "helm";
-      version = "4.0.0.20241204.51511";
+      version = "4.0.0.20250104.104508";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.0.20241204.51511.tar";
-        sha256 = "1dzc1jg6p9r589mzwdzhlhj58239ssy85mz27kwr7yyg36cz3m3l";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-4.0.0.20250104.104508.tar";
+        sha256 = "0xcsfbzkwip67m5lpjwi8a08hfm8nc5xwgvz18d7685gsmizc6hs";
       };
       packageRequires = [
         helm-core
@@ -2486,10 +2528,10 @@
     elpaBuild {
       pname = "helm-core";
       ename = "helm-core";
-      version = "4.0.0.20241204.51511";
+      version = "4.0.0.20250104.104508";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.0.20241204.51511.tar";
-        sha256 = "1xvx1x6p7r1ak40n3740q9iyah2d1npqg7aw1zybshcrai5bm9jm";
+        url = "https://elpa.nongnu.org/nongnu-devel/helm-core-4.0.0.20250104.104508.tar";
+        sha256 = "02silp1myffcm3nwrakfj8zn3c5x8msmmyrqx1id2r6wwki9f8pz";
       };
       packageRequires = [ async ];
       meta = {
@@ -2549,10 +2591,10 @@
     elpaBuild {
       pname = "hl-block-mode";
       ename = "hl-block-mode";
-      version = "0.2.0.20240422.12652";
+      version = "0.2.0.20241208.45934";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20240422.12652.tar";
-        sha256 = "1j3fp1p066j9b67hna6mh7pb96kld9nc0mkv8jl0qdwi95aah81q";
+        url = "https://elpa.nongnu.org/nongnu-devel/hl-block-mode-0.2.0.20241208.45934.tar";
+        sha256 = "0s9x68h46qf49xg7fd7gbrr78l7zc53hnprq6hxhzlw5fara7xsn";
       };
       packageRequires = [ ];
       meta = {
@@ -2619,10 +2661,10 @@
     elpaBuild {
       pname = "hyperdrive";
       ename = "hyperdrive";
-      version = "0.5pre0.20241106.231359";
+      version = "0.6pre0.20241222.235250";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.5pre0.20241106.231359.tar";
-        sha256 = "11b3dvwzrsgg2nj3kasgrz5bwhd2i3ig4v9blzlzhyybw6wy0i1f";
+        url = "https://elpa.nongnu.org/nongnu-devel/hyperdrive-0.6pre0.20241222.235250.tar";
+        sha256 = "0a9z9kbnlzbv21w62zyw3mpbvjfnl5vhjmlpq65w7cc4d1qd2jp5";
       };
       packageRequires = [
         compat
@@ -2764,10 +2806,10 @@
     elpaBuild {
       pname = "inf-ruby";
       ename = "inf-ruby";
-      version = "2.8.1.0.20240925.4944";
+      version = "2.8.1.0.20241220.25141";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/inf-ruby-2.8.1.0.20240925.4944.tar";
-        sha256 = "1wl5nzrbafvmvvvq477lsvc14pvlmq8x9j1cqbd0cj11lvn4k1qb";
+        url = "https://elpa.nongnu.org/nongnu-devel/inf-ruby-2.8.1.0.20241220.25141.tar";
+        sha256 = "0z3vbdb1df0vwjm2lk6bk11c0afg8w6p5n2x8q4wgmwqyp3h3gb2";
       };
       packageRequires = [ ];
       meta = {
@@ -2895,10 +2937,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.0.1.0.20241120.85729";
+      version = "1.0.2.0.20241213.162017";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.0.1.0.20241120.85729.tar";
-        sha256 = "0a6xi5zcq1nfbsjqk84x6avlrzbjdh6fbq1h6jkqcczy7mm5rg5h";
+        url = "https://elpa.nongnu.org/nongnu-devel/julia-mode-1.0.2.0.20241213.162017.tar";
+        sha256 = "09l2awhz4362g03qnpsy4813afjabm2dqh8g3ma354k7ql8rr95h";
       };
       packageRequires = [ ];
       meta = {
@@ -3003,10 +3045,10 @@
     elpaBuild {
       pname = "macrostep";
       ename = "macrostep";
-      version = "0.9.4.0.20241025.145629";
+      version = "0.9.4.0.20241228.221506";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/macrostep-0.9.4.0.20241025.145629.tar";
-        sha256 = "1xbi45ymsqc2vbhl1s3wphirgqz5ky9880fzr949bhd0ff18bw6x";
+        url = "https://elpa.nongnu.org/nongnu-devel/macrostep-0.9.4.0.20241228.221506.tar";
+        sha256 = "0yza9ms8i3nq4fh42s475r0m77b2phq8sx41p6irywi0clc33m0y";
       };
       packageRequires = [
         cl-lib
@@ -3033,10 +3075,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.1.2.0.20241102.130025";
+      version = "4.2.0.0.20250101.180326";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.1.2.0.20241102.130025.tar";
-        sha256 = "1y3fr2qj8a1h7hkrh47zshbmrcfxhw6i8wiqcrrba7ypnas53gcg";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-4.2.0.0.20250101.180326.tar";
+        sha256 = "1w6yfwsy4i1wj9wm7yk7zlxkqsws1g6ql22rw8cc93hhp9rf3a57";
       };
       packageRequires = [
         compat
@@ -3064,10 +3106,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.1.2.0.20241102.130025";
+      version = "4.2.0.0.20250101.180326";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.1.2.0.20241102.130025.tar";
-        sha256 = "1cnpklpsvbsi1wsmfbp5m8379cbr6jdifxm07zj4hnvi8lyr49vn";
+        url = "https://elpa.nongnu.org/nongnu-devel/magit-section-4.2.0.0.20250101.180326.tar";
+        sha256 = "0wyh9fvgnbn35nak6f3v8651j33sz929xwvkqgyrbicxwdwxinbr";
       };
       packageRequires = [
         compat
@@ -3089,10 +3131,10 @@
     elpaBuild {
       pname = "markdown-mode";
       ename = "markdown-mode";
-      version = "2.7alpha0.20241203.113852";
+      version = "2.7alpha0.20241210.10425";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.7alpha0.20241203.113852.tar";
-        sha256 = "14kkg7wj6qkq84jsa5cdwc7i7lqvilx21nb9lyddqxqxm8h7sld8";
+        url = "https://elpa.nongnu.org/nongnu-devel/markdown-mode-2.7alpha0.20241210.10425.tar";
+        sha256 = "1rlja17nqr9ly5mab5824dc97w7sgr45adrfhn5li79g89hazd3n";
       };
       packageRequires = [ ];
       meta = {
@@ -3113,10 +3155,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "1.1.7.0.20241202.183936";
+      version = "1.1.8.0.20241223.104057";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-1.1.7.0.20241202.183936.tar";
-        sha256 = "08683fah6xkfzgxi6si4qgl4mxccczj4dcaivif1qlhfrc3bh66f";
+        url = "https://elpa.nongnu.org/nongnu-devel/mastodon-1.1.8.0.20241223.104057.tar";
+        sha256 = "13iyzv0gyad07215zvvs9q52ikqf97qn851qgjqqhq9k4p07a22q";
       };
       packageRequires = [
         persist
@@ -3189,10 +3231,10 @@
     elpaBuild {
       pname = "meow";
       ename = "meow";
-      version = "1.5.0.0.20241203.160407";
+      version = "1.5.0.0.20241224.211501";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20241203.160407.tar";
-        sha256 = "0a3zdx91j5q0mllm71951392hgnn5q9l960qs2lazs8plpv4pn9f";
+        url = "https://elpa.nongnu.org/nongnu-devel/meow-1.5.0.0.20241224.211501.tar";
+        sha256 = "1xrq21awlf12ki7rdsm6n37hg4m1jjfjz8n0m2193jml94wc4cf8";
       };
       packageRequires = [ ];
       meta = {
@@ -3448,10 +3490,10 @@
     elpaBuild {
       pname = "org-contrib";
       ename = "org-contrib";
-      version = "0.6.0.20241029.204012";
+      version = "0.6.0.20241207.74256";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.6.0.20241029.204012.tar";
-        sha256 = "12pfmv5ns5igdvc06glcc8nxqcj7lwjqc3s86720ys57y4py566w";
+        url = "https://elpa.nongnu.org/nongnu-devel/org-contrib-0.6.0.20241207.74256.tar";
+        sha256 = "0i9ii3ngimx1l8s4pq2zn73lnry1npsbrsxzn92gwayj0sm77bkp";
       };
       packageRequires = [ org ];
       meta = {
@@ -3881,10 +3923,10 @@
     elpaBuild {
       pname = "php-mode";
       ename = "php-mode";
-      version = "1.26.1.0.20241024.124149";
+      version = "1.26.1.0.20250103.15745";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20241024.124149.tar";
-        sha256 = "0h5lzvsssk0nf3g408a7jg25crglsjkhcfp1ckjnzpgiwf59i6w8";
+        url = "https://elpa.nongnu.org/nongnu-devel/php-mode-1.26.1.0.20250103.15745.tar";
+        sha256 = "0ls4wpcn6lk5qn7n7gamk9sx6fm35cdbrv96pzi6srf3q1r71wpr";
       };
       packageRequires = [ ];
       meta = {
@@ -3923,10 +3965,10 @@
     elpaBuild {
       pname = "popup";
       ename = "popup";
-      version = "0.5.9.0.20240721.5155";
+      version = "0.5.9.0.20250101.4328";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20240721.5155.tar";
-        sha256 = "11ay4yknbc6dy7c08dcaz4sy1ly98m0ghchif0m2mm72s2hgw7g7";
+        url = "https://elpa.nongnu.org/nongnu-devel/popup-0.5.9.0.20250101.4328.tar";
+        sha256 = "0qgkwd0kbkifkpfv0gznd4n81xhf62q9s0bd0831yp1mkxd9y03x";
       };
       packageRequires = [ ];
       meta = {
@@ -4008,10 +4050,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20241129.85359";
+      version = "1.0.20250103.151851";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20241129.85359.tar";
-        sha256 = "0j6hs2wpaknzprcm18y1ayqjcr2sl0z22fhw1yla5rv74lyqzglx";
+        url = "https://elpa.nongnu.org/nongnu-devel/racket-mode-1.0.20250103.151851.tar";
+        sha256 = "03m0ky98s647ajrjf85i9zvqwmwh4l33rdywbcc5vg516hgsnh0d";
       };
       packageRequires = [ ];
       meta = {
@@ -4071,10 +4113,10 @@
     elpaBuild {
       pname = "recomplete";
       ename = "recomplete";
-      version = "0.2.0.20240616.234552";
+      version = "0.2.0.20241208.45418";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20240616.234552.tar";
-        sha256 = "0gkd3g1p6i4l7s6gqjsdj20m3y8n75wlcfw6xii0ka7n8j8dmrz4";
+        url = "https://elpa.nongnu.org/nongnu-devel/recomplete-0.2.0.20241208.45418.tar";
+        sha256 = "1pflxqh7ng3khkmn4g760k8v1amd9x18i452cxd5iwfq1cb9l9f4";
       };
       packageRequires = [ ];
       meta = {
@@ -4092,10 +4134,10 @@
     elpaBuild {
       pname = "reformatter";
       ename = "reformatter";
-      version = "0.8.0.20241106.203153";
+      version = "0.8.0.20241204.105138";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20241106.203153.tar";
-        sha256 = "1gni5f8x8d6m063k9bgaqah80w2hnb12d7qwdw1ai0xg7jb92vp7";
+        url = "https://elpa.nongnu.org/nongnu-devel/reformatter-0.8.0.20241204.105138.tar";
+        sha256 = "1j78naw4jikh7nby67gdbx9banchmf1q5fysal1328gxnyqknmzi";
       };
       packageRequires = [ ];
       meta = {
@@ -4224,10 +4266,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "94.0.0.20240926.92457";
+      version = "95.0.0.20250102.95738";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-94.0.0.20240926.92457.tar";
-        sha256 = "09hgnzzfi6wdy3p0nfl6a00npxpsdy30dyc89m1h087wlhkjjyci";
+        url = "https://elpa.nongnu.org/nongnu-devel/scad-mode-95.0.0.20250102.95738.tar";
+        sha256 = "0pzqzz1a0shf0dm70c1d730m3dndal2dvm4dw65vxasj8vc1v8nx";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4245,10 +4287,10 @@
     elpaBuild {
       pname = "scala-mode";
       ename = "scala-mode";
-      version = "1.1.0.0.20240729.42046";
+      version = "1.1.1.0.20241231.83915";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/scala-mode-1.1.0.0.20240729.42046.tar";
-        sha256 = "0981n96zx633iypwyz2f6af7r1lzx0lick7zv0azqglrwgnly35r";
+        url = "https://elpa.nongnu.org/nongnu-devel/scala-mode-1.1.1.0.20241231.83915.tar";
+        sha256 = "079w6awnk36h33fz4gsqcnc3llsfmv1pmwzqyy8vv27x65i9fxjs";
       };
       packageRequires = [ ];
       meta = {
@@ -4351,10 +4393,10 @@
     elpaBuild {
       pname = "slime";
       ename = "slime";
-      version = "2.31.0.20241201.210325";
+      version = "2.31snapshot0.20250101.45918";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31.0.20241201.210325.tar";
-        sha256 = "05skikmrfcwbahph8z50kf1zh5vps7459zw7l1bipgyvhfvpq9fn";
+        url = "https://elpa.nongnu.org/nongnu-devel/slime-2.31snapshot0.20250101.45918.tar";
+        sha256 = "153phs96ibjap5hp0ffs9c9isdhc05vgdqr4hlhjyk62b71n71k4";
       };
       packageRequires = [ macrostep ];
       meta = {
@@ -4386,6 +4428,7 @@
   ) { };
   smartparens = callPackage (
     {
+      dash,
       elpaBuild,
       fetchurl,
       lib,
@@ -4393,12 +4436,12 @@
     elpaBuild {
       pname = "smartparens";
       ename = "smartparens";
-      version = "1.11.0.0.20240713.100215";
+      version = "1.11.0.0.20241220.125445";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20240713.100215.tar";
-        sha256 = "0479n363cz4izdxdl2420fcmngbfjp7a5xv9xlxyab62aph63f0w";
+        url = "https://elpa.nongnu.org/nongnu-devel/smartparens-1.11.0.0.20241220.125445.tar";
+        sha256 = "0ww5m3cj78abbpfrshbszgs21mnd6pfcpwrbnqz81a4qk37q3nny";
       };
-      packageRequires = [ ];
+      packageRequires = [ dash ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu-devel/smartparens.html";
         license = lib.licenses.free;
@@ -4540,10 +4583,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.2.21.0.20241117.83905";
+      version = "1.2.23.0.20250101.141954";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.2.21.0.20241117.83905.tar";
-        sha256 = "0v95g129yp9s3kknbw1fp4iqn0f0g65bhvw4433v3dbinw9l3k74";
+        url = "https://elpa.nongnu.org/nongnu-devel/subed-1.2.23.0.20250101.141954.tar";
+        sha256 = "1srh30xxx7s4y79rc6fkq3aggywvnkd1wrhbmidhqd3lkfw3f1ms";
       };
       packageRequires = [ ];
       meta = {
@@ -4804,10 +4847,10 @@
     elpaBuild {
       pname = "tp";
       ename = "tp";
-      version = "0.6.0.20241031.72940";
+      version = "0.6.0.20250103.142809";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/tp-0.6.0.20241031.72940.tar";
-        sha256 = "1m8qhar75cglg8qjh3sbgwkzkhfp3640nm73nddxrshnajn978bf";
+        url = "https://elpa.nongnu.org/nongnu-devel/tp-0.6.0.20250103.142809.tar";
+        sha256 = "19mrjhi7qxwxp1shqqvkpmj49kari9g74wym3v2k80586kj2j0cm";
       };
       packageRequires = [ transient ];
       meta = {
@@ -4931,10 +4974,10 @@
     elpaBuild {
       pname = "undo-fu";
       ename = "undo-fu";
-      version = "0.5.0.20240707.141050";
+      version = "0.5.0.20241206.21950";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20240707.141050.tar";
-        sha256 = "0glgy1manfv9rykkxhafc969mhazd119zgrkm5fg9shcyb7q629a";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-0.5.0.20241206.21950.tar";
+        sha256 = "0kslql79g5y0sszjm6xxyxjzrnskm70dgglwwl2g4a1rjwavcp3v";
       };
       packageRequires = [ ];
       meta = {
@@ -4952,10 +4995,10 @@
     elpaBuild {
       pname = "undo-fu-session";
       ename = "undo-fu-session";
-      version = "0.7.0.20240713.142701";
+      version = "0.7.0.20241212.4030";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20240713.142701.tar";
-        sha256 = "1c70cvf9f1x96l8gxfl4qpljwsqsqjcn745srsf9w9mcz520fyaa";
+        url = "https://elpa.nongnu.org/nongnu-devel/undo-fu-session-0.7.0.20241212.4030.tar";
+        sha256 = "1nggzbk1xi0w5f5y2xkp2jk4imfbqfaldngavslz1rhskiqwdqqa";
       };
       packageRequires = [ ];
       meta = {
@@ -5062,10 +5105,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.20.0.20240804.82110";
+      version = "17.3.21.0.20241227.53016";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.20.0.20240804.82110.tar";
-        sha256 = "17r0jhcgxnc1k42yxaw1i7wwyb0sp311a1gz8bdjax0zn05ki4xc";
+        url = "https://elpa.nongnu.org/nongnu-devel/web-mode-17.3.21.0.20241227.53016.tar";
+        sha256 = "0syhyqryfh2rvf2688rqfs3j0p0fh794vw85qwdh3kxi57w8ra8h";
       };
       packageRequires = [ ];
       meta = {
@@ -5130,10 +5173,10 @@
     elpaBuild {
       pname = "wgrep";
       ename = "wgrep";
-      version = "3.0.0.0.20231216.120954";
+      version = "3.0.0.0.20241206.130617";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/wgrep-3.0.0.0.20231216.120954.tar";
-        sha256 = "1qadyl29a70d9m5z32s0r18rjxg0jdmbpjr47zgvppl807mfni85";
+        url = "https://elpa.nongnu.org/nongnu-devel/wgrep-3.0.0.0.20241206.130617.tar";
+        sha256 = "1ihwqz865wcdb83aw6nmzhnkrf7rnxqkcncmz7rvzddsrg19hahr";
       };
       packageRequires = [ ];
       meta = {
@@ -5283,10 +5326,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.8.20241118173945.0.20241118.174137";
+      version = "26.9.20241225173150.0.20241225.173444";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.8.20241118173945.0.20241118.174137.tar";
-        sha256 = "196hv8hjzp87b8y9k65w2zag46bx2jhmah1w9mdjxwkfbq6bjcmq";
+        url = "https://elpa.nongnu.org/nongnu-devel/xah-fly-keys-26.9.20241225173150.0.20241225.173444.tar";
+        sha256 = "08c168kcb0ds9g8hfqwd4qnymmg7z32k3g51ap9rqw6048cyl5fw";
       };
       packageRequires = [ ];
       meta = {
@@ -5369,10 +5412,10 @@
     elpaBuild {
       pname = "yasnippet-snippets";
       ename = "yasnippet-snippets";
-      version = "1.0.0.20241014.94920";
+      version = "1.0.0.20241207.222105";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20241014.94920.tar";
-        sha256 = "065wcvb295dhyi6jvb80vagzb8idqycchqgy32pj0fr6vcxx7y88";
+        url = "https://elpa.nongnu.org/nongnu-devel/yasnippet-snippets-1.0.0.20241207.222105.tar";
+        sha256 = "1nd9cnnwqrxizfzqdx3a4l9wj5sdr6gg42fss9dngbd22spa3kkb";
       };
       packageRequires = [ yasnippet ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/nongnu-generated.nix
@@ -220,10 +220,10 @@
     elpaBuild {
       pname = "auto-dim-other-buffers";
       ename = "auto-dim-other-buffers";
-      version = "2.1.1";
+      version = "2.2.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/auto-dim-other-buffers-2.1.1.tar";
-        sha256 = "0rgf0q66kdw9ind5bi01ydk84rclcd3kmlfzm9rfb429xnhqfzw8";
+        url = "https://elpa.nongnu.org/nongnu/auto-dim-other-buffers-2.2.1.tar";
+        sha256 = "00x0niv1zd47b2xl19k3fi0xxskdndiabns107cxzwb7pnkp4f0m";
       };
       packageRequires = [ ];
       meta = {
@@ -284,10 +284,10 @@
     elpaBuild {
       pname = "bash-completion";
       ename = "bash-completion";
-      version = "3.1.1";
+      version = "3.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/bash-completion-3.1.1.tar";
-        sha256 = "1yc1a5cvmnp8dranrglpd7qjg35r6x4ndniinbmzinqr7dmydh62";
+        url = "https://elpa.nongnu.org/nongnu/bash-completion-3.2.tar";
+        sha256 = "19xpv87nb1gskfsfqj8hmhbzlhxk0m6dflizsnrq94bh7rbw3s12";
       };
       packageRequires = [ ];
       meta = {
@@ -1031,10 +1031,10 @@
     elpaBuild {
       pname = "dslide";
       ename = "dslide";
-      version = "0.5.5";
+      version = "0.6.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/dslide-0.5.5.tar";
-        sha256 = "1hnmnl6ildr2cyc8hx1maa3vnz621d41yhsx8naxq3mssz4rkajp";
+        url = "https://elpa.nongnu.org/nongnu/dslide-0.6.2.tar";
+        sha256 = "02lny7c7v6345nlprmpi39pyk7m9lpr85g8xkd70ivkpc122qdy2";
       };
       packageRequires = [ ];
       meta = {
@@ -1104,6 +1104,48 @@
       packageRequires = [ nadvice ];
       meta = {
         homepage = "https://elpa.nongnu.org/nongnu/editorconfig.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  eglot-inactive-regions = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "eglot-inactive-regions";
+      ename = "eglot-inactive-regions";
+      version = "0.6.3";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/eglot-inactive-regions-0.6.3.tar";
+        sha256 = "03958dgr48zqak06qjqdz6qgfxn5rs60425qcvb7wdv2jb4400hc";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/eglot-inactive-regions.html";
+        license = lib.licenses.free;
+      };
+    }
+  ) { };
+  eldoc-diffstat = callPackage (
+    {
+      elpaBuild,
+      fetchurl,
+      lib,
+    }:
+    elpaBuild {
+      pname = "eldoc-diffstat";
+      ename = "eldoc-diffstat";
+      version = "1.0";
+      src = fetchurl {
+        url = "https://elpa.nongnu.org/nongnu/eldoc-diffstat-1.0.tar";
+        sha256 = "0cxmhi1whzh4z62vv1pyvl2v6wr0jbq560m6zib8zicvdfxqlpgk";
+      };
+      packageRequires = [ ];
+      meta = {
+        homepage = "https://elpa.nongnu.org/nongnu/eldoc-diffstat.html";
         license = lib.licenses.free;
       };
     }
@@ -1425,10 +1467,10 @@
     elpaBuild {
       pname = "evil-matchit";
       ename = "evil-matchit";
-      version = "3.0.4";
+      version = "4.0.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/evil-matchit-3.0.4.tar";
-        sha256 = "1ib2xlz7ciaszw2j5184mf6560jmap93vh515sk8dmkkahdwsjgz";
+        url = "https://elpa.nongnu.org/nongnu/evil-matchit-4.0.1.tar";
+        sha256 = "08vnf56zmqicfjwf7ihlmg9iil3bivhwpafq8vwlvp5nkmirhivv";
       };
       packageRequires = [ ];
       meta = {
@@ -2107,10 +2149,10 @@
     elpaBuild {
       pname = "gnosis";
       ename = "gnosis";
-      version = "0.4.8";
+      version = "0.4.10";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gnosis-0.4.8.tar";
-        sha256 = "1sf6213qj6i306rqbp1a5wj7haw5vkmc1684fdfqzyqa1gw2ni5v";
+        url = "https://elpa.nongnu.org/nongnu/gnosis-0.4.10.tar";
+        sha256 = "16z0f93x8x4ldyld2aqpprmk6xqz4qnd5fbrclcvj8gcg6qj4iz8";
       };
       packageRequires = [
         compat
@@ -2281,10 +2323,10 @@
     elpaBuild {
       pname = "gptel";
       ename = "gptel";
-      version = "0.9.6";
+      version = "0.9.7";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.6.tar";
-        sha256 = "0n7d8plabgmpyl224079cqrwlgqq7wwysba0wd0ry75h6z388rcb";
+        url = "https://elpa.nongnu.org/nongnu/gptel-0.9.7.tar";
+        sha256 = "0sh8q80q620d6yr4437ddrjrzygd15iwkc9jvwh3pw9sncv2laqn";
       };
       packageRequires = [
         compat
@@ -2635,10 +2677,10 @@
     elpaBuild {
       pname = "hyperdrive";
       ename = "hyperdrive";
-      version = "0.4.2";
+      version = "0.5.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/hyperdrive-0.4.2.tar";
-        sha256 = "19cgx0x54xj2z98m8mr1xmz0bbja0nilh8n47mkbnzmcqidv75gq";
+        url = "https://elpa.nongnu.org/nongnu/hyperdrive-0.5.2.tar";
+        sha256 = "1gn6kdxvds27bjfsamzihqg8bddwsyfmc2g36p50km2qfa8fgpvz";
       };
       packageRequires = [
         compat
@@ -2911,10 +2953,10 @@
     elpaBuild {
       pname = "julia-mode";
       ename = "julia-mode";
-      version = "1.0.1";
+      version = "1.0.2";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/julia-mode-1.0.1.tar";
-        sha256 = "0203h99yia5k37ansy2wshkiyn105jaahmkm0ncf54far8dw6mwx";
+        url = "https://elpa.nongnu.org/nongnu/julia-mode-1.0.2.tar";
+        sha256 = "1wwnyanxbpzy4n8n3ixafdbx7badkl1krcnk0yf5923f2ahiqhlr";
       };
       packageRequires = [ ];
       meta = {
@@ -3049,10 +3091,10 @@
     elpaBuild {
       pname = "magit";
       ename = "magit";
-      version = "4.1.2";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-4.1.2.tar";
-        sha256 = "1jyivrk78fnp7kcrac9sm2ldbxg9c96qhnlz06wv1m7hbvd3fgfx";
+        url = "https://elpa.nongnu.org/nongnu/magit-4.2.0.tar";
+        sha256 = "04nf4ff7a11z65mcw6qnkxwk9srpi248f1k0li947i4264gl3prd";
       };
       packageRequires = [
         compat
@@ -3080,10 +3122,10 @@
     elpaBuild {
       pname = "magit-section";
       ename = "magit-section";
-      version = "4.1.2";
+      version = "4.2.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/magit-section-4.1.2.tar";
-        sha256 = "0g24aj030fh55y44f3c33708fbm02jwzggh75zvg63bka3g6j242";
+        url = "https://elpa.nongnu.org/nongnu/magit-section-4.2.0.tar";
+        sha256 = "05wlc327x45vfsphwz9bf1hl8w46ychqkp6j7wsngjzwzsifxmb4";
       };
       packageRequires = [
         compat
@@ -3129,10 +3171,10 @@
     elpaBuild {
       pname = "mastodon";
       ename = "mastodon";
-      version = "1.1.7";
+      version = "1.1.8";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/mastodon-1.1.7.tar";
-        sha256 = "0qnkbab6y0gpqq0kvil4gnbajflpv0mz3pzcimcvz79dnmb0vc9p";
+        url = "https://elpa.nongnu.org/nongnu/mastodon-1.1.8.tar";
+        sha256 = "06jy1n7ikz4xdpw4rkma596pqgkxcmh7qfkz93584rjfqav88anl";
       };
       packageRequires = [
         persist
@@ -4031,10 +4073,10 @@
     elpaBuild {
       pname = "racket-mode";
       ename = "racket-mode";
-      version = "1.0.20241129.85359";
+      version = "1.0.20250103.151851";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20241129.85359.tar";
-        sha256 = "0ish7ysdqypw849k9d3cw0bl69r5ksc3hrqdmyh8k2ipq2xbcn2w";
+        url = "https://elpa.nongnu.org/nongnu/racket-mode-1.0.20250103.151851.tar";
+        sha256 = "11m25729hm7m5srjiys1ws070yi2aa7ni5rn240w9290nj1brjnb";
       };
       packageRequires = [ ];
       meta = {
@@ -4243,10 +4285,10 @@
     elpaBuild {
       pname = "scad-mode";
       ename = "scad-mode";
-      version = "94.0";
+      version = "95.0";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/scad-mode-94.0.tar";
-        sha256 = "1cqai7qb9m17rf7llkn9vbxddgn0ixcf3dbnsjk1aflvj8mq9nr3";
+        url = "https://elpa.nongnu.org/nongnu/scad-mode-95.0.tar";
+        sha256 = "1wkpgrkx3cjmh72qg9yiq2x9sqswx6x6pbr8zzhldyjs6kmjl7km";
       };
       packageRequires = [ compat ];
       meta = {
@@ -4264,10 +4306,10 @@
     elpaBuild {
       pname = "scala-mode";
       ename = "scala-mode";
-      version = "1.1.0";
+      version = "1.1.1";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/scala-mode-1.1.0.tar";
-        sha256 = "1x3vw4fzy1z6gavnbsm4lnwzkp47zd8gasvxxvfk57qn09hpwixh";
+        url = "https://elpa.nongnu.org/nongnu/scala-mode-1.1.1.tar";
+        sha256 = "1dmaq00432smrwqx6ybw855vdwp7s8h358c135ji5d581mkhpai5";
       };
       packageRequires = [ ];
       meta = {
@@ -4559,10 +4601,10 @@
     elpaBuild {
       pname = "subed";
       ename = "subed";
-      version = "1.2.21";
+      version = "1.2.23";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/subed-1.2.21.tar";
-        sha256 = "1d0w96amchcpblcbkl16yiwsvj8qfpax66ysjg02550lhpb493x7";
+        url = "https://elpa.nongnu.org/nongnu/subed-1.2.23.tar";
+        sha256 = "0bvsv688mqhga8dffy3841wxs5pkw0vish15dgligll47cj98mzp";
       };
       packageRequires = [ ];
       meta = {
@@ -5056,10 +5098,10 @@
     elpaBuild {
       pname = "web-mode";
       ename = "web-mode";
-      version = "17.3.20";
+      version = "17.3.21";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/web-mode-17.3.20.tar";
-        sha256 = "1l4bmvc53ma2n3y143k86ip0w4am65zwxnl36lzqavs1hr55qvb2";
+        url = "https://elpa.nongnu.org/nongnu/web-mode-17.3.21.tar";
+        sha256 = "0yqaszrkllfgp0ph7rvjhz35wqzi4bas0qw70d49vaxq4z7bikzg";
       };
       packageRequires = [ ];
       meta = {
@@ -5277,10 +5319,10 @@
     elpaBuild {
       pname = "xah-fly-keys";
       ename = "xah-fly-keys";
-      version = "26.8.20241118173945";
+      version = "26.9.20241225173150";
       src = fetchurl {
-        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.8.20241118173945.tar";
-        sha256 = "1l6wwv1zmpsf64v23zzi2idjb14wnbpv5fcspiygiah62zag44vf";
+        url = "https://elpa.nongnu.org/nongnu/xah-fly-keys-26.9.20241225173150.tar";
+        sha256 = "0b2pjrfa130n4bam80p676k3xz417d6dfn8921xh6msf8b14cwpv";
       };
       packageRequires = [ ];
       meta = {

--- a/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
+++ b/pkgs/applications/editors/emacs/elisp-packages/recipes-archive-melpa.json
@@ -318,8 +318,8 @@
   "repo": "abstools/abs-mode",
   "unstable": {
    "version": [
-    20240723,
-    1401
+    20241217,
+    839
    ],
    "deps": [
     "erlang",
@@ -327,8 +327,8 @@
     "maude-mode",
     "yasnippet"
    ],
-   "commit": "c3ba6466507bd35ae1d5a2d12e1da9d5c44a02b3",
-   "sha256": "1xssk5srbs56jibkpl8wb8qn021kwdg36kafi7immnrpic4fx1xk"
+   "commit": "debb48caef334870b4439609a9e818c7fd01f420",
+   "sha256": "0kicw2462pzhhrds2lws8s00d4xwmr7yaaskpj9r5rdr41qyxkxl"
   },
   "stable": {
    "version": [
@@ -1104,8 +1104,8 @@
  },
  {
   "ename": "ac-rtags",
-  "commit": "3dea16daf0d72188c8b4043534f0833fe9b04e07",
-  "sha256": "1w9v32di9135mm598c4506gxf0xr5jyz8dyd9dhga5d60q7g9641",
+  "commit": "8f5d42452235ee9f1590fa8893c4ea3d40ac891b",
+  "sha256": "0p5acs9673sv9nf032b2bsjwxn9n6mfvhrp0ndzjp0gj5g1sc791",
   "fetcher": "github",
   "repo": "Andersbakken/rtags",
   "unstable": {
@@ -1832,11 +1832,11 @@
   "repo": "louabill/ado-mode",
   "unstable": {
    "version": [
-    20240925,
-    1925
+    20241216,
+    2039
    ],
-   "commit": "856d84f4ee29ada5c60eb1c25685822c6701c3d1",
-   "sha256": "1qfswdvcbyd7nlxc96w4ghhx9xsfk894wq1lwafax6b9lrr6w8v7"
+   "commit": "d688bf8889e6ff893558984d3cdb7d4335908a3f",
+   "sha256": "1wksibdw7lamgzvrpn35lix2xknbj1w9xx16pa61kp51sjp7yapc"
   },
   "stable": {
    "version": [
@@ -1927,14 +1927,14 @@
   "repo": "minad/affe",
   "unstable": {
    "version": [
-    20240926,
-    927
+    20250101,
+    910
    ],
    "deps": [
     "consult"
    ],
-   "commit": "569c661aa2333502759aee2d4c7c87a046b09d33",
-   "sha256": "11h7j0j9hw04ph6w4s9hcrxnszaca4krzllm6z0ynxrzbs7075g7"
+   "commit": "a9ed2407f2edf1421b2ca55946dfba190f39b034",
+   "sha256": "1xy8n73vkk19wh8yxzkg8mvs5z5h0979i002n43gnz5vsd58apx6"
   },
   "stable": {
    "version": [
@@ -2866,11 +2866,11 @@
   "repo": "jcs-elpa/alt-codes",
   "unstable": {
    "version": [
-    20240101,
-    927
+    20250101,
+    1002
    ],
-   "commit": "47072beb416aa9d7d702230b1aff87436c81bd22",
-   "sha256": "1w8df7f0k6flmhk632qg7w0cxj5jn5kshmh66nw8z1sv31fd57pj"
+   "commit": "24e3740f88c29efda5c4791720a55c4c548b1ed8",
+   "sha256": "15r3iz438r47bcl2jdx1n81rv061yz8wczhpq83qllfrr94clr90"
   },
   "stable": {
    "version": [
@@ -3283,11 +3283,11 @@
   "repo": "anki-editor/anki-editor",
   "unstable": {
    "version": [
-    20241122,
-    614
+    20250101,
+    945
    ],
-   "commit": "32706314adf6d02a407f2b0b411741d9c4722c05",
-   "sha256": "0kzqrz2dyx67jwhfqjv6j4fjvwn45jy7kxqfxd16iii4kqh24fr8"
+   "commit": "75367008d43d5c120341b3511c4a098b7abd5cbc",
+   "sha256": "0w7bahnxx8d2g157shmg3a05yi6yy5kx25f1nhxbc31mkk01b9r8"
   }
  },
  {
@@ -3969,11 +3969,11 @@
   "repo": "waymondo/apropospriate-theme",
   "unstable": {
    "version": [
-    20241119,
-    1
+    20241215,
+    1911
    ],
-   "commit": "56c8c1b575106e72bcab2227fd73cf34f7f3df79",
-   "sha256": "1ll2j35z2bgxfz4nkiminlfsmqb7gjcjapsmj001qb5sfzcy52p9"
+   "commit": "1e8daa3e21e44a2fbc138db6fb38a915b4288479",
+   "sha256": "1spmmhasky247bn5x6am2n8zpqay4llvqqpl3ibi4crrwncvxipl"
   },
   "stable": {
    "version": [
@@ -4427,20 +4427,20 @@
   "repo": "Sorixelle/astro-ts-mode",
   "unstable": {
    "version": [
-    20240724,
-    332
+    20241230,
+    256
    ],
-   "commit": "78e7e942011839bd4f4de0a1d8460f5879ba4ca5",
-   "sha256": "1aqgpgxi1abfq2frpzrw5qphc3ca85n1l5f1isyhdigqrps8hpw2"
+   "commit": "23b21a067709091681d1d9986e48aae2758b8614",
+   "sha256": "0a952mhgc46pklf3pffyddn8fvp1dfzc6kl9c4a62nrmg5s1ahh4"
   },
   "stable": {
    "version": [
-    2,
+    3,
     0,
-    1
+    0
    ],
-   "commit": "78e7e942011839bd4f4de0a1d8460f5879ba4ca5",
-   "sha256": "1aqgpgxi1abfq2frpzrw5qphc3ca85n1l5f1isyhdigqrps8hpw2"
+   "commit": "23b21a067709091681d1d9986e48aae2758b8614",
+   "sha256": "0a952mhgc46pklf3pffyddn8fvp1dfzc6kl9c4a62nrmg5s1ahh4"
   }
  },
  {
@@ -5022,15 +5022,15 @@
   "repo": "emacs-grammarly/auth-source-keytar",
   "unstable": {
    "version": [
-    20240101,
-    846
+    20250101,
+    849
    ],
    "deps": [
     "keytar",
     "s"
    ],
-   "commit": "6c3389a30a0d998857ff6861b4c05bce5a07be82",
-   "sha256": "0jj8fiqdh5cp2dsvirwq9ll50dmz8hx4m288n7rqmfhgv6hj0wnb"
+   "commit": "2dd34b937e99e367386679e9f42d6ea0411ffe12",
+   "sha256": "12kmh1pix5rzfzdd23a3j8s95l4fppg46nwvgihp639vllb0bkyn"
   },
   "stable": {
    "version": [
@@ -5135,20 +5135,20 @@
   "repo": "emacscollective/auto-compile",
   "unstable": {
    "version": [
-    20240805,
-    1931
+    20250101,
+    1410
    ],
-   "commit": "5cc4e97443727554357f6c57614f12ca87419627",
-   "sha256": "1pgc4m73yxz0hivf6cclqiwmjmg9hs3ncggk7wa10p8scd39ky2p"
+   "commit": "f25aaf8f1e3c38c481aabcf08b7b31280b78a9ae",
+   "sha256": "0cd42xigvw7fy2qy5kn0xlc97sp03w8ja6qjs2y22h29xva6fwsl"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    4
    ],
-   "commit": "5cc4e97443727554357f6c57614f12ca87419627",
-   "sha256": "1pgc4m73yxz0hivf6cclqiwmjmg9hs3ncggk7wa10p8scd39ky2p"
+   "commit": "f25aaf8f1e3c38c481aabcf08b7b31280b78a9ae",
+   "sha256": "0cd42xigvw7fy2qy5kn0xlc97sp03w8ja6qjs2y22h29xva6fwsl"
   }
  },
  {
@@ -5159,15 +5159,14 @@
   "repo": "auto-complete/auto-complete",
   "unstable": {
    "version": [
-    20240320,
-    1734
+    20250101,
+    843
    ],
    "deps": [
-    "cl-lib",
     "popup"
    ],
-   "commit": "0c2f5a7d28b70bfe30b87378d58d74798a62741d",
-   "sha256": "0i70m57isahd9f1pigrx1qdl56cakjnkzyb28449pz9i31gs9sg5"
+   "commit": "01bbfdf12b34ad04d0a44c98c1385df6ef0db449",
+   "sha256": "0vzq2wlyd0n4cs6krx0350992hpf4xn55wrwj6jsqjlxpphx3bjz"
   },
   "stable": {
    "version": [
@@ -5497,11 +5496,11 @@
   "repo": "mina86/auto-dim-other-buffers.el",
   "unstable": {
    "version": [
-    20220209,
-    2101
+    20241219,
+    1845
    ],
-   "commit": "33b5f88b799a17947c266b04ad59462c5aeb4ed7",
-   "sha256": "17h9hh8n6ib1crap8jdgjhaszvlqb4gri1z821apyn66lqvix7x8"
+   "commit": "ef869515118acf41ec37c30f9fe1bcd4243a5f65",
+   "sha256": "1ghzcrrhl2ymz8c9xkydvcx1q4kqdfiy28zj4kz42w9pssa9jsd2"
   }
  },
  {
@@ -5665,11 +5664,11 @@
   "repo": "emacs-vs/auto-rename-tag",
   "unstable": {
    "version": [
-    20240120,
-    1011
+    20250101,
+    906
    ],
-   "commit": "288c708e5c88113a5c8c5c44361f1d3c3e334a2e",
-   "sha256": "0ncq3m2za8i31kfvsjhaijbk0fp1ql2kzgdsg8mzlkihgcwx1cvy"
+   "commit": "b38895ff4821df3a0461959146e9f912d2acde4e",
+   "sha256": "1zyjrbvn9wijwxbxds5rjzdbcnkz2pa06invm9pjiwh01zxniwzh"
   },
   "stable": {
    "version": [
@@ -6738,11 +6737,11 @@
   "repo": "tinted-theming/base16-emacs",
   "unstable": {
    "version": [
-    20240908,
-    114
+    20241215,
+    126
    ],
-   "commit": "077726249216bef6d98d0542eb6289641a58e8d0",
-   "sha256": "0ydr1qmx6f4zpfhhpx180sqp1x4p2an3157m7z51nivs79hx0nsm"
+   "commit": "1d48474c3c07521276f4e7d73317a654997b4381",
+   "sha256": "07zzn261hvckmvsrwxajlkwdwrihr3wz06149hvsibplkfj0rpga"
   },
   "stable": {
    "version": [
@@ -6784,20 +6783,19 @@
   "repo": "szermatt/emacs-bash-completion",
   "unstable": {
    "version": [
-    20241118,
-    1847
+    20250101,
+    1458
    ],
-   "commit": "f3a85184ef9cc925bedcdbd62f66dd63a658f181",
-   "sha256": "0nk62c0qkw4f365sxv21xnv6hk32mkrzr0bv0m5sl9n1li98b9kk"
+   "commit": "a4c8fbc90221b01d5376ad068d3640350d9130a8",
+   "sha256": "1wxxi3ylmc1k4dbd7lbcr33496lnz7zwxf7l4zfhgci1nfywk3ii"
   },
   "stable": {
    "version": [
     3,
-    1,
-    1
+    2
    ],
-   "commit": "a021468eec8ff8cacb74a9ea595d3587186e29ea",
-   "sha256": "0cly0m6msn8xv9857nv4syw8fldqzvsa4kciq7av40y26a61hvrh"
+   "commit": "ed9c76252ac82d6352ba438f664b390fdd0b5d6c",
+   "sha256": "0664dihdfvrbxqxy00fw0skdg454njm673ip54qrgkh38vyv5432"
   }
  },
  {
@@ -7495,11 +7493,11 @@
   "repo": "jcs-elpa/better-scroll",
   "unstable": {
    "version": [
-    20240101,
-    927
+    20250101,
+    1002
    ],
-   "commit": "faded1bd681f3c48337e7165adcabde194c73b2b",
-   "sha256": "0074ffh07ywk6c50kj5w82cply3iclpqihs5fb0xnxavxxh79mhg"
+   "commit": "14c700f8b43771a47f16b3385adbbddb741a03eb",
+   "sha256": "198bg0x8vq55lw6wx7ayql6ypfvxy8ms1nn9vrbsbh3c57pja10y"
   },
   "stable": {
    "version": [
@@ -7606,14 +7604,14 @@
   "repo": "cpitclaudel/biblio.el",
   "unstable": {
    "version": [
-    20230202,
-    1721
+    20250102,
+    1345
    ],
    "deps": [
     "biblio-core"
    ],
-   "commit": "ee52f6cda82ea6fbc3b400e7b12132595cc0374c",
-   "sha256": "0iya5ybc54kia5vnb3bfr8yilykhbn2xvp157vya06cw4af2cw65"
+   "commit": "b700f0f2929829b2ca971511c5ebe61c67027e9f",
+   "sha256": "1wmibsdyfpxi80fyacs6qllcffwdgg1vf7i22a3nr60vciac56f9"
   },
   "stable": {
    "version": [
@@ -7999,26 +7997,26 @@
   "repo": "divyaranjan/binder",
   "unstable": {
    "version": [
-    20241023,
-    1154
+    20250101,
+    1950
    ],
    "deps": [
     "seq"
    ],
-   "commit": "928a68ff2cb186404f4247499a9d8a7a7a8c1f84",
-   "sha256": "0c1zfvfj0zgv6v6xvchyn63lsfni4vrg40ladf193ds9vz44mxjh"
+   "commit": "08a0c9d4179ed31dcbacea3ab0077cd22db341b5",
+   "sha256": "1fdgl31zc15cysv1yys95j0106i2fwfxb3qcwwh7f3mcz2snr2md"
   },
   "stable": {
    "version": [
     0,
-    4,
-    4
+    5,
+    0
    ],
    "deps": [
     "seq"
    ],
-   "commit": "f02d6951b778adfa210dd94f177d2608277c94f4",
-   "sha256": "065cqvdjdb5w60b7ga7q51920ib5vpz63zq9s68q0fjwb55q3k8z"
+   "commit": "08a0c9d4179ed31dcbacea3ab0077cd22db341b5",
+   "sha256": "1fdgl31zc15cysv1yys95j0106i2fwfxb3qcwwh7f3mcz2snr2md"
   }
  },
  {
@@ -8204,8 +8202,8 @@
  },
  {
   "ename": "bitlbee",
-  "commit": "7fabdb05de9b8ec18a3a566f99688b50443b6b44",
-  "sha256": "1lmbmlshr8b645qsb88rswmbbcbbawzl04xdjlygq4dnpkxc8w0f",
+  "commit": "66dfdd37cd5e58e25d259c5bf925418eb9cd26d0",
+  "sha256": "129asyzbxzbv120g06bhgrv2pbf5l7fcw5l3jq3zy5niw4z8pvb1",
   "fetcher": "github",
   "repo": "pjones/bitlbee-el",
   "unstable": {
@@ -8249,14 +8247,19 @@
   "repo": "grettke/blackboard-bold-mode",
   "unstable": {
    "version": [
-    20160813,
-    206
+    20241216,
+    2353
    ],
-   "deps": [
-    "cl-lib"
+   "commit": "f4959eb0adca6b3096e5fea1f7e549533e4d8d79",
+   "sha256": "00s0sckk9wgwp1y1vgwird64mlblzyjqvai8nvzfanqvhr5f9ygb"
+  },
+  "stable": {
+   "version": [
+    2,
+    0
    ],
-   "commit": "5299cb064ba71baa3e331b8560bf8dd38cbbc4ed",
-   "sha256": "00xbcgx4snz4sd7q7ys24rsnf5wdxjn402v8y5dgn4ayx88y1rrj"
+   "commit": "f4959eb0adca6b3096e5fea1f7e549533e4d8d79",
+   "sha256": "00s0sckk9wgwp1y1vgwird64mlblzyjqvai8nvzfanqvhr5f9ygb"
   }
  },
  {
@@ -8870,29 +8873,6 @@
   }
  },
  {
-  "ename": "bookmark-view",
-  "commit": "6dfa514cb33a27d778eb4f8cb5c3118050fc41ae",
-  "sha256": "1i9dc9s45l7idsw6zwk2m31p583sfilrwdvpmnhh68yi7k50mv6l",
-  "fetcher": "github",
-  "repo": "minad/bookmark-view",
-  "unstable": {
-   "version": [
-    20240102,
-    334
-   ],
-   "commit": "2d16b2f88a106e57c58ad2af1f7166a847996512",
-   "sha256": "0sh15mbs5j6nq4d2dh4xg1hh783r6sx4vf30jk07jw1392anxwp8"
-  },
-  "stable": {
-   "version": [
-    0,
-    2
-   ],
-   "commit": "06e41de8ed7050e70627203c93b6132fec7e88d8",
-   "sha256": "07nvbp3b8bf2n5gaiz0fvr2himg624i80im4pzjx81k5fpb16sl7"
-  }
- },
- {
   "ename": "bool-flip",
   "commit": "f56377a7c3f4b75206ad9ba570c35dbf752079e9",
   "sha256": "1xfspqxshx7m8gh6g1snkaahka9f71fnq7hx81nik4s9s8pmxj9c",
@@ -8924,16 +8904,16 @@
   "repo": "jyp/boon",
   "unstable": {
    "version": [
-    20240628,
-    703
+    20250101,
+    2055
    ],
    "deps": [
     "dash",
     "expand-region",
     "multiple-cursors"
    ],
-   "commit": "19a7f76e75759f5266986b40c470edb1f70c43df",
-   "sha256": "1cv6hf3lfhbxaqv0r4d56gfw956mq5ylv2c85hcfhv5jmj4k69w8"
+   "commit": "237b963231eeb820b5024191ebdf2a4353851bbb",
+   "sha256": "1c38yh3ar3wxsk77qwaf8db8ckjmvdb5wf559dpq1201hfda93l6"
   },
   "stable": {
    "version": [
@@ -9208,25 +9188,25 @@
   "url": "https://bitbucket.org/MikeWoolley/brf-mode",
   "unstable": {
    "version": [
-    20240702,
-    1846
+    20241226,
+    2107
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "495d69e5c615a27d928592e0c6c8184e869a23f2",
-   "sha256": "0klw4fgayyaj0pga3n6bq1zhr90mwih4v0qxdi6kp6vwyf1ffm96"
+   "commit": "78ce2179d0bce9a63fe2a7f3f8a7687d427f5bae",
+   "sha256": "088cpq5kppw1kba8hhbqqmj45bgcmcj3y9h47vzs1cgiclhgkgfl"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
    "deps": [
     "fringe-helper"
    ],
-   "commit": "495d69e5c615a27d928592e0c6c8184e869a23f2",
-   "sha256": "0klw4fgayyaj0pga3n6bq1zhr90mwih4v0qxdi6kp6vwyf1ffm96"
+   "commit": "78ce2179d0bce9a63fe2a7f3f8a7687d427f5bae",
+   "sha256": "088cpq5kppw1kba8hhbqqmj45bgcmcj3y9h47vzs1cgiclhgkgfl"
   }
  },
  {
@@ -9394,11 +9374,11 @@
   "url": "https://git.madhouse-project.org/algernon/brutalist-theme.el.git",
   "unstable": {
    "version": [
-    20231120,
-    721
+    20250104,
+    1112
    ],
-   "commit": "c387f3f0aaae147270c61dcd3140fb4eb20965ad",
-   "sha256": "1jbnm4wfz41ns51wl63qm2bkib7hfs437lx1bgdk9djbpiwik4d2"
+   "commit": "29f1c70451075e87a9f1747478cc78ed6d37de26",
+   "sha256": "0qs8qglz0kfrajqr68x4i16q14jd9ja3z8wsinlgwjivs5pxh1gi"
   }
  },
  {
@@ -9667,8 +9647,8 @@
  },
  {
   "ename": "buffer-sets",
-  "commit": "a3645b08cb46e3d91081da7baa982b5283918447",
-  "sha256": "1zvvf62d4sry8xz5ng48472y79xc34xagm3bkwhv06r7asvzm84a",
+  "commit": "66dfdd37cd5e58e25d259c5bf925418eb9cd26d0",
+  "sha256": "033impnaivscc5mb4mnq8nba1wxg46dn5y4z37lv9v26czgsyird",
   "fetcher": "sourcehut",
   "repo": "swflint/buffer-sets",
   "unstable": {
@@ -9693,6 +9673,30 @@
    ],
    "commit": "cdc66804b8a1ec7ddf94d99c7f24b801148b64df",
    "sha256": "0lz7bjmxzxkri6mvqk6lrl6dp58as6py3i41hkfkj9zjmjvsl589"
+  }
+ },
+ {
+  "ename": "buffer-terminator",
+  "commit": "e5782914654d0a7593980aefef446c8694cf9a4e",
+  "sha256": "0gwpjgxpvk58g968hdqjq1ypm4mzsyq67fz2ikwiwn07zdghaif2",
+  "fetcher": "github",
+  "repo": "jamescherti/buffer-terminator.el",
+  "unstable": {
+   "version": [
+    20241217,
+    519
+   ],
+   "commit": "9afade5c176e6fceee37fa034b550f5dc6cdb8cc",
+   "sha256": "0mgvc94y97bw8swsc4gszk9la3bxzqkpizvkpgwjmfvkvk7lf0l3"
+  },
+  "stable": {
+   "version": [
+    1,
+    1,
+    0
+   ],
+   "commit": "8ea821806e58d9e5b7818c3ad2f5bcb51aa1a7ab",
+   "sha256": "1p15vad5yndf89x519a49pliqal5vws8dq8cjr7yvyca0sqkb2y2"
   }
  },
  {
@@ -9757,11 +9761,11 @@
   "repo": "jcs-elpa/buffer-wrap",
   "unstable": {
    "version": [
-    20240101,
-    935
+    20250101,
+    1003
    ],
-   "commit": "c2d12ef25ffac4827dc598d81fac75cb865663b6",
-   "sha256": "037crgbfyfzvd090nairqh1bnpyb3l5m9qy7bcsf7zsifwlj1wz6"
+   "commit": "60f205258981d3433700b9c1c8d14026a001bd5e",
+   "sha256": "1v7jzhqgp884avhi7wk5vnyr8f37ivqpl9dh7hvxqqw3qrybnvdi"
   },
   "stable": {
    "version": [
@@ -10739,22 +10743,22 @@
  },
  {
   "ename": "call-graph",
-  "commit": "1206dea4f7040221775b315fd1e858448ca3dde6",
-  "sha256": "05gzsps5sr8id03imrhvwvns1c97r5kxfjdy3bns6a772n6danxn",
+  "commit": "64d78e41ddf64ea19aaae79075dc86c097856a42",
+  "sha256": "0v13ggqpmrr147qv0sgwhvnqg9vsf22y6xipcr2hynf32qsizk58",
   "fetcher": "github",
-  "repo": "emacsattic/call-graph",
+  "repo": "beacoder/call-graph",
   "unstable": {
    "version": [
-    20241111,
-    117
+    20241209,
+    435
    ],
    "deps": [
     "beacon",
     "ivy",
     "tree-mode"
    ],
-   "commit": "c19effc6d230822e08d181fb5943582878a8903b",
-   "sha256": "12my47321jjajgdqniajxl7wv7r7nh0gnlk8s55qdvi742127zmh"
+   "commit": "e6f02568d1095d01f3bc7f788f39c3901c448e69",
+   "sha256": "0qyx2089rqpr55w06vjg3dkdf8qby9qhmkhwm57inxfp40apb4fc"
   },
   "stable": {
    "version": [
@@ -10883,25 +10887,25 @@
   "repo": "minad/cape",
   "unstable": {
    "version": [
-    20241123,
-    925
+    20250103,
+    1744
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9a7c44fe8b7ace73fa8ebf6b5805474f0ca07d01",
-   "sha256": "0qa4911y61y4nshb4nqq7yf7fp8ms39wjm1da51k48lypmw013yb"
+   "commit": "d981e8f9460f6434e60812780ed81eda54940a97",
+   "sha256": "11ghzcszh2bla4amnmqz7y5isw3ici8fqln327mmdzn97mm45h2z"
   },
   "stable": {
    "version": [
     1,
-    7
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "9110956a5155d5e3c460160fa1b4dac59322c229",
-   "sha256": "0dr7x258n9px15cr90bd2877dc8hzy726g0h6vix284w675c2nvi"
+   "commit": "bd40091f8ce1202632bf660bb8bfe78096ea4c0d",
+   "sha256": "0ij4skr231bh3qs7s49h4ni8zkagg8k6b3jr611c0wax5gas1jzl"
   }
  },
  {
@@ -10921,11 +10925,11 @@
   "stable": {
    "version": [
     1,
-    0,
-    2
+    1,
+    0
    ],
-   "commit": "1a0e12c0a3ba1f0dbbad45ddfef555166e0a14fc",
-   "sha256": "1vxqcjs9fxlms3nxhi0905bwbja5dm9pa72kcw4iyyjka2ln8mrd"
+   "commit": "b34ec28cceaf15b1082b74b50f03f770873c3636",
+   "sha256": "0q1ki9l0rsbp446zkwzvzv3pvykpiqjzilllqrjr7j65naij86c3"
   }
  },
  {
@@ -11069,11 +11073,11 @@
   "repo": "peterstuart/cargo-transient",
   "unstable": {
    "version": [
-    20230512,
-    131
+    20241204,
+    1217
    ],
-   "commit": "34d63dfb99ee9a6068dadd6390763c9735c17a85",
-   "sha256": "0yx3gjwah4phkhwgda56p4ag217l8mf96q7zm1p3dixwnrxbnpbs"
+   "commit": "b75511f911189b6b6c47976dd970eeb80ccfb3ee",
+   "sha256": "1s1kjc7xg55lnwn5ngdp89hnh2qp42x10cyqlji268xiglx0xzs2"
   }
  },
  {
@@ -11260,26 +11264,26 @@
   "repo": "kickingvegas/casual",
   "unstable": {
    "version": [
-    20241126,
-    133
+    20241220,
+    2331
    ],
    "deps": [
     "transient"
    ],
-   "commit": "a84775d63b5a85b0254f8b80d412f3421d001204",
-   "sha256": "19rzqzhy2z03lx65712p1p23c5ji1nv1gxk3hq5q5fhvlm7r8qlz"
+   "commit": "66771bf3b1b947a8586d38ba72e689c7f09c438b",
+   "sha256": "0m1kdr1qyr0cr3mwhihkr6p20rvmlb17y1xrgmfv361cihxqgfmx"
   },
   "stable": {
    "version": [
     2,
     2,
-    2
+    7
    ],
    "deps": [
     "transient"
    ],
-   "commit": "a84775d63b5a85b0254f8b80d412f3421d001204",
-   "sha256": "19rzqzhy2z03lx65712p1p23c5ji1nv1gxk3hq5q5fhvlm7r8qlz"
+   "commit": "66771bf3b1b947a8586d38ba72e689c7f09c438b",
+   "sha256": "0m1kdr1qyr0cr3mwhihkr6p20rvmlb17y1xrgmfv361cihxqgfmx"
   }
  },
  {
@@ -11290,28 +11294,28 @@
   "repo": "kickingvegas/casual-avy",
   "unstable": {
    "version": [
-    20241021,
-    2353
+    20241217,
+    1931
    ],
    "deps": [
     "avy",
     "casual"
    ],
-   "commit": "7e8f7703f4ab4886f27241664aa5e1510103f74e",
-   "sha256": "0ln5abq0fvlph5zz008m5jajshdqj62c9y734mb6hn9pgfvh5hay"
+   "commit": "6716c12e9b7ba8325dab05d55c1ea5cc2b9a44f1",
+   "sha256": "0p4ljzgcr51wpcfs4r0nnpv4rgaivzcq4lbcyr9sfvgqhr1yr271"
   },
   "stable": {
    "version": [
     2,
     0,
-    0
+    1
    ],
    "deps": [
     "avy",
     "casual"
    ],
-   "commit": "7e8f7703f4ab4886f27241664aa5e1510103f74e",
-   "sha256": "0ln5abq0fvlph5zz008m5jajshdqj62c9y734mb6hn9pgfvh5hay"
+   "commit": "6716c12e9b7ba8325dab05d55c1ea5cc2b9a44f1",
+   "sha256": "0p4ljzgcr51wpcfs4r0nnpv4rgaivzcq4lbcyr9sfvgqhr1yr271"
   }
  },
  {
@@ -11412,11 +11416,11 @@
   "repo": "catppuccin/emacs",
   "unstable": {
    "version": [
-    20241016,
-    2258
+    20241211,
+    322
    ],
-   "commit": "4441d5114fdcc2eb05186a974b4bbad7224e43b5",
-   "sha256": "1y2ads0w5l3mm0mxxbi2ppb6csq8hw2fd9cmak3myv13qzw92x3w"
+   "commit": "893981bb3d7aff4c6e41427e92dc514164fdfb59",
+   "sha256": "0d9cykz6pw1i2iil1vyz9njqabfkli4fgrk97kl4wqggdvxahlc9"
   },
   "stable": {
    "version": [
@@ -11495,11 +11499,11 @@
   "repo": "xuchunyang/cc-cedict.el",
   "unstable": {
    "version": [
-    20231209,
-    1109
+    20241221,
+    1256
    ],
-   "commit": "0c124beae160d5ff9be927bfb5e1a5fd8d50817a",
-   "sha256": "0cpmryg6haqlrfz6hwm10k7iw66hgwclm8lhdbikr97b6536bni5"
+   "commit": "4b30010f98b34c7e1b3a3c327f9be0851ef83641",
+   "sha256": "0553i3qf1xkxc6vmr8p6c0c3smilbmq6ky4sgp6bgp13z7q7alx4"
   }
  },
  {
@@ -11697,14 +11701,14 @@
   "repo": "ema2159/centaur-tabs",
   "unstable": {
    "version": [
-    20240921,
-    642
+    20241215,
+    1321
    ],
    "deps": [
     "powerline"
    ],
-   "commit": "3d78b1e608b7c203e4e788894d8fa52a0a13207c",
-   "sha256": "1r0jvy3c5svwq3xj06fin5xzh0gf23r1pfk8bqa6r0fgfrq0rj5g"
+   "commit": "35389777bc7c4972e302d3793e1a5250f501404d",
+   "sha256": "1y2l3h850msrgpnjbzndacfbkcrvqmqym8zr2mrx3wilpnb8ba4v"
   },
   "stable": {
    "version": [
@@ -11846,29 +11850,6 @@
   }
  },
  {
-  "ename": "ceylon-mode",
-  "commit": "09cd1a2ccf33b209a470780a66d54e1b1d597a86",
-  "sha256": "0dgqmmb8qmvzn557h0fw1mx4y0p96870l8f8glizkk3fifg7wgq4",
-  "fetcher": "github",
-  "repo": "lucaswerkmeister/ceylon-mode",
-  "unstable": {
-   "version": [
-    20180606,
-    1324
-   ],
-   "commit": "948515672bc596dc118e8e3ede3ede5ec6a3c95a",
-   "sha256": "1a9f9h5kywfy8c2kmaxc9vf5zcykbhghpi3ra2l3z5hm0knq54ay"
-  },
-  "stable": {
-   "version": [
-    0,
-    2
-   ],
-   "commit": "00f790b3ed5ec48e2461e20a4d466ba45c634e13",
-   "sha256": "08zk6aspy59gv3989zxz0ibxxwkbjasa83ilpzvpcwszrzq8x640"
-  }
- },
- {
   "ename": "cfengine-code-style",
   "commit": "6a0ae196cac93c467cba4221efa8785d44049cb8",
   "sha256": "0f155i1593dvsi4xqww3cxz21hkz0i484k7cczqycp209b69rlrg",
@@ -11924,16 +11905,16 @@
   "repo": "worr/cfn-mode",
   "unstable": {
    "version": [
-    20241013,
-    805
+    20241208,
+    904
    ],
    "deps": [
     "f",
     "s",
     "yaml-mode"
    ],
-   "commit": "442f374ee338c6f7ffacbf1bca4233218303b6c1",
-   "sha256": "1rjyivcsaxc4d7mfks8bc7c8dgibrzfjvbrjc8m04w0g26q2llma"
+   "commit": "0457130319e6d41a28812f293199516378302e0a",
+   "sha256": "1mlyiwlzy49dm6dmrzq9zm2wv88xfx1qsq8b2jwl4df9bd4cmjvn"
   },
   "stable": {
    "version": [
@@ -12197,26 +12178,26 @@
   "repo": "xenodium/chatgpt-shell",
   "unstable": {
    "version": [
-    20241201,
-    2252
+    20250104,
+    1646
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "5fc6c7dba6ef16e57d14f90c1ae05a0b0d36ba36",
-   "sha256": "12raxg5lf3cicj5rib48kc4mh4jdzp8nxhfxjkf807amp6rrlw74"
+   "commit": "8e4e440f1cca3d5ad49d8f90d8ab83617e263247",
+   "sha256": "19acs847kx40drqsc0mn0zc529r8s0h9aaxikhhcc27vz75417f5"
   },
   "stable": {
    "version": [
     2,
-    2,
-    7
+    11,
+    4
    ],
    "deps": [
     "shell-maker"
    ],
-   "commit": "63c7c092d80daa02d85890178bb879ddcfd04bde",
-   "sha256": "022wgc2mdd7b4xs7xjabmy95dx30yjgfbnv773vxfaq7z1c4ymbi"
+   "commit": "054a5635113cce301717afba6e9aadfb3a2f094f",
+   "sha256": "10418cy189k8avqi61spybkig4ddilx1csz61995yz20pms8kp4z"
   }
  },
  {
@@ -12227,15 +12208,15 @@
   "repo": "kimim/chatu",
   "unstable": {
    "version": [
-    20240518,
-    615
+    20250102,
+    1213
    ],
    "deps": [
     "org",
     "plantuml-mode"
    ],
-   "commit": "f813f0bc926346fbd8151d2ae7079119d4657abb",
-   "sha256": "1xg5mcxsjlkayls1zknqgx3niwwrbrvj5dpmx68sljjwz4j8b8y5"
+   "commit": "e1420dc4bb63294ece93bf805424c6b5fafa0295",
+   "sha256": "09b4mkag96096xr71v3zq3ib7j7db1hfkbbgzyfchgmd8dsvj18z"
   }
  },
  {
@@ -12882,8 +12863,8 @@
   "repo": "clojure-emacs/cider",
   "unstable": {
    "version": [
-    20241115,
-    343
+    20250103,
+    1026
    ],
    "deps": [
     "clojure-mode",
@@ -12894,14 +12875,14 @@
     "spinner",
     "transient"
    ],
-   "commit": "c228dec27df6b2c68262f17158208fe699e1ce02",
-   "sha256": "0gxrmi9ykhmhmldrrijl73cz38473y8wapr4i9an4yv34r5g9mng"
+   "commit": "be8b2e5c0da96c17f2ca0d8127f7f2e120ee2829",
+   "sha256": "0cmqqak4908d4p1d9lgibb2p3baznhzqps0sb9klmm115rji13d0"
   },
   "stable": {
    "version": [
     1,
     16,
-    0
+    1
    ],
    "deps": [
     "clojure-mode",
@@ -12912,8 +12893,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "76eac5aa634adba9a5b632cfe670467ebe319126",
-   "sha256": "1r90w7n10zyqspvm52bjbkalxzzp3jxwmbrfmifiyqzqrl0lyfrr"
+   "commit": "588c5790f0c09f5c09076885e11a73eaef70c262",
+   "sha256": "1k0zdi5zpv730gkym98amfp00xpk1hkry231v98iiw1khp345lsm"
   }
  },
  {
@@ -13228,16 +13209,16 @@
   "repo": "pprevos/citar-denote",
   "unstable": {
    "version": [
-    20240908,
-    2154
+    20241223,
+    844
    ],
    "deps": [
     "citar",
     "dash",
     "denote"
    ],
-   "commit": "c0c467653976ab40ff330fcb4586fadb69e48a29",
-   "sha256": "03fqq24ql6pgkjhjfv41xgsxqyd4czns9r9fzcnn1m4gbzpprf4v"
+   "commit": "66fd7a87d715631625d470bc0f9104178f39cef6",
+   "sha256": "1kn8pl0wi1s8s1n8a98jcy6i3rv9czk8s08jlh1sxdyim2szj39j"
   },
   "stable": {
    "version": [
@@ -13294,15 +13275,15 @@
   "repo": "emacs-citar/citar-org-roam",
   "unstable": {
    "version": [
-    20241124,
-    1352
+    20241203,
+    2325
    ],
    "deps": [
     "citar",
     "org-roam"
    ],
-   "commit": "e2cd111456d59fbf0b79e6684ad46c3686169f53",
-   "sha256": "1772k4jg1pr1a43bn80i0f4qhayhvlzvrmfcdh3nv0bxs14ssmwr"
+   "commit": "ff38add0aa40ba2014a6ee28a293fc1b9180cefa",
+   "sha256": "1zc8hy06dndkgl70z4cw45wifsb4ascq0f566ph6kck4qki73wik"
   },
   "stable": {
    "version": [
@@ -13572,15 +13553,15 @@
   "repo": "mzacho/claudia",
   "unstable": {
    "version": [
-    20241104,
-    2217
+    20241216,
+    2112
    ],
    "deps": [
     "markdown-mode",
     "uuidgen"
    ],
-   "commit": "f041f619a0e93ac5b07a05862bcb38a811d56d24",
-   "sha256": "141z590hb2cmrg5q1lv6f5z54gbyxaxl1v91ailsa22jxxr4qnq8"
+   "commit": "6905b1c734d18578537ae97a63a65a896ba341f1",
+   "sha256": "08f1h1dfy3ks3y7shqvj198s150lcja98lm9170cdgjj910akvjc"
   }
  },
  {
@@ -14237,11 +14218,11 @@
   "repo": "clojure-emacs/clojure-mode",
   "unstable": {
    "version": [
-    20241125,
-    1123
+    20241211,
+    1522
    ],
-   "commit": "63356ee3bd6903e7b17822022f5a6ded2512b979",
-   "sha256": "1g1wac0nwlp0kl6wq1aivv0fymrwxb81sd3zy6k20yjg4s5aagvg"
+   "commit": "76630045fb5b1660c91e2ab960f5636f4d567c47",
+   "sha256": "1zgi9vd753af3zipxhj5b4v3b8j8bhs0hbgz8ng8i9dqd92xh6pp"
   },
   "stable": {
    "version": [
@@ -14323,14 +14304,15 @@
   "repo": "mpenet/clojure-snippets",
   "unstable": {
    "version": [
-    20220914,
-    950
+    20241226,
+    1639
    ],
    "deps": [
+    "cl-lib",
     "yasnippet"
    ],
-   "commit": "66d23f0ffedf2cc2be0387c3504b5f89d7300cfa",
-   "sha256": "0s0jcbwz6bb8215v1rsy1kw1jx19zkavykki9yq9njqm3n6imjax"
+   "commit": "1e96ed7215e9da7c003a370eb1f91ed5475e6b0d",
+   "sha256": "1nz16jcndd2vnms4bpjysb2ny2cz8csy3vyb3xlvrbb8ikblwlyh"
   },
   "stable": {
    "version": [
@@ -14606,20 +14588,20 @@
   "url": "https://gitlab.kitware.com/cmake/cmake.git",
   "unstable": {
    "version": [
-    20241121,
-    1615
+    20241219,
+    1518
    ],
-   "commit": "eb281d34548f4234e68ff31d1050aca7e8441d86",
-   "sha256": "1r0s0scrdakp6fiwp91zj7i5svq3wyszhp0cq2lg2wssgkiphgz4"
+   "commit": "41abd532b64f178017ed4ffdbdb5af42d9056a8d",
+   "sha256": "1manw6lvfq5ik7h6lxw9g62i38fhdxr3srgzgfmwvd4hssikmw31"
   },
   "stable": {
    "version": [
     3,
     31,
-    1
+    3
    ],
-   "commit": "eb281d34548f4234e68ff31d1050aca7e8441d86",
-   "sha256": "1r0s0scrdakp6fiwp91zj7i5svq3wyszhp0cq2lg2wssgkiphgz4"
+   "commit": "41abd532b64f178017ed4ffdbdb5af42d9056a8d",
+   "sha256": "1manw6lvfq5ik7h6lxw9g62i38fhdxr3srgzgfmwvd4hssikmw31"
   }
  },
  {
@@ -14807,8 +14789,8 @@
   "repo": "ag91/code-compass",
   "unstable": {
    "version": [
-    20241125,
-    2243
+    20241211,
+    24
    ],
    "deps": [
     "async",
@@ -14816,8 +14798,8 @@
     "s",
     "simple-httpd"
    ],
-   "commit": "6510b97280892d8831ff35dedefe9a7aa7b6326a",
-   "sha256": "0bs5kn9jr7lfaw472aq2c80ii7i76a0pdbijmh2dvdf33k6hy88l"
+   "commit": "76c5732de8746ea61d4d0cf9dad00b3c35874807",
+   "sha256": "0lv37n19gd433zf5y9i0v4f4g8pzy5ls4xfnaz27kqhsp7abbd1p"
   }
  },
  {
@@ -15217,11 +15199,11 @@
   "repo": "emacs-jp/replace-colorthemes",
   "unstable": {
    "version": [
-    20231116,
-    2258
+    20241227,
+    223
    ],
-   "commit": "5f790421b6eff5d2915819fa23cfcdb19827fa91",
-   "sha256": "19r9ymfj7b0m8w2ggmk2syydi57yh2ljg4mrvxi1rljplz4kgqy6"
+   "commit": "99839fe205ff7dd299b15355e98e6b0aeb9cc646",
+   "sha256": "05kqi21hbiib54sjza5k0ban18w236hbgmil43mq7qaplg9m73d3"
   },
   "stable": {
    "version": [
@@ -15367,14 +15349,14 @@
   "repo": "jcs-elpa/com-css-sort",
   "unstable": {
    "version": [
-    20240101,
-    940
+    20250101,
+    1004
    ],
    "deps": [
     "s"
    ],
-   "commit": "ad957f427dd6fe4af2f0690487fb5ebb28791741",
-   "sha256": "113pzvw97qd88f1y5rd4zakf6mfcq21s47gr5il3d9balkkgn0q2"
+   "commit": "4c6f8bfd88c0bcee9ac121f013d1fcd88f462bae",
+   "sha256": "1vf6w0kjzingidqd7bcvfvd5xlgzj9gbvj510xm42bbnsy6a90fh"
   },
   "stable": {
    "version": [
@@ -15544,11 +15526,11 @@
   "repo": "remyferre/comment-dwim-2",
   "unstable": {
    "version": [
-    20230730,
-    1619
+    20241219,
+    1643
    ],
-   "commit": "69415caa1a381063d3e794912dfe88f672854ab0",
-   "sha256": "05ypgsdrgqj8105bvd17jn7w633y3ysbr5sgz33m7kj1ca7sl9ga"
+   "commit": "6ab75d0a690f0080e9b97c730aac817d04144cd0",
+   "sha256": "0v90x1s839bwsprfg9c246x8i52rybjpi59pcyj1aj198wwf8a35"
   },
   "stable": {
    "version": [
@@ -15734,11 +15716,11 @@
   "repo": "company-mode/company-mode",
   "unstable": {
    "version": [
-    20241106,
-    2000
+    20250105,
+    445
    ],
-   "commit": "0ae7c293112248a0c36377d6859a95d216ae5e96",
-   "sha256": "0rg1i31qg4212i9d0020p37snzcaq22fb9lmv4p4x0xysk3wgp8v"
+   "commit": "6b4f28562c0f68e1a93d11ed4e9c08d828de22aa",
+   "sha256": "0gy9glm6b9cqyw2924g9dcfpba70z808azav9n95mi361m0088mp"
   },
   "stable": {
    "version": [
@@ -16215,16 +16197,16 @@
   "repo": "jcs-elpa/company-emojify",
   "unstable": {
    "version": [
-    20240101,
-    926
+    20250101,
+    1006
    ],
    "deps": [
     "company",
     "emojify",
     "ht"
    ],
-   "commit": "f115e03b9d4369f9170f4328028dd9c8080edb3d",
-   "sha256": "0ir20aqs96pmrrd8pa7g7l0vljxgadc5prni87cyryx0x9sj6bhw"
+   "commit": "7eff81607354feb9992ab6ff0f2c44c5a0dab229",
+   "sha256": "1ifqbrf5p3rs7wjlfcwra8g42gcih68sr39rbhmzrnxbn6hrhz27"
   },
   "stable": {
    "version": [
@@ -16243,8 +16225,8 @@
  },
  {
   "ename": "company-erlang",
-  "commit": "ca96ed0b5d6f8aea4de56ddeaa003b9c81d96219",
-  "sha256": "0qlc89c05523kjzsb7j3yfi022la47kgixl74ggkafhn60scwdm7",
+  "commit": "66dfdd37cd5e58e25d259c5bf925418eb9cd26d0",
+  "sha256": "0cvrkzfc6kjkk679dx5k5g70ns6qyw17cfwlpk4qqcznlffnnnga",
   "fetcher": "github",
   "repo": "s-kostyaev/company-erlang",
   "unstable": {
@@ -16319,16 +16301,16 @@
   "repo": "jcs-elpa/company-fuzzy",
   "unstable": {
    "version": [
-    20240616,
-    549
+    20250101,
+    1006
    ],
    "deps": [
     "company",
     "ht",
     "s"
    ],
-   "commit": "204f7d63a5388637a3767c0232173c477ce96df3",
-   "sha256": "1kxij0npbhfr9ngn0dyhlp77ida76nvlxs0a45ycmmj44y5a37ah"
+   "commit": "6b7f4bc22dff085961dc51799d0674e58eb1af0d",
+   "sha256": "06y5si2chn4h51i1wy44kq4kmbzl680gi8jx4fnmfm0pmbf9c86k"
   },
   "stable": {
    "version": [
@@ -17186,8 +17168,8 @@
  },
  {
   "ename": "company-rtags",
-  "commit": "3dea16daf0d72188c8b4043534f0833fe9b04e07",
-  "sha256": "0dicxbp3xn02pflrpfndj7hs494prvz64llsk1xpc2z23kfarp6f",
+  "commit": "8f5d42452235ee9f1590fa8893c4ea3d40ac891b",
+  "sha256": "0vs58xarl6w8zjgqw7z2d1qi4jzw9cn26cmgxicc4pzpmjavarlx",
   "fetcher": "github",
   "repo": "Andersbakken/rtags",
   "unstable": {
@@ -17664,11 +17646,11 @@
   "repo": "jamescherti/compile-angel.el",
   "unstable": {
    "version": [
-    20241130,
-    442
+    20241226,
+    250
    ],
-   "commit": "67a12504ebf2cc43a6846a3e05b6e5c2e179db2f",
-   "sha256": "1kyrcpd5q938byc83f5a100jb4igzxgpj82f7ql39alzhibzskcn"
+   "commit": "ad9ca5af17dd18e73017b9bcedb3cabce5618e21",
+   "sha256": "07fgm3mkw1s4h02jcl2ms0wf5x1fi4v1lh6wv3imsnw8bghhyqnw"
   },
   "stable": {
    "version": [
@@ -17688,19 +17670,19 @@
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20240923,
-    1814
+    20250101,
+    2156
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   }
  },
  {
@@ -17711,25 +17693,25 @@
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20240923,
-    1814
+    20250101,
+    2156
    ],
    "deps": [
     "all-the-icons-completion"
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
    "deps": [
     "all-the-icons-completion"
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   }
  },
  {
@@ -17740,56 +17722,56 @@
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20240923,
-    1814
+    20250101,
+    2156
    ],
    "deps": [
     "compile-multi",
     "embark"
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
    "deps": [
     "compile-multi",
     "embark"
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   }
  },
  {
   "ename": "compile-multi-nerd-icons",
-  "commit": "039b04da36001449531df13611e5663f8e61d313",
-  "sha256": "1bz76skwjmk927a3x6mnklwby4sxc0mq6s7dbixipjf1fyrnlkx3",
+  "commit": "477aae565d0bdec434b7cdc4499ce9890b29eb2c",
+  "sha256": "10krzgrq6rkf1643bjj00zwln9mx9ngbawkklwc127gk9k6x9hhd",
   "fetcher": "github",
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20240921,
-    1212
+    20250101,
+    2156
    ],
    "deps": [
     "nerd-icons-completion"
    ],
-   "commit": "d6115349becc71cce3a335bf9b34265fe073e0bf",
-   "sha256": "06kvp3cmv70gbf4mkwavip9w9z9wx4jwar7sky9dnw1w7agffspb"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
    "deps": [
     "nerd-icons-completion"
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   }
  },
  {
@@ -17800,8 +17782,8 @@
   "repo": "mkcms/compiler-explorer.el",
   "unstable": {
    "version": [
-    20241129,
-    809
+    20241222,
+    1158
    ],
    "deps": [
     "eldoc",
@@ -17809,14 +17791,14 @@
     "plz",
     "seq"
    ],
-   "commit": "b8e7c34757c6b77aec948c143d8c89df08d4b7e8",
-   "sha256": "1lrjxkaf5979k0v0p20p9lk4azwbi629krqq66mybr1bmlw00vi6"
+   "commit": "862d3508e31f5d3ee0142414717d229e30bac477",
+   "sha256": "10qpqglv2vd1cnpd08nvhqhrdllnak5d6dqb0nnm1cq7fzkwyj16"
   },
   "stable": {
    "version": [
     0,
     6,
-    0
+    1
    ],
    "deps": [
     "eldoc",
@@ -17824,8 +17806,8 @@
     "plz",
     "seq"
    ],
-   "commit": "b8e7c34757c6b77aec948c143d8c89df08d4b7e8",
-   "sha256": "1lrjxkaf5979k0v0p20p9lk4azwbi629krqq66mybr1bmlw00vi6"
+   "commit": "862d3508e31f5d3ee0142414717d229e30bac477",
+   "sha256": "10qpqglv2vd1cnpd08nvhqhrdllnak5d6dqb0nnm1cq7fzkwyj16"
   }
  },
  {
@@ -18148,25 +18130,25 @@
   "repo": "minad/consult",
   "unstable": {
    "version": [
-    20241201,
-    1337
+    20250105,
+    39
    ],
    "deps": [
     "compat"
    ],
-   "commit": "eb26bdd008c4c92b1d79e49e2df71acc2a42faa3",
-   "sha256": "1xydhja0hrjv851vs66nwd8amm93qraccad78nxwhlimw2lw1fgn"
+   "commit": "036a13ccd4fdd8bafb20ad6d4baa2622520f1cb8",
+   "sha256": "1w9bbz9cgq7862vy904wdzkr0d3wa9fxymskpd9cv6aabm0bjy9k"
   },
   "stable": {
    "version": [
     1,
-    8
+    9
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4889458dccf842ab6223099f8a73ff8b147e9459",
-   "sha256": "06jckxwagpvp4w8hykc0wr90pba9ih8376562g1q93g0nbb3rhrg"
+   "commit": "0d0ae4659ecaa3c12927fa3982c49610da573a88",
+   "sha256": "0gp5vj96gwlxzm9fqvr1hzqzdiilfypz5nvs46f50lqn2r4bsl96"
   }
  },
  {
@@ -18255,27 +18237,27 @@
   "repo": "mohkale/compile-multi",
   "unstable": {
    "version": [
-    20240923,
-    1814
+    20250101,
+    2156
    ],
    "deps": [
     "compile-multi",
     "consult"
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
    "deps": [
     "compile-multi",
     "consult"
    ],
-   "commit": "94b2f267d1e424cf523643a3c9841c83f0a86368",
-   "sha256": "0myyl5h62c9qn22piinh605pl6sj4jy8vik69w31zpmvskvvcjfh"
+   "commit": "19d16d8871b5f19f5625e1a66c1dc46a7c3f6a3a",
+   "sha256": "0zs7s8k5vf0wl3jh374p62vaak0l6p5xy525ys2nv7mghgbv5a53"
   }
  },
  {
@@ -18335,21 +18317,21 @@
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20241107,
-    2125
+    20250101,
+    2155
    ],
    "deps": [
     "consult",
     "eglot",
     "project"
    ],
-   "commit": "c5f87d92448cd9c22a33ebd1feb54ca2fb89afa8",
-   "sha256": "0l7fg36zqcy0mzcs1fx515mppkf94r4fvss65vhambblrcd7z6nd"
+   "commit": "3ef13f931c6c6b3b2d086ff4c387ab7a05378370",
+   "sha256": "0y3n161kfa4a791jh70n6k1s6vyv55lr3ly8zz2zww5gxkx8m137"
   },
   "stable": {
    "version": [
     0,
-    3,
+    4,
     0
    ],
    "deps": [
@@ -18357,27 +18339,40 @@
     "eglot",
     "project"
    ],
-   "commit": "64262e72452f8fe6dd49d31bcdd4bd577b7d682d",
-   "sha256": "0mn9d87m05bhqrw7sscx4a2a5h7gkqyhv06a80ky9vbzlfjfk6hh"
+   "commit": "3ef13f931c6c6b3b2d086ff4c387ab7a05378370",
+   "sha256": "0y3n161kfa4a791jh70n6k1s6vyv55lr3ly8zz2zww5gxkx8m137"
   }
  },
  {
   "ename": "consult-eglot-embark",
-  "commit": "258a113cb0f7902ca083c931c064c093b3721b52",
-  "sha256": "1k0iq93wx7azm8lxzvihgihlk5sxhax5syynl8irlw8cibfs1wip",
+  "commit": "36a607bac206486e3b6e054106d373a4ecebe8fa",
+  "sha256": "1hz5xl8813yg1wp1523cxliw2bs18rsvfp7xj11967nrznxvynls",
   "fetcher": "github",
   "repo": "mohkale/consult-eglot",
   "unstable": {
    "version": [
-    20241107,
-    2125
+    20250101,
+    2155
    ],
    "deps": [
     "consult-eglot",
     "embark-consult"
    ],
-   "commit": "c5f87d92448cd9c22a33ebd1feb54ca2fb89afa8",
-   "sha256": "0l7fg36zqcy0mzcs1fx515mppkf94r4fvss65vhambblrcd7z6nd"
+   "commit": "3ef13f931c6c6b3b2d086ff4c387ab7a05378370",
+   "sha256": "0y3n161kfa4a791jh70n6k1s6vyv55lr3ly8zz2zww5gxkx8m137"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    0
+   ],
+   "deps": [
+    "consult-eglot",
+    "embark-consult"
+   ],
+   "commit": "3ef13f931c6c6b3b2d086ff4c387ab7a05378370",
+   "sha256": "0y3n161kfa4a791jh70n6k1s6vyv55lr3ly8zz2zww5gxkx8m137"
   }
  },
  {
@@ -18388,15 +18383,15 @@
   "repo": "minad/consult-flycheck",
   "unstable": {
    "version": [
-    20241114,
-    1120
+    20250101,
+    914
    ],
    "deps": [
     "consult",
     "flycheck"
    ],
-   "commit": "fa7a3a3b5d31d318582f7a1935a3c812fcdc4368",
-   "sha256": "1adwmvx48dfp5qrcy02k2d1972ysrazpdl5c7m90b8allcg01y60"
+   "commit": "3bc2141daf8cfad7e4d2e2f78b15d45033f707a5",
+   "sha256": "0x0jbk0pyw2djwskn0f9nsqyyjh8j3g588vh500x4p1bnca4afvc"
   },
   "stable": {
    "version": [
@@ -18437,26 +18432,29 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20241001,
-    23
+    20241227,
+    123
    ],
    "deps": [
     "consult",
-    "markdown-mode"
+    "markdown-mode",
+    "ox-gfm"
    ],
-   "commit": "bdc5516435ffa9efcd4de102b5d8549386b0ba6a",
-   "sha256": "1wc1fdg5f52nrpm7jd3sv3lldm02habr3ldqdgixfg2h867cgp0w"
+   "commit": "28f472574b05647ffdff1d265e28b91250404241",
+   "sha256": "10fpmc05mwzgcwk3yxc0bx4704inz9d2li0n1gxjb27g696ijjbp"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
    "deps": [
-    "consult"
+    "consult",
+    "markdown-mode",
+    "ox-gfm"
    ],
-   "commit": "077c076f1623fd8f2b93f6eb6f8c79ea58662783",
-   "sha256": "114nx7p3gc495hgy0b8227i653qnyawjwrmx1qjpl0gfq3vgnqd9"
+   "commit": "1acaf7b2a5fe8a8be19f83f5b20bb2bc377d1fc8",
+   "sha256": "09s9ph7xk7xrqrs6rw8md4q3pl6b4iw0114krshkyf79rgjgsvzl"
   }
  },
  {
@@ -18467,27 +18465,27 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20240929,
-    803
+    20241224,
+    2130
    ],
    "deps": [
     "consult-gh",
     "embark-consult"
    ],
-   "commit": "4e4a1ef9a4823b37cf7057208f712aa69e1e0e2c",
-   "sha256": "0yx8mqx17iz2q28077z0w2pxnbxqr41mvj418wrqw2fgwm012v6n"
+   "commit": "7197855a46c6e37098257d05a168555a41ffaa51",
+   "sha256": "0a4s8ijxbk1x79fm0hyvsrkr3i45b7vxq2wb9j9pa2rjbq0zr44r"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
    "deps": [
-    "consult",
-    "consult-gh"
+    "consult-gh",
+    "embark-consult"
    ],
-   "commit": "077c076f1623fd8f2b93f6eb6f8c79ea58662783",
-   "sha256": "114nx7p3gc495hgy0b8227i653qnyawjwrmx1qjpl0gfq3vgnqd9"
+   "commit": "1acaf7b2a5fe8a8be19f83f5b20bb2bc377d1fc8",
+   "sha256": "09s9ph7xk7xrqrs6rw8md4q3pl6b4iw0114krshkyf79rgjgsvzl"
   }
  },
  {
@@ -18498,20 +18496,20 @@
   "repo": "armindarvish/consult-gh",
   "unstable": {
    "version": [
-    20240927,
-    1004
+    20241219,
+    507
    ],
    "deps": [
     "consult",
     "consult-gh",
     "forge"
    ],
-   "commit": "79204bab021d9c58687dbce44694419c966d6998",
-   "sha256": "008gak4q21qw4bm1lsrxsz8dad5s6rh8v0fvlasjhhyfwwywdk09"
+   "commit": "1acaf7b2a5fe8a8be19f83f5b20bb2bc377d1fc8",
+   "sha256": "09s9ph7xk7xrqrs6rw8md4q3pl6b4iw0114krshkyf79rgjgsvzl"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0
    ],
    "deps": [
@@ -18519,8 +18517,8 @@
     "consult-gh",
     "forge"
    ],
-   "commit": "077c076f1623fd8f2b93f6eb6f8c79ea58662783",
-   "sha256": "114nx7p3gc495hgy0b8227i653qnyawjwrmx1qjpl0gfq3vgnqd9"
+   "commit": "1acaf7b2a5fe8a8be19f83f5b20bb2bc377d1fc8",
+   "sha256": "09s9ph7xk7xrqrs6rw8md4q3pl6b4iw0114krshkyf79rgjgsvzl"
   }
  },
  {
@@ -18662,16 +18660,16 @@
   "repo": "mclear-tools/consult-notes",
   "unstable": {
    "version": [
-    20240810,
-    1318
+    20241213,
+    1718
    ],
    "deps": [
     "consult",
     "dash",
     "s"
    ],
-   "commit": "6ece62337d6065e88a91b222fac5e252c00a8d53",
-   "sha256": "0jqfybd96wkqcdnwavsp2fzjxmqb7lff8ix23rvq7c1dsgrp0c0v"
+   "commit": "7c9cd970c75fae9a6140ca1beefed9532d8e1b96",
+   "sha256": "1lccpnqqaai6vsjn9v65xhpzs0bmhrsyflaxg3n3iszigmsxrfaz"
   }
  },
  {
@@ -18886,6 +18884,36 @@
   }
  },
  {
+  "ename": "consult-vc-modified-files",
+  "commit": "d43c1de6dc0186c1d056bb6feb921a981fd6845c",
+  "sha256": "011jpw630cx05j0dgx9lk7m6r36sijdn2bhjglmhg0ajh7kg0j1q",
+  "fetcher": "github",
+  "repo": "chmouel/consult-vc-modified-files",
+  "unstable": {
+   "version": [
+    20241216,
+    928
+   ],
+   "deps": [
+    "consult"
+   ],
+   "commit": "06387842bceb47887f6c07b148220a4e256d7eed",
+   "sha256": "1bxq6fny01a0a4gq5xzlrj6jg73pxdyp2fl89jzp5kh9h0kg3h0w"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    3
+   ],
+   "deps": [
+    "consult"
+   ],
+   "commit": "06387842bceb47887f6c07b148220a4e256d7eed",
+   "sha256": "1bxq6fny01a0a4gq5xzlrj6jg73pxdyp2fl89jzp5kh9h0kg3h0w"
+  }
+ },
+ {
   "ename": "consult-yasnippet",
   "commit": "da399d9149261f6fded5a465ba1b6f2353abfa5a",
   "sha256": "08piq6zfj8ixp8shyc69hmmxqqci0xp5mmg51ajddvz8k0sndgn1",
@@ -19063,6 +19091,28 @@
   }
  },
  {
+  "ename": "copilot",
+  "commit": "66e9c25a9c1d4a0ed06f8b134b7eabf9c839704d",
+  "sha256": "11w10jfcsqr43akngmc2gb2w87zajn36k1nyvbkk9fkgiqr1h6av",
+  "fetcher": "github",
+  "repo": "copilot-emacs/copilot.el",
+  "unstable": {
+   "version": [
+    20241228,
+    436
+   ],
+   "deps": [
+    "dash",
+    "editorconfig",
+    "f",
+    "jsonrpc",
+    "s"
+   ],
+   "commit": "c5dfa99f05878db5e6a6a378dc7ed09f11e803d4",
+   "sha256": "1w07i3wyp3b49asjbw83h86sri9f7hj92fs3g0jv0sxv0pq38chp"
+  }
+ },
+ {
   "ename": "copilot-chat",
   "commit": "6e3852d02866ef577717fae04a56c876efa4217d",
   "sha256": "1xzaa9rn8bnbjlcvlir2nnvidnmyhhcjqi7yi7xadv5i0rw66zxz",
@@ -19070,8 +19120,8 @@
   "repo": "chep/copilot-chat.el",
   "unstable": {
    "version": [
-    20241126,
-    815
+    20250104,
+    40
    ],
    "deps": [
     "chatgpt-shell",
@@ -19079,8 +19129,8 @@
     "markdown-mode",
     "request"
    ],
-   "commit": "b6d919022a81ae6f8e024a9cce2a8250a2451d09",
-   "sha256": "1s1g45h2mbs7xsl8wdra5zlgw5rvvamgvc9iicvhbsjhxhpr48vv"
+   "commit": "bad6e96ffbd6553dc3901151b203220e5d2bdd4c",
+   "sha256": "1qzbnnm13fr8n6bvps5q1xdq55kalw4fgdaqbi5mq802afbr0zi3"
   },
   "stable": {
    "version": [
@@ -19247,25 +19297,25 @@
   "repo": "minad/corfu",
   "unstable": {
    "version": [
-    20241127,
-    1554
+    20250103,
+    2029
    ],
    "deps": [
     "compat"
    ],
-   "commit": "f10f58f446e2cbda738ae8738cf4a7464a8aeeab",
-   "sha256": "186y5x8hhq46l7a3m6k8cxg2wm2g4yynrm3fgasy9ys4xb7kjb7r"
+   "commit": "ec846c6aa373931508cc078b49a3a8ba8265c453",
+   "sha256": "0zgki3a3vc1lzx777ppf9b6pk71xkbjjjrh2x3by49zpq9za9p2h"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5e3a959766d2313651c5db3beedd937bfc27b57a",
-   "sha256": "00w0qzx2cqyxy15ndqzl3d6f1k8gvqdxz407zbgy5n46408pjsi0"
+   "commit": "b02f674c4523ee139365fe3c1e218af2a90d46d4",
+   "sha256": "11n8qdjpavvy0s1zhxzxxvcv5i07gsjs02ad7fj51p7j8y4hjvym"
   }
  },
  {
@@ -20318,11 +20368,11 @@
   "repo": "WammKD/Emacs-CRC",
   "unstable": {
    "version": [
-    20241115,
-    253
+    20241215,
+    15
    ],
-   "commit": "0c2d6bd56963c3a8b36e88d748a6cbaf3541c6a1",
-   "sha256": "02i6d0dyh1wfd5rcq91vk516n11mcp7w18m11z2nqdpr588b7zn2"
+   "commit": "527d3b336ccca95abb39b274a566b7c92a66a476",
+   "sha256": "0h85niqgl6jvjsh0qm7wgjly1qd5g6nbpnms8inwwfw761js6kkr"
   },
   "stable": {
    "version": [
@@ -20330,8 +20380,8 @@
     1,
     2
    ],
-   "commit": "0c2d6bd56963c3a8b36e88d748a6cbaf3541c6a1",
-   "sha256": "02i6d0dyh1wfd5rcq91vk516n11mcp7w18m11z2nqdpr588b7zn2"
+   "commit": "527d3b336ccca95abb39b274a566b7c92a66a476",
+   "sha256": "0h85niqgl6jvjsh0qm7wgjly1qd5g6nbpnms8inwwfw761js6kkr"
   }
  },
  {
@@ -21178,6 +21228,29 @@
   }
  },
  {
+  "ename": "current-window-only",
+  "commit": "73f44e8c1ef83c73bc706cc05707bc243dd7bea9",
+  "sha256": "0mnb694i4sxi0yhw79pkc2h5wsmdgjxhflaya3p0v4y11cpx1a6p",
+  "fetcher": "github",
+  "repo": "FrostyX/current-window-only",
+  "unstable": {
+   "version": [
+    20241220,
+    2006
+   ],
+   "commit": "1e9c6fb55a4292c62818035f2bdc159512ac089f",
+   "sha256": "0z58lyw7fqdf2bqazi355fhxsbr0yxyv6nz7z7bprgzh8fgcgpiv"
+  },
+  "stable": {
+   "version": [
+    1,
+    0
+   ],
+   "commit": "7883c1a0cb8ea3aad465bb31f768c3fdaac0a031",
+   "sha256": "10k0yfmydznrrs2789misqfl9y4f7bdikxfhg7190lqimbccpcgq"
+  }
+ },
+ {
   "ename": "current-word-highlight",
   "commit": "02d60c15b4624735ba7e62f7c27a27487f1c7caf",
   "sha256": "0jrcgvc60hzcnd66b0na4rd0lnr92pgfrkwwfvih2qjzxf5lpl72",
@@ -21502,11 +21575,11 @@
   "repo": "Emacs-D-Mode-Maintainers/Emacs-D-Mode",
   "unstable": {
    "version": [
-    20241126,
-    1056
+    20241225,
+    1823
    ],
-   "commit": "de2a20eb21ae9bddfa86468a7522b0ba29f0c387",
-   "sha256": "18d9ndgsx66f0w3a6gsvff6l7lqbmfqqjahm3zzjj50yk43yykig"
+   "commit": "e8754635a7dbb7b1712dc9fcf380acd3ed5a2db6",
+   "sha256": "15wp2iys0pyrwls0hx25gf1lr5f71jf9pak8ljd055c0klhd3yyv"
   },
   "stable": {
    "version": [
@@ -21526,11 +21599,11 @@
   "repo": "andorsk/d2-mode",
   "unstable": {
    "version": [
-    20241107,
-    236
+    20241209,
+    2156
    ],
-   "commit": "872a0d79223d2fe0ecad02fd4474831ec623672f",
-   "sha256": "1hrxn43wavi1q3djbrqrsv732kzadkpnfm58prqrsv8k010ws886"
+   "commit": "e1fc7d6c1915acaf476060c0f79b8bdef6bd1952",
+   "sha256": "101y3mrc652sdfglnrrg8yhgz5y3xnl4wlk9jzplr97nk8af0s79"
   },
   "stable": {
    "version": [
@@ -21588,8 +21661,21 @@
   "repo": "cbowdon/daemons.el",
   "unstable": {
    "version": [
-    20241127,
-    1211
+    20241223,
+    1448
+   ],
+   "deps": [
+    "compat",
+    "s"
+   ],
+   "commit": "e1c0f5bb940b8149e0db414cc77c1ce504f5e3eb",
+   "sha256": "1s91r6zl5c4cbfp6ybz3r8i5kw200nqc92dsidf9wmbzz435m1ds"
+  },
+  "stable": {
+   "version": [
+    2,
+    1,
+    0
    ],
    "deps": [
     "compat",
@@ -21597,15 +21683,6 @@
    ],
    "commit": "0dc7f1ec81fa70b3cafdc394413fe14fd3a413e4",
    "sha256": "1p5f2lf6jlsvyh6zhd6drc2njadlkn73djrykridsphzh92q88k0"
-  },
-  "stable": {
-   "version": [
-    2,
-    0,
-    0
-   ],
-   "commit": "dcf42cb3178d7245d6d49de346d5e2b44e5b7498",
-   "sha256": "00bkzfaw3bqykcks610vk9wlpa2z360xn32bpsrycacwfv29j7g4"
   }
  },
  {
@@ -21772,8 +21849,8 @@
   "repo": "emacs-lsp/dap-mode",
   "unstable": {
    "version": [
-    20241101,
-    659
+    20241216,
+    1315
    ],
    "deps": [
     "bui",
@@ -21786,8 +21863,8 @@
     "posframe",
     "s"
    ],
-   "commit": "605448b4fd90ca25924bf029acf2bdd047045133",
-   "sha256": "1lpw7pgkq2nq5br8am8jz34lvgnkx61nkwf54b83w1rk2rrssam9"
+   "commit": "ffb795761273e1bdc3d0cd1ebdd43e36b7c08921",
+   "sha256": "1vzb3hhdlicy087faqlwm6r9kpmiypb9pacmyad7wk4i0q60ywdd"
   },
   "stable": {
    "version": [
@@ -22147,11 +22224,11 @@
   "repo": "emacs-dashboard/emacs-dashboard",
   "unstable": {
    "version": [
-    20241120,
-    2030
+    20250101,
+    845
    ],
-   "commit": "9479466d39652a8e32b74ee83822421fa08024d9",
-   "sha256": "0xch9w4l1zs52pwlcyy6nrxnp31ysaxkbqpx4wx5nf2sglc8jixc"
+   "commit": "c9f8230f6b7992b7b40c3bb9abc36cc03b6a423d",
+   "sha256": "1jd8nhl84xzx2ij50q5pg094fdkdb27qwjn3x1kvwks68vw9vk2i"
   },
   "stable": {
    "version": [
@@ -22190,14 +22267,14 @@
   "repo": "emacs-dashboard/dashboard-ls",
   "unstable": {
    "version": [
-    20240101,
-    841
+    20250101,
+    845
    ],
    "deps": [
     "dashboard"
    ],
-   "commit": "bc79640e8fcc625ff1af31d5e17b054b1f535f39",
-   "sha256": "07ygiy3i8vjvc6ga9dkxahvcznk1fzshy7m9w94jag5jm1vskrh1"
+   "commit": "4eea843e5b7dcc4fe23eaf67b163ed7b13b56613",
+   "sha256": "089w0sxxyarbsm7hcnw5yvrh6vyj3yc0ymvcnks9slw3ia3svxl9"
   },
   "stable": {
    "version": [
@@ -22477,20 +22554,20 @@
   "repo": "KeyWeeUsr/dbml-mode",
   "unstable": {
    "version": [
-    20241116,
-    752
+    20241206,
+    706
    ],
-   "commit": "8baafca584012247859fe1a9e1d55eeed757a714",
-   "sha256": "0sf7qd5dsd11bawchf6mykxz2nmmisx2yjy933bphn3lqaczkg1a"
+   "commit": "fd2e4ec1356a63b05a15103631bd007bd089867c",
+   "sha256": "0ryjri1vf2pchznjgaxkplmnkvj4jixk7q6g6j930fg9s33jl07s"
   },
   "stable": {
    "version": [
     1,
     2,
-    0
+    1
    ],
-   "commit": "8baafca584012247859fe1a9e1d55eeed757a714",
-   "sha256": "0sf7qd5dsd11bawchf6mykxz2nmmisx2yjy933bphn3lqaczkg1a"
+   "commit": "fd2e4ec1356a63b05a15103631bd007bd089867c",
+   "sha256": "0ryjri1vf2pchznjgaxkplmnkvj4jixk7q6g6j930fg9s33jl07s"
   }
  },
  {
@@ -22516,15 +22593,15 @@
   "repo": "skk-dev/ddskk",
   "unstable": {
    "version": [
-    20230701,
-    2340
+    20241227,
+    2223
    ],
    "deps": [
     "ccc",
     "cdb"
    ],
-   "commit": "8c47f46e38a29a0f3eabcd524268d20573102467",
-   "sha256": "0k97n084wahsfmnv6xq2rifkclazbqp8482ap36iswvlqcmpkxn3"
+   "commit": "f81ed803e617ccd8175d4bf57a3062bc5ffe1945",
+   "sha256": "10kfgqgml8xg9jkghxzm0i4z2j6hjprkgqzgh1ac98m26lyczp9f"
   },
   "stable": {
    "version": [
@@ -22578,16 +22655,16 @@
   "repo": "Wilfred/deadgrep",
   "unstable": {
    "version": [
-    20241130,
-    2235
+    20241210,
+    1630
    ],
    "deps": [
     "dash",
     "s",
     "spinner"
    ],
-   "commit": "d89468d82abb778ef0938c5753be4498d5802a10",
-   "sha256": "0yaik954w89mg3vi6490p3c7aqjq885v5wg8gccdkaa2hl7acsdm"
+   "commit": "bb555790c6f404572d537e1e4adec8b4ff0515f5",
+   "sha256": "04jskm3qlxq7zvyvcn33gsjcd5312nzmrpznpkqai9gb1v2zhrd8"
   },
   "stable": {
    "version": [
@@ -22611,11 +22688,11 @@
   "url": "https://salsa.debian.org/emacsen-team/debian-el.git",
   "unstable": {
    "version": [
-    20241026,
-    559
+    20250103,
+    2349
    ],
-   "commit": "89e0fdfb0c6a387c1fd693b34ee9608d758d0742",
-   "sha256": "1qzg2yky3mjygl8347pn8kms6k6y6br9bii1yq9qnwvwabbxxln4"
+   "commit": "3e7afbae0513a237220b64b08f378b1f78eb460b",
+   "sha256": "0q9i4gbvl4g3fcs6ncfk0xfdj4v4zy4xqgwjlx1x4k6kx0m4k5a7"
   },
   "stable": {
    "version": [
@@ -22746,20 +22823,20 @@
   "repo": "KeyWeeUsr/decor",
   "unstable": {
    "version": [
-    20240818,
-    1100
+    20241210,
+    646
    ],
-   "commit": "f96828a9415f89eebe72a46b84aa047eb38279b9",
-   "sha256": "1jv11z29xn9gap6g62bx8w2pasmk3x986dhdps16ya0h5b39wpfy"
+   "commit": "fa91fd8dabc7e98d7c0fc5e01400aae90966b38d",
+   "sha256": "0nadpclb31fmbbmvfy8h2lbngz48fpfd6iqr6nvg153xdh7lq6fs"
   },
   "stable": {
    "version": [
     1,
     3,
-    1
+    2
    ],
-   "commit": "f96828a9415f89eebe72a46b84aa047eb38279b9",
-   "sha256": "1jv11z29xn9gap6g62bx8w2pasmk3x986dhdps16ya0h5b39wpfy"
+   "commit": "fa91fd8dabc7e98d7c0fc5e01400aae90966b38d",
+   "sha256": "0nadpclb31fmbbmvfy8h2lbngz48fpfd6iqr6nvg153xdh7lq6fs"
   }
  },
  {
@@ -22889,8 +22966,8 @@
   "repo": "jcs-elpa/define-it",
   "unstable": {
    "version": [
-    20240101,
-    933
+    20250101,
+    1006
    ],
    "deps": [
     "define-word",
@@ -22901,8 +22978,8 @@
     "s",
     "wiki-summary"
    ],
-   "commit": "a12331b5f4098b3cb0b046398fc3a34de1651de6",
-   "sha256": "0qxlpzb0bxyqndgg6pcz4y8kn78vzspvx690n4lsp1m85xdzra92"
+   "commit": "28e5ad9ef4bba59b61a9f1f4f5efe545e892540b",
+   "sha256": "1p08p54h5idsm1jv4hy8716c1n72qd5mph7lkb7hwxkcgp4i0raj"
   },
   "stable": {
    "version": [
@@ -23172,21 +23249,33 @@
  },
  {
   "ename": "denote-explore",
-  "commit": "f304db78b4bfeb4e1061b4ef221bf46e1bafe9d0",
-  "sha256": "0md432wh8yfsfhn87ncib04aziqj7mv3pfydj79d2k8dq95flyf5",
+  "commit": "47b58a99798e6366520d3a86f900fc6bd8744145",
+  "sha256": "18fzr8rlyhakjwbli387q1rz2mnx8c5r35rsg8pjl98d2frcprlf",
   "fetcher": "github",
   "repo": "pprevos/denote-explore",
   "unstable": {
    "version": [
-    20240825,
-    2045
+    20250105,
+    308
    ],
    "deps": [
     "dash",
     "denote"
    ],
-   "commit": "3d4b43f73210444942c95ee5db8e9976dfc9a1d9",
-   "sha256": "0d141146dapmrq3gby6ggnvdcp87zqj0amja3yjc2wr6s1z906fh"
+   "commit": "d2c1f94b6560d802755b010fcd4438068ddaa12f",
+   "sha256": "0773691jxyv039y407c8dppkky41b3icacavddcv9m8v481763b7"
+  },
+  "stable": {
+   "version": [
+    3,
+    3
+   ],
+   "deps": [
+    "dash",
+    "denote"
+   ],
+   "commit": "d2c1f94b6560d802755b010fcd4438068ddaa12f",
+   "sha256": "0773691jxyv039y407c8dppkky41b3icacavddcv9m8v481763b7"
   }
  },
  {
@@ -23562,6 +23651,35 @@
   }
  },
  {
+  "ename": "dicom",
+  "commit": "879fe6f4268ea058c6b1b6380dfbd1bc05917ffa",
+  "sha256": "0ixj9mg2q4s4457sxp0qd13q9cicgi3p904x8jc0a6clyz6nlh36",
+  "fetcher": "github",
+  "repo": "minad/dicom",
+  "unstable": {
+   "version": [
+    20250101,
+    915
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "9100999aa85a12828d73dc9b43f49af4929fc86d",
+   "sha256": "0dkdckyp73pizcfxj8qvc55wanz3q41qg5x550sb1san6b4jnsm3"
+  },
+  "stable": {
+   "version": [
+    0,
+    5
+   ],
+   "deps": [
+    "compat"
+   ],
+   "commit": "54440a704c573cd91b663ac79a01264a1aa59c51",
+   "sha256": "02n5wagcznl5fhyfh222kklj4z90pfrqpzm7q97agyx8bynzwr2p"
+  }
+ },
+ {
   "ename": "dictcc",
   "commit": "cdc15fbd060183e2b06f0c776075beddf7433f39",
   "sha256": "023r50vwc3bbbyfmn05lyfpq78cmjr076i2rjd064izbrybififp",
@@ -23655,11 +23773,11 @@
   "repo": "ideasman42/emacs-diff-ansi",
   "unstable": {
    "version": [
-    20240818,
-    2359
+    20241208,
+    511
    ],
-   "commit": "8edf92e34058f49788a085f490ad7ff169ef0d72",
-   "sha256": "17dm7b909j92hlfdz97k12mg7z71xvm9kncip36szflqrm14q33h"
+   "commit": "13f5938a087362776dd0e883734d48c610a0b379",
+   "sha256": "052gil83w9pylf63sqq2c3984gwy8jbr8a78ipyflwyas1l3yn80"
   }
  },
  {
@@ -23685,14 +23803,14 @@
   "repo": "dgutov/diff-hl",
   "unstable": {
    "version": [
-    20241128,
-    2332
+    20241205,
+    2338
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d9f54b512a0f583c6c3b51ce0c8ef62bffac7763",
-   "sha256": "1piy6ivq504zcgam9wabs5k2hinsmwj37wxlq0iy9qb0jhdakpdr"
+   "commit": "65a5de16e21c87b7c12a78a63fc3b57e07c03c86",
+   "sha256": "19ildcyyhakf7v1ycmk6srrsfxrj70mk6cs8m690wkxmh80fzgbj"
   },
   "stable": {
    "version": [
@@ -23808,15 +23926,16 @@
   "repo": "pkryger/difftastic.el",
   "unstable": {
    "version": [
-    20241030,
-    1038
+    20250104,
+    1325
    ],
    "deps": [
     "compat",
-    "magit"
+    "magit",
+    "transient"
    ],
-   "commit": "4980c08f7ad7777c364a3251bcc314b0f0d4d7dc",
-   "sha256": "1yrj9alg55rd4n9n3jsv3w2v8xv3b0bwi6xnw8fzs7zcdi4zn1n1"
+   "commit": "cfb5336ea97224d36883b2d6c05599094de94b77",
+   "sha256": "01av46zbwhfgr6xxim8r8x47llc63lwr66l8msfflvgxdw67zlz0"
   }
  },
  {
@@ -23844,26 +23963,26 @@
  },
  {
   "ename": "digistar-mode",
-  "commit": "851fa17152b664df99b80a654e5c055bb5227181",
-  "sha256": "0khzxlrm09h31i1nqz6rnzhrdssb3kppc4klpxza612l306fih0s",
+  "commit": "05a5f071cf34a94cb22a276f8d10ca46e5da535a",
+  "sha256": "1j2nq0yh0i08y490zmfbw7zpmqndgphqz9a9v1q5gqx9994jkqq9",
   "fetcher": "github",
   "repo": "retroj/digistar-mode",
   "unstable": {
    "version": [
-    20240814,
-    1546
+    20241229,
+    2007
    ],
-   "commit": "2d7e1a11304399f4a625053ffce8a3ad05f4ec7f",
-   "sha256": "1cybl34n18ib051lq5mnrg5f1b8j5rys2bly82x6a5ic640288dn"
+   "commit": "4c1ebcf22007ecc9e5b236864514b8b31c4b2576",
+   "sha256": "0kgc5mvf6k35q8j8ic0rzwydwgmn3xizv4nklv6m23jg8q66xjy3"
   },
   "stable": {
    "version": [
     0,
     9,
-    14
+    15
    ],
-   "commit": "4e5d0b463468fcc4a54df1310360ba13b2bdff6a",
-   "sha256": "10ng3dxckgzanxl4p4yn6syabhkzpiq49c9czdbfqhmabr5ayb3m"
+   "commit": "4c1ebcf22007ecc9e5b236864514b8b31c4b2576",
+   "sha256": "0kgc5mvf6k35q8j8ic0rzwydwgmn3xizv4nklv6m23jg8q66xjy3"
   }
  },
  {
@@ -24066,11 +24185,11 @@
   "repo": "jcs-elpa/diminish-buffer",
   "unstable": {
    "version": [
-    20240926,
-    16
+    20250101,
+    1007
    ],
-   "commit": "cc23f16e3735403eedde64078035240480a445f4",
-   "sha256": "0svp4hzyzxqqi30w088w62grdp92d19yhgj046bk3qn32ids63bb"
+   "commit": "6cc16c7b29b7f77b7df1fc59287551b1120a7bf7",
+   "sha256": "1j106rc9prcyj1l7yqlgvgryklma4zhg7gwx9zxm5k99c513bij1"
   },
   "stable": {
    "version": [
@@ -24154,11 +24273,11 @@
   "repo": "jamescherti/dir-config.el",
   "unstable": {
    "version": [
-    20240823,
-    1339
+    20241203,
+    322
    ],
-   "commit": "39b835572f0d170da51560b583b2416f0b84d2d0",
-   "sha256": "02xfazs28qrqbx4b3v4hl4qrvy32bwy8v58idigxrlg7m5iqqrw3"
+   "commit": "37cca7dae727c9c15f9bfd0fa6be17dd903fe1ef",
+   "sha256": "1ffblq9d8ksp8pyxlpaqz70kg5j2yb8bgrvn08vcwn7bm4ska7g8"
   },
   "stable": {
    "version": [
@@ -24418,30 +24537,6 @@
    ],
    "commit": "3ade0a31b5340271d05e9bf443f2504960f6c6dd",
    "sha256": "0lbm326na005k3pa11rqq5nbhvm55dydi2a7fzs3bzlqwbx7d6fq"
-  }
- },
- {
-  "ename": "dired-fdclone",
-  "commit": "8a0ddc10b11772d72a473e8d24ab4641bf4239a4",
-  "sha256": "11aikq2q3m9h4zpgl24f8npvpwd98jgh8ygjwy2x5q8as8i89vf9",
-  "fetcher": "github",
-  "repo": "knu/dired-fdclone.el",
-  "unstable": {
-   "version": [
-    20241201,
-    1626
-   ],
-   "commit": "e77bf1d5d2dcea903201e9c03fcdff9f0be72aa4",
-   "sha256": "1ch3kqidszva0cyhk3aj05jabcqcwj1xg93fx7zsd8qdir69s98f"
-  },
-  "stable": {
-   "version": [
-    1,
-    6,
-    3
-   ],
-   "commit": "e77bf1d5d2dcea903201e9c03fcdff9f0be72aa4",
-   "sha256": "1ch3kqidszva0cyhk3aj05jabcqcwj1xg93fx7zsd8qdir69s98f"
   }
  },
  {
@@ -24816,25 +24911,25 @@
   "repo": "xuhdev/dired-quick-sort",
   "unstable": {
    "version": [
-    20240805,
-    545
+    20250101,
+    2131
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "eaeab1021b391e3d6275ba7c186c5ac95fb8a10e",
-   "sha256": "1sxdiw1qwpr49a0l2q899r78mnwcwqhj4dfs22261acw7ifk07yb"
+   "commit": "68faa3abf52023edead271422a7ac76c0fd5c4e7",
+   "sha256": "1d4fxcf5dwq80p8jcxbvl4sd2g4kb8rlx9kvchwr8bg6wb237zir"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "79e422be55c72bfe36d2ec8a838f19d1cc8d101a",
-   "sha256": "14hb3d76y4n8qvfl74v9hzgl6774bqdcmsa0npv3gs144fbx9prk"
+   "commit": "9c5c7f3a89a978888ce00d4fdc4a6520b5fd003f",
+   "sha256": "1d4fxcf5dwq80p8jcxbvl4sd2g4kb8rlx9kvchwr8bg6wb237zir"
   }
  },
  {
@@ -24998,14 +25093,15 @@
   "repo": "jojojames/dired-sidebar",
   "unstable": {
    "version": [
-    20240522,
-    2316
+    20241205,
+    259
    ],
    "deps": [
+    "compat",
     "dired-subtree"
    ],
-   "commit": "702165ad53a473992d84e0207b984b9be5114bde",
-   "sha256": "0f9cikyb53ybsawkm9g1sja2wsz2lmnc9zq63sx2h8d86acza2cp"
+   "commit": "dd758094849a05c742868e8a9e57f47f7ec4d07a",
+   "sha256": "1kpg220q4hghdjcxmg87w09yr4z03f9knpf0zxs3wz4ggbllgh5g"
   },
   "stable": {
    "version": [
@@ -25144,6 +25240,30 @@
    ],
    "commit": "0ff2424aa226228c72e47a635f3b5379c424c891",
    "sha256": "01pxm6n7pcp11zbqrhv8hcr44wb1s08zw1gwpfqd3grdkmyqql8j"
+  }
+ },
+ {
+  "ename": "diredfd",
+  "commit": "903b3658d8d36013463584ac4654e12d0f5cf1d0",
+  "sha256": "08jka1pszrbsmzfi6ppg52y41cvm16vhwwz7dwzfbjrg1jclyq49",
+  "fetcher": "github",
+  "repo": "knu/diredfd.el",
+  "unstable": {
+   "version": [
+    20241209,
+    623
+   ],
+   "commit": "d789710c7e9699dae6ca87dcbfc27641a85fa3b6",
+   "sha256": "0xlgzmx089whmmnka0ngz7mdxvdplci3b4xvxjdmsydxx99gj3q6"
+  },
+  "stable": {
+   "version": [
+    2,
+    0,
+    1
+   ],
+   "commit": "e234c0bf91649bd13de984f6ef1b2354565fd4ce",
+   "sha256": "0yb7918kxja9lsri4ak3pkksvs32picw3yg3b8x9j6vp4zd7gd3j"
   }
  },
  {
@@ -25322,14 +25442,14 @@
   "repo": "alexluigit/dirvish",
   "unstable": {
    "version": [
-    20230519,
-    1500
+    20250101,
+    2121
    ],
    "deps": [
     "transient"
    ],
-   "commit": "119f9f59a618bb7b476c93e9ab1d7542c5c1df41",
-   "sha256": "00ap23b6q6qay2hz4nyvf9xsmib68hdf47gwyg9gjlq85qhagw41"
+   "commit": "2682932fb407f233712fe39cf5028163586be0f1",
+   "sha256": "0655prr87mc9llas2far3sqlq71b569a75gi1xf6x4iakh9dc1j2"
   },
   "stable": {
    "version": [
@@ -25595,26 +25715,26 @@
   "repo": "aurtzy/disproject",
   "unstable": {
    "version": [
-    20241128,
-    2134
+    20241226,
+    2043
    ],
    "deps": [
     "transient"
    ],
-   "commit": "15431e0d6947682ffba80f89e70918c86745eb57",
-   "sha256": "0d5bbkzzklr2v2b431mxf5xqm4vdbk220ihwyf90m12b5iq6gzp0"
+   "commit": "1062f228a62ec87fe4c40e46bae098117b412790",
+   "sha256": "15qj84l3dwh4zbg890jkk48fpiiy7mr1i0ixk7zcs6hjl1p8as70"
   },
   "stable": {
    "version": [
     1,
-    2,
-    0
+    3,
+    1
    ],
    "deps": [
     "transient"
    ],
-   "commit": "15431e0d6947682ffba80f89e70918c86745eb57",
-   "sha256": "0d5bbkzzklr2v2b431mxf5xqm4vdbk220ihwyf90m12b5iq6gzp0"
+   "commit": "bbe8f5cb9a2b5ef7482d3a109c81d6622c55677a",
+   "sha256": "03wf14vilnysj9szcffsadhw86p68v3083dv98d99c8axm51n6hz"
   }
  },
  {
@@ -26043,11 +26163,11 @@
   "repo": "ideasman42/emacs-doc-show-inline",
   "unstable": {
    "version": [
-    20240616,
-    2345
+    20241208,
+    505
    ],
-   "commit": "cc363ed39f023642c4d8e7c91b26c802ca356fa3",
-   "sha256": "02kh8wk202qppac7l7ap8hknb1hbg06gi66w5cpxhp32lijh1m90"
+   "commit": "cc9d6b1d0dc0776331daa2d612c17473f1ddd337",
+   "sha256": "0hswfj09mrcjnl8f3px0glpjghl49z0g37i3s2kl428xaixdnfgf"
   }
  },
  {
@@ -26095,8 +26215,8 @@
   "repo": "Silex/docker.el",
   "unstable": {
    "version": [
-    20241111,
-    859
+    20241223,
+    1023
    ],
    "deps": [
     "aio",
@@ -26105,8 +26225,8 @@
     "tablist",
     "transient"
    ],
-   "commit": "ec2391a8e3404958cefee3dda23b2c89dcf807a2",
-   "sha256": "1wn3wks97vx74hgqc42q7fwblyarvjrbgcy2h1r7yf5cliwsl0v5"
+   "commit": "813c00410b40917cbfe7e8227ebd4fd60a027937",
+   "sha256": "0hki17wl3pwr0wnkdjw0kp2ga3sb0p29a66bm524zgnaplgladbl"
   },
   "stable": {
    "version": [
@@ -26318,14 +26438,14 @@
   "repo": "emacs-vs/docstr",
   "unstable": {
    "version": [
-    20240101,
-    901
+    20250101,
+    908
    ],
    "deps": [
     "s"
    ],
-   "commit": "f780904cffd40e34d72bef04f73c7e007c5f98c0",
-   "sha256": "04wczm6xlgj0390sys3g6ja3lc01sgcknw2b9l0fmmlav1hzq6v9"
+   "commit": "76bfff172a1b915165854ed1ad3478d0366d528f",
+   "sha256": "1w1lbaj51q9j0b8x2xf29lbc5hjb6fmhy19m533f31likm2cjjk2"
   },
   "stable": {
    "version": [
@@ -26496,16 +26616,16 @@
   "repo": "seagle0128/doom-modeline",
   "unstable": {
    "version": [
-    20241201,
-    1338
+    20241225,
+    206
    ],
    "deps": [
     "compat",
     "nerd-icons",
     "shrink-path"
    ],
-   "commit": "d4985f0f6ebbc125995fdfd5a909ba6afe692d7d",
-   "sha256": "175c8qa0bfa15d85dn1sajpyajbv1kmsqcn8z9a6xc9g88y8midd"
+   "commit": "9d6f0f9635ae722b6bd943a76e996f54443e373f",
+   "sha256": "1704ikj93j9wvf4gc7dvmbsrhnvjiyd8r2j5i1m4m63f2536gvby"
   },
   "stable": {
    "version": [
@@ -26829,11 +26949,11 @@
   "repo": "dracula/emacs",
   "unstable": {
    "version": [
-    20241102,
-    1301
+    20241217,
+    2145
    ],
-   "commit": "4e521e716c2c914d7003243238a00ed330cd17c9",
-   "sha256": "11jqkp1h2v05k7iasfhgx9j675md13iy8cf2bviyd3g2jz4p99fs"
+   "commit": "a3508f702f96ff262f213de4a49d173449e2cf32",
+   "sha256": "0qzsw6x5d1qpwfr29zkgd5wlafxk9b2x68pm4pyda99bmr9kd0dp"
   },
   "stable": {
    "version": [
@@ -27041,20 +27161,20 @@
   "repo": "positron-solutions/dslide",
   "unstable": {
    "version": [
-    20241128,
-    1102
+    20250102,
+    819
    ],
-   "commit": "c0e4aff0ac8a51df4020bd591d19bd749c92f024",
-   "sha256": "1ah1319lnjzvja5yv0qjb6jz5b0i3xaa5m708c1xgr4mxk3blzvs"
+   "commit": "be47f2dcb939779067f8c77c3493162bcf242b83",
+   "sha256": "0kznpg734vq4k0gz3scm176ak7z0pm7hc19mbnf7n0bba6pnybr5"
   },
   "stable": {
    "version": [
     0,
-    5,
-    5
+    6,
+    2
    ],
-   "commit": "0d9a1f6c27e0543e912213d0a5047999f9e5deb5",
-   "sha256": "02c4v3zv8q2dqln3lfn2055bnffafc7yczrn3jyvw0f9hcw77ibr"
+   "commit": "be47f2dcb939779067f8c77c3493162bcf242b83",
+   "sha256": "0kznpg734vq4k0gz3scm176ak7z0pm7hc19mbnf7n0bba6pnybr5"
   }
  },
  {
@@ -27305,11 +27425,11 @@
   "stable": {
    "version": [
     3,
-    16,
-    0
+    17,
+    1
    ],
-   "commit": "e4380ffddbdf924b3ec4c56048cd8331e1bf39ed",
-   "sha256": "0sxz15g1lhgm880glix2y0dinsidpv83ss7cvb2ff12rbjhk4a4w"
+   "commit": "12010a06d8ec7cdcf8a1f63b242e9626e1bd620f",
+   "sha256": "0z7vzkarwj5r6fg0fapniawjpyh8lzi4q3brg75f95n7dl8vcl7f"
   }
  },
  {
@@ -27602,11 +27722,20 @@
   "repo": "Lindydancer/dynamic-spaces",
   "unstable": {
    "version": [
-    20171027,
-    1851
+    20250102,
+    736
    ],
-   "commit": "97ae8480c257ba573ca3d06dbf602f9b23c41d38",
-   "sha256": "0qs7gqjl6ilwwmd21663345az6766j7h1pv7wvd2kyh24yfs1xkj"
+   "commit": "dade49afa9eb2700a02de0333935a28b39b15b7b",
+   "sha256": "0gfsxpb8lg2ylcvnd67b4n4z1bh9cv6bpx4vhhm1rmxaljskww2j"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "commit": "dade49afa9eb2700a02de0333935a28b39b15b7b",
+   "sha256": "0gfsxpb8lg2ylcvnd67b4n4z1bh9cv6bpx4vhhm1rmxaljskww2j"
   }
  },
  {
@@ -27955,20 +28084,20 @@
   "repo": "emacs-eask/eask",
   "unstable": {
    "version": [
-    20241123,
-    1454
+    20250101,
+    836
    ],
-   "commit": "106755df719ceb202d52146d436f370f5bf8f095",
-   "sha256": "04k7q2jka4dr2sbxx54i18y2j78rfky8fmghxk5sb3pvmkz0j7c1"
+   "commit": "25f7f00ad4d73aacca027d6e1ba6070b8b2019b0",
+   "sha256": "1i6pck66l45x0p04kayjrsvi0516z730wb68cpshyfrbc409narx"
   },
   "stable": {
    "version": [
     0,
     10,
-    1
+    2
    ],
-   "commit": "34c20849530c59547e032900bba87f5ef05f192a",
-   "sha256": "1jy29mjkw0a6y8aawsmzcq246m4bg85iq35jcl7kdjccwywpj1b7"
+   "commit": "1f8ca182fbd857598200d5a324c3913d610e7339",
+   "sha256": "19vkfn9h8yhsb533w4njq8f8w59krjybpganr4xc5kargydvmh4p"
   }
  },
  {
@@ -27979,14 +28108,14 @@
   "repo": "emacs-eask/eask-mode",
   "unstable": {
    "version": [
-    20240101,
-    819
+    20250101,
+    836
    ],
    "deps": [
     "eask"
    ],
-   "commit": "774bf05f2d778a107f27f8fa47034ad15f16395c",
-   "sha256": "00m1ha91clcjwnxyqszbdw7shgjy602x0f89jqmn1jqasf3wp1kb"
+   "commit": "9bab3ad0d9a7df6284daed9ecd2cbd89298b958f",
+   "sha256": "07651b7hblvhh4fw0ak9l9ny20cgsx2qxb3v09xyxnr1n9yl45i3"
   },
   "stable": {
    "version": [
@@ -28006,8 +28135,8 @@
   "repo": "emacs-eask/easky",
   "unstable": {
    "version": [
-    20240608,
-    744
+    20250101,
+    836
    ],
    "deps": [
     "ansi",
@@ -28016,8 +28145,8 @@
     "lv",
     "marquee-header"
    ],
-   "commit": "d75ec4865742a4939bd685360f8ec5b076bdcf77",
-   "sha256": "10zqx7kfjw6rzq0mqpj4s3sdb13rabw98bkgm9nddi387ffmamql"
+   "commit": "fbb64633a690ee1afe8aef873b7be3471e766788",
+   "sha256": "17xdwfq42mvklikfmpf6q6bsa8rli977rgd56z1z1zjif6p5x5jl"
   },
   "stable": {
    "version": [
@@ -28316,28 +28445,27 @@
   "repo": "joostkremers/ebib",
   "unstable": {
    "version": [
-    20241125,
-    1941
+    20241205,
+    1040
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "dabc7d5b14e4371475ddc1061e9c52f0ef91e671",
-   "sha256": "0y9w0b09djji6v1ayrqins7awms121q2k1z9mxyc0kl9d8q72n4d"
+   "commit": "5c68941d6580e5eb9b30ab5ed59a2f02581ec810",
+   "sha256": "19hsrkqk5ydhpfr91j87yp9s7lskkkggj65mq9awxslxm5w44awr"
   },
   "stable": {
    "version": [
     2,
-    44,
-    1
+    48
    ],
    "deps": [
     "compat",
     "parsebib"
    ],
-   "commit": "315a8b067059f7d2c4e19220586dfbb042161fc4",
-   "sha256": "1lba6556ilml3kq8fxd1nkmx3dank36n68v3msad0npkj8083xlb"
+   "commit": "0b5a6b71d723225f19720425fea8229dc77310c2",
+   "sha256": "11rm51lx5nz2drhjb4nm5ls57gz9rqf9wm51qp9r03rlvrr6v85c"
   }
  },
  {
@@ -28498,8 +28626,8 @@
   "repo": "ecukes/ecukes",
   "unstable": {
    "version": [
-    20240315,
-    2350
+    20241226,
+    1759
    ],
    "deps": [
     "ansi",
@@ -28509,8 +28637,8 @@
     "f",
     "s"
    ],
-   "commit": "11225972934b3cfe09ada87dd785f8dd0082b6e3",
-   "sha256": "0m3p25kxqzj4mndb7bpi6ymb309zsq46102g38yq244dsd3xwqdy"
+   "commit": "70cb0748b222b7c96ab9821ef898ffbdb45eacd8",
+   "sha256": "1z1shz6f106kqiihv3ffd1cvkx0lxnylalgbhfmy5wbjdpjy60f1"
   },
   "stable": {
    "version": [
@@ -29524,20 +29652,20 @@
   "url": "https://forge.tedomum.net/hjuvi/eide.git",
   "unstable": {
    "version": [
-    20240122,
-    1953
+    20250104,
+    2056
    ],
-   "commit": "d497539f00c33e3bee85d0f4b8ca367672fa2219",
-   "sha256": "0gsfmjm71xcwhrznalm49ic47d4x7l6rizmyqr8mb4x8sbdbjhgn"
+   "commit": "1ce9aeb3f535843d15cf90d3f5fb07ada3d347a4",
+   "sha256": "0wp4g4agnnrjbjdzwa7da5qmsa79pk8z1zrrz18aix2sbm32w34q"
   },
   "stable": {
    "version": [
     2,
     3,
-    1
+    2
    ],
-   "commit": "8cabc6d77b41bf0c9982ab56530c088d980bc353",
-   "sha256": "02hbvs6dqjcjiws3672frgbnr62l2biqjqs0npkhz6b50h99gzzr"
+   "commit": "7e163774a6a7e1e9f93e7045d3d239e35c424933",
+   "sha256": "0z0c2k0grap483zzkzhiaii3w9p4dgcpnzvmmywclflvylvzhqv5"
   }
  },
  {
@@ -29848,26 +29976,26 @@
   "repo": "meedstrom/el-job",
   "unstable": {
    "version": [
-    20241201,
-    1208
+    20241229,
+    1444
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1bb6865aae4368b6e9f7491bd7c3f3e6fb1d7e7c",
-   "sha256": "1762ck9zp5p9qykf6spl0fs89k7drznjrm3q59j2lgwf1i0dzb9m"
+   "commit": "5c28a27d993c295527e9fa6c0b5d833a9bdcc1f7",
+   "sha256": "0zwnp4larmfbkzlrjhk3qwr25350hf1k859iswzifmkpxcclj70w"
   },
   "stable": {
    "version": [
     0,
     3,
-    15
+    19
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1bb6865aae4368b6e9f7491bd7c3f3e6fb1d7e7c",
-   "sha256": "1762ck9zp5p9qykf6spl0fs89k7drznjrm3q59j2lgwf1i0dzb9m"
+   "commit": "5c28a27d993c295527e9fa6c0b5d833a9bdcc1f7",
+   "sha256": "0zwnp4larmfbkzlrjhk3qwr25350hf1k859iswzifmkpxcclj70w"
   }
  },
  {
@@ -30263,20 +30391,19 @@
   "repo": "emacs-eldev/eldev",
   "unstable": {
    "version": [
-    20241129,
-    2121
+    20241217,
+    1230
    ],
-   "commit": "7001727c9cbb8ee29de7b9761afd887db8cb0a94",
-   "sha256": "1ckhr6h57d5rqzw30079pc92yv6125vls17nwylxvawbj24imng9"
+   "commit": "42f80c129264ab666e3ff589ee3bbc8f6c51a637",
+   "sha256": "0p00m7v1vsf4rs1w19ahy27lvf0wbrc5lh1243fyh74xllmg0kyi"
   },
   "stable": {
    "version": [
     1,
-    10,
-    3
+    11
    ],
-   "commit": "b5f583c70742ba371ff5c176d515c71d5407cf79",
-   "sha256": "0ha2ppxqp36m26nv6lyspq6m6xvvr03cf82rygq45w729gakdw9r"
+   "commit": "d9b35faade3d361a2a263511c16b8c1fe7614f5b",
+   "sha256": "144wf5im2fy1fv8jjik1s9zfyicphh2pi4dp6q4airrkiirmmr3m"
   }
  },
  {
@@ -30326,14 +30453,14 @@
   "repo": "emacs-eask/eldoc-eask",
   "unstable": {
    "version": [
-    20240101,
-    819
+    20250101,
+    837
    ],
    "deps": [
     "eask"
    ],
-   "commit": "ade0f239814f3b8bc77229e903d2c4b806ded90a",
-   "sha256": "1d1zzmsvgp2ww9a53j08v9pk10p2bjzf2937sd1szlhryssgvrmm"
+   "commit": "2433fa00abfa8d4b384aff022f496287e0975776",
+   "sha256": "1mbh62advmgpmd022qijmy5yid3zjg3h6zvzvz1rwx401j40jqdc"
   },
   "stable": {
    "version": [
@@ -30945,38 +31072,6 @@
   }
  },
  {
-  "ename": "elfeed-web",
-  "commit": "62459d16ee44d5fcf170c0ebc981ca2c7d4672f2",
-  "sha256": "14ydwvjjc6wbhkj4g4xdh0c3nh4asqsz8ln7my5vjib881vmaq1n",
-  "fetcher": "github",
-  "repo": "skeeto/elfeed",
-  "unstable": {
-   "version": [
-    20240729,
-    1741
-   ],
-   "deps": [
-    "elfeed",
-    "simple-httpd"
-   ],
-   "commit": "904b6d4feca78e7e5336d7dbb7b8ba53b8c4dac1",
-   "sha256": "0yq93abyadzrmcd40pi06wcr4jg9ddhlz2phg0wjypprqvv4q49z"
-  },
-  "stable": {
-   "version": [
-    3,
-    4,
-    2
-   ],
-   "deps": [
-    "elfeed",
-    "simple-httpd"
-   ],
-   "commit": "904b6d4feca78e7e5336d7dbb7b8ba53b8c4dac1",
-   "sha256": "0yq93abyadzrmcd40pi06wcr4jg9ddhlz2phg0wjypprqvv4q49z"
-  }
- },
- {
   "ename": "elfeed-webkit",
   "commit": "75394f3a128e21c730ca755fca540c4723436733",
   "sha256": "1zy670h0xknrqzhy9vvhlfpn7q4ws3qxr47gwrmw6m51s6w30fyn",
@@ -31062,8 +31157,8 @@
   "repo": "s-kostyaev/elisa",
   "unstable": {
    "version": [
-    20241123,
-    2205
+    20250102,
+    1639
    ],
    "deps": [
     "async",
@@ -31071,14 +31166,14 @@
     "llm",
     "plz"
    ],
-   "commit": "322d7eb839f1e981b8aa09a6ee4a7d6a22173772",
-   "sha256": "0slmp0fzmkww8al6w3h2b0vimbsppxbjrz29braw4j3lskq1isd7"
+   "commit": "bac0e51c7cad21ab25a0824ea816386ea78858b2",
+   "sha256": "1d6qz2skpnbm66yf5i8yd3l543frb6jp36fn325d3jw35kw29799"
   },
   "stable": {
    "version": [
     1,
     1,
-    3
+    4
    ],
    "deps": [
     "async",
@@ -31086,8 +31181,8 @@
     "llm",
     "plz"
    ],
-   "commit": "322d7eb839f1e981b8aa09a6ee4a7d6a22173772",
-   "sha256": "0slmp0fzmkww8al6w3h2b0vimbsppxbjrz29braw4j3lskq1isd7"
+   "commit": "bac0e51c7cad21ab25a0824ea816386ea78858b2",
+   "sha256": "1d6qz2skpnbm66yf5i8yd3l543frb6jp36fn325d3jw35kw29799"
   }
  },
  {
@@ -31364,14 +31459,14 @@
   "repo": "wkirschbaum/elixir-ts-mode",
   "unstable": {
    "version": [
-    20240820,
-    947
+    20241228,
+    919
    ],
    "deps": [
     "heex-ts-mode"
    ],
-   "commit": "b35c983f551ccf821ebebad50747b5b417133e52",
-   "sha256": "0cdkcrjnljdc6nq7ljyrdcfz3x7h1chjrq2b8fbh8xk2fmq8wgqa"
+   "commit": "143b94f4a5ac1f161c232e3f25b84c6768be2f25",
+   "sha256": "18fa062bygiaprph5ysz2xy2nwi1xlzhf89kn48d31a7qq0rk592"
   }
  },
  {
@@ -31412,8 +31507,8 @@
   "repo": "s-kostyaev/ellama",
   "unstable": {
    "version": [
-    20241129,
-    2147
+    20250102,
+    1513
    ],
    "deps": [
     "compat",
@@ -31421,14 +31516,14 @@
     "spinner",
     "transient"
    ],
-   "commit": "d4927093e2988084eac86c3254a7b7f5d4cbd761",
-   "sha256": "1abjp70q9ms6kdd1rs4zcrqzz0hfy7a5bizgl0ddrx7r0sfk9r06"
+   "commit": "d208ec10cebbea5412e6dd333f741a2be7919f87",
+   "sha256": "15p9mdkjda7q9s2wgl4k74bwh72agk5f35al8fpfyzpk3187gpm5"
   },
   "stable": {
    "version": [
     0,
     13,
-    0
+    1
    ],
    "deps": [
     "compat",
@@ -31436,8 +31531,8 @@
     "spinner",
     "transient"
    ],
-   "commit": "d4927093e2988084eac86c3254a7b7f5d4cbd761",
-   "sha256": "1abjp70q9ms6kdd1rs4zcrqzz0hfy7a5bizgl0ddrx7r0sfk9r06"
+   "commit": "d208ec10cebbea5412e6dd333f741a2be7919f87",
+   "sha256": "15p9mdkjda7q9s2wgl4k74bwh72agk5f35al8fpfyzpk3187gpm5"
   }
  },
  {
@@ -31836,8 +31931,8 @@
   "repo": "jorgenschaefer/elpy",
   "unstable": {
    "version": [
-    20240109,
-    1445
+    20241227,
+    2255
    ],
    "deps": [
     "company",
@@ -31846,8 +31941,8 @@
     "s",
     "yasnippet"
    ],
-   "commit": "777e9909c8f1c11f1cfb8dbf5fe4a66d2ab95e1e",
-   "sha256": "0acnlp60f2c9fmjac51xjg9r8qr39al2v5j6yd2mb6hi95sxbz3c"
+   "commit": "bcfd5e8c25e5efbcb26cfcf389f1bf01c2e2f44f",
+   "sha256": "00vvwa7h371fnq687mvccnlv38mjwzlr6h6yrzg0s8bl8vjg85q3"
   },
   "stable": {
    "version": [
@@ -32179,28 +32274,28 @@
   "repo": "emacscollective/elx",
   "unstable": {
    "version": [
-    20241123,
-    2125
+    20250101,
+    1415
    ],
    "deps": [
     "compat",
     "llama"
    ],
-   "commit": "02ceae51c97ee0b05433c58faf874f68a88fa255",
-   "sha256": "0m67xcb1aks29c9zymlwmvkaswzpb8vx9m6x3s6qg9y13kvnxmhh"
+   "commit": "bc6f3c20fff7f1e6fe424e6573b0932d8eb291b8",
+   "sha256": "1j3h45gmqb2zl72ia7h60xp89cjwb9jnirf9sbh8xgbhxhk4wihh"
   },
   "stable": {
    "version": [
     2,
     0,
-    3
+    4
    ],
    "deps": [
     "compat",
     "llama"
    ],
-   "commit": "be1afda54a182c726d7f0c584b2ac4854384ffda",
-   "sha256": "02wy4wsp2lk07kwb2pzi9bsb947walsndbjgllqpc35bhky50l0k"
+   "commit": "bc6f3c20fff7f1e6fe424e6573b0932d8eb291b8",
+   "sha256": "1j3h45gmqb2zl72ia7h60xp89cjwb9jnirf9sbh8xgbhxhk4wihh"
   }
  },
  {
@@ -32211,14 +32306,14 @@
   "repo": "lanceberge/elysium",
   "unstable": {
    "version": [
-    20241102,
-    2222
+    20241203,
+    2249
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "dcb194e0e49e2c1864e0fa2ccec3d7e37b0a44b6",
-   "sha256": "0cygwyg0x136h6im8n87lpw8vck2zava87bqhjv2pp6ibjw3nsqw"
+   "commit": "1847dc71bef86e1828be34539a9ae60c3debedc4",
+   "sha256": "1ci5zbhxmyfkvbz3ssqlaa4s9j9pi6z1k77jqax30cxf8q8j5dqm"
   },
   "stable": {
    "version": [
@@ -32256,20 +32351,20 @@
   "repo": "knu/emacsc",
   "unstable": {
    "version": [
-    20241119,
-    1435
+    20241206,
+    557
    ],
-   "commit": "0868b7f52adae264fb79e10e57a7481632eee76e",
-   "sha256": "1hs8arpbw1q1y3mwz2kyanqp2qs6pfbzfk9icba0cavk481whhjv"
+   "commit": "810f5e8b97e3046bdc7b0195067335b8eecb0bcb",
+   "sha256": "0wc7f6sgwykkmm8awyim9iv5pzjn4vmgmh4kjph4d4hv6n651mdh"
   },
   "stable": {
    "version": [
     1,
-    5,
-    20241119
+    6,
+    20241206
    ],
-   "commit": "0868b7f52adae264fb79e10e57a7481632eee76e",
-   "sha256": "1hs8arpbw1q1y3mwz2kyanqp2qs6pfbzfk9icba0cavk481whhjv"
+   "commit": "810f5e8b97e3046bdc7b0195067335b8eecb0bcb",
+   "sha256": "0wc7f6sgwykkmm8awyim9iv5pzjn4vmgmh4kjph4d4hv6n651mdh"
   }
  },
  {
@@ -32653,29 +32748,28 @@
   "url": "https://git.savannah.gnu.org/git/emms.git",
   "unstable": {
    "version": [
-    20241129,
-    1513
+    20241227,
+    1254
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "c8b56ade72452b3fe1d3eed7b6d2518d592db386",
-   "sha256": "0xwcyq1i4jf51rzp5nam9wk1mmd12n00459z443r5fc390vgzi0p"
+   "commit": "28127920e4e7dfb225bcff250e1efef30d347663",
+   "sha256": "05ynmzgspc66z3i6r95lk302zyx78yn7m6ap3s1dvqb14ykx6gn7"
   },
   "stable": {
    "version": [
-    20,
-    2
+    21
    ],
    "deps": [
     "cl-lib",
     "nadvice",
     "seq"
    ],
-   "commit": "b7e4a4cdbdb7e55300882d6c9a4f71048ec298d5",
-   "sha256": "1csgnhczw761j9kl1kfb173rla31lyyjq5f48m98h92nb07yc9xc"
+   "commit": "a01df752e19458c011dc838bc40a4474728f644e",
+   "sha256": "0dh5iil9liaxmix8g9ha0wyg788zdpmfyabd7z6sn9m7rw48vv22"
   }
  },
  {
@@ -32954,15 +33048,15 @@
   "repo": "jcs-elpa/emoji-github",
   "unstable": {
    "version": [
-    20240101,
-    935
+    20250101,
+    1007
    ],
    "deps": [
     "emojify",
     "request"
    ],
-   "commit": "0f42d10854239b751a2ae06caa43bcf387f43d4d",
-   "sha256": "0pbm7yfp0swyrn8dnyf0fn6yih32wmjwji2qn9v27lkxmsm9v6vy"
+   "commit": "ec055ddb0c650671112fb254257f413f4755e75a",
+   "sha256": "1cwsc0ghcbg1ixmwc0z8vjhkyvk1dvv43lmrhcz3g0fgqiz0ff4v"
   },
   "stable": {
    "version": [
@@ -33065,28 +33159,28 @@
   "repo": "isamert/empv.el",
   "unstable": {
    "version": [
-    20241006,
-    1234
+    20241231,
+    1639
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "ed38218885b99ddccbafb8a37482228a61d87d65",
-   "sha256": "1n6s6a79bfj3lganag3qyc8pnnc1bavplwgq5y4wdachmiagbls9"
+   "commit": "ee29a3ea6459f68100e6365ac150a220b8c80700",
+   "sha256": "16xplsbiv1ybaws3n7xlysyqgx78haa9m260r4z8w5zfvl0h0lxz"
   },
   "stable": {
    "version": [
     4,
-    5,
+    9,
     0
    ],
    "deps": [
     "compat",
     "s"
    ],
-   "commit": "ccfe44bbfa79a2a4d2cab06b807d494d4e85d45b",
-   "sha256": "1qwbxhdcl2vvdf0sjgl1iafh47rgbabzmjjwg6jq32p7q64pw6dr"
+   "commit": "ee29a3ea6459f68100e6365ac150a220b8c80700",
+   "sha256": "16xplsbiv1ybaws3n7xlysyqgx78haa9m260r4z8w5zfvl0h0lxz"
   }
  },
  {
@@ -33253,15 +33347,15 @@
   "repo": "jamescherti/enhanced-evil-paredit.el",
   "unstable": {
    "version": [
-    20241201,
-    2142
+    20241202,
+    2305
    ],
    "deps": [
     "evil",
     "paredit"
    ],
-   "commit": "cc5218d3487605d67056a5738a82875363c61eeb",
-   "sha256": "1annrn991yvqjy5nbxjkxr06xjnwa4prijlilklsc2d8a20n5cyr"
+   "commit": "e4b6c1fd000454d8b7730cc072069cc194f8a2bc",
+   "sha256": "1n26rm0dnknv206spck7cgbpwwv0xg790yb3jzp6jirbw54a59ll"
   },
   "stable": {
    "version": [
@@ -33574,8 +33668,8 @@
   "repo": "emacscollective/epkg",
   "unstable": {
    "version": [
-    20241123,
-    2129
+    20250101,
+    1751
    ],
    "deps": [
     "closql",
@@ -33583,14 +33677,14 @@
     "emacsql",
     "llama"
    ],
-   "commit": "cb104ca2f22686f94bbaba6b96eda0f22c094184",
-   "sha256": "0sym9q4i35cgp02vk3an52j9v9ysj1fnyv0nryi4g78jlxnawhn0"
+   "commit": "d28ce2f7d57c2f082506d25e653b68673daf33c2",
+   "sha256": "0zdlymx44jgrzm68cnh636mpdazihqiakf5m3v1c2rhvh6cb6yg6"
   },
   "stable": {
    "version": [
     4,
     0,
-    2
+    3
    ],
    "deps": [
     "closql",
@@ -33598,8 +33692,8 @@
     "emacsql",
     "llama"
    ],
-   "commit": "f568083014664cc63eb942ee04a925634527793e",
-   "sha256": "1kg0jd8067brd4772sd6r0lj7vbf5pxhbj916nd6293a0hc10i58"
+   "commit": "d28ce2f7d57c2f082506d25e653b68673daf33c2",
+   "sha256": "0zdlymx44jgrzm68cnh636mpdazihqiakf5m3v1c2rhvh6cb6yg6"
   }
  },
  {
@@ -33739,14 +33833,14 @@
   "repo": "emacsomancer/equake",
   "unstable": {
    "version": [
-    20240801,
-    1619
+    20241223,
+    1825
    ],
    "deps": [
     "dash"
    ],
-   "commit": "2506c058fc8cc51539e80d093c9bcdac87720216",
-   "sha256": "0p8b016kqnxhvpb74p54s156qqvrvw20j67if5484y4lkdzispjs"
+   "commit": "1ab9d567830bce355670455c0a91bf2e2730c919",
+   "sha256": "1gy6gxpmw2d649xyvsz4ci2h734f3pgl7ny7ckpng7s1z6p6dqkb"
   }
  },
  {
@@ -33787,11 +33881,11 @@
   "repo": "thisirs/erc-colorize",
   "unstable": {
    "version": [
-    20170107,
-    1339
+    20241205,
+    1612
    ],
-   "commit": "d026a016dcb9d63d9ac66d30627a92a8f1681bbd",
-   "sha256": "1zzmsrlknrpw26kizd4dm1g604y9nkgh85xal9la70k94qcgv138"
+   "commit": "998a37e950dc2ad026bdd192b37889f65d4e858e",
+   "sha256": "0aflxlq5gispm1zvdvbybwv4cnn42ac8dl8zc96fsly30g384ia4"
   }
  },
  {
@@ -34291,20 +34385,19 @@
   "repo": "erlang/otp",
   "unstable": {
    "version": [
-    20241107,
-    1409
+    20241217,
+    813
    ],
-   "commit": "7cbfeee1e0d5a7645fa5931ae916eb944520fb17",
-   "sha256": "0v1b2aq5klpwk7jiiyyllcnyv8h2x14ah62q3d87sw6qblm0yq2s"
+   "commit": "11e5e81a95795b3c17dedc94d20297e20d994f03",
+   "sha256": "1dyy0fma0p6lm2xbyw5law0qji10zvjp8qydd4d1s162iphnpbza"
   },
   "stable": {
    "version": [
     27,
-    1,
     2
    ],
-   "commit": "44ffe8811dfcf3d2fe04d530c6e8fac5ca384e02",
-   "sha256": "1j4dihlbrfz95552fmb5dj8341w4qimnk0hv42n6yp1xz8qckcds"
+   "commit": "6bf99d64a0df3feceb25c166c3a3cb3f80594f59",
+   "sha256": "00zk0cziyylmzg63gq3h5p2p348ahg2wp5h8zhbva4h3v5w6fi7j"
   }
  },
  {
@@ -34995,19 +35088,19 @@
   "repo": "akreisher/eshell-syntax-highlighting",
   "unstable": {
    "version": [
-    20240701,
-    502
+    20241222,
+    2030
    ],
-   "commit": "26f49633308ea876b5850256e07622de34ad0bdd",
-   "sha256": "1p2lqx3rzfmn1lamnx9ns5mr0svjqamx7ah9342l30bmv87skz1h"
+   "commit": "62418fd8b2380114a3f6dad699c1ba45329db1d2",
+   "sha256": "1483a8wcnzlck789445gvq32l2hd2nxfhlbn2vjsy3j0ilc09j7x"
   },
   "stable": {
    "version": [
     0,
-    6
+    7
    ],
-   "commit": "c43f83983dad5f89d842450b97239bb22b5236a7",
-   "sha256": "0maza5vh22psfxg5qavdayqr40aw8jc95bjiz5dwm0xga55clbfg"
+   "commit": "8f8ab503359cd4570db2b46ebeed59085d619208",
+   "sha256": "1v3217r9bwlgzjx0g8m7rqqba405wx4xmsg1dm190cl10ai8xda5"
   }
  },
  {
@@ -35353,11 +35446,11 @@
   "repo": "emacs-ess/ESS",
   "unstable": {
    "version": [
-    20241127,
-    1620
+    20241216,
+    1709
    ],
-   "commit": "e7b0bbc4ac40e6ea209c345042e280d3af0c6d07",
-   "sha256": "0ikp872gfhibc0q5rd5h5lxvnj7vqb2sqz1lbf26wy1j5bzn9lf7"
+   "commit": "dda9a9400b2d03b2fdae25045d2af08a37f907ee",
+   "sha256": "18vriqck8x85gw13qcgcn3gzv0k94y49wmqaxfcgzwg7gcv7clvz"
   },
   "stable": {
    "version": [
@@ -35984,14 +36077,14 @@
   "repo": "daedsidog/evedel",
   "unstable": {
    "version": [
-    20241124,
-    1710
+    20241215,
+    2233
    ],
    "deps": [
     "gptel"
    ],
-   "commit": "baba80b7e38935cd9209aa24867f87aa862ee4ab",
-   "sha256": "0alkmfrqqqpxdfj1gkxr0v1hwf8ixa6wgbd7x2pbbkj89srsp61s"
+   "commit": "d1c7d008fce74bc738231e18064708b2f0d4d710",
+   "sha256": "1p0ncycwh4y6fn8pwxniizmn7h4qlgn2ljsaa8ijbpm5rgydx9cq"
   },
   "stable": {
    "version": [
@@ -36014,11 +36107,11 @@
   "repo": "mekeor/evenok",
   "unstable": {
    "version": [
-    20241031,
-    2134
+    20241207,
+    2102
    ],
-   "commit": "06a84eea4cf9a845266f8bde68abe25d85bd2b77",
-   "sha256": "0fblw7h0w40ipixa0jiwli7hrc8bw7gva61wzblw9xdb0hscx3rk"
+   "commit": "e39c589714c737633fd1302636526ac7cf4fadab",
+   "sha256": "0r9gmff6bw51mk4lqswayg697idsznzklmvxdz8k4kdvprdwkpgk"
   },
   "stable": {
    "version": [
@@ -36061,16 +36154,16 @@
   "repo": "emacs-evil/evil",
   "unstable": {
    "version": [
-    20241006,
-    1754
+    20241229,
+    1623
    ],
    "deps": [
     "cl-lib",
     "goto-chg",
     "nadvice"
    ],
-   "commit": "b7ab3840dbfc1da5f9ad56542fc94e3dab4be5f1",
-   "sha256": "0y2yrxrdcd0ddyby9yrygyyfvdas5zf7y090r5lcaa6l71fj1cgy"
+   "commit": "cc1a7bde72b38cba3f3612aac460fce57f7c3f68",
+   "sha256": "104kwsvz7vbhff10a9h3mrnn7ph3ylfn6fsbr6arby6cgsjp23c0"
   },
   "stable": {
    "version": [
@@ -36263,15 +36356,15 @@
   "repo": "emacs-evil/evil-collection",
   "unstable": {
    "version": [
-    20241201,
-    1942
+    20241217,
+    1415
    ],
    "deps": [
     "annalist",
     "evil"
    ],
-   "commit": "ed8c652b1f49e3b01d787bf33ccb2345399572d4",
-   "sha256": "15ivxqdp90snkq40qvsvf86ndd6c58nsqsd87fvdp1y0f7v97clz"
+   "commit": "a0af9fea1dffcddd5465aa5c67fe3020acafb092",
+   "sha256": "1ljn7yxzywzbwzin49gl5zdniq0aizb9wf84cx1y7mzwk2yck5xa"
   },
   "stable": {
    "version": [
@@ -36394,15 +36487,15 @@
   "repo": "emacsorphanage/evil-escape",
   "unstable": {
    "version": [
-    20231122,
-    2114
+    20241212,
+    1318
    ],
    "deps": [
     "cl-lib",
     "evil"
    ],
-   "commit": "bdb1e69971520cbd65fe61830a1cdea5734d743c",
-   "sha256": "0vdmzp4hxqvng5pw3iz7flc36ndaphnia8s1cg229i8vm27lrmqy"
+   "commit": "aebd1a78a6bd33e5164e7552096b3fe1172d3012",
+   "sha256": "113srj71ayzq5wrn4zma99jbajb77xkl8rh8d19n6cbwwl028y3z"
   },
   "stable": {
    "version": [
@@ -36841,20 +36934,20 @@
   "repo": "redguardtoo/evil-matchit",
   "unstable": {
    "version": [
-    20241111,
-    1201
+    20241205,
+    641
    ],
-   "commit": "19a6cad56bf1080fc526107ff48f2948f2511970",
-   "sha256": "1qri6gnbyblmmvc3lygil6gfinpa9ygprjd38svczj756vrr95js"
+   "commit": "84a6d34c1a1282c43c6ccef2ead3eaa41fd1535f",
+   "sha256": "06ayyw8nim5fi819hr30x54wx2ba6aqvlh7r0vld06xc0zsjdhm3"
   },
   "stable": {
    "version": [
-    3,
+    4,
     0,
-    4
+    1
    ],
-   "commit": "1c4fefa9bb11cc4b1d7f10614d2021c12ed12e89",
-   "sha256": "1m5y5n38w0ijzx2kl9d0nnw70ykx2prmnvv4ip9siad71k7wpwjg"
+   "commit": "84a6d34c1a1282c43c6ccef2ead3eaa41fd1535f",
+   "sha256": "06ayyw8nim5fi819hr30x54wx2ba6aqvlh7r0vld06xc0zsjdhm3"
   }
  },
  {
@@ -37041,14 +37134,14 @@
   "repo": "juliapath/evil-numbers",
   "unstable": {
    "version": [
-    20240416,
-    140
+    20241208,
+    523
    ],
    "deps": [
     "evil"
    ],
-   "commit": "c7899894515d6be40dfcd589fb27c1801c5b199c",
-   "sha256": "0nr07k1c99xdiiz5bpn0rlr2f8qvca21smpcyyxk70cxfpwksd0s"
+   "commit": "f4bbb729eebeef26966fae17bd414a7b49f82275",
+   "sha256": "0gqx0cvpi9cjr9f811ry6294bck919zblq6vib8722b2pfj8mani"
   },
   "stable": {
    "version": [
@@ -38384,10 +38477,10 @@
  },
  {
   "ename": "exotica-theme",
-  "commit": "c3543d83fa2e0ed2b8b313f3c9e7a2c6f42b5085",
-  "sha256": "0jf18siqbwilx9v0mlm6v5k03c1v9jm4xdlk183bnrad09rdw6qh",
+  "commit": "ca71d6b596e2595f356f7848e202b2450d395f49",
+  "sha256": "0bzibc1s7a2qxh03573q43dw4pk1svrvh17n6nzxznag8abnndqn",
   "fetcher": "github",
-  "repo": "zenobht/exotica-theme",
+  "repo": "sacredyak/exotica-theme",
   "unstable": {
    "version": [
     20180212,
@@ -38420,11 +38513,11 @@
   "repo": "magnars/expand-region.el",
   "unstable": {
    "version": [
-    20240919,
-    1427
+    20241217,
+    1840
    ],
-   "commit": "541d971f7c77ca5c0f66c88bcbfeb0d165883023",
-   "sha256": "0i612v2v5s2yjj69wq92rm8qsm5cpqaksslwp02pf64hkf50ylmw"
+   "commit": "351279272330cae6cecea941b0033a8dd8bcc4e8",
+   "sha256": "1d6lvds7wfp9xsx5mh4x4sgync295r0bw0akmv136j5ks56xigf1"
   },
   "stable": {
    "version": [
@@ -38574,11 +38667,11 @@
   "url": "https://repo.or.cz/external-dict.el.git",
   "unstable": {
    "version": [
-    20241101,
-    1326
+    20250104,
+    330
    ],
-   "commit": "3515a8d3485cede35e8cfcf791a83ce30d0f728e",
-   "sha256": "1286isnlxj5lgx7yw4m1a4k9crgc0a8in60hkcizizh3amy4jspw"
+   "commit": "018cc2bad2e8bf29914d39b0119e836fa0f9dc18",
+   "sha256": "0gr694nw01kdk5ki0n4sahyscihv6yp9hrwly8mrwcqd5bah7qip"
   }
  },
  {
@@ -39183,6 +39276,30 @@
   }
  },
  {
+  "ename": "fancy-urls-menu",
+  "commit": "4789ccf260c0c46af32fb30e35fac1d9010110be",
+  "sha256": "07b84sm980g4n50k73gsvpihqkx5ksjwsghxij57c1632zbd4c9j",
+  "fetcher": "codeberg",
+  "repo": "kakafarm/emacs-fancy-urls-menu",
+  "unstable": {
+   "version": [
+    20241216,
+    2300
+   ],
+   "commit": "88135b9964edd47f849830308e9be17813598432",
+   "sha256": "16apb0zkzrg88np7dq20jy75v1zfmd7a9l7fpqr87lwdr8zkmbxj"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    0
+   ],
+   "commit": "4a817ef24a91fb8e53cbece1a8351321c919d62a",
+   "sha256": "0zk5dnprsybnz153xqz5gwdlnvwsga7b836ygg4yrcaqwdd96ar9"
+  }
+ },
+ {
   "ename": "fantom-mode",
   "commit": "d03bcaa727ca822e80f50e9f2e9924be1d9e8c11",
   "sha256": "1d9d0nibj69haj4mlqlz9hakf86svc7p1zrkcb0a5hzr0691p92p",
@@ -39530,14 +39647,14 @@
   "repo": "martianh/fedi.el",
   "unstable": {
    "version": [
-    20241020,
-    1139
+    20250102,
+    1603
    ],
    "deps": [
     "markdown-mode"
    ],
-   "commit": "0b59528b738229421faf4c0b32033150902e5af4",
-   "sha256": "0sl1yq9c9yvb8vrmg4a4dd4x93ajpr3c8mbkiv4yxd4nrxy6myfp"
+   "commit": "8f0afbb5cd264033f10ba58158a5e1f3737b16d4",
+   "sha256": "0lmjqwq0nrimcqs3j9cadl2yz0nvg250vy2l6czg2648x6fdvcc6"
   },
   "stable": {
    "version": [
@@ -39666,15 +39783,15 @@
   "repo": "jcs-elpa/ffmpeg-player",
   "unstable": {
    "version": [
-    20240101,
-    926
+    20250101,
+    1007
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "c3808dc1c39499a81e1b9463526fda924fd1f062",
-   "sha256": "0j0l5239wd14bf0qjr51d0vsx5cbbsfc02qzxzs163lkp9kklzr9"
+   "commit": "dfc78152925c62a575bb135f320b74c1b4a71f2c",
+   "sha256": "1cyyw19z2aj1c62ckvfg0z07k14k2fpqw556p540yh9xdi2n0i1k"
   },
   "stable": {
    "version": [
@@ -39828,8 +39945,8 @@
   "repo": "knpatel401/filetree",
   "unstable": {
    "version": [
-    20221108,
-    236
+    20241229,
+    1923
    ],
    "deps": [
     "dash",
@@ -39837,8 +39954,8 @@
     "seq",
     "transient"
    ],
-   "commit": "1c48ef63a639bfe1ae4d5095725ef88a3f2c590d",
-   "sha256": "1y20zz6n72g4bqlfxfjlc7zgpf2qpd7q6qn13bvrn47104v9qjli"
+   "commit": "dfdddc02a65b7af747f053593a9c9c2db73c45a5",
+   "sha256": "04p9416ybq3r5m9z0ynjwam4mi84bzvzgcl3da8gg8bv39r8w52d"
   }
  },
  {
@@ -39895,11 +40012,11 @@
   "repo": "jcs-elpa/fill-page",
   "unstable": {
    "version": [
-    20240423,
-    924
+    20250101,
+    1009
    ],
-   "commit": "c04d29a83d50c9f1dfc039c05c6508f8370514fd",
-   "sha256": "1z0ni6llpvdh9jwmnzvpxnyy4x605qyh07pwaqck7bxl12xc3wh3"
+   "commit": "b72340d478eead21e409a7a380bc2a61bb4d8732",
+   "sha256": "0nasiwm4gzh6dgvn8xiiac4zbajgqsq550qlfdbrj29acqgr9bz0"
   },
   "stable": {
    "version": [
@@ -39948,40 +40065,6 @@
    ],
    "commit": "ec406d76c97fd8a59df9308d60dba63061dc716a",
    "sha256": "114p7p4qby2mj6z1lz1gv4ca2cqgyr3c1v250ka9m2m46lnrml40"
-  }
- },
- {
-  "ename": "finalize",
-  "commit": "1b55869b5183644de02687d2e56f9b68854ccda3",
-  "sha256": "1n0w4kdzc4hv4pprv13lr88gh46slpxdvsc162nqm5mrqp9giqqq",
-  "fetcher": "github",
-  "repo": "skeeto/elisp-finalize",
-  "unstable": {
-   "version": [
-    20170418,
-    1945
-   ],
-   "deps": [
-    "cl-generic",
-    "cl-lib",
-    "eieio"
-   ],
-   "commit": "0f7d47c4d50f1c76fc3b43bfc2d4886dd3e8ca27",
-   "sha256": "1gvlm4i62af5jscwz0jccc8ra0grprxpg2rlq91d5nn8dn5lpy79"
-  },
-  "stable": {
-   "version": [
-    2,
-    0,
-    0
-   ],
-   "deps": [
-    "cl-generic",
-    "cl-lib",
-    "eieio"
-   ],
-   "commit": "0f7d47c4d50f1c76fc3b43bfc2d4886dd3e8ca27",
-   "sha256": "1gvlm4i62af5jscwz0jccc8ra0grprxpg2rlq91d5nn8dn5lpy79"
   }
  },
  {
@@ -40045,11 +40128,11 @@
   "repo": "redguardtoo/find-file-in-project",
   "unstable": {
    "version": [
-    20230506,
-    544
+    20241207,
+    1249
    ],
-   "commit": "889466d047ee93ab33fa8eaa4e1ef279d884f1da",
-   "sha256": "1vrr3fwifn3lpajh03rx5rzzgc5dks0p6154y1c7f49wqffds36p"
+   "commit": "53752d3ca67fb494e0854902ee54af56b200d279",
+   "sha256": "0kiqc451mrp9rqx84jx4d0sbnyyjx79s5nxq3chmyfv5c47wzrjc"
   },
   "stable": {
    "version": [
@@ -41125,11 +41208,11 @@
   "repo": "flycheck/flycheck",
   "unstable": {
    "version": [
-    20241130,
-    1502
+    20250104,
+    705
    ],
-   "commit": "ebaf48359b3e21879c8f6f3c1b5d0221b345035e",
-   "sha256": "1spbkhsdf7crns2wr4ghs1pdfwz2ff001pbbzmcc39v5d71pb5ri"
+   "commit": "e2a7f331d0e3c3f74981a805ef849cfdfb5657f1",
+   "sha256": "1kqljl40cvzg2ws6hr993zxpgyhm5y2jag959d2w3qgvbyj4p6l0"
   },
   "stable": {
    "version": [
@@ -41769,14 +41852,14 @@
   "repo": "flycheck/flycheck-deno",
   "unstable": {
    "version": [
-    20240101,
-    833
+    20250101,
+    902
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "5e4d66865d7d91e7af3b1b69b02dd540c9ea5aca",
-   "sha256": "0xqp9cycpsliizl7dknpxcvnlx3mcbrqdkp8a2imjxr4ss042pmd"
+   "commit": "47671457b649b2de422cd56f7b3950aabc015c1f",
+   "sha256": "1rsjyilrj3sm1giy1g0g3kzd4g65k3x4rsykfg291cr815fa7fai"
   },
   "stable": {
    "version": [
@@ -41921,14 +42004,14 @@
   "repo": "flycheck/flycheck-eask",
   "unstable": {
    "version": [
-    20240223,
-    1023
+    20250101,
+    901
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "c1c82b359bb94cbca29f2f0fb29b7f5132691d04",
-   "sha256": "05p04454sd3phd4w7i7rjdz861akd8ml55pjhxsnwpacgw05w8zn"
+   "commit": "f93e5dd30aa9f7c612823760867c2f361fde6631",
+   "sha256": "0zfck269hjax9hs1y46gy6b4dg2ymhlh583az3pad99mjhdfyl2m"
   },
   "stable": {
    "version": [
@@ -42194,14 +42277,14 @@
   "repo": "flycheck/flycheck-google-cpplint",
   "unstable": {
    "version": [
-    20240101,
-    833
+    20250101,
+    901
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "2330e8ed99d89010b652dcb8e9a9a546a9e6da3a",
-   "sha256": "1vqrxdprflz6zx01k1rcblzsamak708ny2hgik7nf63kbibpnnzz"
+   "commit": "9b2f8eeb46874cbb0c34caaa91ac3cdc3d0d6f56",
+   "sha256": "1zrphyisppbvga44pz1pp6zhcn3jdxzb37d62w7plbb56ydrf8fd"
   },
   "stable": {
    "version": [
@@ -42271,16 +42354,16 @@
   "repo": "emacs-grammarly/flycheck-grammarly",
   "unstable": {
    "version": [
-    20240101,
-    847
+    20250101,
+    849
    ],
    "deps": [
     "flycheck",
     "grammarly",
     "s"
    ],
-   "commit": "cb011efcc05b111bb4638cc42c24c5b11fc5f378",
-   "sha256": "12xrcwixfx6w5rcavgmxrr1nxlay2f6057g0clxfzyp5mk4aw342"
+   "commit": "3cb1853bcdf62856604a081c0d88ae09d69f1601",
+   "sha256": "0rsinzcwa767hib01hl36p9b6c5swfv45fhbq7dvv6g0zm0hkhrw"
   },
   "stable": {
    "version": [
@@ -42542,14 +42625,14 @@
   "repo": "flycheck/flycheck-inline",
   "unstable": {
    "version": [
-    20240709,
-    1812
+    20250101,
+    1908
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "de96ba2eb4619a9a7d891773629ec70f2be89aec",
-   "sha256": "1nh28p3sf1swxgip732lh9k9bmw1k4x4z0pnjw8ihcas4xw0bygy"
+   "commit": "0fece8283ceb7cb941f506b9f1e3f416a1c5aeda",
+   "sha256": "19i578jdvcxy23ww0588y2z29hkivp30zxk2bvlcd7nxrhzanpas"
   }
  },
  {
@@ -42718,14 +42801,14 @@
   "repo": "emacs-languagetool/flycheck-languagetool",
   "unstable": {
    "version": [
-    20241018,
-    1225
+    20250101,
+    852
    ],
    "deps": [
     "flycheck"
    ],
-   "commit": "03d023c78cca177901afe7223ee57a8e396dcf49",
-   "sha256": "0s11sn0qbq3g6dwrr9r476c59zmp5fya89pf71pl02jijd4a3gr4"
+   "commit": "24910498ea5c9588813cc2c602de935aebb06505",
+   "sha256": "1m0xnq3rynzq6y6zgq6czc8jyz09gn37a13c0fyqxqd0x6x8xikw"
   },
   "stable": {
    "version": [
@@ -43469,8 +43552,8 @@
  },
  {
   "ename": "flycheck-rtags",
-  "commit": "3dea16daf0d72188c8b4043534f0833fe9b04e07",
-  "sha256": "00v6shfs7piqapmyqyi0fk3182rcfa3p8wr2cm5vqlrana13kbw4",
+  "commit": "8f5d42452235ee9f1590fa8893c4ea3d40ac891b",
+  "sha256": "02cwz9pbg6xn6ka6f9m6af1v3yqzayaln8yc9qhz1ys6rb25svy1",
   "fetcher": "github",
   "repo": "Andersbakken/rtags",
   "unstable": {
@@ -43506,8 +43589,8 @@
   "repo": "flycheck/flycheck-rust",
   "unstable": {
    "version": [
-    20240205,
-    1018
+    20250101,
+    902
    ],
    "deps": [
     "dash",
@@ -43515,8 +43598,8 @@
     "let-alist",
     "seq"
    ],
-   "commit": "4d365ed1c9e8b8ac43561eb365d37ab555a6e617",
-   "sha256": "0qdbmy7g8pmaml7sdi9bfpadlb69cyavicwi0w3zb9fbhwqjzbpv"
+   "commit": "d499471ec433a62898a95ce76561964e3d015ce5",
+   "sha256": "09vjwk1k0z3lrl2z1hdf59v9cc2k3sac3vy3s6gcf4az9kvq38zh"
   },
   "stable": {
    "version": [
@@ -43964,11 +44047,11 @@
   "repo": "jamescherti/flymake-ansible-lint.el",
   "unstable": {
    "version": [
-    20241026,
-    2053
+    20241202,
+    1538
    ],
-   "commit": "0503a9b7ace1d0909ba5d20f9474451621c2011a",
-   "sha256": "0bfv9mpxdd767gxjgyw56h8z18gbhrjl6rqv57wc30vbc3p5frpv"
+   "commit": "a68530a0aab9a83382131b46bcace12505c65d29",
+   "sha256": "0nddzhc4jv1lmja1y0f1cafyiagrywcf9brb2yagcv1jhzxjnkcq"
   },
   "stable": {
    "version": [
@@ -44003,14 +44086,14 @@
   "repo": "jamescherti/flymake-bashate.el",
   "unstable": {
    "version": [
-    20240918,
-    1343
+    20241202,
+    1536
    ],
    "deps": [
     "flymake-quickdef"
    ],
-   "commit": "71acb57748694e7f18de252d4f808e12bfa07fef",
-   "sha256": "0ng19madpkvm0mh5lnq51gdvmqv56la1085b94pzipl772z8sly3"
+   "commit": "b3a1031f95b1521b7b12f069914c9f8b004372fc",
+   "sha256": "12lwc81d149dyzwvjqm4ibj1k8vf88qs0m9qq661c5jcxchzz7br"
   },
   "stable": {
    "version": [
@@ -44092,15 +44175,15 @@
   "repo": "mohkale/flymake-collection",
   "unstable": {
    "version": [
-    20241117,
-    1157
+    20250101,
+    2151
    ],
    "deps": [
     "flymake",
     "let-alist"
    ],
-   "commit": "1b62fd9b5844b231cb48b4919064420d64a123ff",
-   "sha256": "0rqviv2m50f2z4kigylfpyprldi5y0hsc69ni1cc84jnwwn8x915"
+   "commit": "5de95adb4c4981cee2f6152ef934230d7b2934eb",
+   "sha256": "1jx2y724xgv238nv3dxgvl1arjzg018vmq5jqy8zcbq21nrmwwgq"
   },
   "stable": {
    "version": [
@@ -44228,14 +44311,14 @@
   "repo": "flymake/flymake-eask",
   "unstable": {
    "version": [
-    20240223,
-    1022
+    20250101,
+    1000
    ],
    "deps": [
     "flymake-easy"
    ],
-   "commit": "0e83cec77aab54365ef8d604151888bb1f61049c",
-   "sha256": "08939vsg1mqs3syngr70vakabrvrjbbna7im6b1gjal8qjz22cxn"
+   "commit": "96fd80e6ff2c34a5898906388cfb6462f9bec7f1",
+   "sha256": "0n14xrgq56pyfh04f2gkw2fcmn64j2adhdpzm41vvxi5fr5pca7a"
   },
   "stable": {
    "version": [
@@ -44504,15 +44587,15 @@
   "repo": "emacs-grammarly/flymake-grammarly",
   "unstable": {
    "version": [
-    20240101,
-    846
+    20250101,
+    849
    ],
    "deps": [
     "grammarly",
     "s"
    ],
-   "commit": "b0041adb03ba1e9a3f20656a475042451868aa19",
-   "sha256": "175l2r6abayin9xnhbyff7kywygiqkfaynrak0wzx0hgzmgsq1qc"
+   "commit": "da1e8030e0148d098bf2cb66ac5402beb1d10825",
+   "sha256": "1nccblkrlijspzgg1fal4fw4chyp81ava63ax3wwy3l7d6nk2yg9"
   },
   "stable": {
    "version": [
@@ -44608,11 +44691,11 @@
   "repo": "DamienCassou/flymake-hledger",
   "unstable": {
    "version": [
-    20230710,
-    1945
+    20241226,
+    1937
    ],
-   "commit": "b42b66186688fbe8dc904d01d9a5378456e011c9",
-   "sha256": "0dx7zky6nfcajpvkgn2jmdgw9b0k6pjsl7my3vcbanvg0863g9il"
+   "commit": "3dd9d58ccd8e4c22c14553ebfac0ca1be3efebc5",
+   "sha256": "0dysfq6k5dgcv1chshs99b9hc816dk5a8pbx1m08jsdjsy92zaaw"
   },
   "stable": {
    "version": [
@@ -44791,14 +44874,14 @@
   "repo": "emacs-languagetool/flymake-languagetool",
   "unstable": {
    "version": [
-    20240307,
-    419
+    20250101,
+    852
    ],
    "deps": [
     "compat"
    ],
-   "commit": "73a1814db4cc387854d72828c0e188c9f5b4c661",
-   "sha256": "03sgfygr0jp3h7lnjl6v7j8rrcj5ib8qrvvijlqpk62vjh2pn4gc"
+   "commit": "c9b6749c5b17a8e58931cf2ce3ab5cbb855ae75d",
+   "sha256": "12sjiwxngv069c08vz2x8n49kcpwf7qc679lf7gh44dmyj0fs8fw"
   },
   "stable": {
    "version": [
@@ -45236,14 +45319,14 @@
   "repo": "erickgnavar/flymake-ruff",
   "unstable": {
    "version": [
-    20241016,
-    1600
+    20241214,
+    532
    ],
    "deps": [
     "project"
    ],
-   "commit": "17a8345f95761090d86e7c97d14f58fad77c0e29",
-   "sha256": "07lqqvpnaffc77aczg5d7p9agwhlqllj9pqiyf514bvrr4nn2jhr"
+   "commit": "b877f47eb9da608a40cc1bc25826d2176494bf6d",
+   "sha256": "0wpcwvnvldm99i0wbvsbxm8bz9acsis8ihp7wp1xd185p8k5cilw"
   }
  },
  {
@@ -45918,11 +46001,20 @@
   "repo": "Lindydancer/font-lock-profiler",
   "unstable": {
    "version": [
-    20170208,
-    2008
+    20250104,
+    2246
    ],
-   "commit": "6e096458416888a4f63cca0d6bc5965a052753c8",
-   "sha256": "186fvyfbakz54fr8j1l7cijvaklw96m1hfbjyw7nha08zc2m1hw5"
+   "commit": "6f19fda11de06f5f6c5b3732f056df762d685fcc",
+   "sha256": "1cjgn91yyha14qqw9gdv15d0a19mjlx5ixigrysks60r6jkzzphi"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    4
+   ],
+   "commit": "6f19fda11de06f5f6c5b3732f056df762d685fcc",
+   "sha256": "1cjgn91yyha14qqw9gdv15d0a19mjlx5ixigrysks60r6jkzzphi"
   }
  },
  {
@@ -45933,11 +46025,20 @@
   "repo": "Lindydancer/font-lock-studio",
   "unstable": {
    "version": [
-    20220629,
-    1909
+    20250104,
+    1653
    ],
-   "commit": "78472ae1f65721b4da17756ee7e506f3d0487033",
-   "sha256": "0gyzl2rz9kzrpvb3pfkcwbd0b7rxjxlklzc7zfh7ch6xxg0ghslw"
+   "commit": "fb932d8eb7d305ee4dcc6f29bb5e56cfb3fe9104",
+   "sha256": "0ssa62qm3zv0l9adz0bpi4iaixbi788ihh1qy5n41h6jzcjig4k4"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    9
+   ],
+   "commit": "fb932d8eb7d305ee4dcc6f29bb5e56cfb3fe9104",
+   "sha256": "0ssa62qm3zv0l9adz0bpi4iaixbi788ihh1qy5n41h6jzcjig4k4"
   }
  },
  {
@@ -46169,8 +46270,8 @@
   "repo": "magit/forge",
   "unstable": {
    "version": [
-    20241201,
-    700
+    20250101,
+    1813
    ],
    "deps": [
     "closql",
@@ -46185,14 +46286,14 @@
     "transient",
     "yaml"
    ],
-   "commit": "8f9e94949f4490273c4991b45f1ef02b9503dfcd",
-   "sha256": "02d5wxv0hnpjf83az96jz8hbldfp48za80ql0xc3ccah6s0hp7mn"
+   "commit": "0c9060626200902f7b0078a85566ef0eea8cc0b6",
+   "sha256": "0mh542c9hy401jcvammd89v9ja3zxc16k7zhfflq67x90987mwhp"
   },
   "stable": {
    "version": [
     0,
     4,
-    4
+    6
    ],
    "deps": [
     "closql",
@@ -46207,8 +46308,8 @@
     "transient",
     "yaml"
    ],
-   "commit": "a63685b921f25e861bf1e172e46beb771e56b924",
-   "sha256": "1nrr3l19p3hcm4jyghkl16d1pn0nqq6v6s19s54xl5yzjxfj44yq"
+   "commit": "0c9060626200902f7b0078a85566ef0eea8cc0b6",
+   "sha256": "0mh542c9hy401jcvammd89v9ja3zxc16k7zhfflq67x90987mwhp"
   }
  },
  {
@@ -46436,11 +46537,11 @@
   "repo": "gmlarumbe/fpga",
   "unstable": {
    "version": [
-    20240828,
-    906
+    20241224,
+    1805
    ],
-   "commit": "2c1b20fde1030208cddb4e50a56821a33f2b1323",
-   "sha256": "1j0hkbhhk9npiafjq3s4vyaw8f9j9skqnajjia4n18l4ga7wc7kc"
+   "commit": "7ba64134609cbb9b7a5dd3b960985fa46a582cf0",
+   "sha256": "0sl3s5bfqmicpg4hp2k6qznrgj71dx0lz3dv2jyd48ys67m9x4dx"
   },
   "stable": {
    "version": [
@@ -47254,26 +47355,27 @@
   "repo": "jojojames/fussy",
   "unstable": {
    "version": [
-    20241202,
-    6
+    20241208,
+    2139
    ],
    "deps": [
     "compat",
     "flx"
    ],
-   "commit": "5c8165619f4c94f7f620df69ab67d7d5bcd15501",
-   "sha256": "1vcqf3pjmhqfsppjvdx0lzqxzr1kia5b21ypdhqxx3b8splg86si"
+   "commit": "309614c3acbdca9d0a50827e94c2ac8cda11f420",
+   "sha256": "10vdzvd8pry732mf7vhn3v3dhnnd4pngcvcm1smlimmc4pg0hhw7"
   },
   "stable": {
    "version": [
     2,
-    0
+    1
    ],
    "deps": [
+    "compat",
     "flx"
    ],
-   "commit": "cd2c93b9b5fd0fe6c61fcc6e1d62b4c1cbb142aa",
-   "sha256": "11i6228xbw4g8ks2z073lzdrsmyilppr1dbcg91r9y267ppl1ijw"
+   "commit": "dd66f96400797f8db5e6335617fafe41340df85c",
+   "sha256": "1120ry2aa97jgjlzz0cpwxm0frks2vqp15i6vfjpnvm6fj09pl9m"
   }
  },
  {
@@ -47327,11 +47429,11 @@
   "repo": "auto-complete/fuzzy-el",
   "unstable": {
    "version": [
-    20240101,
-    830
+    20250101,
+    843
    ],
-   "commit": "295140da741ac02c1bd3dec69ccf7f6268d60ec5",
-   "sha256": "03ryz1793bbab7c6nmya2n1xzjsliidhy5kzrcmch8vlidrgd12d"
+   "commit": "09ef98ecdea03497ae309fd0ed740190e9a3492e",
+   "sha256": "1szzbkvb80hdz3889q1jb8jyn8fzdxsxrmz6qk8w9x4cc7xw70gf"
   },
   "stable": {
    "version": [
@@ -47350,11 +47452,11 @@
   "repo": "10sr/fuzzy-finder-el",
   "unstable": {
    "version": [
-    20210906,
-    217
+    20241219,
+    1044
    ],
-   "commit": "915a281fc8e50df84dcc205f9357e8314d60fa54",
-   "sha256": "15b6nbkv8xpvin8i1443s1mnpag5p33asgwpxijrmwp3xm2xkyl6"
+   "commit": "ed3fb35d33b38d5baad49ed5a2ea046085de4498",
+   "sha256": "0fqdd9mb81mpi24n517rb6bbm3bi6dymnwcz3kpxydkm65cjvmzh"
   },
   "stable": {
    "version": [
@@ -47495,11 +47597,20 @@
   "repo": "Lindydancer/gameoflife",
   "unstable": {
    "version": [
-    20200614,
-    1814
+    20250102,
+    900
    ],
-   "commit": "2483f3d98dbcf7f1633f551cc3691f5659b4b942",
-   "sha256": "1a57fc8ylrdlqlywp81b71jd93hiwkxy6gxpi8358d6d4czslvq7"
+   "commit": "5f4ac265928bfd88765d057b44cebcef71a7aaf6",
+   "sha256": "0ag9qfdjrg6x7aip3drar4gnylgimnk30k24cd9a4i72500fc6qs"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    3
+   ],
+   "commit": "5f4ac265928bfd88765d057b44cebcef71a7aaf6",
+   "sha256": "0ag9qfdjrg6x7aip3drar4gnylgimnk30k24cd9a4i72500fc6qs"
   }
  },
  {
@@ -47651,11 +47762,11 @@
   "repo": "godotengine/emacs-gdscript-mode",
   "unstable": {
    "version": [
-    20241104,
-    821
+    20241207,
+    610
    ],
-   "commit": "bee7f99c6f780497ec112bf01196181fc83511c8",
-   "sha256": "0808lgdca1vpsj1rwyvqcxrqiq60z9ww5yjsrg7fg28c9vba44b2"
+   "commit": "c3d99889843db92fc6e4c51226c222779eadd7d6",
+   "sha256": "1bh7icz4k70x62z50lnjgnrxxh0mhlgrj421wm4sqiphk30vmck4"
   },
   "stable": {
    "version": [
@@ -47840,14 +47951,14 @@
   "repo": "emacs-geiser/chicken",
   "unstable": {
    "version": [
-    20220717,
-    1130
+    20241204,
+    1442
    ],
    "deps": [
     "geiser"
    ],
-   "commit": "a480598b5908c95bc8d3178a48f13e9072a9235b",
-   "sha256": "0jb0zlg82axp44iy51w7fh96z3pmn2k1idipznhw90hkr3wkiiqw"
+   "commit": "5f2c1bb446af6ae4aec9c8d74d4ecb34031706fd",
+   "sha256": "0bzax5fsmjxzinp6rhwrbqbass0pja89khl4adbdp8mafqp46jpk"
   },
   "stable": {
    "version": [
@@ -48307,16 +48418,16 @@
   "repo": "twmr/gerrit.el",
   "unstable": {
    "version": [
-    20241014,
-    1940
+    20241218,
+    820
    ],
    "deps": [
     "dash",
     "magit",
     "s"
    ],
-   "commit": "58e5bbe1485cb15c02b74c327fac6a533e8663da",
-   "sha256": "1v2akprnfmc89iq68aprydgb28lrj497jm8bgmkf8cwljf4x1kh5"
+   "commit": "62ebf2b3d32b9a235103d12e1b131b0c3f42a10c",
+   "sha256": "0zzzm89s11b3zv3s8l5j5xhnmzzpv4qridqgszi19krgw37adb8h"
   }
  },
  {
@@ -48615,30 +48726,30 @@
   "repo": "magit/ghub",
   "unstable": {
    "version": [
-    20241123,
-    2135
+    20241208,
+    2219
    ],
    "deps": [
     "compat",
     "let-alist",
     "treepy"
    ],
-   "commit": "4f39b86544ab064204efd0dda381af90fae70f43",
-   "sha256": "1dxcm82q23djj51ic7j2702jyaygwganrsrcd3fpvg2nw3r5gz7i"
+   "commit": "97edaf450ef74f40e6c0bd6a35ebd3fcb710ca4d",
+   "sha256": "1dlvhpwz4i2z70xh4rzkq8d1wfhbc6n0hp17kdwsy5x5d891dczi"
   },
   "stable": {
    "version": [
     4,
-    1,
-    1
+    2,
+    0
    ],
    "deps": [
     "compat",
     "let-alist",
     "treepy"
    ],
-   "commit": "23d1cd6b089db6619d02d66957c6a274311abd60",
-   "sha256": "1p5lx781z603q943p73p6q9k6qz75ldjwrr9z3h6zvi80gxd7afy"
+   "commit": "97edaf450ef74f40e6c0bd6a35ebd3fcb710ca4d",
+   "sha256": "1dlvhpwz4i2z70xh4rzkq8d1wfhbc6n0hp17kdwsy5x5d891dczi"
   }
  },
  {
@@ -48974,28 +49085,28 @@
   "repo": "liuyinz/git-cliff.el",
   "unstable": {
    "version": [
-    20241029,
-    358
+    20250102,
+    1432
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "7b73709928770959ef731192726ade76f85da877",
-   "sha256": "0225n41dcqm53c4nl0m9a17zg63gnqf90cfhp777vjdfry0mxsfl"
+   "commit": "1a8bed36236338815d5f3c1420d4e6ac9a88ca0f",
+   "sha256": "1s1iq1cnhqn5xh50dcbc7ppl9706ajri9j5dz6sjss5wp0v0n2lb"
   },
   "stable": {
    "version": [
     0,
-    7,
+    9,
     0
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "14be943b04c1a0e9a0771bc6fc748d0e961af825",
-   "sha256": "00bis5dk15wrmccd1pla87z2cbr5fgqg6gqjvkn7iry73sax8c61"
+   "commit": "cc03ce1e7dcf6fd139453ef2cba02fcf98acd6a7",
+   "sha256": "0c6pz4wcr1fkymnb1gx19n8qr48zl0nhlz262r4i6rbp1838507m"
   }
  },
  {
@@ -49029,30 +49140,6 @@
    ],
    "commit": "6cc5c17ca3cc1967b5402bb9a0538fb90933428d",
    "sha256": "0a3ws852ypi34ash39srkwzkfish4n3c5lma10d9xzddjrwapgj9"
-  }
- },
- {
-  "ename": "git-commit",
-  "commit": "301c815541da7eaa552d834bfbed3e6633bd4136",
-  "sha256": "1xqcj7pmlys3ml1nk5fhgqn6d4nr1aagk8z0lskgr3kxzw5n7bcq",
-  "fetcher": "github",
-  "repo": "magit/magit",
-  "unstable": {
-   "version": [
-    20240831,
-    2335
-   ],
-   "commit": "9be8a4ab7a7dc6f34615f1011e8da263651c8f87",
-   "sha256": "02i9j8hxp3v1pd805x7xxd39kqldq2kw5qyxdwsrw7lyia25wrji"
-  },
-  "stable": {
-   "version": [
-    4,
-    1,
-    2
-   ],
-   "commit": "4992c3d1f64e0e983692c7a61d47069f47380dbf",
-   "sha256": "16ix3wsihqpzpx3709fx3wm2087q2miaxwfsh62xnq0nx5z9fl72"
   }
  },
  {
@@ -49181,11 +49268,11 @@
   "repo": "emacsorphanage/git-gutter",
   "unstable": {
    "version": [
-    20240903,
-    418
+    20241212,
+    1415
    ],
-   "commit": "9beaed9e45f92ab0527f54dbf5fb241b84e7821d",
-   "sha256": "0vz6ms419kidlsfdv6w22imvl7y7zr3qv2c5xlvdxgi8kyr2k9p8"
+   "commit": "3bdead17db7b84270c00e5a6b5ad02fa87ddd52e",
+   "sha256": "0c4fb1hcz6xl13yqw1vn7blxyzn0zyhq0zayxjsivv4x4xjm7y2p"
   },
   "stable": {
    "version": [
@@ -49194,36 +49281,6 @@
    ],
    "commit": "3772fdfa673f8a7f7b7894110d78b4070eccf361",
    "sha256": "0qjp1gind95py0zfc3a32j7g6bmdh0pszpyiazqqzxm3rz82m7rn"
-  }
- },
- {
-  "ename": "git-gutter+",
-  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
-  "sha256": "02f314ks9hv8fgbajq1cci3gd9vycz08w87xngz3wa8r1f7ga6gc",
-  "fetcher": "github",
-  "repo": "nonsequitur/git-gutter-plus",
-  "unstable": {
-   "version": [
-    20151204,
-    1723
-   ],
-   "deps": [
-    "dash",
-    "git-commit"
-   ],
-   "commit": "b7726997806d9a2da9fe84ff00ecf21d62b6f975",
-   "sha256": "0bhrrgdzzj8gwxjx7b2kibp1b6s0vgvykfg0n47iq49m6rqkgi5q"
-  },
-  "stable": {
-   "version": [
-    0,
-    4
-   ],
-   "deps": [
-    "git-commit"
-   ],
-   "commit": "f8daebb6569bb116086d8653da3505382e03d940",
-   "sha256": "101hracd77mici778x3ixwrcicd6fqkcr9z76kapkr0dq5z42yjb"
   }
  },
  {
@@ -49257,37 +49314,6 @@
    ],
    "commit": "dfc93d1064df154a809aab350942830408051da3",
    "sha256": "18jpa5i99x0gqizs2qbqr8c1jlza8x9vpb6wg9zqd4np1p6q4lan"
-  }
- },
- {
-  "ename": "git-gutter-fringe+",
-  "commit": "ad320d60e2c95881f31628c19ad3b9ece7e3d165",
-  "sha256": "18h9jkp5blfw4lgxh36x51wjh7fh669q4g7qsifj3lhg595lb757",
-  "fetcher": "github",
-  "repo": "nonsequitur/git-gutter-fringe-plus",
-  "unstable": {
-   "version": [
-    20140729,
-    1103
-   ],
-   "deps": [
-    "fringe-helper",
-    "git-gutter+"
-   ],
-   "commit": "3857d486e5b3eca9281fba1c76756cb39a9f9866",
-   "sha256": "19sz3gaffirr95n4a8jag9wsqa86fpdn13k685lxrv5317h8iqfh"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "deps": [
-    "fringe-helper",
-    "git-gutter+"
-   ],
-   "commit": "ce9d594c0189e78d78df26a0c26bbcf886e373cd",
-   "sha256": "1c7ijbpa7xw831k55cdm2gl8r597rxnp22jcmqnfpwqkqmk48ln9"
   }
  },
  {
@@ -49371,11 +49397,11 @@
   "repo": "sshaw/git-link",
   "unstable": {
    "version": [
-    20241022,
-    2208
+    20241208,
+    1850
    ],
-   "commit": "8df5f1f0a70c0668bafb1b70421b651df3bde999",
-   "sha256": "0fy0v3w7w23ch9z9bkjg7ssplgb5v8vng73c1xd2csja8kfkcirv"
+   "commit": "40f7b1674d2c703199ff2f82b464f17aa6f61b4b",
+   "sha256": "0cqc76pqqdhv7fgfsfyq8ych184gbmyvfh0h7a2zyh5wl2p7kb0i"
   },
   "stable": {
    "version": [
@@ -50548,30 +50574,30 @@
   "url": "https://git.thanosapollo.org/gnosis",
   "unstable": {
    "version": [
-    20241115,
-    1041
+    20241211,
+    1054
    ],
    "deps": [
     "compat",
     "emacsql",
     "transient"
    ],
-   "commit": "eefd0abb3cb7ca8a09c249686ff67555724624da",
-   "sha256": "1g6a5vr5cqnjf15idzqnh6p377dia3bz8x260kiyf157n3h11ms8"
+   "commit": "852c3e25eda24471100ea210f7b0ecbb0225136f",
+   "sha256": "1ccx49f8lh94any0m246wnna7xcb8zhjmsw9c16g9qk6gmzv9fng"
   },
   "stable": {
    "version": [
     0,
     4,
-    8
+    9
    ],
    "deps": [
     "compat",
     "emacsql",
     "transient"
    ],
-   "commit": "b30a06fc16c18b6de7d5a21facf2b5fd8d90b613",
-   "sha256": "1y9f5ms7aivwjfc951m68jfmwncfq5f4h876xvivxhfph4xnc76y"
+   "commit": "383f8b489dbbc7fd13b076acaad10ccf73e1dd48",
+   "sha256": "08pqz0xfih761hmaq1hs3fzmkxn2jhzfbkqrkisl84ayla8shnrn"
   }
  },
  {
@@ -50760,20 +50786,20 @@
   "repo": "unhammer/gnus-recent",
   "unstable": {
    "version": [
-    20230602,
-    957
+    20241218,
+    1308
    ],
-   "commit": "5f85ddccd116b6c0cddf47795f25f930b7b767c4",
-   "sha256": "114pq08a8i9362lp8h6lgky8pd1mcf93lw50zq2qigwixac5cp7m"
+   "commit": "9cd9797c2aa54be4ca03b5ca0c50b64c4dc1d34e",
+   "sha256": "0fjvshab1fvjbvsfn7vk16lxzq2552w11gry12rixsaqps38bsa6"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
-   "commit": "6f13a00c5736c269ed850094cfbc9ea474e24dfe",
-   "sha256": "1x91da1vb48hn2qqdn144gj9n2sas252llcf5jlqqkl8w5wk6z3i"
+   "commit": "9cd9797c2aa54be4ca03b5ca0c50b64c4dc1d34e",
+   "sha256": "0fjvshab1fvjbvsfn7vk16lxzq2552w11gry12rixsaqps38bsa6"
   }
  },
  {
@@ -51588,11 +51614,11 @@
   "repo": "minad/goggles",
   "unstable": {
    "version": [
-    20240926,
+    20250101,
     919
    ],
-   "commit": "142d788e16bf387608b51c8590c852940890f637",
-   "sha256": "0bvr5696i6zbzd160hf0fivxil3a65p22x7vagwydxrx9d2ji4iq"
+   "commit": "d71e85ff8d9e7f8966e4cccece3efa545afc41da",
+   "sha256": "1pvgfhy8a1cmip9vx31lbdm4957hz4gsj2a875gvc8xfl2y4dc3r"
   },
   "stable": {
    "version": [
@@ -51949,6 +51975,24 @@
   }
  },
  {
+  "ename": "gotest-ts",
+  "commit": "86837556b6cdc831bb4bb387a0840fe6186ebedc",
+  "sha256": "1fl8cyykfq9myrs8p5240mp2jh3lb1p5f0fgvrq0bw7cj4rp9306",
+  "fetcher": "github",
+  "repo": "chmouel/gotest-ts.el",
+  "unstable": {
+   "version": [
+    20241209,
+    1346
+   ],
+   "deps": [
+    "gotest"
+   ],
+   "commit": "673f4907ff9f095a62e41701d0f297b5ad05d5b0",
+   "sha256": "1k4q80q5xa55v6qir5vljrcr03yrxx6apl45adcnd0wd5rlqwy32"
+  }
+ },
+ {
   "ename": "gotham-theme",
   "commit": "20b2cc78b41a26e434b984943681fea774fd3c50",
   "sha256": "17nkg3ac8ckk5sa722nqinzhln8nb96yppjyp0567cc8p9a3bp59",
@@ -51980,11 +52024,11 @@
   "repo": "emacs-vs/goto-char-preview",
   "unstable": {
    "version": [
-    20240206,
-    139
+    20250101,
+    908
    ],
-   "commit": "d40eb8c1e8844ab7d265197191a759f62bf1099c",
-   "sha256": "0z4fd6y3cikxgvc86bx2fy04kd136bkh8qymiwsx24i3pa4zwr4b"
+   "commit": "806baf183ca6f6c88aea7f79752e48c4f2f86c89",
+   "sha256": "01r828qpx9bz27nj4d2xj5sdzi5q71nfji21h735bn4r6q6p9hk9"
   },
   "stable": {
    "version": [
@@ -52067,11 +52111,11 @@
   "repo": "emacs-vs/goto-line-preview",
   "unstable": {
    "version": [
-    20240206,
-    138
+    20250101,
+    908
    ],
-   "commit": "4e712da4e5e90b02440bd1f435a89ad02ff5a894",
-   "sha256": "0khcc8qgc9x77wr4lpxjjahcimxk015ikp3lin02lm1pp28a5wa5"
+   "commit": "fa34955bcd1166421757216013945bc9ed520dc5",
+   "sha256": "0x34xkg5g630yiihyqq09l21bfxvz0iz83fw470sq4j3qm6hnykr"
   },
   "stable": {
    "version": [
@@ -52106,8 +52150,8 @@
   "stable": {
    "version": [
     0,
-    46,
-    2
+    47,
+    0
    ],
    "deps": [
     "dash",
@@ -52115,8 +52159,8 @@
     "magit-popup",
     "s"
    ],
-   "commit": "c3916ff7728451023ce84c2eaf726b1d23e623b6",
-   "sha256": "1jr9zwknxbz7f4vlnfjzzslzxy05m24x857rsh4aj9mnwawdppc3"
+   "commit": "95396cdfbb5ce4929e5fc1cf8d3e191408e319b4",
+   "sha256": "177v3lqhaf2yjkl416g3iimf5sz42vn1j31wldmvadk2risxxi9p"
   }
  },
  {
@@ -52166,11 +52210,11 @@
   "repo": "brownts/gpr-ts-mode",
   "unstable": {
    "version": [
-    20241127,
-    2221
+    20241212,
+    104
    ],
-   "commit": "2f23e4ca2225c614314b4d66ab5312dd9cfdd419",
-   "sha256": "01hdip8ivldz00r3ci96zz5m2i2jc18272bx4riy7gn08sw5cdxs"
+   "commit": "4790595bb0a6108a27ee8600dd36dc10d3c9afea",
+   "sha256": "0wv2xshr5ws2v1c5p4jyqp1ad7panm96kzi0qfjgng4kfvvsfxb6"
   }
  },
  {
@@ -52199,11 +52243,11 @@
   "repo": "stuhlmueller/gpt.el",
   "unstable": {
    "version": [
-    20241020,
-    1841
+    20241208,
+    1724
    ],
-   "commit": "3f3d0c4c1f2d5460ed3296a63c7938c5040aaa8e",
-   "sha256": "1prb83vwr16jya920lbbd6pfk9xbdm6fh81s30j3jqyin3vpjkhq"
+   "commit": "3575afcb3c379f9067ab80eefe696f3758564397",
+   "sha256": "0q836g45kwz7a6qrpjk771si3a8rbfvfx376syffvwxb5kmw38h1"
   }
  },
  {
@@ -52270,28 +52314,28 @@
   "repo": "karthink/gptel",
   "unstable": {
    "version": [
-    20241130,
-    1959
+    20250103,
+    1837
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "7934106b74ce60fd5782e840c7efc4f0bbdbc646",
-   "sha256": "1rmfaymci96pf0qmy12cpgsyly04jzy93apa7bdjjnj017pshsyx"
+   "commit": "7ac9201b84f3d132dce0094d135a525ebcfafa12",
+   "sha256": "079yk4mn0ahwlc7vv4w3bvdqm4nvs3gm9wch9xds80dlpgvyl85m"
   },
   "stable": {
    "version": [
     0,
     9,
-    6
+    7
    ],
    "deps": [
     "compat",
     "transient"
    ],
-   "commit": "f24e5ad4740ce5f9829b14e499c9181f9bd7c76e",
-   "sha256": "0cb5wxlc598fs1cmjvkbc76x098ljmik3s39hjfjzn6537yps4da"
+   "commit": "5a5cddb93d610bd59ec52a070b0f89a9ec842152",
+   "sha256": "15ny2d04ci04swmxikkyb7lsjr51gvxpr2cj02gwx88bidx34md2"
   }
  },
  {
@@ -52349,14 +52393,14 @@
   "repo": "xuchunyang/grab-x-link",
   "unstable": {
    "version": [
-    20191113,
-    848
+    20241223,
+    1442
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "d898db46e4864118359fdedfe915e180de3fe290",
-   "sha256": "0npz0da2rcckv0zcf2f8vpjcdnii3z99x6c5c4z7jd4xgkp004xs"
+   "commit": "4aecb0f360320e0a58b4b142d247b1e628612574",
+   "sha256": "05a9f62gn1r283agkirvvgzlz4mv56vwwadvyggpas87lmzcp0h5"
   },
   "stable": {
    "version": [
@@ -52455,16 +52499,16 @@
   "repo": "emacs-grammarly/grammarly",
   "unstable": {
    "version": [
-    20240101,
-    846
+    20250101,
+    849
    ],
    "deps": [
     "request",
     "s",
     "websocket"
    ],
-   "commit": "813944714a04ae2a3cdaca845c1c9d70ced462ca",
-   "sha256": "1v80482vcx9p7fm1crg9vwwrjvb2q1xpkkpxl4fpycd64wimgdk2"
+   "commit": "c67f8d49bf89fb176e4a125b8fc4be4a41446a95",
+   "sha256": "1r9vbkqz9ynawyn7v98lqcadjdns6kyndazsbksxqd3myvf6m6la"
   },
   "stable": {
    "version": [
@@ -52765,15 +52809,15 @@
   "repo": "michelangelo-rodriguez/greader",
   "unstable": {
    "version": [
-    20241025,
-    1237
+    20241231,
+    2331
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "0977a4aea839a6f3907d5475baf4012151a4e556",
-   "sha256": "1jhscp9q5b9qdg9b6k5vypgmnj7hgflx6a68v7b5pg0qj2rxxk8p"
+   "commit": "a7a8d4adc4f4590669cb8cbad086db12d831ad82",
+   "sha256": "0k954p27g6i0ing3gbkzx40g3wisd6wy5p2fjcmq4xxqn18icv20"
   }
  },
  {
@@ -52922,11 +52966,11 @@
   "repo": "seagle0128/grip-mode",
   "unstable": {
    "version": [
-    20241111,
-    936
+    20250104,
+    1058
    ],
-   "commit": "d6c7e33e40d10b529b059ea1d237161dc3e88428",
-   "sha256": "0918ycvbfv5ckmgvjn413v39bz7948f03sjqw6wzcha88hgdizv6"
+   "commit": "df0ba7589db7c54c4b68bd6a96a246676d7893c3",
+   "sha256": "0kmvc7yk9p04iz0jzg0iqa9m2q4v91q9yrl4y6vsmm45diy7r60z"
   },
   "stable": {
    "version": [
@@ -53654,11 +53698,11 @@
   "repo": "idlip/haki",
   "unstable": {
    "version": [
-    20241118,
-    1802
+    20241204,
+    736
    ],
-   "commit": "3b13b5dd594d6cc5798117f216b266d86f1ffa16",
-   "sha256": "19wk54k2z0s073yk84f1wq76a28srqd9wsh1qhs8sr26vjldg24y"
+   "commit": "0609b1bb31340419a458618cc9909f6ba0351357",
+   "sha256": "0br510904vfq12g464b14h4a6rbiphhn9i9qa37msgfzl78q6mac"
   }
  },
  {
@@ -53999,6 +54043,29 @@
   }
  },
  {
+  "ename": "hardtime",
+  "commit": "96f0528a340d145366cad31acbe5e033603c7e69",
+  "sha256": "0pssclhpdnjr9jdks85118m0adbxp8ggl020b0qhxv2a12kc8mjf",
+  "fetcher": "github",
+  "repo": "ichernyshovvv/hardtime.el",
+  "unstable": {
+   "version": [
+    20241203,
+    1647
+   ],
+   "commit": "a14df12bda3951e53553426629f4af7a638f6eee",
+   "sha256": "1jzb20s6m2sv6bkk7rsaizlxx5v7aap92934ml2mj43ry2gzgvpd"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "a14df12bda3951e53553426629f4af7a638f6eee",
+   "sha256": "1jzb20s6m2sv6bkk7rsaizlxx5v7aap92934ml2mj43ry2gzgvpd"
+  }
+ },
+ {
   "ename": "harpoon",
   "commit": "1b8efde9e17f716c518a0cfe8e65ba57cf662b48",
   "sha256": "006b5919zdjbzfl0jdagnmalz5zapp4bj9l2fxphzn6isyw807r0",
@@ -54211,29 +54278,6 @@
    ],
    "commit": "1127f46eca40a48be9cd2380df2cfc5f0b694e63",
    "sha256": "13c2z1i7icpwv60njn83qbla9i0qlq3m0yz88ach1mlvmsdfj9jz"
-  }
- },
- {
-  "ename": "hasklig-mode",
-  "commit": "15a60278102de9e078b613456126945737718ce9",
-  "sha256": "0gz0k9ahk0jpdp893ckbby9ilkac1zp95kpfqdnpfy0a036xfwm7",
-  "fetcher": "github",
-  "repo": "minad/hasklig-mode",
-  "unstable": {
-   "version": [
-    20240102,
-    333
-   ],
-   "commit": "9933e55765f006322c7db4ff41c1c5789295768f",
-   "sha256": "0h6wk7y96h803n5215shb88vszpqahsr54af2zgw1h5s22x32xv3"
-  },
-  "stable": {
-   "version": [
-    0,
-    2
-   ],
-   "commit": "4b73d61f4ef1c73733f7201fbf0b49ba9e3395b6",
-   "sha256": "12a5hgaf2z6prqx45n6y0xyknz2sivpzwxjnzbsdx9sw6rniqm57"
   }
  },
  {
@@ -54486,15 +54530,15 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20241130,
-    526
+    20250104,
+    1759
    ],
    "deps": [
     "helm-core",
     "wfnames"
    ],
-   "commit": "3ca35edd5a5e8f1bee1b03facbbf44df8c729e3f",
-   "sha256": "00xfzw7nvas0x68s9q4s3k737jgrganqyizvr10pybqjyhzlllzm"
+   "commit": "3372d13b928ffc3977516eb5a397ab3a555559ce",
+   "sha256": "0156kjcyx7s34clz3m2qbfsn6ysvj0savwxlqd2lp5x3bqavyyz5"
   },
   "stable": {
    "version": [
@@ -55375,14 +55419,14 @@
   "repo": "emacs-helm/helm",
   "unstable": {
    "version": [
-    20241201,
-    648
+    20250104,
+    1025
    ],
    "deps": [
     "async"
    ],
-   "commit": "05c2a8262fb47762bbd7112b8149578b02d4e44e",
-   "sha256": "06x4xlbq63h4mjr3hcbp9kdaz0xhzlph2z5knhmglny6riqqilyz"
+   "commit": "01b50bc4e427bb9e16581da2ddf34848297b5c59",
+   "sha256": "0v3s9nn28w5rgkgk2ivlazv3z5kl7had81pc2q1k6ffr7g9dkjr1"
   },
   "stable": {
    "version": [
@@ -55557,14 +55601,14 @@
   "repo": "emacs-helm/helm-dictionary",
   "unstable": {
    "version": [
-    20230922,
-    1111
+    20241222,
+    651
    ],
    "deps": [
     "helm"
    ],
-   "commit": "fc1c097cc53dd3451bfb49ea7e99fdfc6d93bc16",
-   "sha256": "1fypysfpl8n6np7mz2wrfy3clhbyy8lnr6c69nlxxs4nznlwyvip"
+   "commit": "6114ef3171cad09c74ac0028db58fb479f3c5d21",
+   "sha256": "07pnzpr67fxam2qih6b3miyb84g27b8m4m37z1mdk4297qr060a5"
   }
  },
  {
@@ -57687,14 +57731,15 @@
   "repo": "markus1189/helm-proc",
   "unstable": {
    "version": [
-    20161006,
-    305
+    20241230,
+    1732
    ],
    "deps": [
+    "cl-lib",
     "helm"
    ],
-   "commit": "576d31c2d74ba3897d56e2acd2b0993f52c2547c",
-   "sha256": "11xahzybwh02ds19y6h5hbpqdj278kcb4239vyykdl3wx8p048a7"
+   "commit": "86265218415c7b26cdc3c25de03d063196ba566a",
+   "sha256": "15r4xnhy142g0l4bwhq0xrahkbisndsnzcdj47kgah4h9d9bz74m"
   },
   "stable": {
    "version": [
@@ -58167,8 +58212,8 @@
  },
  {
   "ename": "helm-rtags",
-  "commit": "3dea16daf0d72188c8b4043534f0833fe9b04e07",
-  "sha256": "1vv6wnniplyls344qzgcf1ivv25c8qilax6sbhvsf46lvrwnr48n",
+  "commit": "8f5d42452235ee9f1590fa8893c4ea3d40ac891b",
+  "sha256": "0dw0kg21aqk74czwpwxpz2p6lg8glj8n1y5zzmqxan9qjwbrwld0",
   "fetcher": "github",
   "repo": "Andersbakken/rtags",
   "unstable": {
@@ -58306,8 +58351,8 @@
   "repo": "emacs-helm/helm-searcher",
   "unstable": {
    "version": [
-    20240101,
-    827
+    20250101,
+    844
    ],
    "deps": [
     "f",
@@ -58315,8 +58360,8 @@
     "s",
     "searcher"
    ],
-   "commit": "893ef3864596412093876657e590f61d4449b487",
-   "sha256": "1hxmy6vlxjngkj8v1vw16jhladln0b3c0hrykm30060grr3w5dss"
+   "commit": "a87a6dfcafbe488e166ae0eb8e3e4ca7d9a3a25f",
+   "sha256": "0n7ipkwdg5zsbk7jff8kqsm4792mia03x5ncjj4bk5vz00p5db5c"
   },
   "stable": {
    "version": [
@@ -59682,11 +59727,11 @@
   "repo": "DarthFennec/highlight-indent-guides",
   "unstable": {
    "version": [
-    20200820,
-    2328
+    20241229,
+    2012
    ],
-   "commit": "cf352c85cd15dd18aa096ba9d9ab9b7ab493e8f6",
-   "sha256": "0wh1sfbbbz52ppr0fkl0csc4n46ipx36dli9pp9nsvpz9r28pc1g"
+   "commit": "3205abe2721053416e354a1ff53947dd122a6941",
+   "sha256": "1w8qqgvviwd439llfpsmcihjx4dz5454r03957p2qi66f1a7g6vw"
   }
  },
  {
@@ -59828,11 +59873,20 @@
   "repo": "Lindydancer/highlight-refontification",
   "unstable": {
    "version": [
-    20170211,
-    2024
+    20250104,
+    1619
    ],
-   "commit": "32632897d88c4611fadb08517ca00ef5cbc989b6",
-   "sha256": "1k6af947h70ivkj31mk3nv2vkxlfpqvpwq8za53n2l7adsjdlf73"
+   "commit": "31ce7f8086a85144695dc6c972bad9f1199bd179",
+   "sha256": "1f3mgsm8jyym6i04ygaq7xb5ab17ca3lrgyd5dfx66qqq231ss2v"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    4
+   ],
+   "commit": "31ce7f8086a85144695dc6c972bad9f1199bd179",
+   "sha256": "1f3mgsm8jyym6i04ygaq7xb5ab17ca3lrgyd5dfx66qqq231ss2v"
   }
  },
  {
@@ -59959,11 +60013,11 @@
   "repo": "dantecatalfamo/himalaya-emacs",
   "unstable": {
    "version": [
-    20240321,
-    1324
+    20241209,
+    1501
    ],
-   "commit": "6c2c7f354a0bed95b2199e1814342620119bf13e",
-   "sha256": "07hih5q0n6af1cr33ilzri3y3nqdmvqgd860qa9wv5wl3s8rymnz"
+   "commit": "934e8f8741e3cfff577d7119eceb2cfdb7cff6f3",
+   "sha256": "1pwn91d7x39np5i9b0d0mi48bxqv7d7h4fmg4ifhwgvglzla3r96"
   },
   "stable": {
    "version": [
@@ -60002,6 +60056,21 @@
    ],
    "commit": "beafb2610fb9a724bdd78339375e6673d46c23fe",
    "sha256": "1hx0sj5afy0glxr3lfr6hvnk0iphmfnfg3wilx2s013a5v0drmxc"
+  }
+ },
+ {
+  "ename": "hindu-calendar",
+  "commit": "ed2c4cc0ce0a0da9863f27cca3abf18f1c198e33",
+  "sha256": "1rb8cp301nn8igqswcmmava1gsj8w41fs9hjy9abdvj8h7hx32ka",
+  "fetcher": "github",
+  "repo": "bdsatish/hindu-calendar",
+  "unstable": {
+   "version": [
+    20241220,
+    1951
+   ],
+   "commit": "057fd579c5d3ca69a11d130bf7972efc9fe2e83a",
+   "sha256": "0v1srz1727bdxg3n96gvcz307majj2yb8hpp15wz53irgbpf9y82"
   }
  },
  {
@@ -60209,11 +60278,11 @@
   "repo": "ideasman42/emacs-hl-block-mode",
   "unstable": {
    "version": [
-    20240422,
-    126
+    20241208,
+    459
    ],
-   "commit": "c182a54a5ad0c7757be7fd5f18223528614a119d",
-   "sha256": "0rmdq00cgjfvi6pfcsmm0fk5wwplhirl5gmw76v0b983irmrg96c"
+   "commit": "e13222b70dcce09400c98e028bb9159148c1a6b4",
+   "sha256": "04im0qkb1nx9vygqi5g7w995fc486dpm986pg5s5cbi5l0a3irkl"
   }
  },
  {
@@ -60696,26 +60765,26 @@
   "repo": "kaorahi/howm",
   "unstable": {
    "version": [
-    20241018,
-    1153
+    20250103,
+    449
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "f7c0b6a71a7dcc97a4ba15295373c3d627ab9a6c",
-   "sha256": "0sl1fzkf29qb7m9m523rzrv5w90f2vhyhw71n7ir844jwlwmhpga"
+   "commit": "b1a3066f089cebda7932f8b2cd41fd6d8a68d364",
+   "sha256": "1vq2nw00s0fv739himswkgpci0b4mv77jkh8gp71mxahy3kvmvkz"
   },
   "stable": {
    "version": [
     1,
     5,
-    1
+    2
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "fc61c312be7cd23c654a02f1f81355d562cd627e",
-   "sha256": "111l502krbrpzm63kbiblchiav8wv38z11snvcx428xjzpl28q1l"
+   "commit": "057516c33dc8f56b54e236944c5d1816207bee60",
+   "sha256": "0kab1k9b25cmvvy7rim3wmsrikfr4fa9gwi20dry52x6nndki9vg"
   }
  },
  {
@@ -60895,11 +60964,11 @@
   "repo": "emacs-vs/htmltagwrap",
   "unstable": {
    "version": [
-    20240120,
-    1010
+    20250101,
+    907
    ],
-   "commit": "96f89ec74e39903d8ed1f87f261032778c19694a",
-   "sha256": "1nc58w73q8l2g1g8f6vpbaxfjyw4vbkd96hzd5lm7fb7mbwl6h3k"
+   "commit": "66dd54079110b4b6d91bb81acf8a31649e3cb29f",
+   "sha256": "16ir33a328qwrmcy2ip9zidad5c5b46rwf3gmnf2rmsqdnxand3g"
   },
   "stable": {
    "version": [
@@ -61323,11 +61392,11 @@
   "url": "https://git.savannah.gnu.org/git/hyperbole.git",
   "unstable": {
    "version": [
-    20241126,
-    917
+    20250104,
+    2227
    ],
-   "commit": "e2749c6348f4783c5175b225e0f964d23c1ccc1f",
-   "sha256": "1rnf3kdwwhhpzcmlix8795zcrlkzhsy31l73pgmvr2fpd36agrli"
+   "commit": "14e002c3f1f405d26f69facb3fe9736a3d79e187",
+   "sha256": "09cbkjxrm7s6kxfq234m6cyy5cvdvg5znj88h5glf8h0jlsysqya"
   },
   "stable": {
    "version": [
@@ -61510,6 +61579,30 @@
    ],
    "commit": "e87e4ca39384c75398c64c920bf4cbc253f6740b",
    "sha256": "0026mlsank67q32sxhjmis9jhsd267gm1v5b7bdw8sm5mh96yx9g"
+  }
+ },
+ {
+  "ename": "hyprlang-ts-mode",
+  "commit": "ed83fb17a56bc5b8d9ab167bf121a7f955a1751c",
+  "sha256": "171y6k5nx4l8gfvyjpb6pa1c9rdiby8cm37sj2dfl0jg0qminm9i",
+  "fetcher": "github",
+  "repo": "Nathan-Melaku/hyprlang-ts-mode",
+  "unstable": {
+   "version": [
+    20241225,
+    914
+   ],
+   "commit": "458636c6a4505ea1eb16321be124ced234469e3f",
+   "sha256": "1dkjhnprkk15532vkjhhk4nh6cw05r92hfw1a2wqa6hm5421mcad"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "458636c6a4505ea1eb16321be124ced234469e3f",
+   "sha256": "1dkjhnprkk15532vkjhhk4nh6cw05r92hfw1a2wqa6hm5421mcad"
   }
  },
  {
@@ -62751,11 +62844,11 @@
   "repo": "QiangF/imbot",
   "unstable": {
    "version": [
-    20241003,
-    1252
+    20250102,
+    1113
    ],
-   "commit": "833777daf76761997687149af688cda51c0c45f5",
-   "sha256": "0dlrc3pbbn33gkzj7i8rcwkxf22lw49nhajg5cyg58375h3d8039"
+   "commit": "d0fe4aca029e251d00102107c3747b41376c32c6",
+   "sha256": "1ywfy009ir90iiza9nig2p241zmypbzf488m20lxrabcxx7qnzq4"
   }
  },
  {
@@ -62917,20 +63010,20 @@
   "repo": "petergardfjall/emacs-immaterial-theme",
   "unstable": {
    "version": [
-    20240908,
-    821
+    20241230,
+    756
    ],
-   "commit": "f1c1c3c49f114dcb93b4068c034641eeaa2a23af",
-   "sha256": "130psdjylb36b4kjkdfp47w78ypv2n890rpn8wdggsmwcjgj18s2"
+   "commit": "de29da5f47e4508c31439d4c29ea57d0659c19df",
+   "sha256": "1vmscxm26g8fy05b0rrhqwdqyjcqdfbilz5mflaiwrlag55r9ir6"
   },
   "stable": {
    "version": [
     0,
     9,
-    2
+    3
    ],
-   "commit": "f1c1c3c49f114dcb93b4068c034641eeaa2a23af",
-   "sha256": "130psdjylb36b4kjkdfp47w78ypv2n890rpn8wdggsmwcjgj18s2"
+   "commit": "de29da5f47e4508c31439d4c29ea57d0659c19df",
+   "sha256": "1vmscxm26g8fy05b0rrhqwdqyjcqdfbilz5mflaiwrlag55r9ir6"
   }
  },
  {
@@ -63027,14 +63120,14 @@
   "repo": "jcs-elpa/impatient-showdown",
   "unstable": {
    "version": [
-    20240617,
-    1944
+    20250101,
+    1009
    ],
    "deps": [
     "impatient-mode"
    ],
-   "commit": "6bdb55c33e99f97a26aab617b686daa6f193eafa",
-   "sha256": "00fh12ryrfvihckrvd9gh1cfxbj8gix0jagw816yzlj6i7530ldl"
+   "commit": "5fa168ec9b74ba1579918eed01fde162d11e209a",
+   "sha256": "1z59h30mdv6ximzw29k18n758y1w15w62i9kdy8p66b002s4cx6w"
   },
   "stable": {
    "version": [
@@ -63194,11 +63287,11 @@
   "repo": "jcs-elpa/indent-control",
   "unstable": {
    "version": [
-    20240925,
-    2347
+    20250101,
+    1009
    ],
-   "commit": "3c3ff2b10289cf6affc0d922908789deade3cbd2",
-   "sha256": "0s62551gr3rjw64r2plxk2x335dlzxb9gfk7011nphjlgvxbyb95"
+   "commit": "6b55986999f230760389a4dcd5d784121305de24",
+   "sha256": "0q3yzsbjjxc6wxbp240l2nyk5vz72s3jihb1va4h0g2ccw4fxk7j"
   },
   "stable": {
    "version": [
@@ -63503,11 +63596,11 @@
   "repo": "nonsequitur/inf-ruby",
   "unstable": {
    "version": [
-    20240925,
-    49
+    20241220,
+    251
    ],
-   "commit": "6399a3668224aa48423c54e81383f73e5e39439a",
-   "sha256": "0x56z9gcw9yxblf7aqgcdfyahdfm4ilf47j0zmsywva1g0bcllrd"
+   "commit": "dad78a13f162200a0f6720fe40e0726525424bba",
+   "sha256": "16bgk4hxnisiv18cnkyjym36yijmig9jln9bglnbvqbvhp2f86b5"
   },
   "stable": {
    "version": [
@@ -63773,11 +63866,11 @@
   "repo": "jamescherti/inhibit-mouse.el",
   "unstable": {
    "version": [
-    20241114,
-    1902
+    20241203,
+    153
    ],
-   "commit": "ce8180dd631d4aadd8b3c434ecbb77c2f5e31012",
-   "sha256": "0nmwx9nckq4gn3nxsf3gpqmk5cyvgy8lhr89gzvl12070npy8r4z"
+   "commit": "436cc1b764873771955ee239c63f5db37f7acc22",
+   "sha256": "0j4xjxs74liz01cs5gqnl2bh50y161zj8q8c74c43wy8qy96p2gm"
   },
   "stable": {
    "version": [
@@ -63812,20 +63905,20 @@
   "repo": "Lindydancer/ini-mode",
   "unstable": {
    "version": [
-    20230211,
-    1512
+    20250103,
+    1901
    ],
-   "commit": "5472abc94e564edc6b469c48d2324519a044a77c",
-   "sha256": "1k2xscd9dhxd4znsxn3ryvds8g9yrd82bz4jdx5p2km9czpjrj88"
+   "commit": "d99a27548a650b8ad531634419ae55f7b4dbe2fa",
+   "sha256": "0lgd7ynbw6yvd2ihfiahnd5fkrbsdykk12pggfcbyqz4gn6kxn88"
   },
   "stable": {
    "version": [
     0,
     0,
-    7
+    8
    ],
-   "commit": "5472abc94e564edc6b469c48d2324519a044a77c",
-   "sha256": "1k2xscd9dhxd4znsxn3ryvds8g9yrd82bz4jdx5p2km9czpjrj88"
+   "commit": "d99a27548a650b8ad531634419ae55f7b4dbe2fa",
+   "sha256": "0lgd7ynbw6yvd2ihfiahnd5fkrbsdykk12pggfcbyqz4gn6kxn88"
   }
  },
  {
@@ -64443,11 +64536,11 @@
   "repo": "BriansEmacs/insert-pair-edit.el",
   "unstable": {
    "version": [
-    20241018,
-    749
+    20241229,
+    54
    ],
-   "commit": "757a9c3bd7b2d1f803e7e83af1a07c1656f3ba1a",
-   "sha256": "006k6mll9p86c6iv34rlvqly4rx7r7mq7xbss9p82hms45za6jyl"
+   "commit": "5701e598a0d115a4f0261c82320d180e6be3045e",
+   "sha256": "0z36s751fsh2a84573754s004x6i65xh29dy5parr9xqsj55x7xx"
   }
  },
  {
@@ -64687,14 +64780,14 @@
   "repo": "jcs-elpa/isearch-project",
   "unstable": {
    "version": [
-    20240101,
-    940
+    20250101,
+    1008
    ],
    "deps": [
     "f"
    ],
-   "commit": "07f26dee4636b8e17179dcf57622d40f8d6fee38",
-   "sha256": "0bbqcn37nngw6dz5k0x9s1h281mp5sdb5c9fd0jalj7v1clxvjy6"
+   "commit": "abd8ee560d1843f9ea01e1a823ddeafe9fbb0b21",
+   "sha256": "07jwn8f8dpcfbh88s7i942ppk6dwkwd3s2zp4qmyqvzlm7zm2m14"
   },
   "stable": {
    "version": [
@@ -64747,11 +64840,11 @@
   "repo": "chmouel/isgd.el",
   "unstable": {
    "version": [
-    20150414,
-    936
+    20241230,
+    1331
    ],
-   "commit": "764306dadd5a9213799081a48aba22f7c75cca9a",
-   "sha256": "09hx28lmldm7z3x22a0qx34id09fdp3z61pdr61flgny213q1ach"
+   "commit": "2dd030ab451cb9e704d173ee1b2388d92362db3b",
+   "sha256": "0wn6nx94pl7nc94bygm4vi1apzp2qlhfc3m2cg7myj9d2n5aa4xd"
   },
   "stable": {
    "version": [
@@ -64794,13 +64887,13 @@
   "repo": "WammKD/emacs-iso-639",
   "unstable": {
    "version": [
-    20240218,
-    1008
+    20241209,
+    539
    ],
    "deps": [
     "levenshtein"
    ],
-   "commit": "c217a36102a566bbaf6f0aec81511fc5a9cfc247",
+   "commit": "e1bfde31c0af34f2fcaed8ca6726e17f2401edf1",
    "sha256": "0hhxp36k1nlvz6bd8g2y0xj0m5sb7zz3yq8pr5dqql6fh78rq2hm"
   },
   "stable": {
@@ -64812,7 +64905,7 @@
    "deps": [
     "levenshtein"
    ],
-   "commit": "c217a36102a566bbaf6f0aec81511fc5a9cfc247",
+   "commit": "e1bfde31c0af34f2fcaed8ca6726e17f2401edf1",
    "sha256": "0hhxp36k1nlvz6bd8g2y0xj0m5sb7zz3yq8pr5dqql6fh78rq2hm"
   }
  },
@@ -64902,11 +64995,11 @@
   "repo": "doublep/iter2",
   "unstable": {
    "version": [
-    20221104,
-    1938
+    20250104,
+    2139
    ],
-   "commit": "5ea6ba6effc4b71e7a4aed16b3f42408f9064c01",
-   "sha256": "0vb6xrv6dnw7x8a2iak8509zz63ss4jkxwg8mbwqgamxcvf39hc8"
+   "commit": "b4657712a6680886c963025f48798a5f1620d236",
+   "sha256": "0y4azqxpl9pnlxxwmkryasvlzfsmg8scvb9bzig0v2sqvlp1h136"
   },
   "stable": {
    "version": [
@@ -65647,8 +65740,8 @@
  },
  {
   "ename": "ivy-rtags",
-  "commit": "3dea16daf0d72188c8b4043534f0833fe9b04e07",
-  "sha256": "18f0jak643dd8lmx701wgk95miajabd8190ls35831slr28lqxsq",
+  "commit": "8f5d42452235ee9f1590fa8893c4ea3d40ac891b",
+  "sha256": "15alnihcsjhl0kkw2vvyxsjsryhpz1wdi8jjh4sgw1mx6nxl8rik",
   "fetcher": "github",
   "repo": "Andersbakken/rtags",
   "unstable": {
@@ -66718,25 +66811,25 @@
   "repo": "minad/jinx",
   "unstable": {
    "version": [
-    20241201,
-    1341
+    20250101,
+    920
    ],
    "deps": [
     "compat"
    ],
-   "commit": "1be1a91c14031b0cf152c87f2cd5341559b2a1ec",
-   "sha256": "0a1frjjdkbhxjsn97bsjmil8winycwdvd4qwabgrzk8c5flnjiaa"
+   "commit": "8407ed958001f6a4718f225737665e50e6666dbf",
+   "sha256": "16830ax1ijy451ikahg1vxadbmjm414jqg2wpkkj36qz0ia6jq4j"
   },
   "stable": {
    "version": [
     1,
-    10
+    11
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4c89699db3851c3ecfa5d007ab56c810e8e3ffeb",
-   "sha256": "1m5895c1vlrma0kpakx6s3q9kbjihss57kwjcx66pr342kjaklvm"
+   "commit": "e603f9b735c342cd6c6de714366cfef77c8b779c",
+   "sha256": "12fnqdxvp8gf2vk37m2v4lfy86m8jjnwl4pw7hsxiamhhvp78y33"
   }
  },
  {
@@ -67102,11 +67195,11 @@
   "repo": "redguardtoo/js-comint",
   "unstable": {
    "version": [
-    20241112,
-    609
+    20241205,
+    2321
    ],
-   "commit": "a2e6f01b999e26047808c1720b7be0805afc7cb6",
-   "sha256": "0ap744yp8m1wfws61k8xi53wj3dk4pg25wfzfafs1y6n2jx9r145"
+   "commit": "68908b5d232738bdc25c4cae502067ef2255a2fd",
+   "sha256": "1lcj8bp16vp7sp6phx5hhg8k6q2ilrbcrhlfzgszsvz3g2jinlzs"
   },
   "stable": {
    "version": [
@@ -67169,6 +67262,21 @@
    ],
    "commit": "9f8b6bc4f080c7146ce7ee5dd5a6572aeb6f1cc7",
    "sha256": "1nlcfqy4wciai7g9zdjy4lx50dipv6yq74fladgsw7yq98hpg501"
+  }
+ },
+ {
+  "ename": "js-pkg-mode",
+  "commit": "7d2d93b6934f62046c1d4f21dc12f372d5891140",
+  "sha256": "1fmxwfkx6lirk4ng5z1qszjsv4nv9gwb3ydb9r1wqf8g13k499ks",
+  "fetcher": "github",
+  "repo": "ovistoica/js-pkg-mode",
+  "unstable": {
+   "version": [
+    20241211,
+    744
+   ],
+   "commit": "d2a609a6cfa0a00d6a96e53e124542e464ccc192",
+   "sha256": "0rminl6an89dy805vhbmnbwdy6afr1cdsgwkss84spamdja9h924"
   }
  },
  {
@@ -67257,14 +67365,14 @@
   "repo": "mooz/js2-mode",
   "unstable": {
    "version": [
-    20240908,
-    1236
+    20241205,
+    140
    ],
    "deps": [
     "cl-lib"
    ],
-   "commit": "62d6cb169ed4cb6d7ae3ddbd8da9c995fed0ab32",
-   "sha256": "0yqj4dm9ky8sx0w1hwl0qskliswyqnmzr6p8lzhm3fviyn6q54x5"
+   "commit": "e0c302872de4d26a9c1614fac8d6b94112b96307",
+   "sha256": "1midf8yib70k6kh50a2r7g9xri2jvvglz4rchjw89wl2zqyl1p91"
   },
   "stable": {
    "version": [
@@ -67395,15 +67503,28 @@
   "repo": "isamert/jsdoc.el",
   "unstable": {
    "version": [
-    20240917,
-    1118
+    20241227,
+    1219
    ],
    "deps": [
     "dash",
     "s"
    ],
-   "commit": "36af204bc1e2582a7a2178249fa88f7995280192",
-   "sha256": "0cg74637xxlr8vz4h6sxc5v7f7p673g979bnnc5a5mlm63ahr8kh"
+   "commit": "623994bb50d845de487c100f5cd393ce1d792460",
+   "sha256": "1aza1p747i6bz2xg2vz63isbnh8agkdffsd7mdxb9xdfnn9cik6f"
+  },
+  "stable": {
+   "version": [
+    0,
+    4,
+    0
+   ],
+   "deps": [
+    "dash",
+    "s"
+   ],
+   "commit": "5b514ad23834b7a584b184125ba4a66bc3c26cff",
+   "sha256": "0j99rax3n905ya0ya42093pl8q7kcb8xx2qz6b918f7d8q0mr44n"
   }
  },
  {
@@ -67772,11 +67893,11 @@
   "repo": "llemaitre19/jtsx",
   "unstable": {
    "version": [
-    20240715,
-    2002
+    20250102,
+    812
    ],
-   "commit": "e81259a7584619ce3266a2d532f674ef45ee4274",
-   "sha256": "0z8z41hy4ssyyb4skzzysayw72jc441bffhbw1mgmgpjr7412b94"
+   "commit": "8043e8339debd66d6d3591c82d8bc8437a1021bd",
+   "sha256": "0n2l1hs8grb7m7mg3vr06r2jibxaaxriv0lkfpzh09x5m8hh6q8r"
   },
   "stable": {
    "version": [
@@ -67814,11 +67935,11 @@
   "repo": "JuliaEditorSupport/julia-emacs",
   "unstable": {
    "version": [
-    20241120,
-    857
+    20241213,
+    1620
    ],
-   "commit": "709c43410fb5da068d7d582cf3f545f7a7a68133",
-   "sha256": "0dmh3cd5mbsxz6fahvq2apzij53zdv2pvlxhqb3ix7ayb8l67a62"
+   "commit": "0f4d74f9049df28e2f522733141bfc5b7a0f69a3",
+   "sha256": "0vyr48afhlm207hidmahp1rsnjdfxdf2li8bisswjd6l3hhd8wxv"
   },
   "stable": {
    "version": [
@@ -67837,14 +67958,14 @@
   "repo": "tpapp/julia-repl",
   "unstable": {
    "version": [
-    20241120,
-    1523
+    20241213,
+    1619
    ],
    "deps": [
     "s"
    ],
-   "commit": "1f4f6b4e01ff1529b0d7917fbd9ce29451a66510",
-   "sha256": "0pp7sixpn0hh3743llxjz9rigq4ifsn249kvb4ph1fl0ys6ckj43"
+   "commit": "317d56021889a336b4be241604ba71e46dc80581",
+   "sha256": "1xmpplqvwqzqb5r3kjs078kh7bqaj3vzv1q797smhsn8mxraa6y0"
   },
   "stable": {
    "version": [
@@ -67885,8 +68006,8 @@
   "repo": "gcv/julia-snail",
   "unstable": {
    "version": [
-    20240812,
-    840
+    20241216,
+    2010
    ],
    "deps": [
     "dash",
@@ -67895,8 +68016,8 @@
     "s",
     "spinner"
    ],
-   "commit": "dff92c4250e40a6cc106f0ea993f9631ad55eb7c",
-   "sha256": "1s2382n7bf741hnyxafx4f323f66xbfnpp3nky629s4sy8r4x0hr"
+   "commit": "e2b08f37b89a39e90e9e7e4f22faa0540a9efb2e",
+   "sha256": "0v7kx6drjzsrbzsc9qnfbq6w6hp0aqyxmrrvxxb1zn5lfka5z61d"
   },
   "stable": {
    "version": [
@@ -68106,8 +68227,8 @@
   "repo": "emacs-jupyter/jupyter",
   "unstable": {
    "version": [
-    20241120,
-    230
+    20241203,
+    1917
    ],
    "deps": [
     "cl-lib",
@@ -68116,8 +68237,8 @@
     "websocket",
     "zmq"
    ],
-   "commit": "577371744b36aa0afa117b7ded21d08f60331ff6",
-   "sha256": "1d2945irdi5s2cm2kzx87k28w2gcg1z8f5zm889rm5fv6dj6x1zj"
+   "commit": "db8a9e233a010a61063f34220821ec76157a2d84",
+   "sha256": "0gjxi84d95sx5fw8q2a8szfhq6kb4xzwq0xr9a3pirkiga9hxymz"
   },
   "stable": {
    "version": [
@@ -68182,8 +68303,8 @@
   "repo": "psibi/justl.el",
   "unstable": {
    "version": [
-    20241123,
-    1442
+    20241212,
+    255
    ],
    "deps": [
     "f",
@@ -68191,8 +68312,8 @@
     "s",
     "transient"
    ],
-   "commit": "16b6ed54ceae839da032e5850075cab43c46be08",
-   "sha256": "0k2m89y9j8i60iwj5pqphf8n9cqkzx7fz6q4if3rddbxp17n72l4"
+   "commit": "1c3d0550cd4f53139ce9a63b9954685162e838f7",
+   "sha256": "04gk6908qb435af9d0f5fl0b9ynh9vwymgcw77ya645p04m74zs0"
   },
   "stable": {
    "version": [
@@ -68551,11 +68672,11 @@
   "repo": "Fabiokleis/kanagawa-emacs",
   "unstable": {
    "version": [
-    20241028,
-    1204
+    20250101,
+    420
    ],
-   "commit": "6fe28070d7b3581415faa3e61af786b596ef3bb0",
-   "sha256": "1akcgvl29lv01cvsrc0lrgkas680dq45lvhfq63prwmgbinb2x6y"
+   "commit": "1d34a95c0f639b035481b5506089bc209769bab6",
+   "sha256": "1gqj62hw442021bjbx7bfqlbk38gvczjd3cfgwycnydia6pgnjxy"
   }
  },
  {
@@ -68630,15 +68751,15 @@
   "repo": "ogdenwebb/emacs-kaolin-themes",
   "unstable": {
    "version": [
-    20241104,
-    1
+    20250104,
+    708
    ],
    "deps": [
     "autothemer",
     "cl-lib"
    ],
-   "commit": "343ad8cd73c7509af2ea7af5eb856ece97dee7a3",
-   "sha256": "0s4pnb8wblnj0kpqd35b6z7b719p7rfs0n2qcs6l8wyd8f3xdzwa"
+   "commit": "fc43da84f4f786f30ee7f34fa4ceda64f2246074",
+   "sha256": "0akvlrsj2x7112vjd61zx3vii5ni4wm02wi8c6dav4yy1xq2y128"
   },
   "stable": {
    "version": [
@@ -69271,11 +69392,11 @@
   "repo": "emacs-grammarly/keytar",
   "unstable": {
    "version": [
-    20240101,
-    846
+    20250101,
+    849
    ],
-   "commit": "b4fdde53ec884c931db8465b334af6057b30daa1",
-   "sha256": "1q39dwzs9hx9ay57j1vqqqaw2fj9xzshldzniaw8rqpakqa751q3"
+   "commit": "5b3501dc95755d85fcf21b00ae0d347446efe73b",
+   "sha256": "0qbabikk1ingkqgbwb4wk9m7zxhn2g1kgs0i0b6mccmn4134sizk"
   },
   "stable": {
    "version": [
@@ -69382,28 +69503,28 @@
   "repo": "khoj-ai/khoj",
   "unstable": {
    "version": [
-    20241129,
-    343
+    20241229,
+    1839
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "439b18c21f0d540fc6c6a9aea0c9b22e4259e6e0",
-   "sha256": "09bzvm603kzh3md5plcc01jwwj3mmb87z7c3p9wz0k662hg7nwdk"
+   "commit": "8f69eb949bb0ab79e2c74aa18e77f82420e9fbe6",
+   "sha256": "1ymz2p9yanblpg3v7l9l990s8dgwayjcicgkh8x6dvsrq2afqvfq"
   },
   "stable": {
    "version": [
     1,
-    30,
-    10
+    33,
+    0
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "439b18c21f0d540fc6c6a9aea0c9b22e4259e6e0",
-   "sha256": "09bzvm603kzh3md5plcc01jwwj3mmb87z7c3p9wz0k662hg7nwdk"
+   "commit": "8f69eb949bb0ab79e2c74aa18e77f82420e9fbe6",
+   "sha256": "1ymz2p9yanblpg3v7l9l990s8dgwayjcicgkh8x6dvsrq2afqvfq"
   }
  },
  {
@@ -69434,6 +69555,30 @@
    ],
    "commit": "ec5f154db3bb0c838e86f527353f08644cede926",
    "sha256": "0ky167xh1hrmqsldybzjhyqjizgjzs1grn5mf8sm2j9qwcvjw2zv"
+  }
+ },
+ {
+  "ename": "kill-dollar-mode",
+  "commit": "ea444357715c05c2bad942928937d9dc80a8b977",
+  "sha256": "0f4r9277yzgjl51nwkaddqi6j3vnz2w59q8p1a97v1pw4sph9m34",
+  "fetcher": "github",
+  "repo": "sandinmyjoints/kill-dollar-mode",
+  "unstable": {
+   "version": [
+    20241217,
+    1947
+   ],
+   "commit": "e51c076f93605c5a651b549731ccfc85a2564aca",
+   "sha256": "1fawyggzmabljs8d5aq39kdq54ifqyyx3sfwpx8x4fzayrzl7g8s"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    0
+   ],
+   "commit": "96c1fe1b40950a2666a39bd53ff9e5faa9d46ef1",
+   "sha256": "1p81dh34s84kyk0d3mn0chyyi2va44vpx6in4cykh6pdf4qk04g0"
   }
  },
  {
@@ -69571,20 +69716,20 @@
   "repo": "kivy/kivy",
   "unstable": {
    "version": [
-    20240105,
-    940
+    20210318,
+    2106
    ],
-   "commit": "9ef218027178115a66b417ae34b21f488bdd3617",
-   "sha256": "17h5nk4h013ja3hm8xn5ljwsnh56qcmwskjg934ky4p9z393v7j0"
+   "commit": "db86b06b9b72e514c122e3f54a0bce74adad44c5",
+   "sha256": "1v14gsk1fal8xqpy8myk02n7s0f0yzpcmgf8a0mizh858y1sbxxv"
   },
   "stable": {
    "version": [
     2,
     3,
-    0
+    1
    ],
-   "commit": "9ef218027178115a66b417ae34b21f488bdd3617",
-   "sha256": "17h5nk4h013ja3hm8xn5ljwsnh56qcmwskjg934ky4p9z393v7j0"
+   "commit": "20d74dcd30f143abbd1aa94c76bafc5bd934d5bd",
+   "sha256": "1i3ka71h3ggli7bajjf0x7knh6qcjv53cqd06236skalz8bnih5b"
   }
  },
  {
@@ -69661,11 +69806,11 @@
   "repo": "WammKD/Emacs-Klondike",
   "unstable": {
    "version": [
-    20240131,
-    453
+    20241215,
+    151
    ],
-   "commit": "1cf14d7b6c14ebde741c36f6aa871dcd41e37cff",
-   "sha256": "0vgf03zqbd6nfxrz90x0favm6d15gba86hp8vg6wcbckc7j2gn1g"
+   "commit": "d5b151ee47f8ad3d57b3bc221389383b1c1cfec3",
+   "sha256": "1hrl2k4092jng8yra53han1cgblpfddvn2j20jqrkv2idv0xrcfl"
   },
   "stable": {
    "version": [
@@ -69673,8 +69818,8 @@
     2,
     0
    ],
-   "commit": "99f7aad1221a76402746a06b57e89622fd9cf33a",
-   "sha256": "07xcc5gryzabxk7czghkwq1v8r09mg9yh8rwy1v2gs8qm9lwypgv"
+   "commit": "4e5d3a15bc66b790bf9c1c759f5ba7394e552112",
+   "sha256": "0bpzvs6j4zi47kdh5xc0wq3084mpzcfl3w74yz7g1nqkxbj9d4b3"
   }
  },
  {
@@ -69839,11 +69984,11 @@
   "repo": "bricka/emacs-kotlin-ts-mode",
   "unstable": {
    "version": [
-    20240917,
-    1401
+    20241226,
+    1643
    ],
-   "commit": "bf1646a386408103e6267599a26e5f5479fa4635",
-   "sha256": "1di16q5cgjkmql5h6ah8bndh58a73rlk9gxkqmdvxh8j3lschryn"
+   "commit": "a25d56cecac9160ba7c140f982ec16ca7b2fe97f",
+   "sha256": "0d1y8inz0ljd85s8ndlg1lk5whqm7y68kfdh2klhf0qc42phrr6z"
   }
  },
  {
@@ -70235,15 +70380,15 @@
   "repo": "tecosaur/LaTeX-auto-activating-snippets",
   "unstable": {
    "version": [
-    20230331,
-    1806
+    20241212,
+    1314
    ],
    "deps": [
     "aas",
     "auctex"
    ],
-   "commit": "a00f0aba237b85b3e5fd60cf84de5759d1bf5d48",
-   "sha256": "0mjq9lkd6r8mlmji0a1i9rjn1xbd6g0swzr3x55k9srla3nm2l0k"
+   "commit": "f5fb180ab23b7eb0695ade84c9077aa701f47bbf",
+   "sha256": "1pkm1qkfsps51rbj5vb0xl7vsqndy719kdw7gai5lmb702q47qmp"
   },
   "stable": {
    "version": [
@@ -70267,12 +70412,11 @@
   "repo": "isamert/lab.el",
   "unstable": {
    "version": [
-    20241004,
-    818
+    20241229,
+    2148
    ],
    "deps": [
     "async-await",
-    "auth-source",
     "compat",
     "f",
     "memoize",
@@ -70280,14 +70424,14 @@
     "request",
     "s"
    ],
-   "commit": "193eb6b74f4c60c455cae276d3881668383b21fc",
-   "sha256": "04qihisw1baly5wspkafjqlw7w8k8v7lmjj6hcldc5bpjpc9f06l"
+   "commit": "7552236f24f704a83ed2c8b8a53f59af312a844e",
+   "sha256": "1mrwqdf5xkv03458jd82v95a965ha6f4jgp0daxjsj2980nv7nx4"
   },
   "stable": {
    "version": [
     2,
-    0,
-    0
+    1,
+    1
    ],
    "deps": [
     "async-await",
@@ -70298,8 +70442,8 @@
     "request",
     "s"
    ],
-   "commit": "bd88c08c02203a66048412672b894c0d7dab3da3",
-   "sha256": "0zxxa99n3wh77fm03mpnz2kxhgs6x2gqhznxh2gy5lx1yd8kg7jp"
+   "commit": "1edebf13309b39a2b0299115e011c751310fa158",
+   "sha256": "1majirap2aqc9ch9d7rzkb7k2az3a8aaaq60f4q9izpdn5pi3wkd"
   }
  },
  {
@@ -70388,16 +70532,16 @@
   "repo": "Deducteam/lambdapi",
   "unstable": {
    "version": [
-    20241110,
-    1640
+    20250102,
+    959
    ],
    "deps": [
     "eglot",
     "highlight",
     "math-symbol-lists"
    ],
-   "commit": "bd45582bb912bad97f614264ff3142d11a6399a1",
-   "sha256": "07aiywrdy4r2y5bm8pmf04lpdj4gwngkkyf2bl8h7kj07s8zy9pq"
+   "commit": "15d4eeaeefd33f44a8e6258dc905dacdb731cacc",
+   "sha256": "0yng70df2rk57bs9l0h69fim9ivd0whvmwvgygxc1d8rrlmhnx8y"
   },
   "stable": {
    "version": [
@@ -71066,6 +71210,24 @@
   }
  },
  {
+  "ename": "le-gpt",
+  "commit": "228594b85d098a800d53acff23d00028c8a4143f",
+  "sha256": "0kzyn2plr55xzv5g9rsi99qc17r16kvnm4zida7p0aqqgrshh88q",
+  "fetcher": "github",
+  "repo": "AnselmC/le-gpt.el",
+  "unstable": {
+   "version": [
+    20241218,
+    909
+   ],
+   "deps": [
+    "markdown-mode"
+   ],
+   "commit": "07c7bce41e33eda70c1d2023f6c96fe4428097a8",
+   "sha256": "15vggpcy1c7gclbkwq72ljf8bnmsldvnxhwvmjwf386948d0hz5c"
+  }
+ },
+ {
   "ename": "le-thesaurus",
   "commit": "4534fab1d43c425745f44465adbd1f8a9168ced8",
   "sha256": "14sg1c7wn9f6xk1sychw857f88ddlx9c6b71p8cw08gz5hdm2463",
@@ -71073,14 +71235,14 @@
   "repo": "AnselmC/le-thesaurus.el",
   "unstable": {
    "version": [
-    20230112,
-    1604
+    20241229,
+    1950
    ],
    "deps": [
     "request"
    ],
-   "commit": "83e8df8957a3b8167cc2bf97849a1eca555ce9a6",
-   "sha256": "00phb69hn8w5zl47k5l8gqlxqjm5ig7rz0v4g47hx7xlnhcsfvj4"
+   "commit": "8c8ea595678da69df817a173ec043ab1b17d96c3",
+   "sha256": "17qg24xi9gs8pnqwzcmb6fpz1ba2zmsm4p8z7z54jwzsbq60b8w2"
   }
  },
  {
@@ -71432,15 +71594,15 @@
   "repo": "martianh/lem.el",
   "unstable": {
    "version": [
-    20241102,
-    1553
+    20241228,
+    1420
    ],
    "deps": [
     "fedi",
     "markdown-mode"
    ],
-   "commit": "79c4b8112be95df0193e7dff99a097ec818b04cb",
-   "sha256": "0arhjcx9yzf9jgrl6f87lqviaq8sqkn8wfbxzbkk952fgp32v6h6"
+   "commit": "64ba2554f2742a05f8208434d23e2dcb2c476c41",
+   "sha256": "15xrs2hygx236driipb1fm2k4ky86ybnv104z178pyvfm6dndnjj"
   },
   "stable": {
    "version": [
@@ -71621,20 +71783,20 @@
   "repo": "fniessen/emacs-leuven-theme",
   "unstable": {
    "version": [
-    20240713,
-    929
+    20241224,
+    1031
    ],
-   "commit": "4f355a9832095c49ec109cfc5b8f82cd8c469572",
-   "sha256": "148qb2k3np5k1sa8i7yc7qbn5s4sm9x2n3akvpvf512byx3mivs3"
+   "commit": "d784771770894bd27659cc9db252ee4578d228b6",
+   "sha256": "01ipwgg3klbq4pc1vpsg2042hlcgqlfp24rildb9ddqzhnfx6mlm"
   },
   "stable": {
    "version": [
     1,
     2,
-    1
+    2
    ],
-   "commit": "4f355a9832095c49ec109cfc5b8f82cd8c469572",
-   "sha256": "148qb2k3np5k1sa8i7yc7qbn5s4sm9x2n3akvpvf512byx3mivs3"
+   "commit": "d784771770894bd27659cc9db252ee4578d228b6",
+   "sha256": "01ipwgg3klbq4pc1vpsg2042hlcgqlfp24rildb9ddqzhnfx6mlm"
   }
  },
  {
@@ -71709,11 +71871,11 @@
   "repo": "rvirding/lfe",
   "unstable": {
    "version": [
-    20230102,
-    1428
+    20241206,
+    1536
    ],
-   "commit": "68c9c7ec8ef441eb79e68772ec4956fd2671b2e7",
-   "sha256": "1lx3szdlhvidys9vk8d0pznnsni31wjm7afks3hhmdjj6hcp3cxi"
+   "commit": "7ba1e7538f3efad909e0a1d7b54fbbb970d84596",
+   "sha256": "18klpw8k6a0waqxl701dwvw5c699ixj1sg276g2qnvfy22a9hgvr"
   },
   "stable": {
    "version": [
@@ -71954,14 +72116,14 @@
   "repo": "jcs-elpa/license-templates",
   "unstable": {
    "version": [
-    20240101,
-    932
+    20250101,
+    1008
    ],
    "deps": [
     "request"
    ],
-   "commit": "62adc47eb36a6f2eabe63c3e9dc8ce7f94007f19",
-   "sha256": "1r9z81xivk4d9gjyr01d55l4wrmvwzj2jli63qmq939h6jk2vvnx"
+   "commit": "93c4374301aa3fdb3dc67e3a7513af02e536d367",
+   "sha256": "0vyq3qnb4f0ig0dd6pa6s7lzxjvl2rmpk1k3j708fwhf8yvkwzdh"
   },
   "stable": {
    "version": [
@@ -72032,16 +72194,16 @@
   "repo": "emacs-vs/line-reminder",
   "unstable": {
    "version": [
-    20240715,
-    2304
+    20250101,
+    909
    ],
    "deps": [
     "fringe-helper",
     "ht",
     "ov"
    ],
-   "commit": "76677e48451b77508673a52dcc0845b87e5f81fe",
-   "sha256": "1zr4fvw286gdibf642hv7jnsyyvw81mxk7695g7wqb7q582lkm3h"
+   "commit": "bab0c4cbe344ca888842278e982155a3916617d0",
+   "sha256": "1xqs488zyd94p4hrfjzbaxs3fm45b60rnl0jjc1wgbqaksmqqbg1"
   },
   "stable": {
    "version": [
@@ -72190,14 +72352,14 @@
   "repo": "noctuid/link-hint.el",
   "unstable": {
    "version": [
-    20240903,
-    2150
+    20241219,
+    2051
    ],
    "deps": [
     "avy"
    ],
-   "commit": "bf4ca2126d5c0a06df7ae26f478e94cb03ab932b",
-   "sha256": "0d3zi7mc4vr60haidb4p4jhfwxwygirpr7kyk8ggpbwh0r2i6k3z"
+   "commit": "826993a0ab736ab09f53a0623fb44edf2182b07c",
+   "sha256": "00grv36l98fzz0iabc2li19k9wf9k9dmsg0lq5p7qnjfizshyzrp"
   }
  },
  {
@@ -72782,11 +72944,11 @@
   "repo": "jingtaozf/literate-elisp",
   "unstable": {
    "version": [
-    20220626,
-    932
+    20250103,
+    132
    ],
-   "commit": "bbc4befbf13f63b92cb1d780501482ae5bd8285b",
-   "sha256": "1ip04jva082c4cvdqa2nmc8kfjwwx21ggr6fylpm0pbj2b55vk0k"
+   "commit": "c559eff46dd7fe0ffc4ad7bf6dd65ee5be516368",
+   "sha256": "1h8j16hqhncbfa6nf046qfzhplzqql9i2jjwx1kmqnyxfcvv1zs6"
   },
   "stable": {
    "version": [
@@ -72894,11 +73056,11 @@
   "repo": "donkirkby/live-py-plugin",
   "unstable": {
    "version": [
-    20241127,
-    2323
+    20241214,
+    1526
    ],
-   "commit": "b417ad93191e8eecaca347f5407dd4bb4c07b6f8",
-   "sha256": "101dd0b1czc28yjsdz0fdvkh8b76rd03a1br7sldlmsy3dfhk669"
+   "commit": "87bfff4da227554162e1148ded42ef848248bacb",
+   "sha256": "0ikkfwcb58zraabn32zhdjrszgyrlsy5j5nspajzx2lni7nlws67"
   },
   "stable": {
    "version": [
@@ -73008,20 +73170,20 @@
   "repo": "tarsius/llama",
   "unstable": {
    "version": [
-    20241104,
-    2206
+    20250101,
+    1412
    ],
-   "commit": "f4e80a582f7ec857783274bee6614560ce49d497",
-   "sha256": "1km89ks7xg89sjqxiri9lxj58hc17z13z7mzcq3y66yv1dfrrziz"
+   "commit": "07a47101ab2b0dab47094b369585443b89ac31c9",
+   "sha256": "1664y6b1djwfhj8iv0hac9y78nqs4hhakvp6f7js3m61hd5rizfp"
   },
   "stable": {
    "version": [
     0,
     4,
-    0
+    1
    ],
-   "commit": "f4e80a582f7ec857783274bee6614560ce49d497",
-   "sha256": "1km89ks7xg89sjqxiri9lxj58hc17z13z7mzcq3y66yv1dfrrziz"
+   "commit": "07a47101ab2b0dab47094b369585443b89ac31c9",
+   "sha256": "1664y6b1djwfhj8iv0hac9y78nqs4hhakvp6f7js3m61hd5rizfp"
   }
  },
  {
@@ -73353,16 +73515,16 @@
   "repo": "jcs-elpa/logms",
   "unstable": {
    "version": [
-    20240101,
-    942
+    20250101,
+    1008
    ],
    "deps": [
     "f",
     "ht",
     "s"
    ],
-   "commit": "ef571d7ab8b2809363197e6867bfc1fbff5d14b7",
-   "sha256": "19cq2sshk7ag76a28q2l039a6d126jiws06mfi1b7kkg1n5fsksm"
+   "commit": "48d50cdc90b68b86333bcdb3f2ebfa4568db198c",
+   "sha256": "1a672vh25iy6552clg1gv594jibnsi4krjbbiv56pqj3brp043h1"
   },
   "stable": {
    "version": [
@@ -73449,27 +73611,30 @@
   "repo": "doublep/logview",
   "unstable": {
    "version": [
-    20241118,
-    1819
+    20241225,
+    1410
    ],
    "deps": [
+    "compat",
     "datetime",
     "extmap"
    ],
-   "commit": "de9694cfdc7006017781e7d32bb8bad38c7fda46",
-   "sha256": "0rl05yy16x0gsc6y58a2zyxc0dbyh5w1c6jx67mkvjxldpqah1sl"
+   "commit": "034c240c816188bf8be7441c9b0925abb92e861c",
+   "sha256": "12sh9mrpgff4sm1yr3zc2crpwiq3zrj3md0hd0mr69gdkq07xfw3"
   },
   "stable": {
    "version": [
     0,
-    19
+    19,
+    1
    ],
    "deps": [
+    "compat",
     "datetime",
     "extmap"
    ],
-   "commit": "50f0b12f9cb3b8bdc9b28c16187495770ff6dff6",
-   "sha256": "1z9w1rdr1d7j6fw9rb05wjrpdj9zka683xj35cxws7qplk3dlz29"
+   "commit": "9ce423a9fc319bb919c681e16939b9f561f7a942",
+   "sha256": "0qgkmjw5prc5zrsccdmh9wfr1fyk9jfdfnqn6ldsbi7jhbr71366"
   }
  },
  {
@@ -73605,8 +73770,8 @@
   "repo": "okamsn/loopy",
   "unstable": {
    "version": [
-    20241129,
-    1652
+    20250104,
+    2303
    ],
    "deps": [
     "compat",
@@ -73614,8 +73779,8 @@
     "seq",
     "stream"
    ],
-   "commit": "159cf1811c2d27552166c9976f8612c487054d31",
-   "sha256": "1dzrh3wiqc8yb6kcrbb38pngygspm9zjm2wrhs041albkj7sz1cx"
+   "commit": "95f7d12f0175519d86c40ecd8c5159dd7b99e540",
+   "sha256": "0j23c1k48dswa183vsw7vj95j0fp34dscjpnlynlas5ycrp8df2q"
   },
   "stable": {
    "version": [
@@ -73635,21 +73800,21 @@
  },
  {
   "ename": "loopy-dash",
-  "commit": "7f4e68f6feb5d0082580cc28f6184a6091e7c117",
-  "sha256": "0hk4c415wp4dqx1xjs246p8hqn15iamj8xiig2cla1f24zd7kd28",
+  "commit": "b51bc89476900ff52cfeeee5943ddee561bcb5dc",
+  "sha256": "0gqy6z8b7iyyhbqy33n1b67v839z5711x49w097phvvm5rbwi7i2",
   "fetcher": "github",
-  "repo": "okamsn/loopy",
+  "repo": "okamsn/loopy-dash",
   "unstable": {
    "version": [
-    20240818,
-    245
+    20241228,
+    323
    ],
    "deps": [
     "dash",
     "loopy"
    ],
-   "commit": "80a30903628bc8de36c51c966e6cf5b114001e47",
-   "sha256": "1yxgv2g42q3nqn24mnrk329jx0d0h2igc499xskfc46a5dqfxjym"
+   "commit": "56c8413dbcffef2b1a0896d53584296619cb1504",
+   "sha256": "0j2aj1z6bh27710c57bkd296zyb12zml4p6jr0dzxrmfssh1w9dd"
   },
   "stable": {
    "version": [
@@ -73862,8 +74027,8 @@
   "repo": "emacs-grammarly/lsp-grammarly",
   "unstable": {
    "version": [
-    20240229,
-    115
+    20250101,
+    850
    ],
    "deps": [
     "grammarly",
@@ -73872,8 +74037,8 @@
     "request",
     "s"
    ],
-   "commit": "39deb23b282785eaffc6ae17838c92c613a49315",
-   "sha256": "0f2kj2d64b9rqz9jf38629b5hwvp7wscbc646ydfmwib5f2m723x"
+   "commit": "0ae43b9d92c0f324d0ad9f3c28c34a305381f13e",
+   "sha256": "03kpxas4b6ld9pzpcy331i9gbn8pyhpvqbb3mr1y66j18czr5vnj"
   },
   "stable": {
    "version": [
@@ -74095,28 +74260,28 @@
   "repo": "ROCKTAKEY/lsp-latex",
   "unstable": {
    "version": [
-    20241006,
-    800
+    20250101,
+    655
    ],
    "deps": [
     "consult",
     "lsp-mode"
    ],
-   "commit": "36a37a8e0a6b0edbea8e67dab89d12980d2a368f",
-   "sha256": "0yfmqjp1bmp8rp9vl9y5qmic3wr2f5p10gyb2rlmpgfnx5c8575g"
+   "commit": "ec9a8674781162c8878f6339087cae0679e3a6e3",
+   "sha256": "0iqy4xfgxfhc17kxrwf1lgz3v8sacazr5m5l0231lf2kbhjb2lnb"
   },
   "stable": {
    "version": [
     3,
-    7,
-    1
+    9,
+    0
    ],
    "deps": [
     "consult",
     "lsp-mode"
    ],
-   "commit": "30e5ee2a387bee7b320564d402b3e587cdae536c",
-   "sha256": "0zfg35mq3a1550l2ds6wg5flxc04fq600apz3z5zfq58qqdiah8k"
+   "commit": "570e61629a3a2a895067f7a5766482717c820004",
+   "sha256": "0q08bazvkpmgbkq2bxw4kj32mljs2is14gyl27hh1v58x17616p0"
   }
  },
  {
@@ -74127,14 +74292,14 @@
   "repo": "emacs-languagetool/lsp-ltex",
   "unstable": {
    "version": [
-    20241130,
-    801
+    20250101,
+    852
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "8338c47dc2ea99dea4797ad110592139b2c66e59",
-   "sha256": "011x1daddvdbih3nawr1f4j0frjnmg8q8p0727bi9xm86yffln51"
+   "commit": "98435127e24719a398c41ebaf14d26928de4632a",
+   "sha256": "0jwn3869dwjw2nyfmhg6dkaz4fslwmb2k2h54gpiwzwv5a1pg03j"
   },
   "stable": {
    "version": [
@@ -74159,8 +74324,8 @@
   "repo": "emacs-lsp/lsp-metals",
   "unstable": {
    "version": [
-    20241112,
-    1142
+    20250102,
+    1828
    ],
    "deps": [
     "dap-mode",
@@ -74172,8 +74337,8 @@
     "scala-mode",
     "treemacs"
    ],
-   "commit": "b5139c959336758a93d0e55458e6ca938d9fd16a",
-   "sha256": "1axbcmfnz176dfpd5nbx2f1nfad8pzl8ah9gddia4smad23cpvcm"
+   "commit": "6a6a345a8a6cd8814b40909aef8e99055b128fa0",
+   "sha256": "0cik7mq8g32h98iyqjmai3k5gi17f71mp3y39a04cp4grbv1jxky"
   },
   "stable": {
    "version": [
@@ -74203,8 +74368,8 @@
   "repo": "emacs-lsp/lsp-mode",
   "unstable": {
    "version": [
-    20241201,
-    2156
+    20250105,
+    453
    ],
    "deps": [
     "dash",
@@ -74215,8 +74380,8 @@
     "markdown-mode",
     "spinner"
    ],
-   "commit": "57ea512212b4cdd650b0bc4bcadd14fd678c212d",
-   "sha256": "0b11lqi7n00xqk9miyazi39nrhf0p110rl7177xy0gbzxjzpcvfm"
+   "commit": "f3bd38d50b6d4f803c490b64f8c5e69988a0b933",
+   "sha256": "1r7garg51bcxzv9cpmpxdzislrwp0803bzli9kh1cqnj1l9zj2jq"
   },
   "stable": {
    "version": [
@@ -74289,35 +74454,6 @@
    ],
    "commit": "110c40eafde81179ec7a78aab94b0b2059689374",
    "sha256": "0z2z0idzpc8mql3mc0szb81j712ad54kpnxj28j6giid1a540bzd"
-  }
- },
- {
-  "ename": "lsp-p4",
-  "commit": "53f0da8b3d2903adeffdbc3d8df7d630bfd9ff71",
-  "sha256": "0cd3n17lqwz08zfkm9g5cr1cj2asznlbhxrym2a7b7shdmn3yx5f",
-  "fetcher": "github",
-  "repo": "dmakarov/p4ls",
-  "unstable": {
-   "version": [
-    20190127,
-    1049
-   ],
-   "deps": [
-    "lsp-mode"
-   ],
-   "commit": "084e33a5782f9153502d9b03e63d9cbbe81cdaeb",
-   "sha256": "0id3rw2p35cs7ax85590qs16zybgrjcapsnly5ifzjk0a5k7548c"
-  },
-  "stable": {
-   "version": [
-    0,
-    1
-   ],
-   "deps": [
-    "lsp-mode"
-   ],
-   "commit": "9ebc597ba37e6f8fccbc08327cf57ca8ec793ffe",
-   "sha256": "0dd4n0c1rbqcy7hl6gb9nqjj7hfv4566d6ipdlnxjma0zjs84sjf"
   }
  },
  {
@@ -74479,14 +74615,14 @@
   "repo": "shader-ls/lsp-shader",
   "unstable": {
    "version": [
-    20240229,
-    111
+    20250101,
+    926
    ],
    "deps": [
     "lsp-mode"
    ],
-   "commit": "02fdc6d74e931db52ba1aa8dcce17d0a26049242",
-   "sha256": "1ky5rds4mvfnpibp4n9zmlczlccncwjhz4ylrzs39d2rlfw953qn"
+   "commit": "802e1a3414f90c5ab37a18716198936cc39e4994",
+   "sha256": "0z4j9f1j5qjpyy03n68cs8z5lbdvci3jagmp0l1bbs9rm4zw4fgy"
   },
   "stable": {
    "version": [
@@ -74628,16 +74764,16 @@
   "repo": "emacs-lsp/lsp-ui",
   "unstable": {
    "version": [
-    20240514,
-    1943
+    20241204,
+    1808
    ],
    "deps": [
     "dash",
     "lsp-mode",
     "markdown-mode"
    ],
-   "commit": "00f1fecdfb41c30428734cf27e492f26f46627fb",
-   "sha256": "1zpmszary67g9wvkjrm1i7ilcmmdbbzp7liq47xii4k78y9dj55l"
+   "commit": "f0edfac7b3736fcab617cbeb07e465c9153ae68b",
+   "sha256": "0i84623jnzp8bdi6bw5r90rcjgfn651qrahvb8qaah5xzrs31kh1"
   },
   "stable": {
    "version": [
@@ -74696,10 +74832,10 @@
  },
  {
   "ename": "lurk-mode",
-  "commit": "8399712211a0fb927970917aec906a97488d00fb",
-  "sha256": "09djfy6d0929csx6f32klm4p41rc6gvr01g60wjiyg7yycw1r4fr",
+  "commit": "f315c69ce5ec82f7daa5e83869cc1440e475e443",
+  "sha256": "02z5jr7q1kikx5vhznvrfpa8if8i87whqrg92w68n52yhf67m4ff",
   "fetcher": "github",
-  "repo": "argumentcomputer/lurk-emacs",
+  "repo": "lurk-lab/lurk-emacs",
   "unstable": {
    "version": [
     20230120,
@@ -74876,16 +75012,16 @@
   "repo": "SqrtMinusOne/lyrics-fetcher.el",
   "unstable": {
    "version": [
-    20231225,
-    2350
+    20241222,
+    1620
    ],
    "deps": [
     "emms",
     "f",
     "request"
    ],
-   "commit": "bcde34a7ae8db84170bfe76260eefed64686ddf0",
-   "sha256": "1ldim9sj9i8mdvsbwv2zs095zbr71z4rksjk8288rkbddhsg72xy"
+   "commit": "2686f97830d6ba03e86992e44405fad9ae58981f",
+   "sha256": "0nqgcl0hish831a0h3miffj5m6m3jv70h6a2pvyj1k6bqq22nxva"
   },
   "stable": {
    "version": [
@@ -74910,14 +75046,14 @@
   "repo": "phillord/m-buffer-el",
   "unstable": {
    "version": [
-    20240302,
-    2255
+    20241215,
+    2214
    ],
    "deps": [
     "seq"
    ],
-   "commit": "8a51de3366599e7fa52e37b596c9ce226b6f04c5",
-   "sha256": "1v632j4c2k8ram18ayaq64rf01y102a40rh9mvrzzvmf2jkmcw6p"
+   "commit": "5e7714835b2289f61dad24c0b5cf98d28fc313b0",
+   "sha256": "16h8nj01h0ahcw4zk9nb8mm8972nl8qw75vj0gvpjlg1zk5kvl45"
   },
   "stable": {
    "version": [
@@ -74987,14 +75123,14 @@
   "repo": "amake/macports.el",
   "unstable": {
    "version": [
-    20241130,
-    1219
+    20241209,
+    2213
    ],
    "deps": [
     "transient"
    ],
-   "commit": "ff24e67cf1e5b3b009f82812049b0406aa3a9fab",
-   "sha256": "1rps0q2djyvxlvs926x15rkfc7iycdk7z54jfbn6si75dvs8qck8"
+   "commit": "3afc12be5f8e544f6ab7a1fdf31a8e69d154b299",
+   "sha256": "102x70q5k0dn4kxbvfy242jm4qdni8965g9mcc2y3qx1dkwa7cbf"
   }
  },
  {
@@ -75028,15 +75164,15 @@
   "repo": "emacsorphanage/macrostep",
   "unstable": {
    "version": [
-    20241025,
-    1456
+    20241224,
+    1752
    ],
    "deps": [
     "cl-lib",
     "compat"
    ],
-   "commit": "419873665f3d0b3d5779aa119b58a3daa96e3326",
-   "sha256": "0271j0f9cb0nwbip2qc9pqr27si3vaalyv6l6w9n39pcmxdxvy8n"
+   "commit": "02967fef0bcf114ab6439fdfb06e4af571d68799",
+   "sha256": "1c4lvipi1bjn56m4m69aq7x7agqzal3x04wwvnmibpgpbjkm8wnn"
   },
   "stable": {
    "version": [
@@ -75190,8 +75326,8 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20241130,
-    1707
+    20250104,
+    2022
    ],
    "deps": [
     "compat",
@@ -75201,14 +75337,14 @@
     "transient",
     "with-editor"
    ],
-   "commit": "e8b85e43d491ca0c0a3fc41ee5d8c4aa34649cd3",
-   "sha256": "0zf8455gix847f8qf24a427mh0bi8bdjmha01fgd09dh4yxjrn4h"
+   "commit": "92f6d57a0a1378555b3e93976ed6ffd77696b990",
+   "sha256": "1k6pky6a54sp4229rb9cdm1dcb7q001bvbbxiq7r9pyw3wnzs8vg"
   },
   "stable": {
    "version": [
     4,
-    1,
-    2
+    2,
+    0
    ],
    "deps": [
     "compat",
@@ -75218,8 +75354,8 @@
     "transient",
     "with-editor"
    ],
-   "commit": "4992c3d1f64e0e983692c7a61d47069f47380dbf",
-   "sha256": "16ix3wsihqpzpx3709fx3wm2087q2miaxwfsh62xnq0nx5z9fl72"
+   "commit": "7dfebba55bf687a25049882c2316166d968048ea",
+   "sha256": "0zmrd6xlrvlr0i1a75xwlknmyx4hvpfxaqjkl61n12gd8598ji1j"
   }
  },
  {
@@ -75779,30 +75915,30 @@
   "repo": "magit/magit",
   "unstable": {
    "version": [
-    20241122,
-    1431
+    20250101,
+    1803
    ],
    "deps": [
     "compat",
     "dash",
     "seq"
    ],
-   "commit": "93a7752842b2d4feff6b5deba44411e9c4249dfe",
-   "sha256": "152i6p9snjpni3ywlfcvj6z6fxr8aa60bjfxvz8i4ddgkp7ymr6n"
+   "commit": "7dfebba55bf687a25049882c2316166d968048ea",
+   "sha256": "0zmrd6xlrvlr0i1a75xwlknmyx4hvpfxaqjkl61n12gd8598ji1j"
   },
   "stable": {
    "version": [
     4,
-    1,
-    2
+    2,
+    0
    ],
    "deps": [
     "compat",
     "dash",
     "seq"
    ],
-   "commit": "4992c3d1f64e0e983692c7a61d47069f47380dbf",
-   "sha256": "16ix3wsihqpzpx3709fx3wm2087q2miaxwfsh62xnq0nx5z9fl72"
+   "commit": "7dfebba55bf687a25049882c2316166d968048ea",
+   "sha256": "0zmrd6xlrvlr0i1a75xwlknmyx4hvpfxaqjkl61n12gd8598ji1j"
   }
  },
  {
@@ -76004,44 +76140,6 @@
    ],
    "commit": "fd6c86c066b14bbf78644d38eca9711d6d9544a1",
    "sha256": "0mq437z9ng2i2amkv26bw9ak7ddw40h2q4wmpf517bv2s7qxfgi1"
-  }
- },
- {
-  "ename": "magithub",
-  "commit": "e555b46f5de7591aa8e10a7cf67421e26a676db8",
-  "sha256": "11par5rncsa866gazdw98d4902rvyjnnwbiwpndlyh06ak0lryab",
-  "fetcher": "github",
-  "repo": "vermiculus/magithub",
-  "unstable": {
-   "version": [
-    20220315,
-    117
-   ],
-   "deps": [
-    "ghub+",
-    "git-commit",
-    "magit",
-    "markdown-mode",
-    "s"
-   ],
-   "commit": "dd62c7057155c0a334e6d9087779a2923d2300b8",
-   "sha256": "1v8nsv1y4fa3y2skx1w3gbf438zlf00zlmsxkh692kmvbkx4sdf4"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    7
-   ],
-   "deps": [
-    "ghub+",
-    "git-commit",
-    "magit",
-    "markdown-mode",
-    "s"
-   ],
-   "commit": "81e75cbbbac820a3297e6b6a1e5dc6d9cfe091d0",
-   "sha256": "1iq8c939c0a6v8gq31vcjw6nxwnz4fpavcd6xf4h2rb6rkmxmhvl"
   }
  },
  {
@@ -76426,14 +76524,14 @@
   "repo": "jcs-elpa/manage-minor-mode-table",
   "unstable": {
    "version": [
-    20240101,
-    931
+    20250101,
+    1012
    ],
    "deps": [
     "manage-minor-mode"
    ],
-   "commit": "ed492f13f71f7897b50da9acd49a7540b0f81a3f",
-   "sha256": "1bjvxj9wrvxpcgqsivfivgxqpxx4y9n39gvck1ffj0vfrvc6ghj2"
+   "commit": "5fee7081b0ed78774448fc923cced0384a83d48c",
+   "sha256": "0wq739br7nqc15yvwajwag9fvbgj1wzs5mqr868canx8nz2s6vn1"
   },
   "stable": {
    "version": [
@@ -76456,11 +76554,11 @@
   "repo": "choppsv1/emacs-mandm-theme",
   "unstable": {
    "version": [
-    20231203,
-    334
+    20250103,
+    814
    ],
-   "commit": "a410c2b66f514bdeb546b7fe8e2d9fee675096ac",
-   "sha256": "0j164b2dg7m815anvli1y5k7zgf5k6qm8gssr4bjp8xrpxbcn989"
+   "commit": "f6475ef40fa9b78de6530610e83cb36ff8ed5d1a",
+   "sha256": "0fjra40wc4b2ai4jd6zg5jsnpyfyfdyj74i3gz2asnqy99c2ryil"
   }
  },
  {
@@ -76609,25 +76707,25 @@
   "repo": "minad/marginalia",
   "unstable": {
    "version": [
-    20241124,
-    1138
+    20250101,
+    920
    ],
    "deps": [
     "compat"
    ],
-   "commit": "643a5f50c9f9d0698c8b1d72678886aefcf69052",
-   "sha256": "0lh7hgqkm4vhnnizarjw5zlxdpmjcmjrvmazzirk9rb7i72b56ia"
+   "commit": "c390456b89ad46bc10c3ef2ee5df59947b72084e",
+   "sha256": "0y1bffnb3lhb273qgmgcnq2g87cavn5qa1f8r3bdkqvvdzrga6ym"
   },
   "stable": {
    "version": [
     1,
-    7
+    8
    ],
    "deps": [
     "compat"
    ],
-   "commit": "7a7f3363d042d1bf43ae697f4401638ed18230a5",
-   "sha256": "1y79fhki7wbfaw24n5n5w80yvchj1ncz74yvfbgf7sna2ngz4yih"
+   "commit": "006a7cd0a14dd651dcff65ed96c0d52d2067b8c1",
+   "sha256": "12kg0zd1zw2rc3pxi655gh37bxbbkpmdb05yi77rdccl8gh9jwry"
   }
  },
  {
@@ -76859,16 +76957,16 @@
   "repo": "ardumont/markdown-toc",
   "unstable": {
    "version": [
-    20241129,
-    1248
+    20241226,
+    1737
    ],
    "deps": [
     "dash",
     "markdown-mode",
     "s"
    ],
-   "commit": "ba74a85ec94a638054ee65cbc8d95581946d018b",
-   "sha256": "0rm8hx0a2ppp0z4jl5c6kyhlwkrla6xvr2nkw7bl7wk46i9hh2g5"
+   "commit": "d2fb4cbd95e558042307d706f9f47f93687c9fcc",
+   "sha256": "13xzcmrhaf0zjbb4ngzqvvwm43h1z9md34n79kl2wrdhmgh7ifd7"
   },
   "stable": {
    "version": [
@@ -77012,11 +77110,11 @@
   "repo": "jcs-elpa/marquee-header",
   "unstable": {
    "version": [
-    20240101,
-    930
+    20250101,
+    1012
    ],
-   "commit": "cb5c17be49fcf96614364eb12079351bf4d749a4",
-   "sha256": "1mcxfzfmlhzj1r77l82d4q9baidcmkb087rmf1ia1f2vz0xjmz5n"
+   "commit": "5f40543099ffe55b64dbcc57308dff7efe948bbe",
+   "sha256": "11a20jy5zg7yp853grd3xjwvs6xb6sqbdq96hizvghj48jra5rl9"
   },
   "stable": {
    "version": [
@@ -77096,30 +77194,30 @@
   "repo": "martianh/mastodon.el",
   "unstable": {
    "version": [
-    20241121,
-    1724
+    20241223,
+    1040
    ],
    "deps": [
     "persist",
     "request",
     "tp"
    ],
-   "commit": "cf6416313084a04e5028f46274e88284e2d120ee",
-   "sha256": "0pc5xjkzxhjwmcbmn9zsqw9z2yyh4vp4qbihk14qyzhz00ni113h"
+   "commit": "e2443f1cd425b31228e87739d1fc5035640bba06",
+   "sha256": "0jc6fyqrc0ygd00vq9ga1d9srawm2c0f1l64xg31dbbmhq2js8li"
   },
   "stable": {
    "version": [
     1,
     1,
-    6
+    8
    ],
    "deps": [
     "persist",
     "request",
     "tp"
    ],
-   "commit": "cf6416313084a04e5028f46274e88284e2d120ee",
-   "sha256": "0pc5xjkzxhjwmcbmn9zsqw9z2yyh4vp4qbihk14qyzhz00ni113h"
+   "commit": "e2443f1cd425b31228e87739d1fc5035640bba06",
+   "sha256": "0jc6fyqrc0ygd00vq9ga1d9srawm2c0f1l64xg31dbbmhq2js8li"
   }
  },
  {
@@ -77257,8 +77355,16 @@
   "repo": "mathworks/Emacs-MATLAB-Mode",
   "unstable": {
    "version": [
-    20241117,
-    1628
+    20241208,
+    1657
+   ],
+   "commit": "935137844e16551a5369f928d2591556be7fb9c2",
+   "sha256": "0gwr1f5mmzgznpvki9nri6lm4lj3qxlv40hsbsjgvmk1921xs6xd"
+  },
+  "stable": {
+   "version": [
+    6,
+    2
    ],
    "commit": "390bca3fd9ac440e6c3dcdc524e77c7590423f08",
    "sha256": "1dfv6f05v7i7966q39knilqjnz1rif4zg6cdk31sy6h8prc6arc3"
@@ -77843,11 +77949,11 @@
   "repo": "meow-edit/meow",
   "unstable": {
    "version": [
-    20241201,
-    1935
+    20241224,
+    2115
    ],
-   "commit": "2d352b94df1a4e633d7941acdafd7b13363eccef",
-   "sha256": "05q2ri3b5m3l3c5nkwgb6nkzrb6df0r3ldy8ysa32qqsn9zyaw9x"
+   "commit": "af3f10e95ebb0754a1afcd4883e8e2e680490c4b",
+   "sha256": "04ryj47a16hy9psx7xry2l4by74b8j6r1j1grgc2185bmxh2j6jb"
   },
   "stable": {
    "version": [
@@ -78030,26 +78136,26 @@
   "repo": "KeyWeeUsr/mermaid-docker-mode",
   "unstable": {
    "version": [
-    20231126,
-    1943
+    20241206,
+    734
    ],
    "deps": [
     "mermaid-mode"
    ],
-   "commit": "9d3421e02704f50e2e695d8dbe6fbb7eb5f2371f",
-   "sha256": "0lxbb2qfkfg9rmf2x9xy08zmfc934rprx809lai83593vakyf9pp"
+   "commit": "92dd790c099f2d90899622421d76cbcc29e36c10",
+   "sha256": "0l879kfi72fasd3067l3fh8mw0ir6nhs8mjaiddxgiqgxwlrdr6q"
   },
   "stable": {
    "version": [
-    1,
     2,
-    0
+    0,
+    2
    ],
    "deps": [
     "mermaid-mode"
    ],
-   "commit": "9d3421e02704f50e2e695d8dbe6fbb7eb5f2371f",
-   "sha256": "0lxbb2qfkfg9rmf2x9xy08zmfc934rprx809lai83593vakyf9pp"
+   "commit": "92dd790c099f2d90899622421d76cbcc29e36c10",
+   "sha256": "0l879kfi72fasd3067l3fh8mw0ir6nhs8mjaiddxgiqgxwlrdr6q"
   }
  },
  {
@@ -78060,11 +78166,11 @@
   "repo": "abrochard/mermaid-mode",
   "unstable": {
    "version": [
-    20240821,
-    1750
+    20241213,
+    1913
    ],
-   "commit": "fc8ae220e8d7769114072493975df821b68df6b3",
-   "sha256": "0cgcbi6ibwkdhmslab1q0iiiyifgiinah1qv4acg3dm5xwlfpdd8"
+   "commit": "e74d4da7612c7a88e07f9dd3369e3b9fd36f396c",
+   "sha256": "0dqg3fyhyxn29b0fw7zr3ykhb5lpqlffhpfcbrk08h8h29mg7jvd"
   }
  },
  {
@@ -78488,20 +78594,20 @@
   "repo": "daut/miasma-theme.el",
   "unstable": {
    "version": [
-    20241201,
-    2218
+    20241225,
+    1559
    ],
-   "commit": "c7a424832aaf982cdb2853b269f2b6fc43685195",
-   "sha256": "1l3zs0jxbbpnn18n9f22jgqsgpnk7bpy99is1nl163dhphna4jzz"
+   "commit": "251408da3b7243035c773c5c299353ab36bd2ec0",
+   "sha256": "0pb2caf4bj1aynj8mf1cy5syw0v3bf8xjxv78krpa6h9j3zpy7nb"
   },
   "stable": {
    "version": [
     1,
-    4,
+    5,
     0
    ],
-   "commit": "c7a424832aaf982cdb2853b269f2b6fc43685195",
-   "sha256": "1l3zs0jxbbpnn18n9f22jgqsgpnk7bpy99is1nl163dhphna4jzz"
+   "commit": "251408da3b7243035c773c5c299353ab36bd2ec0",
+   "sha256": "0pb2caf4bj1aynj8mf1cy5syw0v3bf8xjxv78krpa6h9j3zpy7nb"
   }
  },
  {
@@ -78732,15 +78838,15 @@
   "repo": "liuyinz/mini-echo.el",
   "unstable": {
    "version": [
-    20241201,
-    2106
+    20241213,
+    1102
    ],
    "deps": [
     "dash",
     "hide-mode-line"
    ],
-   "commit": "0e6054359a1826694d50a1be18c419b485ab3d81",
-   "sha256": "04hx6rk1snwjkpvgapqf9naqqac0klk6f0wlxfb9ndx6j60865hj"
+   "commit": "d0fd92f30db71b8fd37cb7f8c18155d26ef8a2f7",
+   "sha256": "1183nwp245yi9vh5zfbzgkgmvhs15hs5w9rp4z8fdi44d4gmr28f"
   },
   "stable": {
    "version": [
@@ -78963,26 +79069,26 @@
   "repo": "tarsius/minions",
   "unstable": {
    "version": [
-    20241123,
-    2136
+    20250101,
+    1417
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e04415dc028ba252f079cfc7d6dff3059a047fbd",
-   "sha256": "1y5a7najnfi2bxpigf0j686z0i07ss81z8dxxsw1vsjxfn47rhl2"
+   "commit": "7ccb5e23a54c10f64880d1f55676f86681ff2f07",
+   "sha256": "1rinshdxln1wvzf7by8gq9wiqgcqy406k5jl1f86jd17b3wv5bxx"
   },
   "stable": {
    "version": [
     1,
     0,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "413b95a0d1c7c10d0f8d440d1982062b73d5ea4a",
-   "sha256": "10pxhsl9yr1nkbkhhvz5iq1q2dbcl315b6q02v23wmns66a9akya"
+   "commit": "7ccb5e23a54c10f64880d1f55676f86681ff2f07",
+   "sha256": "1rinshdxln1wvzf7by8gq9wiqgcqy406k5jl1f86jd17b3wv5bxx"
   }
  },
  {
@@ -79038,11 +79144,11 @@
   "repo": "AjaiKN/minizinc-ts-mode",
   "unstable": {
    "version": [
-    20241202,
-    17
+    20241227,
+    1909
    ],
-   "commit": "0587165602bcf8c6ab768be9cfdc5465d1f1febd",
-   "sha256": "17xihxspc0rii0zz5996rn5zh99vqqya4jwnynkmv2jbpr843k7l"
+   "commit": "0c01f72a6c767bb47ed6c01b70a5f6021fe191cb",
+   "sha256": "1mx0pxmzqjl65clhfxa1m7h65m6bckki24p0pzrk11v0j18l16xj"
   }
  },
  {
@@ -79146,15 +79252,15 @@
   "repo": "liuyinz/mise.el",
   "unstable": {
    "version": [
-    20241106,
-    1515
+    20250102,
+    1433
    ],
    "deps": [
     "dash",
     "inheritenv"
    ],
-   "commit": "6e32b3787dd926cc9d8e9202b5aaa82682398261",
-   "sha256": "10irz22ph0ic9v6l4x1m072nwq63d5j1i7jj01mmh428dnwc84v5"
+   "commit": "99e4ca1acd987099f84993bc8a2facb42628dcbf",
+   "sha256": "0z3z9svs6mf4iypskb6vdzwxjkhk5238b0gzggkys6gn1259fmf7"
   },
   "stable": {
    "version": [
@@ -79178,19 +79284,19 @@
   "repo": "szermatt/mistty",
   "unstable": {
    "version": [
-    20241124,
-    1049
+    20250104,
+    1744
    ],
-   "commit": "45f1b757a3c4bc75103a8eb3c687cd3c08b137c1",
-   "sha256": "0drssrc36pn6fafc45lgvk5iskz0970hjqr2v1ri8xrymvrb9idh"
+   "commit": "e53cfba60cf956294979cdf25e0871425ad5f4c7",
+   "sha256": "10pfps6mvgwgfxkaccqvk539ld5zdcxf4f6ayxc0ad50x65z2izk"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
-   "commit": "f70ea7f5c91f5df6ac0d3a09eaccc283fbdbce70",
-   "sha256": "16l0smp5y2ss9802jijjxs0v42sgcswlpambkc4fa17n47zbb4g1"
+   "commit": "cdf32f4c9f803633f4d2684a70d48858c142faf8",
+   "sha256": "0wyhv6skml0p9lajhmfbwc8wm3r1107kgwyvh31dyi9m4zhc52zh"
   }
  },
  {
@@ -79406,6 +79512,38 @@
    ],
    "commit": "e1d483bc4e341c762bc5c0a8c52306a8d01ea0da",
    "sha256": "04hbd7mv29v3fv4ld0b3skrir0wp9dix2n5nbqp63fj6n5i4cyyz"
+  }
+ },
+ {
+  "ename": "moc",
+  "commit": "03f5ac511e3d23cd9cf8eb1c8e328bf2bf1c7acc",
+  "sha256": "1dah2941n3s59zqa7fwcmk2dm4vyic09jppszsm9vy9888s540w0",
+  "fetcher": "github",
+  "repo": "positron-solutions/moc",
+  "unstable": {
+   "version": [
+    20241229,
+    1056
+   ],
+   "deps": [
+    "hide-mode-line",
+    "transient"
+   ],
+   "commit": "84acdd7d74cfd3b35637b84d49c53db203f657ce",
+   "sha256": "0p5k6jx37z0wgwxj8k43pfl4p25h32zj4myyjbzwa5zixg37j0kk"
+  },
+  "stable": {
+   "version": [
+    0,
+    6,
+    2
+   ],
+   "deps": [
+    "hide-mode-line",
+    "transient"
+   ],
+   "commit": "fda3cf6fae0ccd195cb69c440a56a8a18a7acaf3",
+   "sha256": "0gd4mfsp9mcwz2ki8ipxpnnadkrg6q1p9vdgyc7a2ky3ldhx4i0m"
   }
  },
  {
@@ -79775,11 +79913,11 @@
   "repo": "protesilaos/modus-themes",
   "unstable": {
    "version": [
-    20241120,
-    542
+    20241228,
+    1050
    ],
-   "commit": "df1798234edd56678da975d0d65b64bdebafc314",
-   "sha256": "0n7sbap1y72l9z8ifngfkl1bm2zgmx570i2dc0yd41la54q9ka0r"
+   "commit": "d807e1f013d1dae0e44860f45c9e9b7b4cb2ce49",
+   "sha256": "0lfr9irp6c86922sg6gjsllnn2lh3n3wh9nbjiz0vpzjyv6jyr99"
   },
   "stable": {
    "version": [
@@ -80137,26 +80275,26 @@
   "repo": "tarsius/moody",
   "unstable": {
    "version": [
-    20240805,
-    1425
+    20250101,
+    1418
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2f249978531ff1ec9f601c1e8f2ce83a1b50520e",
-   "sha256": "1dgamndly8lbjwzb4435v99izabdir9fbx31sm9bh1c5yqdka6cp"
+   "commit": "26dd59b300c149a0e2e332023115b280b42ead12",
+   "sha256": "1byphhdp41cn2qs91la6fvgzrwgbyx4yaajknvwz8qxzgl2c4aq2"
   },
   "stable": {
    "version": [
     1,
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2f249978531ff1ec9f601c1e8f2ce83a1b50520e",
-   "sha256": "1dgamndly8lbjwzb4435v99izabdir9fbx31sm9bh1c5yqdka6cp"
+   "commit": "26dd59b300c149a0e2e332023115b280b42ead12",
+   "sha256": "1byphhdp41cn2qs91la6fvgzrwgbyx4yaajknvwz8qxzgl2c4aq2"
   }
  },
  {
@@ -81155,16 +81293,16 @@
   "repo": "lordpretzel/mu4e-views",
   "unstable": {
    "version": [
-    20240401,
-    1150
+    20241206,
+    1347
    ],
    "deps": [
     "esxml",
     "ht",
     "xwidgets-reuse"
    ],
-   "commit": "e0f60e314d034e02fbc3696c3cb9e3598eed9070",
-   "sha256": "0n6s4qab595rda1xfyad9qvry1ipfih4jzkaxabhw3a60jk3h3vy"
+   "commit": "0187c2197761af6df87193c5c1ebd3ed7759f695",
+   "sha256": "05mz45p9f9b39jwm0p41v4mm0xmq0fw3dyqlq8slwllkzyqzf11r"
   },
   "stable": {
    "version": [
@@ -82016,11 +82154,11 @@
   "repo": "kenranunderscore/emacs-naga-theme",
   "unstable": {
    "version": [
-    20240715,
-    1925
+    20241216,
+    1955
    ],
-   "commit": "cca6f1913cc899efaa59df52b8f09dd1a0768e20",
-   "sha256": "0a3fyzrv34k0q8df9iq4wqjsyqqxpvswndslakki6mkg3xl35f64"
+   "commit": "ae7496d54bf279f8fd82ba0a35504b4d6e3a5099",
+   "sha256": "097h3dpx9shnknwrp47w6s7nh11vk83x3yzi9bwb8dn0pz5pwihj"
   }
  },
  {
@@ -82617,11 +82755,11 @@
   "repo": "babashka/neil",
   "unstable": {
    "version": [
-    20241017,
-    1337
+    20241209,
+    1218
    ],
-   "commit": "78ffab1868dc04b2eec5d7195d2d8f92c416e528",
-   "sha256": "0z3imz4b2j64pri0nml3v4lhlycw5ah271q4qi5g8qifbfn9anms"
+   "commit": "0b7373dd1b5a0dc7f8aff83b8e65d75d7d5e23bc",
+   "sha256": "1hbhab0xc7hksfpmjd93zg8xsch3vjnq67hz99s91l8hnqcik939"
   },
   "stable": {
    "version": [
@@ -82664,11 +82802,11 @@
   "repo": "Fuco1/neon-mode",
   "unstable": {
    "version": [
-    20180406,
-    1156
+    20241220,
+    1304
    ],
-   "commit": "99d15e46beaf1e7d71e39a00cce810df1f33229d",
-   "sha256": "07vsi07m5q070fvkqhz32qa2y7dgnyi1kggairimbiwbn98bh642"
+   "commit": "23b12659d72a9520850bca72fe64bb7b06fc7b6b",
+   "sha256": "1wxlnb3w5nf5l50l5r45r7mkasj2rm7xas3pszfa67paaqgxa1d2"
   },
   "stable": {
    "version": [
@@ -82718,11 +82856,11 @@
   "repo": "rainstormstudio/nerd-icons.el",
   "unstable": {
    "version": [
-    20241106,
-    1533
+    20241230,
+    716
    ],
-   "commit": "a6ee08f1619bcde1a69b2defcfe8970c983640c1",
-   "sha256": "16k8wlvpxmjbvrn6abkgk6f97im9d1vhxlwmf81ypfrj9x05fwqg"
+   "commit": "546ee20caf825e65da4c5435d31f13d269ed2a81",
+   "sha256": "0vmzywzaizphj15rqvihw1znjp1i74w8fkhrg7kvic10iv0fpga8"
   },
   "stable": {
    "version": [
@@ -82742,15 +82880,15 @@
   "repo": "rainstormstudio/nerd-icons-completion",
   "unstable": {
    "version": [
-    20240731,
-    1213
+    20241221,
+    1846
    ],
    "deps": [
     "compat",
     "nerd-icons"
    ],
-   "commit": "426a1d7c29a04ae8e6ae9b55b0559f11a1e8b420",
-   "sha256": "03kkyxc9v38v1fc69xqc70gwvsq4pr8bgsk8f6is9z2w7p4y08sm"
+   "commit": "8e5b995eb2439850ab21ba6062d9e6942c82ab9c",
+   "sha256": "0nbyrzz5sscycbr1h65ggzrm1m9agfwig2mjg7jljzw8dk1bmmd2"
   }
  },
  {
@@ -82761,14 +82899,14 @@
   "repo": "LuigiPiucco/nerd-icons-corfu",
   "unstable": {
    "version": [
-    20241101,
-    2309
+    20241202,
+    2355
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "721830b42b35e326a88b338fc53e4752f333fad2",
-   "sha256": "0mls7hz1c2f68lzj4g38plgxyndr3km8lpzyi91ssg4j61zmrbgm"
+   "commit": "41110180ceab9d0edaa856d19633b2b3fdf82e75",
+   "sha256": "0mwng5khhq6iqmr0ip8fv227cnkv0mv5664qz57r7sbjplqyabgf"
   },
   "stable": {
    "version": [
@@ -83026,11 +83164,11 @@
   "repo": "vekatze/neut-mode",
   "unstable": {
    "version": [
-    20241130,
-    1223
+    20241207,
+    16
    ],
-   "commit": "2373c428f314948d433cb6070b237b6243922312",
-   "sha256": "1zvngs8fnpywgn7ryrdb78rj0b730fy1brbl1zqzqzhb4rj54pxh"
+   "commit": "7b599bbe96b77ac75b9c2c5b857126749501b70b",
+   "sha256": "0ivyair2xfyg5agxvfic6k89nw1i5sni400rhk9s8xfa11d4smxg"
   }
  },
  {
@@ -83160,6 +83298,27 @@
    ],
    "commit": "c4ac5de975d65c84893a130a470af32a48b0b66c",
    "sha256": "1zal05l3lnb41pvfxwkzrcf39g7amqbaaffxn3wz7qa45gvvc6fw"
+  }
+ },
+ {
+  "ename": "nice-org-html",
+  "commit": "fd01900a0f11abf8cdae56a84cc6e3c743fce4db",
+  "sha256": "1gm8z02afyikdwd923gznc05j48hl7iigq2gici0ygdqa9cjdr4y",
+  "fetcher": "github",
+  "repo": "ewantown/nice-org-html",
+  "unstable": {
+   "version": [
+    20241227,
+    800
+   ],
+   "deps": [
+    "dash",
+    "htmlize",
+    "s",
+    "uuidgen"
+   ],
+   "commit": "aeb00c4d89f51991cc697b7b52ecdb9ae88866cf",
+   "sha256": "1lrj4gd4kc3lb8jyfv8cb1gc4zjkr8a1mz08y8fpv8s1l8llf9p1"
   }
  },
  {
@@ -83775,24 +83934,6 @@
   }
  },
  {
-  "ename": "no-clown-fiesta-theme",
-  "commit": "7e4b0a546f6e2038369a816936e3a80436e3bc86",
-  "sha256": "0rf411gx8ci4kyhp86njjh41pvhr0pjzxwpg6nhhkq9aq3smyyan",
-  "fetcher": "codeberg",
-  "repo": "ranmaru22/no-clown-fiesta-theme.el",
-  "unstable": {
-   "version": [
-    20240725,
-    2030
-   ],
-   "deps": [
-    "autothemer"
-   ],
-   "commit": "d97f521d4e29181af59412ac32de34ca487345d8",
-   "sha256": "0nf57jasppbnp0df968ikdqyk094qaxlsxwkcinq4572175lgq9h"
-  }
- },
- {
   "ename": "no-emoji",
   "commit": "af6b04c1f95468254f2cf361964df9fd25d23586",
   "sha256": "1lr6bzjxwn3yzw0mq36h2k2h8bqb1ngin42swhv022yx6a022zn2",
@@ -83815,26 +83956,26 @@
   "repo": "emacscollective/no-littering",
   "unstable": {
    "version": [
-    20241201,
-    2109
+    20250101,
+    1420
    ],
    "deps": [
     "compat"
    ],
-   "commit": "74431db47edf44fc1f5f013033560f7bc4f26f24",
-   "sha256": "0l88l1np4s5925d6i33l1cas8mk0nwbgbyw7fa1akzj8qv6782sm"
+   "commit": "0c119d46cce5c018e162fae4b36fd95ef26a76ac",
+   "sha256": "1qr0spndzv03h0lcs2bjajadp9rg7clm506bnwbcqwfqxz9cxnvx"
   },
   "stable": {
    "version": [
     1,
     7,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "74431db47edf44fc1f5f013033560f7bc4f26f24",
-   "sha256": "0l88l1np4s5925d6i33l1cas8mk0nwbgbyw7fa1akzj8qv6782sm"
+   "commit": "0c119d46cce5c018e162fae4b36fd95ef26a76ac",
+   "sha256": "1qr0spndzv03h0lcs2bjajadp9rg7clm506bnwbcqwfqxz9cxnvx"
   }
  },
  {
@@ -83860,16 +84001,16 @@
   "repo": "thomp/noaa",
   "unstable": {
    "version": [
-    20240317,
-    2321
+    20250102,
+    2211
    ],
    "deps": [
     "kv",
     "request",
     "s"
    ],
-   "commit": "7d68b5a580c64123f3bbd75f795a891dfdeb1746",
-   "sha256": "124ak5qvjlg3kb49wmx8pbvdpqz6g79ji811kjvxf9d5gbv85714"
+   "commit": "d162d19dd057430840a08ede0ce333fc30ea5ab9",
+   "sha256": "0gvvdz40brkalviizyvfx3ir05k2qm71ic7va43a5381862cm2fx"
   }
  },
  {
@@ -83903,11 +84044,20 @@
   "repo": "Lindydancer/nocomments-mode",
   "unstable": {
    "version": [
-    20170213,
-    2037
+    20250103,
+    1842
    ],
-   "commit": "5a41a20cc44dfe4a9ea584354ed6dbc15dd92f46",
-   "sha256": "0jwwnypa0lx812p3dqqn9c05g27qavnvr23pzphydx9i15nz80g0"
+   "commit": "aaa9ef1042e0084fb774b3ee4274e1f8edb4d35e",
+   "sha256": "0yvxjby4x9bgbbp2a3j44l96z0dgi3xmjc2jq72fjgm12gzjals8"
+  },
+  "stable": {
+   "version": [
+    0,
+    1,
+    3
+   ],
+   "commit": "aaa9ef1042e0084fb774b3ee4274e1f8edb4d35e",
+   "sha256": "0yvxjby4x9bgbbp2a3j44l96z0dgi3xmjc2jq72fjgm12gzjals8"
   }
  },
  {
@@ -84163,20 +84313,20 @@
   "repo": "ashton314/nordic-night",
   "unstable": {
    "version": [
-    20240626,
-    1936
+    20241204,
+    2203
    ],
-   "commit": "72043ab206dea50b366b3848e8f66c0a7737bda4",
-   "sha256": "0mlpqzql5jghssnx9i474gvc0rdj2sw9wsd46pgs2xn7lcqfjgrf"
+   "commit": "bc7264f14461197919b434f7a30a319873404147",
+   "sha256": "13gy1si8jylsf45hkigvgplwi110x2jb3fpxih3jg81ili7909xy"
   },
   "stable": {
    "version": [
     2,
     0,
-    2
+    3
    ],
-   "commit": "012dc83458dd3d453106806b2590058d5d0f1fdd",
-   "sha256": "1mffyld638k488zwbn64q17xl9ihaa5dyjvyq74yp4yfn72dsyvc"
+   "commit": "608af63b232a8f743277cf274803eddb95c7dcd0",
+   "sha256": "03fcs1whl4palw515lpyxxqhgirva1xnf427nh5jlr22b7hgcgmk"
   }
  },
  {
@@ -84432,30 +84582,30 @@
   "repo": "tarsius/notmuch-transient",
   "unstable": {
    "version": [
-    20240805,
-    1916
+    20250101,
+    1804
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "ee365ca56140ab9c4c2324cb3c42e9037b6fa240",
-   "sha256": "0rzxzp0zzh5j61gwn2sj26gnqdch2jnfqd7m179840h0ap46jl2l"
+   "commit": "f9006043702a3d0178d0118d8348c5733c1c81aa",
+   "sha256": "0pj20k27d1scdva5wh2gxpiv8360gj19lkzd5ljw6x0v6inmh6iy"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
    "deps": [
     "compat",
     "notmuch",
     "transient"
    ],
-   "commit": "ee365ca56140ab9c4c2324cb3c42e9037b6fa240",
-   "sha256": "0rzxzp0zzh5j61gwn2sj26gnqdch2jnfqd7m179840h0ap46jl2l"
+   "commit": "f9006043702a3d0178d0118d8348c5733c1c81aa",
+   "sha256": "0pj20k27d1scdva5wh2gxpiv8360gj19lkzd5ljw6x0v6inmh6iy"
   }
  },
  {
@@ -84535,27 +84685,27 @@
   "repo": "shaneikennedy/npm.el",
   "unstable": {
    "version": [
-    20220428,
-    927
+    20241222,
+    1207
    ],
    "deps": [
     "jest",
     "transient"
    ],
-   "commit": "6eb0a58274870dd75bf848cf5a916a9f2c6ddae5",
-   "sha256": "1shl3ixvbfs84cw62dh0xzc0kacpbvrg49qnbkyvk9kn91x6k9c1"
+   "commit": "45ac45b700c97b61e3133e7a17befb4ebc1d4332",
+   "sha256": "1z9k3j2bxp5s1749ayjhniv9amqd841dsp1ckn4gi57r5cbcxxfh"
   },
   "stable": {
    "version": [
     0,
-    2
+    3
    ],
    "deps": [
     "jest",
     "transient"
    ],
-   "commit": "6eb0a58274870dd75bf848cf5a916a9f2c6ddae5",
-   "sha256": "1shl3ixvbfs84cw62dh0xzc0kacpbvrg49qnbkyvk9kn91x6k9c1"
+   "commit": "45ac45b700c97b61e3133e7a17befb4ebc1d4332",
+   "sha256": "1z9k3j2bxp5s1749ayjhniv9amqd841dsp1ckn4gi57r5cbcxxfh"
   }
  },
  {
@@ -85157,20 +85307,20 @@
   "repo": "KeyWeeUsr/ob-base64",
   "unstable": {
    "version": [
-    20240211,
-    1201
+    20241209,
+    748
    ],
-   "commit": "28a8f448fd706a071b351634482e5c46f80e7d46",
-   "sha256": "1ar12skshi2x2hfrlpy4b2029gqv7wz0cj4a8gjr0gs1hvaj2faz"
+   "commit": "6d3ef9d937838eb69b0a91e4012a0b6084ba26e1",
+   "sha256": "1dikvwvf9b75fxlav0fwz5nm0xwcp66zqiz1j54dcj2p7z3qxixa"
   },
   "stable": {
    "version": [
     1,
     1,
-    5
+    6
    ],
-   "commit": "28a8f448fd706a071b351634482e5c46f80e7d46",
-   "sha256": "1ar12skshi2x2hfrlpy4b2029gqv7wz0cj4a8gjr0gs1hvaj2faz"
+   "commit": "6d3ef9d937838eb69b0a91e4012a0b6084ba26e1",
+   "sha256": "1dikvwvf9b75fxlav0fwz5nm0xwcp66zqiz1j54dcj2p7z3qxixa"
   }
  },
  {
@@ -85482,26 +85632,26 @@
  },
  {
   "ename": "ob-deno",
-  "commit": "d7f97f342c1490e6891fbc55661efb504434b813",
-  "sha256": "175i9xw6f31b69d941l4yjj7f4hw5sqh5wzk3gh2s1klx5znvi47",
+  "commit": "8fb2e12f0e8b80d3f6ba31cb0b9fd01b5c16b18d",
+  "sha256": "1pwgnsbnn1zy51s17sjjcmhdyll41qrivwhkiyy53l9jp2ivr536",
   "fetcher": "github",
-  "repo": "taiju/ob-deno",
+  "repo": "isamert/ob-deno",
   "unstable": {
    "version": [
-    20201019,
-    101
+    20241228,
+    1629
    ],
-   "commit": "e3b06d7662687e402905b9de4ad1d5816e89b842",
-   "sha256": "048xry2bj3xkkjw8n8lmwrjv1rhyhgf7xf8k86vw64754z5394xm"
+   "commit": "fae3e100cc5eed950a52d6cbc93130127ec20830",
+   "sha256": "10qpb0x05jx2ak3wgcp5l1zlljchwybiq0jbajyg5aazli3fhixq"
   },
   "stable": {
    "version": [
-    1,
+    2,
     0,
     1
    ],
-   "commit": "e3b06d7662687e402905b9de4ad1d5816e89b842",
-   "sha256": "048xry2bj3xkkjw8n8lmwrjv1rhyhgf7xf8k86vw64754z5394xm"
+   "commit": "fae3e100cc5eed950a52d6cbc93130127ec20830",
+   "sha256": "10qpb0x05jx2ak3wgcp5l1zlljchwybiq0jbajyg5aazli3fhixq"
   }
  },
  {
@@ -86600,11 +86750,20 @@
   "repo": "Lindydancer/objc-font-lock",
   "unstable": {
    "version": [
-    20141021,
-    1822
+    20250103,
+    1606
    ],
-   "commit": "34b457d577f97ca94b8792d025f9a909c7610612",
-   "sha256": "138c1nm579vr37dqprqsakfkhs2awm3klzyyd6bv9rhkrysrpbqk"
+   "commit": "c971d72599e5a943e8552f929562346ed15446ce",
+   "sha256": "1cs2sl3b3nh7b08qgqrbsbq1g6sn01024ahq0xpasy68v9hlj8ic"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    5
+   ],
+   "commit": "c971d72599e5a943e8552f929562346ed15446ce",
+   "sha256": "1cs2sl3b3nh7b08qgqrbsbq1g6sn01024ahq0xpasy68v9hlj8ic"
   }
  },
  {
@@ -86708,6 +86867,21 @@
   }
  },
  {
+  "ename": "ocaml-eglot",
+  "commit": "7412953fc160708dd9afb1120044b0a997f493ec",
+  "sha256": "16pi2hfsq6mr4w2b7j3g78mmfssd1rjih7nn6nf1cjvfrfbdpdlp",
+  "fetcher": "github",
+  "repo": "tarides/ocaml-eglot",
+  "unstable": {
+   "version": [
+    20241230,
+    1328
+   ],
+   "commit": "7bb5b4ec64a9037b10b316cd48e2e3bfb3d5e662",
+   "sha256": "1zw311kz9wwcjyrk4jvvycfh5ihldm7y46kf308fv0hn1dlymc47"
+  }
+ },
+ {
   "ename": "ocaml-ts-mode",
   "commit": "4d8c5759648815c4f502f25b674e79ac3ef2396b",
   "sha256": "1g4fzyr682v30381fpp1wy9a05zh4jj0vzbjxlzkyvn6kn45j62j",
@@ -86730,11 +86904,11 @@
   "repo": "ocaml-ppx/ocamlformat",
   "unstable": {
    "version": [
-    20241129,
-    1514
+    20241202,
+    1532
    ],
-   "commit": "72cbfd716e619cb8ae3ae52cc0c5288eb2a2f2a8",
-   "sha256": "0fz8a92xdims2rnmhlv60yv5ylci80n4qgavg6jsfaf6fljz13gg"
+   "commit": "5bac2e7f71d9b0a06bd1908dda9b13da1649eee1",
+   "sha256": "0wdzv54s31lckkkwf776j7npcd7i2sscdy9asiaxy50vgi4y7kbx"
   },
   "stable": {
    "version": [
@@ -86742,8 +86916,8 @@
     27,
     0
    ],
-   "commit": "72cbfd716e619cb8ae3ae52cc0c5288eb2a2f2a8",
-   "sha256": "0fz8a92xdims2rnmhlv60yv5ylci80n4qgavg6jsfaf6fljz13gg"
+   "commit": "5bac2e7f71d9b0a06bd1908dda9b13da1649eee1",
+   "sha256": "0wdzv54s31lckkkwf776j7npcd7i2sscdy9asiaxy50vgi4y7kbx"
   }
  },
  {
@@ -86945,26 +87119,26 @@
   "repo": "oer/oer-reveal",
   "unstable": {
    "version": [
-    20240905,
-    1335
+    20241218,
+    1342
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "06538b2073d51197f428f78ff60ebc0e904cc6f6",
-   "sha256": "1z0jl9f0nj22rqf6izj5k87zas76fxifxx818gazx81vd2xhydxi"
+   "commit": "a0b9d95e0b17cce0bcccdfbcb813381c18d1eb7e",
+   "sha256": "0f8cfbf0jkg181jbbfl2d7v4l1wgpfwhcm4amcr2ghy9ls0visfa"
   },
   "stable": {
    "version": [
     4,
-    27,
-    1
+    28,
+    2
    ],
    "deps": [
     "org-re-reveal"
    ],
-   "commit": "06538b2073d51197f428f78ff60ebc0e904cc6f6",
-   "sha256": "1z0jl9f0nj22rqf6izj5k87zas76fxifxx818gazx81vd2xhydxi"
+   "commit": "a0b9d95e0b17cce0bcccdfbcb813381c18d1eb7e",
+   "sha256": "0f8cfbf0jkg181jbbfl2d7v4l1wgpfwhcm4amcr2ghy9ls0visfa"
   }
  },
  {
@@ -87859,25 +88033,25 @@
   "repo": "oantolin/orderless",
   "unstable": {
    "version": [
-    20240926,
-    921
+    20250101,
+    922
    ],
    "deps": [
     "compat"
    ],
-   "commit": "96b74d2450ab4ab1a175d0e86c62f6695c4709b5",
-   "sha256": "0iiyx105fxd0c54h36ypxcjgirj53r89pl2ivir3mw5q9icq0wr5"
+   "commit": "411051c3257d60f0492cf88065193bb443b6ca0d",
+   "sha256": "05n5h53z3siz2ks9zb3k2p070mzzi7m2shrdjyxvylyxl1nybl5n"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "416c62a4a8e7199567a5df63d03cf320dc4d6ab0",
-   "sha256": "0yqnbcrf8ai1fivd13d8w619qwjd51rf4pqyakqp2kf02z7m4kpb"
+   "commit": "2b7a1688f24cc8ef5a3c3a6dab8e00d833bcda59",
+   "sha256": "0w7vrhqg3klr0zxnijmfgfgr5nf6z3cmlrbw3qz9y7z2p2ll5w8m"
   }
  },
  {
@@ -88051,28 +88225,28 @@
   "repo": "spegoraro/org-alert",
   "unstable": {
    "version": [
-    20240612,
-    137
+    20241225,
+    2356
    ],
    "deps": [
     "alert",
     "org"
    ],
-   "commit": "9d54b9d0956b2f9e199d8add48d544d09e58794c",
-   "sha256": "1nhbr8f137c2hxysc2sggnz095ah8qchrmx6g9ligq6gl3v0k7fj"
+   "commit": "0bc04cea718387134c37c9fc4c22215adc3f79db",
+   "sha256": "1r5yr5gwy9wb9wdm42jyn50gh8lqsqkx7kdb7da6z6l8isqmkvd6"
   },
   "stable": {
    "version": [
     0,
-    2,
+    3,
     0
    ],
    "deps": [
     "alert",
     "org"
    ],
-   "commit": "87abaeac60e37fda530787988e00307a1f72fedb",
-   "sha256": "0svvzlp79hgm0cgzbkyfs42j8vjnlzv76ny1y6lhamnh7clr9p9i"
+   "commit": "0bc04cea718387134c37c9fc4c22215adc3f79db",
+   "sha256": "1r5yr5gwy9wb9wdm42jyn50gh8lqsqkx7kdb7da6z6l8isqmkvd6"
   }
  },
  {
@@ -88485,14 +88659,14 @@
   "url": "https://repo.or.cz/org-bookmarks.git",
   "unstable": {
    "version": [
-    20241115,
-    1106
+    20241204,
+    825
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "22c8d837b01b0967910d731592402b57f6d2a3e9",
-   "sha256": "0j6yraf7h6iri6aq5qbxkg38p4rzvvg0b7i6cb20xvqp4sl9rv58"
+   "commit": "a353f97c1ebe65ebd35287dfe3008b5414f7e8ee",
+   "sha256": "0pn1n815hi222w33p263crrspizdn22k6zs1r50nv1pgfph8bj6l"
   },
   "stable": {
    "version": [
@@ -88631,14 +88805,14 @@
   "repo": "dengste/org-caldav",
   "unstable": {
    "version": [
-    20240908,
-    2256
+    20241214,
+    2358
    ],
    "deps": [
     "org"
    ],
-   "commit": "6a2683211baa4b4efed0ca210275bf68dbbcfc4f",
-   "sha256": "16d5kkmclffbv00c1dmshind912gp18wmqzrsaih6qz8kffsj0q6"
+   "commit": "875bebe266f28c77110779b7819227957faab2ba",
+   "sha256": "0bsdmar1s9cwn0i0rccyxpml8xbrmlb1a15b5xvg61adhqz6x8mw"
   },
   "stable": {
    "version": [
@@ -88981,14 +89155,14 @@
   "url": "https://repo.or.cz/org-contacts.git",
   "unstable": {
    "version": [
-    20240807,
-    733
+    20241203,
+    1941
    ],
    "deps": [
     "org"
    ],
-   "commit": "f0a430442b2ae60035dcd74fc6a76299875694f3",
-   "sha256": "1xs8693dhji2fa8gn3j3fr4qvp1zad0g71f9qlrd3ynkhgdai2r3"
+   "commit": "9d80dfa5bfe1eb503e79229cc2f19f841c563709",
+   "sha256": "117l9llrwavwynhp0ws7z9s9s4sjya69h8l97i24l0f7gxzbkgy9"
   }
  },
  {
@@ -89438,20 +89612,20 @@
   "repo": "KeyWeeUsr/org-epa-gpg",
   "unstable": {
    "version": [
-    20240208,
-    20
+    20241206,
+    2357
    ],
-   "commit": "817b8e732c72bacddd8574f2c8f64fb26a1cfcc9",
-   "sha256": "1mpl10np6smap70icw1hyrayfy0sbmz5zmgvaf74zvyf3g3y0f3l"
+   "commit": "6f3b8b77bdf63e96465322bbb545b96c9641d521",
+   "sha256": "1fckdl9dz13rfl69cq87i5ksw51j6n84fpvbj3qvi3iwfhgbs83j"
   },
   "stable": {
    "version": [
-    2,
-    1,
+    3,
+    0,
     0
    ],
-   "commit": "47357e0dcfb8860d5d5aa9f22c12e547a0eb50e9",
-   "sha256": "0g4v73mvc743a0pdhyk72bjia4n3n7v49jw2bmpp12m0pqvznjrx"
+   "commit": "6f3b8b77bdf63e96465322bbb545b96c9641d521",
+   "sha256": "1fckdl9dz13rfl69cq87i5ksw51j6n84fpvbj3qvi3iwfhgbs83j"
   }
  },
  {
@@ -89964,8 +90138,8 @@
  },
  {
   "ename": "org-iv",
-  "commit": "56c38111ad4b7e9f015122ff3151e15cfefff274",
-  "sha256": "1nphccwfl87yz72vj7xf8g4xn8zp7m9p8a35bi7cjz89hk5whx2b",
+  "commit": "66dfdd37cd5e58e25d259c5bf925418eb9cd26d0",
+  "sha256": "0hzxkwk94w423px67c0naqhdxdpdwa6q5q7rzhfk5382rrhspixa",
   "fetcher": "github",
   "repo": "kuangdash/org-iv",
   "unstable": {
@@ -90119,16 +90293,16 @@
   "repo": "SqrtMinusOne/org-journal-tags",
   "unstable": {
    "version": [
-    20240101,
-    4
+    20241229,
+    1923
    ],
    "deps": [
     "magit-section",
     "org-journal",
     "transient"
    ],
-   "commit": "a68e40a8473ff18bef58a171245a9cdef6eee622",
-   "sha256": "1ks7zzvv45i9pblnd5w3845xzg18sn85a5w50gvflrx71dn3z8xs"
+   "commit": "f9959a4de148094e01e9f0b6232f61c6ff320eaa",
+   "sha256": "03glaxna9k4hnlw8grxm100w44p6blndnl3hngw2i8h8fly1bb4n"
   },
   "stable": {
    "version": [
@@ -90225,15 +90399,18 @@
   "repo": "seokbeomKim/org-linenote",
   "unstable": {
    "version": [
-    20241201,
-    1208
+    20241231,
+    616
    ],
    "deps": [
+    "eldoc",
+    "fringe-helper",
+    "lsp-mode",
     "projectile",
     "vertico"
    ],
-   "commit": "bbf8ea8667003ffbda497b8ec21aedeca0ab0ff0",
-   "sha256": "1zprrslqz0dzf6dfypgzs9xbsc25647r2xwd28pzag6yzd7mcf2z"
+   "commit": "407d2ac834d1de82dd1e37f4642f74a81cf03350",
+   "sha256": "12scyxmiirc50qqwxql976560ccipyjrlnxsifwhc7p6xr0jylii"
   }
  },
  {
@@ -90244,16 +90421,15 @@
   "url": "https://repo.or.cz/org-link-beautify.git",
   "unstable": {
    "version": [
-    20241130,
-    1258
+    20250102,
+    150
    ],
    "deps": [
-    "fb2-reader",
     "nerd-icons",
-    "qrencode"
+    "org"
    ],
-   "commit": "d3428752d3e961087ccc462593bd1a0922d3bb67",
-   "sha256": "1dcnpmbww6w96nw2bckzmq0mfk3w2zgks7xfxi3bpvwiqm512h1g"
+   "commit": "1edd6f4a0c4de076e1eddd7bff8e9e157b1cfbde",
+   "sha256": "0vcpb3mm5ln6ljm7ah8bn6w5l03fjaiqzja2pxq435pjkq0dg04r"
   },
   "stable": {
    "version": [
@@ -90509,25 +90685,25 @@
   "repo": "minad/org-modern",
   "unstable": {
    "version": [
-    20240926,
-    922
+    20250101,
+    923
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5b7e8195744f9b6a14a5c72bd13ae52e86952d72",
-   "sha256": "0pb7sxik2mkarbs5vxn0gch23zxj93yh1aw4bl6bbp60an561fp6"
+   "commit": "17549799a05a46d391765e36b544741a3a704cd0",
+   "sha256": "0pyaa0ay8zdw1mnndcfhqsik54nqjrpf1w1zbv6rqszj7ycf6rpq"
   },
   "stable": {
    "version": [
     1,
-    5
+    6
    ],
    "deps": [
     "compat"
    ],
-   "commit": "e306c7df4985f77e5c4e2146900259a23a76c974",
-   "sha256": "0zvg7jqfgaaayw8x3bi704ad47kpk4g8hxxfsd5p0xhyhxkq528m"
+   "commit": "8420e4f839bee2c34488ce94fa08212dfe0b2797",
+   "sha256": "0a7viid1lrn02w1n4yjivjyssbd1qq850giqwnp3mrjf9adwzh2a"
   }
  },
  {
@@ -90569,11 +90745,11 @@
   "repo": "bpanthi977/org-mpv-notes",
   "unstable": {
    "version": [
-    20241119,
-    1627
+    20241222,
+    1958
    ],
-   "commit": "f6c0fc5546cf7168d997a3605cce7c08714cb599",
-   "sha256": "013c90h8qajil7wk1m1q6kqxgl5812bd004lqn0k886mahfm75qn"
+   "commit": "1d8db9ff803122e2a9bfc1b41d806f3b70acfc57",
+   "sha256": "0fii5v7c47jshrv8d064sa7nssixm8hy2fwfjvqaqwpbhvkl3w23"
   }
  },
  {
@@ -90743,30 +90919,30 @@
   "repo": "meedstrom/org-node",
   "unstable": {
    "version": [
-    20241201,
-    2012
+    20241229,
+    1555
    ],
    "deps": [
     "compat",
     "el-job",
     "llama"
    ],
-   "commit": "c1e8d8b1e8bf9463c7b97f290a8307184a19c041",
-   "sha256": "05gniyrl3pffdaa6kbb5cssvmi0gjg6isnyk17zl3c23lf3s4mnf"
+   "commit": "823f2f3d3f2367e181fdcb81db48deafae6b3ae2",
+   "sha256": "15m5wn5qghglqpnhqn1nnpvnwp8jjn5fwcfzp1p89zw851ic44zb"
   },
   "stable": {
    "version": [
     1,
     9,
-    10
+    19
    ],
    "deps": [
     "compat",
     "el-job",
     "llama"
    ],
-   "commit": "c1e8d8b1e8bf9463c7b97f290a8307184a19c041",
-   "sha256": "05gniyrl3pffdaa6kbb5cssvmi0gjg6isnyk17zl3c23lf3s4mnf"
+   "commit": "823f2f3d3f2367e181fdcb81db48deafae6b3ae2",
+   "sha256": "15m5wn5qghglqpnhqn1nnpvnwp8jjn5fwcfzp1p89zw851ic44zb"
   }
  },
  {
@@ -90777,8 +90953,8 @@
   "repo": "meedstrom/org-node-fakeroam",
   "unstable": {
    "version": [
-    20241127,
-    1306
+    20241229,
+    1552
    ],
    "deps": [
     "compat",
@@ -90786,14 +90962,14 @@
     "org-node",
     "org-roam"
    ],
-   "commit": "288d897e12713db7d15162ccf3bdc93147f00943",
-   "sha256": "1lrkqv5bkz2f15vp50j95nnffhl3ibbh47nq4mbl14wqil1bp89m"
+   "commit": "125ef95cee77a19d59d8e071aa14049dd2bbd1e8",
+   "sha256": "1m0qpixf8mnrfrp8p8z4zz8lqnz541lz02b8wkw90ajb81s6k7b9"
   },
   "stable": {
    "version": [
     1,
-    6,
-    4
+    7,
+    0
    ],
    "deps": [
     "compat",
@@ -90801,8 +90977,8 @@
     "org-node",
     "org-roam"
    ],
-   "commit": "288d897e12713db7d15162ccf3bdc93147f00943",
-   "sha256": "1lrkqv5bkz2f15vp50j95nnffhl3ibbh47nq4mbl14wqil1bp89m"
+   "commit": "125ef95cee77a19d59d8e071aa14049dd2bbd1e8",
+   "sha256": "1m0qpixf8mnrfrp8p8z4zz8lqnz541lz02b8wkw90ajb81s6k7b9"
   }
  },
  {
@@ -90989,8 +91165,8 @@
   "repo": "emacsorphanage/org-page",
   "unstable": {
    "version": [
-    20230829,
-    942
+    20241227,
+    814
    ],
    "deps": [
     "cl-lib",
@@ -91002,8 +91178,8 @@
     "org",
     "simple-httpd"
    ],
-   "commit": "7a73b110df12c29804d32ecfb051d3320dce3892",
-   "sha256": "1ygil7c3hilfx630qld90f0y0klkll7svf3zvs885y9z7w30y5im"
+   "commit": "3641afab005b892b586a1e70da29201004c189c3",
+   "sha256": "1d77cmns0zj7mxik2qlfrxd5gxg2xsymyi0zij3cz3wa0adlj91q"
   },
   "stable": {
    "version": [
@@ -91457,15 +91633,15 @@
   "repo": "oer/org-re-reveal",
   "unstable": {
    "version": [
-    20240831,
-    1242
+    20241218,
+    1239
    ],
    "deps": [
     "htmlize",
     "org"
    ],
-   "commit": "91610ba9b010b05c52ae7ab77a7890851222db06",
-   "sha256": "09d0hy5nb485d3dd71a9dmjpbwvhj7zx1wwkl9hggc2gzj4f0snp"
+   "commit": "f04b2227f962c39afb18408b433d5d84d1e136fe",
+   "sha256": "1b7j1bnw51ad49vx3rbncxiq8jizbjbhfq18jmkxlaxkrccmz8bf"
   },
   "stable": {
    "version": [
@@ -91802,8 +91978,8 @@
   "repo": "org-roam/org-roam",
   "unstable": {
    "version": [
-    20241007,
-    1704
+    20250105,
+    443
    ],
    "deps": [
     "dash",
@@ -91811,8 +91987,8 @@
     "magit-section",
     "org"
    ],
-   "commit": "2a630476b3d49d7106f582e7f62b515c62430714",
-   "sha256": "1smllgrbg5idc7cjskaxj7pzgd28bmwa1d7w5x270hbjviw5k27c"
+   "commit": "cad3518788991623aa5621341471aef67108937d",
+   "sha256": "15v72fga505w9y7910lsjxkhhllfrv5sqvlksfvx5lyfcmjkk9zm"
   },
   "stable": {
    "version": [
@@ -91871,8 +92047,8 @@
   "repo": "ahmed-shariff/org-roam-ql",
   "unstable": {
    "version": [
-    20241130,
-    256
+    20241231,
+    1802
    ],
    "deps": [
     "dash",
@@ -91882,8 +92058,8 @@
     "s",
     "transient"
    ],
-   "commit": "661e388bba2b71b2d8b3db287b7f77e400b452f6",
-   "sha256": "0l16gm93cyfvi9wcyrvrb20sdmgz6dgcrc2f2daxhdypkc4c3dzd"
+   "commit": "2b7cf0110c5c13b26c3e1b35c9854263089ba13e",
+   "sha256": "0gwd4cyhwmnwkzc6ps5pikdf1ak17y1k006sl1b0sc2lwxyr4p4v"
   },
   "stable": {
    "version": [
@@ -92049,16 +92225,16 @@
   "repo": "ianxm/emacs-scrum",
   "unstable": {
    "version": [
-    20200131,
-    1129
+    20241231,
+    2251
    ],
    "deps": [
     "cl-lib",
     "org",
     "seq"
    ],
-   "commit": "a383348ea80c2459bfb96fa0652b98f0059bd311",
-   "sha256": "12qw1qs22j367p1lxwq2wihn7h8h6mk9alv2v13qgjm6w2jnffbz"
+   "commit": "c1da15f576c8f55245df4804221c3b0efa7fbf40",
+   "sha256": "1nnah93fd0a5jcyxk0b3xkdi5r7p1izl4qmykgd9i6kjzqp7srss"
   }
  },
  {
@@ -92092,6 +92268,24 @@
    ],
    "commit": "20c33b7310694742b814bf1ca3c05d3496d2a313",
    "sha256": "133mww4fdlkigd5583c45sjb2g34f512h50x65iipy0qmrvj95i0"
+  }
+ },
+ {
+  "ename": "org-shortcut",
+  "commit": "2dc71a43ec3cc8f53f0d7c2ba2297c80fbb3bfd2",
+  "sha256": "0i82r53fr81myddn0rcv7fq9cp5qprnzb3v0nqr2jq8rdz023xd6",
+  "fetcher": "github",
+  "repo": "Endi1/org-shortcut",
+  "unstable": {
+   "version": [
+    20241228,
+    1533
+   ],
+   "deps": [
+    "plz"
+   ],
+   "commit": "69f444830d31e89f2693449f9c122f25989930b9",
+   "sha256": "1pws0v49qyba7fhi0afv5k9jvpizxf8lhnp8hx9dq4mz9y40xpsq"
   }
  },
  {
@@ -92197,8 +92391,8 @@
   "repo": "alhassy/org-special-block-extras",
   "unstable": {
    "version": [
-    20230721,
-    43
+    20241227,
+    124
    ],
    "deps": [
     "dad-joke",
@@ -92209,8 +92403,8 @@
     "s",
     "seq"
    ],
-   "commit": "d7bdf9fcfe28f96f9470719f3985a6e413592de8",
-   "sha256": "060sfkh05fnrk8sfciszggxmyxyp7851i5zx4w9j2ki7kw8rfp2b"
+   "commit": "92443a7a346c60fd00e05464f9af7763a055e4ca",
+   "sha256": "158s48xznd1kfbrchqjlcm05jcbv1gcwmhzypq0klf0w4pbrhipy"
   },
   "stable": {
    "version": [
@@ -92574,14 +92768,14 @@
   "url": "https://repo.or.cz/org-tag-beautify.git",
   "unstable": {
    "version": [
-    20241109,
-    445
+    20241229,
+    516
    ],
    "deps": [
     "nerd-icons"
    ],
-   "commit": "4eb1b403a004daf20bb622c6b708d1c743bbc01a",
-   "sha256": "1hh3f63pf88x9jabwhjis6cpcm9h3rzzq6jjfgqa8vig4fzsa85z"
+   "commit": "245ac5f991f073a4baa68c01cf5330a4fe29bee7",
+   "sha256": "0rpps1grr0xzjghq6wr6k8c7w8mg3sfwprydgkqwm0pz18ac9rwy"
   }
  },
  {
@@ -92673,14 +92867,14 @@
   "repo": "jxq0/org-tidy",
   "unstable": {
    "version": [
-    20240110,
-    114
+    20241212,
+    28
    ],
    "deps": [
     "dash"
    ],
-   "commit": "26d9636f0c43f1ee3f0528880111a4c1dd2bed32",
-   "sha256": "195wl2y38g76n0kcp47inq1jm5v1kxprh99xgp05bfgv6wf4i1hf"
+   "commit": "0bea3a2ceaa999e0ad195ba525c5c1dcf5fba43b",
+   "sha256": "1rwq53j31vixyhsi7khb1xc0fcqdmqyp7ycq5hinligfxk87sr4s"
   }
  },
  {
@@ -93524,8 +93718,8 @@
   "repo": "tumashu/org2web",
   "unstable": {
    "version": [
-    20210203,
-    324
+    20241226,
+    1757
    ],
    "deps": [
     "cl-lib",
@@ -93537,14 +93731,14 @@
     "org",
     "simple-httpd"
    ],
-   "commit": "6f5c5f0cc5c877ac3a383782bbe8751264d807b6",
-   "sha256": "12rgrmcp91y27zcq8kcqvndb38n6ix4amf13cc2gjhi6aayxxx7k"
+   "commit": "0e343770b9785f6150afc98153cd00a316d88d01",
+   "sha256": "103fzmadgd93x1y0c6xsdjx70z0jkwpvj0xnkybdancxz4ba8p9l"
   },
   "stable": {
    "version": [
     0,
     9,
-    1
+    2
    ],
    "deps": [
     "cl-lib",
@@ -93556,8 +93750,8 @@
     "org",
     "simple-httpd"
    ],
-   "commit": "5243b399927a4c474bb3b8d1c8a00799df1f27d7",
-   "sha256": "0wsvfn409a2ivbich8b8zqza78sprirg4bl7igx536ydqclmi0n7"
+   "commit": "0e343770b9785f6150afc98153cd00a316d88d01",
+   "sha256": "103fzmadgd93x1y0c6xsdjx70z0jkwpvj0xnkybdancxz4ba8p9l"
   }
  },
  {
@@ -93583,8 +93777,8 @@
   "repo": "jcs-elpa/organize-imports-java",
   "unstable": {
    "version": [
-    20240101,
-    929
+    20250101,
+    1012
    ],
    "deps": [
     "dash",
@@ -93592,8 +93786,8 @@
     "ht",
     "s"
    ],
-   "commit": "93b1d10a82103d38d8cba09d90b9faf219205df3",
-   "sha256": "1jzzd0qndd9rlds451ww9lwjdbfhlayqbhn9rmsivsiv71gncfm7"
+   "commit": "6221c85b37d7baee27288848fa38d5519cdeafd5",
+   "sha256": "16ffv1il866i8az6lddkhpjdvbslhsab2xk34byb08f817bczbq4"
   },
   "stable": {
    "version": [
@@ -93776,16 +93970,16 @@
   "repo": "isamert/orgmdb.el",
   "unstable": {
    "version": [
-    20231003,
-    2144
+    20250104,
+    1911
    ],
    "deps": [
     "dash",
     "org",
     "s"
    ],
-   "commit": "4338a0a34d500a214df8293590960011f761fe24",
-   "sha256": "1yr553kf6kmq2n328jr6pgxxifkwy2nk1c4w1xjy9m3x7zs1rpsq"
+   "commit": "04c4ea707b7313c3613517baabeae209e2b08a52",
+   "sha256": "1n24v2nlbr99rl2x2cvxfav7vj51x104myvsfd6cqia661vhrpsy"
   }
  },
  {
@@ -93878,11 +94072,11 @@
   "repo": "tbanel/orgaggregate",
   "unstable": {
    "version": [
-    20241002,
-    2020
+    20250102,
+    748
    ],
-   "commit": "fec29053dc6ed97e6b1cae60bc97cb9b8700f3cf",
-   "sha256": "1psjimmanmh3hp7paq86wwim9z64bhrwy0gn3fkxy1nf76p3lrjx"
+   "commit": "366677c0a5792cdcc5157362fd36416c76b9660b",
+   "sha256": "09lrprny3a9hb0wc5y7mclfcdnvlzr3ai9x4inmikngx3m469rkb"
   }
  },
  {
@@ -93908,11 +94102,11 @@
   "repo": "tbanel/orgtblfit",
   "unstable": {
    "version": [
-    20240228,
-    716
+    20250102,
+    735
    ],
-   "commit": "a22f3a137f3590d7f13c3be38bbd1e55d39cb2ad",
-   "sha256": "1mpfxvgjd7cgjdpndibbw2zcsnca8hckd0s25sfy0dbcvdsn6hb7"
+   "commit": "3ab53c983b647fec4dfdd0e3e25bc5d247130c70",
+   "sha256": "1khmvk44g9p17w2pkz6zd46j1x0mz66h77arddgdrs280yps26vy"
   }
  },
  {
@@ -93923,11 +94117,11 @@
   "repo": "tbanel/orgtbljoin",
   "unstable": {
    "version": [
-    20241002,
-    2012
+    20250102,
+    758
    ],
-   "commit": "30cd50e2e913d41d8ee74ed3c0ca0b1fd8c2e264",
-   "sha256": "0rh46an7iqzyrvfd535lgy4l0kyycnlywkdnl2x0jwnha9fp4r9x"
+   "commit": "0b16ccdfadb55bec75d91edea2caaa1a161146ff",
+   "sha256": "01kws6m021msrmpsplkz3lzwp85ajpq7h25374hnz82rrn2hgksm"
   }
  },
  {
@@ -94086,25 +94280,25 @@
   "repo": "minad/osm",
   "unstable": {
    "version": [
-    20241122,
-    130
+    20250101,
+    924
    ],
    "deps": [
     "compat"
    ],
-   "commit": "6a2416dc4c3be22573cd9f5fb285df3f4bd6b6ea",
-   "sha256": "0cfwy4j5zv7axxkfg25cm4rs29d58w89gx58j4pprzf8pwxq6fvw"
+   "commit": "fa52c07484bb5ce57b066c7e59783be3f45205a2",
+   "sha256": "0616d0wphar6m97izrzyf48h6qh315n0i6fyi9pjp2ka05wxql24"
   },
   "stable": {
    "version": [
     1,
-    4
+    5
    ],
    "deps": [
     "compat"
    ],
-   "commit": "25eede7272bb2b4c0b009add264ebb45ab2f3691",
-   "sha256": "10l9nhxmshar4swf62rqgzyvpx0fn0dsyjvfg9dd78nmfkagfkh8"
+   "commit": "fda895f1c38ade3ced65f6142e2f5c0221c3380e",
+   "sha256": "1llk9zkr1a0gicxp7jzx3f674zlj780ghcgnxw8a2jf3kbrn0xb5"
   }
  },
  {
@@ -94359,26 +94553,26 @@
   "repo": "abougouffa/one-tab-per-project",
   "unstable": {
    "version": [
-    20241129,
-    1654
+    20241212,
+    2306
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5f3894c031cd0900739e3cabb3eca3b6eb56f78f",
-   "sha256": "0jwmlqia3h2rb0j1qnlylslajqiz5g28ll3qy7h1mlbh4vb7bk24"
+   "commit": "82c49c5c8551d2c0dd33f6b56549e1890d621651",
+   "sha256": "0dj8mfgzlmvybkg7z4cvaa75v0hq8sbv3fkd2wxs8mhz2hhvmxl2"
   },
   "stable": {
    "version": [
     3,
     1,
-    1
+    2
    ],
    "deps": [
     "compat"
    ],
-   "commit": "5f3894c031cd0900739e3cabb3eca3b6eb56f78f",
-   "sha256": "0jwmlqia3h2rb0j1qnlylslajqiz5g28ll3qy7h1mlbh4vb7bk24"
+   "commit": "82c49c5c8551d2c0dd33f6b56549e1890d621651",
+   "sha256": "0dj8mfgzlmvybkg7z4cvaa75v0hq8sbv3fkd2wxs8mhz2hhvmxl2"
   }
  },
  {
@@ -94409,11 +94603,11 @@
   "repo": "jamescherti/outline-indent.el",
   "unstable": {
    "version": [
-    20241128,
-    1742
+    20241219,
+    1754
    ],
-   "commit": "7767c4a5393fcac626bfc29ceeba2f884b189aec",
-   "sha256": "1l1cpfqldrpxl7k2m0vad3yjmhsa3d9ni5lv1zv9ib8rgr8aagq9"
+   "commit": "7a3d0c896d85b28aeabede47b31e194cc88f8769",
+   "sha256": "0af0gy8yfknx05crsqzyvki1rsdhl107fk8fbk8fg0npxdgr3g5z"
   },
   "stable": {
    "version": [
@@ -94448,26 +94642,26 @@
   "repo": "tarsius/outline-minor-faces",
   "unstable": {
    "version": [
-    20240831,
-    2209
+    20250101,
+    1421
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4628613f3570b865b2c22b750ebd41443c1848c2",
-   "sha256": "1ky204hgkvv69gv5vmfczmhq9df05d37qssg7mx041i5xriv54nl"
+   "commit": "66199fcbd64181f5d74e44ed03bd7bb4502fa547",
+   "sha256": "1zr0ix28vis4y88h8w6lf4lsp0x24qi5v2y3xsk6vi2am08w613g"
   },
   "stable": {
    "version": [
     1,
     1,
-    0
+    1
    ],
    "deps": [
     "compat"
    ],
-   "commit": "4628613f3570b865b2c22b750ebd41443c1848c2",
-   "sha256": "1ky204hgkvv69gv5vmfczmhq9df05d37qssg7mx041i5xriv54nl"
+   "commit": "66199fcbd64181f5d74e44ed03bd7bb4502fa547",
+   "sha256": "1zr0ix28vis4y88h8w6lf4lsp0x24qi5v2y3xsk6vi2am08w613g"
   }
  },
  {
@@ -95725,6 +95919,24 @@
   }
  },
  {
+  "ename": "p4-ts-mode",
+  "commit": "28d52e051460c76c021457b2a0792cf55e8183a1",
+  "sha256": "1hqpwbngvgds277j5sdmxdygrkdx91ifn5p5wrz29ws4r5fckhcw",
+  "fetcher": "github",
+  "repo": "oxidecomputer/p4-ts-mode",
+  "unstable": {
+   "version": [
+    20241215,
+    2358
+   ],
+   "deps": [
+    "xcscope"
+   ],
+   "commit": "a2b8a0ecde12b23487dff2bb85b2a9dcd1962cb8",
+   "sha256": "11jk12i72v2p2569na2igbs1g0nlhwlv1l5ngs261wq51m9hm10d"
+  }
+ },
+ {
   "ename": "pabbrev",
   "commit": "c032b0d126e0196b4526ee04f5103582610681ea",
   "sha256": "1mbfa40pbzbi00sp155zm43sj6nw221mcayc2rk3ppin9ps95hx3",
@@ -95847,14 +96059,14 @@
   "repo": "melpa/package-build",
   "unstable": {
    "version": [
-    20241123,
-    2136
+    20250101,
+    1820
    ],
    "deps": [
     "compat"
    ],
-   "commit": "c1b276904278f0f89da2684f5e044760e3232c29",
-   "sha256": "0lwn4fd996lf4i4jmxfn09jn06k66k19ff76fzg6zzrs3hcsjg3j"
+   "commit": "c8ddc4a9a23b8514a8ee8d95e508b58adbeebd64",
+   "sha256": "1f89570dphwzizk1yyzh630j4a7qd2bzrn2r5cnksin44zj8qlvp"
   },
   "stable": {
    "version": [
@@ -95962,14 +96174,14 @@
   "repo": "Silex/package-utils",
   "unstable": {
    "version": [
-    20220630,
-    2345
+    20241206,
+    754
    ],
    "deps": [
     "restart-emacs"
    ],
-   "commit": "0168172062467b1bff913ea955b2ef709b43ecfa",
-   "sha256": "0pghwwxmn90vfkdzl8fqc7zg3xkcx7lyiihjwvkgfmzmqs4hwn1p"
+   "commit": "8839e98870499c06c3bffe090b4e42a156509a7a",
+   "sha256": "00iw1zq0yjh1wqmzxb677b86nkhw0l7v9sf4abx9cmh955kfchg5"
   },
   "stable": {
    "version": [
@@ -96635,11 +96847,11 @@
   "repo": "mrc/el-csv",
   "unstable": {
    "version": [
-    20160512,
-    1723
+    20241214,
+    246
    ],
-   "commit": "96bef1ffbc89ea12d13311c9fa239c5c3e864890",
-   "sha256": "06xg6f74697zmn042wg259qlik2l21k4al08a06xz4gv9a83nsx6"
+   "commit": "b2e7010ba91ecce25498a73f64f950de4dd8dbe2",
+   "sha256": "1prnv930zr2p6zdimiym8wwd2rp4yyjp7b6a8r8bkgyd7ydkpv3y"
   }
  },
  {
@@ -96650,14 +96862,14 @@
   "repo": "jcs-elpa/parse-it",
   "unstable": {
    "version": [
-    20240101,
-    946
+    20250101,
+    1011
    ],
    "deps": [
     "s"
    ],
-   "commit": "cdc4386ef8e94ccdeff3700021d4a944034ae559",
-   "sha256": "0nya7x9lhphnall1przkpircai9p5r8vc0jg6msrvr02azv2yky9"
+   "commit": "19df0d8d67f0f3b73d80ad2db57a1790f3e43beb",
+   "sha256": "0nl47mlhl27y4cz6qvbch7g3da8jlx08ll7jb99jhn390p4syhxc"
   },
   "stable": {
    "version": [
@@ -96680,19 +96892,19 @@
   "repo": "joostkremers/parsebib",
   "unstable": {
    "version": [
-    20241115,
-    2225
+    20241219,
+    14
    ],
-   "commit": "c0ee4d5f10bf801af03f633b6b73ced4a0ffead7",
-   "sha256": "1c6j45fvs8k8d5smyi4rd9n2rg79i7dv69n98md32qm8w2w7yi5x"
+   "commit": "db2de6e30a4fa2a56f165fe7a493307689cc7279",
+   "sha256": "1rgawqwa7dqfiz74fsj1z6nsmjp7dszrxm9jjc9kgnr8w4s3yb2a"
   },
   "stable": {
    "version": [
-    4,
-    7
+    6,
+    3
    ],
-   "commit": "26fb0fd165bacd160a5e89b966c6d080a740c4c4",
-   "sha256": "0rr1iy9j5s3m95j1kr2cqqk6mp5apva46g4zi3y07n120hz3ndw9"
+   "commit": "db2de6e30a4fa2a56f165fe7a493307689cc7279",
+   "sha256": "1rgawqwa7dqfiz74fsj1z6nsmjp7dszrxm9jjc9kgnr8w4s3yb2a"
   }
  },
  {
@@ -97715,15 +97927,15 @@
   "repo": "overideal/perject",
   "unstable": {
    "version": [
-    20230605,
-    841
+    20241204,
+    1632
    ],
    "deps": [
     "dash",
     "transient"
    ],
-   "commit": "6357ab199c717191e7695a3e3c2545918b97a942",
-   "sha256": "0ll6110sxpykcbbqhd1i4hwvnhhnjgk75gnyzvmcj7s2phf3qjnw"
+   "commit": "27c6fdad199f930aff5b0fb1343654ee3b4c4205",
+   "sha256": "1wi61cy4bkwclsviwcfrhyxg0c9facbgx1jh5syqy6pmccw54gi0"
   }
  },
  {
@@ -98160,25 +98372,25 @@
   "repo": "emarsden/pg-el",
   "unstable": {
    "version": [
-    20241110,
-    1633
+    20241231,
+    1316
    ],
    "deps": [
     "peg"
    ],
-   "commit": "3e7917dfe17d40c08f0028917915682dbf576ee7",
-   "sha256": "12k4y52rv7fwg8yqniq4d3bmhcxdn75kgzvr1qxn56l80hxzfhvs"
+   "commit": "912ad0086a81e672232fa319322a1226bb11fb3c",
+   "sha256": "0z5h1chpvyza7fzqg1li7nl2q7g35xsdpyk51ah34hk5vxq1mwbm"
   },
   "stable": {
    "version": [
     0,
-    44
+    45
    ],
    "deps": [
     "peg"
    ],
-   "commit": "3e7917dfe17d40c08f0028917915682dbf576ee7",
-   "sha256": "12k4y52rv7fwg8yqniq4d3bmhcxdn75kgzvr1qxn56l80hxzfhvs"
+   "commit": "e1510f691bd6bb124e73f6604187c81d2b0c667f",
+   "sha256": "10k166l3zh6wi59il147cal0p50md3dv618wnkg1clax51xk1h44"
   }
  },
  {
@@ -98194,30 +98406,6 @@
    ],
    "commit": "7f1d5bc734750aca98cf67a9491cdbd5615fd132",
    "sha256": "0c9d4c24ic67y07y74bv5b7vc56b6l0lbh2fbzm870r1dl5zbzcj"
-  }
- },
- {
-  "ename": "ph",
-  "commit": "a6ff6bbfa11f08647bf17afe75bfb4dcafd86683",
-  "sha256": "0xrg7d1mqgvv3s0l4biyyccn3bj1khs496rdwih91bazs634g2y4",
-  "fetcher": "github",
-  "repo": "gromnitsky/ph",
-  "unstable": {
-   "version": [
-    20161029,
-    1522
-   ],
-   "commit": "a66e38637d1898b2ec31ee611033ac3f295fd97f",
-   "sha256": "10xznvjszn0smn6wf84rykkkiqyzv7xf7fjjyklhll7zphg714mw"
-  },
-  "stable": {
-   "version": [
-    0,
-    1,
-    0
-   ],
-   "commit": "ed45c371642e313810b56c45af08fdfbd71a7dfe",
-   "sha256": "1qxsc5wyk8l9gkgmqy3mzwxdhji1ljqw9s1jfxkax7fyv4d1v31p"
   }
  },
  {
@@ -98532,20 +98720,20 @@
   "repo": "emacs-php/php-mode",
   "unstable": {
    "version": [
-    20241024,
-    1241
+    20250103,
+    157
    ],
-   "commit": "31f702ee2de35d514fb633c0c37531cb648bff70",
-   "sha256": "0rz0qdi82swvvqmb44jdzwfkaz9xl4y4ic70i6i950rmrbz970pd"
+   "commit": "b45992a6a9d019fafe7a9dcde19401b0f20a20bf",
+   "sha256": "0810hbdakjasldl4vanigjhj7pixkq3dxad2w60grg0kb8xj9rz6"
   },
   "stable": {
    "version": [
     1,
-    26,
-    1
+    27,
+    0
    ],
-   "commit": "9a2fe1c6c34f4f22f11efff0caf1d4e7c8ea233a",
-   "sha256": "12skkn3i5qvlfnifgyp3sm4yjikphckj98y73vhxn73zzbn2lw6m"
+   "commit": "c3fa4e020cdb631743dbb7b6007ea546a8db1f34",
+   "sha256": "0pkvqpzzy7wmbd99gvphfaz2ds79n5fcx4n7f772mgz8x5f9xq1b"
   }
  },
  {
@@ -98644,8 +98832,8 @@
   "repo": "emacs-php/phpactor.el",
   "unstable": {
    "version": [
-    20241128,
-    1559
+    20241211,
+    1614
    ],
    "deps": [
     "async",
@@ -98653,8 +98841,8 @@
     "f",
     "php-runtime"
    ],
-   "commit": "922a4339d796f16c393400ea273ddf61539edf82",
-   "sha256": "1dhss4qzllpgfp3xy2kdw2g2n70rzjzgz747rchx1rfb5vwhmwl8"
+   "commit": "bfbf23983828a067e1dc84d99a45523c60097252",
+   "sha256": "1a3bj2id25lg52qadh85svyjckzn0hh8n20lzddkfl8l11bzgvlr"
   },
   "stable": {
    "version": [
@@ -99327,11 +99515,11 @@
   "repo": "juergenhoetzel/pkgbuild-mode",
   "unstable": {
    "version": [
-    20240923,
-    1652
+    20241216,
+    2246
    ],
-   "commit": "b333ec39d0499492e91cfc0a2a932b956b519714",
-   "sha256": "0qy3q3803f72cz80mrdd2j9dnjs8rjby2agz244a0wjnq0521rmq"
+   "commit": "1531fd0e4112a633ead0a7ba72d51c2255a4b959",
+   "sha256": "1x1nlcywxik19ldy6bsykx7zhbgj20y50hw5r90ysii4yci4in08"
   },
   "stable": {
    "version": [
@@ -99932,8 +100120,8 @@
   "repo": "alphapapa/pocket-reader.el",
   "unstable": {
    "version": [
-    20240924,
-    42
+    20241225,
+    117
    ],
    "deps": [
     "dash",
@@ -99945,8 +100133,8 @@
     "pocket-lib",
     "s"
    ],
-   "commit": "7f55668325fab3dcf1c24b10ee073f7d1df180a3",
-   "sha256": "08fxaffdzxr48lixzk7g9b4aaa107vyyws2ghcw0ismqrfhkq8gz"
+   "commit": "d507c376f0edaee475466e4ecdcead4d4184e5aa",
+   "sha256": "1hyjs6cp23cy10k7f0fdp4qz21ba0qmb04xmpdjl5wkwl0s5wfw9"
   },
   "stable": {
    "version": [
@@ -100321,14 +100509,14 @@
   "repo": "polymode/poly-org",
   "unstable": {
    "version": [
-    20230317,
-    1220
+    20241208,
+    1024
    ],
    "deps": [
     "polymode"
    ],
-   "commit": "5ca02279a4e6f5025cd2c7b1196058d3e74dc5d5",
-   "sha256": "136bph3rmknfqf6kq4yz5wlxsjidcq6w42wis87lbknmphhg1jp7"
+   "commit": "90d9ca9f440d3b6c03b185353edd37a100559ec4",
+   "sha256": "15afhwy09ans90k9y265ihc45clq2y212azx8zwp18mqdx9m44fz"
   },
   "stable": {
    "version": [
@@ -100733,11 +100921,11 @@
   "repo": "auto-complete/popup-el",
   "unstable": {
    "version": [
-    20240101,
-    830
+    20250101,
+    843
    ],
-   "commit": "6fa7c440879ade009dd0ea37eccc771ced0ef86d",
-   "sha256": "0q3kpqip0mj8y8ws290v55z3krzlnrrynvj04qdfpkjxndh8ya3z"
+   "commit": "7a05700a37aae66d2b24f0cd8851f65383a5cf96",
+   "sha256": "1mphrwcdfcknkp874v4yk1pczqb65dyhgjlqwm3c8c2gx3map3mx"
   },
   "stable": {
    "version": [
@@ -100890,6 +101078,29 @@
   }
  },
  {
+  "ename": "portage-modes",
+  "commit": "03e50a626f3926b3e18b3ad764a0071be612de62",
+  "sha256": "1bm67r05wdxmc649n9r6vsigxggd1dplfnkdh12k0c17c1gac55m",
+  "fetcher": "github",
+  "repo": "OpenSauce04/portage-modes",
+  "unstable": {
+   "version": [
+    20241230,
+    1837
+   ],
+   "commit": "5f6b5aa7eb1d8508ca82e5ed1cb4da5870801161",
+   "sha256": "12fl3jx6r650cmiw6d9906ckbqdbcl5qiskz7r1z8dz968pmvn4y"
+  },
+  "stable": {
+   "version": [
+    0,
+    3
+   ],
+   "commit": "5f6b5aa7eb1d8508ca82e5ed1cb4da5870801161",
+   "sha256": "12fl3jx6r650cmiw6d9906ckbqdbcl5qiskz7r1z8dz968pmvn4y"
+  }
+ },
+ {
   "ename": "portage-navi",
   "commit": "0a467702b3ac3c8bdc723262e6919f67fd71d524",
   "sha256": "1wjkh8xj5120v9fz1nrpkd6x4f22ni8h2lfkd82df7kjz6bzdfwg",
@@ -100974,11 +101185,11 @@
   "repo": "tumashu/posframe",
   "unstable": {
    "version": [
-    20241023,
-    319
+    20241202,
+    1311
    ],
-   "commit": "ac9f954ac4c546e68daf403f2ab2b5ad4397f26e",
-   "sha256": "0qq14z8qiwmx0dwbcz6nrhznj34jxkb47dcv1wf8v6qhnm4b7z2i"
+   "commit": "81651536827c96bf5af5265ee7918ab70e1dd5b1",
+   "sha256": "1jpwmzzzsv0p4iv20wk39apg9mahq48d63drlkr6n5ry246g99dd"
   },
   "stable": {
    "version": [
@@ -101241,8 +101452,8 @@
   "repo": "blahgeek/emacs-pr-review",
   "unstable": {
    "version": [
-    20241105,
-    1542
+    20241223,
+    230
    ],
    "deps": [
     "ghub",
@@ -101250,8 +101461,8 @@
     "magit-section",
     "markdown-mode"
    ],
-   "commit": "bd9846fa0636bde8c6f9d88b9f2b9514903e82f8",
-   "sha256": "120ym24d2bccni9dwlk086sbqvfwmwj9kj61yfxh76j6dak28i9j"
+   "commit": "9fa4ef4d1922cbd6dd37b631ea05aed0ef358178",
+   "sha256": "1cm92263jqvq2lg378xqi8ikbqw98lxjpsl29sja2xg2wf6p7gml"
   }
  },
  {
@@ -101317,11 +101528,20 @@
   "repo": "Lindydancer/preproc-font-lock",
   "unstable": {
    "version": [
-    20151107,
-    2018
+    20250103,
+    1541
    ],
-   "commit": "565fda9f5fdeb0598986174a07e9fb09f7604397",
-   "sha256": "0yrfd9qaz16nqcvjyjm9qci526qgkv6k51q5752h3iyqkxnss1pd"
+   "commit": "b16b59afcdc53614e6c3c272d1eaea592a832f65",
+   "sha256": "01c4yf4frvmjgwdkci2nfi1a2gk3lcl49pksys4r0cngsqmrcxfk"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    6
+   ],
+   "commit": "b16b59afcdc53614e6c3c272d1eaea592a832f65",
+   "sha256": "01c4yf4frvmjgwdkci2nfi1a2gk3lcl49pksys4r0cngsqmrcxfk"
   }
  },
  {
@@ -101954,11 +102174,11 @@
   "repo": "jcs-elpa/project-abbrev",
   "unstable": {
    "version": [
-    20240101,
-    932
+    20250101,
+    1011
    ],
-   "commit": "71bceb21c9d9df3ee00c9fbd420fd0c2733941a1",
-   "sha256": "0kd0li894vr9741fmg9cfxcb8lqchwy61v2idbr4d0ilap8l9xbq"
+   "commit": "05eaf3a0f00b68d427b76cd0410519783999807d",
+   "sha256": "0sl8jrg7gscbc3914nx8cn32fr00xvlihy1aza04b5lf0k0l3qcg"
   },
   "stable": {
    "version": [
@@ -102153,26 +102373,26 @@
   "repo": "TxGVNN/project-tasks",
   "unstable": {
    "version": [
-    20241107,
-    330
+    20241220,
+    1028
    ],
    "deps": [
     "project"
    ],
-   "commit": "404723d0b16dd46a3c0a63675d1f0ab9083799db",
-   "sha256": "16krbqz3x0cfvwcc6iiw6ly4n5v38d664gfa7bslv4xgr25s9sm3"
+   "commit": "1faaa975c99e358165cfc3df160c21c2c611e1c3",
+   "sha256": "0wg1biic9sfsdhq1x1hkcbr396vkklhzz2f6an22amk2jc1pmfnn"
   },
   "stable": {
    "version": [
     0,
     7,
-    0
+    1
    ],
    "deps": [
     "project"
    ],
-   "commit": "ff1b159faae5e4f4756e5fc5f01b4a2a304ded13",
-   "sha256": "0fmppgiz7p4kc7rvs6m73gmcbvg44z30wfs79p1dqba3wsn7xp4j"
+   "commit": "1faaa975c99e358165cfc3df160c21c2c611e1c3",
+   "sha256": "0wg1biic9sfsdhq1x1hkcbr396vkklhzz2f6an22amk2jc1pmfnn"
   }
  },
  {
@@ -102586,15 +102806,15 @@
   "repo": "ericbmerritt/projmake-mode",
   "unstable": {
    "version": [
-    20161031,
-    1715
+    20241228,
+    1643
    ],
    "deps": [
     "dash",
     "indicators"
    ],
-   "commit": "a897701f7e8f8cc11459ed44eb0e454db2a460c1",
-   "sha256": "0las0xl4af6sn5pbllq16abw2hj1kswwpkyi6lf31sbwr5wnq4qb"
+   "commit": "93e2a23f929d69ac3d735a05d6bdcd93fca32471",
+   "sha256": "0z5nbbwis749gdsfz7fqzahhr4dx3jxavnnww06pvbyj7g5k3zwk"
   }
  },
  {
@@ -102813,10 +103033,10 @@
   "stable": {
    "version": [
     29,
-    0
+    2
    ],
-   "commit": "2d4414f384dc499af113b5991ce3eaa9df6dd931",
-   "sha256": "0hrd4xm94nn4kazf86ca5wrmca4ss02m262zvm21i1dwq8pmmppf"
+   "commit": "233098326bc268fc03b28725c941519fc77703e6",
+   "sha256": "0jz2cssbgm895cykv8c76sby9q9g6r0ddgv86n7ss95lp67n0afc"
   }
  },
  {
@@ -103381,11 +103601,11 @@
   "repo": "smoeding/puppet-ts-mode",
   "unstable": {
    "version": [
-    20241129,
-    1040
+    20250102,
+    1219
    ],
-   "commit": "5dbce9c6785af03d47561329d38c436f0e18e3f3",
-   "sha256": "1zybz6ikz4i03glc4p659jr5n9i9cxb6yaamnsyavlq8lrjdbhkd"
+   "commit": "e9e40ebfdf61b18bba5986c1ccd33266fce4aaa0",
+   "sha256": "081fszyimxh2r001lzyhwvfppfwsi3p6sk8ab374l8ajp9lin2q1"
   }
  },
  {
@@ -103396,11 +103616,11 @@
   "repo": "purescript-emacs/purescript-mode",
   "unstable": {
    "version": [
-    20240930,
-    737
+    20241210,
+    1117
    ],
-   "commit": "d187b3d4bbb4d9cb36a4c6c55f35d63d159a26e8",
-   "sha256": "1y2x1l1b1vn041q7jva6qpf4bnf84wsq19nv11wl1ka1ypzqi233"
+   "commit": "07e4d6ecfe677d595ed3759c912c0b262d886b98",
+   "sha256": "12g1mrfs6b07n0w3w41w32p5n7j4h5k5g69nymh5zyxjn207nif0"
   }
  },
  {
@@ -103845,8 +104065,8 @@
   "repo": "dwcoates/pygn-mode",
   "unstable": {
    "version": [
-    20230606,
-    42
+    20241216,
+    1959
    ],
    "deps": [
     "ivy",
@@ -103855,22 +104075,24 @@
     "tree-sitter-langs",
     "uci-mode"
    ],
-   "commit": "9957f3e70b48b6cde77e26253feddad2cd4ca0f0",
-   "sha256": "049nvi9m2jsg56fc8a64ipky66yp5gmc7fq7i3lyl91h7c1lbcv8"
+   "commit": "3f1ce4efd1c34b9fc347c848eb4426bfcc851118",
+   "sha256": "0238s7dzrr0g19arah8b385bad5q1vz155f599pgwilj8cpqz7dz"
   },
   "stable": {
    "version": [
     0,
-    5,
-    1
+    6,
+    3
    ],
    "deps": [
     "ivy",
     "nav-flash",
+    "tree-sitter",
+    "tree-sitter-langs",
     "uci-mode"
    ],
-   "commit": "cd06faecb40774fafa69d91085206810d686367a",
-   "sha256": "15hs87ly3gr8qcdfpsyyf8wadyhhij72kkj33hdqbbq9b74yr6qq"
+   "commit": "3f1ce4efd1c34b9fc347c848eb4426bfcc851118",
+   "sha256": "0238s7dzrr0g19arah8b385bad5q1vz155f599pgwilj8cpqz7dz"
   }
  },
  {
@@ -104517,16 +104739,16 @@
   "repo": "wavexx/python-x.el",
   "unstable": {
    "version": [
-    20230117,
-    1408
+    20241230,
+    943
    ],
    "deps": [
     "cl-lib",
     "folding",
     "python"
    ],
-   "commit": "744924e7468200f3e8ac7ad60a496ad9d080308e",
-   "sha256": "127ddg5i31v40calvnd9r4d48my34wnaanaii70mr5jh1w6gw13v"
+   "commit": "122cc32c1e4c312b0c793788aca03eb20cdebc91",
+   "sha256": "01y9ac0c2qf0x6a8qwdxbsz7a8vfkjg7pmigbj5xgh06icfisi3z"
   },
   "stable": {
    "version": [
@@ -104842,15 +105064,15 @@
   "repo": "quelpa/quelpa-leaf",
   "unstable": {
    "version": [
-    20240101,
-    835
+    20250101,
+    904
    ],
    "deps": [
     "leaf",
     "quelpa"
    ],
-   "commit": "162ae6bc91cfe26f0b013c1b6ce83c3fe3fb8463",
-   "sha256": "1wlpgwvszvn1rbh8v33djin9j213mryjm752hk3khp0k2pmsvnlb"
+   "commit": "e800fc73c3aa0a2a4bfe9552a5d45f34e4d98cd3",
+   "sha256": "1jzv1xxf7yg12pckq23x0x0rqg0ngq5dhpqw6xmqshcngsnzxvqa"
   },
   "stable": {
    "version": [
@@ -104951,11 +105173,11 @@
   "repo": "jamescherti/quick-sdcv.el",
   "unstable": {
    "version": [
-    20241130,
-    2051
+    20241202,
+    2303
    ],
-   "commit": "1f0a38c8de2ddea93f2e42b2201c8d642f300008",
-   "sha256": "0m14vzs4ds3f1d2gq1gc10sgcas67nq76w5a5qx1mfzknv54h3zn"
+   "commit": "7209fba2175cccf67827487e9399538396939a82",
+   "sha256": "1qw46y6fx7bgg33qqjhi6xis77r2ld33dn3yxdf9fk9vg55phcjc"
   },
   "stable": {
    "version": [
@@ -105192,11 +105414,11 @@
   "repo": "greghendershott/racket-mode",
   "unstable": {
    "version": [
-    20241129,
-    1353
+    20250103,
+    1921
    ],
-   "commit": "986c9ad883a1b96076a0da6ae75761c75baaac09",
-   "sha256": "1952y4xjyfxw7m748lbcfkjyf0199ziskycmmqnbivqj2cv7c8wc"
+   "commit": "571f8266d3ac4e0a4c6684e0da642fdcd649b6ef",
+   "sha256": "1amy3svp3wpj6cadshn1gyh3a34vfbxls8r8amjvqnd94p25kbad"
   }
  },
  {
@@ -105932,20 +106154,20 @@
   "repo": "xenodium/ready-player",
   "unstable": {
    "version": [
-    20241004,
-    1537
+    20241229,
+    1720
    ],
-   "commit": "4b11f29afbd146b07203af1128cab6012bda4057",
-   "sha256": "0n46j7hzwqgip51c55w75s4lx5xh3z7nwaqh9p7l77icws6h9zig"
+   "commit": "ecd1a42fa02bac4080a7605f4d2243603a2c30fa",
+   "sha256": "19v9a4x18ayqa1m81zcc23bywz74pd2qsqhvcvwrgrpil1mrrp91"
   },
   "stable": {
    "version": [
     0,
-    24,
+    25,
     1
    ],
-   "commit": "08a360e8d4f643c7115bf29c775a1d4b846c7394",
-   "sha256": "00fpjkgldskf5dsk64gnpz0ijfs9fcvway2rsa31rahzkbjij3cn"
+   "commit": "ecd1a42fa02bac4080a7605f4d2243603a2c30fa",
+   "sha256": "19v9a4x18ayqa1m81zcc23bywz74pd2qsqhvcvwrgrpil1mrrp91"
   }
  },
  {
@@ -106361,11 +106583,11 @@
   "repo": "svaante/recall",
   "unstable": {
    "version": [
-    20241201,
-    2002
+    20241226,
+    1135
    ],
-   "commit": "1921316d8ab02c735454b0d51153f1a657430bff",
-   "sha256": "001dgrdfmy3n2qyv7ai84129j463a62yqkdzcpar62iil0sq7n58"
+   "commit": "37da3dc6db4f734f76a6f1a2965da59030cd63df",
+   "sha256": "04add4kx78jslpa24fx1aq88dw57qfih00mazi0v1k6h8msarlin"
   }
  },
  {
@@ -106455,11 +106677,11 @@
   "repo": "ideasman42/emacs-recomplete",
   "unstable": {
    "version": [
-    20240616,
-    2345
+    20241208,
+    454
    ],
-   "commit": "7a5c4c86cdbf8ba6b045d5ace466e5dcb2f10db0",
-   "sha256": "0j9ir47ny9m0kq4da7jvmv5qf282i0imm3xwfbjyxnhmmq5nj3zv"
+   "commit": "42642d2e0208eae4bb2a2a886b720fc4e3491ab9",
+   "sha256": "0c4ps9wm994ngbq2rsr1i7zil7ywwsx7f218ws7njd07xf02ik4h"
   }
  },
  {
@@ -106570,14 +106792,14 @@
   "repo": "minad/recursion-indicator",
   "unstable": {
    "version": [
-    20240926,
-    916
+    20250101,
+    924
    ],
    "deps": [
     "compat"
    ],
-   "commit": "bf7b972b11281e2951d2b8e5523fa27daa586489",
-   "sha256": "1h6w78qnrnzvj4w3ffgs8vfyf10imhra7ppmj0n4y8agvpxk0969"
+   "commit": "8a828f00a42d397639397aa9051fc884eda688d3",
+   "sha256": "06hjn61wsl8xyxsn6878rvprfk54r5pbv12pkf6ijq4mz3iciz8c"
   },
   "stable": {
    "version": [
@@ -106814,11 +107036,11 @@
   "repo": "purcell/emacs-reformatter",
   "unstable": {
    "version": [
-    20240906,
-    1405
+    20241204,
+    1051
    ],
-   "commit": "155b235f6c76f2f5790aa53798c7a7e36ce5aded",
-   "sha256": "0dmwm3pmmjbsvikxijf8sxa091jahgq6ybg7mn9bvgl8db6mkhyp"
+   "commit": "f2cb59466b1c3f85a8c960f7d4b7b7ead015bedc",
+   "sha256": "1k1qlf3pcvwam9qpz60lzs2f9x8dxvvvpkz70b0l3rj62zpsivdw"
   },
   "stable": {
    "version": [
@@ -106906,11 +107128,11 @@
   "repo": "alvarogonzalezsotillo/region-occurrences-highlighter",
   "unstable": {
    "version": [
-    20240626,
-    1101
+    20241219,
+    1705
    ],
-   "commit": "55f9d100ef67f174c55209f8d4cef1962a9adfc2",
-   "sha256": "0cay4dsqrcpwml0bpsmpnx0mkprr8jj1m6a027m7dfpmhf2xlrmn"
+   "commit": "4c2c7a241fd257dd51f2726715cd1be022b3445a",
+   "sha256": "1m763isg6xxhxqpww3xw7c2ynqrgc1kcwcynzgniif6clmbmdb0h"
   }
  },
  {
@@ -107739,15 +107961,15 @@
   "repo": "jcs-elpa/reveal-in-folder",
   "unstable": {
    "version": [
-    20240226,
-    37
+    20250101,
+    1011
    ],
    "deps": [
     "f",
     "s"
    ],
-   "commit": "ef1b86f745ff2e1d13dc57f6f9fe7e0c53fe26bd",
-   "sha256": "18gqrfxar906h4i4gn9wwwrpzi5cmnpzgfh1qkqhyjbh7wl3d37i"
+   "commit": "f3b7d1edcf8534152ce205bf45d7cae2b7793263",
+   "sha256": "139xhkmalqfbxcqi2ci3zglrh7rzgm8azww41jfqlcgssyj7r9w0"
   },
   "stable": {
    "version": [
@@ -107882,11 +108104,11 @@
   "repo": "kmuto/review-el",
   "unstable": {
    "version": [
-    20220817,
-    1010
+    20241210,
+    1258
    ],
-   "commit": "2b24db8d85a1c40dbd67be195caa79c9df1e0f4b",
-   "sha256": "0hw8spbhdwgaaggf8vrmkpg5zdy9s71ygcj8rlp4acw7cfcp6sbx"
+   "commit": "2a297e3e533cd1f9aac85b77a0c549ec36af5ae3",
+   "sha256": "14m7a7ryh34slm2x860ncg6d7ma5xdyvzs79fk92wsid4q0jl9qz"
   }
  },
  {
@@ -107951,15 +108173,15 @@
   "repo": "dajva/rg.el",
   "unstable": {
    "version": [
-    20241112,
-    1353
+    20241221,
+    1420
    ],
    "deps": [
     "transient",
     "wgrep"
    ],
-   "commit": "bd63cd3346fcabab0ff25e841e9d1ee56f5db705",
-   "sha256": "0j3vqnis4wgg9bf5b85xl9f3yrjyz1r5i64yc7ijfiin0cw8rgff"
+   "commit": "50d42b1395d6381fef66ff8aae4b0d171f7e5b36",
+   "sha256": "1l293zd0rbd5yh0v0r6raq7nqnx5r4j63q2pd7a7s1rcg02w1ywh"
   },
   "stable": {
    "version": [
@@ -108194,8 +108416,8 @@
   "repo": "DogLooksGood/emacs-rime",
   "unstable": {
    "version": [
-    20241106,
-    2056
+    20241211,
+    808
    ],
    "deps": [
     "cl-lib",
@@ -108203,8 +108425,8 @@
     "popup",
     "posframe"
    ],
-   "commit": "8837e4b86d3cef73079a3f4ad6d3c79885236aa5",
-   "sha256": "1s5hx4gp0g66mnjwvmb1f8g9r5m3frzhxj0qphky0mssbd62dh60"
+   "commit": "80f09ed36d9f0ca7ce4e1a3ca1020dc4c80ba335",
+   "sha256": "0cgmj0j1kwjxx6077sb3b7hzj1xg6ppynyizs8v0h1x8jbngdrq0"
   },
   "stable": {
    "version": [
@@ -108409,11 +108631,11 @@
   "repo": "jgkamat/rmsbolt",
   "unstable": {
    "version": [
-    20241030,
-    607
+    20241229,
+    1855
    ],
-   "commit": "c152a1c591108a5244026a7e193f053a8e58e135",
-   "sha256": "18mwmcm6d4ii91kyjcmynwypi0ksw7ww16am9pyzlnvlv1clmy9v"
+   "commit": "38f83b717cf5d5c4ee105c140f4f2341b3d2032b",
+   "sha256": "02bxccg34dc893hnbw1j9fybkqmlkknp8c3zk959bg643x5ycrvd"
   }
  },
  {
@@ -108424,14 +108646,14 @@
   "repo": "dgutov/robe",
   "unstable": {
    "version": [
-    20240509,
-    155
+    20241226,
+    520
    ],
    "deps": [
     "inf-ruby"
    ],
-   "commit": "6bc8a07fc483407971de0966d367a11006b3ab80",
-   "sha256": "144cdg0wp53g4rsmr5ps4r9fhqr686qvikf2pcyi0idyx7dcsaij"
+   "commit": "175d97f6321f9247d2831df9119f3bf376f5b572",
+   "sha256": "1f0scs63crz440v5j1hykxjs1jy7r08lmxng5p7m9wrgbl7bcjsj"
   },
   "stable": {
    "version": [
@@ -108541,26 +108763,26 @@
   "repo": "stevenremot/roguel-ike",
   "unstable": {
    "version": [
-    20240924,
-    1706
+    20241228,
+    929
    ],
    "deps": [
     "popup"
    ],
-   "commit": "4f3fe2bce0394f7f00201410d15c72847bd35b2e",
-   "sha256": "19rdmx8wwkl9ivbnykbmib6qj9grrblhrsrnibynb1ih0gzs6z2s"
+   "commit": "e2e0c089129353f0d4c08b42baf6dc9d66a05175",
+   "sha256": "02yq2qy17gafkayzxfvf9nwm950cw54hlqgzc4mjb21al75rfyrn"
   },
   "stable": {
    "version": [
     0,
     1,
-    2
+    3
    ],
    "deps": [
     "popup"
    ],
-   "commit": "4f3fe2bce0394f7f00201410d15c72847bd35b2e",
-   "sha256": "19rdmx8wwkl9ivbnykbmib6qj9grrblhrsrnibynb1ih0gzs6z2s"
+   "commit": "e2e0c089129353f0d4c08b42baf6dc9d66a05175",
+   "sha256": "02yq2qy17gafkayzxfvf9nwm950cw54hlqgzc4mjb21al75rfyrn"
   }
  },
  {
@@ -108646,10 +108868,10 @@
  },
  {
   "ename": "ropgadget",
-  "commit": "a780acaae76a8515bf0fa70c4b3ef2be0f724ab2",
-  "sha256": "181gqggha3zf469z2rzfvl7ngsszl984f1b8vabiqw4983ig06jr",
+  "commit": "30b240738501d41187b006199845e0277b5754b5",
+  "sha256": "0ym5rly5xvszq4ngr8mlx08k8293b7xhm660kfgha5rlvmmlxrhj",
   "fetcher": "github",
-  "repo": "Dragoncraft89/ropgadget-el",
+  "repo": "yvie-k/ropgadget-el",
   "unstable": {
    "version": [
     20230107,
@@ -108719,17 +108941,25 @@
  },
  {
   "ename": "rpm-spec-mode",
-  "commit": "bb7e188fffda3d4e42690511775e5e32a11e1b34",
-  "sha256": "1ygk0pdhq1hvgzd173h79lxb04b9lmvq4hi70qf9244bqbm0m182",
+  "commit": "08bb83cba3a1ce2e2c13ea1ba408aa147e31abb4",
+  "sha256": "0mh5mjaqpyhfcmqb7379pxwf6fzwgs4zrcgk9lbiz1pg5x5cxf67",
   "fetcher": "github",
-  "repo": "stigbjorlykke/rpm-spec-mode",
+  "repo": "Thaodan/rpm-spec-mode",
   "unstable": {
    "version": [
-    20160710,
-    1136
+    20241209,
+    2001
    ],
-   "commit": "c1c38050c48ea330c7cea632b8785d66daeefb2b",
-   "sha256": "0427kcvf2ljhzwxskn3jzk0ncrl3f9zcz2sm83d9pmhh5jax2gch"
+   "commit": "283d2aac4ede343586a1fb9e9d2a5917f34809a1",
+   "sha256": "160kkf4jswlnv0prwxws2l93cq7b1x21kkkrics0cg7kfkkyrvrr"
+  },
+  "stable": {
+   "version": [
+    0,
+    16
+   ],
+   "commit": "7d06d19a31e888b932da6c8202ff2c73f42703a1",
+   "sha256": "01rb6qfsk4f33nkfdzvvjkw96ip1dv0py8i30l8ix9cqbk07svsv"
   }
  },
  {
@@ -108801,8 +109031,8 @@
  },
  {
   "ename": "rtags",
-  "commit": "3dea16daf0d72188c8b4043534f0833fe9b04e07",
-  "sha256": "0s5m4zjvnc1k4gkkizbs4ysvzzbfh45717pksg9bnyzwx5lcw5yd",
+  "commit": "8f5d42452235ee9f1590fa8893c4ea3d40ac891b",
+  "sha256": "0al6p5ixbnw1xd43k1abcj427fcg2jbkdvml18b8v4vadxn1rqni",
   "fetcher": "github",
   "repo": "Andersbakken/rtags",
   "unstable": {
@@ -108824,8 +109054,8 @@
  },
  {
   "ename": "rtags-xref",
-  "commit": "258a113cb0f7902ca083c931c064c093b3721b52",
-  "sha256": "1hwzv2b6g05n6msxs88ylvvq4l503vsscxg0sxnyigpxgw681znh",
+  "commit": "8f5d42452235ee9f1590fa8893c4ea3d40ac891b",
+  "sha256": "0a7mxazfs5203h6rara65i71zinvxhnavw60z3jik5i5534ipklw",
   "fetcher": "github",
   "repo": "Andersbakken/rtags",
   "unstable": {
@@ -109027,11 +109257,20 @@
   "repo": "Lindydancer/ruby-extra-highlight",
   "unstable": {
    "version": [
-    20171106,
-    1933
+    20250103,
+    1518
    ],
-   "commit": "83942d18eae361998d24c1c523b308eea821f048",
-   "sha256": "18mq0ap7f0b22cdp2wdj0y2fqsahm2ngf7fvdy0mkkfs3818awlp"
+   "commit": "d1f6d41e5c2fc4cc7a23f4e79fa3710fdc74ec61",
+   "sha256": "08vrssc30yhyagddajnl4cyc6ar4cldbihq4fr1n0yc8asw1cyfb"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    1
+   ],
+   "commit": "d1f6d41e5c2fc4cc7a23f4e79fa3710fdc74ec61",
+   "sha256": "08vrssc30yhyagddajnl4cyc6ar4cldbihq4fr1n0yc8asw1cyfb"
   }
  },
  {
@@ -109180,20 +109419,20 @@
  },
  {
   "ename": "ruff-format",
-  "commit": "e0b516fcfb447d0cadcf90cd748b6cedba57000e",
-  "sha256": "077inhas0v7bcla08hsq7v08fmsgrfrz4cg1ii8n0h48nrq6anfk",
+  "commit": "8c8ac06cb999a353b1f168dbec17bb85b7a3daf9",
+  "sha256": "0snmzzi2rfyf1nfjw7lhycnph96gf0jsr6sj3gsl9kar64fza8a5",
   "fetcher": "github",
-  "repo": "scop/emacs-ruff-format",
+  "repo": "JoshHayes/emacs-ruff-format",
   "unstable": {
    "version": [
-    20231117,
-    2220
+    20241230,
+    1856
    ],
    "deps": [
     "reformatter"
    ],
-   "commit": "af6bd49b48cd1583b05268b7d2efc1c7e1c6a113",
-   "sha256": "1d7p22rgrmi88jrw3g7ry6h3xdabkcfnchk8x5af12pgqpfh2r2x"
+   "commit": "063a5e703b070103f405a4cb090af47396cfb00b",
+   "sha256": "0sqy3z6j9ha5i9a06kkw22jv7yf6hgp4dg7ldnhnd692jzfyf0q9"
   }
  },
  {
@@ -109285,8 +109524,8 @@
  },
  {
   "ename": "run-command-recipes",
-  "commit": "a0c6900d9bf9a3d203e8ab54e30a9b7090b7d47b",
-  "sha256": "1k60s1p82n03g17i01r2jj4r5rrv2y9r55m2da1bsc0wh1v8gj0q",
+  "commit": "66dfdd37cd5e58e25d259c5bf925418eb9cd26d0",
+  "sha256": "099blr0dhc1nil5bff954fdkl691qh533b6504ybr2xbdy1sphgb",
   "fetcher": "github",
   "repo": "semenInRussia/emacs-run-command-recipes",
   "unstable": {
@@ -109357,6 +109596,30 @@
   }
  },
  {
+  "ename": "russian-calendar",
+  "commit": "bc6756c5d0869b4cbd7f4a1d84f0a41bcbb81963",
+  "sha256": "1bsy9bmq5n9akrvgsq6xyk76z8kkvjix2yak4kd30x2i31a8mcrd",
+  "fetcher": "codeberg",
+  "repo": "Anoncheg/emacs-russian-calendar",
+  "unstable": {
+   "version": [
+    20250103,
+    307
+   ],
+   "commit": "dc5c6db3ab1658d140188609f5e0ecb53bf840a9",
+   "sha256": "1ndxmq4isi3h10fiqbamkrcq8cf73av5bylf3b5wnbyac7hhpipp"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    8
+   ],
+   "commit": "984f568abcbfa29ec13119c8eb13da365a502327",
+   "sha256": "0dkw1m3gvsl8fw9adqgdbc179xjbqn8r2q9mhsvsjm6z0dqc05m2"
+  }
+ },
+ {
   "ename": "russian-holidays",
   "commit": "d4830900e371e7036225ea434c52204f4d2481a7",
   "sha256": "0lawjwz296grbvb4a1mm1j754q7mpcanyfln1gqxr339kqx2aqd8",
@@ -109387,20 +109650,20 @@
   "repo": "dunmaksim/emacs-russian-techwriter-input-method",
   "unstable": {
    "version": [
-    20221229,
-    822
+    20241222,
+    1903
    ],
-   "commit": "1d86134d04ecf2305969c7546ead7ad425cd7243",
-   "sha256": "1d170cjlrpabivqy5xdlq9hykhr6gxmghvhacp1sj8288jv63jjs"
+   "commit": "0798a620136e7cb6a33e5c2952ed658a65633f9d",
+   "sha256": "1vm8a5w1kppi9zcq4gq1jqafkxq1lcvf9rd89fj0xda86ch79y4q"
   },
   "stable": {
    "version": [
     1,
     0,
-    0
+    1
    ],
-   "commit": "1d86134d04ecf2305969c7546ead7ad425cd7243",
-   "sha256": "1d170cjlrpabivqy5xdlq9hykhr6gxmghvhacp1sj8288jv63jjs"
+   "commit": "0798a620136e7cb6a33e5c2952ed658a65633f9d",
+   "sha256": "1vm8a5w1kppi9zcq4gq1jqafkxq1lcvf9rd89fj0xda86ch79y4q"
   }
  },
  {
@@ -110068,25 +110331,25 @@
   "repo": "openscad/emacs-scad-mode",
   "unstable": {
    "version": [
-    20240926,
-    924
+    20250102,
+    957
    ],
    "deps": [
     "compat"
    ],
-   "commit": "2dc2457650d56d7b495a3db1926acdfb57ad430a",
-   "sha256": "0skrrz57k9d9j82d1cxs7hvh3jrw2qnim6ks7bzfjwgk8lvl82rc"
+   "commit": "7f5b0e34885346a18b381ac0dc457e0f347a7187",
+   "sha256": "1l50fd0fr66ws4i071kfzm28jscw3gcl9ss1nf2z97d052p457lj"
   },
   "stable": {
    "version": [
-    94,
+    95,
     0
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3c32b141f083c31539bb24700eb0aa23ea55918c",
-   "sha256": "1fgnvshyyxyhp4qxc29iqdzvdg2cj2d94lbgsii2bby3k18fzqxc"
+   "commit": "8bc0bbb7ab770ec81d7ce460984a000bf7a3c112",
+   "sha256": "1m71n6kx6fg5hprk1zry3is1hg32bmhh476960lygxp195hkx9y8"
   }
  },
  {
@@ -110115,11 +110378,11 @@
   "repo": "hvesalai/emacs-scala-mode",
   "unstable": {
    "version": [
-    20240729,
-    420
+    20241231,
+    839
    ],
-   "commit": "bd0638c32ab0f2eadacf2809329abf5388211760",
-   "sha256": "1cn16cgh51am3skd081xz2di6fybn4c589f0g3qi5w73c5fmzq1d"
+   "commit": "661337d8aa0a0cb418184c83757661603de3b2e3",
+   "sha256": "1nmbgs0ibg1rq8s47f7znp3njcpmvcifkln800ph3hqpyf9lj33z"
   },
   "stable": {
    "version": [
@@ -110184,11 +110447,11 @@
   "repo": "ashinn/scheme-complete",
   "unstable": {
    "version": [
-    20201112,
-    442
+    20241205,
+    111
    ],
-   "commit": "b9a1448c4696f117d9ea4e59b6162dc31112e71a",
-   "sha256": "1smxr5bkzbfrjx21vhrj1wagmqx5yd92i997dbgs16iaqbzzr7cz"
+   "commit": "569277c0caa3edf8b28086b0efca6db4186184a8",
+   "sha256": "10k3pcsn4ic3jii6dgv1g7271ikc4d9js898wsgkph2phdyg60rl"
   }
  },
  {
@@ -110434,11 +110697,11 @@
   "repo": "zk-phi/scratch-palette",
   "unstable": {
    "version": [
-    20240516,
-    1817
+    20250104,
+    1359
    ],
-   "commit": "6b344af6b33b6b0bfd08e213dd0d43b714f7a5e9",
-   "sha256": "0a09lxfj49m1x894byqb6bgcbckiasaxka5r6g2n4rmk7hpj1rmq"
+   "commit": "e4389fbb97f2890c4caebba0588cbc5d5f1ecbc6",
+   "sha256": "1l7n05b605mzry6lg3cgxipis94b86fy0ajxh5qa0jxbbajrgb6s"
   }
  },
  {
@@ -110638,8 +110901,8 @@
   "url": "https://repo.or.cz/sdcv.el.git",
   "unstable": {
    "version": [
-    20220210,
-    1412
+    20241227,
+    319
    ],
    "deps": [
     "cl-lib",
@@ -110647,8 +110910,8 @@
     "pos-tip",
     "showtip"
    ],
-   "commit": "98e239c7380c63282845d5bc55ea6d605f5a33b8",
-   "sha256": "17jxnc8z2a5rdfrjxw6gfkijp06jkjpsvj0pyxrhmg94gimfprxa"
+   "commit": "941ac2fbbb1be9ad595aed6dd782a842c4676a1a",
+   "sha256": "13z0ql5h0rd7saf9ibfmpqymf0nflshxs81j7f16wqc3pxcafv7k"
   }
  },
  {
@@ -110729,15 +110992,15 @@
   "repo": "jcs-elpa/searcher",
   "unstable": {
    "version": [
-    20240101,
-    938
+    20250101,
+    1011
    ],
    "deps": [
     "dash",
     "f"
    ],
-   "commit": "b2b62cb49312725b05d133c2e155b00d885dc8f5",
-   "sha256": "0irpy5sfy5mdxqjrgiy8qiq283gvqrl80bb4xk9k9qb4rfc60gz1"
+   "commit": "12008a7a9e03980e86cfa6d9589665c70ec0ad4d",
+   "sha256": "0rw9rnaspj11ccrxnih50gy8a6gzn2sbq4lnx31kn68v7qp7j07f"
   },
   "stable": {
    "version": [
@@ -110978,6 +111241,30 @@
    ],
    "commit": "e83efa67c4a9d1935c657a15b4487102cb6655de",
    "sha256": "14i8h50n49mw9960vlsahzf1rbn1mj9400gapil9id9q2xysdpmd"
+  }
+ },
+ {
+  "ename": "selected-window-contrast",
+  "commit": "ab4404f1470718f4ce8e7ef32c4b5ae5058d317d",
+  "sha256": "0wbgjzw46vk093rqhn9pzqlhabagcmgj973zwf1dhkwl5xpjhyms",
+  "fetcher": "codeberg",
+  "repo": "Anoncheg/selected-window-contrast",
+  "unstable": {
+   "version": [
+    20241226,
+    953
+   ],
+   "commit": "41003daf4b17f9cc38f24b834e8e26668760f2da",
+   "sha256": "1p7asx9y8ixa8a8jv3ncymf8llz7fnj6ib0pbb7znpw35fjh96pb"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    4
+   ],
+   "commit": "078242b001fe0799200932c41c08e48f8b19ab7d",
+   "sha256": "0ksabq4mi1hppshjkka6yr2h11aq514zgq6v6k5vbyrw0i90ywgi"
   }
  },
  {
@@ -111896,20 +112183,20 @@
   "repo": "xenodium/shell-maker",
   "unstable": {
    "version": [
-    20241128,
-    934
+    20241226,
+    2102
    ],
-   "commit": "d9330f283241142a13a11d5d83aca875c6796f88",
-   "sha256": "15v3hlcasfv6jzabhg9753hg0jhwfbjycsq75qg2q9vcf0ksacm6"
+   "commit": "72ce76bb3059e6c715b2471856851aac21198ac7",
+   "sha256": "0df0mxaz2g4fzdlhxygifmsjnxw7n8v1ghz1pnlhad0anpwdsdv9"
   },
   "stable": {
    "version": [
     0,
-    72,
-    1
+    76,
+    2
    ],
-   "commit": "d9330f283241142a13a11d5d83aca875c6796f88",
-   "sha256": "15v3hlcasfv6jzabhg9753hg0jhwfbjycsq75qg2q9vcf0ksacm6"
+   "commit": "72ce76bb3059e6c715b2471856851aac21198ac7",
+   "sha256": "0df0mxaz2g4fzdlhxygifmsjnxw7n8v1ghz1pnlhad0anpwdsdv9"
   }
  },
  {
@@ -111920,14 +112207,11 @@
   "repo": "kyagi/shell-pop-el",
   "unstable": {
    "version": [
-    20231228,
-    612
+    20241207,
+    1539
    ],
-   "deps": [
-    "cl-lib"
-   ],
-   "commit": "ff3dc705ee1c7bc566b35c17e4635c57061fe3ae",
-   "sha256": "0awhya3v78k5jkhprifd44aycgv2d40hnmldfw4g7cvljvxzclal"
+   "commit": "657171f296fc930b1f335a96e6f67ae04b731b19",
+   "sha256": "1j8bwgrp4ydpd4s08px15sv5ri28zyb8zfpmfanh9k77m4hmx8cq"
   },
   "stable": {
    "version": [
@@ -111972,20 +112256,20 @@
   "repo": "DamienCassou/shell-switcher",
   "unstable": {
    "version": [
-    20210509,
-    1045
+    20241229,
+    1657
    ],
-   "commit": "ed74b20fa12935be0068765f5bc8de97b92a8020",
-   "sha256": "18ynh2j3mq206lqgkd7zmxzxh3661w9nbawkwvgkk2qi3837xrbr"
+   "commit": "4c96dc27afb519bdbf7bbe42d49a51497f078192",
+   "sha256": "0py95c6i7bffidwkwld1j1h2isyq7psna2kz81jigzz0wi885pjr"
   },
   "stable": {
    "version": [
     1,
-    0,
-    1
+    1,
+    0
    ],
-   "commit": "2c5575ae859a82041a4bacd1793b844bfc24c34f",
-   "sha256": "0ia7sdip4hl27avckv3qpqgm3k4ynvp3xxq1cy53bqfzzx0gcria"
+   "commit": "4c96dc27afb519bdbf7bbe42d49a51497f078192",
+   "sha256": "0py95c6i7bffidwkwld1j1h2isyq7psna2kz81jigzz0wi885pjr"
   }
  },
  {
@@ -112232,11 +112516,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20240827,
-    234
+    20241225,
+    152
    ],
-   "commit": "5c9652141ac2eb8ad9bf68d74f760db526095ec4",
-   "sha256": "0dplbgq1n7mgnmn3wzfbkrpskdc71fh5bgqd9cplp0ax9ghcdynh"
+   "commit": "9712e5703cb846b3cff448d5c40b3f8c7e6eedde",
+   "sha256": "1yk3nbgirjv54kkw720x28vq8jr2f2vba096sqn3s2xxvxy2d1jx"
   }
  },
  {
@@ -112323,11 +112607,11 @@
   "repo": "jcs-elpa/show-eol",
   "unstable": {
    "version": [
-    20240101,
-    931
+    20250101,
+    1011
    ],
-   "commit": "febc1df7ac1c7006b3f0993a3436575e8e0dc71d",
-   "sha256": "0lqnh43gbh3aipl6mk07cxpqsylh5bs3gzcr18r4xmdnxvg3q3x4"
+   "commit": "117060c077dca1facb7ea8942ea866d0621ef5ce",
+   "sha256": "1vhkdkww38fxaqiynm2l0f1nqmhxw074a9qfk3yi9vfrn6r8k2q6"
   },
   "stable": {
    "version": [
@@ -112716,14 +113000,14 @@
   "repo": "emacs-sideline/sideline",
   "unstable": {
    "version": [
-    20241130,
-    1105
+    20250101,
+    856
    ],
    "deps": [
     "ht"
    ],
-   "commit": "63c913aeb5836f2376d1ad01580e67f9d1c56e0a",
-   "sha256": "11agf4mzydyksbh869s1rq7z2vi4jk4w0mkbs9xqw69lnasr2iyx"
+   "commit": "709095ca022dd4ea4ceeb6ab18ce9b9dbda0d6a5",
+   "sha256": "01ccmmnizi2wakkb92zp922idcfsmmcspac1shf7lxjqfbbrpr0n"
   },
   "stable": {
    "version": [
@@ -112746,15 +113030,15 @@
   "repo": "emacs-sideline/sideline-blame",
   "unstable": {
    "version": [
-    20241130,
-    1118
+    20250101,
+    857
    ],
    "deps": [
     "sideline",
     "vc-msg"
    ],
-   "commit": "24acacc766f7cc8ffb1a7dda695be6eb67ec5670",
-   "sha256": "18gvg5b89g88ijhx058lvdnwvwgm0jpkg6cnrrf86dj2sv2qzdcd"
+   "commit": "872c232b7f5d3805bde24607bd0050fc9464f8d6",
+   "sha256": "1815l3i4acwhfyf0hdna9fg32jmkzk34b336viiswpmi00h1j4nb"
   },
   "stable": {
    "version": [
@@ -112778,16 +113062,16 @@
   "repo": "emacs-sideline/sideline-flycheck",
   "unstable": {
    "version": [
-    20241130,
-    1119
+    20250101,
+    857
    ],
    "deps": [
     "flycheck",
     "ht",
     "sideline"
    ],
-   "commit": "1cc46a244d76027687136b3db0da1f5535d1352c",
-   "sha256": "0q16mblknwlvs9adg8vc919snr7m3qypz8xj2vbn2vf6m8prs0d3"
+   "commit": "bce7bbc90edc3cdeb3144a8fb8d59f5529e3391b",
+   "sha256": "0mfznzv254rdam67vsdq7nbhiq97cilccbgh14ckq5f2v10sfpil"
   },
   "stable": {
    "version": [
@@ -112811,14 +113095,14 @@
   "repo": "emacs-sideline/sideline-flymake",
   "unstable": {
    "version": [
-    20241130,
-    1119
+    20250101,
+    857
    ],
    "deps": [
     "sideline"
    ],
-   "commit": "096b2fecfdb5a2192541e6099f761dde22b53aec",
-   "sha256": "0z8h403891swpprjfj5pvpnh129p9kmsn0hb7625k7iar6xnywc2"
+   "commit": "c3099660040fb360f4c02a74e50612aefdfe7999",
+   "sha256": "07882x0mxc95liqql873yil4s3cmv6hvf8aswxj3qq0kz0l9bv76"
   },
   "stable": {
    "version": [
@@ -112841,8 +113125,8 @@
   "repo": "emacs-sideline/sideline-lsp",
   "unstable": {
    "version": [
-    20241130,
-    1119
+    20250101,
+    857
    ],
    "deps": [
     "dash",
@@ -112851,8 +113135,8 @@
     "s",
     "sideline"
    ],
-   "commit": "96fd13fa94fc7abfe84dbf1c966cdfe1b5273d94",
-   "sha256": "19jrhyyzsrc6vwj3kbpc9vh1wnyj81w46skk59dm91ws0isyvf6b"
+   "commit": "29b95888a91f53e5161a3f2e2fc27a9cfc71ebe5",
+   "sha256": "0dzfff4wxwpas76cc6rhi152w875j89qiw7fvz8adqdkqbcji306"
   },
   "stable": {
    "version": [
@@ -113133,11 +113417,11 @@
   "repo": "wachikun/simple-screen",
   "unstable": {
    "version": [
-    20240127,
-    214
+    20241228,
+    113
    ],
-   "commit": "1c5d025dd267ec7b0c8f210a27b2b8f8e11fc07b",
-   "sha256": "1lnhfc8axggc0z6jz6d1l0dm5f9mkszg5wzh5nn8z0690mmj97vx"
+   "commit": "66eb5ddab259025ef5790084ca33018c266d6940",
+   "sha256": "1wx509s8zhn2rvxff3197dai5a6giydqfwqknrl5dzaq7l1kf5hv"
   }
  },
  {
@@ -113310,11 +113594,11 @@
   "repo": "laishulu/emacs-smart-input-source",
   "unstable": {
    "version": [
-    20241125,
-    217
+    20241229,
+    1843
    ],
-   "commit": "d55ea5c0271c9fb91cd1eeceadeb20f67b7cf5fb",
-   "sha256": "05c1fhvp29v76151l4pv1qkbxjlqkz4k60ps2yn2zlgmpygpzzkg"
+   "commit": "fa12ae71e96dc3eb620db301c7e16ea1d15cc4c9",
+   "sha256": "1s9irjww9dsd7la81nsczxarp44y3v75axg912337w2pzj569bj1"
   }
  },
  {
@@ -113325,8 +113609,8 @@
   "repo": "magit/sisyphus",
   "unstable": {
    "version": [
-    20241015,
-    1351
+    20250101,
+    1807
    ],
    "deps": [
     "compat",
@@ -113334,14 +113618,14 @@
     "llama",
     "magit"
    ],
-   "commit": "e6ec5d8687f34644b4d049a6be463269792c9fd6",
-   "sha256": "0kgx57liqqfdslxpzm7av1jj5yjpjbabdiijc95jqw47mvvnfj1b"
+   "commit": "b5303108fcccca495fe36202d023a068ee7af2f7",
+   "sha256": "1kc91jicm5xmlchcnvx2mpalqglzxmxkwbvs1kfvkgvkgh5z8d1y"
   },
   "stable": {
    "version": [
     0,
     2,
-    0
+    1
    ],
    "deps": [
     "compat",
@@ -113349,8 +113633,8 @@
     "llama",
     "magit"
    ],
-   "commit": "e6ec5d8687f34644b4d049a6be463269792c9fd6",
-   "sha256": "0kgx57liqqfdslxpzm7av1jj5yjpjbabdiijc95jqw47mvvnfj1b"
+   "commit": "b5303108fcccca495fe36202d023a068ee7af2f7",
+   "sha256": "1kc91jicm5xmlchcnvx2mpalqglzxmxkwbvs1kfvkgvkgh5z8d1y"
   }
  },
  {
@@ -113578,22 +113862,21 @@
   "repo": "emacs-slack/emacs-slack",
   "unstable": {
    "version": [
-    20241126,
-    6
+    20241226,
+    2336
    ],
    "deps": [
     "alert",
     "circe",
     "dash",
     "emojify",
-    "oauth2",
     "request",
     "s",
     "ts",
     "websocket"
    ],
-   "commit": "661041b5c398a1e7c226b2805aaffd4387ec3e94",
-   "sha256": "0h66mb4mfdrwmbsxr5yfsqv580ipyqq0gyzfyz0cw11qwpxnq0x0"
+   "commit": "ea3b1a30dc349df33288eb4eefbbd3a5ee28a9ae",
+   "sha256": "107d4kxj2r62k5p0rdy9dz78qrn104rrmz6ig1983dxjq7sxxfkn"
   }
  },
  {
@@ -113654,14 +113937,14 @@
   "repo": "slime/slime",
   "unstable": {
    "version": [
-    20241201,
-    2103
+    20250101,
+    459
    ],
    "deps": [
     "macrostep"
    ],
-   "commit": "a71e133aa7d3c132bb3a00cedaeee3f76b5f17ab",
-   "sha256": "0rqjw2c5hzmrmvbf37l6fdx6pria6d360nvqka47qc74s4pw1hyi"
+   "commit": "af6f1fca2f45c151f830f42905d6fc0f66053798",
+   "sha256": "0wxxlcik32cggjr591ksvxcrsbwalf1bcysjj5yal8jw0b8k7fi1"
   },
   "stable": {
    "version": [
@@ -114147,11 +114430,11 @@
   "repo": "malsyned/smart-dash",
   "unstable": {
    "version": [
-    20240129,
-    1813
+    20250101,
+    2011
    ],
-   "commit": "04481dd62671a557fa8812c336d23108e2bca2fa",
-   "sha256": "0xhzf1ya1hf5xfswnlz2anfcp9j38yxkwvd1wf05vf68x849n25y"
+   "commit": "98ea891a885fbe54a754a46730be3527dfe24af3",
+   "sha256": "02fwz0jpri18rajf752nk729wx3mxrhrkf76rbk623bm9sfcw0g0"
   }
  },
  {
@@ -114284,14 +114567,14 @@
   "repo": "daviderestivo/smart-mode-line-atom-one-dark-theme",
   "unstable": {
    "version": [
-    20240103,
-    927
+    20250103,
+    1324
    ],
    "deps": [
     "smart-mode-line"
    ],
-   "commit": "f422b79e7b6e2796b1d5f4143913497383840960",
-   "sha256": "1f9003m0wkw2j6b9k1i0ahr4cdslx48rhk8ggksn30523gssa1xp"
+   "commit": "318865f15d33c480216221baff4d1ef85e07552d",
+   "sha256": "1ds4zi45vplnhgfyk0qi3a8j2n8y47kns32cgglxx7m5h7h893hl"
   }
  },
  {
@@ -114463,15 +114746,14 @@
   "repo": "Fuco1/smartparens",
   "unstable": {
    "version": [
-    20240713,
-    1002
+    20241220,
+    1254
    ],
    "deps": [
-    "cl-lib",
     "dash"
    ],
-   "commit": "c7519a1b69f196050a13e2230b7532893b077086",
-   "sha256": "06bdr3vcywg6k89d5dmvj4sdxh95y0jgh5xlddvmv2x0i8d7g69b"
+   "commit": "b0d935c11813bcd40f8d35bae8800e0741334c29",
+   "sha256": "1j3x0bwvgymgaxi6clasr00gwsh7vwbhysfabqxynb044m1kccq6"
   },
   "stable": {
    "version": [
@@ -114914,16 +115196,16 @@
   "repo": "danielfm/smudge",
   "unstable": {
    "version": [
-    20240413,
-    2104
+    20250101,
+    2103
    ],
    "deps": [
     "oauth2",
     "request",
     "simple-httpd"
    ],
-   "commit": "4a9c5b34e9bc0a694d0faf8c2f83dc244b8b6a2f",
-   "sha256": "1xiqxw87sdk9mgy7fdbmzqaf58dc1grhkigirg1bd0b2q5kbnbwx"
+   "commit": "5768ea8048b906bfa6ae942ecd4f533a9a55e8c5",
+   "sha256": "1j4p088kzhsdil4svimhcp02xb09islr7zzk5qy35dxa1ak2pv8r"
   }
  },
  {
@@ -115997,11 +116279,11 @@
   "repo": "gnuhack/spanish-holidays",
   "unstable": {
    "version": [
-    20240302,
-    1542
+    20241209,
+    1141
    ],
-   "commit": "81ef3733da0ab807570c7fad1bab613bf7f30acb",
-   "sha256": "1d2hg6r4zc77xrmid7kz4w91g5ib13hl5kl8ak1w5glb51mfhfbw"
+   "commit": "a596ec68f26c06063718dc83132e2843107cfe5c",
+   "sha256": "1py204463crsjn0qjpz79ngyhk78la0wrhn03xmhb8nlpqmpv64q"
   }
  },
  {
@@ -116102,11 +116384,11 @@
   "repo": "condy0919/spdx.el",
   "unstable": {
    "version": [
-    20241117,
-    126
+    20241220,
+    119
    ],
-   "commit": "c036cfc6e6581b1c23d484d278e278c4d809fc23",
-   "sha256": "1isgv9fzdfgf2dn7nv5wypkm2g4yh508qxh1npgbfgwg38shpq1c"
+   "commit": "050971f33487a676bff4b21c82864dba7cf3b6eb",
+   "sha256": "03prllb4z2izv0wcb814cm78wzi36iw6rrg1bi0gpsbr3ya4axqh"
   }
  },
  {
@@ -116144,11 +116426,11 @@
   "repo": "brailcom/speechd-el",
   "unstable": {
    "version": [
-    20240513,
-    1716
+    20250104,
+    1435
    ],
-   "commit": "ac7497e394bf7d46e0b2c27570f5507f6a50a157",
-   "sha256": "1y8r75sl28kll8r6qzqnbri18j2kgvqfh73yi9kszld5zz8d95mp"
+   "commit": "4dc3e407509e18c383a21b6a2368a27c7dbb354a",
+   "sha256": "1qvrd8w5lx3kgjb3jdnkvhgfi4wpx0d1l526slgrz3nrqi3f7dp3"
   },
   "stable": {
    "version": [
@@ -116877,11 +117159,11 @@
   "repo": "srfi-explorations/emacs-srfi",
   "unstable": {
    "version": [
-    20241121,
-    1857
+    20241230,
+    338
    ],
-   "commit": "e9f6edb09d9cce461249ad54505911d71ca81a45",
-   "sha256": "0hkri3rmyj303lhi4wr6ydc3b553lczra6al9n5i9mcvx2i43gx8"
+   "commit": "9e667e59946c47a78cca88bf708efbe88ccc4a9e",
+   "sha256": "1fqzw7lqh3zrilxmdcsnfn0pbq9wqrjpmmkjsx4al688s31pbhan"
   },
   "stable": {
    "version": [
@@ -116994,11 +117276,11 @@
   "repo": "peterhoeg/ssh-config-mode-el",
   "unstable": {
    "version": [
-    20240901,
-    2018
+    20250101,
+    820
    ],
-   "commit": "2d8e321c34a7535ae6dd0f6a1b0fd54e47aba612",
-   "sha256": "0l5k7g4cq4ay7c5q961562naqq55732q3b2qjgg32800qzrid3kc"
+   "commit": "d0596f5fbeab3d2c3c30eb83527316403bc5b2f7",
+   "sha256": "1xs9ixp2bgbn2whjpj7l1n15fklivfh7544sgai61225jprckyak"
   }
  },
  {
@@ -117154,8 +117436,8 @@
   "repo": "daanturo/starhugger.el",
   "unstable": {
    "version": [
-    20240731,
-    347
+    20241223,
+    1047
    ],
    "deps": [
     "compat",
@@ -117164,8 +117446,8 @@
     "s",
     "spinner"
    ],
-   "commit": "22eceb806947edc1ad35e10fb99bdfc65fe26ca3",
-   "sha256": "1c0xc5sbpgp4nfs4rr1zrzqpxd4jl3cjjpkp43zifahal3gm0am7"
+   "commit": "92ecc8e99a9bfaa19bf1a7581eb1d44d565c10a5",
+   "sha256": "1b8ms769030cnhblva31bgb4rp0h6zirmwgfgx0rh8xxzp2y0p1d"
   },
   "stable": {
    "version": [
@@ -117351,20 +117633,20 @@
   "repo": "stacked-git/stgit",
   "unstable": {
    "version": [
-    20240909,
-    39
+    20250102,
+    253
    ],
-   "commit": "b691c04d4237394977b603867a063778668cbab3",
-   "sha256": "1ind7jprg1gb1zgw0phyxknacg4q1s3536hr0ha9c5jadrshpm3w"
+   "commit": "10db7b5131d11b6bd27fb516fa13ecd2967b50cf",
+   "sha256": "1lcy8sib9l551dp3f5z9akmpdq9jkndfbp8kcj917gkbhdp5a82z"
   },
   "stable": {
    "version": [
     2,
-    4,
-    12
+    5,
+    0
    ],
-   "commit": "b691c04d4237394977b603867a063778668cbab3",
-   "sha256": "1ind7jprg1gb1zgw0phyxknacg4q1s3536hr0ha9c5jadrshpm3w"
+   "commit": "10db7b5131d11b6bd27fb516fa13ecd2967b50cf",
+   "sha256": "1lcy8sib9l551dp3f5z9akmpdq9jkndfbp8kcj917gkbhdp5a82z"
   }
  },
  {
@@ -117380,6 +117662,30 @@
    ],
    "commit": "fec4e1af38f17f5cd80eca361d8e8ef8772db366",
    "sha256": "126zs059snzpg83q9mrb51y0pqawwrj9smr3y7rza4q4qkdp1nk0"
+  }
+ },
+ {
+  "ename": "sticky-scroll-mode",
+  "commit": "fd1261d019d372fe4baeec686441407e7f98b931",
+  "sha256": "1kch1kpaf1zjw6r4rgxanynrxl5im9dgip0dfp0dbr9gr2iyrqr3",
+  "fetcher": "github",
+  "repo": "jclasley/sticky-scroll-mode",
+  "unstable": {
+   "version": [
+    20241213,
+    1543
+   ],
+   "commit": "a1acf1065f88a586770d0eeddec376907d8320c6",
+   "sha256": "1szckrmcr49byr42qnghrivcnbwb1rnwfszwf22b5b7m0gazqhxd"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "4c8cad80f63ce23eb35c9955824b7f07812ee0fc",
+   "sha256": "029wxbi1zzmjh1bdbxn589gawhbmg3a7jpdh0ywwzx4006y2nagh"
   }
  },
  {
@@ -118127,20 +118433,18 @@
   "repo": "tlikonen/suomalainen-kalenteri",
   "unstable": {
    "version": [
-    20230102,
-    904
+    20250103,
+    1003
    ],
-   "commit": "95d8b7f9b404c749831d7b4e0e396c76bd822015",
-   "sha256": "107fzsz7c1cl92ryl6dg198bi5jpkl99rlgw544my2yw728bwnfk"
+   "commit": "4b63a82c3145bfff2dc1f7b45ce2463824462da0",
+   "sha256": "0i14py15rrnyaq4hysijff6y1c4l440y9y1xf9xba8w2sxni4wpv"
   },
   "stable": {
    "version": [
-    2023,
-    1,
-    2
+    2025
    ],
-   "commit": "95d8b7f9b404c749831d7b4e0e396c76bd822015",
-   "sha256": "107fzsz7c1cl92ryl6dg198bi5jpkl99rlgw544my2yw728bwnfk"
+   "commit": "4b63a82c3145bfff2dc1f7b45ce2463824462da0",
+   "sha256": "0i14py15rrnyaq4hysijff6y1c4l440y9y1xf9xba8w2sxni4wpv"
   }
  },
  {
@@ -118936,6 +119240,25 @@
   }
  },
  {
+  "ename": "symbol-overlay-mc",
+  "commit": "a7a8867ce1daa4f1f9746e9903814657a6e1d175",
+  "sha256": "0nkbrvjxbqjlaxa5hjc1x0lxgad8kx5k7s83pgv8gb7j0b3jv606",
+  "fetcher": "github",
+  "repo": "xenodium/symbol-overlay-mc",
+  "unstable": {
+   "version": [
+    20241216,
+    1436
+   ],
+   "deps": [
+    "multiple-cursors",
+    "symbol-overlay"
+   ],
+   "commit": "188fa07fe5cc142dbabcd2b4a102a9ec5f132839",
+   "sha256": "1afm3dqijdyfpkjdp7l7sfjfdiavapby4l4aa63wyz6r64ijgpv1"
+  }
+ },
+ {
   "ename": "symbolist",
   "commit": "967f1819c8d3a6ead5cc5bb7a577be07dabdbe5e",
   "sha256": "1i940i77agy7c1rv7cqarxcbgjwvjnl05gwi0k2n45pzb91pvgld",
@@ -118999,8 +119322,8 @@
   "repo": "drym-org/symex.el",
   "unstable": {
    "version": [
-    20241126,
-    352
+    20250102,
+    50
    ],
    "deps": [
     "evil",
@@ -119013,8 +119336,8 @@
     "tree-sitter",
     "tsc"
    ],
-   "commit": "2a5ad0113a906aca9f4adade2776706657b314bc",
-   "sha256": "056c5n21xq0r82nysjn7m230h85pd3z1fiz38asabcpkd5cxbbir"
+   "commit": "94e5040f0c24f870b7217d8ddf6675c6b17eaff4",
+   "sha256": "11lj9vrfiiz2my519kc54lrg5dfhk66bp34c3rg1psjr99f118zv"
   },
   "stable": {
    "version": [
@@ -119100,20 +119423,20 @@
   "repo": "KeyWeeUsr/emacs-syncthing",
   "unstable": {
    "version": [
-    20241126,
-    247
+    20241210,
+    2345
    ],
-   "commit": "70569dd11762125205015b0e59638c6b1683f0f5",
-   "sha256": "11jynl1wg13vysnzl0xakwl6h3kqvjbdjcxxvc0gq2qg73iz4am1"
+   "commit": "5dbb9516f346c390bd9488da52cb4c4b6dda470d",
+   "sha256": "1q755rcmlmpz9zb1i3ic3a3svyqwavncnfzmx0bsg6229qg06d0l"
   },
   "stable": {
    "version": [
     3,
     0,
-    0
+    1
    ],
-   "commit": "70569dd11762125205015b0e59638c6b1683f0f5",
-   "sha256": "11jynl1wg13vysnzl0xakwl6h3kqvjbdjcxxvc0gq2qg73iz4am1"
+   "commit": "5dbb9516f346c390bd9488da52cb4c4b6dda470d",
+   "sha256": "1q755rcmlmpz9zb1i3ic3a3svyqwavncnfzmx0bsg6229qg06d0l"
   }
  },
  {
@@ -119486,20 +119809,20 @@
   "repo": "jimeh/tab-bar-notch",
   "unstable": {
    "version": [
-    20231120,
-    2029
+    20241224,
+    109
    ],
-   "commit": "6d1101d8156e336f45122c04889327a4c5be253c",
-   "sha256": "1s0j89g93jq0p2p9w1wj9aycm74iar2vg0gkhf87xxf88ldhafs7"
+   "commit": "49a0f4948bc3dc51ae36b026dec89698b26c0cb2",
+   "sha256": "1fa00yqw93h6p9q0swbnp3892zv69g4dnrzgdaqmndfk954gx9yn"
   },
   "stable": {
    "version": [
     0,
     0,
-    6
+    7
    ],
-   "commit": "6d1101d8156e336f45122c04889327a4c5be253c",
-   "sha256": "1s0j89g93jq0p2p9w1wj9aycm74iar2vg0gkhf87xxf88ldhafs7"
+   "commit": "49a0f4948bc3dc51ae36b026dec89698b26c0cb2",
+   "sha256": "1fa00yqw93h6p9q0swbnp3892zv69g4dnrzgdaqmndfk954gx9yn"
   }
  },
  {
@@ -119557,8 +119880,8 @@
    "deps": [
     "nerd-icons"
    ],
-   "commit": "e44d16276f5df80a2d2b86e5fafb132f43bfd550",
-   "sha256": "0plmb9m8hpini73v2z1kcpwkm5jvdikbkadp8x6p78d9wi2iss78"
+   "commit": "7a49880f3ae39a8709d6887b26ec84ba2b92360c",
+   "sha256": "0iwxiixdhc5j4gx6mqplav4jcik1kvc0dnai84vdxiii7222zfq7"
   }
  },
  {
@@ -119639,11 +119962,20 @@
   "repo": "isamert/tabgo.el",
   "unstable": {
    "version": [
-    20240204,
-    1326
+    20250103,
+    1740
    ],
-   "commit": "83b7d3261e9a6aaffd8e97bc047b77a6131789ee",
-   "sha256": "09qdmdivvnwkslq124flgijvxlvix3spglmx8676fjz6gnyzd6zs"
+   "commit": "23b6397fd61db31689feacb4b7df2b1f64e69572",
+   "sha256": "13d72g9h33a8gkrw76nz6dzpalj91pp17707mqwz6zn0miyyzx9d"
+  },
+  "stable": {
+   "version": [
+    1,
+    0,
+    1
+   ],
+   "commit": "23b6397fd61db31689feacb4b7df2b1f64e69572",
+   "sha256": "13d72g9h33a8gkrw76nz6dzpalj91pp17707mqwz6zn0miyyzx9d"
   }
  },
  {
@@ -119677,8 +120009,8 @@
   "repo": "shuxiao9058/tabnine",
   "unstable": {
    "version": [
-    20241123,
-    715
+    20250102,
+    1608
    ],
    "deps": [
     "dash",
@@ -119687,8 +120019,8 @@
     "s",
     "transient"
    ],
-   "commit": "1f7e417eb18e097c0c08c9d151f40f476aa64608",
-   "sha256": "0vd43cj7fmrjig6abibz5nlag8f3m8qgdb4ncqygq81fl39f5sif"
+   "commit": "7c103aa9e1dd46e8507d341fee42ce30417e69f5",
+   "sha256": "04zkn014mjqwscc4iyjjajx98431gi31082pw1wcl4wrz2lc808y"
   },
   "stable": {
    "version": [
@@ -119921,11 +120253,11 @@
   "repo": "saf-dmitry/taskpaper-mode",
   "unstable": {
    "version": [
-    20241126,
-    1304
+    20241231,
+    1206
    ],
-   "commit": "fff056c76220ea87eb45ee115f3a54a1abf1273e",
-   "sha256": "1hn2mfafkzbv8cwz3ch83by3x9nxq6m4ymx75chg0np55l9hmdxg"
+   "commit": "1558c12b647d289285b638075be016f7f0c3466e",
+   "sha256": "0ksa9ndypkvjm00zzhd1bj163jd7v5rim4ssvnqhhsps0mdrch6l"
   },
   "stable": {
    "version": [
@@ -120112,15 +120444,15 @@
   "repo": "zevlg/telega.el",
   "unstable": {
    "version": [
-    20241118,
-    1404
+    20241220,
+    1052
    ],
    "deps": [
     "transient",
     "visual-fill-column"
    ],
-   "commit": "f4f957253093a449c806397fd6157e19d84a7c02",
-   "sha256": "1v6v813lglgwcl8kv6jrvqjyqgp4crpbkv8qyckh9bhkjbmcgxma"
+   "commit": "3836cff15393fe1dc1addb4fe46b11878dab4891",
+   "sha256": "14f3hsc6rkbb7b6z35154y9hqhgv2rmwnkl0xz18py8y8s524j77"
   },
   "stable": {
    "version": [
@@ -120251,25 +120583,25 @@
   "repo": "minad/tempel",
   "unstable": {
    "version": [
-    20241115,
-    656
+    20250101,
+    927
    ],
    "deps": [
     "compat"
    ],
-   "commit": "3659036edbc332746dec556d0dec69ac4c52dcac",
-   "sha256": "14xw8sf5frws7qrpq4p08nphj1hflrnzlxa0bd78p6dkr86pjnij"
+   "commit": "12a2072ce97d7489296dbb950da946b77d215506",
+   "sha256": "1yjp2fk0fzvj9xsshvbha9csranqgrwhf8ggx52qmfn4shssxrn7"
   },
   "stable": {
    "version": [
     1,
-    2
+    3
    ],
    "deps": [
     "compat"
    ],
-   "commit": "317c0e41d542721db11a7a8a1c6b78762959259b",
-   "sha256": "1yyq59rkcqlqm6ra6wp98sqn823a7f2r8nabd1kffqq38rgfj1hr"
+   "commit": "40a85c3dc9a7f073e36fb05b835814a4e68fa5b3",
+   "sha256": "0sh477bx437d3lz6v0m418bk1iwr3mjj8xf396qdi7kiiaic0drz"
   }
  },
  {
@@ -120280,14 +120612,14 @@
   "repo": "Crandel/tempel-collection",
   "unstable": {
    "version": [
-    20241107,
-    1417
+    20241229,
+    1149
    ],
    "deps": [
     "tempel"
    ],
-   "commit": "85f8e1d80963bc717abb8bf160274455093e3b6f",
-   "sha256": "0nc23339y09r8ngx154bdcnlx1kbz1pr4l0j28nli79zcvxb4akf"
+   "commit": "b2fd7929bd767db9d31b2782168f91dcdc75af5b",
+   "sha256": "0m52k8fx88ry9ay6xs5xaq6j56rx2lykb1jgxmia26xyf4h5ykd9"
   }
  },
  {
@@ -120691,11 +121023,11 @@
   "repo": "davidshepherd7/terminal-here",
   "unstable": {
    "version": [
-    20240227,
-    2236
+    20241231,
+    1234
    ],
-   "commit": "c996304c1e873e561108a509129b9e4358d354d5",
-   "sha256": "0dk9wvsbx0szhn8r7ls4729fi2840ywwfir905b6dmvdxxy85q7k"
+   "commit": "dad595abd278a89f14e9f0231bb96ed089822245",
+   "sha256": "0c41ymawgipxg3y8slmsw8nh5n546xy1iyki827jrfdr3767a84h"
   },
   "stable": {
    "version": [
@@ -120857,6 +121189,29 @@
   }
  },
  {
+  "ename": "terraform-docs",
+  "commit": "0215a9cf52a9023dccee73768cf14f507ff0e585",
+  "sha256": "0bg667w37bdbl6lbkl8lm2k9s1lvydl1mbya0wk1nls36dj9y7cj",
+  "fetcher": "github",
+  "repo": "loispostula/terraform-docs.el",
+  "unstable": {
+   "version": [
+    20241216,
+    649
+   ],
+   "commit": "c70d19c4007d81244b276b9d150cdfe3c2e7b8dd",
+   "sha256": "0ad9gv9ks7zii3s20bxlskd22hsrci2r0sa0s0zvw4k78xq90xfm"
+  },
+  "stable": {
+   "version": [
+    0,
+    1
+   ],
+   "commit": "94a78999ec03e66ce49f7343cc8705354e195c3a",
+   "sha256": "0qwbazypfy75k9lbari276yw05857x529bymjyqdvqcysh2lqrmd"
+  }
+ },
+ {
   "ename": "terraform-mode",
   "commit": "6e881965abc08d699c4b878b2c097e51af0096f0",
   "sha256": "1vvkx2k73b752x0ndrl2aadmv461g0nbb8mcqnfxzc85bm80h17n",
@@ -120864,15 +121219,15 @@
   "repo": "hcl-emacs/terraform-mode",
   "unstable": {
    "version": [
-    20240801,
-    921
+    20241217,
+    1628
    ],
    "deps": [
     "dash",
     "hcl-mode"
    ],
-   "commit": "abfc10f5e313c4bb99de136a14636e9bc6df74f6",
-   "sha256": "0rlzx80dx1gv0hcpkjnlvabhf124l442pfish1vii1jaqm5b07ps"
+   "commit": "5bdd734a87f67f6574664f63eb4d02a0bc74c0d0",
+   "sha256": "08zvcy8kqaz5zjrmaiqn9h9msx7p937mq58374cp29hrcns0jxb5"
   },
   "stable": {
    "version": [
@@ -121430,21 +121785,21 @@
   "repo": "facebook/fbthrift",
   "unstable": {
    "version": [
-    20241125,
-    830
+    20241229,
+    2000
    ],
-   "commit": "13a0cd43ea3f14bc58b7685dbb28bb5325c6a398",
-   "sha256": "126gb3z9y2jz74qx5hv4zpwlx9chhip996ihlzk7c8zcvyj86gdv"
+   "commit": "1b906076d75be39b1b6b5e7bcae9a43530ec0d80",
+   "sha256": "0apiyi0715xigyqf168kxm85jsjyy0ryqvphmmb9rm5hi510ixi9"
   },
   "stable": {
    "version": [
     2024,
-    11,
-    25,
+    12,
+    30,
     0
    ],
-   "commit": "13a0cd43ea3f14bc58b7685dbb28bb5325c6a398",
-   "sha256": "126gb3z9y2jz74qx5hv4zpwlx9chhip996ihlzk7c8zcvyj86gdv"
+   "commit": "1b906076d75be39b1b6b5e7bcae9a43530ec0d80",
+   "sha256": "0apiyi0715xigyqf168kxm85jsjyy0ryqvphmmb9rm5hi510ixi9"
   }
  },
  {
@@ -122099,11 +122454,11 @@
   "repo": "vifon/tmsu.el",
   "unstable": {
    "version": [
-    20240421,
-    1056
+    20241230,
+    2209
    ],
-   "commit": "46e0c960629c82c090f42c196876aaf4d6edff1a",
-   "sha256": "0bmshvrw66rhszqqgfvnpvgvjzqvwi5mlylzz4v3dhvpr32bpb3b"
+   "commit": "c75ae9bed8f3bb2229e873fcc85fe62701e47974",
+   "sha256": "0mxz9bmdcdxkj7f4ih405i4vpd35c72xgs1i8cbi0132dpnnblpz"
   }
  },
  {
@@ -122431,11 +122786,11 @@
   "repo": "jamescherti/tomorrow-night-deepblue-theme.el",
   "unstable": {
    "version": [
-    20241128,
-    1605
+    20241202,
+    1540
    ],
-   "commit": "a6f73ee3cafd580a8704f6d1a596dc19c783e31c",
-   "sha256": "01mfial0jh595pk6imn6z0g4r3mk15c508xnkkrsazs3614brwq8"
+   "commit": "44b864c94b76310fd8429dbd6b7484c7c2ac50cf",
+   "sha256": "1sj8a3vvl2kz9hkbfc4zk4k6qykp7ds0h7y6a8bxpqrcmna9m4c5"
   },
   "stable": {
    "version": [
@@ -122710,14 +123065,14 @@
   "repo": "martianh/tp.el",
   "unstable": {
    "version": [
-    20241031,
-    729
+    20250103,
+    1428
    ],
    "deps": [
     "transient"
    ],
-   "commit": "df6490d86f24fff22f5ea4f7d887fc60caed1163",
-   "sha256": "14vdn5syv7jghxvqlih9gvh82755r5gd8yxskq8bv6wkm4b0y0cs"
+   "commit": "32f4e7492aa041afff8190d06edbf0343c4bf6a7",
+   "sha256": "1q8pw5lxjl1ahr24dy7shvn03fck8wsdkffgra7xwqsa5vsl1lib"
   },
   "stable": {
    "version": [
@@ -122950,6 +123305,25 @@
   }
  },
  {
+  "ename": "transform-symbol-at-point",
+  "commit": "082ba556ec7c2ca6091b493b0e7c220309a30107",
+  "sha256": "0z187ji96b1bv2gzh3cnmfv7gx01yq2x2w1bm3qj5bzydv3sp51c",
+  "fetcher": "github",
+  "repo": "waymondo/transform-symbol-at-point",
+  "unstable": {
+   "version": [
+    20241202,
+    1802
+   ],
+   "deps": [
+    "s",
+    "transient"
+   ],
+   "commit": "57911a5065a694bf0b404bde2ebf64b8ee8f5d89",
+   "sha256": "1cl6w7xpfjqwh8ivimdkziyl83vkg7aib25xym7g7q6kjqfr8qnq"
+  }
+ },
+ {
   "ename": "transient",
   "commit": "a74629656e9a23133219a0bd805982f1497b35d7",
   "sha256": "0pjj4zj3sa6mhf7fwb5b33y9b506g3bcjyzy44h5n6s79shbak60",
@@ -122957,28 +123331,28 @@
   "repo": "magit/transient",
   "unstable": {
    "version": [
-    20241201,
-    1616
+    20250103,
+    1731
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "37be15575a8e7618de59b6aec5a42ba5656dc36f",
-   "sha256": "1whz9zkzid34rz5753xxyvsxnhs24xcnbv31bvc6n8l1szdncfzi"
+   "commit": "000ff15942878aa1108abaa020da86ada675fea9",
+   "sha256": "137h1m67dyrnb9l3lm90xfwsl56ih8rc0vahw38fm6ny87sl64sd"
   },
   "stable": {
    "version": [
     0,
-    7,
-    9
+    8,
+    3
    ],
    "deps": [
     "compat",
     "seq"
    ],
-   "commit": "00fabc76eb3dc75f742d8d2720c44e25e5772e8f",
-   "sha256": "17qhj3i57i6yz28bvznimls7z1y3f4mln0axk2782jcysz7f80bl"
+   "commit": "000ff15942878aa1108abaa020da86ada675fea9",
+   "sha256": "137h1m67dyrnb9l3lm90xfwsl56ih8rc0vahw38fm6ny87sl64sd"
   }
  },
  {
@@ -123170,11 +123544,11 @@
   "repo": "jcs-elpa/transwin",
   "unstable": {
    "version": [
-    20240126,
-    720
+    20250101,
+    1013
    ],
-   "commit": "99f9296a18654cb38f2ffb8682b7532be60bec5e",
-   "sha256": "1h65dc50ia64q9gm8xyiljif7sjzphj6fdbc7ra4bkxj8amivy05"
+   "commit": "bcf4cc2e83ab771dcec43973106951c643637a91",
+   "sha256": "1k97zyjifk7ghpncd75h58d3rwix32i731z633hlxww85bc0d8l3"
   },
   "stable": {
    "version": [
@@ -123315,8 +123689,8 @@
  },
  {
   "ename": "tree-sitter",
-  "commit": "570bde6b4b89eb74eaf47dda64004cd575f9d953",
-  "sha256": "1r2b0v10h21xi14z4dc1k3hlw3dchf7qylsfy22ah22yzbsldc30",
+  "commit": "66dfdd37cd5e58e25d259c5bf925418eb9cd26d0",
+  "sha256": "18aqdfhqfhq4r9i3f35kqlm2nvywav62vgf1fjv8nqqj11gyamk2",
   "fetcher": "github",
   "repo": "emacs-tree-sitter/elisp-tree-sitter",
   "unstable": {
@@ -123433,26 +123807,26 @@
   "repo": "emacs-tree-sitter/tree-sitter-langs",
   "unstable": {
    "version": [
-    20241201,
-    1840
+    20241229,
+    1957
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "c5ca30e1fa43ca1fdcb7f423ec4c97732ccb8753",
-   "sha256": "0cj6x17yc6j8byqvb7y0k8s2vpwzyq9myqbrj2jj5i38y7d6zcb8"
+   "commit": "e2ee3f66c62139f4cd4483c4d97ec34cb279df9d",
+   "sha256": "18yzy3xgiidrxz30fyj4wagjz55m3xh78cm7k8fqb4inir1hi7ws"
   },
   "stable": {
    "version": [
     0,
     12,
-    238
+    245
    ],
    "deps": [
     "tree-sitter"
    ],
-   "commit": "c5ca30e1fa43ca1fdcb7f423ec4c97732ccb8753",
-   "sha256": "0cj6x17yc6j8byqvb7y0k8s2vpwzyq9myqbrj2jj5i38y7d6zcb8"
+   "commit": "e2ee3f66c62139f4cd4483c4d97ec34cb279df9d",
+   "sha256": "18yzy3xgiidrxz30fyj4wagjz55m3xh78cm7k8fqb4inir1hi7ws"
   }
  },
  {
@@ -123529,8 +123903,8 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20241113,
-    2139
+    20250104,
+    1240
    ],
    "deps": [
     "ace-window",
@@ -123542,8 +123916,8 @@
     "pfuture",
     "s"
    ],
-   "commit": "2fd7745f1bc446fc590dc7ba2eb4e062a51fbb3e",
-   "sha256": "0pspxkja58zpic2gnprhg5jkdy49ydw09rgg9wpf6vjwr5zbxp5b"
+   "commit": "ac3f0706bf6248b7321da683438efdcc6bce3e4c",
+   "sha256": "0r0iwf4606l21aljh971lbndjdynbm9yxvzcg9srrlgmf80ghzxp"
   },
   "stable": {
    "version": [
@@ -123603,15 +123977,15 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20240131,
-    2042
+    20241222,
+    1336
    ],
    "deps": [
     "evil",
     "treemacs"
    ],
-   "commit": "bcba09c1581c4bd93ff0217d464aead04f6d26d4",
-   "sha256": "051x78qpzclzr8mic5z3rpr1j3f5a5apcnn9rhah1rnxg5z9gqa7"
+   "commit": "011f310eeb51db0ccad7b00b7cbd0f1ccddbb588",
+   "sha256": "1d988i32j4y3c1w4b5sh4962z2j78nyi4x0r6l4rp171g6649k1v"
   },
   "stable": {
    "version": [
@@ -123812,15 +124186,15 @@
   "repo": "Alexander-Miller/treemacs",
   "unstable": {
    "version": [
-    20240131,
-    2042
+    20241202,
+    2117
    ],
    "deps": [
     "dash",
     "treemacs"
    ],
-   "commit": "bcba09c1581c4bd93ff0217d464aead04f6d26d4",
-   "sha256": "051x78qpzclzr8mic5z3rpr1j3f5a5apcnn9rhah1rnxg5z9gqa7"
+   "commit": "4364a660447fa5f322c172f6b310115bbc091d12",
+   "sha256": "0kaj5yhi9380xhdgkybn6qwlm92d8j53rd00qf516nvwjg1fsnys"
   },
   "stable": {
    "version": [
@@ -124283,14 +124657,14 @@
   "repo": "smallwat3r/tubestatus.el",
   "unstable": {
    "version": [
-    20240322,
-    2129
+    20241215,
+    2343
    ],
    "deps": [
     "request"
    ],
-   "commit": "26c2627f70badfd4cf6069c31ebc20fa8b03136d",
-   "sha256": "0xqk230ah7dr2casm4hmxhp85dks030v310ah3n7az5csdzs6xpr"
+   "commit": "bf482b445ac00addffcff634bc4ca51021d7f373",
+   "sha256": "187laykgr5cs7y8fl08arsmyav0imhjiqismgbgxbvdvfanf4bgj"
   }
  },
  {
@@ -124517,14 +124891,14 @@
   "repo": "deadblackclover/twtxt-el",
   "unstable": {
    "version": [
-    20240730,
-    151
+    20241219,
+    937
    ],
    "deps": [
     "request"
    ],
-   "commit": "d6a0fc57bcc7dd4a4a76a0836beb33900878ea0b",
-   "sha256": "1s5xzi1zqvl6395ynyrlq89d8cisnwzsdj1hgyw6zzd2vz4xy65z"
+   "commit": "8780c0f637ce5687033a0a0820df41d60d0d49b9",
+   "sha256": "0r469n76xahhqsyalan45fhn67i4a4fw3cnlkfi6yxgfh33hbl2w"
   }
  },
  {
@@ -125117,11 +125491,11 @@
   "repo": "ideasman42/emacs-undo-fu",
   "unstable": {
    "version": [
-    20240707,
-    1410
+    20241206,
+    219
    ],
-   "commit": "dbb3e4b699dd488497ef9b32a04b8e928a6bc8ef",
-   "sha256": "1f4vsg68fylcp2cqc74mbw4zls3n0zq8wvyd0vahy9km7fr753p4"
+   "commit": "399cc12f907f81a709f9014b6fad0205700d5772",
+   "sha256": "1d4ff3y67fy1zrs1qcbwh4grnw0jw9gvnrwrsripyav5w7bd03sw"
   }
  },
  {
@@ -125132,11 +125506,11 @@
   "repo": "ideasman42/emacs-undo-fu-session",
   "unstable": {
    "version": [
-    20240713,
-    1427
+    20241212,
+    40
    ],
-   "commit": "beb0e285d074145eaf481a959c903b77c19ae91e",
-   "sha256": "02wvdnzc229aga5pjb5sqbpi22afjqn6q5v8qay901bgc6r6f9pl"
+   "commit": "d90d42ddba8fa42ef5dc109196545caeabb42b75",
+   "sha256": "167y0hjpcgg2g6pf69kgimk0mx9afki53q1prwrl89ph5w7lf6db"
   }
  },
  {
@@ -125481,11 +125855,20 @@
   "repo": "Lindydancer/unifdef",
   "unstable": {
    "version": [
-    20200517,
-    514
+    20250102,
+    1047
    ],
-   "commit": "7a4b76f664c4375e3d98e8af0a29270752c13701",
-   "sha256": "0xx954cyvzndj7fy6k203nlnhaxi6d0pn3xrvy287dh9ydklng0m"
+   "commit": "4a428d544893e91835b625fab38fdac964dcff88",
+   "sha256": "1608krphhk9igwn4snc2xh4zlmbjfl968h5y27k2nag25g0igmv1"
+  },
+  "stable": {
+   "version": [
+    0,
+    0,
+    2
+   ],
+   "commit": "4a428d544893e91835b625fab38fdac964dcff88",
+   "sha256": "1608krphhk9igwn4snc2xh4zlmbjfl968h5y27k2nag25g0igmv1"
   }
  },
  {
@@ -125520,14 +125903,14 @@
   "repo": "tbanel/uniline",
   "unstable": {
    "version": [
-    20241130,
-    1714
+    20250102,
+    729
    ],
    "deps": [
     "hydra"
    ],
-   "commit": "f9177e8b476db6f388ad4eac1a98b5d6129e7f61",
-   "sha256": "1vhan0dpxq7k5bi863hyb3fn8k8x7m6vidr4b4blj601bmdygk7k"
+   "commit": "9a40005adb12f2c66a9457a8088f8b44c9fae9f4",
+   "sha256": "1ppalp1y5azs7yi42aynrxzalhf59hxybnyhlvnwdsy8i1m8d2vm"
   }
  },
  {
@@ -126178,11 +126561,11 @@
   "repo": "jcs-elpa/use-ttf",
   "unstable": {
    "version": [
-    20240401,
-    611
+    20250101,
+    1013
    ],
-   "commit": "694282b9ba7669fcbceb7088808147f68e3ac066",
-   "sha256": "1760x85gisl5s2wh7b4y7h334b2vv7cz2a158w0w2kjgshbjdwdi"
+   "commit": "78a0a55a036cce9442ffb3aae1bb00a2e1e4a78c",
+   "sha256": "1kvpfw8gblyiy9vymvi52d9967xz7544dskx3qs9x4djcc95ayqh"
   },
   "stable": {
    "version": [
@@ -126309,6 +126692,24 @@
    ],
    "commit": "f096f35a6e1f27d2bc9e9093cd61dd97bc33f502",
    "sha256": "1nzf7cllyvx7kwdzpf0nl3g5a8mn6qgifa60aw68h0sx9a80xp01"
+  }
+ },
+ {
+  "ename": "uv-mode",
+  "commit": "82304b059d6594ae5723d5dd72abb310130d8541",
+  "sha256": "0p12wnr8w9jvymmcam1fpb8w8dnccd2cfvz9714a1h1vdqg7f29k",
+  "fetcher": "github",
+  "repo": "z80dev/uv-mode",
+  "unstable": {
+   "version": [
+    20241216,
+    640
+   ],
+   "deps": [
+    "pythonic"
+   ],
+   "commit": "4055d9e05fb54a4fbb655fa4413728b3db7bcd68",
+   "sha256": "1kyb5a6bpji0j6znq0whnvnz3h0np3giz5q0hdbiz20bs8iq5894"
   }
  },
  {
@@ -127047,20 +127448,20 @@
   "repo": "federicotdn/verb",
   "unstable": {
    "version": [
-    20241021,
-    1914
+    20241223,
+    1316
    ],
-   "commit": "c05263f8cad09b9bf13b03ad9198c40400f31483",
-   "sha256": "1dihjsyi7qi7znqai3r2fa9ggb7mggzsap3723bhj5pkl0gfq9ld"
+   "commit": "2c46542a64e79919496f5a8255b7321f6ba00fd1",
+   "sha256": "0kkdlckbmj8sq1r8if53c6hdqgy92vxvcx5c2dm8byndmjnqqc2n"
   },
   "stable": {
    "version": [
-    2,
-    16,
+    3,
+    0,
     0
    ],
-   "commit": "442e9ddaa658bc9e8d3e50f930e2024fd88a3aa9",
-   "sha256": "1jyav9y2awzaaiz8drlwgb3170pv6ra95zaichfyywdhxxny0fw5"
+   "commit": "2c46542a64e79919496f5a8255b7321f6ba00fd1",
+   "sha256": "0kkdlckbmj8sq1r8if53c6hdqgy92vxvcx5c2dm8byndmjnqqc2n"
   }
  },
  {
@@ -127108,8 +127509,8 @@
   "repo": "gmlarumbe/verilog-ext",
   "unstable": {
    "version": [
-    20240917,
-    2129
+    20241205,
+    2105
    ],
    "deps": [
     "ag",
@@ -127124,14 +127525,14 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "e8af8cfea86dd3cddacf5d069f04f2d84e6f6a71",
-   "sha256": "1m47cvqcyv7i2wjy3hadpma223kkr0jpnf9wp8jbcqzin30sp8cx"
+   "commit": "ca8713c3a406877976314e41ff75896cb44c7560",
+   "sha256": "1q5ca8la3wynqwkgaqwdyk36dshrr3yzmn9a22zpcmwnddhgahrn"
   },
   "stable": {
    "version": [
     0,
     6,
-    1
+    2
    ],
    "deps": [
     "ag",
@@ -127146,8 +127547,8 @@
     "verilog-ts-mode",
     "yasnippet"
    ],
-   "commit": "a30077eaee6187551003c8176c42e18145fe6be4",
-   "sha256": "0ypyp3j40nalq9sixn3dcjxh4m0fmhaibvzb6w13r2jsgw5dr0dd"
+   "commit": "f7e70560d817125721aa7e02a2f527fce15bcf30",
+   "sha256": "18vig4bkd74vzws9kgqlgalx0j1dcszg2i5gc3h00is7gimhhgj8"
   }
  },
  {
@@ -127158,23 +127559,26 @@
   "repo": "gmlarumbe/verilog-ts-mode",
   "unstable": {
    "version": [
-    20240925,
-    1626
+    20241211,
+    1357
    ],
    "deps": [
     "verilog-mode"
    ],
-   "commit": "583bd26d05981820a8e4280278cb638cd00b4fd2",
-   "sha256": "1bd0hlb9fcf1zmprfp54kdmp28s2i5ipvzqi2plz5f510aif20h0"
+   "commit": "096d385bb7d6f03ac93ccc21ebeb6b4a1313d463",
+   "sha256": "0cir562zxlspmbyx644a7cpvr5nly7qw5ili4sg91vpnvvzxgxi2"
   },
   "stable": {
    "version": [
     0,
-    2,
-    1
+    3,
+    0
    ],
-   "commit": "460d78f524cae677e86c8bbba2ce4e3c57e47cbf",
-   "sha256": "1s8p1yacxx8l85kfw71q6y9hrii918h4478jvxkjkcxai0qkrfan"
+   "deps": [
+    "verilog-mode"
+   ],
+   "commit": "85153dd3442b88213cb53b4c484b4173f9f040a3",
+   "sha256": "12da6drd429bdk8figvfnp7jwzd0vvcirdngl8v717agk9mbzh7n"
   }
  },
  {
@@ -127263,25 +127667,25 @@
   "repo": "minad/vertico",
   "unstable": {
    "version": [
-    20241105,
-    2131
+    20250101,
+    928
    ],
    "deps": [
     "compat"
    ],
-   "commit": "b0f9e7679be590b976576e4056b6af4b31212ab0",
-   "sha256": "0wsd1d5grrmpyywxl1fgfw2wd4i65fd6g5dml7a58i6fq44jr8r9"
+   "commit": "7f36ecf5a550b7605da3433448970448deac4bb3",
+   "sha256": "02kz5ahg3b0m2ymllzmbzcpcr1kqjlcpanpd244mmgfyyrcr81a7"
   },
   "stable": {
    "version": [
     1,
-    9
+    10
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d70fdeb67be9ecc88c438039eefa9ef0e2104005",
-   "sha256": "1jszk3dlw6r9h7i858paby341zh1rbbrxafjg1sp890a0cjdd50p"
+   "commit": "6ef99c9219b55b7618d111d352caf795ba07bc54",
+   "sha256": "1np7qjfydbbq1zkp9dsmgx7pnv4yw4rqhg7b0s1l9sqmdka0n4ph"
   }
  },
  {
@@ -127370,8 +127774,8 @@
   "repo": "gmlarumbe/vhdl-ext",
   "unstable": {
    "version": [
-    20241016,
-    1217
+    20241205,
+    1630
    ],
    "deps": [
     "ag",
@@ -127383,14 +127787,14 @@
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "28838b9722933889c8af4b9b543db07ccd2d2b66",
-   "sha256": "1fm42f0fhnychix1mzhlnrchnipi9qq5cl9sjlhmfxz0wflrbqij"
+   "commit": "3f5f0778e87d9d4272903797a2366e603f9f1641",
+   "sha256": "0vgmhsgrh8x8br5grnh1jnf01r2q148xxyf028jgaq09wwjkdvkc"
   },
   "stable": {
    "version": [
     0,
     5,
-    3
+    4
    ],
    "deps": [
     "ag",
@@ -127402,8 +127806,8 @@
     "ripgrep",
     "vhdl-ts-mode"
    ],
-   "commit": "28838b9722933889c8af4b9b543db07ccd2d2b66",
-   "sha256": "1fm42f0fhnychix1mzhlnrchnipi9qq5cl9sjlhmfxz0wflrbqij"
+   "commit": "3f5f0778e87d9d4272903797a2366e603f9f1641",
+   "sha256": "0vgmhsgrh8x8br5grnh1jnf01r2q148xxyf028jgaq09wwjkdvkc"
   }
  },
  {
@@ -127447,20 +127851,20 @@
   "repo": "gmlarumbe/vhdl-ts-mode",
   "unstable": {
    "version": [
-    20240917,
-    2134
+    20241211,
+    1404
    ],
-   "commit": "c7531eea98e2947f7dae0339510060a25bb34568",
-   "sha256": "0wxv5ryrik84wj4qzxpplgwvg2rdcrhf78z98w4wpxm6qzi1mr5x"
+   "commit": "05bb98bec618395ab59e1c11a27dafc0a8b7ee96",
+   "sha256": "1095y6a0pph8pimzypxb3y6pl6v33r9lxhcjd8sliz3v9x5blpy7"
   },
   "stable": {
    "version": [
     0,
-    1,
-    4
+    2,
+    2
    ],
-   "commit": "bfde06b42d4cb03df7fa50495adb2994bdec99d9",
-   "sha256": "16h0h7dwf5lhc14ldxj675dqy5paiklzbh7yqxa0v05wis1iyi4j"
+   "commit": "0f2e70eddab3bc000ad12625f31c62bea0c5994b",
+   "sha256": "0vqq1819czzliicanv00hhv13zy9apvj4326pnj9n3iqx45q6a96"
   }
  },
  {
@@ -127561,11 +127965,11 @@
   "repo": "jamescherti/vim-tab-bar.el",
   "unstable": {
    "version": [
-    20240830,
-    340
+    20241202,
+    2307
    ],
-   "commit": "4d101f14bd388ddc6264c276013eac9760559b0f",
-   "sha256": "0dhkzbcr2dc0pq9g15ggx3vryik8xchlw2kknznsr8x1b2jg2kmq"
+   "commit": "51c0fb29613ab9e7544723667b32be79e7b33c7c",
+   "sha256": "0rdsz2caiac103f338njnga9rpnc257dr7z5d17j0phhfh4xbwnx"
   },
   "stable": {
    "version": [
@@ -127866,19 +128270,19 @@
   "repo": "szermatt/visual-replace",
   "unstable": {
    "version": [
-    20241124,
-    1051
+    20250102,
+    2043
    ],
-   "commit": "19544555e7b5bba624238217a295fd4c80c0ed1d",
-   "sha256": "1sqxwl8ahn4sm553chidh281nj46ppn2yhwlgfj4d0bv7ng0fj8r"
+   "commit": "a2ae4d0116192d34d5142857cb7c27c8091c4da5",
+   "sha256": "054z8p1kw698ifigcx5pyb8wnz988h0k2hny89515n84p3d0z0m0"
   },
   "stable": {
    "version": [
     1,
-    1
+    2
    ],
-   "commit": "d9a89fa02c6170a1b417b3e71e85d481213f318b",
-   "sha256": "05s21qhq23mmv8in88qxfbq79h26j14vcw5pc112sjr1a4fl5306"
+   "commit": "64fce4fd7d3df297be52045992e44591d49f4d52",
+   "sha256": "1bvaw44mkiz6yq1r5hvayfp0iaxqcwbzihdrbizyynm4qjzspca1"
   }
  },
  {
@@ -128034,11 +128438,11 @@
   "repo": "emacs-vs/vs-dark-theme",
   "unstable": {
    "version": [
-    20240729,
-    2203
+    20250101,
+    910
    ],
-   "commit": "54f887bea8a5846b96febd1faf93c5910b8ac10b",
-   "sha256": "0rs1ppx82bhvnjakn4k12ycfxlia8v0gzbv8wgmyxr4gkl8c1n2g"
+   "commit": "a1a59ebd0fb9294224da31d4b62070ea3fe3c28d",
+   "sha256": "1fml15d9hy8fqbz1wnkz4l31h2fdfpb64dqd3pphqzqgxrx5qamr"
   },
   "stable": {
    "version": [
@@ -128057,11 +128461,11 @@
   "repo": "emacs-vs/vs-light-theme",
   "unstable": {
    "version": [
-    20240729,
-    2203
+    20250101,
+    910
    ],
-   "commit": "e07fdeb808763b65dd918d7ae936744bc60d49fa",
-   "sha256": "0c4djxj5wzp394rdn3q425qcdpgzm5qla7s4dykpn9ysj0dsj71w"
+   "commit": "b469a2b7376789494e3448b0722b12556043204a",
+   "sha256": "03cyfkww8kss3xpsymb9y2ld7jhsb6rslyl5skhjpmsr85gj74wa"
   },
   "stable": {
    "version": [
@@ -128149,11 +128553,11 @@
   "repo": "akermu/emacs-libvterm",
   "unstable": {
    "version": [
-    20241118,
-    1627
+    20241218,
+    331
    ],
-   "commit": "fd50624723200f4ac261f122f6332f57796c782f",
-   "sha256": "0sfgpg6d4xj97sf3vsmxyh13vmdz9gsln1lcp05inkavyxz02xb1"
+   "commit": "f64729ed8b59e46ce827d28222c4087c538de562",
+   "sha256": "0bbkw9l44ir03s8lxbnci0gaaqhgj5wb3rqgj2nygaq0ih4mqvg9"
   }
  },
  {
@@ -128426,11 +128830,11 @@
   "repo": "emacs-w3m/emacs-w3m",
   "unstable": {
    "version": [
-    20241030,
-    52
+    20241220,
+    536
    ],
-   "commit": "cce39eb257b27f737b4264f7b41c70ae70dc3906",
-   "sha256": "0zzc7p2b8nqqp8gn0px5jds3fj895gx1n2igvkwmz4v429p7wkgb"
+   "commit": "2118b53c2ce16bb8568a9948d7378d3515c2471c",
+   "sha256": "1ynmaml2hyf1r1pmm5b2fkrmj4kslgqq55bhy32ps0759imwv7la"
   }
  },
  {
@@ -128581,16 +128985,16 @@
   "repo": "abrochard/walkman",
   "unstable": {
    "version": [
-    20221007,
-    1937
+    20241204,
+    2234
    ],
    "deps": [
     "json-mode",
     "org",
     "transient"
    ],
-   "commit": "f5021a4d9f16a2013e67a9fa7c121f87bf030203",
-   "sha256": "0i2yr9iv8zd8nwhap96smab1657gldrayypm18jpbfq8md6cmkg5"
+   "commit": "b8260b6c1c6bdc8878c6f8cbeeea05040ac92b65",
+   "sha256": "1l3hg4spzgf4ymqp9ka7dys4hp1p227y1lf4cbni4ngz6ajynh26"
   },
   "stable": {
    "version": [
@@ -128991,11 +129395,11 @@
   "repo": "fxbois/web-mode",
   "unstable": {
    "version": [
-    20240804,
-    821
+    20241227,
+    530
    ],
-   "commit": "0c83581d1e93d1d802c730a1d5e90cd1c740e1b2",
-   "sha256": "0lvixg4c5apwrpqljj11b3yrq8nklz4ky4njnh8y6h1j5bisx40p"
+   "commit": "be2d59c8fa02b1a45ae54ce4079e502e659cefe6",
+   "sha256": "0v1yq3lk0lvvc3yjs38lsmipa8x5lkz38pdm0v30npsi0dmh1h5r"
   },
   "stable": {
    "version": [
@@ -129305,60 +129709,6 @@
    ],
    "commit": "4669115f02d9c6fee067cc5369bb38c0f9db88b2",
    "sha256": "19hgb5knqqc4rb8yl8s604xql8ar6m9r4d379cfakn15jvwqnl98"
-  }
- },
- {
-  "ename": "weechat",
-  "commit": "e38255a31a4ca31541c97a506a55f82e2670abe6",
-  "sha256": "0sxrms5024bi4irv8x8s8j1zcyd62cpqm0zv4dgpm65wnpc7xc46",
-  "fetcher": "github",
-  "repo": "the-kenny/weechat.el",
-  "unstable": {
-   "version": [
-    20190520,
-    1551
-   ],
-   "deps": [
-    "cl-lib",
-    "s",
-    "tracking"
-   ],
-   "commit": "d9a13306ea8be27367f92e9202d116a88fa1f441",
-   "sha256": "1z9lav09jsmhshlk0xnbp21y9apzhd9zv08h88sdg942v0fn2fid"
-  },
-  "stable": {
-   "version": [
-    0,
-    5,
-    0
-   ],
-   "deps": [
-    "cl-lib",
-    "s",
-    "tracking"
-   ],
-   "commit": "8cbda2738149b070c09288df550781b6c604beb2",
-   "sha256": "1i930jaxpva9s6y3fj3nny46b70g4mqdjl54mcv2rzj95bp4f908"
-  }
- },
- {
-  "ename": "weechat-alert",
-  "commit": "7a69ad48eabb166f66e6eb5c5cdc75aefc8b989f",
-  "sha256": "026hkddvd4a6wy7s8s0lklw8b99fpjawdgi7amvpcrn79ylwbf22",
-  "fetcher": "github",
-  "repo": "Kungi/weechat-alert",
-  "unstable": {
-   "version": [
-    20160416,
-    1248
-   ],
-   "deps": [
-    "alert",
-    "cl-lib",
-    "weechat"
-   ],
-   "commit": "a8fd557c8f335322f132c1c6c08b6741d6394e2e",
-   "sha256": "1hkhim2jfdywx6ks4qfcizycp5qsx4ms6929kbgmzzb8i7j380x6"
   }
  },
  {
@@ -130229,15 +130579,15 @@
   "repo": "bmag/emacs-purpose",
   "unstable": {
    "version": [
-    20240504,
-    1017
+    20241207,
+    148
    ],
    "deps": [
     "imenu-list",
     "let-alist"
    ],
-   "commit": "776c5ef8fe2f0da0f9885526e3556af0f5736600",
-   "sha256": "0w23mljzw314nbr63wzl8m04ii1zjbl5gxgvmr9g8mfq848brsbf"
+   "commit": "c827f45cd9b278b3eb9c2f4bcb55ef2fca5d3048",
+   "sha256": "0qfbhi3kaxh8bn889iwh6y9ix6cx94valj9nn3119nxipxpl9r9c"
   },
   "stable": {
    "version": [
@@ -130814,11 +131164,11 @@
   "repo": "progfolio/wordel",
   "unstable": {
    "version": [
-    20240104,
-    603
+    20250104,
+    1247
    ],
-   "commit": "38a05283c014812c0a54207aa6146f163c707fa5",
-   "sha256": "181am26kb18aw0g93la2c5037p5d6fn6da8knsj0zf1rmisr2qyc"
+   "commit": "f6ca7c7068e2cca8260ae8b061b41cee60d5845c",
+   "sha256": "1zb6rf9f71kskzfrg5ynzy1mjp733yprkbnamnqk900cd9yzna5p"
   }
  },
  {
@@ -130859,11 +131209,11 @@
   "repo": "gromnitsky/wordnut",
   "unstable": {
    "version": [
-    20180313,
-    443
+    20241229,
+    739
    ],
-   "commit": "feac531404041855312c1a046bde7ea18c674915",
-   "sha256": "1jl0b6g64a9w0q7bfvwha67vgws5xd15b7mkfyb5gkz3pymqhfxn"
+   "commit": "dffc75a455d0d4458b7555f4c051c51d71c8e18a",
+   "sha256": "1clhgpxicy9pbgq4bwr2iiwgnhzgxlqvqn1anxka9zlk04parmwm"
   }
  },
  {
@@ -130874,11 +131224,11 @@
   "repo": "martianh/wordreference.el",
   "unstable": {
    "version": [
-    20241020,
-    1145
+    20241203,
+    1648
    ],
-   "commit": "698fa410232830a8acb249a422be33a58dd4c6ee",
-   "sha256": "0cbvg9pgclkf2mwnslnvalnl6z9gznkmzpap83g8pvgrbjrjbgcc"
+   "commit": "4f68d155ceb3328c3263faee86cfb82d50402f05",
+   "sha256": "0kv0b2nbaafjznclahymxcrp2mj06v71887jg5rlj2i09mb0igf1"
   }
  },
  {
@@ -131087,16 +131437,16 @@
   "repo": "dangom/writefreely.el",
   "unstable": {
    "version": [
-    20221221,
-    1456
+    20241222,
+    1909
    ],
    "deps": [
     "org",
-    "ox-gfm",
+    "ox-hugo",
     "request"
    ],
-   "commit": "db70444eb5fbe0820754574d70b1ae44967607dc",
-   "sha256": "1570vi25pwsws8dskmgclnxc6hjwma44wwvddnnmp8jy8a4fsa3l"
+   "commit": "cfcd21b82dc4a4543efb6209fc0a4f4bc3c78e4a",
+   "sha256": "1m2gcw61p0aqfchvz6y35938jv0b49p7jp0lkm0q7v7pbf0qmk3l"
   }
  },
  {
@@ -132234,26 +132584,26 @@
   "repo": "zkry/yaml-pro",
   "unstable": {
    "version": [
-    20240623,
-    1904
+    20241223,
+    1723
    ],
    "deps": [
     "yaml"
    ],
-   "commit": "5f06949e92dc19dcc48dc31662b2aa958fe33726",
-   "sha256": "0affakq60pyi649gnc7xvjcb7dg1h8rvmwbcpxd2zicj9np289h2"
+   "commit": "f7706ea170de98d29b7cdd5a4f189bd038b1e27b",
+   "sha256": "0gx6sxr68bbmqv6rbs9gd4kfgw0avg2fqgbwq14n35yfgr18xc7l"
   },
   "stable": {
    "version": [
     1,
-    2,
-    0
+    3,
+    1
    ],
    "deps": [
     "yaml"
    ],
-   "commit": "5f06949e92dc19dcc48dc31662b2aa958fe33726",
-   "sha256": "0affakq60pyi649gnc7xvjcb7dg1h8rvmwbcpxd2zicj9np289h2"
+   "commit": "f7706ea170de98d29b7cdd5a4f189bd038b1e27b",
+   "sha256": "0gx6sxr68bbmqv6rbs9gd4kfgw0avg2fqgbwq14n35yfgr18xc7l"
   }
  },
  {
@@ -132501,14 +132851,14 @@
   "repo": "AndreaCrotti/yasnippet-snippets",
   "unstable": {
    "version": [
-    20241014,
-    949
+    20241207,
+    2221
    ],
    "deps": [
     "yasnippet"
    ],
-   "commit": "23bcbcd11f567a2659ae413c62c82892eb50a3f1",
-   "sha256": "0g1d676jq6ayisck2garlk9cwvf8m6w17ajw07mybcadq2nm03g9"
+   "commit": "f1907ed38acc479e78d5c113810465e4d77d8604",
+   "sha256": "063vfm49909qqy6m2qh8bcliwznh6758178va3g2vn06hqhz3znb"
   },
   "stable": {
    "version": [
@@ -132694,14 +133044,14 @@
   "url": "https://git.thanosapollo.org/yeetube",
   "unstable": {
    "version": [
-    20241022,
-    2200
+    20250104,
+    1648
    ],
    "deps": [
     "compat"
    ],
-   "commit": "d3437030bcd8d64b2e5a3bc579e2f2f0b4581d1f",
-   "sha256": "1szi2ghx67vrs76dnv3bfjx12rdhyskm6bf2yjkrlf03fy1r8api"
+   "commit": "c4e3488b0a4ca3113c27f55aefc7ae44837e4fda",
+   "sha256": "06frawlz2b6lh2cc53039sga6zv2jq1gwdi5s7csfhgck3hkq2mm"
   },
   "stable": {
    "version": [
@@ -133125,10 +133475,10 @@
  },
  {
   "ename": "zeno-theme",
-  "commit": "e6f007367d181005ebd1a4d73085d73e807d3583",
-  "sha256": "01kp0j27q9v62d45ail65al9zzfxpx7d7bj6gdzilbmwk3k7lxq5",
+  "commit": "f6633f0376fd50b6cc45d96c67848dbf8f38e210",
+  "sha256": "0akc4llnam4p699v01szhf0xj7r6475y14kbpxli29n5612cwdax",
   "fetcher": "github",
-  "repo": "zenobht/zeno-theme",
+  "repo": "sacredyak/zeno-theme",
   "unstable": {
    "version": [
     20211205,
@@ -133616,11 +133966,11 @@
   "repo": "localauthor/zk",
   "unstable": {
    "version": [
-    20240926,
-    1826
+    20241205,
+    926
    ],
-   "commit": "8e361577b8cf01f20a65222ca4ce90720a3d74a6",
-   "sha256": "1qj560cy1ncj7czl0jbbjahxcqjn01263ahd7db78m3kgshjv6r7"
+   "commit": "2bd80f73485927a081d06a754d7f299b1350c5e7",
+   "sha256": "14kszbnd0yj5y2q0ba71a0r969b6nwz8sij84h2g3aqdlnnj7f6m"
   },
   "stable": {
    "version": [
@@ -134080,15 +134430,15 @@
   "repo": "egh/zotxt-emacs",
   "unstable": {
    "version": [
-    20240203,
-    647
+    20241231,
+    1929
    ],
    "deps": [
     "deferred",
     "request"
    ],
-   "commit": "7eae5196dbe6fa3045b31412538ce4a81204abc4",
-   "sha256": "12h0fi1fz33747h807gg29wgqqm3yzfn34m79zkvdicxiaj920ny"
+   "commit": "4057a310d0fc6034f3825ee584f8ea6f81dd6251",
+   "sha256": "1fmm0n1ck7xrgxy6jnyyfhw3vz4i9f82gjx87vv74mscb3v8l8mm"
   },
   "stable": {
    "version": [


### PR DESCRIPTION
- emacs-overlay commit fac7acbab55f1dbbf078c99d7dbce94c9590b073
- [hydra](https://hydra.nix-community.org/eval/212670?filter=x86_64-linux.unstable.packages.&compare=212608&full=#tabs-still-fail)
- new build failures
  - [ ] [consult-gh](https://hydra.nix-community.org/build/2568421) #371742
  - [ ] [gotest-ts](https://hydra.nix-community.org/build/2447857) https://github.com/chmouel/gotest-ts.el/pull/1 #371772
  - [X] [org-link-beautify](https://hydra.nix-community.org/build/2527307) #371729
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
