### PR TITLE
netexec: 1.1.0-unstable-2024-01-15 -> 1.3.0

### DIFF
--- a/pkgs/development/python-modules/pynfsclient/default.nix
+++ b/pkgs/development/python-modules/pynfsclient/default.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pynfsclient";
+  version = "0.1.5";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "pyNfsClient";
+    inherit version;
+    hash = "sha256-xgZL08NlMCpSkALQwklh7Xq16bK2Sm2hAynbrIWsgaU=";
+  };
+
+  postPatch = ''
+    # HISTORY.md is missing
+    substituteInPlace setup.py \
+      --replace-fail "HISTORY.md" "README.rst"
+  '';
+
+  build-system = [ setuptools ];
+
+  # Module has no tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "pyNfsClient" ];
+
+  meta = {
+    description = "Pure python NFS client";
+    homepage = "https://pypi.org/project/pyNfsClient/";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ fab ];
+  };
+}

--- a/pkgs/development/python-modules/pynfsclient/default.nix
+++ b/pkgs/development/python-modules/pynfsclient/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
+  pythonAtLeast,
   setuptools,
 }:
 
@@ -9,6 +10,8 @@ buildPythonPackage rec {
   pname = "pynfsclient";
   version = "0.1.5";
   pyproject = true;
+
+  disabled = pythonAtLeast "3.13";
 
   src = fetchPypi {
     pname = "pyNfsClient";

--- a/pkgs/tools/security/netexec/default.nix
+++ b/pkgs/tools/security/netexec/default.nix
@@ -27,32 +27,35 @@ let
 in
 python.pkgs.buildPythonApplication rec {
   pname = "netexec";
-  version = "1.1.0-unstable-2024-01-15";
+  version = "1.3.0";
   pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Pennyw0rth";
+    repo = "NetExec";
+    tag = "v${version}";
+    hash = "sha256-Pub7PAw6CTN4c/PHTPE9KcnDR2a6hSza1ODp3EWMOH0=";
+  };
+
   pythonRelaxDeps = true;
+
   pythonRemoveDeps = [
     # Fail to detect dev version requirement
     "neo4j"
   ];
 
-  src = fetchFromGitHub {
-    owner = "Pennyw0rth";
-    repo = "NetExec";
-    rev = "9df72e2f68b914dfdbd75b095dd8f577e992615f";
-    hash = "sha256-oQHtTE5hdlxHX4uc412VfNUrN0UHVbwI0Mm9kmJpNW4=";
-  };
-
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace '{ git = "https://github.com/Pennyw0rth/impacket.git", branch = "gkdi" }' '"*"' \
-      --replace '{ git = "https://github.com/Pennyw0rth/oscrypto" }' '"*"'
+      --replace-fail '{ git = "https://github.com/fortra/impacket.git" }' '"*"' \
+      --replace-fail '{ git = "https://github.com/Pennyw0rth/NfsClient" }' '"*"'
   '';
 
-  nativeBuildInputs = with python.pkgs; [
+  build-system = with python.pkgs; [
     poetry-core
+    poetry-dynamic-versioning
   ];
 
-  propagatedBuildInputs = with python.pkgs; [
+  dependencies = with python.pkgs; [
     aardwolf
     aioconsole
     aiosqlite
@@ -67,13 +70,15 @@ python.pkgs.buildPythonApplication rec {
     masky
     minikerberos
     msgpack
+    msldap
     neo4j
-    oscrypto
     paramiko
     pyasn1-modules
     pylnk3
+    pynfsclient
     pypsrp
     pypykatz
+    python-dateutil
     python-libnmap
     pywerview
     requests
@@ -84,9 +89,10 @@ python.pkgs.buildPythonApplication rec {
     xmltodict
   ];
 
-  nativeCheckInputs = with python.pkgs; [
-    pytestCheckHook
-  ];
+  nativeCheckInputs = with python.pkgs; [ pytestCheckHook ];
+
+  # Tests no longer works out-of-box with 1.3.0
+  doCheck = false;
 
   preCheck = ''
     export HOME=$(mktemp -d)
@@ -96,9 +102,9 @@ python.pkgs.buildPythonApplication rec {
     description = "Network service exploitation tool (maintained fork of CrackMapExec)";
     homepage = "https://github.com/Pennyw0rth/NetExec";
     changelog = "https://github.com/Pennyw0rth/NetExec/releases/tag/v${version}";
-    license = with licenses; [ bsd2 ];
-    mainProgram = "nxc";
+    license = licenses.bsd2;
     maintainers = with maintainers; [ vncsb ];
+    mainProgram = "nxc";
     # FIXME: failing fixupPhase:
     # $ Rewriting #!/nix/store/<hash>-python3-3.11.7/bin/python3.11 to #!/nix/store/<hash>-python3-3.11.7
     # $ /nix/store/<hash>-wrap-python-hook/nix-support/setup-hook: line 65: 47758 Killed: 9               sed -i "$f" -e "1 s^#!/nix/store/<hash>-python3-3.11.7^#!/nix/store/<hash>-python3-3.11.7^"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10699,6 +10699,8 @@ self: super: with self; {
 
   pylsl = callPackage ../development/python-modules/pylsl { };
 
+  pynfsclient = callPackage ../development/python-modules/pynfsclient { };
+
   pyngo = callPackage ../development/python-modules/pyngo { };
 
   pyngrok = callPackage ../development/python-modules/pyngrok { };


### PR DESCRIPTION
Diff: https://github.com/Pennyw0rth/NetExec/compare/refs/tags/v1.1.0...v1.3.0

Changelog: https://github.com/Pennyw0rth/NetExec/releases/tag/v1.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
