### PR TITLE
socalabs-sid: init at 1.1.0

### DIFF
--- a/pkgs/by-name/so/socalabs-sid/package.nix
+++ b/pkgs/by-name/so/socalabs-sid/package.nix
@@ -1,0 +1,171 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  copyDesktopItems,
+  makeDesktopItem,
+  xorg,
+  freetype,
+  expat,
+  libGL,
+  libjack2,
+  curl,
+  webkitgtk_4_0,
+  libsysprof-capture,
+  pcre2,
+  util-linux,
+  libselinux,
+  libsepol,
+  libthai,
+  libxkbcommon,
+  libdatrie,
+  libepoxy,
+  libsoup_2_4,
+  lerc,
+  sqlite,
+  ninja,
+  # Disable VST building by default, since NixOS doesn't have a VST license
+  enableVST2 ? false,
+}:
+stdenv.mkDerivation {
+  pname = "socalabs-sid";
+  version = "1.1.0";
+
+  src =
+    (fetchFromGitHub {
+      owner = "FigBug";
+      repo = "SID";
+      rev = "bb826fdea39da0804c53d81d35bea29aeff4436d";
+      hash = "sha256-6IStysItOS7EltTCqdyo9vrsnSA1YYoN4y8Bjv1fhNk=";
+      fetchSubmodules = true;
+    }).overrideAttrs
+      (_: {
+        GIT_CONFIG_COUNT = 1;
+        GIT_CONFIG_KEY_0 = "url.https://github.com/.insteadOf";
+        GIT_CONFIG_VALUE_0 = "git@github.com:";
+      });
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "socalabs-sid";
+      desktopName = "Socalabs SID";
+      comment = "Socalabs Commodore 64 SID Emulation Plugin (Standalone)";
+      icon = "SID";
+      exec = "SID";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    copyDesktopItems
+    ninja
+  ];
+
+  buildInputs = [
+    alsa-lib
+    xorg.libX11
+    xorg.libXcomposite
+    xorg.libXcursor
+    xorg.libXinerama
+    xorg.libXrandr
+    xorg.libXtst
+    xorg.libXdmcp
+    xorg.xvfb
+    libGL
+    libjack2
+    libsysprof-capture
+    libselinux
+    libsepol
+    libthai
+    libxkbcommon
+    libdatrie
+    libepoxy
+    libsoup_2_4
+    lerc
+    freetype
+    curl
+    webkitgtk_4_0
+    pcre2
+    util-linux
+    sqlite
+    expat
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+    "--preset ninja-gcc"
+  ];
+
+  patchPhase = ''
+    substituteInPlace CMakeLists.txt \
+    --replace-fail 'FORMATS Standalone VST VST3 AU LV2' 'FORMATS Standalone ${lib.optionalString enableVST2 "VST"} VST3 LV2'
+
+    # we need to patch JUCE itself to enable jack MIDI support
+    # please https://github.com/juce-framework/JUCE/issues/952
+    # TODO: remove when juce updates :D
+    substituteInPlace modules/juce/modules/juce_audio_devices/native/juce_Midi_linux.cpp \
+    --replace-fail "port = client.createPort (portName, forInput, false);" "port = client.createPort (portName, forInput, true);"
+  '';
+
+  cmakeBuildType = "Release";
+
+  strictDeps = true;
+
+  preBuild = ''
+    # build takes 10 years without this set
+    HOME=(mktemp -d)
+
+    cd ../Builds/ninja-gcc
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2 $out/bin
+
+    ${lib.optionalString enableVST2 ''
+      mkdir -p $out/lib/vst
+      cp -r SID_artefacts/Release/VST/libSID.so $out/lib/vst
+    ''}
+
+    cp -r SID_artefacts/Release/LV2/SID.lv2 $out/lib/lv2
+    cp -r SID_artefacts/Release/VST3/SID.vst3 $out/lib/vst3
+
+    install -Dm755 SID_artefacts/Release/Standalone/SID $out/bin
+
+    install -Dm444 $src/plugin/Resources/icon.png $out/share/pixmaps/SID.png
+
+    runHook postInstall
+  '';
+
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcomposite"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-lXtst"
+      "-lXdmcp"
+    ]
+  );
+
+  meta = {
+    description = "Socalabs Commodore 64 SID Emulation Plugin";
+    homepage = "https://socalabs.com/synths/commodore-64-sid/";
+    mainProgram = "SID";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.gpl3 ] ++ lib.optional enableVST2 lib.licenses.unfree;
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Socalabs is an open source plugin maker, this adds their Commodore 64 SID chip emulation plugin to nixpkgs.

https://socalabs.com/synths/commodore-64-sid/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
