### PR TITLE
cbmc: 6.4.0 -> 6.4.1, fix darwin, drop unnecessary cadical dependency

### DIFF
--- a/pkgs/by-name/cb/cbmc/package.nix
+++ b/pkgs/by-name/cb/cbmc/package.nix
@@ -46,10 +46,6 @@ stdenv.mkDerivation (finalAttrs: {
     makeWrapper
   ];
 
-  buildInputs = [ cadical ];
-
-  # do not download sources
-  # link existing cadical instead
   patches = [
     (substituteAll {
       src = ./0001-Do-not-download-sources-in-cmake.patch;
@@ -104,7 +100,6 @@ stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     "-DWITH_JBMC=OFF"
     "-Dsat_impl=cadical"
-    "-Dcadical_INCLUDE_DIR=${cadical.dev}/include"
   ];
 
   passthru.tests.version = testers.testVersion {

--- a/pkgs/by-name/cb/cbmc/package.nix
+++ b/pkgs/by-name/cb/cbmc/package.nix
@@ -12,7 +12,6 @@
   perl,
   substituteAll,
   cudd,
-  fetchurl,
   nix-update-script,
 }:
 

--- a/pkgs/by-name/cb/cbmc/package.nix
+++ b/pkgs/by-name/cb/cbmc/package.nix
@@ -2,10 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  testers,
   bison,
   cadical,
-  cbmc,
   cmake,
   flex,
   makeWrapper,
@@ -14,6 +12,7 @@
   cudd,
   nix-update-script,
   fetchpatch,
+  versionCheckHook,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -109,10 +108,12 @@ stdenv.mkDerivation (finalAttrs: {
     "-Dsat_impl=cadical"
   ];
 
-  passthru.tests.version = testers.testVersion {
-    package = cbmc;
-    command = "cbmc --version";
-  };
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/cbmc";
+  versionCheckProgramArg = "--version";
 
   passthru.updateScript = nix-update-script {
     extraArgs = [

--- a/pkgs/by-name/cb/cbmc/package.nix
+++ b/pkgs/by-name/cb/cbmc/package.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "cbmc";
-  version = "6.4.0";
+  version = "6.4.1";
 
   src = fetchFromGitHub {
     owner = "diffblue";
     repo = "cbmc";
     tag = "cbmc-${finalAttrs.version}";
-    hash = "sha256-PZZnseOE3nodE0zwyG+82gm55BO4rsCcP4T+fZq7L6I=";
+    hash = "sha256-O8aZTW+Eylshl9bmm9GzbljWB0+cj2liZHs2uScERkM=";
   };
 
   srcglucose = fetchFromGitHub {

--- a/pkgs/by-name/cb/cbmc/package.nix
+++ b/pkgs/by-name/cb/cbmc/package.nix
@@ -107,7 +107,12 @@ stdenv.mkDerivation (finalAttrs: {
     command = "cbmc --version";
   };
 
-  passthru.updateScript = nix-update-script { };
+  passthru.updateScript = nix-update-script {
+    extraArgs = [
+      "--version-regex"
+      "cbmc-(.*)"
+    ];
+  };
 
   meta = {
     description = "CBMC is a Bounded Model Checker for C and C++ programs";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Updated to 6.4.1. Diff: https://github.com/diffblue/cbmc/compare/cbmc-6.4.0...cbmc-6.4.1 
- Fixed update script.
- Removed unnecessary dependency on `cadical` in `buildInputs`, as since https://github.com/NixOS/nixpkgs/pull/355122 cadical is compiled from source.
- Fixed darwin build upstream https://github.com/diffblue/cbmc/pull/8559. Thanks @paparodeo for pointing out the bug: https://github.com/NixOS/nixpkgs/pull/371275#issuecomment-2571816860.
- Dropped stale flags for GNU, which aren't necessary anymore.
- Use `versionCheckHook` instead of `testers.testVersion`, since that's the recommended thing to do when possible: [stdenv documentation](https://github.com/NixOS/nixpkgs/blob/44be85240ff42a5a190d1f05f5e2bb773275cdae/doc/stdenv/passthru.chapter.md#package-tests-var-passthru-tests-packages).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
