### PR TITLE
librashader: init at 0.6.2

### DIFF
--- a/pkgs/by-name/li/librashader/package.nix
+++ b/pkgs/by-name/li/librashader/package.nix
@@ -1,0 +1,70 @@
+{
+  fetchFromGitHub,
+  lib,
+  rustPlatform,
+  stdenv,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "librashader";
+  version = "0.6.2";
+
+  src = fetchFromGitHub {
+    owner = "SnowflakePowered";
+    repo = "librashader";
+    rev = "librashader-v0.6.2";
+    hash = "sha256-zkvCpQ5Cq3sDOspc12/gPmNi6hn/nBe1UfWrMGi/o0Q=";
+  };
+
+  patches = [
+    ./patches/fix-optional-dep-syntax.patch
+  ];
+
+  cargoHash = "sha256-eUZOFdbOPs81LAMEV4i6eYRN8NYVcnmble/L+ptx2EA=";
+
+  RUSTC_BOOTSTRAP = 1;
+
+  buildPhase = ''
+    runHook preBuild
+    cargo run -p librashader-build-script -- --profile optimized
+    runHook postBuild
+  '';
+
+  doCheck = false;
+
+  installPhase =
+    ''
+      runHook preInstall
+      cd target/optimized
+      mkdir -p $out/lib $out/include/librashader
+    ''
+    + (
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          install_name_tool -id $out/lib/librashader.dylib librashader.dylib
+          install -m755 librashader.dylib $out/lib/librashader.dylib
+        ''
+      else
+        ''
+          patchelf --set-soname librashader.so.2 librashader.so
+          install -m755 librashader.so $out/lib/librashader.so.2
+          ln -s $out/lib/librashader.so.2 $out/lib/librashader.so
+        ''
+    )
+    + ''
+      install -m644 librashader.h -t $out/include/librashader
+      install -m644 ../../include/librashader_ld.h -t $out/include/librashader
+      runHook postInstall
+    '';
+
+  meta = {
+    description = "RetroArch Shaders for All";
+    homepage = "https://github.com/SnowflakePowered/librashader";
+    license = with lib.licenses; [
+      mpl20
+      gpl3Only
+    ];
+    maintainers = with lib.maintainers; [ nadiaholmquist ];
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/by-name/li/librashader/patches/fix-optional-dep-syntax.patch
+++ b/pkgs/by-name/li/librashader/patches/fix-optional-dep-syntax.patch
@@ -1,0 +1,31 @@
+diff --git a/librashader-capi/Cargo.toml b/librashader-capi/Cargo.toml
+index 4a103ab7..38971ddb 100644
+--- a/librashader-capi/Cargo.toml
++++ b/librashader-capi/Cargo.toml
+@@ -17,12 +17,12 @@ crate-type = [ "cdylib", "staticlib" ]
+ [features]
+ default = ["runtime-all" ]
+ runtime-all = ["runtime-opengl", "runtime-d3d9", "runtime-d3d11", "runtime-d3d12", "runtime-vulkan", "runtime-metal"]
+-runtime-opengl = ["glow", "librashader/runtime-gl"]
+-runtime-d3d11 = ["windows", "librashader/runtime-d3d11", "windows/Win32_Graphics_Direct3D11"]
+-runtime-d3d12 = ["windows", "librashader/runtime-d3d12", "windows/Win32_Graphics_Direct3D12"]
+-runtime-d3d9 = ["windows", "librashader/runtime-d3d9", "windows/Win32_Graphics_Direct3D9"]
++runtime-opengl = ["dep:glow", "librashader/runtime-gl"]
++runtime-d3d11 = ["dep:windows", "librashader/runtime-d3d11", "windows/Win32_Graphics_Direct3D11"]
++runtime-d3d12 = ["dep:windows", "librashader/runtime-d3d12", "windows/Win32_Graphics_Direct3D12"]
++runtime-d3d9 = ["dep:windows", "librashader/runtime-d3d9", "windows/Win32_Graphics_Direct3D9"]
+ 
+-runtime-vulkan = ["ash", "librashader/runtime-vk"]
++runtime-vulkan = ["dep:ash", "librashader/runtime-vk"]
+ runtime-metal = ["__cbindgen_internal_objc", "librashader/runtime-metal"]
+ 
+ reflect-unstable = []
+@@ -33,7 +33,7 @@ __cbindgen_internal = ["runtime-all"]
+ 
+ # make runtime-metal depend on this, so its automatically implied.
+ # this will make cbindgen generate __OBJC__ ifdefs for metal functions.
+-__cbindgen_internal_objc = ["objc2-metal", "objc2"]
++__cbindgen_internal_objc = ["dep:objc2-metal", "dep:objc2"]
+ 
+ [dependencies]
+ thiserror = "2"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Creates a package for [librashader](https://github.com/SnowflakePowered/librashader), a Rust-based reimplementation of RetroArch's shader system that can be used by other applications.

Only the C API/dylib is packaged.

The motivation for packaging it is that the ares emulator added it as a dependency in a newer version than what is packaged in nixpkgs. I wanted to update ares so I figured it would be nice to package librashader so it can be enabled for extra shader support, rather than having to disable it in the updated build of ares.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
