### PR TITLE
doc: removing pypy39 from Python documentation

### DIFF
--- a/doc/doc-support/python-interpreter-table.nix
+++ b/doc/doc-support/python-interpreter-table.nix
@@ -15,7 +15,9 @@ let
       - `python3Minimal` contains python packages, left behind conservatively.
       - `rustpython` lacks `pythonVersion` and `implementation`.
     */
-    (lib.strings.match "(pypy|python)([[:digit:]]*)" name) != null;
+    ((lib.strings.match "(pypy|python)([[:digit:]]*)" name) != null)
+    # Throw-alias after upstream discontinuation
+    && (name != "pypy39");
 
   interpreterName =
     pname:

--- a/doc/languages-frameworks/python.section.md
+++ b/doc/languages-frameworks/python.section.md
@@ -57,7 +57,6 @@ sets are
 * `pkgs.python313Packages`
 * `pkgs.python314Packages`
 * `pkgs.pypy27Packages`
-* `pkgs.pypy39Packages`
 * `pkgs.pypy310Packages`
 
 and the aliases
@@ -66,7 +65,7 @@ and the aliases
 * `pkgs.python3Packages` pointing to `pkgs.python312Packages`
 * `pkgs.pythonPackages` pointing to `pkgs.python2Packages`
 * `pkgs.pypy2Packages` pointing to `pkgs.pypy27Packages`
-* `pkgs.pypy3Packages` pointing to `pkgs.pypy39Packages`
+* `pkgs.pypy3Packages` pointing to `pkgs.pypy310Packages`
 * `pkgs.pypyPackages` pointing to `pkgs.pypy2Packages`
 
 


### PR DESCRIPTION
Trying to avoid the issues with `pypy39` removal with an alias that throws.

Fixes the build of `./pkgs/top-level/release.nix -A nixpkgs-manual.x86_64-linux` after #370527 

An alternative would be to give a no-`allowAliases` version of `pkgs` to the eager Python-version-enumerator. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
