### PR TITLE
rcu: Fix running it

### DIFF
--- a/pkgs/by-name/rc/rcu/package.nix
+++ b/pkgs/by-name/rc/rcu/package.nix
@@ -9,6 +9,7 @@
   desktopToDarwinBundle,
   libsForQt5,
   makeDesktopItem,
+  protobuf,
   python3Packages,
   system-config-printer,
 }:
@@ -43,11 +44,16 @@ python3Packages.buildPythonApplication rec {
 
     substituteInPlace package_support/gnulinux/50-remarkable.rules \
       --replace-fail 'GROUP="yourgroup"' 'GROUP="users"'
+
+    # This must match the protobuf version imported at runtime, regenerate it
+    rm src/model/update_metadata_pb2.py
+    protoc --proto_path src/model src/model/update_metadata.proto --python_out=src/model
   '';
 
   nativeBuildInputs =
     [
       copyDesktopItems
+      protobuf
       libsForQt5.wrapQtAppsHook
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
@@ -66,7 +72,7 @@ python3Packages.buildPythonApplication rec {
     pdfminer-six
     pikepdf
     pillow
-    protobuf
+    python3Packages.protobuf # otherwise it picks up protobuf from function args
     pyside2
   ];
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/nix/store/m0bj7vzh8d4fhd4bz21v8lb8lqfazglv-rcu-2024.001q/share/rcu/main.py", line 65, in <module>
    from controllers import MainUtilityController
  File "/nix/store/plq93gn0s0cxcpflha6iihgnlj26bc64-shiboken2-5.15.15/lib/python3.10/site-packages/shiboken2/files.dir/shibokensupport/feature.py", line 139, in _import
    return original_import(name, *args, **kwargs)
  File "/nix/store/m0bj7vzh8d4fhd4bz21v8lb8lqfazglv-rcu-2024.001q/share/rcu/controllers/__init__.py", line 3, in <module>
    from .MainUtilityController import MainUtilityController
  File "/nix/store/plq93gn0s0cxcpflha6iihgnlj26bc64-shiboken2-5.15.15/lib/python3.10/site-packages/shiboken2/files.dir/shibokensupport/feature.py", line 139, in _import
    return original_import(name, *args, **kwargs)
  File "/nix/store/m0bj7vzh8d4fhd4bz21v8lb8lqfazglv-rcu-2024.001q/share/rcu/controllers/MainUtilityController.py", line 27, in <module>
    from panes import paneslist, IncompatiblePane, AboutPane
  File "/nix/store/plq93gn0s0cxcpflha6iihgnlj26bc64-shiboken2-5.15.15/lib/python3.10/site-packages/shiboken2/files.dir/shibokensupport/feature.py", line 139, in _import
    return original_import(name, *args, **kwargs)
  File "/nix/store/m0bj7vzh8d4fhd4bz21v8lb8lqfazglv-rcu-2024.001q/share/rcu/panes/__init__.py", line 3, in <module>
    from .deviceinfo.pane import DeviceInfoPane
  File "/nix/store/plq93gn0s0cxcpflha6iihgnlj26bc64-shiboken2-5.15.15/lib/python3.10/site-packages/shiboken2/files.dir/shibokensupport/feature.py", line 139, in _import
    return original_import(name, *args, **kwargs)
  File "/nix/store/m0bj7vzh8d4fhd4bz21v8lb8lqfazglv-rcu-2024.001q/share/rcu/panes/deviceinfo/pane.py", line 35, in <module>
    from model.firmware import Firmware
  File "/nix/store/plq93gn0s0cxcpflha6iihgnlj26bc64-shiboken2-5.15.15/lib/python3.10/site-packages/shiboken2/files.dir/shibokensupport/feature.py", line 139, in _import
    return original_import(name, *args, **kwargs)
  File "/nix/store/m0bj7vzh8d4fhd4bz21v8lb8lqfazglv-rcu-2024.001q/share/rcu/model/firmware.py", line 45, in <module>
    from .update_metadata_pb2 import DeltaArchiveManifest 
  File "/nix/store/plq93gn0s0cxcpflha6iihgnlj26bc64-shiboken2-5.15.15/lib/python3.10/site-packages/shiboken2/files.dir/shibokensupport/feature.py", line 139, in _import
    return original_import(name, *args, **kwargs)
  File "/nix/store/m0bj7vzh8d4fhd4bz21v8lb8lqfazglv-rcu-2024.001q/share/rcu/model/update_metadata_pb2.py", line 32, in <module>
    _descriptor.EnumValueDescriptor(
  File "/nix/store/vp9pnzdr4w0g3r22w7frr59wnf94dzf6-python3.10-protobuf-5.28.3/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 920, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates
```

Regenerate the affected file to fix startup.

Still abit borked at runtime, but seems to be an issue with support for the latest firmware. Let's at least fix starting it for now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
