### PR TITLE
uutils-coreutils: move to by-name, add versionCheckHook

### DIFF
--- a/pkgs/by-name/uu/uutils-coreutils/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils/package.nix
@@ -6,6 +6,7 @@
   cargo,
   python3Packages,
   versionCheckHook,
+  nix-update-script,
 
   prefix ? "uutils-",
   buildMulticallBinary ? true,
@@ -56,6 +57,10 @@ stdenv.mkDerivation rec {
     "${placeholder "out"}/bin/${prefix'}ls";
   versionCheckProgramArg = [ "--version" ];
   doInstallCheck = true;
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
 
   meta = {
     description = "Cross-platform Rust rewrite of the GNU coreutils";

--- a/pkgs/by-name/uu/uutils-coreutils/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils/package.nix
@@ -4,9 +4,7 @@
   fetchFromGitHub,
   rustPlatform,
   cargo,
-  sphinx,
-  Security,
-  libiconv,
+  python3Packages,
   prefix ? "uutils-",
   buildMulticallBinary ? true,
 }:
@@ -30,17 +28,12 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     rustPlatform.cargoSetupHook
-    sphinx
-  ];
-
-  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
-    Security
-    libiconv
+    python3Packages.sphinx
   ];
 
   makeFlags =
     [
-      "CARGO=${cargo}/bin/cargo"
+      "CARGO=${lib.getExe cargo}"
       "PREFIX=${placeholder "out"}"
       "PROFILE=release"
       "INSTALLDIR_MAN=${placeholder "out"}/share/man/man1"

--- a/pkgs/by-name/uu/uutils-coreutils/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils/package.nix
@@ -5,6 +5,8 @@
   rustPlatform,
   cargo,
   python3Packages,
+  versionCheckHook,
+
   prefix ? "uutils-",
   buildMulticallBinary ? true,
 }:
@@ -43,6 +45,17 @@ stdenv.mkDerivation rec {
 
   # too many impure/platform-dependent tests
   doCheck = false;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram =
+    let
+      prefix' = lib.optionalString (prefix != null) prefix;
+    in
+    "${placeholder "out"}/bin/${prefix'}ls";
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
 
   meta = {
     description = "Cross-platform Rust rewrite of the GNU coreutils";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3170,11 +3170,6 @@ with pkgs;
 
   uusi = haskell.lib.compose.justStaticExecutables haskellPackages.uusi;
 
-  uutils-coreutils = callPackage ../tools/misc/uutils-coreutils {
-    inherit (python3Packages) sphinx;
-    inherit (darwin.apple_sdk.frameworks) Security;
-  };
-
   uutils-coreutils-noprefix = uutils-coreutils.override { prefix = null; };
 
   vorta = qt6Packages.callPackage ../applications/backup/vorta { };


### PR DESCRIPTION
## Things done

- **uutils-coreutils: move to by-name**
- **uutils-coreutils: add versionCheckHook**

cc @siraben

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
