### PR TITLE
frida-python: support aarch64-{darwin,linux}, x86_64-darwin

### DIFF
--- a/pkgs/development/python-modules/frida-python/default.nix
+++ b/pkgs/development/python-modules/frida-python/default.nix
@@ -1,19 +1,44 @@
 {
   lib,
   fetchPypi,
+  stdenvNoCC,
   buildPythonPackage,
 }:
-
-buildPythonPackage rec {
-  pname = "frida-python";
+let
   version = "16.5.7";
   format = "wheel";
+  inherit (stdenvNoCC.hostPlatform) system;
+
+  # https://pypi.org/project/frida/#files
+  pypiMeta =
+    {
+      x86_64-linux = {
+        hash = "sha256-+2P+Be7xDWBHesqcGupt6gGdUmda0zIp8HkyJqzGgio=";
+        platform = "manylinux1_x86_64";
+      };
+      aarch64-linux = {
+        hash = "sha256-CH7+4ehbrQ4JcRO7CxCVeMLPO57qzAWQPOhywbpmRE8=";
+        platform = "manylinux2014_aarch64";
+      };
+      x86_64-darwin = {
+        hash = "sha256-nG/ZDZ8jbClbzn3/raMC2JdqS2QQMEyGN/jnJLZGfWs=";
+        platform = "macosx_10_13_x86_64";
+      };
+      aarch64-darwin = {
+        hash = "sha256-6hbIKv3R4deqrZyCGXwpXk84ej8elpPGYvfUi5DCmtM=";
+        platform = "macosx_11_0_arm64";
+      };
+    }
+    .${system} or (throw "Unsupported system: ${system}");
+in
+buildPythonPackage {
+  pname = "frida-python";
+  inherit version format;
 
   src = fetchPypi {
     pname = "frida";
     inherit version format;
-    hash = "sha256-+2P+Be7xDWBHesqcGupt6gGdUmda0zIp8HkyJqzGgio=";
-    platform = "manylinux1_x86_64";
+    inherit (pypiMeta) hash platform;
     abi = "abi3";
     python = "cp37";
     dist = "cp37";
@@ -31,6 +56,9 @@ buildPythonPackage rec {
     maintainers = with lib.maintainers; [ s1341 ];
     platforms = [
       "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
     ];
   };
 }


### PR DESCRIPTION
Added support for `aarch64-darwin`.

## Things done

Tested on my `aarch64-darwin` and `x86_64-linux` systems. `aarch64-linux` should be easy to add, but I don't immediate have access to a system to test it.

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
