### PR TITLE
firebird_4: fix strictDeps build

### DIFF
--- a/pkgs/servers/firebird/default.nix
+++ b/pkgs/servers/firebird/default.nix
@@ -79,7 +79,8 @@ let base = {
       sha256 = "sha256-hddW/cozboGw693q4k5f4+x9ccQFWFytXPUaBVkFnL4=";
     };
 
-    buildInputs = base.buildInputs ++ [ zlib unzip libtommath libtomcrypt ];
+    nativeBuildInputs = base.nativeBuildInputs ++ [ unzip ];
+    buildInputs = base.buildInputs ++ [ zlib libtommath libtomcrypt ];
   });
 
   firebird = firebird_4;


### PR DESCRIPTION
Unzip is only used at build time.

Cross-compile is still broken due to `checking for /proc/self/maps... configure: error: cannot check for file existence when cross compiling`.

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).