### PR TITLE
eid-sk: init at 5.0

### DIFF
--- a/pkgs/by-name/ei/eid-sk/package.nix
+++ b/pkgs/by-name/ei/eid-sk/package.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  appimageTools,
+  fetchzip,
+}:
+
+let
+  pname = "eid-sk";
+  version = "5.0";
+
+  src = fetchzip {
+    url = "https://eidas.minv.sk/downloadservice/eidklient/linux/eID_klient_x86_64.tar.gz";
+    hash = "sha256-NQC0ZhlX2VzRZ2KkFOAIBdThgOlGSbgBAfRaXmEw2Lk=";
+    stripRoot = false;
+  };
+
+  appimageContents = appimageTools.extract {
+    inherit pname version;
+    src = "${src}/eID_klient-x86_64.AppImage";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version;
+
+  src = "${src}/eID_klient-x86_64.AppImage";
+
+  extraPkgs = pkgs: [ pkgs.pcsclite ];
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/eid-klient-mw.desktop $out/share/applications/${pname}.desktop
+    install -m 444 -D ${appimageContents}/sk_logo.svg $out/share/icons/hicolor/512x512/apps/sk_logo.svg
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace "Exec=AppRun --no-sandbox %U" "Exec=$out/bin/eID_Client"
+  '';
+
+  meta = with lib; {
+    description = "eID client application (Slovak)";
+    longDescription = ''
+      Allows user authentication and digital signatures with Slovak ID cards.
+
+      Also requires a running pcscd service and compatible card reader:
+
+          services.pcscd.enable = true;
+
+      To use eIDs in Firefox in NixOS use follwing configuration:
+
+          programs.firefox.enable = true;
+          programs.firefox.nativeMessagingHosts.euwebid = true;
+    '';
+    homepage = "https://www.slovensko.sk";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ ktor ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Added eid-sk package that packages AppImage used to access electronic services provided by Slovak government- www.slovensko.sk. Similar to [eid-mw](https://search.nixos.org/packages?channel=24.11&from=0&size=50&sort=relevance&type=packages&query=eid) package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
