### PR TITLE
arp-scan-rs: init at 0.14.0

### DIFF
--- a/pkgs/by-name/ar/arp-scan-rs/package.nix
+++ b/pkgs/by-name/ar/arp-scan-rs/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  fetchFromGitHub,
+  gitUpdater,
+  rustPlatform,
+  versionCheckHook,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "arp-scan-rs";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "kongbytes";
+    repo = "arp-scan-rs";
+    tag = "v${version}";
+    hash = "sha256-CLxeT2olrxRCJ12IZ1PvLW7ZuX0HPsoNuFyxmGBhB8w=";
+  };
+
+  cargoHash = "sha256-+Ph5k3qaK4USggTnZqyOdH6oKv5Xr2/NeQ9C0Q6g5sQ=";
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  preCheck = ''
+    # Test fails
+    substituteInPlace src/network.rs \
+      --replace-fail 'Some("one.one.one.one".to_string())' 'None'
+  '';
+
+  versionCheckProgram = [ "${placeholder "out"}/bin/arp-scan" ];
+
+  versionCheckProgramArg = "--version";
+
+  doInstallCheck = true;
+
+  passthru.updateScript = gitUpdater { };
+
+  meta = {
+    description = "ARP scan tool for fast local network scans";
+    homepage = "https://github.com/kongbytes/arp-scan-rs";
+    changelog = "https://github.com/kongbytes/arp-scan-rs/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ fab ];
+    mainProgram = "arp-scan";
+  };
+}


### PR DESCRIPTION
ARP scan tool for fast local network scans

https://github.com/kongbytes/arp-scan-rs

Related https://github.com/NixOS/nixpkgs/issues/81418
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
