### PR TITLE
badchars: 0.4.0 -> 0.5.0

### DIFF
--- a/pkgs/by-name/ba/badchars/package.nix
+++ b/pkgs/by-name/ba/badchars/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  gitUpdater,
   python3,
 }:
 

--- a/pkgs/tools/security/badchars/default.nix
+++ b/pkgs/tools/security/badchars/default.nix
@@ -1,28 +1,22 @@
 {
   lib,
-  buildPythonApplication,
-  fetchPypi,
+  fetchFromGitHub,
   python3,
 }:
 
 python3.pkgs.buildPythonApplication rec {
   pname = "badchars";
-  version = "0.4.0";
+  version = "0.5.0";
   pyproject = true;
 
-  src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-4neV1S5gwQ03kEXEyZezNSj+PVXJyA5MO4lyZzGKE/c=";
+  src = fetchFromGitHub {
+    owner = "cytopia";
+    repo = "badchars";
+    tag = version;
+    hash = "sha256-VWe3k34snEviBK7VBCDTWAu3YjZfh1gXHXjlnFlefJw=";
   };
 
-  postPatch = ''
-    substituteInPlace setup.py \
-      --replace-fail "argparse" ""
-  '';
-
-  build-system = with python3.pkgs; [
-    setuptools
-  ];
+  build-system = with python3.pkgs; [ setuptools ];
 
   # no tests are available and it can't be imported (it's only a script, not a module)
   doCheck = false;

--- a/pkgs/tools/security/badchars/default.nix
+++ b/pkgs/tools/security/badchars/default.nix
@@ -21,7 +21,7 @@ python3.pkgs.buildPythonApplication rec {
   # no tests are available and it can't be imported (it's only a script, not a module)
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "HEX badchar generator for different programming languages";
     longDescription = ''
       A HEX bad char generator to instruct encoders such as shikata-ga-nai to
@@ -29,8 +29,8 @@ python3.pkgs.buildPythonApplication rec {
     '';
     homepage = "https://github.com/cytopia/badchars";
     changelog = "https://github.com/cytopia/badchars/releases/tag/${version}";
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ fab ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
     mainProgram = "badchars";
   };
 }

--- a/pkgs/tools/security/badchars/default.nix
+++ b/pkgs/tools/security/badchars/default.nix
@@ -21,6 +21,8 @@ python3.pkgs.buildPythonApplication rec {
   # no tests are available and it can't be imported (it's only a script, not a module)
   doCheck = false;
 
+  passthru.updateScript = gitUpdater { };
+
   meta = {
     description = "HEX badchar generator for different programming languages";
     longDescription = ''

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1958,8 +1958,6 @@ with pkgs;
 
   babelfish = callPackage ../shells/fish/babelfish.nix { };
 
-  badchars = python3Packages.callPackage ../tools/security/badchars { };
-
   bat-extras = recurseIntoAttrs (callPackages ../tools/misc/bat-extras { });
 
   beauty-line-icon-theme = callPackage ../data/icons/beauty-line-icon-theme {


### PR DESCRIPTION
Diff: https://github.com/cytopia/badchars/compare/refs/tags/0.4.0...0.5.0

Changelog: https://github.com/cytopia/badchars/releases/tag/0.5.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
