### PR TITLE
umami: init at 2.15.1

### DIFF
--- a/pkgs/by-name/um/umami/package.nix
+++ b/pkgs/by-name/um/umami/package.nix
@@ -1,0 +1,102 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, fetchYarnDeps
+, yarnConfigHook
+, yarnBuildHook
+, nodejs
+, postgresql
+, prisma
+, makeWrapper
+, openssl
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "umami";
+  version = "2.15.1";
+
+  nativeBuildInputs = [
+    yarnConfigHook
+    yarnBuildHook
+    nodejs
+    postgresql
+    prisma
+    openssl
+    makeWrapper
+  ];
+
+  src = fetchFromGitHub {
+    owner = "umami-software";
+    repo = "umami";
+    rev = "v${finalAttrs.version}";
+    hash = "sha256-BYqIGxNJWeJxYV6qZH4nELffl5Yz4pftq30Bvp/tTNw=";
+  };
+
+  # srcs = [
+  #   (
+  #     fetchFromGitHub {
+  #       owner = "umami-software";
+  #       repo = "umami";
+  #       rev = "v${finalAttrs.version}";
+  #       hash = "sha256-BYqIGxNJWeJxYV6qZH4nELffl5Yz4pftq30Bvp/tTNw=";
+  #     }
+  #   )
+  #   (fetchurl {
+  #     url="https://raw.githubusercontent.com/GitSquared/node-geolite2-redist/master/redist/GeoLite2-City.tar.gz";
+  #     hash = "sha256-vBm+ABC+8EIcJv077HvDvKCMGSgo1ZoVGEVCLcRCB0I=";
+  #   })
+  # ];
+
+  yarnOfflineCache = fetchYarnDeps {
+    yarnLock = finalAttrs.src + "/yarn.lock";
+    hash = "sha256-fTvFqyU6CGxeFqC0QYT0G+RrwNwJWkTICY1TIk8ZmYE=";
+  };
+
+  env.CYPRESS_INSTALL_BINARY = "0";
+  env.NODE_ENV = "production";
+  env.NEXT_TELEMETRY_DISABLED = "1";
+
+  # copy-db-files uses this variable, but doesn't connect to the DB
+  env.DATABASE_URL = "postgres:dummy";
+
+  buildPhase = ''
+    runHook preBuild
+
+    yarn --offline copy-db-files
+    # yarn --offline build-db-client
+    prisma generate
+
+    yarn --offline build-tracker
+    # TODO
+    # yarn --offline build-geo
+    yarn --offline build-app
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+
+    mv .next/standalone $out
+
+    cp -R public $out/public
+
+    mv .next/static $out/.next/static
+
+    cp next.config.js $out
+
+    cp -R prisma $out/prisma
+    cp -R scripts $out/scripts
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs}/bin/node $out/bin/umami-server  \
+      --set NODE_ENV production \
+      --add-flags "$out/server.js"
+  '';
+
+  meta = with lib; {
+    description = "simple, easy to use, self-hosted web analytics solution";
+    homepage = "https://umami.is/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add umami

There a similar PR: #371889, but I'm taking a different approach here, I don't think we must require a real DB, the build should just generate the nextjs application. The user must initialize the database somehow before using this package, but that it is the user responsibility.  

There are still 2 think to do here:

- Create another binary to initialize the DB with prisma. It shouldn't be too hard, since all the prisma files are already there
- The `yarn build-geo` script fails because it needs network access. But the only thing is doing is downlading and unpacking this file: https://raw.githubusercontent.com/GitSquared/node-geolite2-redist/master/redist/GeoLite2-City.tar.gz. We should be able to do that with nix.

----

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
