### PR TITLE
thunderbird: Add languagePacks option

### DIFF
--- a/nixos/modules/programs/thunderbird.nix
+++ b/nixos/modules/programs/thunderbird.nix
@@ -65,6 +65,84 @@ in
         - `"clear"`: Value has no effect. Resets to factory defaults on each startup.
       '';
     };
+
+    languagePacks = lib.mkOption {
+      # Available languages can be found in https://releases.mozilla.org/pub/thunderbird/releases/${cfg.package.version}/linux-x86_64/xpi/
+      type = lib.types.listOf (
+        lib.types.enum ([
+          "af"
+          "ar"
+          "ast"
+          "be"
+          "bg"
+          "br"
+          "ca"
+          "cak"
+          "cs"
+          "cy"
+          "da"
+          "de"
+          "dsb"
+          "el"
+          "en-CA"
+          "en-GB"
+          "en-US"
+          "es-AR"
+          "es-ES"
+          "es-MX"
+          "et"
+          "eu"
+          "fi"
+          "fr"
+          "fy-NL"
+          "ga-IE"
+          "gd"
+          "gl"
+          "he"
+          "hr"
+          "hsb"
+          "hu"
+          "hy-AM"
+          "id"
+          "is"
+          "it"
+          "ja"
+          "ka"
+          "kab"
+          "kk"
+          "ko"
+          "lt"
+          "lv"
+          "ms"
+          "nb-NO"
+          "nl"
+          "nn-NO"
+          "pa-IN"
+          "pl"
+          "pt-BR"
+          "pt-PT"
+          "rm"
+          "ro"
+          "ru"
+          "sk"
+          "sl"
+          "sq"
+          "sr"
+          "sv-SE"
+          "th"
+          "tr"
+          "uk"
+          "uz"
+          "vi"
+          "zh-CN"
+          "zh-TW"
+        ])
+      );
+      default = [ ];
+      description = ''
+        The language packs to install.
+      '';
+    };
   };
 
   config = lib.mkIf cfg.enable {
@@ -82,6 +160,15 @@ in
         Value = value;
         Status = cfg.preferencesStatus;
       }) cfg.preferences;
+      ExtensionSettings = builtins.listToAttrs (
+        builtins.map (
+          lang:
+          lib.attrsets.nameValuePair "langpack-${lang}@thunderbird.mozilla.org" {
+            installation_mode = "normal_installed";
+            install_url = "https://releases.mozilla.org/pub/thunderbird/releases/${cfg.package.version}/linux-x86_64/xpi/${lang}.xpi";
+          }
+        ) cfg.languagePacks
+      );
     };
   };
 


### PR DESCRIPTION
This PR adds a languagePacks option to the thunderbird module. The option definition was copied from the firefox module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
