### PR TITLE
python313Packages.pygitguardian: 1.18.0 -> 1.19.0

### DIFF
--- a/pkgs/development/python-modules/pygitguardian/default.nix
+++ b/pkgs/development/python-modules/pygitguardian/default.nix
@@ -16,7 +16,7 @@
 
 buildPythonPackage rec {
   pname = "pygitguardian";
-  version = "1.18.0";
+  version = "1.19.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -25,7 +25,7 @@ buildPythonPackage rec {
     owner = "GitGuardian";
     repo = "py-gitguardian";
     tag = "v${version}";
-    hash = "sha256-4qMcBtelLiqLXKV8YIw9M6e97Nbo/K8UpsKoR0W7uKM=";
+    hash = "sha256-g3OH6pPk6Whd0JW6voILEK40/z6gWrdT6ibSa5kW47Q=";
   };
 
   pythonRelaxDeps = [
@@ -33,9 +33,7 @@ buildPythonPackage rec {
     "setuptools"
   ];
 
-  build-system = [
-    pdm-backend
-  ];
+  build-system = [ pdm-backend ];
 
   dependencies = [
     marshmallow
@@ -53,33 +51,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "pygitguardian" ];
 
-  disabledTests = [
-    # Tests require an API key
-    "test_api_tokens"
-    "test_bogus_rate_limit"
-    "test_compute_sca_files"
-    "test_content_scan_exceptions"
-    "test_content_scan"
-    "test_create_honeytoken"
-    "test_create_jwt"
-    "test_extra_headers"
-    "test_health_check"
-    "test_multi_content_exceptions"
-    "test_multi_content_scan"
-    "test_multiscan_parameters"
-    "test_quota_overview"
-    "test_rate_limit"
-    "test_read_metadata_bad_response"
-    "test_read_metadata_no_remediation_message"
-    "test_read_metadata_remediation_message"
-    "test_retrieve_secret_incident"
-    "test_sca_client_scan_diff"
-    "test_sca_scan_all_with_params"
-    "test_sca_scan_directory_invalid_tar"
-    "test_sca_scan_directory"
-    "test_scan"
-    "test_versions_from_headers"
-  ];
+  env.GITGUARDIAN_API_KEY = "Test key for tests";
 
   meta = with lib; {
     description = "Library to access the GitGuardian API";


### PR DESCRIPTION
Diff: https://github.com/GitGuardian/py-gitguardian/compare/refs/tags/v1.18.0...v1.19.0

Changelog: https://github.com/GitGuardian/py-gitguardian/blob/v1.19.0/CHANGELOG.md


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
