### PR TITLE
workflows/eval: add swapfile to tackle recent borderline OOM

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -85,6 +85,13 @@ jobs:
       matrix:
         system: ${{ fromJSON(needs.attrs.outputs.systems) }}
     steps:
+      - name: Enable swap
+        run: |
+          sudo fallocate -l 10G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+
       - name: Download the list of all attributes
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:


### PR DESCRIPTION
Removed in https://github.com/NixOS/nixpkgs/pull/356023#discussion_r1844961453.

After some discussion on Matrix with @infinisil, we think its best to just add swapfile back.

Due to recent issues where eval failing due to out of memory https://github.com/NixOS/nixpkgs/issues/355847#issuecomment-2566688172 https://github.com/NixOS/nixpkgs/issues/355847#issuecomment-2559907806 https://github.com/NixOS/nixpkgs/issues/355847#issuecomment-2543915995