### PR TITLE
pnpm_10: init at 10.0.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -182,6 +182,8 @@
 
 - `linuxPackages.nvidiaPackages.dc_520` has been removed since it is marked broken and there are better newer alternatives.
 
+- `pnpm` was updated to version 10. If your project is incompatible, you can install the previous version from the package attribute `pnpm_9`.
+
 - `programs.less.lessopen` is now null by default. To restore the previous behaviour, set it to `''|${lib.getExe' pkgs.lesspipe "lesspipe.sh"} %s''`.
 
 - `hardware.pulseaudio` has been renamed to `services.pulseaudio`.  The deprecated option names will continue to work, but causes a warning.

--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -5,7 +5,7 @@
 , copyDesktopItems
 , electron
 , nodejs
-, pnpm
+, pnpm_9
 , makeDesktopItem
 , autoSignDarwinBinariesHook
 , nix-update-script
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-07lf9jy22JUT+Vc5y9Tu1nkWaXU5RTdu3GibcvQsSs8=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-LPsNRd1c/cQeyBn3LZKnKeAsZ981sOkLYTnXIZL82LA=";
   };
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   nativeBuildInputs = [
-    makeWrapper nodejs pnpm.configHook
+    makeWrapper nodejs pnpm_9.configHook
   ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     copyDesktopItems
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/ap/apache-answer/package.nix
+++ b/pkgs/by-name/ap/apache-answer/package.nix
@@ -2,7 +2,7 @@
   buildGoModule,
   lib,
   fetchFromGitHub,
-  pnpm,
+  pnpm_9,
   nodejs,
   fetchpatch,
   stdenv,
@@ -25,14 +25,14 @@ buildGoModule rec {
 
     sourceRoot = "${src.name}/ui";
 
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = pnpm_9.fetchDeps {
       inherit src version pname;
       sourceRoot = "${src.name}/ui";
       hash = "sha256-/se6IWeHdazqS7PzOpgtT4IxCJ1WptqBzZ/BdmGb4BA=";
     };
 
     nativeBuildInputs = [
-      pnpm.configHook
+      pnpm_9.configHook
       nodejs
     ];
 

--- a/pkgs/by-name/as/astro-language-server/package.nix
+++ b/pkgs/by-name/as/astro-language-server/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm,
+  pnpm_9,
   nodejs_22,
 }:
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-NBLUeg1WqxTXtu8eg1fihQSfm8koYAEWhfXAj/fIdC8=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs)
       pname
       version
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     nodejs_22
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   buildInputs = [ nodejs_22 ];

--- a/pkgs/by-name/cl/clash-verge-rev/webui.nix
+++ b/pkgs/by-name/cl/clash-verge-rev/webui.nix
@@ -2,7 +2,7 @@
   version,
   src,
   pname,
-  pnpm,
+  pnpm_9,
   nodejs,
   stdenv,
   meta,
@@ -11,14 +11,14 @@
 stdenv.mkDerivation {
   inherit version src meta;
   pname = "${pname}-webui";
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = npm-hash;
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   postPatch = ''

--- a/pkgs/by-name/da/daed/package.nix
+++ b/pkgs/by-name/da/daed/package.nix
@@ -1,5 +1,5 @@
 {
-  pnpm,
+  pnpm_9,
   nodejs,
   stdenv,
   clang,
@@ -22,14 +22,14 @@ let
   web = stdenv.mkDerivation {
     inherit pname version src;
 
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = pnpm_9.fetchDeps {
       inherit pname version src;
       hash = "sha256-vqkiZzd5WOeJem0zUyMsJd6/aHHAjlsIQMkNf+SUvHY=";
     };
 
     nativeBuildInputs = [
       nodejs
-      pnpm.configHook
+      pnpm_9.configHook
     ];
 
     buildPhase = ''

--- a/pkgs/by-name/fl/flood/package.nix
+++ b/pkgs/by-name/fl/flood/package.nix
@@ -2,7 +2,7 @@
 , buildNpmPackage
 , fetchFromGitHub
 , nixosTests
-, pnpm
+, pnpm_9
 , nix-update-script
 }:
 
@@ -17,9 +17,9 @@ buildNpmPackage rec {
     hash = "sha256-lm+vPo7V99OSUAVEvdiTNMlD/+iHGPIyPLc1WzO1aTU=";
   };
 
-  npmConfigHook = pnpm.configHook;
+  npmConfigHook = pnpm_9.configHook;
   npmDeps = pnpmDeps;
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-NuU9O3bEboxmuEuk1WSUeZRNgVK5cwFiUAN3+7vACGw=";
   };

--- a/pkgs/by-name/fo/follow/package.nix
+++ b/pkgs/by-name/fo/follow/package.nix
@@ -6,7 +6,7 @@
   makeDesktopItem,
   makeWrapper,
   nodejs,
-  pnpm,
+  pnpm_9,
   stdenv,
 }:
 stdenv.mkDerivation rec {
@@ -23,12 +23,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
     makeWrapper
     imagemagick
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-FzMjN0rIjYxexf6tix4qi3mnuPkadjKihhN0Pj5y2nU=";
   };

--- a/pkgs/by-name/fr/froide/package.nix
+++ b/pkgs/by-name/fr/froide/package.nix
@@ -5,7 +5,7 @@
   makeWrapper,
   gdal,
   geos,
-  pnpm,
+  pnpm_9,
   nodejs,
   postgresql,
   postgresqlTestHook,
@@ -42,7 +42,7 @@ python.pkgs.buildPythonApplication rec {
   nativeBuildInputs = [
     makeWrapper
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   dependencies = with python.pkgs; [
@@ -99,7 +99,7 @@ python.pkgs.buildPythonApplication rec {
     websockets
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-DMoaXNm5S64XBERHFnFM6IKBkzXRGDEYWSTruccK9Hc=";
   };

--- a/pkgs/by-name/gi/gitify/package.nix
+++ b/pkgs/by-name/gi/gitify/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm,
+  pnpm_9,
   nodejs,
   electron,
   makeDesktopItem,
@@ -25,13 +25,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
     copyDesktopItems
     imagemagick
     makeWrapper
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-I78AvOBdDd59eVJJ51xxNwVvMnNvLdJJpFEtE/I1H8U=";
   };

--- a/pkgs/by-name/go/goofcord/package.nix
+++ b/pkgs/by-name/go/goofcord/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm,
+  pnpm_9,
   nodejs_22,
   nix-update-script,
   electron,
@@ -14,7 +14,7 @@
 }:
 
 let
-  pnpm' = pnpm.override { nodejs = nodejs_22; };
+  pnpm' = pnpm_9.override { nodejs = nodejs_22; };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "goofcord";

--- a/pkgs/by-name/gu/gui-for-clash/package.nix
+++ b/pkgs/by-name/gu/gui-for-clash/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   nodejs,
-  pnpm,
+  pnpm_9,
   fetchFromGitHub,
   buildGoModule,
   lib,
@@ -30,10 +30,10 @@ let
 
     nativeBuildInputs = [
       nodejs
-      pnpm.configHook
+      pnpm_9.configHook
     ];
 
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/frontend";
       hash = "sha256-mG8b16PP876EyaX3Sc4WM41Yc/oDGZDiilZPaxPvvuQ=";

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   nodejs,
-  pnpm,
+  pnpm_9,
   fetchFromGitHub,
   buildGoModule,
   lib,
@@ -30,10 +30,10 @@ let
 
     nativeBuildInputs = [
       nodejs
-      pnpm.configHook
+      pnpm_9.configHook
     ];
 
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/frontend";
       hash = "sha256-dLI1YMzs9lLk9lJBkBgc6cpirM79khy0g5VaOVEzUAc=";

--- a/pkgs/by-name/ho/homebox/package.nix
+++ b/pkgs/by-name/ho/homebox/package.nix
@@ -2,7 +2,7 @@
   lib,
   buildGo123Module,
   fetchFromGitHub,
-  pnpm,
+  pnpm_9,
   nodejs,
   go_1_23,
   git,
@@ -35,7 +35,7 @@ buildGo123Module {
     preBuild = "";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version;
     src = "${src}/frontend";
     hash = "sha256-x7sWSH84UJEXNRLCgEgXc4NrTRsn6OplANi+XGtIN9Y=";
@@ -56,8 +56,8 @@ buildGo123Module {
   '';
 
   nativeBuildInputs = [
-    pnpm
-    pnpm.configHook
+    pnpm_9
+    pnpm_9.configHook
     nodejs
   ];
 

--- a/pkgs/by-name/ho/homer/package.nix
+++ b/pkgs/by-name/ho/homer/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
-  pnpm,
+  pnpm_9,
   nodejs,
   dart-sass,
   nix-update-script,
@@ -17,7 +17,7 @@ stdenvNoCC.mkDerivation rec {
     hash = "sha256-nOhovVqWlHPunwruJrgqFhhDxccKBp/iEyB3Y3C5Cz8=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit
       pname
       version
@@ -33,7 +33,7 @@ stdenvNoCC.mkDerivation rec {
   nativeBuildInputs = [
     nodejs
     dart-sass
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/le/legcord/package.nix
+++ b/pkgs/by-name/le/legcord/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  pnpm,
+  pnpm_9,
   nodejs,
   electron_32,
   makeWrapper,
@@ -22,13 +22,13 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    pnpm.configHook
+    pnpm_9.configHook
     nodejs
     makeWrapper
     copyDesktopItems
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-QTePf/QE85OzXIcnwLJsCJJyRxwoV+FNef2Z9nAt35E=";
   };

--- a/pkgs/by-name/me/metacubexd/package.nix
+++ b/pkgs/by-name/me/metacubexd/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   nix-update-script,
   nodejs,
-  pnpm,
+  pnpm_9,
   stdenv,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -18,11 +18,11 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    pnpm.configHook
+    pnpm_9.configHook
     nodejs
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-aw8Sh4BecQ09rC0OLWebdWc7D/LE8vPs9uqh6w5G/FM=";
   };

--- a/pkgs/by-name/mi/misskey/package.nix
+++ b/pkgs/by-name/mi/misskey/package.nix
@@ -4,7 +4,7 @@
   nixosTests,
   fetchFromGitHub,
   nodejs,
-  pnpm,
+  pnpm_9,
   makeWrapper,
   python3,
   bash,
@@ -30,13 +30,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
     makeWrapper
     python3
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild.xcrun ];
 
   # https://nixos.org/manual/nixpkgs/unstable/#javascript-pnpm
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-YWZhm5eKjB6JGP45WC3UrIkr7vuBUI4Q3oiK8Lst3dI=";
   };
@@ -87,7 +87,7 @@ stdenv.mkDerivation (finalAttrs: {
       # Otherwise, maybe somehow bindmount a writable directory into <package>/data/files.
       ln -s /var/lib/misskey $out/data/files
 
-      makeWrapper ${pnpm}/bin/pnpm $out/bin/misskey \
+      makeWrapper ${pnpm_9}/bin/pnpm $out/bin/misskey \
         --run "${checkEnvVarScript} || exit" \
         --chdir $out/data \
         --add-flags run \
@@ -95,7 +95,7 @@ stdenv.mkDerivation (finalAttrs: {
         --prefix PATH : ${
           lib.makeBinPath [
             nodejs
-            pnpm
+            pnpm_9
             bash
           ]
         } \

--- a/pkgs/by-name/mo/moonfire-nvr/package.nix
+++ b/pkgs/by-name/mo/moonfire-nvr/package.nix
@@ -10,7 +10,7 @@
   moonfire-nvr,
   darwin,
   nodejs,
-  pnpm,
+  pnpm_9,
 }:
 
 let
@@ -28,9 +28,9 @@ let
     sourceRoot = "${src.name}/ui";
     nativeBuildInputs = [
       nodejs
-      pnpm.configHook
+      pnpm_9.configHook
     ];
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname version src;
       sourceRoot = "${finalAttrs.src.name}/ui";
       hash = "sha256-7fMhUFlV5lz+A9VG8IdWoc49C2CTdLYQlEgBSBqJvtw=";

--- a/pkgs/by-name/n8/n8n/package.nix
+++ b/pkgs/by-name/n8/n8n/package.nix
@@ -4,7 +4,7 @@
   nixosTests,
   fetchFromGitHub,
   nodejs,
-  pnpm,
+  pnpm_9,
   python3,
   node-gyp,
   xcbuild,
@@ -25,13 +25,13 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-gPdJKVOZlizdS0o+2nBgCImnIhtHzRjE2xk0zJA52go=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-Am9R2rfQiw1IPd22/UraqzEqvVeB5XuSrrLSYXWsWfU=";
   };
 
   nativeBuildInputs = [
-    pnpm.configHook
+    pnpm_9.configHook
     python3 # required to build sqlite3 bindings
     node-gyp # required to build sqlite3 bindings
     makeWrapper

--- a/pkgs/by-name/oc/ocis/package.nix
+++ b/pkgs/by-name/oc/ocis/package.nix
@@ -5,7 +5,7 @@
   buildGoModule,
   callPackage,
   gnumake,
-  pnpm,
+  pnpm_9,
   nodejs,
   ocis,
 }:
@@ -44,10 +44,10 @@ buildGoModule rec {
   nativeBuildInputs = [
     gnumake
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     sourceRoot = "${src.name}/services/idp";
     hash = "sha256-gNlN+u/bobnTsXrsOmkDcWs67D/trH3inT5AVQs3Brs=";

--- a/pkgs/by-name/oc/ocis/web.nix
+++ b/pkgs/by-name/oc/ocis/web.nix
@@ -2,7 +2,7 @@
   lib,
   stdenvNoCC,
   nodejs,
-  pnpm,
+  pnpm_9,
   fetchFromGitHub,
 }:
 stdenvNoCC.mkDerivation rec {
@@ -18,7 +18,7 @@ stdenvNoCC.mkDerivation rec {
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   buildPhase = ''
@@ -34,7 +34,7 @@ stdenvNoCC.mkDerivation rec {
     runHook postInstall
   '';
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-3Erva6srdkX1YQ727trx34Ufx524nz19MUyaDQToz6M=";
   };

--- a/pkgs/by-name/ov/overlayed/webui.nix
+++ b/pkgs/by-name/ov/overlayed/webui.nix
@@ -4,21 +4,21 @@
   version,
   stdenv,
   nodejs,
-  pnpm,
+  pnpm_9,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   inherit version src meta;
   pname = "overlayed-webui";
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) src pname version;
     hash = "sha256-+yyxoodcDfqJ2pkosd6sMk77/71RDsGthedo1Oigwto=";
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/pa/parca/package.nix
+++ b/pkgs/by-name/pa/parca/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   lib,
   nodejs,
-  pnpm,
+  pnpm_9,
   stdenv,
 }:
 let
@@ -22,7 +22,7 @@ let
     pname = "parca-ui";
     src = "${parca-src}/ui";
 
-    pnpmDeps = pnpm.fetchDeps {
+    pnpmDeps = pnpm_9.fetchDeps {
       inherit (finalAttrs) pname src version;
       hash = "sha256-MVNO24Oksy/qRUmEUoWoviQEo6Eimb18ZnDj5Z1vJkY=";
     };
@@ -30,7 +30,7 @@ let
     nativeBuildInputs = [
       faketty
       nodejs
-      pnpm.configHook
+      pnpm_9.configHook
     ];
 
     # faketty is required to work around a bug in nx.

--- a/pkgs/by-name/pg/pgrok/package.nix
+++ b/pkgs/by-name/pg/pgrok/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   nodejs,
-  pnpm,
+  pnpm_9,
 }:
 
 let
@@ -28,10 +28,10 @@ buildGoModule {
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-xObDEkNGMXcUqX9thAJoE45yzd7f15k2odDWv9X3RRE=";
   };

--- a/pkgs/by-name/pi/piped/package.nix
+++ b/pkgs/by-name/pi/piped/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildNpmPackage,
-  pnpm,
+  pnpm_9,
   fetchFromGitHub,
   unstableGitUpdater,
 }:
@@ -17,7 +17,7 @@ buildNpmPackage rec {
     hash = "sha256-o3TwE0s5rim+0VKR+oW9Rv3/eQRf2dgRQK4xjZ9pqCE=";
   };
 
-  npmConfigHook = pnpm.configHook;
+  npmConfigHook = pnpm_9.configHook;
 
   installPhase = ''
     runHook preInstall
@@ -26,7 +26,7 @@ buildNpmPackage rec {
   '';
 
   npmDeps = pnpmDeps;
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-WtZfRZFRV9I1iBlAoV69GGFjdiQhTSBG/iiEadPVcys=";
   };

--- a/pkgs/by-name/rq/rquickshare/package.nix
+++ b/pkgs/by-name/rq/rquickshare/package.nix
@@ -12,7 +12,7 @@
   openssl,
   perl,
   pkg-config,
-  pnpm,
+  pnpm_9,
   protobuf,
   rustPlatform,
   stdenv,
@@ -55,7 +55,7 @@ rustPlatform.buildRustPackage rec {
   '';
 
   pnpmRoot = "app/${app-type}";
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
 
     sourceRoot = "${src.name}/app/${app-type}";
@@ -73,7 +73,7 @@ rustPlatform.buildRustPackage rec {
 
     # Setup pnpm
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
 
     # Make sure we can find our libraries
     perl

--- a/pkgs/by-name/rs/rsshub/package.nix
+++ b/pkgs/by-name/rs/rsshub/package.nix
@@ -3,7 +3,7 @@
   fetchFromGitHub,
   makeBinaryWrapper,
   nodejs,
-  pnpm,
+  pnpm_9,
   replaceVars,
   stdenv,
 }:
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-mAAo4SdJ8cj8aqnbm+azcnxq8lFBvOy3BlSEKz9MA0Q=";
   };
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     makeBinaryWrapper
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/sk/sketchybar-app-font/package.nix
+++ b/pkgs/by-name/sk/sketchybar-app-font/package.nix
@@ -1,7 +1,7 @@
 {
   fetchFromGitHub,
   lib,
-  pnpm,
+  pnpm_9,
   stdenvNoCC,
   nodejs,
   nix-update-script,
@@ -18,14 +18,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     hash = "sha256-8SWN22pjHnXWM+RUEYNux0ZWhRUVMib3M7r2SlI33tQ=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-NGAgueJ+cuK/csjdf94KNklu+Xf91BHoWKVgEctX6eA=";
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   buildPhase = ''

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -17,7 +17,7 @@
   openssl,
   pango,
   pkg-config,
-  pnpm,
+  pnpm_9,
   rustc,
   rustPlatform,
   stdenv,
@@ -76,7 +76,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchFlags = [ "-p2" ];
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-JwOY6Z8UjbrodSQ3csnT+puftbQUDF3NIK7o6rSpl2o=";
   };
@@ -90,7 +90,7 @@ stdenv.mkDerivation (finalAttrs: {
     moreutils
     nodejs
     pkg-config
-    pnpm.configHook
+    pnpm_9.configHook
     rustc
     rustPlatform.cargoSetupHook
   ];

--- a/pkgs/by-name/sy/synchrony/package.nix
+++ b/pkgs/by-name/sy/synchrony/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nodejs,
-  pnpm,
+  pnpm_9,
   nix-update-script,
   fetchurl,
   runCommand,
@@ -22,10 +22,10 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-+hS4UK7sncCxv6o5Yl72AeY+LSGLnUTnKosAYB6QsP0=";
   };

--- a/pkgs/by-name/ta/tabby-agent/package.nix
+++ b/pkgs/by-name/ta/tabby-agent/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   nix-update-script,
   nodejs,
-  pnpm,
+  pnpm_9,
   wrapGAppsHook3,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    pnpm.configHook
+    pnpm_9.configHook
     wrapGAppsHook3
   ];
 
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-fpzl2w0o5bJhppVUl6vRNqAVQNMPLK0+JX/KYEtUGGA=";
   };

--- a/pkgs/by-name/ta/tailwindcss-language-server/package.nix
+++ b/pkgs/by-name/ta/tailwindcss-language-server/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nodejs_22,
-  pnpm,
+  pnpm_9,
 }:
 
 let
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-FphKiGMTMQj/tBmrwkPVlb+dEGjf+N4EgZtOVg7iL2M=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs)
       pname
       version
@@ -33,7 +33,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     nodejs_22
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   buildInputs = [ nodejs_22 ];

--- a/pkgs/by-name/ta/taler-wallet-core/package.nix
+++ b/pkgs/by-name/ta/taler-wallet-core/package.nix
@@ -8,7 +8,7 @@
   srcOnly,
   removeReferencesTo,
   nodejs,
-  pnpm,
+  pnpm_9,
   python3,
   git,
   jq,
@@ -48,13 +48,13 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     customPython
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
     git
     jq
     zip
   ];
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-BVVmv0VVvQ2YhL0zOKiM1oVKJKvqwMGNR47DkcCj874=";
   };

--- a/pkgs/by-name/ve/vencord/package.nix
+++ b/pkgs/by-name/ve/vencord/package.nix
@@ -7,7 +7,7 @@
   lib,
   nix-update,
   nodejs,
-  pnpm,
+  pnpm_9,
   stdenv,
   writeShellScript,
   buildWebExtension ? false,
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-sU2eJUUw7crvzMGGBQP6rbxISkL+S5nmT3QspyYXlRQ=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname src;
 
     hash = "sha256-vVzERis1W3QZB/i6SQR9dQR56yDWadKWvFr+nLTQY9Y=";
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     git
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   env = {

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -9,7 +9,7 @@
   nodejs,
   openssl,
   pkg-config,
-  pnpm,
+  pnpm_9,
   rustPlatform,
   webkitgtk_4_1,
   wrapGAppsHook3,
@@ -27,7 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-2g5zfRRxRm7/pCyut7weC4oTegwxCbvYpWSC2+qfcR8=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) src pname version;
     hash = "sha256-CNk4zysIIDzDxozCrUnsR63eme28mDsBkRVB/1tXnJI=";
   };
@@ -47,7 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     moreutils
     nodejs
     pkg-config
-    pnpm.configHook
+    pnpm_9.configHook
     rustPlatform.cargoSetupHook
     wrapGAppsHook3
   ];

--- a/pkgs/by-name/za/zammad/package.nix
+++ b/pkgs/by-name/za/zammad/package.nix
@@ -14,7 +14,7 @@
   jq,
   moreutils,
   nodejs,
-  pnpm,
+  pnpm_9,
   cacert,
   redis,
   dataDir ? "/var/lib/zammad",
@@ -94,7 +94,7 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [
     redis
     postgresql
-    pnpm.configHook
+    pnpm_9.configHook
     nodejs
     procps
     cacert
@@ -102,7 +102,7 @@ stdenvNoCC.mkDerivation {
 
   env.RAILS_ENV = "production";
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname src;
 
     hash = "sha256-bdm1nkJnXE7oZZhG2uBnk3fYhITaMROHGKPbf0G3bFs=";

--- a/pkgs/development/python-modules/django-filingcabinet/default.nix
+++ b/pkgs/development/python-modules/django-filingcabinet/default.nix
@@ -28,7 +28,7 @@
   poppler_utils,
   pytest-playwright,
   playwright-driver,
-  pnpm,
+  pnpm_9,
   nodejs,
 }:
 
@@ -55,7 +55,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
   ];
 
   dependencies = [
@@ -85,7 +85,7 @@ buildPythonPackage rec {
     #annotate = [ fcdocs-annotate ];
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit pname version src;
     hash = "sha256-32kOhB2+37DD4hKXKep08iDxhXpasKPfcv9fkwISxeU=";
   };

--- a/pkgs/development/tools/pnpm/default.nix
+++ b/pkgs/development/tools/pnpm/default.nix
@@ -15,6 +15,10 @@ let
       version = "9.15.3";
       hash = "sha256-wdpDcnzLwe1Cr/T9a9tLHpHmWoGObv/1skD78HC6Tq8=";
     };
+    "10" = {
+      version = "10.0.0";
+      hash = "sha256-Q6v25yD7e8U8WRsIYmBcfTI9Cp0t0zvKwHsGLhPPSUg=";
+    };
   };
 
   callPnpm = variant: callPackage ./generic.nix { inherit (variant) version hash; };

--- a/pkgs/games/heroic/default.nix
+++ b/pkgs/games/heroic/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
-  pnpm,
+  pnpm_9,
   nodejs,
   python3,
   makeWrapper,
@@ -26,14 +26,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-AndJqk1VAUdC4pOTRzyfhdxmzJMskGF6pUiqPs3fIy4=";
   };
 
-  pnpmDeps = pnpm.fetchDeps {
+  pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
     hash = "sha256-/7JIeQZt3QsKrjujSucRLiHfhfSllK7FeumNA4eHqSY=";
   };
 
   nativeBuildInputs = [
     nodejs
-    pnpm.configHook
+    pnpm_9.configHook
     python3
     makeWrapper
   ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4760,7 +4760,7 @@ with pkgs;
   };
 
   inherit (callPackage ../development/tools/pnpm { })
-    pnpm_8 pnpm_9;
+    pnpm_8 pnpm_9 pnpm_10;
   pnpm = pnpm_9;
 
   po4a = perlPackages.Po4a;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -1634,6 +1634,7 @@ with pkgs;
 
   authelia = callPackage ../servers/authelia {
     buildGoModule = buildGo123Module;
+    pnpm = pnpm_9;
   };
 
   authentik-outposts = recurseIntoAttrs (callPackages ../by-name/au/authentik/outposts.nix { });
@@ -4761,7 +4762,7 @@ with pkgs;
 
   inherit (callPackage ../development/tools/pnpm { })
     pnpm_8 pnpm_9 pnpm_10;
-  pnpm = pnpm_9;
+  pnpm = pnpm_10;
 
   po4a = perlPackages.Po4a;
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Release: https://github.com/pnpm/pnpm/releases/tag/v10.0.0

Since the store and lockfile format has changed, we can't use `pnpm_10` for packages previously using the latest `pnpm`. Therefore I pinned packages' `pnpm` to `pnpm_9`.

### TODO

- [x] read through the release notes and see if we can improve on the current infrastructure
    > Store version bumped to v10.

	> Upgraded @yarnpkg/extensions to v2.0.3. This may alter your lockfile.

	`pnpm.fetchDeps` hashes will change, as expected from a new major release

	> Lifecycle scripts of dependencies are not executed during installation by default

	In the pnpm tools already use `--ignore-scripts` where possible, this may affect packages

	Overall there doesn't seem to be any new features for us

- [x] bump default pnpm to pnpm_10 (packages using `pnpm` are now pinned to `pnpm_9`)
- [x] ~~update release notes (we can skip this if we stick to pinning old `pnpm` packages to `pnpm_9`)~~
- [x] figure out error: "Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent"
  - removing `--force` from the `pnpm install` command will say "Lockfile /build/source/pnpm-lock.yaml not compatible with current pnpm"
  - needs testing with a pnpm 10 compatible project
    - `pnpm config set store-dir my-store && pnpm install` installs deps to `my-store` on v9, but installs to default location in v10, but this only happens if there are no node_modules/dist folders
    - **solution**: have a pnpm 10 compatible project with no existing generated store
- [x] find all PRs that are using the `pnpm` package and warn them that it's being changed from `pnpm_9` to `pnpm_10`to avoid breakages (after this is merged)
  <details><summary>there are 15 such PRs (last updated: 2024-01-15)</summary>

	```
	195231
	265771
	317162
	326238
	329349
	350065
	350645
	353814
	355762
	358582
	359016
	366043
	369278
	369554
    372249
	```

	</details>

### How should we deal with soon EOL pnpm 8? (followup PR)

With a new major release and pnpm_8 being [EOL](https://endoflife.date/pnpm) in about 4 months, I think we should try to bump pnpm version in packages.

How much we should wait before starting to bump?
- wait a few days: at least this to give pnpm some time to stabilize, just in case if a major issue is found that would require changing the hashes or similar
- wait ~3 months: hopefully we can migrate more packages to pnpm 10 by this time, however we shouldn't leave it to the last minute, because if we can't finish it in time for whatever reason, EOL eval warnings can be frustrating to users; it may also lead to less hash changes overall, breaking less PRs

I'd start it ~1-2 months depending on how many PRs are touching pnpm versions, what do you think @Scrumplex?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
