### PR TITLE
nixos/tabby: fix invalid mkRemovedOptionModule import

### DIFF
--- a/nixos/modules/services/misc/tabby.nix
+++ b/nixos/modules/services/misc/tabby.nix
@@ -16,7 +16,8 @@ in
 {
   imports = [
     (mkRemovedOptionModule [
-      "settings"
+      "services"
+      "tabby"
       "indexInterval"
     ] "These options are now managed within the tabby WebGUI")
   ];


### PR DESCRIPTION
## Things done

Fixes an invalid `mkRemovedOptionModule` import in `nixos/tabby`.

Introduced in https://github.com/NixOS/nixpkgs/pull/364586 / 68d4a7df4998cc112d32f38c74bb6004070ee075, causes build failures on my system:
```
       … while calling the 'abort' builtin
         at /nix/store/4x5p45ib1jnjlchbdga18k9vg235kc8d-source/lib/attrsets.nix:322:26:
          321|     set:
          322|     attrByPath attrPath (abort ("cannot find attribute `" + concatStringsSep "." attrPath + "'")) set;
             |                          ^
          323|

       error: evaluation aborted with the following error message: 'cannot find attribute `settings.indexInterval''
```

EDIT: This seems to only be happening to me because I have a module from times of yore that uses `settings.*`. Regardless, it's wrong and should be fixed.

In the meantime, I've worked around it with:
```nix
        ({ ... }: {
          disabledModules = [
            "services/misc/tabby.nix"
          ];
        })
```
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
