### PR TITLE
openbsd.fsck: init

### DIFF
--- a/pkgs/os-specific/bsd/openbsd/pkgs/fsck.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/fsck.nix
@@ -1,0 +1,4 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/fsck";
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/fsck/fsck-path.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/fsck/fsck-path.patch
@@ -1,0 +1,25 @@
+diff --git a/sbin/fsck/fsck.c b/sbin/fsck/fsck.c
+index 19e730a484f..176d614d986 100644
+--- a/sbin/fsck/fsck.c
++++ b/sbin/fsck/fsck.c
+@@ -308,18 +308,8 @@ checkfs(const char *vfstype, const char *spec, const char *mntpt, void *auxarg,
+ 			_exit(0);
+ 
+ 		/* Go find an executable. */
+-		edir = edirs;
+-		do {
+-			(void)snprintf(execname,
+-			    sizeof(execname), "%s/fsck_%s", *edir, vfstype);
+-			execv(execname, (char * const *)argv);
+-			if (errno != ENOENT) {
+-				if (spec)
+-					warn("exec %s for %s", execname, spec);
+-				else
+-					warn("exec %s", execname);
+-			}
+-		} while (*++edir != NULL);
++		(void)snprintf(execname, sizeof(execname), "fsck_%s", vfstype);
++		execvp(execname, (char * const *)argv);
+ 
+ 		if (errno == ENOENT) {
+ 			if (spec)

--- a/pkgs/os-specific/bsd/openbsd/pkgs/fsck/fsck-path.patch
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/fsck/fsck-path.patch
@@ -1,8 +1,17 @@
 diff --git a/sbin/fsck/fsck.c b/sbin/fsck/fsck.c
-index 19e730a484f..176d614d986 100644
+index 19e730a484f..cb548971abd 100644
 --- a/sbin/fsck/fsck.c
 +++ b/sbin/fsck/fsck.c
-@@ -308,18 +308,8 @@ checkfs(const char *vfstype, const char *spec, const char *mntpt, void *auxarg,
+@@ -115,6 +115,8 @@ main(int argc, char *argv[])
+ 		err(1, "unveil %s", _PATH_FSTAB);
+ 	if (unveil("/sbin", "x") == -1)
+ 		err(1, "unveil /sbin");
++	if (unveil("/nix/store", "rx") == -1)
++		err(1, "unveil /nix/store");
+ 	if (pledge("stdio rpath wpath disklabel proc exec", NULL) == -1)
+ 		err(1, "pledge");
+ 
+@@ -308,18 +310,8 @@ checkfs(const char *vfstype, const char *spec, const char *mntpt, void *auxarg,
  			_exit(0);
  
  		/* Go find an executable. */

--- a/pkgs/os-specific/bsd/openbsd/pkgs/fsck/package.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/fsck/package.nix
@@ -1,4 +1,6 @@
 { mkDerivation }:
 mkDerivation {
   path = "sbin/fsck";
+
+  patches = [ ./fsck-path.patch ];
 }

--- a/pkgs/os-specific/bsd/openbsd/pkgs/fsck_ffs.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/fsck_ffs.nix
@@ -1,0 +1,8 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/fsck_ffs";
+  extraPaths = [
+    "sbin/fsck"
+    "sys/ufs/ffs"
+  ];
+}

--- a/pkgs/os-specific/bsd/openbsd/pkgs/fsck_msdos.nix
+++ b/pkgs/os-specific/bsd/openbsd/pkgs/fsck_msdos.nix
@@ -1,0 +1,5 @@
+{ mkDerivation }:
+mkDerivation {
+  path = "sbin/fsck_msdos";
+  extraPaths = [ "sbin/fsck" ];
+}


### PR DESCRIPTION
Adds OpenBSD's fsck + helper programs and patches it to work in a nix context.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
  - [x] x86_64-openbsd (cross)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
