### PR TITLE
python312Packages.cufflinks: fix Numpy 2 compatibility

### DIFF
--- a/pkgs/development/python-modules/cufflinks/default.nix
+++ b/pkgs/development/python-modules/cufflinks/default.nix
@@ -23,6 +23,12 @@ buildPythonPackage rec {
     hash = "sha256-SMGzQG3AMABBIZZkie68VRjOpw/U4/FjebSRMoUBpkQ=";
   };
 
+  patches = [
+    # fix for Numpy 2.x
+    # https://github.com/santosjorge/cufflinks/pull/288
+    ./numpy2.patch
+  ];
+
   # replace duplicated pandas method
   # https://github.com/santosjorge/cufflinks/pull/249#issuecomment-1759619149
   postPatch = ''

--- a/pkgs/development/python-modules/cufflinks/numpy2.patch
+++ b/pkgs/development/python-modules/cufflinks/numpy2.patch
@@ -1,0 +1,12 @@
+diff --git a/cufflinks/colors.py b/cufflinks/colors.py
+index 55c75fb..d0b5b78 100644
+--- a/cufflinks/colors.py
++++ b/cufflinks/colors.py
+@@ -37,6 +37,7 @@ def to_rgba(color, alpha):
+             to_rgba('#f03',0.7)
+             to_rgba('rgb(23,23,23)',.5)
+     """
++    alpha = float(alpha)
+     if type(color) == tuple:
+         color, alpha = color
+     color = color.lower()


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).