### PR TITLE
docs: add separate Nixpkgs release notes

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -1,14 +1,146 @@
 # Nixpkgs 25.05 (2025.05/??) {#sec-nixpkgs-release-25.05}
 
+## Highlights {#sec-nixpkgs-release-25.05-highlights}
+
+- **This release of Nixpkgs requires macOS Big Sur 11.3 or newer, as announced in the 24.11 release notes.**
+  We cannot guarantee that packages will continue to work on older versions of macOS.
+  Future Nixpkgs releases will only support [macOS versions supported by Apple](https://endoflife.date/macos); this means that **Nixpkgs 25.11 will require macOS Sonoma 14 or newer**.
+  Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
+  If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
+
+- GCC has been updated from GCC 13 to GCC 14.
+  This introduces some backwards‐incompatible changes; see the [upstream porting guide](https://gcc.gnu.org/gcc-14/porting_to.html) for details.
+
+- LLVM has been updated from LLVM 16 (on Darwin) and LLVM 18 (on other platforms) to LLVM 19.
+  This introduces some backwards‐incompatible changes; see the [upstream release notes](https://releases.llvm.org/) for details.
+
+- The default PHP version has been updated to 8.3.
+
+- The default Erlang OTP version has been updated to 27.
+
+- The default Elixir version has been updated to 1.18.
+
 ## Backward Incompatibilities {#sec-nixpkgs-release-25.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- `binwalk` was updated to 3.1.0, which has been rewritten in rust. The python module is no longer available.
+  See the release notes of [3.1.0](https://github.com/ReFirmLabs/binwalk/releases/tag/v3.1.0) for more information.
+
+- `buildGoModule` now passes environment variables via the `env` attribute. `CGO_ENABLED` should now be specified with `env.CGO_ENABLED` when passing to buildGoModule. Direct specification of `CGO_ENABLED` is now redirected by a compatibility layer with a warning, but will become an error in future releases.
+
+  Go-related environment variables previously shadowed by `buildGoModule` now results in errors when specified directly. Such variables include `GOOS` and `GOARCH`.
+
+  Third-party projects supporting both stable and unstable channels could detect this change through the absence of the `CGO_ENABLED` function argument in `buildGoModule` (`!((lib.functionArgs buildGoModule) ? CGO_ENABLED)`).
+
+- `buildGoPackage` has been removed. Use `buildGoModule` instead. See the [Go section in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go) for details.
+
+- top-level `playwright` now refers to the github Microsoft/playwright package
+  instead of the python tester launcher. You can still refer to the python
+  launcher via `python3Packages.toPythonApplication python3Packages.playwright`
+
+- `strawberry` has been updated to 1.2, which drops support for the VLC backend and Qt 5. The `strawberry-qt5` package
+  and `withGstreamer`/`withVlc` override options have been removed due to this.
+
+- `ps3-disc-dumper` was updated to 4.2.5, which removed the CLI project and now exclusively offers the GUI
+
+- Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
+
+- `nodePackages.vls` has been deprecated, as the upstream consumer of it, vetur, has been deprecated by upstream. Upstream suggests migrating to Volar for Vue LSP tooling instead.
+
+- `nodePackages.create-react-native-app` has been removed, as it is deprecated. Upstream suggests using a framework for React Native apps instead.
+
+- `nodePackages.insect` has been removed, as it's deprecated by upstream. The suggested replacement is `numbat`.
+
+- `nodePackages.webpack-dev-server` has been removed, as it should be installed in projects that use it instead.
+
+- `nodePackages.copy-webpack-plugin` has been removed, as it should be installed in projects that use it instead.
+
+- `linuxPackages.nvidiaPackages.dc_520` has been removed since it is marked broken and there are better newer alternatives.
+
+- `minetest` has been renamed to `luanti` to match the upstream name change but aliases have been added. The new name hasn't resulted in many changes as of yet but older references to minetest should be sunset. See the [new name announcement](https://blog.minetest.net/2024/10/13/Introducing-Our-New-Name/) for more details.
+
+- `racket_7_9` has been removed, as it is insecure. It is recommended to use Racket 8 instead.
+
+- `rofi` has been updated from 1.7.5 to 1.7.6 which introduces some breaking changes to binary plugins, and also contains a lot of new features and bug fixes. This is highlighted because the patch version bump does not indicate the volume of changes by itself. See the [upstream release notes](https://github.com/davatorium/rofi/releases/tag/1.7.6) for the full list of changes.
+
+- `ente-auth` now uses the name `enteauth` for its binary. The previous name was `ente_auth`.
+
+- `foundationdb` was upgraded to 7.3.
+
+- `fluxus` has been removed, as it depends on `racket_7_9` and had no updates in 9 years.
+
+- `sm64ex-coop` has been removed as it was archived upstream. Consider migrating to `sm64coopdx`.
+
+- `renovate` was updated to v39. See the [upstream release notes](https://docs.renovatebot.com/release-notes-for-major-versions/#version-39) for breaking changes.
+  Like upstream's docker images, renovate now runs on NodeJS 22.
+
+- `python3Packages.jaeger-client` was removed because it was deprecated upstream. [OpenTelemetry](https://opentelemetry.io) is the recommended replacement.
+
+- `nodePackages.meshcommander` has been removed, as the package was deprecated by Intel.
+
+- `kanata` was updated to v1.7.0, which introduces several breaking changes.
+  See the release notes of
+  [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)
+  for more information.
+
+- `nodePackages.expo-cli` has been removed, as it was deprecated by upstream. The suggested replacement is the `npx expo` command.
+
+- `vscode-utils.buildVscodeExtension` now requires pname as an argument
+
+- `nerdfonts` has been separated into individual font packages under the namespace `nerd-fonts`. The directories for font
+  files have changed from `$out/share/fonts/{opentype,truetype}/NerdFonts` to
+  `$out/share/fonts/{opentype,truetype}/NerdFonts/<fontDirName>`, where `<fontDirName>` can be found in the
+  [official website](https://www.nerdfonts.com/font-downloads) as the titles in preview images, with the "Nerd Font"
+  suffix and any whitespaces trimmed. Configuration changes are required, see build output.
+
+- `retroarch` has been refactored and the older `retroarch.override { cores = [ ... ]; }` to create a RetroArch derivation with custom cores doesn't work anymore, use `retroarch.withCores (cores: [ ... ])` instead. If you need more customization (e.g.: custom settings), use `wrapRetroArch` instead.
+
+- `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
+
+- `matomo` now defaults to version 5 (previously available as `matomo_5`). Version 4 has been removed as it reached EOL on December 19, 2024.
+
+- `docker_24` has been removed, as it was EOL with vulnerabilites since June 08, 2024.
+
+- `containerd` has been updated to v2, which contains breaking changes. See the [containerd
+  2.0](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) documentation for more
+  details.
+
+- `nodePackages.stackdriver-statsd-backend` has been removed, as the StackDriver service has been discontinued by Google, and therefore the package no longer works.
+
+- `python3Packages.opentracing` has been removed due to being unmaintained upstream. [OpenTelemetry](https://opentelemetry.io/) is the recommended replacement.
+
+- the notmuch vim plugin now lives in a separate output of the `notmuch`
+  package. Installing `notmuch` will not bring the notmuch vim package anymore,
+  add `vimPlugins.notmuch-vim` to your (Neo)vim configuration if you want the
+  vim plugin.
+
+- `prisma` and `prisma-engines` have been updated to version 6.0.1, which
+  introduces several breaking changes. See the
+  [Prisma ORM upgrade guide](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6)
+  for more information.
+
+- `nq` was updated to 1.0, which renames the `fq` and `tq` utilities to `nqtail` and `nqterm` respectively.
+
+- `zf` was updated to 0.10.2, which includes breaking changes from the [0.10.0 release](https://github.com/natecraddock/zf/releases/tag/0.10.0).
+  `zf` no longer does Unicode normalization of the input and no longer supports terminal escape sequences in the `ZF_PROMPT` environment variable.
+
+- `siduck76-st` has been renamed to `st-snazzy`, like the project's [flake](https://github.com/siduck/st/blob/main/flake.nix).
+
+- `python3Packages.jax` now directly depends on `python3Packages.jaxlib`.
+  As a result, packages that depend on jax no longer need to include jaxlib to their dependencies.
+  There is also a breaking change in the handling of CUDA. Instead of using a CUDA compatible jaxlib
+  as before, you can use plugins like `python3Packages.jax-cuda12-plugin`.
+
+- []{#sec-nixpkgs-release-25.05-incompatibilities-titanium-removed} `titaniumenv`, `titanium`, and `titanium-alloy` have been removed due to lack of maintenance in Nixpkgs.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-### Titanium removed {#sec-nixpkgs-release-25.05-incompatibilities-titanium-removed}
+## Other Notable Changes {#sec-nixpkgs-release-25.05-notable-changes}
 
-- `titaniumenv`, `titanium`, and `titanium-alloy` have been removed due to lack of maintenance in Nixpkgs.
+- GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
+
+- `gerbera` now has wavpack support.
 
 ## Nixpkgs Library {#sec-nixpkgs-release-25.05-lib}
 

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -1,30 +1,13 @@
-# Release 25.05 (“Warbler”, 2025.05/??) {#sec-release-25.05}
+# NixOS 25.05 (“Warbler”, 2025.05/??) {#sec-release-25.05}
 
 ## Highlights {#sec-release-25.05-highlights}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- **This release of Nixpkgs requires macOS Big Sur 11.3 or newer, as announced in the 24.11 release notes.**
-  We cannot guarantee that packages will continue to work on older versions of macOS.
-  Future Nixpkgs releases will only support [macOS versions supported by Apple](https://endoflife.date/macos); this means that **Nixpkgs 25.11 will require macOS Sonoma 14 or newer**.
-  Users on old macOS versions should consider upgrading to a supported version (potentially using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/) for old hardware) or installing NixOS.
-  If neither of those options are viable and you require new versions of software, [MacPorts](https://www.macports.org/) supports versions back to Mac OS X Snow Leopard 10.6.
-
-- GCC has been updated from GCC 13 to GCC 14.
-  This introduces some backwards‐incompatible changes; see the [upstream porting guide](https://gcc.gnu.org/gcc-14/porting_to.html) for details.
-
-- LLVM has been updated from LLVM 16 (on Darwin) and LLVM 18 (on other platforms) to LLVM 19.
-  This introduces some backwards‐incompatible changes; see the [upstream release notes](https://releases.llvm.org/) for details.
-
-- The default PHP version has been updated to 8.3.
-
-- The default Erlang OTP version has been updated to 27.
-
-- The default Elixir version has been updated to 1.18.
-
 - `services.dex` now restarts upon changes to the `.environmentFile` or entries in `.settings.staticClients[].secretFile` when the entry is a `path` type.
 
 - `nixos-rebuild-ng`, a full rewrite of `nixos-rebuild` in Python, is available for testing. You can enable it by setting [system.rebuild.enableNg](options.html#opt-system.rebuild.enableNg) in your configuration (this will replace the old `nixos-rebuild`), or by adding `nixos-rebuild-ng` to your `environment.systemPackages` (in this case, it will live side-by-side with `nixos-rebuild` as `nixos-rebuild-ng`). It is expected that the next major version of NixOS (25.11) will enable `system.rebuild.enableNg` by default.
+
 - A `nixos-rebuild build-image` sub-command has been added.
 
   It allows users to build platform-specific (disk) images from their NixOS configurations. `nixos-rebuild build-image` works similar to the popular [nix-community/nixos-generators](https://github.com/nix-community/nixos-generators) project. See new [section on image building in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-image-nixos-rebuild-build-image).
@@ -101,26 +84,6 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
-- `binwalk` was updated to 3.1.0, which has been rewritten in rust. The python module is no longer available.
-  See the release notes of [3.1.0](https://github.com/ReFirmLabs/binwalk/releases/tag/v3.1.0) for more information.
-
-- `buildGoModule` now passes environment variables via the `env` attribute. `CGO_ENABLED` should now be specified with `env.CGO_ENABLED` when passing to buildGoModule. Direct specification of `CGO_ENABLED` is now redirected by a compatibility layer with a warning, but will become an error in future releases.
-
-  Go-related environment variables previously shadowed by `buildGoModule` now results in errors when specified directly. Such variables include `GOOS` and `GOARCH`.
-
-  Third-party projects supporting both stable and unstable channels could detect this change through the absence of the `CGO_ENABLED` function argument in `buildGoModule` (`!((lib.functionArgs buildGoModule) ? CGO_ENABLED)`).
-
-- `buildGoPackage` has been removed. Use `buildGoModule` instead. See the [Go section in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-language-go) for details.
-
-- top-level `playwright` now refers to the github Microsoft/playwright package
-  instead of the python tester launcher. You can still refer to the python
-  launcher via `python3Packages.toPythonApplication python3Packages.playwright`
-
-- `strawberry` has been updated to 1.2, which drops support for the VLC backend and Qt 5. The `strawberry-qt5` package
-  and `withGstreamer`/`withVlc` override options have been removed due to this.
-
-- `ps3-disc-dumper` was updated to 4.2.5, which removed the CLI project and now exclusively offers the GUI
-
 - [](#opt-services.nextcloud.config.dbtype) is unset by default, the previous default was `sqlite`.
   This was done because `sqlite` is not a reasonable default since it's
   [not recommended by upstream](https://docs.nextcloud.com/server/30/admin_manual/installation/system_requirements.html)
@@ -143,8 +106,6 @@
     After you run ALTER EXTENSION, you must run [this SQL script](https://github.com/timescale/timescaledb-extras/blob/master/utils/2.15.X-fix_hypertable_foreign_keys.sql). For more details, see the following pull requests [#6797](https://github.com/timescale/timescaledb/pull/6797).
     PostgreSQL 13 is no longer supported in TimescaleDB v2.16.
 
-- Support for CUDA 10 has been dropped, as announced in the 24.11 release notes.
-
 - `zammad` has had its support for MySQL removed, since it was never working correctly and is now deprecated upstream. Check the [migration guide](https://docs.zammad.org/en/latest/appendix/migrate-to-postgresql.html) for how to convert your database to PostgreSQL.
 
 - The `earlyoom` service is now using upstream systemd service, which enables
@@ -152,68 +113,18 @@
   access or want to access home directory via `killHook`, hardening setting can
   be changed via, e.g. `systemd.services.earlyoom.serviceConfig.ProtectSystem`.
 
-- `nodePackages.vls` has been deprecated, as the upstream consumer of it, vetur, has been deprecated by upstream. Upstream suggests migrating to Volar for Vue LSP tooling instead.
-
-- `nodePackages.create-react-native-app` has been removed, as it is deprecated. Upstream suggests using a framework for React Native apps instead.
-
-- `nodePackages.insect` has been removed, as it's deprecated by upstream. The suggested replacement is `numbat`.
-
-- `nodePackages.webpack-dev-server` has been removed, as it should be installed in projects that use it instead.
-
-- `nodePackages.copy-webpack-plugin` has been removed, as it should be installed in projects that use it instead.
-
-- `linuxPackages.nvidiaPackages.dc_520` has been removed since it is marked broken and there are better newer alternatives.
-
 - `programs.less.lessopen` is now null by default. To restore the previous behaviour, set it to `''|${lib.getExe' pkgs.lesspipe "lesspipe.sh"} %s''`.
 
 - `hardware.pulseaudio` has been renamed to `services.pulseaudio`.  The deprecated option names will continue to work, but causes a warning.
 
-- `minetest` has been renamed to `luanti` to match the upstream name change but aliases have been added. The new name hasn't resulted in many changes as of yet but older references to minetest should be sunset. See the [new name announcement](https://blog.minetest.net/2024/10/13/Introducing-Our-New-Name/) for more details.
-
-- `racket_7_9` has been removed, as it is insecure. It is recommended to use Racket 8 instead.
-
-- `rofi` has been updated from 1.7.5 to 1.7.6 which introduces some breaking changes to binary plugins, and also contains a lot of new features and bug fixes. This is highlighted because the patch version bump does not indicate the volume of changes by itself. See the [upstream release notes](https://github.com/davatorium/rofi/releases/tag/1.7.6) for the full list of changes.
-
-- `ente-auth` now uses the name `enteauth` for its binary. The previous name was `ente_auth`.
-
-- `foundationdb` was upgraded to 7.3.
-
-- `fluxus` has been removed, as it depends on `racket_7_9` and had no updates in 9 years.
-
-- `sm64ex-coop` has been removed as it was archived upstream. Consider migrating to `sm64coopdx`.
-
-- `renovate` was updated to v39. See the [upstream release notes](https://docs.renovatebot.com/release-notes-for-major-versions/#version-39) for breaking changes.
-  Like upstream's docker images, renovate now runs on NodeJS 22.
-
 - The behavior of the `networking.nat.externalIP` and `networking.nat.externalIPv6` options has been changed. `networking.nat.forwardPorts` now only forwards packets destined for the specified IP addresses.
-
-- `python3Packages.jaeger-client` was removed because it was deprecated upstream. [OpenTelemetry](https://opentelemetry.io) is the recommended replacement.
-
-- `nodePackages.meshcommander` has been removed, as the package was deprecated by Intel.
-
-- `kanata` was updated to v1.7.0, which introduces several breaking changes.
-  See the release notes of
-  [v1.7.0](https://github.com/jtroo/kanata/releases/tag/v1.7.0)
-  for more information.
-
-- `nodePackages.expo-cli` has been removed, as it was deprecated by upstream. The suggested replacement is the `npx expo` command.
 
 - DokuWiki with the Caddy webserver (`services.dokuwiki.webserver = "caddy"`) now sets up sites with Caddy's automatic HTTPS instead of HTTP-only.
   To keep the old behavior for a site `example.com`, set `services.caddy.virtualHosts."example.com".hostName = "http://example.com"`.
   If you set custom Caddy options for a DokuWiki site, migrate these options by removing `http://` from `services.caddy.virtualHosts."http://example.com"`.
 
-- `vscode-utils.buildVscodeExtension` now requires pname as an argument
-
 - The behavior of `services.hostapd.radios.<name>.networks.<name>.authentication.enableRecommendedPairwiseCiphers` was changed to not include `CCMP-256` anymore.
   Since all configured pairwise ciphers have to be supported by the radio, this caused startup failures on many devices which is hard to debug in hostapd.
-
-- `nerdfonts` has been separated into individual font packages under the namespace `nerd-fonts`. The directories for font
-  files have changed from `$out/share/fonts/{opentype,truetype}/NerdFonts` to
-  `$out/share/fonts/{opentype,truetype}/NerdFonts/<fontDirName>`, where `<fontDirName>` can be found in the
-  [official website](https://www.nerdfonts.com/font-downloads) as the titles in preview images, with the "Nerd Font"
-  suffix and any whitespaces trimmed. Configuration changes are required, see build output.
-
-- `retroarch` has been refactored and the older `retroarch.override { cores = [ ... ]; }` to create a RetroArch derivation with custom cores doesn't work anymore, use `retroarch.withCores (cores: [ ... ])` instead. If you need more customization (e.g.: custom settings), use `wrapRetroArch` instead.
 
 - `gkraken` software and `hardware.gkraken.enable` option have been removed, use `coolercontrol` via `programs.coolercontrol.enable` option instead.
 
@@ -233,23 +144,9 @@
   +extraCreateArgs+=("--exclude" "/some/path")
   ```
 
-- `nodePackages.ganache` has been removed, as the package has been deprecated by upstream.
-
 - `virtualisation.azure.agent` option provided by `azure-agent.nix` is replaced by `services.waagent`, and will be removed in a future release.
 
-- `matomo` now defaults to version 5 (previously available as `matomo_5`). Version 4 has been removed as it reached EOL on December 19, 2024.
-
-- `docker_24` has been removed, as it was EOL with vulnerabilites since June 08, 2024.
-
-- `containerd` has been updated to v2, which contains breaking changes. See the [containerd
-  2.0](https://github.com/containerd/containerd/blob/main/docs/containerd-2.0.md) documentation for more
-  details.
-
 - The ZFS import service now respects `fileSystems.*.options = [ "noauto" ];` and does not add that pool's import service to `zfs-import.target`, meaning it will not be automatically imported at boot.
-
-- `nodePackages.stackdriver-statsd-backend` has been removed, as the StackDriver service has been discontinued by Google, and therefore the package no longer works.
-
-- `python3Packages.opentracing` has been removed due to being unmaintained upstream. [OpenTelemetry](https://opentelemetry.io/) is the recommended replacement.
 
 - Default file names of images generated by several builders in `system.build` have been changed as outlined in the table below.
 
@@ -280,30 +177,7 @@
 - `security.apparmor.policies.<name>.enforce` and `security.apparmor.policies.<name>.enable` were removed.
   Configuring the state of apparmor policies must now be done using `security.apparmor.policies.<name>.state` tristate option.
 
-- the notmuch vim plugin now lives in a separate output of the `notmuch`
-  package. Installing `notmuch` will not bring the notmuch vim package anymore,
-  add `vimPlugins.notmuch-vim` to your (Neo)vim configuration if you want the
-  vim plugin.
-
-- `prisma` and `prisma-engines` have been updated to version 6.0.1, which
-  introduces several breaking changes. See the
-  [Prisma ORM upgrade guide](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-6)
-  for more information.
-
-- `nq` was updated to 1.0, which renames the `fq` and `tq` utilities to `nqtail` and `nqterm` respectively.
-
-- `zf` was updated to 0.10.2, which includes breaking changes from the [0.10.0 release](https://github.com/natecraddock/zf/releases/tag/0.10.0).
-  `zf` no longer does Unicode normalization of the input and no longer supports terminal escape sequences in the `ZF_PROMPT` environment variable.
-
 - `programs.clash-verge.tunMode` was deprecated and removed because now service mode is neccessary to start program. Without `programs.clash-verge.enable`, clash-verge-rev will refuse to start.
-
-- `siduck76-st` has been renamed to `st-snazzy`, like the project's [flake](https://github.com/siduck/st/blob/main/flake.nix).
-
-- `python3Packages.jax` now directly depends on `python3Packages.jaxlib`.
-  As a result, packages that depend on jax no longer need to include jaxlib to their dependencies.
-  There is also a breaking change in the handling of CUDA. Instead of using a CUDA compatible jaxlib
-  as before, you can use plugins like `python3Packages.jax-cuda12-plugin`.
-
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
@@ -319,8 +193,6 @@
   - Wayland session is still [experimental](https://wiki.xfce.org/releng/wayland_roadmap) and requires opt-in using `enableWaylandSession` option.
   - Overriding Wayland compositor is possible using `enableWaylandSession` option, but you might need to take care [`xfce4-session`](https://gitlab.xfce.org/xfce/xfce4-session/-/merge_requests/49), [`dbus-update-activation-environment`](https://github.com/labwc/labwc/blob/eaf11face68ee1f1bcc7ce1498304ca8c108c8ba/src/config/session.c#L234) and [`systemctl --user import-environment`](https://github.com/labwc/labwc/blob/eaf11face68ee1f1bcc7ce1498304ca8c108c8ba/src/config/session.c#L239) on startup.
   - For new Xfce installations, default panel layout has [changed](https://gitlab.xfce.org/xfce/xfce4-panel/-/merge_requests/158/diffs) to not include external panel plugins by default. You can still add them yourself using the "Panel Preferences" dialog.
-
-- GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
 
 - [`services.jupyter`](#opt-services.jupyter.enable) is now compatible with `Jupyter Notebook 7`. See [the migration guide](https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html) for details.
 
@@ -363,8 +235,6 @@
   in Linux 6.13.
 
 - `programs.fzf.keybindings` now supports the fish shell.
-
-- `gerbera` now has wavpack support.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 


### PR DESCRIPTION
the initial change was already made ad hoc in 10a75ab5b2c237e3c30556d65de3ee49ff4b6830, in response to the recently introduced enforced redirects mapping that is supposed to keep stable URLs.

due to the redirect mechanism's current limitation to locations within
the same site (that is, either the Nixpkgs xor the NixOS manual), and
the observation that noteworthy Nixpkgs changes tend to be
self-contained, it seemed reasonable to introduce a seperate release
notes document. it also has the advantage that users of only Nixpkgs
don't have to deal with release notes that are only relevant for NixOS.

the original change was already lossless for NixOS users, since the
Nixpkgs release notes are appended to the NixOS release notes.

this change moves the pre-existing Nixpkgs notes to the new dedicated page.

thanks @infinisil for pointing out in https://github.com/NixOS/nixpkgs/pull/363755#discussion_r1904209339 that we didn't leave a paper trail!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc