### PR TITLE
[haskell-updates] haskell.packages.ghc9101: remove all references to removed attrs

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -60,35 +60,13 @@ self: super: {
 
   # Upgrade to accommodate new core library versions, where the authors have
   # already made the relevant changes.
-  aeson = doDistribute self.aeson_2_2_3_0;
-  attoparsec-aeson = doDistribute self.attoparsec-aeson_2_2_2_0;
-  auto-update = doDistribute self.auto-update_0_2_6;
-  dependent-sum-template = doJailbreak self.dependent-sum-template_0_2_0_1; # template-haskell < 2.22
   extensions = doDistribute self.extensions_0_1_0_2;
   fourmolu = doDistribute self.fourmolu_0_16_2_0;
-  hashable = doDistribute self.hashable_1_4_7_0;
-  integer-conversion = doDistribute self.integer-conversion_0_1_1;
   ghc-lib = doDistribute self.ghc-lib_9_10_1_20250103;
   ghc-lib-parser = doDistribute self.ghc-lib-parser_9_10_1_20250103;
   ghc-lib-parser-ex = doDistribute self.ghc-lib-parser-ex_9_10_0_0;
-  http2 = doDistribute self.http2_5_3_9;
-  http-semantics = doDistribute self.http-semantics_0_3_0;
   htree = doDistribute self.htree_0_2_0_0;
-  lens = doDistribute self.lens_5_3_2;
-  lukko = doDistribute self.lukko_0_1_2;
-  network-control = super.network-control_0_1_3;
-  network-run = super.network-run_0_4_0;
   ormolu = doDistribute self.ormolu_0_7_7_0;
-  primitive = doDistribute self.primitive_0_9_0_0;
-  quickcheck-instances = doDistribute self.quickcheck-instances_0_3_32;
-  rebase = doDistribute self.rebase_1_21_1;
-  rerebase = doDistribute self.rerebase_1_21_1;
-  scientific = doDistribute self.scientific_0_3_8_0;
-  semirings = doDistribute self.semirings_0_7;
-  time-manager = doDistribute self.time-manager_0_2_2;
-  th-abstraction = doDistribute self.th-abstraction_0_7_1_0;
-  uuid-types = doDistribute self.uuid-types_1_0_6;
-  warp = pkgs.haskell.lib.dontCheck super.warp_3_4_7; # test suite assumes it can freely call curl
 
   # A given major version of ghc-exactprint only supports one version of GHC.
   ghc-exactprint = doDistribute self.ghc-exactprint_1_9_0_0;
@@ -116,7 +94,7 @@ self: super: {
 
   bitvec = doJailbreak super.bitvec; # primitive <0.9
 
-  hashable_1_4_7_0 = doJailbreak super.hashable_1_4_7_0; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
+  hashable = doJailbreak super.hashable; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
   hashable_1_5_0_0 = doJailbreak super.hashable_1_5_0_0; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
 
   broadcast-chan = doJailbreak super.broadcast-chan; # base <4.19  https://github.com/merijn/broadcast-chan/pull/19
@@ -126,7 +104,6 @@ self: super: {
   #
   call-stack = dontCheck super.call-stack; # https://github.com/sol/call-stack/issues/19
   lifted-base = dontCheck super.lifted-base; # doesn't compile with transformers ==0.6.*
-  lukko_0_1_2 = dontCheck super.lukko_0_1_2; # doesn't compile with tasty ==1.4.*
   resolv = dontCheck super.resolv; # doesn't compile with filepath ==1.5.*
   primitive-unlifted = dontCheck super.primitive-unlifted; # doesn't compile with primitive ==0.9.*
   bsb-http-chunked = pkgs.haskell.lib.dontCheck super.bsb-http-chunked; # https://github.com/sjakobi/bsb-http-chunked/issues/45


### PR DESCRIPTION
Stackage LTS 23 uses the versions that have been “removed” here by default.

WARNING: Builds are untested, so the package still may or may not be broken.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
