### PR TITLE
Revert "python312Packages.cffi: remove unnecessary Darwin patch"

### DIFF
--- a/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
+++ b/pkgs/development/python-modules/cffi/darwin-use-libffi-closures.diff
@@ -1,0 +1,29 @@
+diff --git a/src/c/_cffi_backend.c b/src/c/_cffi_backend.c
+index 537271f..9c3bf94 100644
+--- a/src/c/_cffi_backend.c
++++ b/src/c/_cffi_backend.c
+@@ -103,11 +103,11 @@
+ # define CFFI_CHECK_FFI_PREP_CIF_VAR 0
+ # define CFFI_CHECK_FFI_PREP_CIF_VAR_MAYBE 0
+ 
+-#elif defined(__APPLE__) && defined(FFI_AVAILABLE_APPLE)
++#elif defined(__APPLE__)
+ 
+-# define CFFI_CHECK_FFI_CLOSURE_ALLOC __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++# define CFFI_CHECK_FFI_CLOSURE_ALLOC 1
+ # define CFFI_CHECK_FFI_CLOSURE_ALLOC_MAYBE 1
+-# define CFFI_CHECK_FFI_PREP_CLOSURE_LOC __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++# define CFFI_CHECK_FFI_PREP_CLOSURE_LOC 1
+ # define CFFI_CHECK_FFI_PREP_CLOSURE_LOC_MAYBE 1
+-# define CFFI_CHECK_FFI_PREP_CIF_VAR __builtin_available(macos 10.15, ios 13, watchos 6, tvos 13, *)
++# define CFFI_CHECK_FFI_PREP_CIF_VAR 1
+ # define CFFI_CHECK_FFI_PREP_CIF_VAR_MAYBE 1
+@@ -6422,7 +6422,7 @@ static PyObject *b_callback(PyObject *self, PyObject *args)
+     else
+ #endif
+     {
+-#if defined(__APPLE__) && defined(FFI_AVAILABLE_APPLE) && !FFI_LEGACY_CLOSURE_API
++#if defined(__APPLE__) && !FFI_LEGACY_CLOSURE_API
+         PyErr_Format(PyExc_SystemError, "ffi_prep_closure_loc() is missing");
+         goto error;
+ #else

--- a/pkgs/development/python-modules/cffi/default.nix
+++ b/pkgs/development/python-modules/cffi/default.nix
@@ -24,6 +24,20 @@ else
       hash = "sha256-HDnGAWwyvEjdVFYZUOvWg24WcPKuRhKPZ89J54nFKCQ=";
     };
 
+    patches = [
+      #
+      # Trusts the libffi library inside of nixpkgs on Apple devices.
+      #
+      # Based on some analysis I did:
+      #
+      #   https://groups.google.com/g/python-cffi/c/xU0Usa8dvhk
+      #
+      # I believe that libffi already contains the code from Apple's fork that is
+      # deemed safe to trust in cffi.
+      #
+      ./darwin-use-libffi-closures.diff
+    ];
+
     nativeBuildInputs = [ pkg-config ];
 
     build-system = [ setuptools ];


### PR DESCRIPTION
Fix the build on `aarch64-darwin`. Need to figure out why either `!defined(FFI_AVAILABLE_APPLE)` or the `__builtin_available` checks are failing, but that’s a next cycle problem.

This reverts commit eff89e3bd808ba8949356d0f4a4a61ac93cba81c.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
