### PR TITLE
xmlformat: switch to someth2say's fork

### DIFF
--- a/pkgs/by-name/xm/xmlformat/package.nix
+++ b/pkgs/by-name/xm/xmlformat/package.nix
@@ -28,6 +28,9 @@ stdenv.mkDerivation rec {
   meta = {
     description = "Configurable formatter (or 'pretty-printer') for XML documents";
     mainProgram = "xmlformat";
+    maintainers = with lib.maintainers; [
+      gepbird
+    ];
     homepage = "https://github.com/someth2say/xmlformat";
     license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;

--- a/pkgs/by-name/xm/xmlformat/package.nix
+++ b/pkgs/by-name/xm/xmlformat/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   perl,
+  unstableGitUpdater,
 }:
 
 stdenv.mkDerivation {
@@ -22,6 +23,8 @@ stdenv.mkDerivation {
     mkdir -p $out/bin
     cp bin/xmlformat.pl $out/bin/xmlformat
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Configurable formatter (or 'pretty-printer') for XML documents";

--- a/pkgs/by-name/xm/xmlformat/package.nix
+++ b/pkgs/by-name/xm/xmlformat/package.nix
@@ -1,16 +1,18 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   perl,
 }:
 stdenv.mkDerivation rec {
   pname = "xmlformat";
-  version = "1.04";
+  version = "1.9-unstable-2021-09-15";
 
-  src = fetchurl {
-    url = "http://www.kitebird.com/software/xmlformat/xmlformat-${version}.tar.gz";
-    sha256 = "1vwgzn4ha0az7dx0cyc6dx5nywwrx9gxhyh08mvdcq27wjbh79vi";
+  src = fetchFromGitHub {
+    owner = "someth2say";
+    repo = "xmlformat";
+    rev = "15a22213b341ab2800806f052a32d29898fecaad";
+    hash = "sha256-XCjvGeMerSqyMaVEu6EvLuwgsOxZ/v6ahgFCbzRqC7w=";
   };
 
   buildInputs = [ perl ];
@@ -20,15 +22,14 @@ stdenv.mkDerivation rec {
 
   installPhase = ''
     mkdir -p $out/bin
-    cp ./xmlformat.pl $out/bin/xmlformat
-    cp ./LICENSE $out/
+    cp bin/xmlformat.pl $out/bin/xmlformat
   '';
 
   meta = {
     description = "Configurable formatter (or 'pretty-printer') for XML documents";
     mainProgram = "xmlformat";
-    homepage = "http://www.kitebird.com/software/xmlformat/";
-    license = lib.licenses.bsd3;
+    homepage = "https://github.com/someth2say/xmlformat";
+    license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/xm/xmlformat/package.nix
+++ b/pkgs/by-name/xm/xmlformat/package.nix
@@ -4,7 +4,8 @@
   fetchFromGitHub,
   perl,
 }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation {
   pname = "xmlformat";
   version = "1.9-unstable-2021-09-15";
 
@@ -16,9 +17,6 @@ stdenv.mkDerivation rec {
   };
 
   buildInputs = [ perl ];
-  buildPhase = ''
-    patchShebangs ./xmlformat.pl
-  '';
 
   installPhase = ''
     mkdir -p $out/bin
@@ -27,12 +25,12 @@ stdenv.mkDerivation rec {
 
   meta = {
     description = "Configurable formatter (or 'pretty-printer') for XML documents";
+    homepage = "https://github.com/someth2say/xmlformat";
+    license = lib.licenses.gpl3Only;
     mainProgram = "xmlformat";
     maintainers = with lib.maintainers; [
       gepbird
     ];
-    homepage = "https://github.com/someth2say/xmlformat";
-    license = lib.licenses.gpl3Only;
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The download link no longer works: http://www.kitebird.com/software/xmlformat/xmlformat-1.04.tar.gz.
And http://www.kitebird.com/ redirects to a site that's unrelated to the software: https://wynsep.com/
There was also no activity on the package since it was added in 2018 and it has no maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
