### PR TITLE
arpack-mpi: workaround darwin link error / append '-mpi' to pname

### DIFF
--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -13,7 +13,7 @@ assert useMpi -> !blas.isILP64;
 assert useAccel -> stdenv.hostPlatform.isDarwin;
 
 stdenv.mkDerivation rec {
-  pname = "arpack";
+  pname = "arpack${lib.optionalString useMpi "-mpi"}";
   version = "3.9.1";
 
   src = fetchFromGitHub {

--- a/pkgs/by-name/ar/arpack/package.nix
+++ b/pkgs/by-name/ar/arpack/package.nix
@@ -12,14 +12,14 @@
 assert useMpi -> !blas.isILP64;
 assert useAccel -> stdenv.hostPlatform.isDarwin;
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "arpack${lib.optionalString useMpi "-mpi"}";
   version = "3.9.1";
 
   src = fetchFromGitHub {
     owner = "opencollab";
     repo = "arpack-ng";
-    rev = version;
+    tag = finalAttrs.version;
     sha256 = "sha256-HCvapLba8oLqx9I5+KDAU0s/dTmdWOEilS75i4gyfC0=";
   };
 
@@ -53,11 +53,11 @@ stdenv.mkDerivation rec {
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" stdenv.hostPlatform.hasSharedLibraries)
     (lib.cmakeBool "EIGEN" true)
-    (lib.cmakeBool "EXAMPLES" doCheck)
+    (lib.cmakeBool "EXAMPLES" finalAttrs.doCheck)
     (lib.cmakeBool "ICB" true)
     (lib.cmakeBool "INTERFACE64" (!useAccel && blas.isILP64))
     (lib.cmakeBool "MPI" useMpi)
-    (lib.cmakeBool "TESTS" doCheck)
+    (lib.cmakeBool "TESTS" finalAttrs.doCheck)
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     "-DBLA_VENDOR=${if useAccel then "Apple" else "Generic"}"
   ];
@@ -71,7 +71,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     homepage = "https://github.com/opencollab/arpack-ng";
-    changelog = "https://github.com/opencollab/arpack-ng/blob/${src.rev}/CHANGES";
+    changelog = "https://github.com/opencollab/arpack-ng/blob/${finalAttrs.version}/CHANGES";
     description = ''
       A collection of Fortran77 subroutines to solve large scale eigenvalue
       problems.
@@ -80,4 +80,4 @@ stdenv.mkDerivation rec {
     maintainers = with lib.maintainers; [ ttuegel dotlambda ];
     platforms = lib.platforms.unix;
   };
-}
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

 arpack-mpi: workaround `ld: file not found: @rpath/libquadmath.0.dylib`
    
work around for `ld: file not found: @rpath/libquadmath.0.dylib` which occurs due to an mpi test linking with `-flat_namespace` can remove once `-flat_namespace` is removed or https://github.com/NixOS/nixpkgs/pull/370526 is merged.

note: the required `mpi` package on release-24-11 is missing eeffd96dbd1fa95190b1e48022ff46fd3faf94cd which provides `mpirun / mpiexec` which is required to run tests.

testing: built `arpack-mpi` on aarch64-darwin with `openblas` (default) and with `Accelerate` and both passed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
