### PR TITLE
python312Packages.rebulk: fix test inputs, cleanup

### DIFF
--- a/pkgs/development/python-modules/rebulk/default.nix
+++ b/pkgs/development/python-modules/rebulk/default.nix
@@ -5,12 +5,13 @@
   pytestCheckHook,
   pythonOlder,
   regex,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "rebulk";
   version = "3.2.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -19,9 +20,11 @@ buildPythonPackage rec {
     hash = "sha256-DTC/gPygD6nGlxhaxHXarJveX2Rs4zOMn/XV3B69/rw=";
   };
 
-  propagatedBuildInputs = [ regex ];
+  build-system = [ setuptools ];
 
-  buildInputs = [ pytestCheckHook ];
+  dependencies = [ regex ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "rebulk" ];
 


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).