### PR TITLE
nixos/hardware: add ST-Link udev rules

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -16,6 +16,8 @@
 
 - [Nezha](https://github.com/nezhahq/nezha), a self-hosted, lightweight server and website monitoring and O&M tool. Available as [services.nezha](#opt-services.nezha.enable).
 
+- [ST-Link](https://www.st.com/en/development-tools/st-link-v2.html) udev rules. Available as [hardware.stlink](#opt-hardware.stlink.enable).
+
 - [mail-tlsa-check-exporter](https://github.com/ietf-tools/mail-tlsa-check-exporter), validates SMTP / IMAP server certificates against a TLSA record as a Prometheus exporter. Available as [services.prometheus.exporters.mail-tlsa-check](#opt-services.prometheus.exporters.mail-tlsa-check.enable).
 
 - [CastSponsorSkip](https://github.com/gabe565/CastSponsorSkip/), skips YouTube sponsorships (and sometimes ads) on all local Google Cast devices.

--- a/nixos/modules/hardware/stlink.nix
+++ b/nixos/modules/hardware/stlink.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  config,
+  options,
+  ...
+}:
+let
+  cfg = config.hardware.stlink;
+  opt = options.hardware.stlink;
+in
+{
+  options.hardware.stlink = {
+    enable = lib.mkEnableOption "udev rules for ST-Link programmer devices";
+    owner = lib.mkOption {
+      type = lib.types.str;
+      default = "root";
+      description = "Owner of ST-Link devices";
+    };
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "plugdev";
+      description = "Group of ST-Link devices";
+    };
+    mode = lib.mkOption {
+      type = lib.types.str;
+      default = "0660";
+      example = "0640";
+      description = "Mode of ST-Link devices";
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf cfg.enable {
+      assertions = [
+        {
+          assertion = builtins.hasAttr cfg.owner config.users.users;
+          message = "Owner '${cfg.owner}' set in `${opt.owner}` is not configured via `${options.users.users}.\"${cfg.owner}\"`.";
+        }
+        {
+          assertion = (cfg.group == opt.group.default) || (builtins.hasAttr cfg.group config.users.groups);
+          message = "Group '${cfg.group}' set in `${opt.group}` is not configured via `${options.users.groups}.\"${cfg.group}\"`.";
+        }
+      ];
+      # Source: https://www.linux-usb.org/usb.ids
+      services.udev.extraRules = ''
+        # ST-Link V1
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3744", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+
+        # ST-Link V2
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3748", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3752", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+
+        # ST-Link V2.1
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="374b", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3752", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+
+        # ST-Link V3
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="374e", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="374f", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="3753", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+        # ST-Link V3 Loader (what is this?)
+        SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="374d", OWNER="${cfg.owner}", GROUP="${cfg.group}", MODE="${cfg.mode}"
+      '';
+      users.groups.plugdev = lib.mkIf (config.group == "plugdev") { };
+    })
+  ];
+
+  meta.maintainers = with lib.maintainers; [ pandapip1 ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -111,6 +111,7 @@
   ./hardware/sensor/iio.nix
   ./hardware/sheep-net.nix
   ./hardware/steam-hardware.nix
+  ./hardware/stlink.nix
   ./hardware/system-76.nix
   ./hardware/tenstorrent.nix
   ./hardware/tuxedo-drivers.nix


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

~~There are other ST-Link devices, but this is the only one I own and therefore have vendor/device IDs for.~~

Found http://www.linux-usb.org/usb.ids, which agreed with my ST-Link V2. I have therefore copied the rest of the ST-Link devices from it.

Derived from `x86-msr.nix`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
