### PR TITLE
ubootNanoPiR5S: init

### DIFF
--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -395,6 +395,17 @@ in
     ];
   };
 
+  ubootNanoPiR5S = buildUBoot {
+    defconfig = "nanopi-r5s-rk3568_defconfig";
+    extraMeta.platforms = [ "aarch64-linux" ];
+    BL31 = rkbin.BL31_RK3568;
+    ROCKCHIP_TPL = rkbin.TPL_RK3568;
+    filesToInstall = [
+      "idbloader.img"
+      "u-boot.itb"
+    ];
+  };
+
   ubootNovena = buildUBoot {
     defconfig = "novena_defconfig";
     extraMeta.platforms = [ "armv7l-linux" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -10371,6 +10371,7 @@ with pkgs;
     ubootLibreTechCC
     ubootNanoPCT4
     ubootNanoPCT6
+    ubootNanoPiR5S
     ubootNovena
     ubootOdroidC2
     ubootOdroidXU3


### PR DESCRIPTION
Adds uboot build for FriendlyElec NanoPi R5S.

The board fits well in network scenarios, as it provides three Ethernet ports (1x1Gbe and 2x2.5Gbe).

Board Wiki: https://wiki.friendlyelec.com/wiki/index.php/NanoPi_R5S