### PR TITLE
veroroute: init at 2.39

### DIFF
--- a/pkgs/by-name/ve/veroroute/package.nix
+++ b/pkgs/by-name/ve/veroroute/package.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenv,
+  fetchsvn,
+  qt5,
+}:
+
+let
+  inherit (qt5) qmake wrapQtAppsHook;
+in
+stdenv.mkDerivation {
+  pname = "veroroute";
+  version = "2.39";
+
+  src = fetchsvn {
+    url = "https://svn.code.sf.net/p/veroroute/code/trunk";
+    rev = "660";
+    hash = "sha256-5H1eU0ymzsFUShpAEAebGM2eRhKqeZPCzW60W24WG64=";
+  };
+
+  qmakeFlags = [ "src/veroroute.pro" ];
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+  ];
+
+  postInstall = ''
+    mkdir $out/bin
+    install -Dm755 veroroute $out/bin
+  '';
+
+  meta = {
+    homepage = "https://sourceforge.net/projects/veroroute/";
+    description = "Qt based electronics layout and routing application";
+    longDescription = ''
+      Qt based Veroboard, Perfboard, and PCB layout and routing application
+    '';
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.unix;
+    mainProgram = "veroroute";
+    maintainers = with lib.maintainers; [ gm6k ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adding veroroute, a Qt based Veroboard, Perfboard, and PCB layout and routing application.

Apparently, https://github.com/NixOS/nixpkgs/pull/369345 has been uploaded since I started working on this. Uploading my version anyway since the other PR fails on CI.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
