### PR TITLE
python312Packages.jaxopt: disable failing test

### DIFF
--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -2,20 +2,24 @@
   lib,
   stdenv,
   buildPythonPackage,
-  pythonOlder,
   fetchFromGitHub,
   fetchpatch,
-  pytest-xdist,
-  pytestCheckHook,
+
+  # build-system
   setuptools,
+
+  # dependencies
   absl-py,
-  cvxpy,
   jax,
-  jaxlib,
   matplotlib,
   numpy,
-  optax,
   scipy,
+
+  # tests
+  cvxpy,
+  optax,
+  pytest-xdist,
+  pytestCheckHook,
   scikit-learn,
 }:
 
@@ -23,8 +27,6 @@ buildPythonPackage rec {
   pname = "jaxopt";
   version = "0.8.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "google";
@@ -48,17 +50,16 @@ buildPythonPackage rec {
   dependencies = [
     absl-py
     jax
-    jaxlib
     matplotlib
     numpy
     scipy
   ];
 
   nativeCheckInputs = [
-    pytest-xdist
-    pytestCheckHook
     cvxpy
     optax
+    pytest-xdist
+    pytestCheckHook
     scikit-learn
   ];
 
@@ -74,12 +75,19 @@ buildPythonPackage rec {
     [
       # https://github.com/google/jaxopt/issues/592
       "test_solve_sparse"
+
+      # AssertionError: Not equal to tolerance rtol=1e-06, atol=1e-06
+      # https://github.com/google/jaxopt/issues/618
+      "test_binary_logit_log_likelihood"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
       # https://github.com/google/jaxopt/issues/577
       "test_binary_logit_log_likelihood"
       "test_solve_sparse"
       "test_logreg_with_intercept_manual_loop3"
+
+      # Flaky (AssertionError)
+      "test_inv_hessian_product_pytree3"
 
       # https://github.com/google/jaxopt/issues/593
       # Makes the test suite crash


### PR DESCRIPTION
## Things done

See https://github.com/google/jaxopt/issues/618

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
