### PR TITLE
nexus: 3.70.1-02 -> 3.71.0-06

### DIFF
--- a/nixos/modules/services/web-apps/nexus.nix
+++ b/nixos/modules/services/web-apps/nexus.nix
@@ -93,6 +93,22 @@ in
           for further information.
         '';
       };
+
+      jdkOpts = mkOption {
+        type = types.lines;
+        default = ''
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.net=ALL-UNNAMED
+        '';
+        defaultText = literalExpression ''
+          '''
+            --add-opens=java.base/java.util=ALL-UNNAMED
+            --add-opens=java.base/java.net=ALL-UNNAMED
+          '''
+        '';
+
+        description = '' Options passed to JDK_JAVA_OPTIONS'';
+      };
     };
   };
 
@@ -118,6 +134,7 @@ in
 
         INSTALL4J_JAVA_HOME = cfg.jdkPackage;
         VM_OPTS_FILE = pkgs.writeText "nexus.vmoptions" cfg.jvmOpts;
+        JDK_JAVA_OPTIONS = cfg.jdkOpts;
       };
 
       preStart = ''

--- a/nixos/modules/services/web-apps/nexus.nix
+++ b/nixos/modules/services/web-apps/nexus.nix
@@ -14,7 +14,7 @@ in
 
       package = lib.mkPackageOption pkgs "nexus" { };
 
-      jdkPackage = lib.mkPackageOption pkgs "openjdk8" { };
+      jdkPackage = lib.mkPackageOption pkgs "openjdk17" { };
 
       user = mkOption {
         type = types.str;
@@ -53,7 +53,6 @@ in
           -Xmx1200M
           -XX:MaxDirectMemorySize=2G
           -XX:+UnlockDiagnosticVMOptions
-          -XX:+UnsyncloadClass
           -XX:+LogVMOutput
           -XX:LogFile=${cfg.home}/nexus3/log/jvm.log
           -XX:-OmitStackTraceInFastThrow
@@ -73,7 +72,6 @@ in
             -Xmx1200M
             -XX:MaxDirectMemorySize=2G
             -XX:+UnlockDiagnosticVMOptions
-            -XX:+UnsyncloadClass
             -XX:+LogVMOutput
             -XX:LogFile=''${home}/nexus3/log/jvm.log
             -XX:-OmitStackTraceInFastThrow

--- a/pkgs/by-name/ne/nexus/package.nix
+++ b/pkgs/by-name/ne/nexus/package.nix
@@ -13,8 +13,8 @@ stdenv.mkDerivation rec {
   version = "3.70.1-02";
 
   src = fetchurl {
-    url = "https://download.sonatype.com/nexus/3/nexus-${version}-unix.tar.gz";
-    hash = "sha256-oBappm8WRcgyD5HWqJKPbMHjlwCUo9y5+FtB2Kq1PCE=";
+    url = "https://download.sonatype.com/nexus/3/nexus-${version}-java11-unix.tar.gz";
+    hash = "sha256-OMb4HXjC9q5GH0kdkyHTbpj/Lhnu42UnDZvJI3fTZYg=";
   };
 
   preferLocalBuild = true;

--- a/pkgs/by-name/ne/nexus/package.nix
+++ b/pkgs/by-name/ne/nexus/package.nix
@@ -10,11 +10,11 @@
 
 stdenv.mkDerivation rec {
   pname = "nexus";
-  version = "3.70.1-02";
+  version = "3.71.0-06";
 
   src = fetchurl {
-    url = "https://download.sonatype.com/nexus/3/nexus-${version}-java11-unix.tar.gz";
-    hash = "sha256-OMb4HXjC9q5GH0kdkyHTbpj/Lhnu42UnDZvJI3fTZYg=";
+    url = "https://download.sonatype.com/nexus/3/nexus-${version}-unix.tar.gz";
+    hash = "sha256-sCUodVgYRnf8IxA1yfXl5sxLwcr9dtE6BiM6TtCdCPY=";
   };
 
   preferLocalBuild = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Following the migration guide between nexus versions 3.69 to 3.71+, requires changing the java version inbetween. You first have to go to 3.70 on java 8, then switch to java 17 and switch the database to a h2 database, then you can upgrade to 3.71+

That's why this non-latest version should be in nixpkgs as well imho.

An even better way would probably be to split up nexus into something like nexus-3-69, nexus-3-70, nexus-3-71 packages or something like that to prevent breaking changes simply by doing a normal update on a stable release. But I am not familiar enough with the best practices in Nixpkgs regarding such changes and would request some help by someone more experienced to not fuck stuff up and break peoples installation without notification.

After 3.71.0-06 it seems as if updates are easy and such complicated migration paths are not necessary anymore.

You can find the nexus docs regarding updates here: https://help.sonatype.com/en/installation-and-upgrades.html

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
