### PR TITLE
weektodo: init at 2.2.0

### DIFF
--- a/pkgs/by-name/we/weektodo/package.nix
+++ b/pkgs/by-name/we/weektodo/package.nix
@@ -1,0 +1,41 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+}:
+let
+  pname = "weektodo";
+  version = "2.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/manuelernestog/weektodo/releases/download/v2.2.0/WeekToDo-2.2.0.AppImage";
+    hash = "sha256-5MmvmtsLFrifzPQk1zgLwKQz30XiYTU0lBe7gaAZyMA=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+
+in
+
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    desktop_file="${appimageContents}/weektodo.desktop"
+    install -m 444 -D "$desktop_file" $out/share/applications/weektodo.desktop
+    sed -i 's/.*Exec.*/Exec=weektodo/' $out/share/applications/weektodo.desktop
+    install -m 444 -D ${appimageContents}/weektodo.png $out/share/icons/hicolor/256x256/apps/weektodo.png
+  '';
+
+  meta = {
+    description = "WeekToDo";
+    longDescription = ''
+       WeekToDo is a Free and Open Source Minimalist Weekly Planner and To Do list App focused on privacy. Available for Windows, Mac, Linux or online.
+    '';
+    homepage = "https://weektodo.me/";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "weektodo";
+    maintainers = with lib.maintainers; [ harbiinger ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/we/weektodo/package.nix
+++ b/pkgs/by-name/we/weektodo/package.nix
@@ -29,7 +29,7 @@ appimageTools.wrapType2 {
   meta = {
     description = "WeekToDo";
     longDescription = ''
-       WeekToDo is a Free and Open Source Minimalist Weekly Planner and To Do list App focused on privacy. Available for Windows, Mac, Linux or online.
+      WeekToDo is a Free and Open Source Minimalist Weekly Planner and To Do list App focused on privacy. Available for Windows, Mac, Linux or online.
     '';
     homepage = "https://weektodo.me/";
     license = lib.licenses.gpl3Only;


### PR DESCRIPTION
WeekToDo is an open source week planner app: https://weektodo.me/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
