### PR TITLE
python312Packages.dctorch: allow Numpy 2

### DIFF
--- a/pkgs/development/python-modules/dctorch/default.nix
+++ b/pkgs/development/python-modules/dctorch/default.nix
@@ -28,6 +28,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "dctorch" ];
 
+  pythonRelaxDeps = [
+    "numpy"
+  ];
+
   doCheck = false; # no tests
 
   meta = with lib; {


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).