### PR TITLE
python312Packages.py2bit: 0.3.0 -> 0.3.3

### DIFF
--- a/pkgs/development/python-modules/py2bit/default.nix
+++ b/pkgs/development/python-modules/py2bit/default.nix
@@ -2,28 +2,39 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  pytest,
+  pytestCheckHook,
+  setuptools,
+  setuptools-scm,
 }:
 
 buildPythonPackage rec {
   pname = "py2bit";
-  version = "0.3.0";
-  format = "setuptools";
-
-  checkInput = [ pytest ];
+  version = "0.3.3";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
-    sha256 = "1vw2nvw1yrl7ikkqsqs1pg239yr5nspvd969r1x9arms1k25a1a5";
+    hash = "sha256-Jk9b/DnXKfGsrVTHYKwE+oog1BhPS1BdnDM9LgMlN3A=";
   };
 
-  meta = with lib; {
+  build-system = [
+    setuptools
+    setuptools-scm
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pytestFlagsArray = [ "py2bitTest/test.py" ];
+
+  meta = {
     homepage = "https://github.com/deeptools/py2bit";
     description = "File access to 2bit files";
     longDescription = ''
       A python extension, written in C, for quick access to 2bit files. The extension uses lib2bit for file access.
     '';
-    license = licenses.mit;
-    maintainers = with maintainers; [ scalavision ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ scalavision ];
   };
 }


### PR DESCRIPTION
Also fixes GCC 14 build failure (#356812).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).