### PR TITLE
python312Packages.anthropic: 0.39.0 -> 0.42.0

### DIFF
--- a/pkgs/development/python-modules/anthropic/default.nix
+++ b/pkgs/development/python-modules/anthropic/default.nix
@@ -10,9 +10,11 @@
   hatchling,
   httpx,
   jiter,
+  nest-asyncio,
   pydantic,
   pytest-asyncio,
   pytestCheckHook,
+  pythonAtLeast,
   pythonOlder,
   respx,
   sniffio,
@@ -22,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "anthropic";
-  version = "0.39.0";
+  version = "0.42.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -31,7 +33,7 @@ buildPythonPackage rec {
     owner = "anthropics";
     repo = "anthropic-sdk-python";
     tag = "v${version}";
-    hash = "sha256-lpW+waHvwgbhK7EnPZy/XI8gK3a8JjFflPqUFbDN1z8=";
+    hash = "sha256-7cRXKXiyq3ty21klkitjjnm9rzBRmAXGYvvVxTNWeZ4=";
   };
 
   build-system = [
@@ -57,16 +59,22 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     dirty-equals
     pytest-asyncio
+    nest-asyncio
     pytestCheckHook
     respx
   ];
 
   pythonImportsCheck = [ "anthropic" ];
 
-  disabledTests = [
-    # Test require network access
-    "test_copy_build_request"
-  ];
+  disabledTests =
+    [
+      # Test require network access
+      "test_copy_build_request"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      # Fails on RuntimeWarning: coroutine method 'aclose' of 'AsyncStream._iter_events' was never awaited
+      "test_multi_byte_character_multiple_chunks[async]"
+    ];
 
   disabledTestPaths = [
     # Test require network access


### PR DESCRIPTION
Also fixes a test failure on Python 3.13

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).