### PR TITLE
slimevr-server: fix OSC support

### DIFF
--- a/pkgs/by-name/sl/slimevr-server/package.nix
+++ b/pkgs/by-name/sl/slimevr-server/package.nix
@@ -4,13 +4,14 @@
   runCommand,
   replaceVars,
   slimevr,
-  jdk17_headless,
+  jdk17,
   gradle,
   hidapi,
   makeWrapper,
 }:
 let
-  java = jdk17_headless;
+  # JDK can't be headless while SlimeVR uses JavaOSC 0.8.
+  java = jdk17;
   # Without this the hidapi bundled with `org.hid4java:hid4java` will be used.
   # The bundled version won't be able to find `libudev.so.1`.
   javaOptions =


### PR DESCRIPTION
Fixes #371329.

See https://github.com/SlimeVR/SlimeVR-Server/pull/1133 for why SlimeVR currently uses an older JavaOSC version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
