### PR TITLE
linuxPackages.hyperv-daemons: Fix aarch64 builds on latest kernel

### DIFF
--- a/pkgs/os-specific/linux/hyperv-daemons/default.nix
+++ b/pkgs/os-specific/linux/hyperv-daemons/default.nix
@@ -12,7 +12,12 @@
 let
   libexec = "libexec/hypervkvpd";
 
-  fcopy_name = (if lib.versionOlder kernel.version "6.10" then "fcopy" else "fcopy_uio");
+  fcopy_name =
+    if lib.versionOlder kernel.version "6.10" then
+      "fcopy"
+    else
+      # The fcopy program is explicitly left out in the Makefile on aarch64
+      (if stdenv.hostPlatform.isAarch64 then null else "fcopy_uio");
 
   daemons = stdenv.mkDerivation rec {
     pname = "hyperv-daemons-bin";
@@ -21,31 +26,18 @@ let
     nativeBuildInputs = [ makeWrapper ];
     buildInputs = [ python3 ];
 
-    # as of 4.9 compilation will fail due to -Werror=format-security
-    hardeningDisable = [ "format" ];
-
     postPatch = ''
       cd tools/hv
       substituteInPlace hv_kvp_daemon.c \
         --replace /usr/libexec/hypervkvpd/ $out/${libexec}/
     '';
 
-    # We don't actually need the hv_get_{dhcp,dns}_info scripts on NixOS in
-    # their current incarnation but with them in place, we stop the spam of
-    # errors in the log.
-    installPhase = ''
-      runHook preInstall
-
-      for f in ${fcopy_name} kvp vss ; do
-        install -Dm755 hv_''${f}_daemon -t $out/bin
-      done
-
-      install -Dm755 lsvmbus             $out/bin/lsvmbus
-      install -Dm755 hv_get_dhcp_info.sh $out/${libexec}/hv_get_dhcp_info
-      install -Dm755 hv_get_dns_info.sh  $out/${libexec}/hv_get_dns_info
-
-      runHook postInstall
-    '';
+    makeFlags = [
+      "ARCH=${stdenv.hostPlatform.parsed.cpu.name}"
+      "DESTDIR=$(out)"
+      "sbindir=/bin"
+      "libexecdir=/libexec"
+    ];
 
     postFixup = ''
       wrapProgram $out/bin/hv_kvp_daemon \
@@ -90,22 +82,29 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [ daemons ];
+  passthru = {
+    inherit daemons;
+  };
 
   buildCommand = ''
     system=$lib/lib/systemd/system
 
-    install -Dm444 ${
-      service "${
-        fcopy_name
-      }" "file copy (FCOPY)" "/sys/bus/vmbus/devices/eb765408-105f-49b6-b4aa-c123b64d17d4/uio"
-    } $system/hv-fcopy.service
+    ${lib.optionalString (fcopy_name != null) ''
+      install -Dm444 ${
+        service fcopy_name "file copy (FCOPY)"
+          "/sys/bus/vmbus/devices/eb765408-105f-49b6-b4aa-c123b64d17d4/uio"
+      } $system/hv-fcopy.service
+    ''}
     install -Dm444 ${service "kvp" "key-value pair (KVP)" "hv_kvp"} $system/hv-kvp.service
     install -Dm444 ${service "vss" "volume shadow copy (VSS)" "hv_vss"} $system/hv-vss.service
 
     cat > $system/hyperv-daemons.target <<EOF
     [Unit]
     Description=Hyper-V Daemons
-    Wants=hv-fcopy.service hv-kvp.service hv-vss.service
+    Wants=hv-kvp.service hv-vss.service
+    ${lib.optionalString (fcopy_name != null) ''
+      Wants=hv-fcopy.service
+    ''}
     EOF
 
     for f in $lib/lib/systemd/system/*.service ; do


### PR DESCRIPTION
This is necessary in order to include the latest kernel as a boot option in the ISO: https://github.com/NixOS/nixpkgs/pull/355893

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
