### PR TITLE
diversion-cli: init at 0.7.195

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7010,7 +7010,10 @@
     github = "ethancedwards8";
     githubId = 60861925;
     name = "Ethan Carter Edwards";
-    keys = [ { fingerprint = "0E69 0F46 3457 D812 3387  C978 F93D DAFA 26EF 2458"; } ];
+    keys = [
+      { fingerprint = "0E69 0F46 3457 D812 3387  C978 F93D DAFA 26EF 2458"; }
+      { fingerprint = "2E51 F618 39D1 FA94 7A73  00C2 34C0 4305 D581 DBFE"; }
+    ];
   };
   ethercrow = {
     email = "ethercrow@gmail.com";

--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11864,6 +11864,12 @@
     githubId = 546087;
     name = "Kristoffer K. Føllesdal";
   };
+  kggx = {
+    name = "Kilian Braun";
+    email = "hello@kilianbraun.de";
+    github = "kggx";
+    githubId = 31655619;
+  };
   kgtkr = {
     email = "contact@kgtkr.net";
     github = "kgtkr";

--- a/pkgs/by-name/di/diversion-cli/package.nix
+++ b/pkgs/by-name/di/diversion-cli/package.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  fetchurl,
+  lib,
+  nix-update-script,
+}:
+let
+  srcs = {
+    "x86_64-linux" = {
+      url = "https://archive.org/download/diversion-cli/dv_linux_x86_64_0-7-195";
+      sha256 = "15fDNp4isdgmMkL6g+LVC90S6FItoT29X3cCIqtbxLc=";
+    };
+
+  };
+in
+stdenv.mkDerivation {
+  pname = "diversion-cli";
+  version = "0.7.195";
+  src =
+    assert lib.assertMsg (builtins.hasAttr stdenv.hostPlatform.system srcs)
+      "Diversion CLI is not available for ${stdenv.hostPlatform.system}";
+    fetchurl {
+      url = srcs.${stdenv.hostPlatform.system}.url;
+      sha256 = srcs.${stdenv.hostPlatform.system}.sha256;
+    };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin"
+    install -D $src $out/bin/dv
+    runHook postInstall
+  '';
+
+  # nix-shell maintainers/scripts/update.nix --argstr package diversion-cli
+  passthru.updateScript = ./update.sh;
+
+  meta = with lib; {
+    description = "Official CLI to work with Diversion repositories";
+    homepage = "https://diversion.dev";
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    license = licenses.unfree;
+    mainProgram = "dv";
+    platforms = builtins.attrNames srcs;
+    maintainers = with maintainers; [
+      kggx
+    ];
+  };
+}

--- a/pkgs/by-name/di/diversion-cli/update.sh
+++ b/pkgs/by-name/di/diversion-cli/update.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p curl common-updater-scripts
+
+set -eu -o pipefail
+
+# Get linux version
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+
+curl -#L "https://dv-binaries.s3.us-east-2.amazonaws.com/linux_x86_64/dv" --output "./dv"
+chmod a+x ./dv
+
+new_version="$(./dv --version | grep -oP '(\d+\.)?(\d+\.)?(\*|\d+).*')"
+
+update-source-version diversion-cli "$new_version"
+
+rm ./dv

--- a/pkgs/by-name/dn/dnscontrol/package.nix
+++ b/pkgs/by-name/dn/dnscontrol/package.nix
@@ -9,16 +9,16 @@
 
 buildGoModule rec {
   pname = "dnscontrol";
-  version = "4.15.2";
+  version = "4.15.3";
 
   src = fetchFromGitHub {
     owner = "StackExchange";
     repo = "dnscontrol";
     rev = "v${version}";
-    hash = "sha256-/bYu/zOwWTgLx7vexp/V8+llaVoioQLiQdSHV9w5Qug=";
+    hash = "sha256-0vg3y/bUp5BTFhJbIdohvuj1DNu9bykDwMM3bWnKvNU=";
   };
 
-  vendorHash = "sha256-lfefR0NjeQEYIl1GyjzfsNJgdDGO/ULZtIhleL3CyC8=";
+  vendorHash = "sha256-JMi4FDgZT94KyqDR57xgp1vnP7Htdn/bksntbQdGyZ0=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Diversion is a modern code and assets management software aimed at industries like game development or virtual productions. This is the CLI application for Linux systems required to work with Diversion repositories. 

More information can be found under:
- https://www.diversion.dev
- https://docs.diversion.dev/quickstart

I've been in contact with the Diversion staff but they at this time are not providing fixed version links and it is encouraged to use the latest version of Diversion as the backed changes frequently.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
