### PR TITLE
ghostty: add darwin version

### DIFF
--- a/pkgs/by-name/gh/ghostty/darwin.nix
+++ b/pkgs/by-name/gh/ghostty/darwin.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenvNoCC,
+  _7zz,
+  fetchurl,
+  makeBinaryWrapper,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  src = fetchurl {
+    url = "https://release.files.ghostty.org/${finalAttrs.version}/Ghostty.dmg";
+    hash = "sha256-QA9oy9EXLSFbzcRybKM8CxmBnUYhML82w48C+0gnRmM=";
+  };
+
+  sourceRoot = ".";
+
+  nativeBuildInputs = [
+    _7zz
+    makeBinaryWrapper
+  ];
+
+  postInstall = ''
+    mkdir -p $out/Applications
+    mv Ghostty.app $out/Applications/
+    makeWrapper $out/Applications/Ghostty.app/Contents/MacOS/ghostty $out/bin/ghostty
+  '';
+
+  /**
+     Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
+
+     - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
+     - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
+     - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
+
+     terminfo and shell integration should also be installable on remote machines
+
+     ```nix
+     { pkgs, ... }: {
+       environment.systemPackages = [ pkgs.ghostty.terminfo ];
+
+       programs.bash = {
+         interactiveShellInit = ''
+           if [[ "$TERM" == "xterm-ghostty" ]]; then
+             builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
+           fi
+         '';
+       };
+     }
+     ```
+
+     On linux we can move the original files and make symlinks to them
+     but on darwin (when using the .app bundle) we need to copy the files
+     in order to maintain signed integrity
+  */
+  resourceDir = "${placeholder "out"}/Applications/Ghostty.app/Contents/Resources";
+  postFixup = ''
+    mkdir -p $terminfo/share
+    cp -r $resourceDir/terminfo $terminfo/share/terminfo
+
+    cp -r $resourceDir/ghostty/shell-integration $shell_integration
+
+    cp -r $resourceDir/vim/vimfiles $vim
+  '';
+
+  # Usually the multiple-outputs hook would take care of this, but
+  # our manpages are in the .app bundle
+  preFixup = ''
+    mkdir -p $man/share
+    cp -r $resourceDir/man $man/share/man
+  '';
+
+  meta = {
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/by-name/gh/ghostty/deps.nix
+++ b/pkgs/by-name/gh/ghostty/deps.nix
@@ -16,15 +16,11 @@ with lib;
 let
   unpackZigArtifact =
     { name, artifact }:
-    runCommandLocal name
-      {
-        nativeBuildInputs = [ zig ];
-      }
-      ''
-        hash="$(zig fetch --global-cache-dir "$TMPDIR" ${artifact})"
-        mv "$TMPDIR/p/$hash" "$out"
-        chmod 755 "$out"
-      '';
+    runCommandLocal name { nativeBuildInputs = [ zig ]; } ''
+      hash="$(zig fetch --global-cache-dir "$TMPDIR" ${artifact})"
+      mv "$TMPDIR/p/$hash" "$out"
+      chmod 755 "$out"
+    '';
 
   fetchZig =
     {

--- a/pkgs/by-name/gh/ghostty/linux.nix
+++ b/pkgs/by-name/gh/ghostty/linux.nix
@@ -1,0 +1,160 @@
+{
+  lib,
+  stdenv,
+  bzip2,
+  callPackage,
+  fetchFromGitHub,
+  fontconfig,
+  freetype,
+  glib,
+  glslang,
+  harfbuzz,
+  libGL,
+  libX11,
+  libadwaita,
+  ncurses,
+  nixosTests,
+  oniguruma,
+  pandoc,
+  pkg-config,
+  removeReferencesTo,
+  versionCheckHook,
+  wrapGAppsHook4,
+  zig_0_13,
+  # Usually you would override `zig.hook` with this, but we do that internally
+  # since upstream recommends a non-default level
+  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/PACKAGING.md#build-options
+  optimizeLevel ? "ReleaseFast",
+  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/build.zig#L106
+  withAdwaita ? true,
+}:
+
+let
+  zig_hook = zig_0_13.hook.overrideAttrs {
+    zig_default_flags = "-Dcpu=baseline -Doptimize=${optimizeLevel} --color off";
+  };
+
+  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/apprt.zig#L72-L76
+  appRuntime = if stdenv.hostPlatform.isLinux then "gtk" else "none";
+  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/font/main.zig#L94
+  fontBackend = if stdenv.hostPlatform.isDarwin then "coretext" else "fontconfig_freetype";
+  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/renderer.zig#L51-L52
+  renderer = if stdenv.hostPlatform.isDarwin then "metal" else "opengl";
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  src = fetchFromGitHub {
+    owner = "ghostty-org";
+    repo = "ghostty";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-BiXFNeoL+BYpiqzCuDIrZGQ6JVI8cBOXerJH48CbnxU=";
+  };
+
+  deps = callPackage ./deps.nix {
+    name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs =
+    [
+      ncurses
+      pandoc
+      pkg-config
+      removeReferencesTo
+      zig_hook
+    ]
+    ++ lib.optionals (appRuntime == "gtk") [
+      glib # Required for `glib-compile-schemas`
+      wrapGAppsHook4
+    ];
+
+  buildInputs =
+    [
+      glslang
+      oniguruma
+    ]
+    ++ lib.optional (appRuntime == "gtk" && withAdwaita) libadwaita
+    ++ lib.optional (appRuntime == "gtk") libX11
+    ++ lib.optional (renderer == "opengl") libGL
+    ++ lib.optionals (fontBackend == "fontconfig_freetype") [
+      bzip2
+      fontconfig
+      freetype
+      harfbuzz
+    ];
+
+  zigBuildFlags =
+    [
+      "--system"
+      "${finalAttrs.deps}"
+      "-Dversion-string=${finalAttrs.version}"
+
+      "-Dapp-runtime=${appRuntime}"
+      "-Dfont-backend=${fontBackend}"
+      "-Dgtk-adwaita=${lib.boolToString withAdwaita}"
+      "-Drenderer=${renderer}"
+    ]
+    ++ lib.mapAttrsToList (name: package: "-fsys=${name} --search-prefix ${lib.getLib package}") {
+      inherit glslang;
+    };
+
+  zigCheckFlags = finalAttrs.zigBuildFlags;
+
+  doCheck = true;
+
+  /**
+    Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
+
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
+    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
+
+    terminfo and shell integration should also be installable on remote machines
+
+    ```nix
+    { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.ghostty.terminfo ];
+
+      programs.bash = {
+        interactiveShellInit = ''
+          if [[ "$TERM" == "xterm-ghostty" ]]; then
+            builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
+          fi
+        '';
+      };
+    }
+    ```
+  */
+  postFixup = ''
+    ln -s $man/share/man $out/share/man
+
+    moveToOutput share/terminfo $terminfo
+    ln -s $terminfo/share/terminfo $out/share/terminfo
+
+    mv $out/share/ghostty/shell-integration $shell_integration
+    ln -s $shell_integration $out/share/ghostty/shell-integration
+
+    mv $out/share/vim/vimfiles $vim
+    rmdir $out/share/vim
+    ln -s $vim $out/share/vim-plugins
+
+
+    remove-references-to -t ${finalAttrs.deps} $out/bin/.ghostty-wrapped
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
+
+  versionCheckProgramArg = [ "--version" ];
+
+  passthru = {
+    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
+      inherit (nixosTests) allTerminfo;
+      nixos = nixosTests.terminal-emulators.ghostty;
+    };
+  };
+})

--- a/pkgs/by-name/gh/ghostty/package.nix
+++ b/pkgs/by-name/gh/ghostty/package.nix
@@ -1,201 +1,55 @@
 {
   lib,
   stdenv,
-  bzip2,
   callPackage,
-  fetchFromGitHub,
-  fontconfig,
-  freetype,
-  glib,
-  glslang,
-  harfbuzz,
-  libGL,
-  libX11,
-  libadwaita,
-  ncurses,
-  nixosTests,
-  oniguruma,
-  pandoc,
-  pkg-config,
-  removeReferencesTo,
-  versionCheckHook,
-  wrapGAppsHook4,
-  zig_0_13,
-  # Usually you would override `zig.hook` with this, but we do that internally
-  # since upstream recommends a non-default level
-  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/PACKAGING.md#build-options
-  optimizeLevel ? "ReleaseFast",
-  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/build.zig#L106
-  withAdwaita ? true,
 }:
 
 let
-  zig_hook = zig_0_13.hook.overrideAttrs {
-    zig_default_flags = "-Dcpu=baseline -Doptimize=${optimizeLevel} --color off";
-  };
-
-  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/apprt.zig#L72-L76
-  appRuntime = if stdenv.hostPlatform.isLinux then "gtk" else "none";
-  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/font/main.zig#L94
-  fontBackend = if stdenv.hostPlatform.isDarwin then "coretext" else "fontconfig_freetype";
-  # https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/renderer.zig#L51-L52
-  renderer = if stdenv.hostPlatform.isDarwin then "metal" else "opengl";
+  package = callPackage (if stdenv.hostPlatform.isDarwin then ./darwin.nix else ./linux.nix) { };
 in
+package.overrideAttrs (
+  finalAttrs: oldAttrs: {
+    pname = "ghostty";
+    version = "1.0.1";
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "ghostty";
-  version = "1.0.1";
-  outputs = [
-    "out"
-    "man"
-    "shell_integration"
-    "terminfo"
-    "vim"
-  ];
-
-  src = fetchFromGitHub {
-    owner = "ghostty-org";
-    repo = "ghostty";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-BiXFNeoL+BYpiqzCuDIrZGQ6JVI8cBOXerJH48CbnxU=";
-  };
-
-  deps = callPackage ./deps.nix {
-    name = "${finalAttrs.pname}-cache-${finalAttrs.version}";
-  };
-
-  strictDeps = true;
-
-  nativeBuildInputs =
-    [
-      ncurses
-      pandoc
-      pkg-config
-      removeReferencesTo
-      zig_hook
-    ]
-    ++ lib.optionals (appRuntime == "gtk") [
-      glib # Required for `glib-compile-schemas`
-      wrapGAppsHook4
-    ];
-
-  buildInputs =
-    [
-      glslang
-      oniguruma
-    ]
-    ++ lib.optional (appRuntime == "gtk" && withAdwaita) libadwaita
-    ++ lib.optional (appRuntime == "gtk") libX11
-    ++ lib.optional (renderer == "opengl") libGL
-    ++ lib.optionals (fontBackend == "fontconfig_freetype") [
-      bzip2
-      fontconfig
-      freetype
-      harfbuzz
-    ];
-
-  zigBuildFlags =
-    [
-      "--system"
-      "${finalAttrs.deps}"
-      "-Dversion-string=${finalAttrs.version}"
-
-      "-Dapp-runtime=${appRuntime}"
-      "-Dfont-backend=${fontBackend}"
-      "-Dgtk-adwaita=${lib.boolToString withAdwaita}"
-      "-Drenderer=${renderer}"
-    ]
-    ++ lib.mapAttrsToList (name: package: "-fsys=${name} --search-prefix ${lib.getLib package}") {
-      inherit glslang;
-    };
-
-  zigCheckFlags = finalAttrs.zigBuildFlags;
-
-  doCheck = true;
-
-  /**
-    Ghostty really likes all of it's resources to be in the same directory, so link them back after we split them
-
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/os/resourcesdir.zig#L11-L52
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L745-L750
-    - https://github.com/ghostty-org/ghostty/blob/4b4d4062dfed7b37424c7210d1230242c709e990/src/termio/Exec.zig#L818-L834
-
-    terminfo and shell integration should also be installable on remote machines
-
-    ```nix
-    { pkgs, ... }: {
-      environment.systemPackages = [ pkgs.ghostty.terminfo ];
-
-      programs.bash = {
-        interactiveShellInit = ''
-          if [[ "$TERM" == "xterm-ghostty" ]]; then
-            builtin source ${pkgs.ghostty.shell_integration}/bash/ghostty.bash
-          fi
-        '';
-      };
-    }
-    ```
-  */
-  postFixup = ''
-    ln -s $man/share/man $out/share/man
-
-    moveToOutput share/terminfo $terminfo
-    ln -s $terminfo/share/terminfo $out/share/terminfo
-
-    mv $out/share/ghostty/shell-integration $shell_integration
-    ln -s $shell_integration $out/share/ghostty/shell-integration
-
-    mv $out/share/vim/vimfiles $vim
-    rmdir $out/share/vim
-    ln -s $vim $out/share/vim-plugins
-
-
-    remove-references-to -t ${finalAttrs.deps} $out/bin/.ghostty-wrapped
-  '';
-
-  nativeInstallCheckInputs = [
-    versionCheckHook
-  ];
-
-  doInstallCheck = true;
-
-  versionCheckProgramArg = [ "--version" ];
-
-  passthru = {
-    tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
-      inherit (nixosTests) allTerminfo;
-      nixos = nixosTests.terminal-emulators.ghostty;
-    };
-  };
-
-  meta = {
-    description = "Fast, native, feature-rich terminal emulator pushing modern features";
-    longDescription = ''
-      Ghostty is a terminal emulator that differentiates itself by being
-      fast, feature-rich, and native. While there are many excellent terminal
-      emulators available, they all force you to choose between speed,
-      features, or native UIs. Ghostty provides all three.
-    '';
-    homepage = "https://ghostty.org/";
-    downloadPage = "https://ghostty.org/download";
-    changelog = "https://ghostty.org/docs/install/release-notes/${
-      builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
-    }";
-    license = lib.licenses.mit;
-    mainProgram = "ghostty";
-    maintainers = with lib.maintainers; [
-      jcollie
-      pluiedev
-      getchoo
-    ];
-    outputsToInstall = [
+    outputs = [
       "out"
       "man"
       "shell_integration"
       "terminfo"
+      "vim"
     ];
-    platforms = lib.platforms.linux ++ lib.platforms.darwin;
-    # Issues finding the SDK in the sandbox
-    broken = stdenv.hostPlatform.isDarwin;
-  };
-})
+
+    # Point `nix edit`, etc. to the file that defines the attribute
+    pos = builtins.unsafeGetAttrPos "src" finalAttrs;
+
+    meta = lib.recursiveUpdate (oldAttrs.meta or { }) {
+      description = "Fast, native, feature-rich terminal emulator pushing modern features";
+      longDescription = ''
+        Ghostty is a terminal emulator that differentiates itself by being
+        fast, feature-rich, and native. While there are many excellent terminal
+        emulators available, they all force you to choose between speed,
+        features, or native UIs. Ghostty provides all three.
+      '';
+      homepage = "https://ghostty.org/";
+      downloadPage = "https://ghostty.org/download";
+      changelog = "https://ghostty.org/docs/install/release-notes/${
+        builtins.replaceStrings [ "." ] [ "-" ] finalAttrs.version
+      }";
+      license = lib.licenses.mit;
+      mainProgram = "ghostty";
+      maintainers = with lib.maintainers; [
+        jcollie
+        pluiedev
+        getchoo
+      ];
+      outputsToInstall = [
+        "out"
+        "man"
+        "shell_integration"
+        "terminfo"
+      ];
+      platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    };
+  }
+)


### PR DESCRIPTION
Adds the darwin version of ghostty by combining the work done in #369080 and #369529 (many thanks to @DimitarNestorov and @getchoo) while maintaining integrity of the extracted bundle. Obviously we would ideally build from source but  we currently need to wait for better nixpkgs/Xcode interoperability for zig to be able to find the macOS and iOS toolchains in a clean nix environment and for now the [recommendation](https://ghostty.org/download) is to use the official binary build (as homebrew does).

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
