### PR TITLE
testers.testBuildFailure: fix structuredAttrs support

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -13,6 +13,7 @@ Here are some common neovim flags used in the tests:
 , neovim-unwrapped
 , fetchFromGitLab
 , runCommandLocal
+, testers
 , pkgs
 }:
 let
@@ -107,8 +108,7 @@ in
 
   inherit nmt;
 
-  # Disabled because of https://github.com/NixOS/nixpkgs/pull/352727
-  # failed_check = pkgs.testers.testBuildFailure nvim-run-failing-check;
+  failed_check = testers.testBuildFailure nvim-run-failing-check;
 
   vim_empty_config = vimUtils.vimrcFile { beforePlugins = ""; customRC = ""; };
 

--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -24,7 +24,12 @@
   testBuildFailure = drv: drv.overrideAttrs (orig: {
     builder = buildPackages.bash;
     args = [
-      (replaceVars ./expect-failure.sh { coreutils = buildPackages.coreutils; })
+      (replaceVars ./expect-failure.sh {
+        coreutils = buildPackages.coreutils;
+        vars = lib.toShellVars {
+          outputNames = (orig.outputs or [ "out" ]);
+        };
+      })
       orig.realBuilder or stdenv.shell
     ] ++ orig.args or ["-e" (orig.builder or ../../stdenv/generic/default-builder.sh)];
   });

--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -34,19 +34,28 @@ echo "testBuildFailure: Original builder produced exit code: $r"
 
 # -----------------------------------------
 # Write the build log to the default output
-#
-# # from stdenv setup.sh
-getAllOutputNames() {
-    if [ -n "$__structuredAttrs" ]; then
-        echo "${!outputs[*]}"
-    else
-        echo "$outputs"
-    fi
-}
 
-outs=( $(getAllOutputNames) )
-defOut=${outs[0]}
-defOutPath=${!defOut}
+# Source structured attrs as per nixpkgs/pkgs/stdenv/generic/default-builder.sh
+#
+# We need this so that we can read $outputs when `__structuredAttrs` is enabled
+#
+# NOTE: This MUST be done after the original builder has finished!
+#       Otherwise we could pollute its environment.
+if [ -e "${NIX_ATTRS_SH_FILE:-}" ]; then . "$NIX_ATTRS_SH_FILE"; elif [ -f .attrs.sh ]; then . .attrs.sh; fi
+
+# Variables injected by replaceVars
+#
+# `$outputs` is unordered when `__structuredAttrs` is enabled,
+# so we use `replaceVars` to pass in an ordered `$outputNames` array
+@vars@
+
+declare -a outputPaths
+for name in "${outputNames[@]}"; do
+    # Either dereference $name, or access $outputs[] associative array
+    outputPath=${!name:-${outputs[$name]}}
+    outputPaths+=( "$outputPath" )
+done
+defOutPath=${outputPaths[0]}
 
 if [[ ! -d $defOutPath ]]; then
   if [[ -e $defOutPath ]]; then
@@ -63,8 +72,7 @@ echo $r >$defOutPath/testBuildFailure.exit
 # ------------------------------------------------------
 # Put empty directories in place for any missing outputs
 
-for outputName in ${outputs:-out}; do
-  outputPath="${!outputName}"
+for outputPath in "${outputPaths[@]}"; do
   if [[ ! -e "${outputPath}" ]]; then
     @coreutils@/bin/mkdir "${outputPath}";
   fi

--- a/pkgs/build-support/testers/test/default.nix
+++ b/pkgs/build-support/testers/test/default.nix
@@ -22,6 +22,15 @@ let
     label = "test";
   };
 
+  overrideStructuredAttrs =
+    enable: drv:
+    drv.overrideAttrs (old: {
+      failed = old.failed.overrideAttrs (oldFailed: {
+        name = oldFailed.name + "${lib.optionalString (!enable) "-no"}-structuredAttrs";
+        __structuredAttrs = enable;
+      });
+    });
+
 in
 lib.recurseIntoAttrs {
   lycheeLinkCheck = lib.recurseIntoAttrs pkgs.lychee.tests;
@@ -93,7 +102,7 @@ lib.recurseIntoAttrs {
     }
   );
 
-  testBuildFailure = lib.recurseIntoAttrs {
+  testBuildFailure = lib.recurseIntoAttrs rec {
     happy =
       runCommand "testBuildFailure-happy"
         {
@@ -122,6 +131,8 @@ lib.recurseIntoAttrs {
 
           touch $out
         '';
+
+    happyStructuredAttrs = overrideStructuredAttrs true happy;
 
     helloDoesNotFail =
       runCommand "testBuildFailure-helloDoesNotFail"
@@ -169,6 +180,8 @@ lib.recurseIntoAttrs {
           touch $out
         '';
 
+    multiOutputStructuredAttrs = overrideStructuredAttrs true multiOutput;
+
     sideEffects =
       runCommand "testBuildFailure-sideEffects"
         {
@@ -203,6 +216,8 @@ lib.recurseIntoAttrs {
 
           touch $out
         '';
+
+    sideEffectStructuredAttrs = overrideStructuredAttrs true sideEffects;
   };
 
   testEqualContents = lib.recurseIntoAttrs {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I noticed that `testers.testBuildFailure` was not working with `__structuredAttrs`.

The main issues are, when `structuredAttrs` is enabled:
- `$__structuredAttrs` is not set
- `$outputs` is not set
- `$outputs` defined by `NIX_ATTRS_SH_FILE` is an associative array
  - This means it is unordered, so we cannot determine the "default" output

As per:
https://github.com/NixOS/nixpkgs/blob/ecd810c4cc90890229ef353a12fb384c47ee75c3/pkgs/stdenv/generic/default-builder.sh#L1-L3

- `$outputs` not being set is fixed by sourcing `$NIX_ATTRS_SH_FILE`
- `$__structuredAttrs` not being set is fixed by sourcing `setup.sh`
- `$outputs` being unordered is worked-around by passing in `head orig.outputs` using `replaceVars`

#### Test using:
```sh
nix-build -A tests.testers.testBuildFailure
```

<details><summary>Original Description</summary>
<p>


The main issue was that when structuredAttrs is enabled, none of the attr-vars get sourced. Therefore accessing any of them results in "unbound variable" errors.

This is fixed by sourcing `$NIX_ATTRS_SH_FILE`, as-per 8bc5104a6e6a6acf09f9d7ddf1c6a9293efb405a
https://github.com/NixOS/nixpkgs/blob/ecd810c4cc90890229ef353a12fb384c47ee75c3/pkgs/stdenv/generic/default-builder.sh#L1

However `$__structuredAttrs` itself is still unbound, as it is not declared by that file. To work around this, I injected the value using `replaceVars`.

Once the main issue was resolved, I still had to re-work some implementation details due to differences in the `$outputs` variable in structured & non-structured attrs.

Without structuredAttrs, `$outputs` is an array of variable-names, which should be _dereferenced_ to access the actual path. However, with structuredAttrs, `$outputs` is an associative array:
```sh
declare -A outputs=(['out']='/nix/store/2z4mnrzxi1sb4k7zq49gibvvly7gs9rl-example' )
```

Tested using:
```nix
{
  structured = pkgs.testers.testBuildFailure (
    pkgs.runCommandLocal "example" { __structuredAttrs = true; } ''
      exit 1
    ''
  );
  unstructured = pkgs.testers.testBuildFailure (
    pkgs.runCommandLocal "example" { __structuredAttrs = false; } ''
      exit 1
    ''
  );
  unspecified = pkgs.testers.testBuildFailure (
    pkgs.runCommandLocal "example" { } ''
      exit 1
    ''
  );
}
```

</p>
</details>

Closes #355953

Also, uncomments a neovim test that was disabled in #352727 due to this bug

cc @wolfgangwalther @teto

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
