### PR TITLE
Update maildrop 2.6.0 -> 3.1.8

### DIFF
--- a/pkgs/by-name/co/courier-unicode/package.nix
+++ b/pkgs/by-name/co/courier-unicode/package.nix
@@ -1,0 +1,32 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+  perl,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "courier-unicode";
+  version = "2.3.1";
+
+  src = fetchurl {
+    url = "mirror://sourceforge/courier/courier-unicode/${version}/courier-unicode-${version}.tar.bz2";
+    sha256 = "sha256-uD7mRqR8Kp1pL7bvuThWRmjDLsF51PrAwH6s6KG4/JE=";
+  };
+
+  nativeBuildInputs = [
+    perl
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  meta = {
+    homepage = "http://www.courier-mta.org/unicode/";
+    description = "The Courier Unicode Library is used by most other Courier packages";
+    license = lib.licenses.gpl3;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/by-name/ma/maildrop/maildrop.configure.hack.patch
+++ b/pkgs/by-name/ma/maildrop/maildrop.configure.hack.patch
@@ -1,6 +1,6 @@
---- a/maildrop/configure	2012-09-06 01:52:13.000000000 +0100
-+++ b/maildrop/configure	2013-01-04 03:00:57.095628327 +0000
-@@ -17562,8 +17562,8 @@
+--- a/libs/maildrop/configure	2012-09-06 01:52:13.000000000 +0100
++++ b/libs/maildrop/configure	2013-01-04 03:00:57.095628327 +0000
+@@ -19857,8 +19862,8 @@
  check_spooldir() {
    if test "$CHECKED_SPOOLDIR" != 1
    then

--- a/pkgs/by-name/ma/maildrop/package.nix
+++ b/pkgs/by-name/ma/maildrop/package.nix
@@ -3,22 +3,26 @@
   lib,
   stdenv,
   pkg-config,
-  pcre,
+  courier-unicode,
+  pcre2,
+  libidn2,
   perl,
 }:
 
 stdenv.mkDerivation rec {
   pname = "maildrop";
-  version = "2.6.0";
+  version = "3.1.8";
 
   src = fetchurl {
     url = "mirror://sourceforge/courier/maildrop/${version}/maildrop-${version}.tar.bz2";
-    sha256 = "1a94p2b41iy334cwfwmzi19557dn5j61abh0cp2rfc9dkc8ibhdg";
+    sha256 = "sha256-foJsAxkXRE8berccH82QODWVZEhG4rOyYONSsc4D6VA=";
   };
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
-    pcre
+    courier-unicode
+    libidn2
+    pcre2
     perl
   ];
 


### PR DESCRIPTION
Update maildrop 2.6.0 -> 3.1.8
courier-unicode: init at 2.3.1 (new dependency of maildrop)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
