### PR TITLE
airwindows: init at 0-unstable-2025-01-06

### DIFF
--- a/pkgs/by-name/ai/airwindows/cmakelists-and-helper.patch
+++ b/pkgs/by-name/ai/airwindows/cmakelists-and-helper.patch
@@ -1,0 +1,31 @@
+diff --git a/plugins/LinuxVST/CMakeLists.txt b/plugins/LinuxVST/CMakeLists.txt
+index f43ea128..b87a5c03 100755
+--- a/plugins/LinuxVST/CMakeLists.txt
++++ b/plugins/LinuxVST/CMakeLists.txt
+@@ -2,11 +2,24 @@ cmake_minimum_required(VERSION 3.9)
+ project(airwindows_ports)
+ 
+ set(CMAKE_CXX_STANDARD 14)
+-add_compile_options(-O2 -D__cdecl=)
++add_compile_options(-D__cdecl=)
++
++set(VST2_SDK_PATH "${PROJECT_SOURCE_DIR}/include/vstsdk" CACHE STRING "VST2 SDK Path")
++
++set(VSTSDK_ROOT
++    "${VST2_SDK_PATH}"
++    "${VST2_SDK_PATH}/pluginterfaces/vst2.x/"
++    "${VST2_SDK_PATH}/public.sdk/source/vst2.x/"
++)
++
++set(VSTSDK_SOURCES
++    "${VST2_SDK_PATH}/public.sdk/source/vst2.x/audioeffectx.cpp"
++    "${VST2_SDK_PATH}/public.sdk/source/vst2.x/audioeffect.cpp"
++    "${VST2_SDK_PATH}/public.sdk/source/vst2.x/vstplugmain.cpp"
++)
+ 
+ include(Helpers.cmake)
+ 
+-add_subdirectory(include/vstsdk)
+ add_airwindows_plugin(Acceleration)
+ add_airwindows_plugin(Acceleration2)
+ add_airwindows_plugin(ADClip7)

--- a/pkgs/by-name/ai/airwindows/package.nix
+++ b/pkgs/by-name/ai/airwindows/package.nix
@@ -66,9 +66,12 @@ stdenv.mkDerivation {
   ];
 
   installPhase = ''
-    mkdir -p $out/lib/vst/airwindows
+    runHook preInstall
 
+    mkdir -p $out/lib/vst/airwindows
     find "$PWD" -type f -name "*.so" -exec install -Dm755 {} $out/lib/vst/airwindows \;
+
+    runHook postInstall
   '';
 
   passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };

--- a/pkgs/by-name/ai/airwindows/package.nix
+++ b/pkgs/by-name/ai/airwindows/package.nix
@@ -1,0 +1,86 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  fetchzip,
+  lib,
+  cmake,
+  nix-update-script,
+}:
+let
+  # adapted from oxefmsynth
+  vst-sdk = stdenv.mkDerivation {
+    dontConfigure = true;
+    dontPatch = true;
+    dontBuild = true;
+    dontStrip = true;
+    dontPatchELF = true;
+
+    name = "vstsdk3610_11_06_2018_build_37";
+    src = fetchzip {
+      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/vstsdk3610_11_06_2018_build_37.zip";
+      sha256 = "0da16iwac590wphz2sm5afrfj42jrsnkr1bxcy93lj7a369ildkj";
+    };
+
+    installPhase = ''
+      cp -r VST2_SDK $out
+    '';
+  };
+in
+stdenv.mkDerivation {
+  pname = "airwindows";
+  version = "0-unstable-2025-01-06";
+
+  src = fetchFromGitHub {
+    owner = "airwindows";
+    repo = "airwindows";
+    rev = "0ca33035253b9fc0c6c876592d9e5ff3a654cd10";
+    hash = "sha256-+AyB6y179BRWTvflA9Ld5utpF2scSJDszkGa8BCvPdM=";
+  };
+
+  # we patch helpers because honestly im spooked out by where those variables
+  # came from.
+  prePatch = ''
+    mkdir -p plugins/LinuxVST/include
+    ln -s ${vst-sdk.out} plugins/LinuxVST/include/vstsdk
+  '';
+
+  patches = [
+    ./cmakelists-and-helper.patch
+  ];
+
+  # we are building for linux, so we go to linux
+  preConfigure = ''
+    cd plugins/LinuxVST
+  '';
+
+  cmakeBuildType = "Release";
+
+  cmakeFlags = [ ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    vst-sdk
+  ];
+
+  installPhase = ''
+    mkdir -p $out/lib/vst/airwindows
+
+    find "$PWD" -type f -name "*.so" -exec install -Dm755 {} $out/lib/vst/airwindows \;
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "All Airwindows VST Plugins";
+    homepage = "https://airwindows.com/";
+    platforms = lib.platforms.linux;
+    license = [
+      lib.licenses.mit
+      lib.licenses.unfree
+    ];
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Airwindows is a collection of GUI-less free plugins. This adds them to nixpkgs. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
