### PR TITLE
[staging-next] uhd: fix for boost187

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -1,6 +1,8 @@
 {
   lib,
   stdenv,
+  substitute,
+  fetchpatch,
   fetchurl,
   fetchFromGitHub,
   cmake,
@@ -179,6 +181,23 @@ stdenv.mkDerivation (finalAttrs: {
   # Build only the host software
   preConfigure = "cd host";
   patches = [
+    # fix for boost 187 remove on next update
+    (substitute {
+      src = fetchpatch {
+        name = "boost-187.patch";
+        url = "https://github.com/EttusResearch/uhd/commit/adfe953d965e58b5931c1b1968899492c8087cf6.patch";
+        hash = "sha256-qzxe6QhGoyBul7YjCiPJfeP+3dIoo1hh2sjgYmc9IiI=";
+      };
+      # The last two hunks in client.cc will fail without these substitutions
+      substitutions = [
+        "--replace-fail"
+        "[buffer, idx, func_name, p, this]"
+        "[=]"
+        "--replace-fail"
+        "[buffer, this]"
+        "[=]"
+      ];
+    })
     # Disable tests that fail in the sandbox, last checked at version 4.6.0.0
     ./no-adapter-tests.patch
   ];


### PR DESCRIPTION
 fixes: https://hydra.nixos.org/build/284398575

https://github.com/EttusResearch/uhd/commit/adfe953d965e58b5931c1b1968899492c8087cf6

the last two hunks of client.cc will fail due to changes in from this commit https://github.com/EttusResearch/uhd/commit/2dc7b3e572830c71d49ee0648eef445e7f3abfd6#diff-50231ca4dc15fab04d2c68cf5176f914c9f22c9e9e4a707e65daa93cb92a42c9 so use a substitute to revert the change out of the diff.

pinning to boost_186 seems like a viable alternative given the size of the diff.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
