### PR TITLE
quill: remove obsolete protobuf and openssl

### DIFF
--- a/pkgs/by-name/qu/quill/package.nix
+++ b/pkgs/by-name/qu/quill/package.nix
@@ -3,12 +3,9 @@
   stdenv,
   rustPlatform,
   fetchFromGitHub,
-  openssl,
   libiconv,
   udev,
   pkg-config,
-  protobuf,
-  buildPackages,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -39,9 +36,6 @@ rustPlatform.buildRustPackage rec {
     export IC_ICRC1_ARCHIVE_WASM_PATH=${ic}/rs/rosetta-api/icrc1/wasm/ic-icrc1-archive.wasm.gz
     export LEDGER_ARCHIVE_NODE_CANISTER_WASM_PATH=${ic}/rs/rosetta-api/icp_ledger/wasm/ledger-archive-node-canister.wasm
     cp ${ic}/rs/rosetta-api/icp_ledger/ledger.did /build/quill-${version}-vendor/ledger.did
-    export PROTOC=${buildPackages.protobuf}/bin/protoc
-    export OPENSSL_DIR=${openssl.dev}
-    export OPENSSL_LIB_DIR=${lib.getLib openssl}/lib
   '';
 
   useFetchCargoVendor = true;
@@ -49,11 +43,9 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [
     pkg-config
-    protobuf
   ];
   buildInputs =
     [
-      openssl
       udev
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [


### PR DESCRIPTION
It seems the package no longer needs these to build.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux (cross)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).