### PR TITLE
usbkvm: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/by-name/us/usbkvm/package.nix
+++ b/pkgs/by-name/us/usbkvm/package.nix
@@ -11,6 +11,7 @@
   pkg-config,
   python3,
   stdenv,
+  udev,
   wrapGAppsHook3,
 }:
 
@@ -51,6 +52,7 @@ stdenv.mkDerivation {
     ninja
     makeWrapper
     wrapGAppsHook3
+    udev
   ];
 
   buildInputs = [
@@ -71,6 +73,11 @@ stdenv.mkDerivation {
       --replace-fail "@MSLIB_H_PRECOMPILED@" "${ms-tools-lib}/mslib.h"
   '';
 
+  # Install udev rules in this package's out path:
+  mesonFlags = [
+    "-Dudevrulesdir=lib/udev/rules.d"
+  ];
+
   postFixup =
     let
       GST_PLUGIN_PATH = lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" [
@@ -82,11 +89,6 @@ stdenv.mkDerivation {
       wrapProgram $out/bin/usbkvm \
         --prefix GST_PLUGIN_PATH : "${GST_PLUGIN_PATH}"
     '';
-
-  postInstall = ''
-    mkdir -p $out/lib/udev/rules.d/
-    cp ../70-usbkvm.rules $out/lib/udev/rules.d/
-  '';
 
   meta = {
     homepage = "https://github.com/carrotIndustries/usbkvm";

--- a/pkgs/by-name/us/usbkvm/package.nix
+++ b/pkgs/by-name/us/usbkvm/package.nix
@@ -15,11 +15,11 @@
 }:
 
 let
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchzip {
     url = "https://github.com/carrotIndustries/usbkvm/releases/download/v${version}/usbkvm-v${version}.tar.gz";
-    sha256 = "sha256-OuZ7+IjsvK7/PaiTRwssaQFJDFWJ8HX+kqV13CUyTZA=";
+    sha256 = "sha256-ng6YpaN7sKEBPJcJAm0kcYtT++orweWRx6uOZFnOGG8=";
   };
 
   ms-tools-lib = buildGoModule {


### PR DESCRIPTION

Updates the `usbkvm` app to version 0.2.0.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
