### PR TITLE
igir: 2.11.0 -> 3.0.2, adding support for darwin

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5969,6 +5969,13 @@
     githubId = 466723;
     name = "David Reiss";
   };
+  docbobo = {
+    email = "docbobo@pm.me";
+    github = "docbobo";
+    githubId = 1257060;
+    name = "Boris Prüßmann";
+    keys = [ { fingerprint = "FEA5 C6A4 7600 A6ED 0052 5169 F45C 18DC 37EC 0AB0"; } ];
+  };
   dochang = {
     email = "dochang@gmail.com";
     github = "dochang";

--- a/pkgs/by-name/ig/igir/package.nix
+++ b/pkgs/by-name/ig/igir/package.nix
@@ -2,46 +2,83 @@
   lib,
   buildNpmPackage,
   fetchFromGitHub,
-
-  # for patching bundled 7z binary from the 7zip-bin node module
-  # at lib/node_modules/igir/node_modules/7zip-bin/linux/x64/7za
   autoPatchelfHook,
   stdenv,
+  SDL2,
+  libuv,
+  lz4,
+  #tests
+  runCommand,
+  igir,
+  nodejs,
 }:
-
 buildNpmPackage rec {
   pname = "igir";
-  version = "2.11.0";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "emmercm";
     repo = "igir";
     rev = "v${version}";
-    hash = "sha256-NG0ZP8LOm7fZVecErTuLOfbp1yvXwHnwPkWTBzUJXWE=";
+    hash = "sha256-DYQn5VF6kBwN6wzImayVqftb28CzmRCUd0jqRExQdoY=";
   };
 
-  npmDepsHash = "sha256-ADIEzr6PkGaJz27GKSVyTsrbz5zbud7BUb+OXPtP1Vo=";
+  npmDepsHash = "sha256-/lbe5YgBb5VIX2Y7ZoCbrYyMchIb+3yZ1Rwp2JDuQfM=";
 
   # I have no clue why I have to do this
   postPatch = ''
     patchShebangs scripts/update-readme-help.sh
   '';
 
-  nativeBuildInputs = [ autoPatchelfHook ];
+  buildInputs = [
+    (lib.getLib stdenv.cc.cc)
+    SDL2
+    libuv
+    lz4
+  ];
 
-  buildInputs = [ (lib.getLib stdenv.cc.cc) ];
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
 
-  # from lib/node_modules/igir/node_modules/@node-rs/crc32-linux-x64-musl/crc32.linux-x64-musl.node
-  # Irrelevant to our use
-  autoPatchelfIgnoreMissingDeps = [ "libc.musl-x86_64.so.1" ];
+  postFixup = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    # Fix chdman
+    find $out/lib/node_modules/igir/node_modules/@emmercm/ -name chdman -executable -type f \
+      -exec install_name_tool -change /opt/homebrew/opt/sdl2/lib/libSDL2-2.0.0.dylib ${SDL2}/lib/libSDL2-2.0.0.dylib {} \;
 
-  meta = with lib; {
+    # Fix maxcso
+    find $out/lib/node_modules/igir/node_modules/@emmercm/ -name maxcso -executable -type f \
+      -exec install_name_tool -change /opt/homebrew/opt/libuv/lib/libuv.1.dylib ${libuv}/lib/libuv.1.dylib {} \;
+    find $out/lib/node_modules/igir/node_modules/@emmercm/ -name maxcso -executable -type f \
+      -exec install_name_tool -change /opt/homebrew/opt/lz4/lib/liblz4.1.dylib ${lz4.lib}/lib/liblz4.1.dylib {} \;
+  '';
+
+  passthru.tests =
+    let
+      igirDir = "${igir}/lib/node_modules/igir";
+      npxCmd = "${nodejs}/bin/npx";
+    in
+    {
+      chdman = runCommand "${pname}-chdman" { meta.timeout = 30; } ''
+        set +e
+        cd ${igirDir}
+        ${npxCmd} chdman > $out
+        grep -q "chdman - MAME Compressed Hunks of Data (CHD) manager" $out
+      '';
+
+      maxcso = runCommand "${pname}-maxcso" { meta.timeout = 30; } ''
+        set +e
+        cd ${igirDir}
+        ${npxCmd} maxcso 2> $out
+        grep -q "maxcso v1.13.0" $out
+      '';
+    };
+
+  meta = {
     description = "Video game ROM collection manager to help filter, sort, patch, archive, and report on collections on any OS";
     mainProgram = "igir";
     homepage = "https://igir.io";
     changelog = "https://github.com/emmercm/igir/releases/tag/${src.rev}";
-    license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.linux;
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ docbobo ];
+    platforms = with lib.platforms; linux ++ darwin;
   };
 }


### PR DESCRIPTION
_Pronounced "eager," [Igir](https😊/igir.io) is a zero-setup ROM collection manager that sorts, filters, extracts or archives, patches, and reports on collections of any size on any OS._ 

This PR achieves two things that are described in more detail below: upgrading to version `3.0.2`, and enabling platform support for Darwin.

## 2.11.0 -> 3.0.2

Version `2.11.0` of igir already contains some pre-built binaries that require their dependencies to be updated via `autoPatchelfHook`. Version `3.0.0` (and thus `3.0.2`) adds two more binaries that require this treatment: `chdman` and `maxcso`.

## Support for Darwin

Similar to Linux, the Darwin build requires patching of binaries since the bundled ones are compiled against homebrew libraries found under `/opt/homebrew`. However, no hook comparable to `autoPatchelfHook` seems to exist (`fixDarwinDylibNames` does not apply in this scenario) at this point in time, and patching is done "manually" via `install_name_tool` on a case by case basis.

### Tests

Since the whole process of manually patching binaries is somewhat more fragile than using `autoPatchelfHook`, this PR also introduces two test cases that execute `chdman` and `maxcso` to determine if they start correctly. As a nice side-effect, the `maxcso` test case also breaks with the stock `v3.0.1` because the `maxcso` binary is missing there (at least on aarch64-linux).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
