### PR TITLE
nixos/nextcloud: Update logreader warning description

### DIFF
--- a/nixos/modules/services/web-apps/nextcloud.md
+++ b/nixos/modules/services/web-apps/nextcloud.md
@@ -245,7 +245,7 @@ that are managed by Nix. If you want automatic updates it is recommended that yo
 
 ## Known warnings {#module-services-nextcloud-known-warnings}
 
-### Failed to get an iterator for log entries: Logreader application only supports "file" log_type {#module-services-nextcloud-warning-logreader}
+### Logreader application only supports "file" log_type {#module-services-nextcloud-warning-logreader}
 
 This is because
 
@@ -253,10 +253,10 @@ This is because
 * the Logreader application that allows reading logs in the admin panel is enabled
   by default and requires logs written to a file.
 
-The logreader application doesn't work, as it was the case before. The only change is that
-it complains loudly now. So nothing actionable here by default. Alternatively you can
+The logreader application doesn't work, as it was the case before.
+So nothing actionable here by default. Alternatively you can
 
-* disable the logreader application to shut up the "error".
+* disable the logreader application to shut up the "info".
 
   We can't really do that by default since whether apps are enabled/disabled is part
   of the application's state and tracked inside the database.

--- a/nixos/modules/services/web-apps/nextcloud.md
+++ b/nixos/modules/services/web-apps/nextcloud.md
@@ -253,16 +253,12 @@ This is because
 * the Logreader application that allows reading logs in the admin panel is enabled
   by default and requires logs written to a file.
 
-The logreader application doesn't work, as it was the case before.
-So nothing actionable here by default. Alternatively you can
+If you want to view logs in the admin panel,
+set [](#opt-services.nextcloud.settings.log_type) to "file".
 
-* disable the logreader application to shut up the "info".
-
-  We can't really do that by default since whether apps are enabled/disabled is part
-  of the application's state and tracked inside the database.
-
-* set [](#opt-services.nextcloud.settings.log_type) to "file" to be able to view logs
-  from the admin panel.
+If you prefer logs in the journal, disable the logreader application to shut up the
+"info". We can't really do that by default since whether apps are enabled/disabled
+is part of the application's state and tracked inside the database.
 
 ## Maintainer information {#module-services-nextcloud-maintainer-info}
 


### PR DESCRIPTION
The error is no longer logged since https://github.com/nextcloud/logreader/pull/1449. This was a bug in the app, since the error is not fixable by the admin due to the logging configuration.

CC @schneefux @bachp @globin @Ma27 @britter

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
