### PR TITLE
tmuxPlugins.tmux-which-key: init at 0-unstable-2024-06-08

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16635,6 +16635,12 @@
     githubId = 126072875;
     name = "nova madeline";
   };
+  novaviper = {
+    email = "coder.nova99@mailbox.org";
+    github = "novaviper";
+    githubId = 7191115;
+    name = "Nova Leary";
+  };
   novoxd = {
     email = "radnovox@gmail.com";
     github = "novoxd";

--- a/pkgs/misc/tmux-plugins/default.nix
+++ b/pkgs/misc/tmux-plugins/default.nix
@@ -882,6 +882,10 @@ in rec {
     };
   };
 
+  tmux-which-key = pkgs.callPackage ./tmux-which-key {
+    inherit mkTmuxPlugin;
+  };
+
   yank = mkTmuxPlugin {
     pluginName = "yank";
     version = "unstable-2023-07-19";

--- a/pkgs/misc/tmux-plugins/tmux-which-key/default.nix
+++ b/pkgs/misc/tmux-plugins/tmux-which-key/default.nix
@@ -1,0 +1,45 @@
+{
+  mkTmuxPlugin,
+  fetchFromGitHub,
+  lib,
+  check-jsonschema,
+  python3,
+}:
+mkTmuxPlugin {
+  pluginName = "tmux-which-key";
+  rtpFilePath = "plugin.sh.tmux";
+  version = "0-unstable-2024-06-08";
+  buildInputs = [
+    check-jsonschema
+    (python3.withPackages (ps: with ps; [ pyyaml ]))
+  ];
+
+  postPatch = ''
+    substituteInPlace plugin.sh.tmux --replace-fail \
+      python3 "${lib.getExe (python3.withPackages (ps: with ps; [ pyyaml ]))}"
+  '';
+
+  preInstall = ''
+    rm -rf plugin/pyyaml
+    ln -s ${python3.pkgs.pyyaml.src} plugin/pyyaml
+  '';
+
+  postInstall = ''
+    patchShebangs plugin.sh.tmux plugin/build.py
+  '';
+
+  src = fetchFromGitHub {
+    owner = "alexwforsythe";
+    repo = "tmux-which-key";
+    rev = "1f419775caf136a60aac8e3a269b51ad10b51eb6";
+    hash = "sha256-X7FunHrAexDgAlZfN+JOUJvXFZeyVj9yu6WRnxMEA8E=";
+  };
+
+  meta = {
+    homepage = "https://github.com/alexwforsythe/tmux-which-key";
+    description = "Tmux plugin that allows users to select actions from a customizable popup menu";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.unix;
+    maintainers = with lib.maintainers; [ novaviper ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Fixes #367462
> A plugin for tmux that allows users to select actions from a customizable popup menu. Inspired by the likes of [vscode-which-key](https://github.com/VSpaceCode/vscode-which-key), [emacs-which-key](https://github.com/justbur/emacs-which-key), and [which-key.nvim](https://github.com/folke/which-key.nvim), this plugin aims to make users more effective at using tmux by reducing keyboard shortcut memorization and increasing feature discoverability.
homepage: https://github.com/alexwforsythe/tmux-which-key

Additionally, I add myself as maintainer of the package. I tested basic functionality in my flake (as well built it with `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`) and found that it works correctly.
flake info:
```
❯ nix-info -m
 - system: `"x86_64-linux"`
 - host os: `Linux 6.12.8, NixOS, 25.05 (Warbler), 25.05.20250104.8f3e1f8`
 - multi-user?: `yes`
 - sandbox: `yes`
 - version: `nix-env (Nix) 2.25.3`
 - nixpkgs: `/nix/store/khbvilmsrv4l69nwd52h27j1mp44a0xi-source`
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
