### PR TITLE
bpftools: fix cross for riscv64-linux

### DIFF
--- a/pkgs/by-name/bp/bpftools/package.nix
+++ b/pkgs/by-name/bp/bpftools/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenv,
+  fetchpatch,
   linuxHeaders,
   buildPackages,
   libopcodes,
@@ -25,6 +26,25 @@ stdenv.mkDerivation rec {
   patches = [
     # fix unknown type name '__vector128' on ppc64le
     ./include-asm-types-for-ppc64le.patch
+    # fix build for riscv64
+    (fetchpatch {
+      # libbpf: Add missing per-arch include path
+      # https://patchwork.kernel.org/project/linux-riscv/patch/20240927131355.350918-1-bjorn@kernel.org/
+      url = "https://patchwork.kernel.org/project/linux-riscv/patch/20240927131355.350918-1-bjorn@kernel.org/raw/";
+      hash = "sha256-edXY/ejHW5L7rGgY5B2GmVZxUgnLdBadNhBOSAgcL7M=";
+    })
+    (fetchpatch {
+      # selftests: bpf: Add missing per-arch include path
+      # https://patchwork.kernel.org/project/linux-riscv/patch/20240927131355.350918-2-bjorn@kernel.org/
+      url = "https://patchwork.kernel.org/project/linux-riscv/patch/20240927131355.350918-2-bjorn@kernel.org/raw/";
+      hash = "sha256-7yNWE/L/qd3vcLtJYoSyGxB3ytySlr20R0D3t5ni2Fc=";
+    })
+    (fetchpatch {
+      # tools: Override makefile ARCH variable if defined, but empty
+      # https://patchwork.kernel.org/project/linux-riscv/patch/20241127101748.165693-1-bjorn@kernel.org/
+      url = "https://patchwork.kernel.org/project/linux-riscv/patch/20241127101748.165693-1-bjorn@kernel.org/raw/";
+      hash = "sha256-y8N71Hm1XfX9g3S6PzW2m7Lxp6wQQMfQE9L0QNt8cYY=";
+    })
   ];
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -67,6 +87,9 @@ stdenv.mkDerivation rec {
     "bpf_asm"
     "bpf_dbg"
   ];
+
+  # needed for cross to riscv64
+  makeFlags = [ "ARCH=${stdenv.hostPlatform.linuxArch}" ];
 
   installPhase = ''
     make -C bpftool install


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fix for https://github.com/NixOS/nixpkgs/pull/367690#pullrequestreview-2520915166

Tested by building:

- [X] pkgs.bpftools
- [X] pkgsCross.riscv64.bpftools
- [X] pkgsCross.aarch64-multiplatform.bpftools

Closes: https://github.com/NixOS/nixpkgs/issues/366859

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
