### PR TITLE
sollya: fix cross build

### DIFF
--- a/pkgs/by-name/so/sollya/package.nix
+++ b/pkgs/by-name/so/sollya/package.nix
@@ -26,6 +26,10 @@ stdenv.mkDerivation rec {
     fplll
   ];
 
+  configureFlags = [
+    "--with-xml2-config=${lib.getExe' (lib.getDev libxml2) "xml2-config"}"
+  ];
+
   doCheck = true;
 
   meta = with lib; {


### PR DESCRIPTION
Also relevant for regular strictDeps build, ref. #178468

I tried using pkg-config instead, did not work.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).