### PR TITLE
buildFHSEnv: allow specifying `executableName` explicitly

### DIFF
--- a/doc/build-helpers/special/fhs-environments.section.md
+++ b/doc/build-helpers/special/fhs-environments.section.md
@@ -6,11 +6,13 @@ It uses Linux' namespaces feature to create temporary lightweight environments w
 Accepted arguments are:
 
 - `name`
-        The name of the environment, and the wrapper executable if `pname` is unset.
+        The name of the environment.
 - `pname`
-        The pname of the environment and the wrapper executable.
+        The pname of the environment.
 - `version`
         The version of the environment.
+- `executableName`
+        The name of the wrapper executable. Defaults to `pname` if set, or `name` otherwise.
 - `targetPkgs`
         Packages to be installed for the main host's architecture (i.e. x86_64 on x86_64 installations). Along with libraries binaries are also installed.
 - `multiPkgs`

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -12,10 +12,13 @@
 }:
 
 {
+  pname ? throw "You must provide either `name` or `pname`",
+  version ? throw "You must provide either `name` or `version`",
+  name ? "${pname}-${version}",
   runScript ? "bash",
   nativeBuildInputs ? [ ],
   extraInstallCommands ? "",
-  executableName ? args.pname or args.name,
+  executableName ? args.pname or name,
   meta ? { },
   passthru ? { },
   extraPreBwrapCmds ? "",
@@ -31,7 +34,12 @@
   ...
 }@args:
 
-assert (!args ? pname || !args ? version) -> (args ? name); # You must provide name if pname or version (preferred) is missing.
+# NOTE:
+# `pname` and `version` will throw if they were not provided.
+# Use `name` instead of directly evaluating `pname` or `version`.
+#
+# If you need `pname` or `version` sepcifically, use `args` instead:
+# e.g. `args.pname or ...`.
 
 let
   inherit (lib)
@@ -49,7 +57,6 @@ let
   # explicit about which package set it's coming from.
   inherit (pkgsHostTarget) pkgsi686Linux;
 
-  name = args.name or "${args.pname}-${args.version}";
   # we don't know which have been supplied, and want to avoid defaulting missing attrs to null. Passed into runCommandLocal
   nameAttrs = lib.filterAttrs (
     key: value:

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -15,6 +15,7 @@
   runScript ? "bash",
   nativeBuildInputs ? [ ],
   extraInstallCommands ? "",
+  executableName ? args.pname or args.name,
   meta ? { },
   passthru ? { },
   extraPreBwrapCmds ? "",
@@ -49,7 +50,6 @@ let
   inherit (pkgsHostTarget) pkgsi686Linux;
 
   name = args.name or "${args.pname}-${args.version}";
-  executableName = args.pname or args.name;
   # we don't know which have been supplied, and want to avoid defaulting missing attrs to null. Passed into runCommandLocal
   nameAttrs = lib.filterAttrs (
     key: value:


### PR DESCRIPTION
Motivated by https://github.com/NixOS/nixpkgs/pull/369259/files#r1902238426, allows packages to specify a different exe name & pname.

Also simplified some logic with the name fallback, making it clearer what function args are available.

Tested with:
```sh
nix-build -A tests.buildFHSEnv
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
