### PR TITLE
electron{-source,-bin,-chromedriver}: 32.2.7 -> 32.2.8, 33.3.0 -> 33.3.1

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -67,14 +67,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "71e76a0a81a0c1c10e9e4862caf96437ba85a18c8fa7d8e15d59e3c057b893bd",
-            "aarch64-linux": "fb6e1f24385c3058844bd768320d5b332b4cbd011ab930e7252dc330c8ee17b3",
-            "armv7l-linux": "4a95643e88cadfb011354d25cafe242cdb8c5327d65f86b4fbabe64717367ed2",
-            "headers": "1c05mm83qjirlj1mzggycndjxf0fv55dkrpha5bbnspk430zbn0g",
-            "x86_64-darwin": "34310ed51d32b6c02ba3e3f447b0807ea85804d1f2b239e02a9de58b9080fbf8",
-            "x86_64-linux": "98007545e1d3700b32de5cb5eebcc10b9d105fb0dad6396155fdab1b40abb638"
+            "aarch64-darwin": "39d5298563ec488b3b329c9ad6e4f40e941a7326e82683a588d2f103a6f7dd78",
+            "aarch64-linux": "67782c4208cb64347552c003ded53ae993af8de16fadd19fd43105d1b592971f",
+            "armv7l-linux": "e1ace6669dc5aa9696b6f37af0d1210125e96ebda4dbb82496896047191a1810",
+            "headers": "0qw1nfi0c53d346lchmya6dr0l3c94ssdbazbr547qih2njc7jbz",
+            "x86_64-darwin": "91cb09191798606e4666952f8bb01d4851eab68973874ba5e26d6c7d1287b3be",
+            "x86_64-linux": "b01f9f5fcef719f0d76dc2f61c3f5a5b411970e425639de65aa823804918ce22"
         },
-        "version": "32.2.7"
+        "version": "32.2.8"
     },
     "33": {
         "hashes": {

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -78,13 +78,13 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "c534ef4b8e7859620e7944b42a460b3fd2e27db1512b3820150b73c7df81b63d",
-            "aarch64-linux": "73baabb2a6d8dc778051183d2e792ecf4b265eaf2a49f5a665976674f0a3a96f",
-            "armv7l-linux": "0dff7adde4f550beed0bf89880299cb1bfebf542786edb07ea22fd5676132c3a",
-            "headers": "1xvwi8b9arsfax04lzjmxmm6mz7jp65jrlcc6jm2gfqxbjlva7pp",
-            "x86_64-darwin": "de05d4004facdb4693f5b8ecad7d1b1bb162919edf59b4c1ce9f5ee3906e1742",
-            "x86_64-linux": "301ff45db3ee5e4222adecc07555c31dd1b56d82c20540d7ad6da504dde332c8"
+            "aarch64-darwin": "f5886daefc3ea8851a087eafd23826337f97e0e921256a70f887c8acc8128bca",
+            "aarch64-linux": "b428ecca13d4ffc05c28e28759a310f317e4e89b05e9a30ba07e0d58fbaedef5",
+            "armv7l-linux": "e9e74509304e87a889bc59fe86eb2efc901d3c43b02d18acd5a9ba07800334a5",
+            "headers": "054d8hkm8kvknwamcblpyvgzmfqwb954x6gxgi0ma9xym8dl2qks",
+            "x86_64-darwin": "2d6015ff12c8b712b7e928dd163c1fd0e4c988665ce626c441ceb97753d48e1d",
+            "x86_64-linux": "cdca6f9ec2f98708dcbcb8baba3d0521e15ed4e5aab68b2d1c6668f99faafc38"
         },
-        "version": "33.3.0"
+        "version": "33.3.1"
     }
 }

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "0729d2cb830425c4591b40d7189c2f7da020f5adb887a49a4faa022d551b1e6f",
-            "aarch64-linux": "45314c8c7127f6083469c2c067aa78beb20055ba4d7a63eb2108b27e594a647a",
-            "armv7l-linux": "7e976a7131dcfd55f781c073ae59c8a24a1393119d831fbac13c6a335eb71467",
-            "headers": "1c05mm83qjirlj1mzggycndjxf0fv55dkrpha5bbnspk430zbn0g",
-            "x86_64-darwin": "a7d61c68d3b3522c0ec383915b6ab3d9f269d9ada0e09aa87a4e7d9fc24fe928",
-            "x86_64-linux": "3437feb5d8e7157476d2e7a6558346061cd7e46506874bc7870eed8a3a43642a"
+            "aarch64-darwin": "f7aef40a833edda014b50e5c3db52a8f966045f3e16b113bd410afc0fea24da0",
+            "aarch64-linux": "b81a9f916d49f1867d6326f34a1e2e5f4069c4ac445123a90dc2034a0a1bfd34",
+            "armv7l-linux": "e3573aa5940158aa953c8b58a6c709288466347675cca032adb71f6f7042fb06",
+            "headers": "0qw1nfi0c53d346lchmya6dr0l3c94ssdbazbr547qih2njc7jbz",
+            "x86_64-darwin": "7428bb4dc438596875138a8f06c67b18266850797988f7c862cb39ca86eb5269",
+            "x86_64-linux": "57fe434c5437e45c866789622dac20f7b33204d51a7b923ad1e8b7259789d498"
         },
-        "version": "32.2.7"
+        "version": "32.2.8"
     },
     "33": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,13 +45,13 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "0c7b450f69ccc8a36ccbc419f993e8990fe79292a60fca81518994dc4645b033",
-            "aarch64-linux": "810822e352e4f3121ee4b6609094a79b6f894549a9ea84d520ce65ae84f0ba01",
-            "armv7l-linux": "092e277b4aa50344a2315fd3812f52dd5f73f27bd8be949c93dc766bca1e25cb",
-            "headers": "1xvwi8b9arsfax04lzjmxmm6mz7jp65jrlcc6jm2gfqxbjlva7pp",
-            "x86_64-darwin": "53a9f584a106c331712be5e30554e4566c53e1627f0db612aa9c9a2a32e9a5bb",
-            "x86_64-linux": "215176975b520addc9bf13dd449336c58cc7614a8b657fcb34a9617911a3dbdd"
+            "aarch64-darwin": "c2b4a3bb8a609e5272db39321d567f900eed1c2284eda89d7a4c41557e5b9ba3",
+            "aarch64-linux": "4b08bd54413a72d1a991f427cc8d27c313def385431f7e045e5b3efbbc880e39",
+            "armv7l-linux": "f84e71d37358d574fee6519c8dc1335c52bb783d92c2fa92c2fb4a48f9661413",
+            "headers": "054d8hkm8kvknwamcblpyvgzmfqwb954x6gxgi0ma9xym8dl2qks",
+            "x86_64-darwin": "c3c0cb8eec909cad52eb9f6b2d9ff2bffc9d2246f37280eb44ffc45fdb6b4861",
+            "x86_64-linux": "6e288cf2be3ceba26bec0cb1f86504574326bacd933a5da208dabef111abde6d"
         },
-        "version": "33.3.0"
+        "version": "33.3.1"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -1882,7 +1882,7 @@
         "version": "32.2.8"
     },
     "33": {
-        "chrome": "130.0.6723.152",
+        "chrome": "130.0.6723.170",
         "chromium": {
             "deps": {
                 "gn": {
@@ -1892,15 +1892,15 @@
                     "version": "2024-09-09"
                 }
             },
-            "version": "130.0.6723.152"
+            "version": "130.0.6723.170"
         },
         "chromium_npm_hash": "sha256-4w5m/bTMygidlb4TZHMx1Obp784DLxMwrfe1Uvyyfp8=",
         "deps": {
             "src": {
                 "fetcher": "fetchFromGitiles",
-                "hash": "sha256-mrikcQQ77vMwYJ1fxSziS+CwfVAVJq8lBiXPkSsxNhQ=",
+                "hash": "sha256-zhEHb3Jjr6CAgIAqMV4uwzVE80lAkVnlxi4FYnpkzdw=",
                 "postFetch": "rm -r $out/third_party/blink/web_tests; rm -r $out/third_party/hunspell/tests; rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                "rev": "130.0.6723.152",
+                "rev": "130.0.6723.170",
                 "url": "https://chromium.googlesource.com/chromium/src.git"
             },
             "src/chrome/test/data/perf/canvas_bench": {
@@ -1929,10 +1929,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-tMHiQXOR7ikVkZcmCRA2AljX/+BaVS0B7M8iHmm3NaA=",
+                "hash": "sha256-PaWXPOPPvxpZNDXF+bdouxZCJRYxVVbwDsVNsnf5oXo=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v33.3.0"
+                "rev": "v33.3.1"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -2824,14 +2824,14 @@
             },
             "src/v8": {
                 "fetcher": "fetchFromGitiles",
-                "hash": "sha256-2AfHUG0THFgOcRGA1CZJMdakxXuX4iyiFCO+5PeTfNM=",
-                "rev": "526ebc5576bd2342a8266cf69e29775cc3033386",
+                "hash": "sha256-4DcSWkMhPwMh6ZvURj2piKaIPNe2Rur+nA3vAirgvcM=",
+                "rev": "932a8d7bb284242fd92234cf734921b8383ae4f6",
                 "url": "https://chromium.googlesource.com/v8/v8.git"
             }
         },
         "electron_yarn_hash": "0bzsswcg62b39xinq5vikk7qz7d15276s2vc15v1gcb5wvh05ff8",
         "modules": "130",
         "node": "20.18.1",
-        "version": "33.3.0"
+        "version": "33.3.1"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -988,10 +988,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-gdJraz3wgF+n8+1tM7R50LGaE8Ls1AHRsHX7BxJZnJ0=",
+                "hash": "sha256-TLTgZMpIqmdCPh+b45YDmWVGWrl4LmB0xqRfv0bc3o4=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v32.2.7"
+                "rev": "v32.2.8"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -1879,7 +1879,7 @@
         "electron_yarn_hash": "122y1vnizwg0rwz8qf37mvpa0i78141y98wn4h11l6b9gyshrs65",
         "modules": "128",
         "node": "20.18.1",
-        "version": "32.2.7"
+        "version": "32.2.8"
     },
     "33": {
         "chrome": "130.0.6723.152",


### PR DESCRIPTION
Will run `nixpkgs-review` on `x86_64-linux` and report back when it's done :)

Let me know if I messed something up.

https://github.com/electron/electron/releases/tag/v32.2.8
https://github.com/electron/electron/compare/refs/tags/v32.2.7...v32.2.8
Fixes CVE-2024-12053

https://github.com/electron/electron/releases/tag/v33.3.1
https://github.com/electron/electron/compare/refs/tags/v33.3.0...v33.3.1

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
