### PR TITLE
casadi: unpin LLVM17

### DIFF
--- a/pkgs/by-name/ca/casadi/clang-19.diff
+++ b/pkgs/by-name/ca/casadi/clang-19.diff
@@ -1,0 +1,35 @@
+diff --git a/casadi/interfaces/clang/clang_compiler.hpp b/casadi/interfaces/clang/clang_compiler.hpp
+index 7f54853..9f8d4b1 100644
+--- a/casadi/interfaces/clang/clang_compiler.hpp
++++ b/casadi/interfaces/clang/clang_compiler.hpp
+@@ -52,7 +52,7 @@
+ #include "llvm/IR/LLVMContext.h"
+ //#include "llvm/IR/Verifier.h"
+ #include <llvm/Support/FileSystem.h>
+-#include <llvm/Support/Host.h>
++#include <llvm/TargetParser/Host.h>
+ #include <llvm/Support/ManagedStatic.h>
+ #include <llvm/Support/Path.h>
+ #include <llvm/Support/TargetSelect.h>
+diff --git a/cmake/FindCLANG.cmake b/cmake/FindCLANG.cmake
+index 4edf60b..f23a348 100644
+--- a/cmake/FindCLANG.cmake
++++ b/cmake/FindCLANG.cmake
+@@ -16,7 +16,7 @@ set(CLANG_CXX_FLAGS "-fPIC -fvisibility-inlines-hidden -ffunction-sections -fdat
+ set(CLANG_INCLUDE_DIR ${LLVM_INSTALL_PREFIX}/include)
+ 
+ # All clang libraries
+-set(CLANG_DEP clangFrontend clangDriver clangCodeGen clangRewriteFrontend clangSerialization clangParse clangSema clangAnalysis clangEdit clangAST clangLex clangBasic ${LLVM_DEP})
++set(CLANG_DEP clangFrontend clangDriver clangCodeGen clangRewriteFrontend clangSerialization clangParse clangSema clangAPINotes clangAnalysis clangEdit clangAST clangLex clangBasic ${LLVM_DEP})
+ 
+ # Get libraries
+ set(CLANG_LIBRARIES)
+@@ -86,7 +86,7 @@ set(CLANG_INCLUDE_DIR ${CLANG_LLVM_INCLUDE_DIR})
+ 
+ # All clang libraries
+ set(CLANG_DEP clangFrontend clangDriver clangCodeGen clangRewriteFrontend clangSerialization
+-              clangParse clangSema clangAnalysis clangEdit clangAST clangLex clangBasic)
++              clangParse clangSema clangAPINotes clangAnalysis clangEdit clangAST clangLex clangBasic)
+ 
+ # Get libraries
+ foreach(D ${CLANG_DEP})

--- a/pkgs/by-name/ca/casadi/package.nix
+++ b/pkgs/by-name/ca/casadi/package.nix
@@ -17,8 +17,9 @@
   lib,
   ipopt,
   lapack,
-  llvmPackages_17, # llvm/Support/Host.h required by casadi 3.6.5 and not available in llvm 18
+  llvmPackages,
   mumps,
+  ninja,
   osqp,
   pkg-config,
   pythonSupport ? false,
@@ -52,6 +53,9 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://github.com/casadi/casadi/pull/3899/commits/274f4b23f73e60c5302bec0479fe1e92682b63d2.patch";
       hash = "sha256-3GWEWlN8dKLD6htpnOQLChldcT3hE09JWLeuCfAhY+4=";
     })
+    # update include file path and link with clangAPINotes
+    # https://github.com/casadi/casadi/issues/3969
+    ./clang-19.diff
   ];
 
   postPatch =
@@ -64,7 +68,7 @@ stdenv.mkDerivation (finalAttrs: {
       # nix provide lib/clang headers in libclang, not in llvm.
       substituteInPlace casadi/interfaces/clang/CMakeLists.txt --replace-fail \
         '$'{CLANG_LLVM_LIB_DIR} \
-        ${lib.getLib llvmPackages_17.libclang}/lib
+        ${lib.getLib llvmPackages.libclang}/lib
 
       # help casadi find its own libs
       substituteInPlace casadi/core/casadi_os.cpp --replace-fail \
@@ -101,6 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     cmake
+    ninja
     pkg-config
   ];
 
@@ -118,9 +123,9 @@ stdenv.mkDerivation (finalAttrs: {
       hpipm
       ipopt
       lapack
-      llvmPackages_17.clang
-      llvmPackages_17.libclang
-      llvmPackages_17.llvm
+      llvmPackages.clang
+      llvmPackages.libclang
+      llvmPackages.llvm
       mumps
       osqp
       proxsuite
@@ -140,7 +145,7 @@ stdenv.mkDerivation (finalAttrs: {
       python3Packages.numpy
       python3Packages.python
     ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages_17.openmp ];
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ llvmPackages.openmp ];
 
   cmakeFlags = [
     (lib.cmakeBool "WITH_PYTHON" pythonSupport)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://github.com/casadi/casadi/issues/3969

LLVM-17 is broken on aarch64-linux https://github.com/NixOS/nixpkgs/issues/371077 thus breaking this and all packages relying on it.
https://hydra.nixos.org/build/281889288


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
