### PR TITLE
satysfi: 0.0.10 -> 0.0.11

### DIFF
--- a/pkgs/by-name/sa/satysfi/package.nix
+++ b/pkgs/by-name/sa/satysfi/package.nix
@@ -90,7 +90,10 @@ ocamlPackages.buildDunePackage {
     description = "Statically-typed, functional typesetting system";
     changelog = "https://github.com/gfngfn/SATySFi/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ mt-caret ];
+    maintainers = with lib.maintainers; [
+      mt-caret
+      momeemt
+    ];
     platforms = lib.platforms.all;
     mainProgram = "satysfi";
   };

--- a/pkgs/by-name/sa/satysfi/package.nix
+++ b/pkgs/by-name/sa/satysfi/package.nix
@@ -33,12 +33,12 @@ let
 in
 ocamlPackages.buildDunePackage rec {
   pname = "satysfi";
-  version = "0.0.10";
+  version = "0.0.11";
   src = fetchFromGitHub {
     owner = "gfngfn";
     repo = "SATySFi";
-    rev = "v${version}";
-    hash = "sha256-qgVM7ExsKtzNQkZO+I+rcWLj4LSvKL5uyitH7Jg+ns0=";
+    tag = "v${version}";
+    hash = "sha256-eeeoUVTGId56SQvrmmMc7nwH/blrXgwcw3+0FLbvc34=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/by-name/sa/satysfi/package.nix
+++ b/pkgs/by-name/sa/satysfi/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  ocamlPackages,
+  ocaml-ng,
   ipaexfont,
   junicode,
   lmodern,
@@ -29,6 +29,7 @@ let
     propagatedBuildInputs = [ ocamlPackages.biniou ];
     inherit (ocamlPackages.yojson) meta;
   };
+  ocamlPackages = ocaml-ng.ocamlPackages_4_14;
 in
 ocamlPackages.buildDunePackage rec {
   pname = "satysfi";

--- a/pkgs/by-name/sa/satysfi/package.nix
+++ b/pkgs/by-name/sa/satysfi/package.nix
@@ -30,10 +30,12 @@ let
     inherit (ocamlPackages.yojson) meta;
   };
   ocamlPackages = ocaml-ng.ocamlPackages_4_14;
-in
-ocamlPackages.buildDunePackage rec {
-  pname = "satysfi";
   version = "0.0.11";
+in
+ocamlPackages.buildDunePackage {
+  pname = "satysfi";
+  inherit version;
+
   src = fetchFromGitHub {
     owner = "gfngfn";
     repo = "SATySFi";
@@ -83,13 +85,13 @@ ocamlPackages.buildDunePackage rec {
       $out/share/satysfi/dist/fonts/Junicode.ttf
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/gfngfn/SATySFi";
     description = "Statically-typed, functional typesetting system";
     changelog = "https://github.com/gfngfn/SATySFi/blob/v${version}/CHANGELOG.md";
-    license = licenses.lgpl3Only;
-    maintainers = [ maintainers.mt-caret ];
-    platforms = platforms.all;
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ mt-caret ];
+    platforms = lib.platforms.all;
     mainProgram = "satysfi";
   };
 }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -18065,10 +18065,6 @@ with pkgs;
 
   sane-frontends = callPackage ../applications/graphics/sane/frontends.nix { };
 
-  satysfi = callPackage ../tools/typesetting/satysfi {
-    ocamlPackages = ocaml-ng.ocamlPackages_4_14;
-  };
-
   sc-controller = python3Packages.callPackage ../misc/drivers/sc-controller {
     inherit libusb1; # Shadow python.pkgs.libusb1.
   };


### PR DESCRIPTION
- Updated satysfi 0.0.10 to 0.0.11
	- https://github.com/gfngfn/SATySFi/releases/tag/v0.0.11
- Moved to `pkgs/by-name`
- Modernized this derivation
	- Formatted via nixfmt-rfc-style
	- Removed unnecessary `rec` (ref: [nix.dev/guides/best-practices#recursive-attribute-set-rec](https://nix.dev/guides/best-practices#recursive-attribute-set-rec))
	- Removed `with lib`;

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
