### PR TITLE
gittyup: Fix build with GCC 14

### DIFF
--- a/pkgs/applications/version-management/gittyup/0001-Fix-incorrect-order-of-argument-to-calloc-345.patch
+++ b/pkgs/applications/version-management/gittyup/0001-Fix-incorrect-order-of-argument-to-calloc-345.patch
@@ -1,0 +1,25 @@
+From 687b5424128fd637555be4a0d18c72c4e870bd6f Mon Sep 17 00:00:00 2001
+From: Alfie <30699769+AHSauge@users.noreply.github.com>
+Date: Sat, 11 May 2024 13:11:08 +0200
+Subject: [PATCH] Fix incorrect order of argument to calloc (#345)
+
+---
+ src/zip.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/zip.c b/src/zip.c
+index b14f9e3..a7e5ef8 100644
+--- a/test/dep/zip/src/zip.c
++++ b/test/dep/zip/src/zip.c
+@@ -1874,7 +1874,7 @@ ssize_t zip_stream_copy(struct zip_t *zip, void **buf, size_t *bufsize) {
+     *bufsize = n;
+   }
+ 
+-  *buf = calloc(sizeof(unsigned char), n);
++  *buf = calloc(n, sizeof(unsigned char));
+   memcpy(*buf, zip->archive.m_pState->m_pMem, n);
+ 
+   return (ssize_t)n;
+-- 
+2.47.0
+

--- a/pkgs/applications/version-management/gittyup/default.nix
+++ b/pkgs/applications/version-management/gittyup/default.nix
@@ -48,6 +48,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    cmark
     ninja
     pkg-config
     wrapQtAppsHook

--- a/pkgs/applications/version-management/gittyup/default.nix
+++ b/pkgs/applications/version-management/gittyup/default.nix
@@ -29,6 +29,12 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    # Fix GCC 14 build error (remove for next update)
+    # https://github.com/Murmele/Gittyup/pull/759
+    ./0001-Fix-incorrect-order-of-argument-to-calloc-345.patch
+  ];
+
   cmakeFlags =
     let
       inherit (lib) cmakeBool;

--- a/pkgs/applications/version-management/gittyup/default.nix
+++ b/pkgs/applications/version-management/gittyup/default.nix
@@ -88,7 +88,10 @@ stdenv.mkDerivation rec {
     description = "Graphical Git client designed to help you understand and manage your source code history";
     homepage = "https://murmele.github.io/Gittyup";
     license = with licenses; [ mit ];
-    maintainers = [ ];
+    maintainers = with maintainers; [
+      fliegendewurst
+      phijor
+    ];
     platforms = platforms.unix;
     broken = stdenv.hostPlatform.isDarwin;
   };

--- a/pkgs/applications/version-management/gittyup/default.nix
+++ b/pkgs/applications/version-management/gittyup/default.nix
@@ -29,18 +29,22 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=OFF"
-    "-DUSE_SYSTEM_CMARK=ON"
-    "-DUSE_SYSTEM_GIT=ON"
-    "-DUSE_SYSTEM_HUNSPELL=ON"
-    # upstream uses its own fork of libgit2 as of 1.2.2, however this may change in the future
-    # "-DUSE_SYSTEM_LIBGIT2=ON"
-    "-DUSE_SYSTEM_LIBSSH2=ON"
-    "-DUSE_SYSTEM_LUA=ON"
-    "-DUSE_SYSTEM_OPENSSL=ON"
-    "-DENABLE_UPDATE_OVER_GUI=OFF"
-  ];
+  cmakeFlags =
+    let
+      inherit (lib) cmakeBool;
+    in
+    [
+      (cmakeBool "BUILD_SHARED_LIBS" false)
+      (cmakeBool "USE_SYSTEM_CMARK" true)
+      (cmakeBool "USE_SYSTEM_GIT" true)
+      (cmakeBool "USE_SYSTEM_HUNSPELL" true)
+      # upstream uses its own fork of libgit2 as of 1.2.2, however this may change in the future
+      # (cmakeBool "USE_SYSTEM_LIBGIT2" true)
+      (cmakeBool "USE_SYSTEM_LIBSSH2" true)
+      (cmakeBool "USE_SYSTEM_LUA" true)
+      (cmakeBool "USE_SYSTEM_OPENSSL" true)
+      (cmakeBool "ENABLE_UPDATE_OVER_GUI" false)
+    ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
The test suite of gittyup depends on a vendored version of a ZIP library (https://github.com/kuba--/zip), and the build breaks when compiled with GCC 14.  This is fixed in an unreleased commit (https://github.com/Murmele/Gittyup/commit/d36eba172a01d541945d59427b4f643aaed55da0) upstream.

~~Fix the build by disabling the test suite.  In a future release, the test suite should be re-enabled.~~

Patch the affected file and leave a note to remove the patch in a future release.

This fixes #371778, and (imo) supersedes #371808. @FliegendeWurst can you try and see if this the build failure you mention in https://github.com/NixOS/nixpkgs/pull/371808#issuecomment-2575957466? 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
