### PR TITLE
oterm: fix runtime error

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8169,6 +8169,12 @@
     name = "Florian Brandes";
     keys = [ { fingerprint = "0200 3EF8 8D2B CF2D 8F00  FFDC BBB3 E40E 5379 7FD9"; } ];
   };
+  gaelj = {
+    name = "Gaël James";
+    email = "gaeljames@gmail.com";
+    github = "gaelj";
+    githubId = 8884632;
+  };
   gaelreyrol = {
     email = "me@gaelreyrol.dev";
     matrix = "@Zevran:matrix.org";

--- a/pkgs/by-name/ot/oterm/package.nix
+++ b/pkgs/by-name/ot/oterm/package.nix
@@ -40,6 +40,7 @@ python3Packages.buildPythonApplication rec {
     python-dotenv
     rich-pixels
     textual
+    textualeffects
     typer
   ];
 

--- a/pkgs/by-name/ot/oterm/package.nix
+++ b/pkgs/by-name/ot/oterm/package.nix
@@ -54,7 +54,7 @@ python3Packages.buildPythonApplication rec {
     homepage = "https://github.com/ggozad/oterm";
     changelog = "https://github.com/ggozad/oterm/releases/tag/${version}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ suhr ];
+    maintainers = with lib.maintainers; [ gaelj ];
     mainProgram = "oterm";
   };
 }

--- a/pkgs/development/python-modules/textualeffects/default.nix
+++ b/pkgs/development/python-modules/textualeffects/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  pythonOlder,
+  hatchling,
+  terminaltexteffects,
+}:
+
+buildPythonPackage rec {
+  pname = "textualeffects";
+  version = "0.1.3";
+  pyproject = true;
+
+  disabled = pythonOlder "3.10";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-s6LrsCJu/ubDIXQqxQlY2HVbzDc9+FtUE9oBSulUsm8=";
+  };
+
+  build-system = [ hatchling ];
+
+  dependencies = [ terminaltexteffects ];
+
+  pythonImportsCheck = [ "textualeffects" ];
+
+  # no tests implemented
+  doCheck = false;
+
+  meta = {
+    description = "Visual effects for Textual, a TerminalTextEffects wrapper";
+    homepage = "https://github.com/ggozad/textualeffects";
+    changelog = "https://github.com/ggozad/textualeffects/blob/v${version}/CHANGES.txt";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gaelj ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16138,6 +16138,8 @@ self: super: with self; {
 
   textual-universal-directorytree = callPackage ../development/python-modules/textual-universal-directorytree { };
 
+  textualeffects = callPackage ../development/python-modules/textualeffects { };
+
   textual-textarea = callPackage ../development/python-modules/textual-textarea { };
 
   testbook = callPackage ../development/python-modules/testbook { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
 Fix and update oterm by adding new python package `textualeffects`

- oterm: fix runtime error: missing textualeffects (#366021)
- ~~oterm: 0.6.9 -> 0.7.2~~ updated by the bot to 0.7.3 in the meantime
- textualeffects: init at 0.1.3

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@suhr 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
