### PR TITLE
chatterino2: generalize expression; chatterino7: init at 7.5.2; chatterino2: 2.5.1 -> 2.5.2

### DIFF
--- a/pkgs/by-name/ch/chatterino2/common.nix
+++ b/pkgs/by-name/ch/chatterino2/common.nix
@@ -1,0 +1,46 @@
+{
+  enableAvifSupport ? false,
+  stdenv,
+  lib,
+  cmake,
+  pkg-config,
+  boost,
+  openssl,
+  libsecret,
+  libavif,
+  kdePackages,
+}:
+
+stdenv.mkDerivation {
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    kdePackages.wrapQtAppsHook
+  ];
+
+  buildInputs =
+    (with kdePackages; [
+      qtbase
+      qtsvg
+      qt5compat
+      qtkeychain
+    ])
+    ++ [
+      boost
+      openssl
+      libsecret
+    ]
+    ++ lib.optional stdenv.hostPlatform.isLinux kdePackages.qtwayland
+    ++ lib.optional enableAvifSupport libavif;
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_WITH_QT6" true)
+    (lib.cmakeBool "USE_SYSTEM_QTKEYCHAIN" true)
+    (lib.cmakeBool "CHATTERINO_UPDATER" false)
+  ];
+
+  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    mkdir -p "$out/Applications"
+    mv bin/chatterino.app "$out/Applications/"
+  '';
+}

--- a/pkgs/by-name/ch/chatterino2/package.nix
+++ b/pkgs/by-name/ch/chatterino2/package.nix
@@ -7,13 +7,13 @@
 
 (callPackage ./common.nix { }).overrideAttrs (finalAttrs: _: {
   pname = "chatterino2";
-  version = "2.5.1";
+  version = "2.5.2";
 
   src = fetchFromGitHub {
     owner = "Chatterino";
     repo = "chatterino2";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-c3Vhzes54xLjKV0Of7D1eFpQvIWJwcUBXvLT2p6VwBE=";
+    hash = "sha256-nrw4dQ7QjPPMbZXMC+p3VgUQKwc1ih6qS13D9+9oNuw=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/ch/chatterino2/package.nix
+++ b/pkgs/by-name/ch/chatterino2/package.nix
@@ -1,37 +1,28 @@
-{ stdenv, lib, cmake, pkg-config, fetchFromGitHub, qt6, boost, openssl, libsecret }:
+{
+  lib,
+  callPackage,
+  fetchFromGitHub,
+  nix-update-script,
+}:
 
-stdenv.mkDerivation rec {
+(callPackage ./common.nix { }).overrideAttrs (finalAttrs: _: {
   pname = "chatterino2";
   version = "2.5.1";
+
   src = fetchFromGitHub {
     owner = "Chatterino";
-    repo = pname;
-    rev = "v${version}";
+    repo = "chatterino2";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-c3Vhzes54xLjKV0Of7D1eFpQvIWJwcUBXvLT2p6VwBE=";
     fetchSubmodules = true;
   };
-  nativeBuildInputs = [ cmake pkg-config qt6.wrapQtAppsHook ];
-  buildInputs = [
-    qt6.qtbase
-    qt6.qtsvg
-    qt6.qtimageformats
-    qt6.qttools
-    qt6.qt5compat
-    boost
-    openssl
-    libsecret
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    qt6.qtwayland
-  ];
-  cmakeFlags = [ "-DBUILD_WITH_QT6=ON" ];
-  postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p "$out/Applications"
-    mv bin/chatterino.app "$out/Applications/"
-  '' + ''
-    mkdir -p $out/share/icons/hicolor/256x256/apps
-    cp $src/resources/icon.png $out/share/icons/hicolor/256x256/apps/chatterino.png
-  '';
-  meta = with lib; {
+
+  passthru = {
+    buildChatterino = args: callPackage ./common.nix args;
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
     description = "Chat client for Twitch chat";
     mainProgram = "chatterino";
     longDescription = ''
@@ -41,9 +32,12 @@ stdenv.mkDerivation rec {
       "Chatterino".
     '';
     homepage = "https://github.com/Chatterino/chatterino2";
-    changelog = "https://github.com/Chatterino/chatterino2/blob/master/CHANGELOG.md";
-    license = licenses.mit;
-    platforms = platforms.unix;
-    maintainers = with maintainers; [ rexim supa ];
+    changelog = "https://github.com/Chatterino/chatterino2/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      rexim
+      supa
+    ];
   };
-}
+})

--- a/pkgs/by-name/ch/chatterino2/package.nix
+++ b/pkgs/by-name/ch/chatterino2/package.nix
@@ -38,6 +38,7 @@
     maintainers = with lib.maintainers; [
       rexim
       supa
+      marie
     ];
   };
 })

--- a/pkgs/by-name/ch/chatterino7/package.nix
+++ b/pkgs/by-name/ch/chatterino7/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  chatterino2,
+  fetchFromGitHub,
+  nix-update-script,
+}:
+
+(chatterino2.buildChatterino {
+  enableAvifSupport = true;
+}).overrideAttrs
+  (
+    finalAttrs: _: {
+      pname = "chatterino7";
+      version = "7.5.2";
+
+      src = fetchFromGitHub {
+        owner = "SevenTV";
+        repo = "chatterino7";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-kQeW9Qa8NPs47xUlqggS4Df4fxIoknG8O5IBdOeIo+4=";
+        fetchSubmodules = true;
+      };
+
+      passthru.updateScript = nix-update-script { };
+
+      meta = {
+        description = "Chat client for Twitch chat";
+        mainProgram = "chatterino";
+        longDescription = ''
+          Chatterino is a chat client for Twitch chat. It aims to be an
+          improved/extended version of the Twitch web chat. Chatterino 7 is
+          a fork of Chatterino 2, which contains additional 7TV features
+          not found in Chatterino 2.
+        '';
+        homepage = "https://github.com/SevenTV/chatterino7";
+        changelog = "https://github.com/SevenTV/chatterino7/blob/${finalAttrs.src.rev}/CHANGELOG.c7.md";
+        license = lib.licenses.mit;
+        platforms = lib.platforms.unix;
+        maintainers = with lib.maintainers; [ marie ];
+      };
+    }
+  )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
- generalized chatterino2's expression
- new package using generalized expression: [chatterino7](https://github.com/SevenTV/chatterino7)
- added myself as a maintainer for chatterino 2 & 7

I don't own a mac, so it would be great if someone could test this on macOS.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
