### PR TITLE
python312Packages.neurokit2: init at 0.2.10 and python312Packages.biosppy: init at 2.2.2

### DIFF
--- a/pkgs/development/python-modules/biosppy/default.nix
+++ b/pkgs/development/python-modules/biosppy/default.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  bidict,
+  h5py,
+  matplotlib,
+  numpy,
+  scikit-learn,
+  scipy,
+  shortuuid,
+  six,
+  joblib,
+  pywavelets,
+  mock,
+  tkinter,
+  opencv-python,
+}:
+
+buildPythonPackage rec {
+  pname = "biosppy";
+  version = "2.2.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "scientisst";
+    repo = "BioSPPy";
+    tag = "v${version}";
+    hash = "sha256-U0ZftAlRlazSO66raH74o/6eP1RpmuFoA6HJ+xmgKR8=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies = [
+    opencv-python
+    bidict
+    h5py
+    matplotlib
+    numpy
+    scikit-learn
+    scipy
+    shortuuid
+    six
+    joblib
+    pywavelets
+    mock
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ tkinter ];
+
+  doCheck = false; # no tests
+
+  pythonImportsCheck = [
+    "biosppy"
+    "biosppy.signals"
+    "biosppy.synthesizers"
+    "biosppy.inter_plotting"
+    "biosppy.features"
+  ];
+
+  meta = {
+    description = "Biosignal Processing in Python";
+    homepage = "https://biosppy.readthedocs.io/";
+    changelog = "https://github.com/scientisst/BioSPPy/releases/tag/v${version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ genga898 ];
+  };
+}

--- a/pkgs/development/python-modules/neurokit2/default.nix
+++ b/pkgs/development/python-modules/neurokit2/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  pytest,
+  scipy,
+  scikit-learn,
+  pandas,
+  matplotlib,
+  requests,
+  cvxopt,
+  biosppy,
+  pytest-cov-stub,
+  mock,
+  plotly,
+  astropy,
+  coverage,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "neurokit2";
+  version = "0.2.10";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "neuropsychology";
+    repo = "NeuroKit";
+    tag = "v${version}";
+    hash = "sha256-e/B1JvO6uYZ6iVskFvxZLSSXi0cPep9bBZ0JXZTVS28=";
+  };
+
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail '"pytest-runner"' '"pytest"'
+  '';
+
+  build-system = [
+    setuptools
+    pytest
+  ];
+
+  dependencies = [
+    scipy
+    scikit-learn
+    pandas
+    matplotlib
+    requests
+    cvxopt
+    biosppy
+  ];
+
+  nativeCheckInputs = [
+    pytest-cov-stub
+    mock
+    plotly
+    astropy
+    coverage
+    pytestCheckHook
+  ];
+
+  disabledTests = lib.optionals stdenv.hostPlatform.isDarwin [
+    # Crash in matplotlib (Fatal Python error: Aborted)
+    "test_events_plot"
+  ];
+
+  disabledTestPaths = [
+    # Required dependencies not available in nixpkgs
+    "tests/tests_complexity.py"
+    "tests/tests_eeg.py"
+    "tests/tests_eog.py"
+    "tests/tests_ecg.py"
+    "tests/tests_bio.py"
+    "tests/tests_data.py"
+    "tests/tests_epochs.py"
+    "tests/tests_ecg_findpeaks.py"
+    "tests/tests_eda.py"
+    "tests/tests_emg.py"
+    "tests/tests_hrv.py"
+    "tests/tests_rsp.py"
+    "tests/tests_ppg.py"
+    "tests/tests_signal.py"
+
+    # Dependency is broken `mne-python`
+    "tests/tests_microstates.py"
+  ];
+
+  pythonImportsCheck = [
+    "neurokit2"
+  ];
+
+  meta = {
+    description = "Python Toolbox for Neurophysiological Signal Processing";
+    homepage = "https://github.com/neuropsychology/NeuroKit";
+    changelog = "https://github.com/neuropsychology/NeuroKit/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ genga898 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -1677,6 +1677,8 @@ self: super: with self; {
 
   biopython = callPackage ../development/python-modules/biopython { };
 
+  biosppy = callPackage ../development/python-modules/biosppy { };
+
   biothings-client = callPackage ../development/python-modules/biothings-client { };
 
   biplist = callPackage ../development/python-modules/biplist { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9191,6 +9191,8 @@ self: super: with self; {
 
   neuralfoil = callPackage ../development/python-modules/neuralfoil { };
 
+  neurokit2 = callPackage ../development/python-modules/neurokit2 { };
+
   neuron-full = pkgs.neuron-full.override { python3 = python; };
 
   neuronpy = toPythonModule neuron-full;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Closes #371375

Add [neurokit2](https://github.com/neuropsychology/NeuroKit) and [biosppy](https://github.com/scientisst/BioSPPy)

Tests for neurokit get stuck on the second test, have been trying to build it for couple of hours, hence the omission of the test checks, was not able to determine if all the tests pass or fail.

Biosppy is a dependency of the neurokit python lib.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
