### PR TITLE
airwin2rack: init at 2.13.0

### DIFF
--- a/pkgs/by-name/ai/airwin2rack/juce-clap-juce-extensions-src-juce-cmakelists.patch
+++ b/pkgs/by-name/ai/airwin2rack/juce-clap-juce-extensions-src-juce-cmakelists.patch
@@ -1,0 +1,36 @@
+diff --git a/src-juce/CMakeLists.txt b/src-juce/CMakeLists.txt
+index 1f41088..10bdbb4 100644
+--- a/src-juce/CMakeLists.txt
++++ b/src-juce/CMakeLists.txt
+@@ -1,28 +1,8 @@
+ # vi:set sw=2 et:
+ project(airwin-consolidated VERSION ${CMAKE_PROJECT_VERSION})
+ 
+-include ("../cmake/CPM.cmake")
+-
+-
+-if (DEFINED AWCO_ONJUCE7)
+-  set(AWCO_JUCETAG 7.0.12)
+-else()
+-  set(AWCO_JUCETAG 8.0.4)
+-endif()
+-
+-message(STATUS "Getting JUCE TAG ${AWCO_JUCETAG}")
+-CPMAddPackage(
+-        NAME JUCE
+-        GITHUB_REPOSITORY juce-framework/JUCE
+-        GIT_TAG ${AWCO_JUCETAG} # specify the tag to a version of your choice
+-)
+-
+-CPMAddPackage(
+-        NAME clap-juce-extensions
+-        GITHUB_REPOSITORY free-audio/clap-juce-extensions
+-        GIT_TAG main
+-        SUBMODULE_RECURSIVE ON
+-)
++add_subdirectory(juce)
++add_subdirectory(clap-juce-extensions)
+ 
+ if (NOT DEFINED AWCO_ARM64EC)
+   list(APPEND AWCO_FORMATS VST3)
+

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -214,12 +214,11 @@ stdenv.mkDerivation {
     description = "JUCE Plugin Version of Airwindows Consolidated";
     homepage = "https://airwindows.com/";
     platforms = [ "x86_64-linux" ];
-    license =
-      [ lib.licenses.mit ]
-      ++ lib.optional enableVCVRack [
-        lib.licenses.gpl3Plus
-        lib.licenses.cc-by-nc-40
-        lib.licenses.unfreeRedistributable
+    license = with lib.licenses
+      [ mit ] ++ lib.optional enableVCVRack [
+        gpl3Plus
+        cc-by-nc-40
+        unfreeRedistributable
       ];
     mainProgram = "Airwindows Consolidated";
     maintainers = [ lib.maintainers.l1npengtul ];

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -214,8 +214,10 @@ stdenv.mkDerivation {
     description = "JUCE Plugin Version of Airwindows Consolidated";
     homepage = "https://airwindows.com/";
     platforms = [ "x86_64-linux" ];
-    license = with lib.licenses
-      [ mit ] ++ lib.optional enableVCVRack [
+    license =
+      with lib.licenses;
+      [ mit ]
+      ++ lib.optional enableVCVRack [
         gpl3Plus
         cc-by-nc-40
         unfreeRedistributable

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation {
     owner = "baconpaul";
     repo = "airwin2rack";
     tag = "DAWPlugin";
-    hash = "sha256-utqDmQgnYUtUv0E0xhO5rGx+9RXTAn8kKhTzkyXjcbE=";
+    hash = "sha256-xjE9M5fMeOOYncq7xe+v++XvfUL6QZc2tF0jnYWSwKQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -80,8 +80,8 @@ stdenv.mkDerivation {
       copyDesktopItems
     ]
     ++ lib.optionals enableVCVRack [
-      pkgs.jq
-      pkgs.zstd
+      jq
+      zstd
     ];
 
   buildInputs =
@@ -136,7 +136,7 @@ stdenv.mkDerivation {
     ]
     ++ lib.optionals enableVCVRack [
       (lib.cmakeBool "BUILD_RACK_PLUGIN" true)
-      "-DRACK_SDK_DIR=${vcvRackSdk}"
+      (lib.cmakeFeature "RACK_SDK_DIR" "${vcvRackSdk}")
     ];
 
   cmakeBuildType = "Release";
@@ -153,7 +153,9 @@ stdenv.mkDerivation {
   preConfigure = lib.optionalString enableVCVRack ''export RACK_DIR=${vcvRackSdk}'';
 
   buildPhase = ''
+    runHook preBuild
     cmake --build . --target awcons-products ${lib.optionalString enableVCVRack "build_plugin"} --parallel $NIX_BUILD_CORES
+    runHook postBuild
   '';
 
   installPhase = ''

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -1,7 +1,6 @@
 {
   stdenv,
   fetchFromGitHub,
-  pkgs,
   lib,
   makeDesktopItem,
   copyDesktopItems,

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -51,7 +51,7 @@ let
     fetchSubmodules = true;
   };
 
-  vcvRackSdk = srcOnly pkgs.vcv-rack;
+  vcvRackSdk = srcOnly vcv-rack;
   pname = "airwin2rack";
   version = "2.13.0";
 in

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -30,6 +30,17 @@
   glib,
   gtk3-x11,
   curl,
+  vcv-rack,
+  jansson,
+  glew,
+  glfw,
+  libarchive,
+  speexdsp,
+  libpulseaudio,
+  libsamplerate,
+  rtmidi,
+  zstd,
+  jq,
   enableVCVRack ? false,
 }:
 let
@@ -117,16 +128,16 @@ stdenv.mkDerivation {
       sqlite
     ]
     ++ lib.optionals enableVCVRack [
-      pkgs.vcv-rack
-      pkgs.jansson
-      pkgs.glew
-      pkgs.glfw
-      pkgs.libarchive
-      pkgs.speexdsp
-      pkgs.libpulseaudio
-      pkgs.libsamplerate
-      pkgs.rtmidi
-      pkgs.zstd
+      vcv-rack
+      jansson
+      glew
+      glfw
+      libarchive
+      speexdsp
+      libpulseaudio
+      libsamplerate
+      rtmidi
+      zstd
     ];
 
   cmakeFlags =

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "baconpaul";
     repo = "airwin2rack";
-    rev = "db56d13f853831ab94a5e1713282e4e518f50d5c";
+    tag = "DAWPlugin";
     hash = "sha256-utqDmQgnYUtUv0E0xhO5rGx+9RXTAn8kKhTzkyXjcbE=";
     fetchSubmodules = true;
   };

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -41,7 +41,7 @@ let
     fetchSubmodules = true;
   };
 
-  vcvRackSdk = if enableVCVRack then (srcOnly pkgs.vcv-rack) else null;
+  vcvRackSdk = srcOnly pkgs.vcv-rack;
   pname = "airwin2rack";
   version = "2.13.0";
 in
@@ -150,7 +150,7 @@ stdenv.mkDerivation {
     ln -s ${clapJuceExtensions} src-juce/clap-juce-extensions
   '';
 
-  preConfigure = (lib.optionalString enableVCVRack ''export RACK_DIR=${vcvRackSdk}'');
+  preConfigure = lib.optionalString enableVCVRack ''export RACK_DIR=${vcvRackSdk}'';
 
   buildPhase = ''
     cmake --build . --target awcons-products ${lib.optionalString enableVCVRack "build_plugin"} --parallel $NIX_BUILD_CORES

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -42,11 +42,12 @@ let
   };
 
   vcvRackSdk = if enableVCVRack then (srcOnly pkgs.vcv-rack) else null;
-
-in
-stdenv.mkDerivation rec {
   pname = "airwin2rack";
   version = "2.13.0";
+in
+stdenv.mkDerivation {
+  inherit pname;
+  inherit version;
 
   src = fetchFromGitHub {
     owner = "baconpaul";

--- a/pkgs/by-name/ai/airwin2rack/package.nix
+++ b/pkgs/by-name/ai/airwin2rack/package.nix
@@ -1,0 +1,214 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  pkgs,
+  lib,
+  makeDesktopItem,
+  copyDesktopItems,
+  srcOnly,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  xorg,
+  freetype,
+  libGLU,
+  libjack2,
+  juce,
+  webkitgtk_4_0,
+  libsysprof-capture,
+  pcre2,
+  util-linux,
+  libselinux,
+  libsepol,
+  libthai,
+  libxkbcommon,
+  libdatrie,
+  libepoxy,
+  libsoup_2_4,
+  lerc,
+  sqlite,
+  glib,
+  gtk3-x11,
+  curl,
+  enableVCVRack ? false,
+}:
+let
+  clapJuceExtensions = fetchFromGitHub {
+    owner = "free-audio";
+    repo = "clap-juce-extensions";
+    rev = "4f33b4930b6af806018c009f0f24b3a50808af99";
+    hash = "sha256-M+T7ll3Ap6VIP5ub+kfEKwT2RW2IxxY4wUPRQKFIotk=";
+    fetchSubmodules = true;
+  };
+
+  vcvRackSdk = if enableVCVRack then (srcOnly pkgs.vcv-rack) else null;
+
+in
+stdenv.mkDerivation rec {
+  pname = "airwin2rack";
+  version = "2.13.0";
+
+  src = fetchFromGitHub {
+    owner = "baconpaul";
+    repo = "airwin2rack";
+    rev = "db56d13f853831ab94a5e1713282e4e518f50d5c";
+    hash = "sha256-utqDmQgnYUtUv0E0xhO5rGx+9RXTAn8kKhTzkyXjcbE=";
+    fetchSubmodules = true;
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "Airwin2rack";
+      desktopName = "Airwindows Consolidated";
+      comment = "Various Airwindows Plugins Consolidated (Standalone)";
+      exec = "Airwindows Consolidated";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  strictDeps = true;
+
+  nativeBuildInputs =
+    [
+      cmake
+      pkg-config
+      copyDesktopItems
+    ]
+    ++ lib.optionals enableVCVRack [
+      pkgs.jq
+      pkgs.zstd
+    ];
+
+  buildInputs =
+    [
+      alsa-lib
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXcursor
+      xorg.libXext
+      xorg.libXinerama
+      xorg.libXrandr
+      xorg.libXrender
+      xorg.libXtst
+      xorg.libXdmcp
+      libGLU
+      libjack2
+      freetype
+      webkitgtk_4_0
+      glib
+      gtk3-x11
+      curl
+      libsysprof-capture
+      pcre2
+      util-linux
+      libselinux
+      libsepol
+      libthai
+      libxkbcommon
+      libdatrie
+      libepoxy
+      libsoup_2_4
+      lerc
+      sqlite
+    ]
+    ++ lib.optionals enableVCVRack [
+      pkgs.vcv-rack
+      pkgs.jansson
+      pkgs.glew
+      pkgs.glfw
+      pkgs.libarchive
+      pkgs.speexdsp
+      pkgs.libpulseaudio
+      pkgs.libsamplerate
+      pkgs.rtmidi
+      pkgs.zstd
+    ];
+
+  cmakeFlags =
+    [
+      (lib.cmakeBool "BUILD_JUCE_PLUGIN" true)
+      (lib.cmakeBool "USE_JUCE_PROGRAMS" true)
+    ]
+    ++ lib.optionals enableVCVRack [
+      (lib.cmakeBool "BUILD_RACK_PLUGIN" true)
+      "-DRACK_SDK_DIR=${vcvRackSdk}"
+    ];
+
+  cmakeBuildType = "Release";
+
+  patches = [
+    ./juce-clap-juce-extensions-src-juce-cmakelists.patch
+  ];
+
+  prePatch = ''
+    ln -s ${juce.src} src-juce/juce
+    ln -s ${clapJuceExtensions} src-juce/clap-juce-extensions
+  '';
+
+  preConfigure = (lib.optionalString enableVCVRack ''export RACK_DIR=${vcvRackSdk}'');
+
+  buildPhase = ''
+    cmake --build . --target awcons-products ${lib.optionalString enableVCVRack "build_plugin"} --parallel $NIX_BUILD_CORES
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2 $out/lib/clap $out/bin
+
+    cp -r "awcons-products/Airwindows Consolidated.vst3" $out/lib/vst3
+    cp -r "awcons-products/Airwindows Consolidated.lv2" $out/lib/lv2
+    install -Dm644 "awcons-products/Airwindows Consolidated.clap" -t $out/lib/clap
+
+    install -Dm755 "awcons-products/Airwindows Consolidated" $out/bin/Airwindows\ Consolidated
+
+    ${lib.optionalString enableVCVRack ''
+      mkdir ../${pname}
+      strip -s plugin.so
+      mv plugin.so ../${pname}
+      cd ..
+      mv LICENSE.md ${pname}
+      mv README.md ${pname}
+      mv plugin.json ${pname}
+      mv res ${pname}
+      tar -c ${pname} | zstd -19 -o "${pname}-${version}-lin-x64.vcvplugin"
+      # got the directory from arch wiki
+      install -Dm755 "${pname}-${version}-lin-x64.vcvplugin" $out/usr/lib/vcvrack/plugins
+    ''}
+
+    runHook postInstall
+  '';
+
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcomposite"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-lXrender"
+      "-lXtst"
+      "-lXdmcp"
+    ]
+  );
+
+  meta = {
+    description = "JUCE Plugin Version of Airwindows Consolidated";
+    homepage = "https://airwindows.com/";
+    platforms = [ "x86_64-linux" ];
+    license =
+      [ lib.licenses.mit ]
+      ++ lib.optional enableVCVRack [
+        lib.licenses.gpl3Plus
+        lib.licenses.cc-by-nc-40
+        lib.licenses.unfreeRedistributable
+      ];
+    mainProgram = "Airwindows Consolidated";
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Creates a package for airwin2rack, aka Airwindows Consolidated, which is a port of all Airwindows plugins to JUCE and VCVRack. 

You can read more about it [from the github](https://github.com/baconpaul/airwin2rack) and [at airwindows](https://www.airwindows.com/consolidated/). For now, only builds for windows. 

For VCVRack, the resulting output is saved to `$out/usr/lib/vcvrack/plugins`. 

VCVRack is gated behind the input `enableVCVRack` which defaults to false.

The patch file is needed due to the original using CPM, which will attempt to pull from the internet (which isn't allowed). Instead, needed items are symlinked.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
