### PR TITLE
pmix: fix cross build

### DIFF
--- a/pkgs/by-name/pm/pmix/package.nix
+++ b/pkgs/by-name/pm/pmix/package.nix
@@ -86,7 +86,7 @@ stdenv.mkDerivation (finalAttrs: {
       # Pin the compiler to the current version in a cross compiler friendly way.
       # Same pattern as for openmpi (see https://github.com/NixOS/nixpkgs/pull/58964#discussion_r275059427).
       substituteInPlace "''${!outputDev}"/share/pmix/pmixcc-wrapper-data.txt \
-        --replace-fail compiler=gcc \
+        --replace-fail compiler=${stdenv.cc.targetPrefix}gcc \
           compiler=${targetPackages.stdenv.cc}/bin/${targetPackages.stdenv.cc.targetPrefix}cc
     '';
 


### PR DESCRIPTION
Did not test whether the cross build actually works.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).