### PR TITLE
qc71_slimbook_laptop: init at 0-unstable-2025-02-17

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -14535,6 +14535,12 @@
     githubId = 15693688;
     name = "Lucas Eduardo Wendt";
   };
+  lucasfa = {
+    name = "Lucas Fehlau Arbulu";
+    githubId = 23667494;
+    github = "LucasFA";
+    matrix = "@lucasfa:matrix.org";
+  };
   lucastso10 = {
     email = "lucastso10@gmail.com";
     github = "lucastso10";

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -20,6 +20,8 @@
 - [LACT](https://github.com/ilya-zlobintsev/LACT), a GPU monitoring and configuration tool, can now be enabled through [services.lact.enable](#opt-services.lact.enable).
   Note that for LACT to work properly on AMD GPU systems, you need to enable [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable).
 
+- [qc71_slimbook_laptop](https://github.com/Slimbook-Team/qc71_laptop), a kernel module for Slimbook laptops.
+
 - [Broadcast Box](https://github.com/Glimesh/broadcast-box), a WebRTC broadcast server. Available as [services.broadcast-box](options.html#opt-services.broadcast-box.enable).
 
 - [SuiteNumérique Docs](https://github.com/suitenumerique/docs), a collaborative note taking, wiki and documentation web platform and alternative to Notion or Outline. Available as [services.lasuite-docs](#opt-services.lasuite-docs.enable).

--- a/pkgs/os-specific/linux/qc71_slimbook_laptop/default.nix
+++ b/pkgs/os-specific/linux/qc71_slimbook_laptop/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "qc71_slimbook_laptop";
+  version = "0-unstable-2025-02-17";
+
+  src = fetchFromGitHub {
+    owner = "Slimbook-Team";
+    repo = "qc71_laptop";
+    rev = "f1475751a272a7cf78321f60390da6108b4b3904";
+    hash = "sha256-/D3/v0mKaExMlUnGGTtRDEXOlylMWYeylJih/gzqqGA=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "VERSION=${version}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -D qc71_laptop.ko -t $out/lib/modules/${kernel.modDirVersion}/extra
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=branch=slimbook" ];
+  };
+
+  meta = with lib; {
+    description = "Linux driver for QC71 laptop, with Slimbook patches";
+    homepage = "https://github.com/Slimbook-Team/qc71_laptop/";
+    license = licenses.gpl2Only;
+    maintainers = with maintainers; [ lucasfa ];
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -709,6 +709,8 @@ in
 
         qc71_laptop = callPackage ../os-specific/linux/qc71_laptop { };
 
+        qc71_slimbook_laptop = callPackage ../os-specific/linux/qc71_slimbook_laptop { };
+
         hid-ite8291r3 = callPackage ../os-specific/linux/hid-ite8291r3 { };
 
         hid-t150 = callPackage ../os-specific/linux/hid-t150 { };


### PR DESCRIPTION
Package fork of the [qc71_laptop package](https://github.com/NixOS/nixpkgs/blob/6faa3519ed0ac0107729849d6a6a23412c65c72e/pkgs/os-specific/linux/qc71_laptop/default.nix) for Slimbook laptop compatibility, hosted at the [Slimbook-Team repo, 'slimbook' branch](https://github.com/Slimbook-Team/qc71_laptop/tree/slimbook)

The difference between the packaging nix files is minimal. 

<!--
For new packages please briefly describe the package or provide a link to its homepage.
-->
This package includes the patches developed by the Slimbook manufacturer, which mainly revolve around adding support to their own systems for features such as RGB keyboard lighting control and the behaviour of a performance button that some of their models have. They have developed some applications depending on this module. 
Certainly limited in potential users, I hope that it is considered "enough usage" for inclusion into Nixpkgs

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (NixOS)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
My laptop tends to OOM on nixpkgs-review, but I'll try. Compiling 22 kernels will take a good while, though...
- [x] Tested basic functionality of all binary files: **I have compiled and loaded the module successfully in kernel versions 6_6 and 6_12, and `journalctl` shows the new features available in my Slimbook laptop**, NixOS 24.11, rev: cbd8ec4de4469333c82ff40d057350c30e9f7d36
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
