### PR TITLE
code-cursor: 0.44.9 -> 0.44.11

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -8,11 +8,11 @@
 }:
 let
   pname = "cursor";
-  version = "0.44.9";
+  version = "0.44.11";
   appKey = "230313mzl4w4u92";
   src = fetchurl {
-    url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.9-build-2412268nc6pfzgo-x86_64.AppImage";
-    hash = "sha256-DV4Om5eAt7hDDPsyCwhALGhH36YAfvDk5u8Mnlhalsw=";
+    url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.11-build-250103fqxdt5u9z-x86_64.AppImage";
+    hash = "sha256-eOZuofnpED9F6wic0S9m933Tb7Gq7cb/v0kRDltvFVg=";
   };
   appimageContents = appimageTools.extractType2 { inherit version pname src; };
 in


### PR DESCRIPTION
Automatic update run via `nix-shell maintainers/scripts/update.nix --argstr package code-cursor --argstr commit true`

Built and checked functionality on x86_64-Linux. cursor.com didn't publish a specific changelog.
