### PR TITLE
gradle: fix cross builds

### DIFF
--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -48,6 +48,7 @@ rec {
       runCommand,
       writeText,
       autoPatchelfHook,
+      buildPackages,
 
       # The JDK/JRE used for running Gradle.
       java ? defaultJava,
@@ -78,7 +79,6 @@ rec {
         ];
 
       buildInputs = [
-        java
         stdenv.cc.cc
         ncurses5
         ncurses6
@@ -121,6 +121,8 @@ rec {
           newFileEvents = toString (lib.versionAtLeast version "8.12");
         in
         ''
+          # get the correct jar executable for cross
+          export PATH="${buildPackages.jdk}/bin:$PATH"
           . ${./patching.sh}
 
           nativeVersion="$(extractVersion native-platform $out/lib/gradle/lib/native-platform-*.jar)"


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).