### PR TITLE
qc71_laptop: fix incorrect license

### DIFF
--- a/pkgs/os-specific/linux/qc71_laptop/default.nix
+++ b/pkgs/os-specific/linux/qc71_laptop/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Linux driver for QC71 laptop";
     homepage = "https://github.com/pobrn/qc71_laptop/";
-    license = licenses.gpl2Plus;
+    license = licenses.gpl2Only;
     maintainers = with maintainers; [ aacebedo ];
     platforms = platforms.linux;
   };


### PR DESCRIPTION
[Upstream repo](https://github.com/pobrn/qc71_laptop) is GPL2 only

I have not tested this, I take it it is inconsequential. `gpl2Only` is a valid license according to `nipkgs/lib/licenses.nix`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
