### PR TITLE
vscode-remote-ssh: Use $VSCODE_AGENT_FOLDER instead of ~/.vscode-server to unbreak insiders

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/ms-vscode-remote.remote-ssh/default.nix
@@ -19,7 +19,7 @@ let
     # Use Node from nixpkgs for NixOS hosts
     #
 
-    serverDir="$HOME/.vscode-server/bin/$COMMIT_ID"
+    serverDir="$VSCODE_AGENT_FOLDER/bin/$COMMIT_ID"
     serverNode="$serverDir/node"
     echo "VS Code Node: $serverNode"
 
@@ -67,12 +67,12 @@ let
     ${lib.optionalString useLocalExtensions ''
       # Use local extensions
       if [ -d $HOME/.vscode/extensions ]; then
-        if [ -e $HOME/.vscode-server/extensions ]; then
-          mv $HOME/.vscode-server/extensions $HOME/.vscode-server/extensions.bak
+        if [ -e $VSCODE_AGENT_FOLDER/extensions ]; then
+          mv $VSCODE_AGENT_FOLDER/extensions $VSCODE_AGENT_FOLDER/extensions.bak
         fi
 
-        mkdir -p $HOME/.vscode-server
-        ln -s $HOME/.vscode/extensions $HOME/.vscode-server/extensions
+        mkdir -p $VSCODE_AGENT_FOLDER
+        ln -s $HOME/.vscode/extensions $VSCODE_AGENT_FOLDER/extensions
       fi
     ''}
 


### PR DESCRIPTION
This fixes remote ssh on vscode insiders where the path is
~/.vscode-server-insiders instead of ~/.vscode-server. (#371686)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested, as applicable:
  - [x] `nix-build -A nixosTests.vscode-remote-ssh`. This tests the functionality on vanilla (non-insiders) vscode.
  - [x] Manually verified that the change fixes the issue on vscode-insiders.
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
