### PR TITLE
balena-cli: fix build by using an older nodejs

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/default.nix
+++ b/pkgs/build-support/node/build-npm-package/hooks/default.nix
@@ -40,7 +40,9 @@
       installShellFiles
       makeWrapper
       nodejsInstallManuals
-      nodejsInstallExecutables
+      (nodejsInstallExecutables.override {
+        inherit nodejs;
+      })
     ];
     substitutions = {
       jq = "${jq}/bin/jq";

--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -22,16 +22,16 @@ let
 in
 buildNpmPackage' rec {
   pname = "balena-cli";
-  version = "20.1.2";
+  version = "20.2.1";
 
   src = fetchFromGitHub {
     owner = "balena-io";
     repo = "balena-cli";
     rev = "v${version}";
-    hash = "sha256-E27EHOxi54ZyNCoJuV/P6wjlJ29/JAQc/YqikP5SgZ8=";
+    hash = "sha256-D+V4WJ7/jkhUmEeRnYCtYtUzT7OXnHitIaGk2aimDFI=";
   };
 
-  npmDepsHash = "sha256-dXvqgv+0jwDyyZrTN5/t/QnrLRJl8rBNdCq4+iex9eI=";
+  npmDepsHash = "sha256-HslQ7Jvn8M7eKMePnwWd/xDhx1QyXwwjOS6EexRULJM=";
 
   postPatch = ''
     ln -s npm-shrinkwrap.json package-lock.json

--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -10,7 +10,6 @@
   udev,
   cctools,
   apple-sdk_12,
-  darwinMinVersionHook,
 }:
 
 buildNpmPackage rec {

--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -56,7 +56,7 @@ buildNpmPackage rec {
     inherit version;
   };
 
-  meta = with lib; {
+  meta = {
     description = "Command line interface for balenaCloud or openBalena";
     longDescription = ''
       The balena CLI is a Command Line Interface for balenaCloud or openBalena. It is a software
@@ -66,10 +66,10 @@ buildNpmPackage rec {
     '';
     homepage = "https://github.com/balena-io/balena-cli";
     changelog = "https://github.com/balena-io/balena-cli/blob/v${version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = [
-      maintainers.kalebpace
-      maintainers.doronbehar
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [
+      kalebpace
+      doronbehar
     ];
     mainProgram = "balena";
   };

--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -3,8 +3,7 @@
   stdenv,
   buildNpmPackage,
   fetchFromGitHub,
-  testers,
-  balena-cli,
+  versionCheckHook,
   node-gyp,
   python3,
   udev,
@@ -34,6 +33,7 @@ buildNpmPackage rec {
     [
       node-gyp
       python3
+      versionCheckHook
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       cctools
@@ -47,14 +47,8 @@ buildNpmPackage rec {
       apple-sdk_12
     ];
 
-  passthru.tests.version = testers.testVersion {
-    package = balena-cli;
-    command = ''
-      # Override default cache directory so Balena CLI's unavoidable update check does not fail due to write permissions
-      BALENARC_DATA_DIRECTORY=./ balena --version
-    '';
-    inherit version;
-  };
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/balena";
 
   meta = {
     description = "Command line interface for balenaCloud or openBalena";

--- a/pkgs/by-name/ba/balena-cli/package.nix
+++ b/pkgs/by-name/ba/balena-cli/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildNpmPackage,
   fetchFromGitHub,
+  nodejs_20,
   versionCheckHook,
   node-gyp,
   python3,
@@ -11,7 +12,15 @@
   apple-sdk_12,
 }:
 
-buildNpmPackage rec {
+let
+  buildNpmPackage' = buildNpmPackage.override {
+    nodejs = nodejs_20;
+  };
+  node-gyp' = node-gyp.override {
+    nodejs = nodejs_20;
+  };
+in
+buildNpmPackage' rec {
   pname = "balena-cli";
   version = "20.1.2";
 
@@ -31,7 +40,7 @@ buildNpmPackage rec {
 
   nativeBuildInputs =
     [
-      node-gyp
+      node-gyp'
       python3
       versionCheckHook
     ]


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
