### PR TITLE
[staging-next-24.11] Node.js backports

### DIFF
--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -321,6 +321,9 @@ let
         "test-watch-mode-files_watcher"
       ] ++ lib.optionals (!lib.versionAtLeast version "22") [
         "test-tls-multi-key"
+      ] ++ lib.optionals stdenv.hostPlatform.is32bit [
+        # utime (actually utimensat) fails with EINVAL on 2038 timestamp
+        "test-fs-utimes-y2K38"
       ] ++ lib.optionals stdenv.buildPlatform.isDarwin [
         # Disable tests that don’t work under macOS sandbox.
         "test-macos-app-sandbox"

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -291,6 +291,7 @@ let
       "FLAKY_TESTS=skip"
       # Skip some tests that are not passing in this context
       "CI_SKIP_TESTS=${lib.concatStringsSep "," ([
+        # Tests don't work in sandbox.
         "test-child-process-exec-env"
         "test-child-process-uid-gid"
         "test-fs-write-stream-eagain"

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -65,5 +65,15 @@ buildNodejs {
       stripLen = 1;
       hash = "sha256-6y3aEqxNC4iTQEv1oewodJrhOHxjp5xZMq1P1QL94Rg=";
     })
+    # Fix for https://github.com/NixOS/nixpkgs/issues/355919
+    # FIXME: remove after a minor point release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/a094a8166cd772f89e92b5deef168e5e599fa815.patch?full_index=1";
+      hash = "sha256-5FZfozYWRa1ZI/f+e+xpdn974Jg2DbiHbua13XUQP5E=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
+      hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -63,5 +63,12 @@ buildNodejs {
       url = "https://github.com/nodejs/node/commit/d0a6b605fba6cd69a82e6f12ff0363eef8fe1ee9.patch";
       hash = "sha256-TfYal/PikRZHL6zpAlC3SmkYXCe+/8Gs83dLX/X/P/k=";
     })
+    # Remove unused `fdopen` in vendored zlib, which causes compilation failures with clang 18 on Darwin.
+    (fetchpatch2 {
+      url = "https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9.patch?full_index=1";
+      extraPrefix = "deps/v8/third_party/zlib/";
+      stripLen = 1;
+      hash = "sha256-WVxsoEcJu0WBTyelNrVQFTZxJhnekQb1GrueeRBRdnY=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -70,5 +70,20 @@ buildNodejs {
       stripLen = 1;
       hash = "sha256-WVxsoEcJu0WBTyelNrVQFTZxJhnekQb1GrueeRBRdnY=";
     })
+    # Backport V8 fixes for LLVM 19.
+    (fetchpatch2 {
+      url = "https://chromium.googlesource.com/v8/v8/+/182d9c05e78b1ddb1cb8242cd3628a7855a0336f%5E%21/?format=TEXT";
+      decode = "base64 -d";
+      extraPrefix = "deps/v8/";
+      stripLen = 1;
+      hash = "sha256-bDTwFbATPn5W4VifWz/SqaiigXYDWHq785C64VezuUE=";
+    })
+    (fetchpatch2 {
+      url = "https://chromium.googlesource.com/v8/v8/+/1a3ecc2483b2dba6ab9f7e9f8f4b60dbfef504b7%5E%21/?format=TEXT";
+      decode = "base64 -d";
+      extraPrefix = "deps/v8/";
+      stripLen = 1;
+      hash = "sha256-6y3aEqxNC4iTQEv1oewodJrhOHxjp5xZMq1P1QL94Rg=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v18.nix
+++ b/pkgs/development/web/nodejs/v18.nix
@@ -1,9 +1,6 @@
 {
   callPackage,
   lib,
-  overrideCC,
-  pkgs,
-  buildPackages,
   openssl,
   python311,
   fetchpatch2,
@@ -11,25 +8,8 @@
 }:
 
 let
-  # Clang 16+ cannot build Node v18 due to -Wenum-constexpr-conversion errors.
-  # Use an older version of clang with the current libc++ for compatibility (e.g., with icu).
-  ensureCompatibleCC =
-    packages:
-    if packages.stdenv.cc.isClang && lib.versionAtLeast (lib.getVersion packages.stdenv.cc.cc) "16" then
-      overrideCC packages.llvmPackages_15.stdenv (
-        packages.llvmPackages_15.stdenv.cc.override {
-          inherit (packages.llvmPackages) libcxx;
-        }
-      )
-    else
-      packages.stdenv;
-
   buildNodejs = callPackage ./nodejs.nix {
     inherit openssl;
-    stdenv = ensureCompatibleCC pkgs;
-    buildPackages = buildPackages // {
-      stdenv = ensureCompatibleCC buildPackages;
-    };
     python = python311;
   };
 

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -27,5 +27,13 @@ buildNodejs {
     ./bypass-darwin-xcrun-node16.patch
     ./node-npm-build-npm-package-logic.patch
     ./use-correct-env-in-tests.patch
+
+    # Remove unused `fdopen` in vendored zlib, which causes compilation failures with clang 18 on Darwin.
+    (fetchpatch2 {
+      url = "https://github.com/madler/zlib/commit/4bd9a71f3539b5ce47f0c67ab5e01f3196dc8ef9.patch?full_index=1";
+      extraPrefix = "deps/v8/third_party/zlib/";
+      stripLen = 1;
+      hash = "sha256-WVxsoEcJu0WBTyelNrVQFTZxJhnekQb1GrueeRBRdnY=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -50,5 +50,10 @@ buildNodejs {
       stripLen = 1;
       hash = "sha256-6y3aEqxNC4iTQEv1oewodJrhOHxjp5xZMq1P1QL94Rg=";
     })
+    # fixes test failure, remove when included in release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/b6fe731c55eb4cb9d14042a23e5002ed39b7c8b7.patch?full_index=1";
+      hash = "sha256-KoKsQBFKUji0GeEPTR8ixBflCiHBhPqd2cPVPuKyua8=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -35,5 +35,20 @@ buildNodejs {
       stripLen = 1;
       hash = "sha256-WVxsoEcJu0WBTyelNrVQFTZxJhnekQb1GrueeRBRdnY=";
     })
+    # Backport V8 fixes for LLVM 19.
+    (fetchpatch2 {
+      url = "https://chromium.googlesource.com/v8/v8/+/182d9c05e78b1ddb1cb8242cd3628a7855a0336f%5E%21/?format=TEXT";
+      decode = "base64 -d";
+      extraPrefix = "deps/v8/";
+      stripLen = 1;
+      hash = "sha256-bDTwFbATPn5W4VifWz/SqaiigXYDWHq785C64VezuUE=";
+    })
+    (fetchpatch2 {
+      url = "https://chromium.googlesource.com/v8/v8/+/1a3ecc2483b2dba6ab9f7e9f8f4b60dbfef504b7%5E%21/?format=TEXT";
+      decode = "base64 -d";
+      extraPrefix = "deps/v8/";
+      stripLen = 1;
+      hash = "sha256-6y3aEqxNC4iTQEv1oewodJrhOHxjp5xZMq1P1QL94Rg=";
+    })
   ] ++ gypPatches;
 }

--- a/pkgs/development/web/nodejs/v20.nix
+++ b/pkgs/development/web/nodejs/v20.nix
@@ -35,6 +35,16 @@ buildNodejs {
       stripLen = 1;
       hash = "sha256-WVxsoEcJu0WBTyelNrVQFTZxJhnekQb1GrueeRBRdnY=";
     })
+    # Fix for https://github.com/NixOS/nixpkgs/issues/355919
+    # FIXME: remove after a minor point release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/a094a8166cd772f89e92b5deef168e5e599fa815.patch?full_index=1";
+      hash = "sha256-5FZfozYWRa1ZI/f+e+xpdn974Jg2DbiHbua13XUQP5E=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
+      hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";
+    })
     # Backport V8 fixes for LLVM 19.
     (fetchpatch2 {
       url = "https://chromium.googlesource.com/v8/v8/+/182d9c05e78b1ddb1cb8242cd3628a7855a0336f%5E%21/?format=TEXT";

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -8,8 +8,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "22.10.0";
-  sha256 = "3180710d3130ad9df01466abf010e408d41b374be54301d1480d10eca73558e0";
+  version = "22.11.0";
+  sha256 = "bbf0297761d53aefda9d7855c57c7d2c272b83a7b5bad4fea9cb29006d8e1d35";
   patches = [
     ./configure-emulator.patch
     ./configure-armv6-vfpv2.patch

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -19,6 +19,16 @@ buildNodejs {
     ./use-correct-env-in-tests.patch
     ./bin-sh-node-run-v22.patch
 
+    # Fix for https://github.com/NixOS/nixpkgs/issues/355919
+    # FIXME: remove after a minor point release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/a094a8166cd772f89e92b5deef168e5e599fa815.patch?full_index=1";
+      hash = "sha256-5FZfozYWRa1ZI/f+e+xpdn974Jg2DbiHbua13XUQP5E=";
+    })
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
+      hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";
+    })
     # fixes test failure, remove when included in release
     (fetchpatch2 {
       url = "https://github.com/nodejs/node/commit/b6fe731c55eb4cb9d14042a23e5002ed39b7c8b7.patch?full_index=1";

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -18,5 +18,11 @@ buildNodejs {
     ./node-npm-build-npm-package-logic.patch
     ./use-correct-env-in-tests.patch
     ./bin-sh-node-run-v22.patch
+
+    # fixes test failure, remove when included in release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/b6fe731c55eb4cb9d14042a23e5002ed39b7c8b7.patch?full_index=1";
+      hash = "sha256-KoKsQBFKUji0GeEPTR8ixBflCiHBhPqd2cPVPuKyua8=";
+    })
   ];
 }

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -8,8 +8,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "22.11.0";
-  sha256 = "bbf0297761d53aefda9d7855c57c7d2c272b83a7b5bad4fea9cb29006d8e1d35";
+  version = "22.12.0";
+  sha256 = "fe1bc4be004dc12721ea2cb671b08a21de01c6976960ef8a1248798589679e16";
   patches = [
     ./configure-emulator.patch
     ./configure-armv6-vfpv2.patch
@@ -21,10 +21,6 @@ buildNodejs {
 
     # Fix for https://github.com/NixOS/nixpkgs/issues/355919
     # FIXME: remove after a minor point release
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/a094a8166cd772f89e92b5deef168e5e599fa815.patch?full_index=1";
-      hash = "sha256-5FZfozYWRa1ZI/f+e+xpdn974Jg2DbiHbua13XUQP5E=";
-    })
     (fetchpatch2 {
       url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
       hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";

--- a/pkgs/development/web/nodejs/v23.nix
+++ b/pkgs/development/web/nodejs/v23.nix
@@ -14,8 +14,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "23.2.0";
-  sha256 = "3cf7a8a36682775693691f1de901bb5973ad3c0ae2aa87b1add9de515e7b2fc7";
+  version = "23.5.0";
+  sha256 = "32e77b36c0774c68baab41bc7c2acc58663ca0a2b7c4d3e9bec6f761c15fdac0";
   patches = [
     ./configure-emulator.patch
     ./configure-armv6-vfpv2.patch
@@ -53,20 +53,10 @@ buildNodejs {
       hash = "sha256-gmIyiSyNzC3pClL1SM2YicckWM+/2tsbV1xv2S3d5G0=";
       revert = true;
     })
-    # Fix for https://github.com/NixOS/nixpkgs/issues/355919
     # FIXME: remove after a minor point release
     (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/a094a8166cd772f89e92b5deef168e5e599fa815.patch?full_index=1";
-      hash = "sha256-5FZfozYWRa1ZI/f+e+xpdn974Jg2DbiHbua13XUQP5E=";
-    })
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
-      hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";
-    })
-    # fixes test failure, remove when included in release
-    (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/b6fe731c55eb4cb9d14042a23e5002ed39b7c8b7.patch?full_index=1";
-      hash = "sha256-KoKsQBFKUji0GeEPTR8ixBflCiHBhPqd2cPVPuKyua8=";
+      url = "https://github.com/nodejs/node/commit/49acdc8748fe9fe83bc1b444e24c456dff00ecc5.patch?full_index=1";
+      hash = "sha256-iK7bj4KswTeQ9I3jJ22ZPTsvCU8xeGGXEOo43dxg3Mk=";
     })
   ];
 }

--- a/pkgs/development/web/nodejs/v23.nix
+++ b/pkgs/development/web/nodejs/v23.nix
@@ -63,5 +63,10 @@ buildNodejs {
       url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
       hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";
     })
+    # fixes test failure, remove when included in release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/b6fe731c55eb4cb9d14042a23e5002ed39b7c8b7.patch?full_index=1";
+      hash = "sha256-KoKsQBFKUji0GeEPTR8ixBflCiHBhPqd2cPVPuKyua8=";
+    })
   ];
 }


### PR DESCRIPTION
This brings the `staging-next-24.11` Node.js derivation up to date with `staging`, apart from:

* the change to the default version;
* https://github.com/NixOS/nixpkgs/pull/352147 and the SQLite changes in https://github.com/NixOS/nixpkgs/commit/e4f44407a7a9a5561cd6b589a6d27e7a8f91a720, since eating that rebuild right now seems awful;
* and https://github.com/NixOS/nixpkgs/commit/982e3fc31d8f83e1f6792e5cfe0af21881a2c801 since we don’t have the newer `libuv` on that branch.

I’m hoping this will fix https://github.com/NixOS/nixpkgs/pull/369690#issuecomment-2571506861, but I still need to build it. It will be a fair few rebuilds to eat, of course; the alternative would be guessing at which parts of these make the difference and conditionalizing them on `x86_64-darwin`. Not sure that’s worth it.

I’m also not really sure what the cause of all this is; the only real changes to the Node derivation from `release-24.11` to `staging-next-24.11` are Python and `libxml2` bumps, but the Python bump is on `master` as well. My hope is that it’s LLVM or something. My fear is that maybe we’re exposing some `libuv` issue that the bump on `master` hid. I dunno.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
