### PR TITLE
homepage-dashboard: prefix nixpkgs-specific env var with NIXPKGS_

### DIFF
--- a/nixos/modules/services/misc/homepage-dashboard.nix
+++ b/nixos/modules/services/misc/homepage-dashboard.nix
@@ -240,7 +240,7 @@ in
 
         environment = {
           HOMEPAGE_CONFIG_DIR = configDir;
-          HOMEPAGE_CACHE_DIR = "/var/cache/homepage-dashboard";
+          NIXPKGS_HOMEPAGE_CACHE_DIR = "/var/cache/homepage-dashboard";
           PORT = toString cfg.listenPort;
           LOG_TARGETS = lib.mkIf managedConfig "stdout";
         };

--- a/pkgs/servers/homepage-dashboard/default.nix
+++ b/pkgs/servers/homepage-dashboard/default.nix
@@ -76,7 +76,7 @@ buildNpmPackage rec {
     # write its prerender cache.
     #
     # This patch ensures that the cache implementation respects the env
-    # variable `HOMEPAGE_CACHE_DIR`, which is set by default in the
+    # variable `NIXPKGS_HOMEPAGE_CACHE_DIR`, which is set by default in the
     # wrapper below.
     pushd $out
     git apply ${./prerender_cache_path.patch}
@@ -85,7 +85,7 @@ buildNpmPackage rec {
     makeWrapper $out/share/homepage/server.js $out/bin/homepage \
       --set-default PORT 3000 \
       --set-default HOMEPAGE_CONFIG_DIR /var/lib/homepage-dashboard \
-      --set-default HOMEPAGE_CACHE_DIR /var/cache/homepage-dashboard
+      --set-default NIXPKGS_HOMEPAGE_CACHE_DIR /var/cache/homepage-dashboard
 
     ${if enableLocalIcons then installLocalIcons else ""}
 

--- a/pkgs/servers/homepage-dashboard/prerender_cache_path.patch
+++ b/pkgs/servers/homepage-dashboard/prerender_cache_path.patch
@@ -12,7 +12,7 @@ index b1b74d8..a46c80b 100644
          this.fs = ctx.fs;
          this.flushToDisk = ctx.flushToDisk;
 -        this.serverDistDir = ctx.serverDistDir;
-+        this.serverDistDir = path.join(process.env.HOMEPAGE_CACHE_DIR, "homepage");
++        this.serverDistDir = path.join(process.env.NIXPKGS_HOMEPAGE_CACHE_DIR, "homepage");
          this.appDir = !!ctx._appDir;
          if (ctx.maxMemoryCacheSize) {
              this.memoryCache = new _lruCache.default({


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

I thought HOMEPAGE_CACHE_DIR was an upstream env var, and it confused me
a lot. Let's prefix it with NIXPKGS_ to make it clear that it's nixpkgs
specific.


<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
