### PR TITLE
openbsd: many new small packages

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/cap_mkdb.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/cap_mkdb.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/cap_mkdb";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/cap_mkdb.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/cap_mkdb.nix
@@ -1,4 +1,5 @@
 { mkDerivation }:
 mkDerivation {
   path = "usr.bin/cap_mkdb";
+  meta.mainProgram = "cap_mkdb";
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/cat.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/cat.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/cat";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/chmod/no-sbin.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/chmod/no-sbin.patch
@@ -1,0 +1,24 @@
+diff --git a/bin/chmod/Makefile b/bin/chmod/Makefile
+index 82854bae3a3..39813dc8882 100644
+--- a/bin/chmod/Makefile
++++ b/bin/chmod/Makefile
+@@ -3,17 +3,8 @@
+ PROG=	chmod
+ MAN=	chmod.1 chgrp.1 chown.8 chflags.1
+ LINKS=	${BINDIR}/chmod ${BINDIR}/chgrp \
+-	${BINDIR}/chmod /sbin/chown
+-
+-# XXX compatibility
+-afterinstall:
+-	(cd ${DESTDIR}/usr/sbin && \
+-	    ln -sf ../../sbin/chown . && \
+-	    ln -sf ../../bin/chgrp . && \
+-	    chown -h ${BINOWN}:${BINGRP} chown chgrp)
+-	(cd ${DESTDIR}/usr/bin && \
+-	    ln -sf ../../bin/chmod chflags && \
+-	    chown -h ${BINOWN}:${BINGRP} chflags)
++	${BINDIR}/chmod ${BINDIR}/chown \
++	${BINDIR}/chmod ${BINDIR}/chflags
+ 
+ 
+ .include <bsd.prog.mk>

--- a/pkgs/os-specific/bsd/openbsd/pkgs/chmod/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/chmod/package.nix
@@ -1,0 +1,6 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/chmod";
+
+  patches = [ ./no-sbin.patch ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/cmp.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/cmp.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/cmp";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/cp.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/cp.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/cp";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/date.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/date.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/date";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/dd.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/dd.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/dd";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/dev_mkdb.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/dev_mkdb.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.sbin/dev_mkdb";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/df.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/df.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/df";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/dhcpleasectl.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/dhcpleasectl.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.sbin/dhcpleasectl";
+
+  extraPaths = [ "sbin/dhcpleased" ];
+
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/dhcpleased.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/dhcpleased.nix
@@ -1,0 +1,15 @@
+{
+  mkDerivation,
+  libevent,
+  byacc,
+}:
+mkDerivation {
+  path = "sbin/dhcpleased";
+
+  postPatch = ''
+    sed -i 's/DPADD/#DPADD/' $BSDSRCDIR/sbin/dhcpleased/Makefile
+  '';
+
+  buildInputs = [ libevent ];
+  extraNativeBuildInputs = [ byacc ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/dmesg.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/dmesg.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, libkvm }:
+mkDerivation {
+  path = "sbin/dmesg";
+
+  buildInputs = [ libkvm ];
+
+  postPatch = ''
+    sed -i /DPADD/d $BSDSRCDIR/sbin/dmesg/Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/domainname.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/domainname.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/domainname";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/echo.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/echo.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/echo";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ed.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ed.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/ed";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/expr.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/expr.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/expr";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/getent.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/getent.nix
@@ -1,0 +1,1 @@
+{ mkDerivation }: mkDerivation { path = "usr.bin/getent"; }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/getty.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/getty.nix
@@ -4,10 +4,16 @@
 }:
 mkDerivation {
   path = "libexec/getty";
+  extraPaths = [ "etc/gettytab" ];
 
   postPatch = ''
     substituteInPlace $BSDSRCDIR/libexec/getty/pathnames.h \
         --replace-fail "/usr/libexec/getty" "$out/bin/getty" \
         --replace-fail "/usr/bin/login" "${login}/bin/login"
+  '';
+
+  postInstall = ''
+    mkdir -p $out/etc
+    cp $BSDSRCDIR/etc/gettytab $out/etc/gettytab
   '';
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/getty.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/getty.nix
@@ -16,4 +16,6 @@ mkDerivation {
     mkdir -p $out/etc
     cp $BSDSRCDIR/etc/gettytab $out/etc/gettytab
   '';
+
+  meta.mainProgram = "getty";
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/getty/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/getty/package.nix
@@ -1,0 +1,6 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "libexec/getty";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/getty/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/getty/package.nix
@@ -1,6 +1,13 @@
 {
   mkDerivation,
+  login,
 }:
 mkDerivation {
   path = "libexec/getty";
+
+  postPatch = ''
+    substituteInPlace $BSDSRCDIR/libexec/getty/pathnames.h \
+        --replace-fail "/usr/libexec/getty" "$out/bin/getty" \
+        --replace-fail "/usr/bin/login" "${login}/bin/login"
+  '';
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/hostname.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/hostname.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/hostname";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/id.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/id.nix
@@ -1,0 +1,6 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/id";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ifconfig.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ifconfig.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/ifconfig";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/kdump.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/kdump.nix
@@ -1,0 +1,8 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/kdump";
+  extraPaths = [
+    "sys"
+    "usr.bin/ktrace"
+  ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/kill.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/kill.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/kill";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ktrace.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ktrace.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/ktrace";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/kvm_mkdb.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/kvm_mkdb.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.sbin/kvm_mkdb";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libc.nix
@@ -7,6 +7,7 @@
   libm,
   librpcsvc,
   libutil,
+  libexecinfo,
   rtld,
   version,
 }:
@@ -36,6 +37,7 @@ symlinkJoin rec {
           librthread
           librpcsvc
           libutil
+          libexecinfo
         ]
         ++ (lib.optional (!stdenvNoLibc.hostPlatform.isStatic) rtld)
       );

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libcurses.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libcurses.nix
@@ -1,0 +1,13 @@
+{
+  lib,
+  mkDerivation,
+  buildPackages,
+}:
+mkDerivation {
+  path = "lib/libcurses";
+
+  makeFlags = [
+    "AWK=${lib.getBin buildPackages.gawk}/bin/awk"
+    "HOSTCC=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
+  ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libevent.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libevent.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "lib/libevent";
+  preInstall = ''
+    mkdir -p $out/include
+  '';
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libexecinfo.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libexecinfo.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "gnu/lib/libexecinfo";
+  extraPaths = [
+    "gnu/llvm/libunwind"
+    "gnu/llvm/libcxx"
+    "gnu/lib/libcxx"
+  ];
+
+  libcMinimal = true;
+
+  outputs = [
+    "out"
+    "man"
+  ];
+
+  meta.platforms = lib.platforms.openbsd;
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/libkvm.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/libkvm.nix
@@ -1,0 +1,6 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "lib/libkvm";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ln.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ln.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/ln";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/login.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/login.nix
@@ -1,0 +1,10 @@
+{
+  mkDerivation,
+  libutil,
+}:
+mkDerivation {
+  path = "usr.bin/login";
+  buildInputs = [
+    libutil
+  ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/login.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/login.nix
@@ -7,4 +7,6 @@ mkDerivation {
   buildInputs = [
     libutil
   ];
+
+  meta.mainProgram = "login";
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/login_passwd.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/login_passwd.nix
@@ -1,0 +1,10 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "libexec/login_passwd";
+
+  postPatch = ''
+    sed -i 's/4555/0555/' $BSDSRCDIR/libexec/login_passwd/Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ls.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ls.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/ls";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/md5.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/md5.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/md5";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mkdir.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mkdir.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/mkdir";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount/package.nix
@@ -1,0 +1,9 @@
+{
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/mount";
+  meta.mainProgram = "mount";
+  patches = [ ./search-path.patch ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount/search-path.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount/search-path.patch
@@ -1,0 +1,39 @@
+diff --git a/sbin/mount/mount.c b/sbin/mount/mount.c
+index eaff190b572..4bce21559f6 100644
+--- a/sbin/mount/mount.c
++++ b/sbin/mount/mount.c
+@@ -338,12 +338,6 @@ mountfs(const char *vfstype, const char *spec, const char *name,
+ {
+ 	char *cp;
+ 
+-	/* List of directories containing mount_xxx subcommands. */
+-	static const char *edirs[] = {
+-		_PATH_SBIN,
+-		_PATH_USRSBIN,
+-		NULL
+-	};
+ 	const char **argv, **edir;
+ 	struct statfs sf;
+ 	pid_t pid;
+@@ -427,15 +421,12 @@ mountfs(const char *vfstype, const char *spec, const char *name,
+ 		return (1);
+ 	case 0:					/* Child. */
+ 		/* Go find an executable. */
+-		edir = edirs;
+-		do {
+-			(void)snprintf(execname,
+-			    sizeof(execname), "%s/mount_%s", *edir, vfstype);
+-			argv[0] = execname;
+-			execv(execname, (char * const *)argv);
+-			if (errno != ENOENT)
+-				warn("exec %s for %s", execname, name);
+-		} while (*++edir != NULL);
++		(void)snprintf(execname,
++		    sizeof(execname), "mount_%s", vfstype);
++		argv[0] = execname;
++		execvp(execname, (char * const *)argv);
++		if (errno != ENOENT)
++			warn("exec %s for %s", execname, name);
+ 
+ 		if (errno == ENOENT)
+ 			warn("no mount helper program found for %s", vfstype);

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount_ffs/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount_ffs/package.nix
@@ -1,0 +1,8 @@
+{
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/mount_ffs";
+  extraPaths = [ "sbin/mount" ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mount_tmpfs/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mount_tmpfs/package.nix
@@ -1,0 +1,8 @@
+{
+  mkDerivation,
+}:
+
+mkDerivation {
+  path = "sbin/mount_tmpfs";
+  extraPaths = [ "sbin/mount" ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mt.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mt.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/mt";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mtree/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mtree/package.nix
@@ -1,0 +1,6 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.sbin/mtree";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/mv.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/mv.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/mv";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/newsyslog.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/newsyslog.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/newsyslog";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/pfctl/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/pfctl/package.nix
@@ -1,0 +1,16 @@
+{
+  mkDerivation,
+  byacc,
+}:
+mkDerivation {
+  path = "sbin/pfctl";
+  extraPaths = [
+    "sys/net"
+  ];
+
+  extraNativeBuildInputs = [
+    byacc
+  ];
+
+  meta.mainProgram = "pfctl";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/pkill.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/pkill.nix
@@ -1,0 +1,15 @@
+{
+  mkDerivation,
+  libkvm,
+}:
+mkDerivation {
+  path = "usr.bin/pkill";
+
+  buildInputs = [
+    libkvm
+  ];
+
+  postPatch = ''
+    sed -i /DPADD/d $BSDSRCDIR/usr.bin/pkill/Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ps.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ps.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, libkvm }:
+mkDerivation {
+  path = "bin/ps";
+
+  buildInputs = [ libkvm ];
+  postPatch = ''
+    sed -i /DPADD/d $BSDSRCDIR/bin/ps/Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/pwd.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/pwd.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/pwd";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/pwd_mkdb.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/pwd_mkdb.nix
@@ -1,0 +1,4 @@
+{ mkDerivation, ... }:
+mkDerivation {
+  path = "usr.sbin/pwd_mkdb";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/rm.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rm.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/rm";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/rmdir.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/rmdir.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/rmdir";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/route.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/route.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/route";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sed.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sed.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.bin/sed";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/shutdown.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/shutdown.nix
@@ -1,0 +1,8 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/shutdown";
+
+  preBuild = ''
+    sed -i 's/4550/0550/' Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/slaacctl.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/slaacctl.nix
@@ -1,0 +1,7 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "usr.sbin/slaacctl";
+
+  extraPaths = [ "sbin/slaacd" ];
+
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/slaacd.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/slaacd.nix
@@ -1,0 +1,15 @@
+{
+  mkDerivation,
+  libevent,
+  byacc,
+}:
+mkDerivation {
+  path = "sbin/slaacd";
+
+  postPatch = ''
+    sed -i 's/DPADD/#DPADD/' $BSDSRCDIR/sbin/slaacd/Makefile
+  '';
+
+  buildInputs = [ libevent ];
+  extraNativeBuildInputs = [ byacc ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sleep.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sleep.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/sleep";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/stty.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/stty.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/stty";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/su.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/su.nix
@@ -1,0 +1,12 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "usr.bin/su";
+
+  postPatch = ''
+    sed -i /BINMODE/d $BSDSRCDIR/usr.bin/su/Makefile
+  '';
+
+  meta.mainProgram = "su";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/swapctl.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/swapctl.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/swapctl";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sync.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sync.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/sync";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sysctl/no-perms.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sysctl/no-perms.patch
@@ -1,0 +1,13 @@
+diff --git a/sbin/sysctl/Makefile b/sbin/sysctl/Makefile
+index 6454e1dc888..53ddf3f3038 100644
+--- a/sbin/sysctl/Makefile
++++ b/sbin/sysctl/Makefile
+@@ -5,8 +5,4 @@ MAN=	sysctl.8
+ 
+ CPPFLAGS+=	-D_LIBKVM
+ 
+-afterinstall:
+-	ln -sf ../../sbin/sysctl ${DESTDIR}/usr/sbin
+-	chown -h ${BINOWN}:${BINGRP} ${DESTDIR}/usr/sbin/sysctl
+-
+ .include <bsd.prog.mk>

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sysctl/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sysctl/package.nix
@@ -1,0 +1,7 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "sbin/sysctl";
+  patches = [ ./no-perms.patch ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/sysctl/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/sysctl/package.nix
@@ -4,4 +4,5 @@
 mkDerivation {
   path = "sbin/sysctl";
   patches = [ ./no-perms.patch ];
+  meta.mainProgram = "sysctl";
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/syslogd.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/syslogd.nix
@@ -1,0 +1,17 @@
+{
+  mkDerivation,
+  libressl,
+  libevent,
+}:
+mkDerivation {
+  path = "usr.sbin/syslogd";
+
+  buildInputs = [
+    libressl
+    libevent
+  ];
+
+  postPatch = ''
+    sed -i /DPADD/d $BSDSRCDIR/usr.sbin/syslogd/Makefile
+  '';
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/test.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/test.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "bin/test";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/top.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/top.nix
@@ -1,0 +1,6 @@
+{ mkDerivation, libcurses }:
+mkDerivation {
+  path = "usr.bin/top";
+
+  buildInputs = [ libcurses ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/ttyflags/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/ttyflags/package.nix
@@ -1,0 +1,6 @@
+{
+  mkDerivation,
+}:
+mkDerivation {
+  path = "sbin/ttyflags";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/vmstat.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/vmstat.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, libkvm }:
+mkDerivation {
+  path = "usr.bin/vmstat";
+
+  buildInputs = [ libkvm ];
+  postPatch = ''
+    sed -i /DPADD/d $BSDSRCDIR/usr.bin/vmstat/Makefile
+  '';
+}

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -88,6 +88,7 @@ let
               else pkgs.netbsd.getent;
       darwin = pkgs.netbsd.getent;
       freebsd = pkgs.freebsd.getent;
+      openbsd = pkgs.openbsd.getent;
     };
     getopt = {
       linux = pkgs.util-linux;

--- a/pkgs/top-level/unixtools.nix
+++ b/pkgs/top-level/unixtools.nix
@@ -111,11 +111,13 @@ let
       linux = pkgs.nettools;
       darwin = pkgs.darwin.shell_cmds;
       freebsd = pkgs.freebsd.bin;
+      openbsd = pkgs.openbsd.hostname;
     };
     ifconfig = {
       linux = pkgs.nettools;
       darwin = pkgs.darwin.network_cmds;
       freebsd = pkgs.freebsd.ifconfig;
+      openbsd = pkgs.openbsd.ifconfig;
     };
     killall = {
       linux = pkgs.psmisc;
@@ -142,6 +144,7 @@ let
       linux = pkgs.util-linux;
       darwin = pkgs.darwin.diskdev_cmds;
       freebsd = freebsd.mount;
+      openbsd = pkgs.openbsd.mount;
       # technically just targeting the darwin version; binlore already
       # ids the util-linux copy as 'cannot'
       # no obvious exec in manpage args; I think binlore flags 'can'
@@ -164,6 +167,7 @@ let
       linux = pkgs.procps;
       darwin = pkgs.darwin.ps;
       freebsd = pkgs.freebsd.bin;
+      openbsd = pkgs.openbsd.ps;
       # technically just targeting procps ps (which ids as can)
       # but I don't see obvious exec in args; have yet to look
       # for underlying cause in source
@@ -179,6 +183,7 @@ let
       linux = pkgs.nettools;
       darwin = pkgs.darwin.network_cmds;
       freebsd = pkgs.freebsd.route;
+      openbsd = pkgs.openbsd.route;
     };
     script = {
       linux = pkgs.util-linux;
@@ -188,11 +193,13 @@ let
       linux = pkgs.procps;
       darwin = pkgs.darwin.system_cmds;
       freebsd = pkgs.freebsd.sysctl;
+      openbsd = pkgs.openbsd.sysctl;
     };
     top = {
       linux = pkgs.procps;
       darwin = pkgs.darwin.top;
       freebsd = pkgs.freebsd.top;
+      openbsd = pkgs.openbsd.top;
       # technically just targeting procps top; haven't needed this in
       # any scripts so far, but overriding it for consistency with ps
       # override above and in procps. (procps also overrides 'free',
@@ -219,6 +226,7 @@ let
       # Darwin/FreeBSD. Unfortunately no other implementations exist currently!
       darwin = pkgs.callPackage ../os-specific/linux/procps-ng {};
       freebsd = pkgs.callPackage ../os-specific/linux/procps-ng {};
+      openbsd = pkgs.callPackage ../os-specific/linux/procps-ng {};
     };
     write = {
       linux = pkgs.util-linux;


### PR DESCRIPTION
All of these packages are necessary for an OpenBSD system to boot.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
