### PR TITLE
python312Packages.immutabledict: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/immutabledict/default.nix
+++ b/pkgs/development/python-modules/immutabledict/default.nix
@@ -27,6 +27,11 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [ pytestCheckHook ];
 
+  disabledTests = [
+    # fails if builder load is highly variable
+    "test_performance"
+  ];
+
   meta = with lib; {
     description = "Fork of frozendict, an immutable wrapper around dictionaries";
     homepage = "https://github.com/corenting/immutabledict";


### PR DESCRIPTION
This test fails randomly if the builder is oversubscribed. https://paste.fliegendewurst.eu/W1NRec.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).