### PR TITLE
libsixel: fix CVE-2021-45340

### DIFF
--- a/pkgs/by-name/li/libsixel/fix-CVE-2021-45340.patch
+++ b/pkgs/by-name/li/libsixel/fix-CVE-2021-45340.patch
@@ -1,0 +1,12 @@
+diff --git a/src/stb_image.h b/src/stb_image.h
+index f12c30b..526281c 100644
+--- a/src/stb_image.h
++++ b/src/stb_image.h
+@@ -1534,6 +1534,7 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
+    int i,j;
+    unsigned char *good;
+ 
++   if (data == NULL) return data;
+    if (req_comp == img_n) return data;
+    STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+ 

--- a/pkgs/by-name/li/libsixel/package.nix
+++ b/pkgs/by-name/li/libsixel/package.nix
@@ -19,6 +19,11 @@ stdenv.mkDerivation rec {
     sha256 = "1nny4295ipy4ajcxmmh04c796hcds0y7z7rv3qd17mj70y8j0r2d";
   };
 
+  patches = [
+    # https://github.com/NixOS/nixpkgs/issues/160670
+    ./fix-CVE-2021-45340.patch
+  ];
+
   buildInputs = [
     gdk-pixbuf
     gd
@@ -43,7 +48,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "SIXEL library for console graphics, and converter programs";
     homepage = "https://github.com/libsixel/libsixel";
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ hzeller ];
     license = licenses.mit;
     platforms = platforms.unix;
   };


### PR DESCRIPTION
Fixes: #160670

Also, while at it, adopt abandoned package.

Fix tested:

```bash
wget https://github.com/libsixel/libsixel/files/7715065/stbi_1561_poc.zip
unzip stbi_1561_poc.zip

# Before: this will result in a core-dump
nix-shell -p libsixel --run "img2sixel ./stbi_1561_poc.bin"

# After: build this patched version - emits proper error message
nix-build -A libsixel
result/bin/img2sixel ./stbi_1561_poc.bin
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
