### PR TITLE
nixos/yubikey-touch-detector: move from programs to services, add packages

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -870,6 +870,7 @@
   ./services/misc/weechat.nix
   ./services/misc/workout-tracker.nix
   ./services/misc/xmrig.nix
+  ./services/misc/yubikey-touch-detector.nix
   ./services/misc/zoneminder.nix
   ./services/misc/zookeeper.nix
   ./services/monitoring/alerta.nix

--- a/nixos/modules/programs/yubikey-touch-detector.nix
+++ b/nixos/modules/programs/yubikey-touch-detector.nix
@@ -43,21 +43,13 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    systemd.packages = [ pkgs.yubikey-touch-detector ];
+    services.yubikey-touch-detector = cfg;
 
-    systemd.user.services.yubikey-touch-detector = {
-      path = [ pkgs.gnupg ];
-
-      environment = {
-        YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY = builtins.toString cfg.libnotify;
-        YUBIKEY_TOUCH_DETECTOR_NOSOCKET = builtins.toString (!cfg.unixSocket);
-        YUBIKEY_TOUCH_DETECTOR_VERBOSE = builtins.toString cfg.verbose;
-      };
-
-      wantedBy = [ "graphical-session.target" ];
-    };
-    systemd.user.sockets.yubikey-touch-detector = {
-      wantedBy = [ "sockets.target" ];
-    };
+    warnings = [
+      ''
+        The module programs.yubikey-touch-detector is deprecated.
+        Please use services.yubikey-touch-detector instead.
+      ''
+    ];
   };
 }

--- a/nixos/modules/services/misc/yubikey-touch-detector.nix
+++ b/nixos/modules/services/misc/yubikey-touch-detector.nix
@@ -1,0 +1,63 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib) types;
+  cfg = config.services.yubikey-touch-detector;
+in
+{
+  options.services.yubikey-touch-detector = {
+
+    enable = lib.mkEnableOption "yubikey-touch-detector";
+
+    package = lib.mkPackageOption pkgs "yubikey-touch-detector" { };
+
+    libnotify = lib.mkOption {
+      # This used to be true previously and using libnotify would be a sane default.
+      default = true;
+      type = types.bool;
+      description = ''
+        If set to true, yubikey-touch-detctor will send notifications using libnotify
+      '';
+    };
+
+    unixSocket = lib.mkOption {
+      default = true;
+      type = types.bool;
+      description = ''
+        If set to true, yubikey-touch-detector will send notifications to a unix socket
+      '';
+    };
+
+    verbose = lib.mkOption {
+      default = false;
+      type = types.bool;
+      description = ''
+        Enables verbose logging
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.packages = [ cfg.package ];
+
+    systemd.user.services.yubikey-touch-detector = {
+      path = [ pkgs.gnupg ];
+
+      environment = {
+        YUBIKEY_TOUCH_DETECTOR_LIBNOTIFY = builtins.toString cfg.libnotify;
+        YUBIKEY_TOUCH_DETECTOR_NOSOCKET = builtins.toString (!cfg.unixSocket);
+        YUBIKEY_TOUCH_DETECTOR_VERBOSE = builtins.toString cfg.verbose;
+      };
+
+      wantedBy = [ "graphical-session.target" ];
+    };
+    systemd.user.sockets.yubikey-touch-detector = {
+      wantedBy = [ "sockets.target" ];
+    };
+  };
+}


### PR DESCRIPTION
Since yubikey-touch-detector is more of a service running in the background, I propose to move to the services section under misc. I also added a package option to enable custom packages to be run instead of the default one.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
