### PR TITLE
asymptote: 2.92 -> 2.95

### DIFF
--- a/pkgs/tools/graphics/asymptote/default.nix
+++ b/pkgs/tools/graphics/asymptote/default.nix
@@ -18,6 +18,7 @@
   boehmgc,
   libGLU,
   libGL,
+  libglvnd,
   ncurses,
   readline,
   gsl,
@@ -25,7 +26,7 @@
   python3,
   qtbase,
   qtsvg,
-  boost,
+  boost186,
   zlib,
   perl,
   curl,
@@ -35,7 +36,7 @@
 }:
 
 stdenv.mkDerivation (finalAttrs: {
-  version = "2.92";
+  version = "2.95";
   pname = "asymptote";
 
   outputs = [
@@ -48,8 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "mirror://sourceforge/asymptote/${finalAttrs.version}/asymptote-${finalAttrs.version}.src.tgz";
-    hash = "sha256-nZtcb6fg+848HlT+sl4tUdKMT+d5jyTHbNyugpGo6mY=";
+    hash = "sha256-FWBP0Cy23bxbgHUp0ub8YXyCWhhN0Ne3E5DFZ66seOc=";
   };
+
+  # https://github.com/vectorgraphics/asymptote/issues/513
+  postConfigure = ''
+    substituteInPlace Makefile \
+      --replace-fail 'glew.o -lGLX' 'glew.o'
+  '';
 
   # override with TeX Live containers to avoid building sty, docs from source
   texContainer = null;
@@ -64,7 +71,17 @@ stdenv.mkDerivation (finalAttrs: {
       texinfo
       wrapQtAppsHook
       cmake
+      ghostscriptX
+      perl
       pkg-config
+      (python3.withPackages (
+        ps: with ps; [
+          click
+          cson
+          numpy
+          pyqt5
+        ]
+      ))
     ]
     ++ lib.optional (finalAttrs.texContainer == null || finalAttrs.texdocContainer == null) (
       texliveSmall.withPackages (
@@ -94,7 +111,9 @@ stdenv.mkDerivation (finalAttrs: {
     curl
     qtbase
     qtsvg
-    boost
+    # relies on removed asio::io_service
+    # https://github.com/kuafuwang/LspCpp/issues/52
+    boost186
     (python3.withPackages (
       ps: with ps; [
         cson
@@ -112,6 +131,7 @@ stdenv.mkDerivation (finalAttrs: {
       libglut
       libGLU
       libGL
+      libglvnd
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin (
       with darwin.apple_sdk.frameworks;
@@ -155,6 +175,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   postInstall = ''
     rm "$out"/bin/xasy
+    chmod +x "$out"/share/asymptote/GUI/xasy.py
     makeQtWrapper "$out"/share/asymptote/GUI/xasy.py "$out"/bin/xasy --prefix PATH : "$out"/bin
 
     if [[ -z $texdocContainer ]] ; then
@@ -199,6 +220,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   meta = with lib; {
     description = "Tool for programming graphics intended to replace Metapost";
+    homepage = "https://asymptote.sourceforge.io/";
     license = licenses.gpl3Plus;
     maintainers = [ maintainers.raskin ];
     platforms = platforms.linux ++ platforms.darwin;


### PR DESCRIPTION
Also pin Boost 1.86, ref. #369118

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).