### PR TITLE
ucspi-tcp: use debian's 0.88-11 patch set

### DIFF
--- a/pkgs/by-name/uc/ucspi-tcp/package.nix
+++ b/pkgs/by-name/uc/ucspi-tcp/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenv,
   fetchurl,
+  fetchzip,
+  quilt,
 }:
 
 stdenv.mkDerivation rec {
@@ -13,21 +15,22 @@ stdenv.mkDerivation rec {
     sha256 = "171yl9kfm8w7l17dfxild99mbf877a9k5zg8yysgb1j8nz51a1ja";
   };
 
-  # Plain upstream tarball doesn't build, get patches from Debian
   patches = [
-    (fetchurl {
-      url = "http://ftp.de.debian.org/debian/pool/main/u/ucspi-tcp/ucspi-tcp_0.88-3.diff.gz";
-      sha256 = "0mzmhz8hjkrs0khmkzs5i0s1kgmgaqz07h493bd5jj5fm5njxln6";
-    })
     ./remove-setuid.patch
   ];
 
-  # Apply Debian patches
+  debian = fetchzip {
+    url = "http://ftp.de.debian.org/debian/pool/main/u/ucspi-tcp/ucspi-tcp_0.88-11.debian.tar.xz";
+    sha256 = "0x8h46wkm62dvyj1acsffcl4s06k5zh6139qxib3zzhk716hv5xg";
+  };
+
+  nativeBuildInputs = [
+    quilt
+  ];
+
+  # Plain upstream tarball doesn't build, apply patches from Debian
   postPatch = ''
-    for fname in debian/diff/*.diff; do
-        echo "Applying patch $fname"
-        patch < "$fname"
-    done
+    QUILT_PATCHES=$debian/patches quilt push -a
   '';
 
   # The build system is weird; 'make install' doesn't install anything, instead
@@ -40,7 +43,7 @@ stdenv.mkDerivation rec {
   preBuild = ''
     echo "$out" > conf-home
 
-    echo "main() { return 0; }" > chkshsgr.c
+    echo "int main() { return 0; }" > chkshsgr.c
   '';
 
   installPhase = ''
@@ -51,7 +54,7 @@ stdenv.mkDerivation rec {
     ./install
 
     # Install Debian man pages (upstream has none)
-    cp debian/ucspi-tcp-man/*.1 "$out/share/man/man1"
+    cp $debian/ucspi-tcp-man/*.1 "$out/share/man/man1"
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Use Debian's most current patches to allow building ucspi-tcp again.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
