### PR TITLE
pshash: init at 0.1.14.6

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22847,6 +22847,12 @@
     githubId = 678511;
     name = "Thomas Mader";
   };
+  thornoar = {
+    email = "r.a.maksimovich@gmail.com";
+    github = "thornoar";
+    githubId = 84677666;
+    name = "Roman Maksimovich";
+  };
   thornycrackers = {
     email = "codyfh@gmail.com";
     github = "thornycrackers";

--- a/pkgs/by-name/ps/pshash/package.nix
+++ b/pkgs/by-name/ps/pshash/package.nix
@@ -1,0 +1,41 @@
+{
+  haskellPackages,
+  fetchFromGitHub,
+  lib,
+}:
+haskellPackages.mkDerivation rec {
+  pname = "pshash";
+  version = "0.1.14.6";
+  src = fetchFromGitHub {
+    owner = "thornoar";
+    repo = "pshash";
+    tag = "v${version}";
+    hash = "sha256-gqIdfIC8f9aF4ojHBhKOTvIr34kuTGQ5R/q1D+0c4bA=";
+  };
+
+  postPatch = ''
+    patchShebangs --build test/output.sh
+  '';
+
+  isLibrary = false;
+  isExecutable = true;
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    test/output.sh dist/build/pshash/pshash
+    runHook postCheck
+  '';
+
+  executableHaskellDepends = with haskellPackages; [
+    base
+    containers
+    directory
+  ];
+
+  license = lib.licenses.mit;
+  description = "Functional pseudo-hash password creation tool";
+  homepage = "https://github.com/thornoar/pshash";
+  maintainers = with lib.maintainers; [ thornoar ];
+  mainProgram = "pshash";
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Summary

Adding a simple password generation tool called `pshash`, designed to create very secure passwords using a pseudo-hashing function and a set of public and private keys, without storing the resulting passwords anywhere. E.g. running `pshash google 123 456` (with private keys 123 and 456) will yield `VLCJXY4y*tm&Z3Db$5a0h#?jo`, which can then be used as one's password to Google. See more at https://github.com/thornoar/pshash#synopsis and even more in the accompanying paper proposal at https://github.com/thornoar/pshash/blob/master/documentation/main.pdf.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
    - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
    - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
    - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
