### PR TITLE
edencommon: skip flaky test everywhere

### DIFF
--- a/pkgs/by-name/ed/edencommon/package.nix
+++ b/pkgs/by-name/ed/edencommon/package.nix
@@ -75,16 +75,14 @@ stdenv.mkDerivation (finalAttrs: {
   checkPhase = ''
     runHook preCheck
 
-    # Skip flaky test on darwin
+    # Skip flaky test
     ctest -j $NIX_BUILD_CORES --output-on-failure ${
-      lib.optionalString stdenv.hostPlatform.isDarwin (
-        lib.escapeShellArgs [
-          "--exclude-regex"
-          (lib.concatMapStringsSep "|" (test: "^${lib.escapeRegex test}$") [
-            "ProcessInfoCache.addFromMultipleThreads"
-          ])
-        ]
-      )
+      lib.escapeShellArgs [
+        "--exclude-regex"
+        (lib.concatMapStringsSep "|" (test: "^${lib.escapeRegex test}$") [
+          "ProcessInfoCache.addFromMultipleThreads"
+        ])
+      ]
     }
 
     runHook postCheck


### PR DESCRIPTION
Follow-up to https://github.com/NixOS/nixpkgs/pull/369477#pullrequestreview-2526544827. The same test fails on Linux

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).