### PR TITLE
python312Packages.inkex: clean up test inputs

### DIFF
--- a/pkgs/development/python-modules/inkex/default.nix
+++ b/pkgs/development/python-modules/inkex/default.nix
@@ -23,8 +23,7 @@
 buildPythonPackage {
   pname = "inkex";
   inherit (inkscape) version;
-
-  format = "pyproject";
+  pyproject = true;
 
   inherit (inkscape) src;
 
@@ -38,16 +37,19 @@ buildPythonPackage {
     })
   ];
 
-  nativeBuildInputs = [ poetry-core ];
+  build-system = [ poetry-core ];
 
   pythonRelaxDeps = [ "numpy" ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     cssselect
     lxml
     numpy
+    pillow
     pygobject3
+    pyparsing
     pyserial
+    scour
     tinycss2
   ];
 
@@ -60,10 +62,6 @@ buildPythonPackage {
 
   checkInputs = [
     gtk3
-    packaging
-    pillow
-    pyparsing
-    scour
   ];
 
   disabledTests =


### PR DESCRIPTION
Several of these are supposedly required at runtime.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).