### PR TITLE
nixos/doc/manual/installation: improve explanation of when channels are updated

### DIFF
--- a/nixos/doc/manual/installation/upgrading.chapter.md
+++ b/nixos/doc/manual/installation/upgrading.chapter.md
@@ -4,7 +4,9 @@ The best way to keep your NixOS installation up to date is to use one of
 the NixOS *channels*. A channel is a Nix mechanism for distributing Nix
 expressions and associated binaries. The NixOS channels are updated
 automatically from NixOS's Git repository after certain tests have
-passed and all packages have been built. These channels are:
+passed and a selection of packages has been built successfully
+(see `nixos/release-combined.nix` and `nixos/release-small.nix`).
+These channels are:
 
 -   *Stable channels*, such as [`nixos-24.11`](https://channels.nixos.org/nixos-24.11).
     These only get conservative bug fixes and package upgrades. For


### PR DESCRIPTION
The phrasing that channels are updated automatically "[when] all packages have been built" could be
read as "all packages have been built successfully". However, in reality, it only meant to say that
all packages have been *attempted* to be built, so a channel may still contain broken packages. This
patch aims to make this clearer by mentioning that only a selection of packages is required to be
built successfully and by pointing to the files which contain these selections.

---

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
