### PR TITLE
zsh-history-to-fish: fix runtime error via patch

### DIFF
--- a/pkgs/by-name/zs/zsh-history-to-fish/fix-runtime-error.patch
+++ b/pkgs/by-name/zs/zsh-history-to-fish/fix-runtime-error.patch
@@ -1,0 +1,50 @@
+From 121ba93b2860b7ee6bbe2430c818bba2da822a8e Mon Sep 17 00:00:00 2001
+From: zjeffer <4633209+zjeffer@users.noreply.github.com>
+Date: Sun, 29 Dec 2024 20:15:29 +0100
+Subject: [PATCH] Fixes & improvements
+
+---
+ zsh_history_to_fish/command.py | 14 ++++++++++----
+ 1 file changed, 10 insertions(+), 4 deletions(-)
+
+diff --git a/zsh_history_to_fish/command.py b/zsh_history_to_fish/command.py
+index 4d8a12d..136c553 100644
+--- a/zsh_history_to_fish/command.py
++++ b/zsh_history_to_fish/command.py
+@@ -19,7 +19,12 @@
+ 
+ def read_history(input_file):
+     command = ZSH_HISTORY_READER.format(input_file)
+-    p = subprocess.run(command, capture_output=True, shell=True, encoding='utf8')
++    lines: list[str] = []
++    try:
++        p = subprocess.run(command, capture_output=True, shell=True, encoding='utf8', check=True)
++    except Exception as e:
++        print(f'An exception occurred while reading history: {e}')
++        sys.exit(1)
+     lines = p.stdout.splitlines()
+     yield from map(lambda x: x.replace('\\n', '\n'), lines)
+ 
+@@ -48,11 +53,11 @@ def display_changed(zsh, fish):
+ def writer_factory(output_file, dry_run):
+     if dry_run:
+         yield lambda x: None
+-        print(f'No file has been written.')
++        print('No file has been written.')
+         return
+ 
+-    with open(output_file, 'a') as out:
+-        yield lambda x: out.write(x)
++    with open(output_file, 'a', encoding='utf8') as out:
++        yield out.write
+     print(f'\nFile "{output_file}" has been written successfully.')
+ 
+ 
+@@ -74,6 +79,7 @@ def exporter(input_file, output_file, dry_run, no_convert):
+     converter = (lambda x: x) if no_convert else naive_zsh_to_fish
+     changed = []
+     with writer_factory(output_file, dry_run) as writer:
++        i = 0
+         for i, (timestamp, command_zsh) in enumerate(parse_history(input_file)):
+             command_fish = converter(command_zsh)
+             fish_history = f'- cmd: {command_fish}\n  when: {timestamp}\n'

--- a/pkgs/by-name/zs/zsh-history-to-fish/package.nix
+++ b/pkgs/by-name/zs/zsh-history-to-fish/package.nix
@@ -25,6 +25,13 @@ python3.pkgs.buildPythonApplication rec {
     "zsh_history_to_fish"
   ];
 
+  patches = [
+    # Patch from currently-unmerged PR, fixing runtime error.
+    # Should be removed when PR is merged or error is otherwise fixed.
+    # Check https://github.com/rsalmei/zsh-history-to-fish/pull/15 if you're in the future
+    ./fix-runtime-error.patch
+  ];
+
   meta = with lib; {
     description = "Bring your ZSH history to Fish shell";
     homepage = "https://github.com/rsalmei/zsh-history-to-fish";


### PR DESCRIPTION
Without the patch, you get this error:
```
UnboundLocalError: cannot access local variable 'i' where it is not associated with a value
```
We grab the patch from a commit on an unmerged PR by @zjeffe that fixes the issue.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
