### PR TITLE
Add zerotier desktop UI

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -10337,6 +10337,12 @@
     githubId = 45598;
     name = "William Casarin";
   };
+  jbbjarnason = {
+    email = "jbbjarnason@gmail.com";
+    github = "jbbjarnason";
+    githubId = 15651464;
+    name = "Jón Bjarni Bjarnason";
+  };
   jbcrail = {
     name = "Joseph Crail";
     email = "jbcrail@gmail.com";

--- a/pkgs/by-name/ze/zerotierone-desktop-ui/package.nix
+++ b/pkgs/by-name/ze/zerotierone-desktop-ui/package.nix
@@ -1,0 +1,112 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  gtk3,
+  libappindicator,
+}:
+
+let
+  pname = "zerotierone-desktop-ui";
+  version = "1.8.3-unstable-2024-09-26";
+
+  src = fetchFromGitHub {
+    owner = "zerotier";
+    repo = "DesktopUI";
+    rev = "452eca3270f84ef4ac81c955f4777c8f1a82b988";
+    hash = "sha256-1gYF9v7sxCO7+pBRBSCYSRaoHEW3Xvx7nh28TsERZy8=";
+  };
+
+  libui = stdenv.mkDerivation {
+    pname = "libui-ng";
+    inherit version src;
+
+    sourceRoot = "${src.name}/libui-ng";
+
+    nativeBuildInputs = [
+      meson
+      ninja
+      pkg-config
+    ];
+
+    buildInputs = [ gtk3 ];
+
+    mesonFlags = [
+      "-Dc_args=-Wno-error=implicit-function-declaration"
+      "--default-library=static"
+    ];
+  };
+
+  tray = stdenv.mkDerivation {
+    pname = "tray";
+    inherit version src;
+
+    sourceRoot = "${src.name}/tray";
+
+    nativeBuildInputs = [ pkg-config ];
+
+    buildInputs = [
+      gtk3
+      libappindicator
+    ];
+
+    installPhase = ''
+      mkdir -p $out/lib
+      mkdir -p $out/include
+      cp libzt_desktop_tray.a $out/lib/
+      cp tray.h $out/include/
+    '';
+
+    NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
+  };
+in
+rustPlatform.buildRustPackage rec {
+  inherit pname version src;
+
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "mac-notification-sys-0.5.0" = "sha256-VIFkZWksV7CxeVAiXWtTdJe1v4keoiQSSnZVv8uZTeo=";
+    };
+  };
+
+  buildInputs = [
+    libui
+    tray
+    gtk3
+    libappindicator
+  ];
+
+  buildPhase = ''
+    cargo build --release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/applications
+    mkdir -p $out/share/icons/hicolor/440x440/apps
+    mkdir -p $out/share/zerotier
+    cp target/release/zerotier_desktop_ui $out/bin/
+    cp ZeroTierIcon.png $out/share/icons/hicolor/440x440/apps/zerotier.png
+    cp zerotier-ui.desktop $out/share/applications/
+    substituteInPlace $out/share/applications/zerotier-ui.desktop \
+      --replace "/usr/bin/zerotier_desktop_ui" "$out/bin/zerotier_desktop_ui" \
+      --replace "/usr/share/zerotier/ZeroTierIcon.png" "zerotier"
+  '';
+
+  meta = {
+    homepage = "https://zerotier.com/";
+    downloadPage = "https://github.com/zerotier/DesktopUI/releases";
+    description = "ZeroTier Desktop UI";
+    license = lib.licenses.mpl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      jbbjarnason
+    ];
+    badPlatforms = [ "darwin" ];
+  };
+}


### PR DESCRIPTION

Zerotier One Desktop UI

Applet to connect and disconnect from Zerotier One networks.
https://github.com/zerotier/DesktopUI/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)

I got this error when testing the above: `error: cannot build '/nix/store/a962j472psil967m5nq25ksam01fn6vi-source.drv^out' during evaluation because the option 'allow-import-from-derivation' is disabled`
Any help resolving this matter would be greatly appreciated.

- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
