### PR TITLE
GNOME updates 2025-01-08

### DIFF
--- a/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
+++ b/pkgs/applications/networking/mailreaders/evolution/evolution/default.nix
@@ -46,11 +46,11 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution";
-  version = "3.54.2";
+  version = "3.54.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    hash = "sha256-7eopEv/bZZnA6gKJw6muIBe/43oI14IjWEUhqlaGtXY=";
+    hash = "sha256-dGz4HvXDJa8X9Tsvq0bWcmDzsT2gFNiZTUrZ6Ea4Ves=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ev/evolution-data-server/hardcode-gsettings.patch
+++ b/pkgs/by-name/ev/evolution-data-server/hardcode-gsettings.patch
@@ -1,5 +1,5 @@
 diff --git a/src/addressbook/libebook/e-book-client.c b/src/addressbook/libebook/e-book-client.c
-index 5e65ec8..8ca28c6 100644
+index 5e65ec8..2cae29d 100644
 --- a/src/addressbook/libebook/e-book-client.c
 +++ b/src/addressbook/libebook/e-book-client.c
 @@ -1924,7 +1924,18 @@ e_book_client_get_self (ESourceRegistry *registry,
@@ -42,23 +42,25 @@ index 5e65ec8..8ca28c6 100644
  	g_settings_set_string (
  		settings, SELF_UID_KEY,
  		e_contact_get_const (contact, E_CONTACT_UID));
-@@ -2028,8 +2050,18 @@ e_book_client_is_self (EContact *contact)
+@@ -2028,8 +2050,20 @@ e_book_client_is_self (EContact *contact)
  	 * unfortunately the API doesn't allow that.
  	 */
  	g_mutex_lock (&mutex);
 -	if (!settings)
 -		settings = g_settings_new (SELF_UID_PATH_ID);
 +	if (!settings) {
-+		g_autoptr(GSettingsSchemaSource) schema_source;
-+		g_autoptr(GSettingsSchema) schema;
-+		schema_source = g_settings_schema_source_new_from_directory("@EDS@",
-+									    g_settings_schema_source_get_default(),
-+									    TRUE,
-+									    NULL);
-+		schema = g_settings_schema_source_lookup(schema_source,
-+							 SELF_UID_PATH_ID,
-+							 FALSE);
-+		settings = g_settings_new_full(schema, NULL, NULL);
++		{
++			g_autoptr(GSettingsSchemaSource) schema_source;
++			g_autoptr(GSettingsSchema) schema;
++			schema_source = g_settings_schema_source_new_from_directory("@EDS@",
++										    g_settings_schema_source_get_default(),
++										    TRUE,
++										    NULL);
++			schema = g_settings_schema_source_lookup(schema_source,
++								 SELF_UID_PATH_ID,
++								 FALSE);
++			settings = g_settings_new_full(schema, NULL, NULL);
++		}
 +	}
  	uid = g_settings_get_string (settings, SELF_UID_KEY);
  	g_mutex_unlock (&mutex);

--- a/pkgs/by-name/ev/evolution-data-server/package.nix
+++ b/pkgs/by-name/ev/evolution-data-server/package.nix
@@ -51,7 +51,7 @@
 
 stdenv.mkDerivation rec {
   pname = "evolution-data-server";
-  version = "3.54.2";
+  version = "3.54.3";
 
   outputs = [
     "out"
@@ -60,7 +60,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "mirror://gnome/sources/evolution-data-server/${lib.versions.majorMinor version}/evolution-data-server-${version}.tar.xz";
-    hash = "sha256-EfAlMInIq/RWz/2j/mWKNaDeK4rpPY8lfWsCCueWPSA=";
+    hash = "sha256-UQjcOO5cwfjvkVXof2xBKflkRVCglixa4j/4B7V8uNA=";
   };
 
   patches = [

--- a/pkgs/by-name/gl/glycin-loaders/package.nix
+++ b/pkgs/by-name/gl/glycin-loaders/package.nix
@@ -23,11 +23,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "glycin-loaders";
-  version = "1.1.2";
+  version = "1.1.4";
 
   src = fetchurl {
     url = "mirror://gnome/sources/glycin/${lib.versions.majorMinor finalAttrs.version}/glycin-${finalAttrs.version}.tar.xz";
-    hash = "sha256-Qccr4eybpV2pDIL8GFc7dC3/WCsJr8N7RWXEfpnMj/Q=";
+    hash = "sha256-0bbVkLaZtmgaZ9ARmKWBp/cQ2Mp0UJNN1/XbJB+hJQA=";
   };
 
   patches = [

--- a/pkgs/by-name/gn/gnome-maps/package.nix
+++ b/pkgs/by-name/gn/gnome-maps/package.nix
@@ -30,11 +30,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gnome-maps";
-  version = "47.2";
+  version = "47.3";
 
   src = fetchurl {
     url = "mirror://gnome/sources/gnome-maps/${lib.versions.major finalAttrs.version}/gnome-maps-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WFHnhtrsZY8h5FeiBv8KmtFlnzdBqtlJCxvzGSFU/ps=";
+    hash = "sha256-HpAwe6/njiML1OrdCUcicakp+1FolCJFkG+fEdrhPLg=";
   };
 
   doCheck = !stdenv.hostPlatform.isDarwin;

--- a/pkgs/by-name/gn/gnote/package.nix
+++ b/pkgs/by-name/gn/gnote/package.nix
@@ -20,11 +20,11 @@
 
 stdenv.mkDerivation rec {
   pname = "gnote";
-  version = "47.0";
+  version = "47.2";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-vrNcreIMYOQxVRbyCsfr7p37wrgPAHy+2LxaUlIuRC4=";
+    hash = "sha256-mmDxaSSA9k0WbTHmVkoP8kgSelmOL/f2NX3AsuwlsWg=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/gt/gtk-vnc/package.nix
+++ b/pkgs/by-name/gt/gtk-vnc/package.nix
@@ -12,12 +12,13 @@
   cyrus_sasl,
   pulseaudioSupport ? stdenv.hostPlatform.isLinux,
   libpulseaudio,
-  libgcrypt,
+  gmp,
   gtk3,
   vala,
   gettext,
   perl,
   python3,
+  gi-docgen,
   gnome,
   gdk-pixbuf,
   zlib,
@@ -25,18 +26,19 @@
 
 stdenv.mkDerivation rec {
   pname = "gtk-vnc";
-  version = "1.3.1";
+  version = "1.4.0";
 
   outputs = [
     "out"
     "bin"
     "man"
     "dev"
+    "devdoc"
   ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "USdjrE4FWdAVi2aCyl3Ro71jPwgvXkNJ1xWOa1+A8c4=";
+    url = "mirror://gnome/sources/gtk-vnc/${lib.versions.majorMinor version}/gtk-vnc-${version}.tar.xz";
+    sha256 = "G+ZMTkdgxSs+wzBnKQ0e+kCtTOyrbGc4E4BOPFWdloM=";
   };
 
   nativeBuildInputs = [
@@ -48,6 +50,7 @@ stdenv.mkDerivation rec {
     gettext
     perl # for pod2man
     python3
+    gi-docgen
   ];
 
   buildInputs =
@@ -57,7 +60,7 @@ stdenv.mkDerivation rec {
       gdk-pixbuf
       zlib
       glib
-      libgcrypt
+      gmp
       cyrus_sasl
       gtk3
     ]
@@ -69,9 +72,14 @@ stdenv.mkDerivation rec {
     "-Dpulseaudio=disabled"
   ];
 
+  postFixup = ''
+    # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
+    moveToOutput "share/doc" "$devdoc"
+  '';
+
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "gtk-vnc";
       versionPolicy = "none";
     };
   };

--- a/pkgs/by-name/li/libshumate/package.nix
+++ b/pkgs/by-name/li/libshumate/package.nix
@@ -23,7 +23,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libshumate";
-  version = "1.3.0";
+  version = "1.3.1";
 
   outputs = [
     "out"
@@ -34,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://gnome/sources/libshumate/${lib.versions.majorMinor finalAttrs.version}/libshumate-${finalAttrs.version}.tar.xz";
-    hash = "sha256-giem6Cgc3hIjKJT++Ddg1E+maznvAzxh7ZNKhsbcddQ=";
+    hash = "sha256-bv6TUtkXRIItQerUcUoqtLN4SBqGoiBLe+xAgt/8G4s=";
   };
 
   depsBuildBuild = [

--- a/pkgs/by-name/me/meld/package.nix
+++ b/pkgs/by-name/me/meld/package.nix
@@ -22,13 +22,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "meld";
-  version = "3.22.2";
+  version = "3.22.3";
 
   format = "other";
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
-    sha256 = "sha256-RqCnE/vNGxU7N3oeB1fIziVcmCJGdljqz72JsekjFu8=";
+    sha256 = "sha256-N/fynrH/D+xNiwiNVIPFVt4QifbQGP5tSBmTyvJJnYQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -29,13 +29,13 @@
 
 python3.pkgs.buildPythonApplication rec {
   pname = "orca";
-  version = "47.2";
+  version = "47.3";
 
   format = "other";
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.major version}/${pname}-${version}.tar.xz";
-    hash = "sha256-XmevNX9xmOoApEOByrTE+U5oJtbtgAZo85QWziqrjlo=";
+    url = "mirror://gnome/sources/orca/${lib.versions.major version}/orca-${version}.tar.xz";
+    hash = "sha256-GwsUW7aFzXTso+KMt7cJf5jRPuHMWLce3u06j5BFIxs=";
   };
 
   patches = [
@@ -93,7 +93,7 @@ python3.pkgs.buildPythonApplication rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = "orca";
     };
   };
 


### PR DESCRIPTION
- Skipping evolution-ews https://discourse.gnome.org/t/releasing-gnome-modules/25566/43
- Skipping gnome-software https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/2188

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Skimmed NEWS and upstream diffs.
- [x] Built and ran loupe (for glycin-loaders)
- [x] Built gnome-connections (for  gtk-vnc)
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - [x] meld
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
