### PR TITLE
treewide: remove obsolete `TARGET_OS_*` workarounds

### DIFF
--- a/pkgs/applications/audio/grandorgue/default.nix
+++ b/pkgs/applications/audio/grandorgue/default.nix
@@ -47,8 +47,6 @@ stdenv.mkDerivation rec {
     "-DINSTALL_DEPEND=OFF"
   ] ++ lib.optional (!includeDemo) "-DINSTALL_DEMO=OFF";
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DTARGET_OS_IPHONE=0";
-
   postInstall = lib.optionalString stdenv.hostPlatform.isDarwin ''
     mkdir -p $out/{Applications,bin,lib}
     mv $out/GrandOrgue.app $out/Applications/

--- a/pkgs/applications/networking/remote/freerdp/3.nix
+++ b/pkgs/applications/networking/remote/freerdp/3.nix
@@ -197,8 +197,6 @@ stdenv.mkDerivation (finalAttrs: {
 
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optionals stdenv.hostPlatform.isDarwin [
-      "-DTARGET_OS_IPHONE=0"
-      "-DTARGET_OS_WATCH=0"
       "-include AudioToolbox/AudioToolbox.h"
     ]
     ++ lib.optionals stdenv.cc.isClang [

--- a/pkgs/applications/networking/remote/freerdp/default.nix
+++ b/pkgs/applications/networking/remote/freerdp/default.nix
@@ -217,8 +217,6 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optionals stdenv.hostPlatform.isDarwin [
-      "-DTARGET_OS_IPHONE=0"
-      "-DTARGET_OS_WATCH=0"
       "-include AudioToolbox/AudioToolbox.h"
     ]
     ++ lib.optionals stdenv.cc.isClang [

--- a/pkgs/applications/networking/remote/remmina/default.nix
+++ b/pkgs/applications/networking/remote/remmina/default.nix
@@ -125,11 +125,6 @@ stdenv.mkDerivation (finalAttrs: {
       "-DWITH_ICON_CACHE=OFF"
     ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [
-    "-DTARGET_OS_IPHONE=0"
-    "-DTARGET_OS_WATCH=0"
-  ]);
-
   dontWrapQtApps = true;
 
   preFixup = ''

--- a/pkgs/by-name/al/alac/package.nix
+++ b/pkgs/by-name/al/alac/package.nix
@@ -26,9 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
     autoreconfHook
   ];
 
-  # error: 'TARGET_OS_MAC' is not defined, evaluates to 0
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DTARGET_OS_MAC";
-
   passthru = {
     updateScript = unstableGitUpdater { };
     tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/by-name/cd/cdo/package.nix
+++ b/pkgs/by-name/cd/cdo/package.nix
@@ -42,12 +42,6 @@ stdenv.mkDerivation rec {
     ++ lib.optional enable_all_static "--enable-all-static"
     ++ lib.optional enable_cxx "--enable-cxx";
 
-  # address error: 'TARGET_OS_MACCATALYST' is not defined,
-  # evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
-  # we don't want to appear to be a catalyst build;
-  # we are a TARGET_OS_MAC
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DTARGET_OS_MACCATALYST=0";
-
   meta = with lib; {
     description = "Collection of command line Operators to manipulate and analyse Climate and NWP model Data";
     mainProgram = "cdo";

--- a/pkgs/by-name/fl/fluent-bit/package.nix
+++ b/pkgs/by-name/fl/fluent-bit/package.nix
@@ -52,11 +52,9 @@ stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.13" ];
 
   env.NIX_CFLAGS_COMPILE = toString (
-    # Used by the embedded luajit, but is not predefined on older mac SDKs.
-    lib.optionals stdenv.hostPlatform.isDarwin [ "-DTARGET_OS_IPHONE=0" ]
     # Assumes GNU version of strerror_r, and the posix version has an
     # incompatible return type.
-    ++ lib.optionals (!stdenv.hostPlatform.isGnu) [ "-Wno-int-conversion" ]
+    lib.optionals (!stdenv.hostPlatform.isGnu) [ "-Wno-int-conversion" ]
   );
 
   outputs = [

--- a/pkgs/by-name/gt/gtk-frdp/package.nix
+++ b/pkgs/by-name/gt/gtk-frdp/package.nix
@@ -48,13 +48,6 @@ stdenv.mkDerivation rec {
     };
   };
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals stdenv.hostPlatform.isDarwin [
-      "-DTARGET_OS_IPHONE=0"
-      "-DTARGET_OS_WATCH=0"
-    ]
-  );
-
   meta = with lib; {
     homepage = "https://gitlab.gnome.org/GNOME/gtk-frdp";
     description = "RDP viewer widget for GTK";

--- a/pkgs/by-name/ic/icoutils/package.nix
+++ b/pkgs/by-name/ic/icoutils/package.nix
@@ -37,9 +37,6 @@ stdenv.mkDerivation rec {
   ];
   propagatedBuildInputs = [ perlPackages.LWP ];
 
-  # Fixes build failures on Darwin. These should be defined in `TargetConditional.h`, but it’s failing anyway.
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DTARGET_OS_IPHONE=0 -DTARGET_OS_EMBEDDED=0";
-
   postPatch = ''
     patchShebangs extresso/extresso
     patchShebangs extresso/extresso.in

--- a/pkgs/by-name/jw/jwhois/package.nix
+++ b/pkgs/by-name/jw/jwhois/package.nix
@@ -33,11 +33,6 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/bin/jwhois $out/bin/whois
   '';
 
-  # Work around error from <stdio.h> on aarch64-darwin:
-  #     error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0 [-Werror,-Wundef-prefix=TARGET_OS_]
-  # TODO: this should probably be fixed at a lower level than this?
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-Wno-undef-prefix";
-
   env.NIX_LDFLAGS = lib.optionalString stdenv.hostPlatform.isDarwin "-liconv";
 
   meta = {

--- a/pkgs/by-name/li/libtomcrypt/package.nix
+++ b/pkgs/by-name/li/libtomcrypt/package.nix
@@ -16,10 +16,6 @@ stdenv.mkDerivation rec {
     sha256 = "113vfrgapyv72lalhd3nkw7jnks8az0gcb5wqn9hj19nhcxlrbcn";
   };
 
-  # Fixes a build failure on aarch64-darwin. Define for all Darwin targets for when x86_64-darwin
-  # upgrades to a newer SDK.
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-DTARGET_OS_IPHONE=0";
-
   patches = [
     (fetchpatch {
       name = "CVE-2019-17362.patch";

--- a/pkgs/by-name/li/libtommath/package.nix
+++ b/pkgs/by-name/li/libtommath/package.nix
@@ -29,10 +29,6 @@ stdenv.mkDerivation rec {
 
   makefile = "makefile.shared";
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString (
-    stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64
-  ) "-DTARGET_OS_IPHONE=0";
-
   enableParallelBuilding = true;
 
   meta = with lib; {

--- a/pkgs/by-name/my/mynewt-newt/package.nix
+++ b/pkgs/by-name/my/mynewt-newt/package.nix
@@ -19,10 +19,6 @@ buildGoModule rec {
 
   doCheck = false;
 
-  # CGO_ENABLED=0 required for mac - "error: 'TARGET_OS_MAC' is not defined, evaluates to 0"
-  # https://github.com/shirou/gopsutil/issues/976
-  env.CGO_ENABLED = if stdenv.hostPlatform.isLinux then 1 else 0;
-
   meta = with lib; {
     homepage = "https://mynewt.apache.org/";
     description = "Build and package management tool for embedded development";

--- a/pkgs/tools/system/gotop/default.nix
+++ b/pkgs/tools/system/gotop/default.nix
@@ -32,9 +32,6 @@ buildGoModule rec {
     "-X main.Version=v${version}"
   ];
 
-  # prevent `error: 'TARGET_OS_MAC' is not defined`
-  env.CGO_CFLAGS = "-Wno-undef-prefix";
-
   nativeBuildInputs = [ installShellFiles ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ IOKit ];


### PR DESCRIPTION
These should no longer be necessary with LLVM 19. I’ll build this soon to confirm.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
