### PR TITLE
parseable: init at 1.7.1

### DIFF
--- a/pkgs/by-name/pa/parseable/package.nix
+++ b/pkgs/by-name/pa/parseable/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  rdkafka,
+  pkg-config,
+  fetchFromGitHub,
+  rustPlatform,
+  fetchzip,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "parseable";
+  version = "1.7.1";
+
+  src = fetchFromGitHub {
+    owner = "parseablehq";
+    repo = "parseable";
+    tag = "v${version}";
+    hash = "sha256-Uoejniv6hUpxTZ6gosP+LHTo4FD+o1AlUEWopdpz5M0=";
+  };
+
+  LOCAL_ASSETS_PATH = fetchzip {
+    url = "https://github.com/parseablehq/console/releases/download/v0.9.15/build.zip";
+    hash = "sha256-T37pI7adfKPDkCETcGcZVzcYVcxROSZLDrFhV4XO4tc=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-rT/ORTOPsOgYlS8VCMBXo/cjfSJYcCtJofcPEIlc/cI=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [ rdkafka ];
+
+  buildFeatures = [ "rdkafka/dynamic-linking" ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Disk less, cloud native database for logs, observability, security, and compliance";
+    homepage = "https://www.parseable.com";
+    changelog = "https://github.com/parseablehq/parseable/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    maintainers = with lib.maintainers; [ ilyakooo0 ];
+    mainProgram = "parseable";
+  };
+}


### PR DESCRIPTION
Adds parseable: https://www.parseable.com/ https://github.com/parseablehq/parseable

Parseable is a disk less, cloud native database for logs, observability, security, and compliance. Parseable is built with focus on simplicity & resource efficiency. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
