### PR TITLE
nitrocli: init at 0.4.1

### DIFF
--- a/pkgs/by-name/ni/nitrocli/package.nix
+++ b/pkgs/by-name/ni/nitrocli/package.nix
@@ -1,0 +1,54 @@
+{
+  fetchFromGitHub,
+  installShellFiles,
+  lib,
+  libnitrokey,
+  rustPlatform,
+  stdenv,
+}:
+let
+  version = "0.4.1";
+in
+rustPlatform.buildRustPackage {
+  pname = "nitrocli";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "d-e-s-o";
+    repo = "nitrocli";
+    tag = "v${version}";
+    hash = "sha256-j1gvh/CmRhPTeesMIK5FtaqUW7c8hN3ub+kQ2NM3dNM=";
+  };
+
+  cargoHash = "sha256-loCVYe4vdalo2AvoMo9th/V9xXulaq6HlPOw3idbqEw=";
+
+  # tests require a connected Nitrokey device
+  doCheck = false;
+
+  # link against packaged libnitrokey
+  USE_SYSTEM_LIBNITROKEY = 1;
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  buildInputs = [ libnitrokey ];
+
+  postInstall =
+    (lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      installShellCompletion --cmd nitrocli \
+        --bash <($out/bin/shell-complete bash nitrocli) \
+        --fish <($out/bin/shell-complete fish nitrocli) \
+        --zsh <($out/bin/shell-complete zsh nitrocli)
+    '')
+    + ''
+      installManPage doc/nitrocli.1
+      rm $out/bin/shell-complete
+    '';
+
+  meta = {
+    description = "Command line tool for interacting with Nitrokey devices";
+    homepage = "https://github.com/d-e-s-o/nitrocli";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "nitrocli";
+    maintainers = with lib.maintainers; [ robinkrahl ];
+  };
+}


### PR DESCRIPTION
[`nitrocli`](https://github.com/d-e-s-o/nitrocli) is a command-line tool for interacting with Nitrokey devices like the Nitrokey Pro or Storage.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
