### PR TITLE
vorbisgain: Fix build with GCC 14

### DIFF
--- a/pkgs/by-name/vo/vorbisgain/fprintf.patch
+++ b/pkgs/by-name/vo/vorbisgain/fprintf.patch
@@ -1,0 +1,12 @@
+--- vorbisgain-0.37/misc.c	2004-01-03 16:17:28.000000000 -0500
++++ vorbisgain-0.37-patched/misc.c	2025-01-07 20:51:12.989521816 -0500
+@@ -56,8 +56,7 @@
+     vfprintf(stderr, message, args);
+     va_end(args);
+ 
+-    fprintf(stderr, strerror(err_num));
+-    fprintf(stderr, "\n");
++    fprintf(stderr, "%s\n", strerror(err_num));
+ }
+ 
+ 

--- a/pkgs/by-name/vo/vorbisgain/isatty.patch
+++ b/pkgs/by-name/vo/vorbisgain/isatty.patch
@@ -1,0 +1,10 @@
+--- vorbisgain-0.37/misc.c	2004-01-03 16:17:28.000000000 -0500
++++ vorbisgain-0.37-patched/misc.c	2025-01-07 20:35:13.056221211 -0500
+@@ -23,6 +23,7 @@
+ #else /* WIN32 */
+ #include <errno.h>
+ #include <ctype.h>
++#include <unistd.h>
+ 
+ #ifndef DISABLE_WINSIZE
+ 

--- a/pkgs/by-name/vo/vorbisgain/package.nix
+++ b/pkgs/by-name/vo/vorbisgain/package.nix
@@ -22,11 +22,6 @@ stdenv.mkDerivation rec {
     libvorbis
   ];
 
-  patchPhase = ''
-    chmod -v +x configure
-    configureFlags="--mandir=$out/share/man"
-  '';
-
   meta = with lib; {
     homepage = "https://sjeng.org/vorbisgain.html";
     description = "Utility that corrects the volume of an Ogg Vorbis file to a predefined standardized loudness";

--- a/pkgs/by-name/vo/vorbisgain/package.nix
+++ b/pkgs/by-name/vo/vorbisgain/package.nix
@@ -17,9 +17,8 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./isatty.patch
+    ./fprintf.patch
   ];
-
-  hardeningDisable = [ "format" ];
 
   buildInputs = [
     libogg

--- a/pkgs/by-name/vo/vorbisgain/package.nix
+++ b/pkgs/by-name/vo/vorbisgain/package.nix
@@ -15,6 +15,10 @@ stdenv.mkDerivation rec {
     sha256 = "1v1h6mhnckmvvn7345hzi9abn5z282g4lyyl4nnbqwnrr98v0vfx";
   };
 
+  patches = [
+    ./isatty.patch
+  ];
+
   hardeningDisable = [ "format" ];
 
   buildInputs = [


### PR DESCRIPTION
`vorbisgain` currently doesn't build on master since GCC was updated to version 14.

* Remove `patchPhase` (it's redundant)
* Add patch to fix implicit declaration of `isatty()` (fixes the build)
* Add patch for incorrect usage of `fprintf()` and remove `hardeningDisable = [ "format" ]` (improves safety)

Fixes #370032

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
