### PR TITLE
nixos/image.modules: siplify type for better UX

### DIFF
--- a/nixos/modules/image/images.nix
+++ b/nixos/modules/image/images.nix
@@ -9,59 +9,52 @@ let
   inherit (lib) types;
 
   imageModules = {
-    amazon = [ ../../maintainers/scripts/ec2/amazon-image.nix ];
-    azure = [ ../virtualisation/azure-image.nix ];
-    digital-ocean = [ ../virtualisation/digital-ocean-image.nix ];
-    google-compute = [ ../virtualisation/google-compute-image.nix ];
-    hyperv = [ ../virtualisation/hyperv-image.nix ];
-    linode = [ ../virtualisation/linode-image.nix ];
-    lxc = [ ../virtualisation/lxc-container.nix ];
-    lxc-metadata = [ ../virtualisation/lxc-image-metadata.nix ];
-    oci = [ ../virtualisation/oci-image.nix ];
-    openstack = [ ../../maintainers/scripts/openstack/openstack-image.nix ];
-    openstack-zfs = [ ../../maintainers/scripts/openstack/openstack-image-zfs.nix ];
-    proxmox = [ ../virtualisation/proxmox-image.nix ];
-    proxmox-lxc = [ ../virtualisation/proxmox-lxc.nix ];
-    qemu-efi = [ ../virtualisation/disk-image.nix ];
-    qemu = [
-      ../virtualisation/disk-image.nix
-      {
-        image.efiSupport = false;
-      }
-    ];
-    raw-efi = [
-      ../virtualisation/disk-image.nix
-      {
-        image.format = "raw";
-      }
-    ];
-    raw = [
-      ../virtualisation/disk-image.nix
-      {
-        image.format = "raw";
-        image.efiSupport = false;
-      }
-    ];
-    kubevirt = [ ../virtualisation/kubevirt.nix ];
-    vagrant-virtualbox = [ ../virtualisation/vagrant-virtualbox-image.nix ];
-    virtualbox = [ ../virtualisation/virtualbox-image.nix ];
-    vmware = [ ../virtualisation/vmware-image.nix ];
-    iso = [ ../installer/cd-dvd/iso-image.nix ];
-    iso-installer = [ ../installer/cd-dvd/installation-cd-base.nix ];
-    sd-card = [
-      (
+    amazon = ../../maintainers/scripts/ec2/amazon-image.nix;
+    azure = ../virtualisation/azure-image.nix;
+    digital-ocean = ../virtualisation/digital-ocean-image.nix;
+    google-compute = ../virtualisation/google-compute-image.nix;
+    hyperv = ../virtualisation/hyperv-image.nix;
+    linode = ../virtualisation/linode-image.nix;
+    lxc = ../virtualisation/lxc-container.nix;
+    lxc-metadata = ../virtualisation/lxc-image-metadata.nix;
+    oci = ../virtualisation/oci-image.nix;
+    openstack = ../../maintainers/scripts/openstack/openstack-image.nix;
+    openstack-zfs = ../../maintainers/scripts/openstack/openstack-image-zfs.nix;
+    proxmox = ../virtualisation/proxmox-image.nix;
+    proxmox-lxc = ../virtualisation/proxmox-lxc.nix;
+    qemu-efi = ../virtualisation/disk-image.nix;
+    qemu = {
+      imports = [ ../virtualisation/disk-image.nix ];
+      image.efiSupport = false;
+    };
+    raw-efi = {
+      imports = [ ../virtualisation/disk-image.nix ];
+      image.format = "raw";
+    };
+    raw = {
+      imports = [ ../virtualisation/disk-image.nix ];
+      image.format = "raw";
+      image.efiSupport = false;
+    };
+    kubevirt = ../virtualisation/kubevirt.nix;
+    vagrant-virtualbox = ../virtualisation/vagrant-virtualbox-image.nix;
+    virtualbox = ../virtualisation/virtualbox-image.nix;
+    vmware = ../virtualisation/vmware-image.nix;
+    iso = ../installer/cd-dvd/iso-image.nix;
+    iso-installer = ../installer/cd-dvd/installation-cd-base.nix;
+    sd-card = {
+      imports =
         let
           module = ../. + "/installer/sd-card/sd-image-${pkgs.targetPlatform.linuxArch}.nix";
         in
-        if builtins.pathExists module then module else throw "The module ${module} does not exist."
-      )
-    ];
-    kexec = [ ../installer/netboot/netboot-minimal.nix ];
+        if builtins.pathExists module then [ module ] else throw "The module ${module} does not exist.";
+    };
+    kexec = ../installer/netboot/netboot-minimal.nix;
   };
   imageConfigs = lib.mapAttrs (
-    name: modules:
+    name: module:
     extendModules {
-      inherit modules;
+      modules = [ module ];
     }
   ) config.image.modules;
 in
@@ -77,7 +70,7 @@ in
       };
     };
     image.modules = lib.mkOption {
-      type = types.attrsOf (types.listOf types.deferredModule);
+      type = types.attrsOf types.deferredModule;
       description = ''
         image-specific NixOS Modules used for `system.build.images`.
       '';


### PR DESCRIPTION
Usage before:

```nix
image.modules.my-format = [
  (
    { config, pkgs, ... }:
    {
      imports = [ ./my-other-module.nix ];
      foo = "bar";
    };
  )
]
```

Usage after:

```nix
image.modules.my-format = { config, pkgs, ... }: {
  imports = [ ./my-other-module.nix ];
  foo = "bar";
};
```

If the user wants to pass a list of modules only:
```nix
image.modules.my-format.imports = [
  ./module1.nix
  ./module2.nix
]
```

cc @phaer @zimbatm


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
