### PR TITLE
stdenv: use lib.fix for referencing self

### DIFF
--- a/pkgs/stdenv/generic/default.nix
+++ b/pkgs/stdenv/generic/default.nix
@@ -1,69 +1,73 @@
 let
   lib = import ../../../lib;
-  stdenv-overridable = lib.makeOverridable (
+in
 
-    argsStdenv@{
-      name ? "stdenv",
-      preHook ? "",
-      initialPath,
+lib.makeOverridable (
+  {
+    name ? "stdenv",
+    preHook ? "",
+    initialPath,
 
-      # If we don't have a C compiler, we might either have `cc = null` or `cc =
-      # throw ...`, but if we do have a C compiler we should definiely have `cc !=
-      # null`.
-      #
-      # TODO(@Ericson2314): Add assert without creating infinite recursion
-      hasCC ? cc != null,
-      cc,
+    # If we don't have a C compiler, we might either have `cc = null` or `cc =
+    # throw ...`, but if we do have a C compiler we should definiely have `cc !=
+    # null`.
+    #
+    # TODO(@Ericson2314): Add assert without creating infinite recursion
+    hasCC ? cc != null,
+    cc,
 
-      shell,
-      allowedRequisites ? null,
-      extraAttrs ? { },
-      overrides ? (self: super: { }),
-      config,
-      disallowedRequisites ? [ ],
+    shell,
+    allowedRequisites ? null,
+    extraAttrs ? { },
+    overrides ? (self: super: { }),
+    config,
+    disallowedRequisites ? [ ],
 
-      # The `fetchurl' to use for downloading curl and its dependencies
-      # (see all-packages.nix).
-      fetchurlBoot,
+    # The `fetchurl' to use for downloading curl and its dependencies
+    # (see all-packages.nix).
+    fetchurlBoot,
 
-      setupScript ? ./setup.sh,
+    setupScript ? ./setup.sh,
 
-      extraNativeBuildInputs ? [ ],
-      extraBuildInputs ? [ ],
-      __stdenvImpureHostDeps ? [ ],
-      __extraImpureHostDeps ? [ ],
-      stdenvSandboxProfile ? "",
-      extraSandboxProfile ? "",
+    extraNativeBuildInputs ? [ ],
+    extraBuildInputs ? [ ],
+    __stdenvImpureHostDeps ? [ ],
+    __extraImpureHostDeps ? [ ],
+    stdenvSandboxProfile ? "",
+    extraSandboxProfile ? "",
 
-      ## Platform parameters
-      ##
-      ## The "build" "host" "target" terminology below comes from GNU Autotools. See
-      ## its documentation for more information on what those words mean. Note that
-      ## each should always be defined, even when not cross compiling.
-      ##
-      ## For purposes of bootstrapping, think of each stage as a "sliding window"
-      ## over a list of platforms. Specifically, the host platform of the previous
-      ## stage becomes the build platform of the current one, and likewise the
-      ## target platform of the previous stage becomes the host platform of the
-      ## current one.
-      ##
+    ## Platform parameters
+    ##
+    ## The "build" "host" "target" terminology below comes from GNU Autotools. See
+    ## its documentation for more information on what those words mean. Note that
+    ## each should always be defined, even when not cross compiling.
+    ##
+    ## For purposes of bootstrapping, think of each stage as a "sliding window"
+    ## over a list of platforms. Specifically, the host platform of the previous
+    ## stage becomes the build platform of the current one, and likewise the
+    ## target platform of the previous stage becomes the host platform of the
+    ## current one.
+    ##
 
-      # The platform on which packages are built. Consists of `system`, a
-      # string (e.g.,`i686-linux') identifying the most import attributes of the
-      # build platform, and `platform` a set of other details.
-      buildPlatform,
+    # The platform on which packages are built. Consists of `system`, a
+    # string (e.g.,`i686-linux') identifying the most import attributes of the
+    # build platform, and `platform` a set of other details.
+    buildPlatform,
 
-      # The platform on which packages run.
-      hostPlatform,
+    # The platform on which packages run.
+    hostPlatform,
 
-      # The platform which build tools (especially compilers) build for in this stage,
-      targetPlatform,
+    # The platform which build tools (especially compilers) build for in this stage,
+    targetPlatform,
 
-      # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
-      # This is convient to have as a parameter so the stdenv "adapters" work better
-      mkDerivationFromStdenv ?
-        stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation,
-    }:
+    # The implementation of `mkDerivation`, parameterized with the final stdenv so we can tie the knot.
+    # This is convient to have as a parameter so the stdenv "adapters" work better
+    mkDerivationFromStdenv ?
+      stdenv: (import ./make-derivation.nix { inherit lib config; } stdenv).mkDerivation,
+  }:
+
+  lib.fix (
+    stdenv:
 
     let
       defaultNativeBuildInputs =
@@ -86,9 +90,6 @@ let
         ++ lib.optionals hasCC [ cc ];
 
       defaultBuildInputs = extraBuildInputs;
-
-      stdenv = (stdenv-overridable argsStdenv);
-
     in
     # The stdenv that we are producing.
     derivation (
@@ -223,6 +224,5 @@ let
     # all-packages.nix for that platform (meaning that it has a line
     # like curl = if stdenv ? curl then stdenv.curl else ...).
     // extraAttrs
-  );
-in
-stdenv-overridable
+  )
+)


### PR DESCRIPTION
Converts
`let f = args: let stdenv = f args; in { a = g stdenv; }; in f`
to
`args: lib.fix (stdenv: { a = g stdenv; })`

Possible alternative:
`args: let stdenv = { a = g stdenv; } in stdenv`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
