### PR TITLE
amdgpu-i2c: init at 0.0.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22587,6 +22587,12 @@
     githubId = 1141680;
     name = "Thane Gill";
   };
+  thardin = {
+    email = "th020394@gmail.com";
+    github = "Tyler-Hardin";
+    githubId = 5404976;
+    name = "Tyler Hardin";
+  };
   thblt = {
     name = "Thibault Polge";
     email = "thibault@thb.lt";

--- a/pkgs/development/python-modules/holidays/default.nix
+++ b/pkgs/development/python-modules/holidays/default.nix
@@ -14,7 +14,7 @@
 
 buildPythonPackage rec {
   pname = "holidays";
-  version = "0.63";
+  version = "0.64";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -23,7 +23,7 @@ buildPythonPackage rec {
     owner = "vacanza";
     repo = "python-holidays";
     tag = "v${version}";
-    hash = "sha256-XA6XvxWHttt+ic5027Q/3VGqrFYznYCiExSFBHU7qcY=";
+    hash = "sha256-rPQr7nyouBepTi4tW0+wrbROYyWo92KkZUI6ff5jl7I=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/mypy-boto3/default.nix
+++ b/pkgs/development/python-modules/mypy-boto3/default.nix
@@ -678,8 +678,8 @@ rec {
       "sha256-LFhzVLxycvIbGPCIMvD18XAL8KkA1rnE+3LkFty4Q8s=";
 
   mypy-boto3-iotsecuretunneling =
-    buildMypyBoto3Package "iotsecuretunneling" "1.35.0"
-      "sha256-A1sYvlnpbfKZyxZvFCzBfD/Jbzd1PwlQwgj+fvcybGU=";
+    buildMypyBoto3Package "iotsecuretunneling" "1.35.93"
+      "sha256-HBXnSdkTqLdcwSQl42FfFZhQVDiErGfJShaGgt0I7bU=";
 
   mypy-boto3-iotsitewise =
     buildMypyBoto3Package "iotsitewise" "1.35.64"

--- a/pkgs/os-specific/linux/amdgpu-i2c/default.nix
+++ b/pkgs/os-specific/linux/amdgpu-i2c/default.nix
@@ -1,0 +1,39 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  kernel,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "amdgpu-i2c";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "twifty";
+    repo = pname;
+    rev = "master";
+    sha256 = "sha256-GVyrwnwNSBW4OCNDqQMU6e31C4bG14arC0MPkRWfiJQ=";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  KDIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
+
+  buildPhase = "make -C ${KDIR} M=/build/source modules";
+  installPhase = ''
+    make -C ${KDIR} M=/build/source INSTALL_MOD_PATH="$out" modules_install
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/twifty/amd-gpu-i2c";
+    downloadPage = "https://github.com/twifty/amd-gpu-i2c";
+    description = "Exposes i2c interface to set colors on AMD GPUs";
+    broken = lib.versionOlder kernel.version "6.11.0";
+    license = licenses.gpl2Plus;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ thardin ];
+  };
+}

--- a/pkgs/test/cc-wrapper/hardening.nix
+++ b/pkgs/test/cc-wrapper/hardening.nix
@@ -3,6 +3,7 @@
 , runCommand
 , runCommandWith
 , runCommandCC
+, bintools
 , hello
 , debian-devscripts
 }:
@@ -130,6 +131,56 @@ let
   '';
 
   brokenIf = cond: drv: if cond then drv.overrideAttrs (old: { meta = old.meta or {} // { broken = true; }; }) else drv;
+  overridePlatforms = platforms: drv: drv.overrideAttrs (old: { meta = old.meta or {} // { inherit platforms; }; });
+
+  instructionPresenceTest = label: mnemonicPattern: testBin: expectFailure: runCommand "${label}-instr-test" {
+    nativeBuildInputs = [
+      bintools
+    ];
+    buildInputs = [
+      testBin
+    ];
+  } ''
+    touch $out
+    if $OBJDUMP -d \
+      --no-addresses \
+      --no-show-raw-insn \
+      "$(PATH=$HOST_PATH type -P test-bin)" \
+      | grep -E '${mnemonicPattern}' > /dev/null ; then
+      echo "Found ${label} instructions" >&2
+      ${lib.optionalString expectFailure "exit 1"}
+    else
+      echo "Did not find ${label} instructions" >&2
+      ${lib.optionalString (!expectFailure) "exit 1"}
+    fi
+  '';
+
+  pacRetTest = testBin: expectFailure: overridePlatforms [ "aarch64-linux" ] (
+    instructionPresenceTest "pacret" "\\bpaciasp\\b" testBin expectFailure
+  );
+
+  elfNoteTest = label: pattern: testBin: expectFailure: runCommand "${label}-elf-note-test" {
+    nativeBuildInputs = [
+      bintools
+    ];
+    buildInputs = [
+      testBin
+    ];
+  } ''
+    touch $out
+    if $READELF -n "$(PATH=$HOST_PATH type -P test-bin)" \
+      | grep -E '${pattern}' > /dev/null ; then
+      echo "Found ${label} note" >&2
+      ${lib.optionalString expectFailure "exit 1"}
+    else
+      echo "Did not find ${label} note" >&2
+      ${lib.optionalString (!expectFailure) "exit 1"}
+    fi
+  '';
+
+  shadowStackTest = testBin: expectFailure: brokenIf stdenv.hostPlatform.isMusl (overridePlatforms [ "x86_64-linux" ] (
+    elfNoteTest "shadowstack" "\\bSHSTK\\b" testBin expectFailure
+  ));
 
 in nameDrvAfterAttrName ({
   bindNowExplicitEnabled = brokenIf stdenv.hostPlatform.isStatic (checkTestBin (f2exampleWithStdEnv stdenv {
@@ -204,6 +255,14 @@ in nameDrvAfterAttrName ({
     ignoreStackClashProtection = false;
   });
 
+  pacRetExplicitEnabled = pacRetTest (helloWithStdEnv stdenv {
+    hardeningEnable = [ "pacret" ];
+  }) false;
+
+  shadowStackExplicitEnabled = shadowStackTest (f1exampleWithStdEnv stdenv {
+    hardeningEnable = [ "shadowstack" ];
+  }) false;
+
   bindNowExplicitDisabled = checkTestBin (f2exampleWithStdEnv stdenv {
     hardeningDisable = [ "bindnow" ];
   }) {
@@ -270,6 +329,14 @@ in nameDrvAfterAttrName ({
     ignoreStackClashProtection = false;
     expectFailure = true;
   };
+
+  pacRetExplicitDisabled = pacRetTest (helloWithStdEnv stdenv {
+    hardeningDisable = [ "pacret" ];
+  }) true;
+
+  shadowStackExplicitDisabled = shadowStackTest (f1exampleWithStdEnv stdenv {
+    hardeningDisable = [ "shadowstack" ];
+  }) true;
 
   # most flags can't be "unsupported" by compiler alone and
   # binutils doesn't have an accessible hardeningUnsupportedFlags
@@ -472,4 +539,12 @@ in {
     ignoreStackClashProtection = false;
     expectFailure = true;
   };
+
+  allExplicitDisabledPacRet = pacRetTest (helloWithStdEnv stdenv {
+    hardeningDisable = [ "all" ];
+  }) true;
+
+  allExplicitDisabledShadowStack = shadowStackTest (f1exampleWithStdEnv stdenv {
+    hardeningDisable = [ "all" ];
+  }) true;
 }))

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -324,6 +324,8 @@ in {
 
     akvcam = callPackage ../os-specific/linux/akvcam { };
 
+    amdgpui2c = callPackage ../os-specific/linux/amdgpu-i2c { };
+
     amneziawg = callPackage ../os-specific/linux/amneziawg { };
 
     apfs = callPackage ../os-specific/linux/apfs { };


### PR DESCRIPTION
This module exposes the i2c interfaces necessary for OpenRGB and similar tools to set colors on the GPU.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
