### PR TITLE
lha: unstable-2021-01-07 -> unstable-2024-11-27

### DIFF
--- a/pkgs/by-name/lh/lha/package.nix
+++ b/pkgs/by-name/lh/lha/package.nix
@@ -24,6 +24,7 @@ stdenv.mkDerivation {
     platforms = lib.platforms.unix;
     maintainers = with lib.maintainers; [
       sander
+      momeemt
     ];
     # Some of the original LHa code has been rewritten and the current author
     # considers adopting a "true" free and open source license for it.

--- a/pkgs/by-name/lh/lha/package.nix
+++ b/pkgs/by-name/lh/lha/package.nix
@@ -7,27 +7,30 @@
 
 stdenv.mkDerivation {
   pname = "lha";
-  version = "unstable-2021-01-07";
+  version = "1.14i-unstable-2024-11-27";
 
   src = fetchFromGitHub {
     owner = "jca02266";
     repo = "lha";
-    rev = "03475355bc6311f7f816ea9a88fb34a0029d975b";
-    sha256 = "18w2x0g5yq89yxkxh1fmb05lz4hw7a3b4jmkk95gvh11mwbbr5lm";
+    rev = "26b71be85a762098bdeb95f4533045c7dad86f31";
+    hash = "sha256-jiYTBqDXvxTdrvHYaK+1eo4xIpl+B9ZljhBBYD0BGzQ=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  meta = with lib; {
+  meta = {
     description = "LHa is an archiver and compressor using the LZSS and Huffman encoding compression algorithms";
-    platforms = platforms.unix;
-    maintainers = [ maintainers.sander ];
-    # Some of the original LhA code has been rewritten and the current author
+    homepage = "https://github.com/jca02266/lha";
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [
+      sander
+    ];
+    # Some of the original LHa code has been rewritten and the current author
     # considers adopting a "true" free and open source license for it.
     # However, old code is still covered by the original LHa license, which is
     # not a free software license (it has additional requirements on commercial
     # use).
-    license = licenses.unfree;
+    license = lib.licenses.unfree;
     mainProgram = "lha";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Closes #370358 

- Updated lha from unstable-2021-01-07 to unstable-2024-11-27
	- There are no more build bugs #370358 
- Removed `with lib;`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
