### PR TITLE
percona-server_8_{0,4}: fix build on aarch64-linux

### DIFF
--- a/pkgs/servers/sql/percona-server/8_0.nix
+++ b/pkgs/servers/sql/percona-server/8_0.nix
@@ -63,6 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
+    ./coredumper-explicitly-import-unistd.patch # fix build on aarch64-linux
   ];
 
   ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.

--- a/pkgs/servers/sql/percona-server/8_4.nix
+++ b/pkgs/servers/sql/percona-server/8_4.nix
@@ -71,6 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
+    ./coredumper-explicitly-import-unistd.patch # fix build on aarch64-linux
   ];
 
   ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.

--- a/pkgs/servers/sql/percona-server/coredumper-explicitly-import-unistd.patch
+++ b/pkgs/servers/sql/percona-server/coredumper-explicitly-import-unistd.patch
@@ -1,0 +1,12 @@
+diff --git a/extra/coredumper/src/thread_lister.c b/extra/coredumper/src/thread_lister.c
+index 15fedac..181889b 100644
+--- a/extra/coredumper/src/thread_lister.c
++++ b/extra/coredumper/src/thread_lister.c
+@@ -35,6 +35,7 @@
+
+ #include <stdio.h> /* needed for NULL on some powerpc platforms (?!) */
+ #include <sys/prctl.h>
++#include <unistd.h>
+
+ #include "linuxthreads.h"
+ /* Include other thread listers here that define THREADS macro


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This build failed on aarch64-linux after the GCC merge. See https://hydra.nixos.org/build/283893139.
```
/build/percona-server-8.0.40-31/extra/coredumper/src/thread_lister.c: In function 'ListAllProcessThreads':
/build/percona-server-8.0.40-31/extra/coredumper/src/thread_lister.c:57:15: error: implicit declaration of function 'getpid' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
   57 |   pid_t pid = getpid();
      |               ^~~~~~
make[2]: *** [extra/coredumper/src/CMakeFiles/coredumper.dir/build.make:90: extra/coredumper/src/CMakeFiles/coredumper.dir/thread_lister.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4346: extra/coredumper/src/CMakeFiles/coredumper.dir/all] Error 2
```


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
