### PR TITLE
stenc: 1.1.1 -> 2.0.0, enable tests, install bash completions

### DIFF
--- a/pkgs/by-name/st/stenc/package.nix
+++ b/pkgs/by-name/st/stenc/package.nix
@@ -30,6 +30,8 @@ stdenv.mkDerivation rec {
     pandoc
   ];
 
+  doCheck = true;
+
   passthru.updateScript = gitUpdater { };
 
   meta = {

--- a/pkgs/by-name/st/stenc/package.nix
+++ b/pkgs/by-name/st/stenc/package.nix
@@ -6,6 +6,7 @@
   autoreconfHook,
   pkg-config,
   pandoc,
+  installShellFiles,
 }:
 
 stdenv.mkDerivation rec {
@@ -28,9 +29,14 @@ stdenv.mkDerivation rec {
     autoreconfHook
     pkg-config
     pandoc
+    installShellFiles
   ];
 
   doCheck = true;
+
+  postInstall = ''
+    installShellCompletion --bash bash-completion/stenc
+  '';
 
   passthru.updateScript = gitUpdater { };
 

--- a/pkgs/by-name/st/stenc/package.nix
+++ b/pkgs/by-name/st/stenc/package.nix
@@ -4,27 +4,31 @@
   fetchFromGitHub,
   gitUpdater,
   autoreconfHook,
+  pkg-config,
+  pandoc,
 }:
 
 stdenv.mkDerivation rec {
   pname = "stenc";
-  version = "1.1.1";
+  version = "2.0.0";
+
+  outputs = [
+    "out"
+    "man"
+  ];
 
   src = fetchFromGitHub {
     owner = "scsitape";
     repo = "stenc";
-    rev = version;
-    sha256 = "GcCRVkv+1mREq3MhMRn5fICthwI4WRQJSP6InuzxP1Q=";
+    tag = version;
+    sha256 = "sha256-L0g285H8bf3g+HDYUDRWBZMOBCnWz3Vm38Ijttu404U=";
   };
 
-  postPatch = ''
-    # Fix gcc-13 build by pulling missing header. UPstream also fixed it
-    # in next major version, but there are many other patch dependencies.
-    # TODO: remove on next major version update
-    sed -e '1i #include <cstdint>' -i src/scsiencrypt.h
-  '';
-
-  nativeBuildInputs = [ autoreconfHook ];
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+    pandoc
+  ];
 
   passthru.updateScript = gitUpdater { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
