### PR TITLE
hamlib_4: 4.5.5 -> 4.6

### DIFF
--- a/pkgs/development/libraries/hamlib/4.nix
+++ b/pkgs/development/libraries/hamlib/4.nix
@@ -22,11 +22,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "hamlib";
-  version = "4.5.5";
+  version = "4.6";
 
   src = fetchurl {
-    url = "mirror://sourceforge/${pname}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-YByJ8y7SJelSet49ZNDQXSMgLAWuIf+nflnXDuRZf80=";
+    url = "mirror://sourceforge/hamlib/hamlib-${version}.tar.gz";
+    hash = "sha256-b4c1ebxODvTlQDE+wqzU8Zi1UQ192Tl6SuaP6P8g0Wc=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
###### Updates performed
- Version update

###### To inspect upstream changes





###### Impact

<b>Checks done</b>

---

- built on NixOS
- The tests defined in `passthru.tests`, if any, passed
- found 4.6 with grep in /nix/store/312zvhq4v5bdrd8b49ik3nk09p4s6v4m-hamlib-4.6
- found 4.6 in filename of file in /nix/store/312zvhq4v5bdrd8b49ik3nk09p4s6v4m-hamlib-4.6

---

<details>
<summary>
<b>Rebuild report</b> (if merged into master) (click to expand)
</summary>

```
1 total rebuild path(s)

1 package rebuild(s)

First fifty rebuilds by attrpath
hamlib_4
```

</details>

<details>
<summary>
<b>Instructions to test this update</b> (click to expand)
</summary>

---

Build yourself:
```
nix-build -A hamlib_4 https://github.com/MarcFontaine/nixpkgs/archive/c0ecfd748d27306a1aa3d9c3eb9b214b23a62620.tar.gz
```
Or:
```
nix build github:MarcFontaine/nixpkgs/c0ecfd748d27306a1aa3d9c3eb9b214b23a62620#hamlib_4
```

After you've downloaded or built it, look at the files and if there are any, run the binaries:
```
ls -la /nix/store/312zvhq4v5bdrd8b49ik3nk09p4s6v4m-hamlib-4.6
ls -la /nix/store/312zvhq4v5bdrd8b49ik3nk09p4s6v4m-hamlib-4.6/bin
```

---

</details>
<br/>



### Pre-merge build results

NixPkgs review skipped

---

###### Maintainer pings

cc @relrod for [testing](https://github.com/ryantm/nixpkgs-update/blob/main/doc/nixpkgs-maintainer-faq.md#r-ryantm-opened-a-pr-for-my-package-what-do-i-do).

> [!TIP]
> As a maintainer, if your package is located under `pkgs/by-name/*`, you can comment **`@NixOS/nixpkgs-merge-bot merge`** to automatically merge this update using the [`nixpkgs-merge-bot`](https://github.com/NixOS/nixpkgs-merge-bot).

---

Add a :+1: [reaction] to [pull requests you find important].
