### PR TITLE
code-nautilus: init at 0-unstable-2024-09-11

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2887,6 +2887,14 @@
     githubId = 727571;
     keys = [ { fingerprint = "AAD4 3B70 A504 9675 CFC8  B101 BAFD 205D 5FA2 B329"; } ];
   };
+  berrij = {
+    email = "jonathan@berrisch.biz";
+    matrix = "@berrij:fairydust.space";
+    name = "Jonathan Berrisch";
+    github = "BerriJ";
+    githubId = 37799358;
+    keys = [ { fingerprint = "42 B6 CC90 6 A91 EA4F 8 A7E 315 B 30 DC 5398 152 C 5310"; } ];
+  };
   berryp = {
     email = "berryphillips@gmail.com";
     github = "berryp";

--- a/pkgs/by-name/co/code-nautilus/package.nix
+++ b/pkgs/by-name/co/code-nautilus/package.nix
@@ -1,0 +1,38 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nautilus-python,
+  python3,
+}:
+stdenv.mkDerivation rec {
+  pname = "code-nautilus";
+  version = "0-unstable-2024-09-11";
+
+  src = fetchFromGitHub {
+    owner = "harry-cpp";
+    repo = "code-nautilus";
+    rev = "8ea0ce78f3f1f7a6af5f9e9cf93fc3e70015f61e";
+    sha256 = "u10laS3BwUVCJYlQ6WivU7o/sFFv6cTeV+uxBEdD7oA=";
+  };
+
+  buildInputs = [
+    nautilus-python
+    python3.pkgs.pygobject3
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm555 ./code-nautilus.py -t $out/share/nautilus-python/extensions
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "VSCode extension for Nautilus: 'Open in Code'";
+    homepage = "https://github.com/harry-cpp/code-nautilus";
+    license = licenses.unlicense;
+    platforms = platforms.linux;
+    maintainers = with maintainers; [ berrij ];
+  };
+
+}


### PR DESCRIPTION
code-nautilus is a small extension for nautilus that ass 'Open in Code' to the context menu to quickly open files and folders in VS-Code. 

https://github.com/harry-cpp/code-nautilus

It is very similar to [nautilus-open-in-blackbox](https://search.nixos.org/packages?channel=24.11&show=nautilus-open-in-blackbox&from=0&size=50&sort=relevance&type=packages&query=nautilus-open-in-blackbox)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc