### PR TITLE
samtools: 1.19.2 -> 1.21

### DIFF
--- a/pkgs/applications/science/biology/samtools/default.nix
+++ b/pkgs/applications/science/biology/samtools/default.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation rec {
   pname = "samtools";
-  version = "1.19.2";
+  version = "1.21";
 
   src = fetchurl {
     url = "https://github.com/samtools/samtools/releases/download/${version}/${pname}-${version}.tar.bz2";
-    hash = "sha256-cfYEmWaOTAjn10X7/yTBXMigl3q6sazV0rtBm9sGXpY=";
+    hash = "sha256-BXJLCDprbwMF/K5SQ6BWzDbPgmMJw8uTR6a4nuP8Wto=";
   };
 
   # tests require `bgzip` from the htslib package


### PR DESCRIPTION
Simple update. `python3Packages.pysam` still fails to build.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).