### PR TITLE
hatch: skip failing tests

### DIFF
--- a/pkgs/by-name/ha/hatch/package.nix
+++ b/pkgs/by-name/ha/hatch/package.nix
@@ -74,6 +74,19 @@ python3Packages.buildPythonApplication rec {
     export HOME=$(mktemp -d);
   '';
 
+  pytestFlagsArray = [
+    # AssertionError on the version metadata
+    # https://github.com/pypa/hatch/issues/1877
+    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_all"
+    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_license_expression"
+    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_all"
+    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_license_expression"
+    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_all"
+    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_expression"
+    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_files"
+    "--deselect=tests/backend/metadata/test_spec.py::TestProjectMetadataFromCoreMetadata::test_license_files"
+  ];
+
   disabledTests =
     [
       # AssertionError: assert (1980, 1, 2, 0, 0, 0) == (2020, 2, 2, 0, 0, 0)
@@ -117,14 +130,21 @@ python3Packages.buildPythonApplication rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isAarch64 [ "test_resolve" ];
 
-  disabledTestPaths = lib.optionals stdenv.hostPlatform.isDarwin [
-    # AssertionError: assert [call('test h...2p32/bin/sh')] == [call('test h..., shell=True)]
-    # At index 0 diff:
-    #    call('test hatch-test.py3.10', shell=True, executable='/nix/store/b34ianga4diikh0kymkpqwmvba0mmzf7-bash-5.2p32/bin/sh')
-    # != call('test hatch-test.py3.10', shell=True)
-    "tests/cli/fmt/test_fmt.py"
-    "tests/cli/test/test_test.py"
-  ];
+  disabledTestPaths =
+    [
+      # ModuleNotFoundError: No module named 'hatchling.licenses.parse'
+      # https://github.com/pypa/hatch/issues/1850
+      "tests/backend/licenses/test_parse.py"
+      "tests/backend/licenses/test_supported.py"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # AssertionError: assert [call('test h...2p32/bin/sh')] == [call('test h..., shell=True)]
+      # At index 0 diff:
+      #    call('test hatch-test.py3.10', shell=True, executable='/nix/store/b34ianga4diikh0kymkpqwmvba0mmzf7-bash-5.2p32/bin/sh')
+      # != call('test hatch-test.py3.10', shell=True)
+      "tests/cli/fmt/test_fmt.py"
+      "tests/cli/test/test_test.py"
+    ];
 
   passthru = {
     updateScript = nix-update-script {


### PR DESCRIPTION
## Things done

Fix `hatch` build by skipping failing tests.
They have all been reported upstream:
- https://github.com/pypa/hatch/issues/1850
- https://github.com/pypa/hatch/issues/1877

Fixes #366359

cc @onny

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
