### PR TITLE
python312Packages.altair: 5.4.1 -> 5.5.0, disable flaky tests

### DIFF
--- a/pkgs/development/python-modules/altair/default.nix
+++ b/pkgs/development/python-modules/altair/default.nix
@@ -60,6 +60,9 @@ buildPythonPackage rec {
   disabledTests = [
     # ValueError: Saving charts in 'svg' format requires the vl-convert-python or altair_saver package: see http://github.com/altair-viz/altair_saver/
     "test_renderer_with_none_embed_options"
+    # Sometimes conflict due to parallelism
+    "test_dataframe_to_csv[polars]"
+    "test_dataframe_to_csv[pandas]"
   ];
 
   disabledTestPaths = [

--- a/pkgs/development/python-modules/altair/default.nix
+++ b/pkgs/development/python-modules/altair/default.nix
@@ -22,16 +22,16 @@
 
 buildPythonPackage rec {
   pname = "altair";
-  version = "5.4.1";
+  version = "5.5.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "altair-viz";
     repo = "altair";
     tag = "v${version}";
-    hash = "sha256-7C51ACaBuNtOSXqLpuCI5bnLyE9U64vNXlD4/msPq2k=";
+    hash = "sha256-lrKC4FYRQEax5E0lQNhO9FLk5UOJ0TnYzqZjndlRpGI=";
   };
 
   build-system = [ hatchling ];
@@ -63,6 +63,8 @@ buildPythonPackage rec {
     # Sometimes conflict due to parallelism
     "test_dataframe_to_csv[polars]"
     "test_dataframe_to_csv[pandas]"
+    # Network access
+    "test_theme_remote_lambda"
   ];
 
   disabledTestPaths = [


### PR DESCRIPTION
Simple update

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).