### PR TITLE
libnvidia-container: include binaries from driver package

### DIFF
--- a/pkgs/by-name/li/libnvidia-container/0002-nvc-nvidia-docker-compatible-binary-lookups.patch
+++ b/pkgs/by-name/li/libnvidia-container/0002-nvc-nvidia-docker-compatible-binary-lookups.patch
@@ -9,7 +9,7 @@ This patch maintains compatibility with NixOS' `virtualisation.docker.enableNvid
  1 file changed, 14 insertions(+), 2 deletions(-)
 
 diff --git a/src/nvc_info.c b/src/nvc_info.c
-index cf4b1905fd2127c28ee16649501be122d3be5261..2ab552860ef98879b76398a6f9be95f07b2c8a4a 100644
+index cf4b1905fd2127c28ee16649501be122d3be5261..a238fba3f4ff7786cd1a84b80b1f623553e2d377 100644
 --- a/src/nvc_info.c
 +++ b/src/nvc_info.c
 @@ -243,16 +243,28 @@ static int
@@ -31,7 +31,7 @@ index cf4b1905fd2127c28ee16649501be122d3be5261..2ab552860ef98879b76398a6f9be95f0
 +
 +        // TODO: Remove this patch once `virtualisation.docker.enableNvidia` is removed from NixOS.
 +        // It only exists to maintain compatibility with the old nvidia-docker package.
-+        int p_rv = snprintf(env, PATH_MAX, "/run/nvidia-docker/bin:/run/nvidia-docker/extras/bin:%s", os_path);
++        int p_rv = snprintf(env, PATH_MAX, "/run/nvidia-docker/bin:/run/nvidia-docker/extras/bin:@driverLink@/bin:%s", os_path);
 +        if (p_rv >= PATH_MAX) {
 +                error_setx(err, "PATH environment variable too long");
 +                return (-1);

--- a/pkgs/by-name/li/libnvidia-container/0002-nvc-nvidia-docker-compatible-binary-lookups.patch
+++ b/pkgs/by-name/li/libnvidia-container/0002-nvc-nvidia-docker-compatible-binary-lookups.patch
@@ -3,42 +3,26 @@ From: Moritz Sanft <58110325+msanft@users.noreply.github.com>
 Date: Fri, 20 Dec 2024 16:37:07 +0100
 Subject: [PATCH] nvc: nvidia-docker-compatible binary lookups
 
-This patch maintains compatibility with NixOS' `virtualisation.docker.enableNvidia` option (which is to be removed soon), while also enabling supplying a custom PATH, to work with the modern CDI-based approach.
+This patch maintains compatibility with NixOS' `virtualisation.docker.enableNvidia` option (which is to be removed soon), while also including the driver package's path, to work with the modern CDI-based approach.
 ---
- src/nvc_info.c | 16 ++++++++++++++--
- 1 file changed, 14 insertions(+), 2 deletions(-)
+ src/nvc_info.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/nvc_info.c b/src/nvc_info.c
-index cf4b1905fd2127c28ee16649501be122d3be5261..a238fba3f4ff7786cd1a84b80b1f623553e2d377 100644
+index cf4b1905fd2127c28ee16649501be122d3be5261..cdfa19721bc913d8e2adb96d106cd65ee6111623 100644
 --- a/src/nvc_info.c
 +++ b/src/nvc_info.c
-@@ -243,16 +243,28 @@ static int
- find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_driver_info* info,
-                   const char *root, const char * const bins[], size_t size)
- {
--        char *env, *ptr;
-+        char *env, *ptr, *os_path;
-         const char *dir;
-         char tmp[PATH_MAX];
+@@ -249,10 +249,13 @@ find_binary_paths(struct error *err, struct dxcore_context* dxcore, struct nvc_d
          char path[PATH_MAX];
          int rv = -1;
  
 -        if ((env = secure_getenv("PATH")) == NULL) {
-+        if ((os_path = secure_getenv("PATH")) == NULL) {
++        // TODO: Remove this patch once `virtualisation.docker.enableNvidia` is removed from NixOS.
++        // It only exists to maintain compatibility with the old nvidia-docker package.
++        if ((env = "/run/nvidia-docker/bin:/run/nvidia-docker/extras/bin:@driverLink@/bin") == NULL) {
                  error_setx(err, "environment variable PATH not found");
                  return (-1);
          }
-+
-+        // TODO: Remove this patch once `virtualisation.docker.enableNvidia` is removed from NixOS.
-+        // It only exists to maintain compatibility with the old nvidia-docker package.
-+        int p_rv = snprintf(env, PATH_MAX, "/run/nvidia-docker/bin:/run/nvidia-docker/extras/bin:@driverLink@/bin:%s", os_path);
-+        if (p_rv >= PATH_MAX) {
-+                error_setx(err, "PATH environment variable too long");
-+                return (-1);
-+        } else if (p_rv < 0) {
-+                error_setx(err, "error setting PATH environment variable");
-+                return (-1);
-+        }
 +
          if ((env = ptr = xstrdup(err, env)) == NULL)
                  return (-1);

--- a/pkgs/by-name/li/libnvidia-container/package.nix
+++ b/pkgs/by-name/li/libnvidia-container/package.nix
@@ -52,7 +52,9 @@ stdenv.mkDerivation rec {
     # for binary lookups.
     # TODO: Remove the legacy compatibility once nvidia-docker is removed
     # from NixOS.
-    ./0002-nvc-nvidia-docker-compatible-binary-lookups.patch
+    (replaceVars ./0002-nvc-nvidia-docker-compatible-binary-lookups.patch {
+      inherit (addDriverRunpath) driverLink;
+    })
 
     # fix bogus struct declaration
     ./0003-nvc-fix-struct-declaration.patch


### PR DESCRIPTION
There's really no reason to require the binaries from the nvidia driver package to be passed to libnvidia-container via the PATH. We do the same thing via driverLink for the libraries already, so let's be consistent here.

This also fixes a segfault in the patch I wrote in https://github.com/NixOS/nixpkgs/pull/366855, which causes uninitialized memory to be written if binaries are mounted into the container. Thus, I scrap the complicated patch entirely here, going back to just including the binaries from the driver package and not via PATH.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
