### PR TITLE
cargonode: 0.1.2 -> 0.1.3

### DIFF
--- a/pkgs/by-name/ca/cargonode/package.nix
+++ b/pkgs/by-name/ca/cargonode/package.nix
@@ -3,21 +3,20 @@
   rustPlatform,
   fetchFromGitHub,
   pkg-config,
-  bzip2,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "cargonode";
-  version = "0.1.2";
+  version = "0.1.3";
 
   src = fetchFromGitHub {
     owner = "xosnrdev";
     repo = "cargonode";
     tag = version;
-    hash = "sha256-xzBLuQRyKmd9k0sbBFV5amtFWwKqXR0CEsRv8SHiJcQ=";
+    hash = "sha256-O5+wAM99m1rgQpwz36mkHEU/FvGnY6hBCKPMIGXCeCU=";
   };
 
-  cargoHash = "sha256-v+Fs2VJrpnIOk9nPRanYYChlR7WOfkXF1kbYOKjOUYc=";
+  cargoHash = "sha256-ZmWpqASh//iCg8blpbso3fhhqJzeOmxLXA1zyUobmwU=";
 
   checkFlags = [
     # Skip test that requires network access
@@ -35,7 +34,7 @@ rustPlatform.buildRustPackage rec {
   meta = {
     description = "Unified tooling for Node.js";
     mainProgram = "cargonode";
-    homepage = "https://github.com/xosnrdev/cargonode";
+    homepage = "https://github.com/xosnrdev/cargonode?tab=readme-ov-file#readme";
     changelog = "https://github.com/xosnrdev/cargonode/blob/${version}/CHANGELOG.md";
     license = with lib.licenses; [
       asl20 # or


### PR DESCRIPTION
Changelog: https://github.com/xosnrdev/cargonode/blob/master/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
