### PR TITLE
ci/request-reviews: Fix code owner requests for filenames with spaces

### DIFF
--- a/ci/request-reviews/get-code-owners.sh
+++ b/ci/request-reviews/get-code-owners.sh
@@ -36,7 +36,8 @@ declare -A users=()
 for file in "${touchedFiles[@]}"; do
     result=$(codeowners --file "$tmp"/codeowners "$file")
 
-    read -r file owners <<< "$result"
+    # Remove the file prefix and trim the surrounding spaces
+    read -r owners <<< "${result#"$file"}"
     if [[ "$owners" == "(unowned)" ]]; then
         log "File $file is unowned"
         continue


### PR DESCRIPTION
Discovered in https://github.com/NixOS/nixpkgs/pull/368656#issuecomment-2564266513

Ping @SigmaSquadron 

## Things done
- [x] Tested `get-code-owners.sh` locally with a commit that changes a file with a filename that has a space

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
