### PR TITLE
bicon: unstable-2020-06-04 -> unstable-2024-01-31

### DIFF
--- a/pkgs/by-name/bi/bicon/package.nix
+++ b/pkgs/by-name/bi/bicon/package.nix
@@ -10,13 +10,13 @@
   xkbutils,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "bicon";
-  version = "unstable-2024-01-31";
+  version = "0.5-unstable-2024-01-31";
 
   src = fetchFromGitHub {
     owner = "behdad";
-    repo = pname;
+    repo = "bicon";
     rev = "48720c0f22197d4d5f7b0f5162a3d8f071e6e8a8";
     hash = "sha256-4pvI4T+fdgCirHDc0h3vP5AZyqfnBKv5R3fJICnpmF4=";
   };
@@ -36,15 +36,15 @@ stdenv.mkDerivation rec {
     patchShebangs .
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Bidirectional console";
     homepage = "https://github.com/behdad/bicon";
-    license = [
-      licenses.lgpl21
-      licenses.psfl
-      licenses.bsd0
+    license = with lib.licenses; [
+      lgpl21
+      psfl
+      bsd0
     ];
     maintainers = [ ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
   };
-}
+})

--- a/pkgs/by-name/bi/bicon/package.nix
+++ b/pkgs/by-name/bi/bicon/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   autoreconfHook,
   pkg-config,
   perl,
@@ -13,24 +12,14 @@
 
 stdenv.mkDerivation rec {
   pname = "bicon";
-  version = "unstable-2020-06-04";
+  version = "unstable-2024-01-31";
 
   src = fetchFromGitHub {
     owner = "behdad";
     repo = pname;
-    rev = "64ae10c94b94a573735a2c2b1502334b86d3b1f7";
-    sha256 = "0ixsf65j4dbdl2aazjc2j0hiagbp6svvfwfmyivha0i1k5yx12v1";
+    rev = "48720c0f22197d4d5f7b0f5162a3d8f071e6e8a8";
+    hash = "sha256-4pvI4T+fdgCirHDc0h3vP5AZyqfnBKv5R3fJICnpmF4=";
   };
-
-  patches = [
-    # Fix build on clang-13. Pull the change pending upstream
-    # inclusion: https://github.com/behdad/bicon/pull/29
-    (fetchpatch {
-      name = "clang.patch";
-      url = "https://github.com/behdad/bicon/commit/20f5a79571f222f96e07d7c0c5e76e2c9ff1c59a.patch";
-      sha256 = "0l1dm7w52k57nv3lvz5pkbwp021mlsk3csyalxi90np1lx5sqbd1";
-    })
-  ];
 
   buildInputs = [
     fribidi


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
