### PR TITLE
stumpwm: 22.11 -> 24.11 + moved outside lisp-modules

### DIFF
--- a/nixos/modules/services/x11/window-managers/stumpwm.nix
+++ b/nixos/modules/services/x11/window-managers/stumpwm.nix
@@ -14,16 +14,17 @@ in
 {
   options = {
     services.xserver.windowManager.stumpwm.enable = mkEnableOption "stumpwm";
+    services.xserver.windowManager.stumpwm.package = mkPackageOption pkgs "stumpwm" { };
   };
 
   config = mkIf cfg.enable {
     services.xserver.windowManager.session = singleton {
       name = "stumpwm";
       start = ''
-        ${pkgs.sbclPackages.stumpwm}/bin/stumpwm &
+        ${cfg.package}/bin/stumpwm &
         waitPID=$!
       '';
     };
-    environment.systemPackages = [ pkgs.sbclPackages.stumpwm ];
+    environment.systemPackages = [ cfg.package ];
   };
 }

--- a/pkgs/applications/window-managers/stumpwm/default.nix
+++ b/pkgs/applications/window-managers/stumpwm/default.nix
@@ -1,0 +1,41 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  autoreconfHook,
+  sbcl,
+  texinfo,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "stumpwm";
+  version = "24.11";
+
+  src = fetchFromGitHub {
+    owner = "stumpwm";
+    repo = "stumpwm";
+    rev = "${finalAttrs.version}";
+    hash = "sha256-Ba2HcAmNcZvnqU0jpLTxsBe8L+4aHbO/oM4Bp/IYEC0=";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    sbcl
+    texinfo
+  ];
+
+  doCheck = true;
+
+  postConfigure = ''
+    export ASDF_OUTPUT_TRANSLATIONS=$(pwd):$(pwd)
+  '';
+
+  meta = {
+    description = "Tiling, keyboard driven window manager";
+    homepage = "https://stumpwm.github.io/";
+    license = lib.licenses.gpl2Plus;
+    mainProgram = "stumpwm";
+    maintainers = lib.teams.lisp.members;
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/development/lisp-modules/packages.nix
+++ b/pkgs/development/lisp-modules/packages.nix
@@ -190,45 +190,12 @@ let
     lispLibs = super.mathkit.lispLibs ++ [ super.sb-cga ];
   };
 
-  stumpwm = super.stumpwm.overrideLispAttrs (o: rec {
-    version = "22.11";
-    src = pkgs.fetchFromGitHub {
-      owner = "stumpwm";
-      repo = "stumpwm";
-      rev = version;
-      hash = "sha256-zXj17ucgyFhv7P0qEr4cYSVRPGrL1KEIofXWN2trr/M=";
+  stumpwm = super.stumpwm.overrideAttrs {
+    inherit (pkgs.stumpwm) src version;
+    meta = {
+      inherit (pkgs.stumpwm.meta) description license homepage;
     };
-    buildScript = pkgs.writeText "build-stumpwm.lisp" ''
-      (load "${super.stumpwm.asdfFasl}/asdf.${super.stumpwm.faslExt}")
-
-      (asdf:load-system 'stumpwm)
-
-      ;; Prevents package conflict error
-      (when (uiop:version<= "3.1.5" (asdf:asdf-version))
-        (uiop:symbol-call '#:asdf '#:register-immutable-system :stumpwm)
-        (dolist (system-name (uiop:symbol-call '#:asdf
-                                               '#:system-depends-on
-                                               (asdf:find-system :stumpwm)))
-          (uiop:symbol-call '#:asdf '#:register-immutable-system system-name)))
-
-      ;; Prevents "cannot create /homeless-shelter" error
-      (asdf:disable-output-translations)
-
-      (sb-ext:save-lisp-and-die
-        "stumpwm"
-        :executable t
-        :purify t
-        #+sb-core-compression :compression
-        #+sb-core-compression t
-        :toplevel #'stumpwm:stumpwm)
-    '';
-    installPhase = ''
-      mkdir -p $out/bin
-      cp -v stumpwm $out/bin
-    '';
-  });
-
-  stumpwm-unwrapped = super.stumpwm;
+  };
 
   clfswm = super.clfswm.overrideAttrs (o: rec {
     buildScript = pkgs.writeText "build-clfswm.lisp" ''
@@ -471,6 +438,7 @@ let
   } // optionalAttrs pkgs.config.allowAliases {
     cl-glib_dot_gio = throw "cl-glib_dot_gio was replaced by cl-gio";
     cl-gtk4_dot_webkit2 = throw "cl-gtk4_dot_webkit2 was replaced by cl-gtk4_dot_webkit";
+    stumpwm-unwrapped = throw "stumpwm-unwrapped is now just stumpwm";
   });
 
 in packages

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -15323,9 +15323,14 @@ with pkgs;
 
   inherit (ocaml-ng.ocamlPackages) stog;
 
-  stumpwm = sbclPackages.stumpwm;
+  stumpwm = callPackage ../applications/window-managers/stumpwm {
+    stdenv = stdenvNoCC;
+    sbcl = sbcl.withPackages (ps: with ps; [
+      alexandria cl-ppcre clx fiasco
+    ]);
+  };
 
-  stumpwm-unwrapped = sbclPackages.stumpwm-unwrapped;
+  stumpwm-unwrapped = sbclPackages.stumpwm;
 
   sublime3Packages = recurseIntoAttrs (callPackage ../applications/editors/sublime/3/packages.nix { });
 


### PR DESCRIPTION
Moved outside lisp-modules to a separate package, so as to re-use its Makefile-based build-system and make a step in the direction of leaving just development libraries in lisp-modules.

Continuing discussion from: [link](https://github.com/NixOS/nixpkgs/pull/369210
)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
