### PR TITLE
python312Packages.castepxbin: allow Numpy 2, clean up

### DIFF
--- a/pkgs/development/python-modules/castepxbin/default.nix
+++ b/pkgs/development/python-modules/castepxbin/default.nix
@@ -12,10 +12,9 @@
 buildPythonPackage rec {
   pname = "castepxbin";
   version = "0.3.0";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
-
-  format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "zhubonan";
@@ -24,11 +23,15 @@ buildPythonPackage rec {
     hash = "sha256-6kumVnm4PLRxuKO6Uz0iHzfYuu21hFC7EPRsc3S1kxE=";
   };
 
-  nativeBuildInputs = [ flit-core ];
+  build-system = [ flit-core ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     numpy
     scipy
+  ];
+
+  pythonRelaxDeps = [
+    "numpy"
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).