### PR TITLE
elixir: use env shebang only on Darwin

### DIFF
--- a/pkgs/development/interpreters/elixir/generic-builder.nix
+++ b/pkgs/development/interpreters/elixir/generic-builder.nix
@@ -57,6 +57,16 @@ let
       true
     else
       versionOlder (versions.major (getVersion erlang)) maxShiftMajor;
+
+  elixirShebang =
+    if stdenv.hostPlatform.isDarwin then
+      # Darwin disallows shebang scripts from using other scripts as their
+      # command. Use env as an intermediary instead of calling elixir directly
+      # (another shebang script).
+      # See https://github.com/NixOS/nixpkgs/pull/9671
+      "${coreutils}/bin/env $out/bin/elixir"
+    else
+      "$out/bin/elixir";
 in
 assert assertMsg (versionAtLeast (getVersion erlang) minimumOTPVersion) compatibilityMsg;
 assert assertMsg maxAssert compatibilityMsg;
@@ -104,7 +114,7 @@ stdenv.mkDerivation ({
     done
 
     substituteInPlace $out/bin/mix \
-      --replace "/usr/bin/env elixir" "${coreutils}/bin/env $out/bin/elixir"
+      --replace "/usr/bin/env elixir" "${elixirShebang}"
   '';
 
   pos = builtins.unsafeGetAttrPos "sha256" args;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The `mix` program from the `elixir` package has a long shebang:

```
#!/nix/store/b1wvkjx96i3s7wblz38ya0zr8i93zbc5-coreutils-9.5/bin/env /nix/store/mhm5dbd3lxhndrz5rcnl383jpp2k6xqq-elixir-1.17.3/bin/elixir
```

136 characters. Historical PR comments note that we include the `env` invocation even though we give an exact binary path because Darwin won't use another interpreted script as this program's interpreter.

I'm working on improving compatibility with older Linux kernels, which have a limit of 127 characters in the shebang command. This PR removes the `env` command other than in Darwin, which will bring us well under 127 characters.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) <- kind of, only `mix`
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
