### PR TITLE
openbsd.{sys,stand}: Pin clang18 & make useful running out of a nix store

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/stand/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/stand/package.nix
@@ -8,6 +8,8 @@ mkDerivation {
   path = "sys/arch/amd64/stand";
   extraPaths = [ "sys" ];
 
+  patches = [ ../sys/initpath.patch ];
+
   # gcc compat
   postPatch = ''
     find $BSDSRCDIR -name Makefile -print0 | xargs -0 sed -E -i -e 's/-nopie/-no-pie/g'

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sys.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sys.nix
@@ -1,66 +1,72 @@
 {
+  buildPackages,
+  stdenvNoLibc,
+  overrideCC,
   mkDerivation,
   boot-config,
   pkgsBuildTarget,
   baseConfig ? "GENERIC",
 }:
-mkDerivation {
-  path = "sys/arch/amd64";
-  pname = "sys";
-  extraPaths = [ "sys" ];
-  noLibc = true;
+(mkDerivation.override {
+  stdenvNoLibc = overrideCC stdenvNoLibc buildPackages.llvmPackages_18.clangNoLibc;
+})
+  {
+    path = "sys/arch/amd64";
+    pname = "sys";
+    extraPaths = [ "sys" ];
+    noLibc = true;
 
-  extraNativeBuildInputs = [
-    boot-config
-  ];
+    extraNativeBuildInputs = [
+      boot-config
+    ];
 
-  postPatch =
-    # The in-kernel debugger (DDB) requires compiler flags not supported by clang, disable it
-    ''
-      sed -E -i -e '/DDB/d' $BSDSRCDIR/sys/conf/GENERIC
-      sed -E -i -e '/pseudo-device\tdt/d' $BSDSRCDIR/sys/arch/amd64/conf/GENERIC
-    ''
-    +
-      # Clang flags compatibility
+    postPatch =
+      # The in-kernel debugger (DDB) requires compiler flags not supported by clang, disable it
       ''
-        find $BSDSRCDIR -name 'Makefile*' -exec sed -E -i -e 's/-fno-ret-protector/-fno-stack-protector/g' -e 's/-nopie/-no-pie/g' {} +
-        sed -E -i -e 's_^\tinstall.*$_\tinstall bsd ''${out}/bsd_' -e s/update-link// $BSDSRCDIR/sys/arch/*/conf/Makefile.*
+        sed -E -i -e '/DDB/d' $BSDSRCDIR/sys/conf/GENERIC
+        sed -E -i -e '/pseudo-device\tdt/d' $BSDSRCDIR/sys/arch/amd64/conf/GENERIC
       ''
-    +
-      # Remove randomness in build
+      +
+        # Clang flags compatibility
+        ''
+          find $BSDSRCDIR -name 'Makefile*' -exec sed -E -i -e 's/-fno-ret-protector/-fno-stack-protector/g' -e 's/-nopie/-no-pie/g' {} +
+          sed -E -i -e 's_^\tinstall.*$_\tinstall bsd ''${out}/bsd_' -e s/update-link// $BSDSRCDIR/sys/arch/*/conf/Makefile.*
+        ''
+      +
+        # Remove randomness in build
+        ''
+          sed -E -i -e 's/^PAGE_SIZE=.*$/PAGE_SIZE=4096/g' -e '/^random_uniform/a echo 0; return 0;' $BSDSRCDIR/sys/conf/makegap.sh
+          sed -E -i -e 's/^v=.*$/v=0 u=nixpkgs h=nixpkgs t=`date -d @1`/g' $BSDSRCDIR/sys/conf/newvers.sh
+        '';
+
+    postConfigure = ''
+      export BSDOBJDIR=$TMP/obj
+      mkdir $BSDOBJDIR
+      make obj
+
+      cd conf
+      config ${baseConfig}
+      cd -
+    '';
+
+    preBuild =
+      # A lot of files insist on calling unprefixed GNU `ld` and `objdump`.
+      # It's easier to add them to PATH than patch and substitute.
       ''
-        sed -E -i -e 's/^PAGE_SIZE=.*$/PAGE_SIZE=4096/g' -e '/^random_uniform/a echo 0; return 0;' $BSDSRCDIR/sys/conf/makegap.sh
-        sed -E -i -e 's/^v=.*$/v=0 u=nixpkgs h=nixpkgs t=`date -d @1`/g' $BSDSRCDIR/sys/conf/newvers.sh
-      '';
-
-  postConfigure = ''
-    export BSDOBJDIR=$TMP/obj
-    mkdir $BSDOBJDIR
-    make obj
-
-    cd conf
-    config ${baseConfig}
-    cd -
-  '';
-
-  preBuild =
-    # A lot of files insist on calling unprefixed GNU `ld` and `objdump`.
-    # It's easier to add them to PATH than patch and substitute.
-    ''
-      mkdir $TMP/bin
-      export PATH=$TMP/bin:$PATH
-      ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}objdump $TMP/bin/objdump
-      ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}ld $TMP/bin/ld
-    ''
-    +
-      # The Makefile claims it needs includes, but it really doesn't.
-      # Tell it includes aren't real and can't hurt it.
+        mkdir $TMP/bin
+        export PATH=$TMP/bin:$PATH
+        ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}objdump $TMP/bin/objdump
+        ln -s ${pkgsBuildTarget.binutils}/bin/${pkgsBuildTarget.binutils.targetPrefix}ld $TMP/bin/ld
       ''
-        cd compile/${baseConfig}/obj
-        echo 'includes:' >>Makefile
-      '';
+      +
+        # The Makefile claims it needs includes, but it really doesn't.
+        # Tell it includes aren't real and can't hurt it.
+        ''
+          cd compile/${baseConfig}/obj
+          echo 'includes:' >>Makefile
+        '';
 
-  # stand is in a separate package
-  env.SKIPDIR = "stand";
-  env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument -Wno-visibility";
-}
+    # stand is in a separate package
+    env.SKIPDIR = "stand";
+    env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument -Wno-visibility";
+  }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sys/initpath.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sys/initpath.patch
@@ -1,0 +1,166 @@
+OpenBSD hardcodes the /sbin/init path which is super unhelpful for booting a
+NixOS system. This patch adds a boot parameter that can be passed through the
+bootloader and into the kernel specifying which init binary to use. This patch
+will assuredly not be accepted upstream but is very relevant to nixpkgs.
+
+This patch applies for both sys and stand.
+
+diff --git a/sys/arch/amd64/amd64/machdep.c b/sys/arch/amd64/amd64/machdep.c
+index f58e6c585c1..874f5a74d6d 100644
+--- a/sys/arch/amd64/amd64/machdep.c
++++ b/sys/arch/amd64/amd64/machdep.c
+@@ -181,6 +181,7 @@ int	physmem;
+ u_int64_t	dumpmem_low;
+ u_int64_t	dumpmem_high;
+ extern int	boothowto;
++extern char	initpath[MAXPATHLEN];
+ int	cpu_class;
+ 
+ paddr_t	dumpmem_paddr;
+@@ -255,6 +256,7 @@ bios_memmap_t	*bios_memmap;
+ u_int32_t	bios_cksumlen;
+ bios_efiinfo_t	*bios_efiinfo;
+ bios_ucode_t	*bios_ucode;
++char		*passed_init;
+ 
+ #if NEFI > 0
+ EFI_MEMORY_DESCRIPTOR *mmap;
+@@ -1992,6 +1994,7 @@ getbootinfo(char *bootinfo, int bootinfo_size)
+ 	bios_ddb_t *bios_ddb;
+ 	bios_bootduid_t *bios_bootduid;
+ 	bios_bootsr_t *bios_bootsr;
++	char *init_param;
+ #undef BOOTINFO_DEBUG
+ #ifdef BOOTINFO_DEBUG
+ 	printf("bootargv:");
+@@ -2089,6 +2092,11 @@ getbootinfo(char *bootinfo, int bootinfo_size)
+ 			bios_ucode = (bios_ucode_t *)q->ba_arg;
+ 			break;
+ 
++		case BOOTARG_INIT:
++			init_param = (char*)q->ba_arg;
++			memcpy(initpath, init_param, sizeof(initpath));
++			break;
++
+ 		default:
+ #ifdef BOOTINFO_DEBUG
+ 			printf(" unsupported arg (%d) %p", q->ba_type,
+diff --git a/sys/arch/amd64/include/biosvar.h b/sys/arch/amd64/include/biosvar.h
+index b0c71ea0350..93e81b1b051 100644
+--- a/sys/arch/amd64/include/biosvar.h
++++ b/sys/arch/amd64/include/biosvar.h
+@@ -225,6 +225,8 @@ typedef struct _bios_ucode {
+ 	uint64_t	uc_size;
+ } __packed bios_ucode_t;
+ 
++#define BOOTARG_INIT 13
++
+ #if defined(_KERNEL) || defined (_STANDALONE)
+ 
+ #ifdef _LOCORE
+diff --git a/sys/arch/amd64/stand/efiboot/efiboot.c b/sys/arch/amd64/stand/efiboot/efiboot.c
+index 95cf92d298d..ee77f6769fd 100644
+--- a/sys/arch/amd64/stand/efiboot/efiboot.c
++++ b/sys/arch/amd64/stand/efiboot/efiboot.c
+@@ -965,6 +965,9 @@ efi_makebootargs(void)
+ #endif
+ 
+ 	addbootarg(BOOTARG_EFIINFO, sizeof(bios_efiinfo), &bios_efiinfo);
++	if (cmd.init[0] != 0) {
++		addbootarg(BOOTARG_INIT, sizeof(cmd.init), &cmd.init);
++	}
+ }
+ 
+ /* Vendor device path used to indicate the mmio UART on AMD SoCs. */
+diff --git a/sys/kern/init_main.c b/sys/kern/init_main.c
+index b4816b2e9a0..db412097035 100644
+--- a/sys/kern/init_main.c
++++ b/sys/kern/init_main.c
+@@ -103,6 +103,8 @@ extern void stoeplitz_init(void);
+ #include "vscsi.h"
+ #include "softraid.h"
+ 
++#define DEBUG 1
++
+ const char	copyright[] =
+ "Copyright (c) 1982, 1986, 1989, 1991, 1993\n"
+ "\tThe Regents of the University of California.  All rights reserved.\n"
+@@ -127,6 +129,7 @@ int	db_active = 0;
+ int	ncpus =  1;
+ int	ncpusfound = 1;			/* number of cpus we find */
+ volatile int start_init_exec;		/* semaphore for start_init() */
++char	initpath[MAXPATHLEN];
+ 
+ #if !defined(NO_PROPOLICE)
+ long	__guard_local __attribute__((section(".openbsd.randomdata")));
+@@ -557,6 +560,7 @@ static char *initpaths[] = {
+ 	"/sbin/init",
+ 	"/sbin/oinit",
+ 	"/sbin/init.bak",
++	initpath,
+ 	NULL,
+ };
+ 
+diff --git a/sys/stand/boot/boot.c b/sys/stand/boot/boot.c
+index e090a0d0180..1a20b1ece47 100644
+--- a/sys/stand/boot/boot.c
++++ b/sys/stand/boot/boot.c
+@@ -74,7 +74,7 @@ boot(dev_t bootdev)
+ 	devboot(bootdev, cmd.bootdev);
+ 	strlcpy(cmd.image, kernelfile, sizeof(cmd.image));
+ 	cmd.boothowto = 0;
+-	cmd.conf = "/etc/boot.conf";
++	cmd.conf = "/boot/nixos/default.conf";
+ 	cmd.timeout = boottimeout;
+ 
+ 	if (upgrade()) {
+diff --git a/sys/stand/boot/cmd.h b/sys/stand/boot/cmd.h
+index 5045f052b8b..327f3de8d84 100644
+--- a/sys/stand/boot/cmd.h
++++ b/sys/stand/boot/cmd.h
+@@ -43,6 +43,7 @@ struct cmd_table {
+ struct cmd_state {
+ 	char bootdev[BOOTDEVLEN]; /* device */
+ 	char image[MAXPATHLEN - 16]; /* image */
++	char init[MAXPATHLEN];
+ 	int  boothowto; /* howto */
+ 	char *conf; /* /etc/boot.conf normally */
+ 	int timeout;
+diff --git a/sys/stand/boot/vars.c b/sys/stand/boot/vars.c
+index d1516776315..b12edcdaeac 100644
+--- a/sys/stand/boot/vars.c
++++ b/sys/stand/boot/vars.c
+@@ -42,6 +42,7 @@ static int Xdevice(void);
+ static int Xdebug(void);
+ #endif
+ static int Xdb_console(void);
++static int Xinit(void);
+ static int Ximage(void);
+ static int Xhowto(void);
+ #ifdef BOOT_STTY
+@@ -63,6 +64,7 @@ const struct cmd_table cmd_set[] = {
+ 	{"image",  CMDT_VAR, Ximage},
+ 	{"timeout",CMDT_VAR, Xtimeout},
+ 	{"db_console", CMDT_VAR, Xdb_console},
++	{"init", CMDT_VAR, Xinit},
+ 	{NULL,0}
+ };
+ 
+@@ -107,6 +109,17 @@ Xdb_console(void)
+ 	return (0);
+ }
+ 
++int
++Xinit(void)
++{
++	if (cmd.argc != 2) {
++		printf("%s\n", cmd.init);
++	} else {
++		strlcpy(cmd.init, cmd.argv[1], sizeof(cmd.init));
++	}
++	return 0;
++}
++
+ static int
+ Xtimeout(void)
+ {

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sys/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sys/package.nix
@@ -16,6 +16,8 @@
     extraPaths = [ "sys" ];
     noLibc = true;
 
+    patches = [ ./initpath.patch ];
+
     extraNativeBuildInputs = [
       boot-config
     ];


### PR DESCRIPTION
- Clang19 build is broken so pinned to clang18 - self-explanatory
- Make useful running out of a nix store - openbsd hardcodes the /sbin/init path which is super unhelpful for booting a nixos system. This adds a boot parameter that can be passed through the bootloader and into the kernel specifying which init binary to use. This patch will assuredly not be accepted upstream but is very relevant to nixpkgs.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
