### PR TITLE
nixos/nginx: fix mkDefaultListenVhost mapping for unix sockets

### DIFF
--- a/nixos/modules/services/web-servers/nginx/default.nix
+++ b/nixos/modules/services/web-servers/nginx/default.nix
@@ -339,7 +339,7 @@ let
             map (
               listen:
               {
-                port = cfg.defaultSSLListenPort;
+                port = if (hasPrefix "unix:" listen.addr) then null else cfg.defaultSSLListenPort;
                 ssl = true;
               }
               // listen
@@ -351,7 +351,7 @@ let
             map (
               listen:
               {
-                port = cfg.defaultHTTPListenPort;
+                port = if (hasPrefix "unix:" listen.addr) then null else cfg.defaultHTTPListenPort;
                 ssl = false;
               }
               // listen

--- a/nixos/tests/nginx-unix-socket.nix
+++ b/nixos/tests/nginx-unix-socket.nix
@@ -1,5 +1,6 @@
 { ... }:
 let
+  defaultNginxSocketPath = "/var/run/nginx/default-test.sock";
   nginxSocketPath = "/var/run/nginx/test.sock";
 in
 {
@@ -11,6 +12,13 @@ in
       {
         services.nginx = {
           enable = true;
+
+          defaultListen = [ { addr = "unix:${defaultNginxSocketPath}"; } ];
+          virtualHosts.defaultLocalhost = {
+            serverName = "defaultLocalhost";
+            locations."/default".return = "200 'bar'";
+          };
+
           virtualHosts.localhost = {
             serverName = "localhost";
             listen = [ { addr = "unix:${nginxSocketPath}"; } ];
@@ -22,8 +30,10 @@ in
 
   testScript = ''
     webserver.wait_for_unit("nginx")
-    webserver.wait_for_open_unix_socket("${nginxSocketPath}")
+    webserver.wait_for_open_unix_socket("${defaultNginxSocketPath}", timeout=1)
+    webserver.wait_for_open_unix_socket("${nginxSocketPath}", timeout=1)
 
+    webserver.succeed("curl --fail --silent --unix-socket '${defaultNginxSocketPath}' http://defaultLocalhost/default | grep '^bar$'")
     webserver.succeed("curl --fail --silent --unix-socket '${nginxSocketPath}' http://localhost/test | grep '^foo$'")
   '';
 }


### PR DESCRIPTION
Fixes #370905

Includes additional nixos-test code in a separate commit. ~~This test hangs then fails without the fix because long default timeout on function <host>.wait_for_unit, I'm not sure if this is a good failure mode.~~ Timeout=1 (second) was added to quickly error if the unix socket path doesn't exist. If the configuration is correct, the paths exist before the systemd unit status changes to running.

Maps port to null if the listen address is a unix socket. This fix impacts generated nginx configuration files.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
