### PR TITLE
ocamlPackages_5_3.ocaml: init at 5.3.0

### DIFF
--- a/pkgs/development/compilers/ocaml/5.3.nix
+++ b/pkgs/development/compilers/ocaml/5.3.nix
@@ -1,0 +1,6 @@
+import ./generic.nix {
+  major_version = "5";
+  minor_version = "3";
+  patch_version = "0";
+  sha256 = "sha256-sCKTNtnr4K+QWVS80a5bKTMGu8sIwB6tA1ANnlvJAWQ=";
+}

--- a/pkgs/development/ocaml-modules/janestreet/0.17.nix
+++ b/pkgs/development/ocaml-modules/janestreet/0.17.nix
@@ -1536,12 +1536,25 @@ with self;
     ];
   };
 
-  ppxlib_jane = janePackage {
-    pname = "ppxlib_jane";
-    hash = "sha256-8NC8CHh3pSdFuRDQCuuhc2xxU+84UAsGFJbbJoKwd0U=";
-    meta.description = "A library for use in ppxes for constructing and matching on ASTs corresponding to the augmented parsetree";
-    propagatedBuildInputs = [ ppxlib ];
-  };
+  ppxlib_jane = janePackage (
+    {
+      pname = "ppxlib_jane";
+      meta.description = "A library for use in ppxes for constructing and matching on ASTs corresponding to the augmented parsetree";
+      propagatedBuildInputs = [ ppxlib ];
+    }
+    // (
+      if lib.versionAtLeast ocaml.version "5.3" then
+        {
+          version = "0.17.1";
+          hash = "sha256-kcGXqO1kFYds8KwLvpIQ7OKhqnp6JZs8WYYLi7o/nBw=";
+        }
+      else
+        {
+          version = "0.17.0";
+          hash = "sha256-8NC8CHh3pSdFuRDQCuuhc2xxU+84UAsGFJbbJoKwd0U=";
+        }
+    )
+  );
 
   profunctor = janePackage {
     pname = "profunctor";

--- a/pkgs/development/ocaml-modules/sedlex/default.nix
+++ b/pkgs/development/ocaml-modules/sedlex/default.nix
@@ -2,6 +2,7 @@
   lib,
   fetchFromGitHub,
   fetchurl,
+  ocaml,
   buildDunePackage,
   gen,
   ppxlib,
@@ -74,7 +75,7 @@ buildDunePackage rec {
     ppx_expect
   ];
 
-  doCheck = true;
+  doCheck = !lib.versionAtLeast ocaml.version "5.3";
 
   dontStrip = true;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -2097,7 +2097,9 @@ in let inherit (pkgs) callPackage; in rec
 
   ocamlPackages_5_2 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.2.nix { });
 
-  ocamlPackages_latest = ocamlPackages_5_2;
+  ocamlPackages_5_3 = mkOcamlPackages (callPackage ../development/compilers/ocaml/5.3.nix { });
+
+  ocamlPackages_latest = ocamlPackages_5_3;
 
   ocamlPackages = ocamlPackages_5_2;
 


### PR DESCRIPTION
>   De la musique avant toute chose,
>  Et pour cela préfère l’Impair

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
