### PR TITLE
nixos/invoiceplane: Don't force http with Caddy

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -200,6 +200,10 @@ See <https://github.com/NixOS/nixpkgs/issues/481673>.
   - `nextcloud31` is EOL and was thus removed.
   - Please note that an upgrade from v31 (or older) to v33 directly is not possible. Please upgrade to `nextcloud32` (or earlier) first. Nextcloud prohibits skipping major versions while upgrading. You can upgrade by declaring [`services.nextcloud.package = pkgs.nextcloud32;`](#opt-services.nextcloud.package).
 
+- InvoicePlane with the Caddy webserver (`services.invoiceplane.webserver = "caddy"`) now sets up sites with Caddy's automatic HTTPS instead of HTTP-only.
+  To keep the old behavior for a site `example.com`, set `services.caddy.virtualHosts."example.com".hostName = "http://example.com"`.
+  If you set custom Caddy options for a InvoicePlane site, migrate these options by removing `http://` from `services.caddy.virtualHosts."http://example.com"`.
+
 - `services.slurm` now supports slurmrestd usage through the `services.slurm.rest` NixOS options.
 
 - `services.kanidm` options for server, client and unix were moved under dedicated namespaces.

--- a/nixos/modules/services/web-apps/invoiceplane.nix
+++ b/nixos/modules/services/web-apps/invoiceplane.nix
@@ -441,7 +441,7 @@ in
         enable = true;
         virtualHosts = mapAttrs' (
           hostName: cfg:
-          (nameValuePair "http://${hostName}" {
+          (nameValuePair hostName {
             extraConfig = ''
               root * ${pkg hostName cfg}
               file_server

--- a/nixos/tests/invoiceplane.nix
+++ b/nixos/tests/invoiceplane.nix
@@ -26,7 +26,17 @@
           };
         };
 
-        networking.firewall.allowedTCPPorts = [ 80 ];
+        services.caddy.virtualHosts."site1.local".extraConfig = ''
+          tls internal
+        '';
+        services.caddy.virtualHosts."site2.local".extraConfig = ''
+          tls internal
+        '';
+
+        networking.firewall.allowedTCPPorts = [
+          80
+          443
+        ];
         networking.hosts."127.0.0.1" = [
           "site1.local"
           "site2.local"
@@ -76,41 +86,41 @@
           machine.wait_for_unit(f"phpfpm-invoiceplane-{site_name}")
 
           with subtest("Website returns welcome screen"):
-              assert "Please install InvoicePlane" in machine.succeed(f"curl -L {site_name}")
+              assert "Please install InvoicePlane" in machine.succeed(f"curl -sSfkL {site_name}")
 
           with subtest("Finish InvoicePlane setup"):
             machine.succeed(
-              f"curl -sSfL --cookie-jar cjar {site_name}/setup/language"
+              f"curl -sSfkL --cookie-jar cjar {site_name}/setup/language"
             )
             csrf_token = machine.succeed(
               "grep ip_csrf_cookie cjar | cut -f 7 | tr -d '\n'"
             )
             machine.succeed(
-              f"curl -sSfL --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&ip_lang=english&btn_continue=Continue' {site_name}/setup/language"
+              f"curl -sSfkL --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&ip_lang=english&btn_continue=Continue' {site_name}/setup/language"
             )
             csrf_token = machine.succeed(
               "grep ip_csrf_cookie cjar | cut -f 7 | tr -d '\n'"
             )
             machine.succeed(
-              f"curl -sSfL --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/prerequisites"
+              f"curl -sSfkL --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/prerequisites"
             )
             csrf_token = machine.succeed(
               "grep ip_csrf_cookie cjar | cut -f 7 | tr -d '\n'"
             )
             machine.succeed(
-              f"curl -sSfL --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/configure_database"
+              f"curl -sSfkL --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/configure_database"
             )
             csrf_token = machine.succeed(
               "grep ip_csrf_cookie cjar | cut -f 7 | tr -d '\n'"
             )
             machine.succeed(
-              f"curl -sSfl --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/install_tables"
+              f"curl -sSfkl --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/install_tables"
             )
             csrf_token = machine.succeed(
               "grep ip_csrf_cookie cjar | cut -f 7 | tr -d '\n'"
             )
             machine.succeed(
-              f"curl -sSfl --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/upgrade_tables"
-            )
+              f"curl -sSfkl --cookie cjar --cookie-jar cjar -d '_ip_csrf={csrf_token}&btn_continue=Continue' {site_name}/setup/upgrade_tables"
+          )
   '';
 }


### PR DESCRIPTION
Caddy usually expects just a hostname without scheme to do its automatic HTTPS. The InvoicePlane module always adds `http://` to the hostname, which is surprising and probably not what most users want. It is possible to get the old behavior (only HTTP) by setting `services.caddy.virtualHosts.<host>.hostName`.

Inspired by PR from @lluchs https://github.com/NixOS/nixpkgs/pull/327743
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
