### PR TITLE
qc71_laptop: unstable-2023-03-02 -> 0-unstable-2025-01-07

### DIFF
--- a/pkgs/os-specific/linux/qc71_laptop/default.nix
+++ b/pkgs/os-specific/linux/qc71_laptop/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "qc71_laptop";
-  version = "unstable-2023-03-02";
+  version = "0-unstable-2025-01-07";
 
   src = fetchFromGitHub {
     owner = "pobrn";
     repo = "qc71_laptop";
-    rev = "8805dc5639f6659addf153a295ad4bbaa2483fa3";
-    hash = "sha256-wg7APGArjrl9DEAHTG6BknOBx+UbtNrzziwmLueKPfA=";
+    rev = "ebab4af0b2c5b162bb9f27c80cd284c36b8fb7a9";
+    hash = "sha256-sRvxcdocYKnwMH/qYkKj66uClI1bSmMSxXHrHsc7uco=";
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;

--- a/pkgs/os-specific/linux/qc71_laptop/default.nix
+++ b/pkgs/os-specific/linux/qc71_laptop/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   kernel,
   kernelModuleMakeFlags,
+  nix-update-script,
 }:
 
 stdenv.mkDerivation rec {
@@ -29,6 +30,10 @@ stdenv.mkDerivation rec {
     install -D qc71_laptop.ko -t $out/lib/modules/${kernel.modDirVersion}/extra
     runHook postInstall
   '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch" ];
+  };
 
   meta = with lib; {
     description = "Linux driver for QC71 laptop";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Updated package. Changelog from git commits:
<details>

```
6305ec3 (HEAD -> master, upstream/master, origin/master, origin/HEAD) treewide: simplify error handling
ac32742 events: adapt to Linux 6.12 change in function signature
9da7bdb events: add placeholder function instead of #if
451fe22 events: remove unnecessary empty line
5af1f11 ec: remove unused `qc71_ec_{,un}lock()`
e47c812 ec: align buffer
2193788 ec: simplify buffer initialization
469e53d battery: add missing include
66ec7b3 events: add missing include
c4b71e3 hwmon: add missing include
889252e hwmon_pwm: remove unused include
1b95640 hwmon_pwn: add missing include
69916ed hwmon_fan: add missing include
406ba66 debugfs: rework cleanup flow
8e288dc debugfs: use `debugfs_create_file_size()`
```

</details>
Notably, adds support for kernel version 6.12.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`, built on NixOS
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage) (This required compiling 22 kernels)
- [x] Tested basic functionality of all binary files -- I tested manually that the module loads on my system on kernels 6_6 and 6_12
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md). (AFAIK)

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
