### PR TITLE
nixos/caddy: Fix default log file for http:// hostnames

### DIFF
--- a/nixos/modules/services/web-servers/caddy/vhost-options.nix
+++ b/nixos/modules/services/web-servers/caddy/vhost-options.nix
@@ -58,7 +58,7 @@ in
     logFormat = mkOption {
       type = types.lines;
       default = ''
-        output file ${cfg.logDir}/access-${config.hostName}.log
+        output file ${cfg.logDir}/access-${lib.replaceStrings [ "/" " " ] [ "_" "_" ] config.hostName}.log
       '';
       defaultText = ''
         output file ''${config.services.caddy.logDir}/access-''${hostName}.log

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -41,6 +41,11 @@ import ./make-test-python.nix (
               "http://localhost:8081" = { };
             };
           };
+          specialisation.multiple-hostnames.configuration = {
+            services.caddy.virtualHosts = {
+              "http://localhost:8080 http://localhost:8081" = { };
+            };
+          };
           specialisation.rfc42.configuration = {
             services.caddy.settings = {
               apps.http.servers.default = {
@@ -93,6 +98,7 @@ import ./make-test-python.nix (
         explicitConfigFile = "${nodes.webserver.system.build.toplevel}/specialisation/explicit-config-file";
         justReloadSystem = "${nodes.webserver.system.build.toplevel}/specialisation/config-reload";
         multipleConfigs = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-configs";
+        multipleHostnames = "${nodes.webserver.system.build.toplevel}/specialisation/multiple-hostnames";
         rfc42Config = "${nodes.webserver.system.build.toplevel}/specialisation/rfc42";
         withPluginsConfig = "${nodes.webserver.system.build.toplevel}/specialisation/with-plugins";
       in
@@ -113,6 +119,13 @@ import ./make-test-python.nix (
         with subtest("multiple configs are correctly merged"):
             webserver.succeed(
                 "${multipleConfigs}/bin/switch-to-configuration test >&2"
+            )
+            webserver.wait_for_open_port(8080)
+            webserver.wait_for_open_port(8081)
+
+        with subtest("a virtual host with multiple hostnames works"):
+            webserver.succeed(
+                "${multipleHostnames}/bin/switch-to-configuration test >&2"
             )
             webserver.wait_for_open_port(8080)
             webserver.wait_for_open_port(8081)

--- a/nixos/tests/caddy.nix
+++ b/nixos/tests/caddy.nix
@@ -70,7 +70,7 @@ import ./make-test-python.nix (
             services.caddy = {
               package = pkgs.caddy.withPlugins {
                 plugins = [ "github.com/caddyserver/replace-response@v0.0.0-20241211194404-3865845790a7" ];
-                hash = "sha256-zgMdtOJbmtRSfTlrrg8njr11in2C7OAXLB+34V23jek=";
+                hash = "sha256-BorJJWICgAWU7DrpDZJWifMnIYtGWldt/4S1VELwGJI=";
               };
               configFile = pkgs.writeText "Caddyfile" ''
                 {


### PR DESCRIPTION
Caddy hostnames can begin with http:// to disable automatic HTTPS. The default value for `services.caddy.<host>.logFormat` puts the hostname in the log filename, resulting in a broken path.

Since version 2.9.0 (commit 7c52e7a), caddy fails to start if it cannot open the log file. This caused NixOS test failures (e.g., nixosTests.dokuwiki).

See also https://github.com/NixOS/nixpkgs/pull/327743

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
