### PR TITLE
lxterminal: unbreak with patch adapted from upstream

### DIFF
--- a/pkgs/by-name/lx/lxterminal/fix-gcc14-pr122.patch
+++ b/pkgs/by-name/lx/lxterminal/fix-gcc14-pr122.patch
@@ -1,0 +1,24 @@
+diff --git a/src/lxterminal.c b/src/lxterminal.c
+index 015f5e4..32e3b68 100644
+--- a/src/lxterminal.c
++++ b/src/lxterminal.c
+@@ -1210,6 +1210,8 @@ static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gch
+     vte_terminal_match_set_cursor_type(VTE_TERMINAL(term->vte), ret, GDK_HAND2);
+     ret = vte_terminal_match_add_regex(VTE_TERMINAL(term->vte), dingus2, 0);
+     vte_terminal_match_set_cursor_type(VTE_TERMINAL(term->vte), ret, GDK_HAND2);
++    vte_regex_unref(dingus1);
++    vte_regex_unref(dingus2);
+ #else
+     GRegex * dingus1 = g_regex_new(DINGUS1, G_REGEX_OPTIMIZE, 0, NULL);
+     GRegex * dingus2 = g_regex_new(DINGUS2, G_REGEX_OPTIMIZE, 0, NULL);
+@@ -1217,9 +1219,9 @@ static Term * terminal_new(LXTerminal * terminal, const gchar * label, const gch
+     vte_terminal_match_set_cursor_type(VTE_TERMINAL(term->vte), ret, GDK_HAND2);
+     ret = vte_terminal_match_add_gregex(VTE_TERMINAL(term->vte), dingus2, 0);
+     vte_terminal_match_set_cursor_type(VTE_TERMINAL(term->vte), ret, GDK_HAND2);
+-#endif
+     g_regex_unref(dingus1);
+     g_regex_unref(dingus2);
++#endif
+ 
+     /* Create a horizontal box inside an event box as the toplevel for the tab label. */
+     term->tab = gtk_event_box_new();

--- a/pkgs/by-name/lx/lxterminal/package.nix
+++ b/pkgs/by-name/lx/lxterminal/package.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
+    ./fix-gcc14-pr122.patch # manual port of https://github.com/lxde/lxterminal/pull/122
     ./respect-xml-catalog-files-var.patch
   ];
 


### PR DESCRIPTION
fixes https://github.com/NixOS/nixpkgs/issues/371831 by adapting https://github.com/lxde/lxterminal/pull/122 to v0.4.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
