### PR TITLE
crab-hole: 0.1.10 -> 0.1.12

### DIFF
--- a/pkgs/by-name/cr/crab-hole/package.nix
+++ b/pkgs/by-name/cr/crab-hole/package.nix
@@ -6,16 +6,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "crab-hole";
-  version = "0.1.10";
+  version = "0.1.12";
 
   src = fetchFromGitHub {
     owner = "LuckyTurtleDev";
     repo = "crab-hole";
     tag = "v${version}";
-    hash = "sha256-OyZ+GkWU+OMnS6X7yk7H1e1MzfQQQkhOkoxUmWn6k7I=";
+    hash = "sha256-HJQpzUdvjGhZnH5+qlgaekDpqSUmOhR30VPzg1lZIl0=";
   };
 
-  cargoHash = "sha256-NeVCGN2ZIyrufa3geO8bbwV7ncenguftnr5SClRZLi8=";
+  cargoHash = "sha256-6g5l4sQv8OsOLJZ/Vl3RLU8k/zx3Bj13STonsY2+lf0=";
 
   meta = {
     description = "Pi-Hole clone written in Rust using Hickory DNS";


### PR DESCRIPTION
Diff: https://github.com/LuckyTurtleDev/crab-hole/compare/refs/tags/v0.1.10...v0.1.12

Updated crab-hole from 0.1.10 to 0.1.12
v0.1.11 was skipped due to the release of 0.1.12 shortly after 0.1.11

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
