### PR TITLE
workflows/eval: run when base branch changed

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -2,7 +2,6 @@ name: Check that files are formatted
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited]
 
 permissions: {}
 

--- a/.github/workflows/codeowners-v2.yml
+++ b/.github/workflows/codeowners-v2.yml
@@ -24,7 +24,7 @@ name: Codeowners v2
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, synchronize, reopened, edited]
+    types: [opened, ready_for_review, synchronize, reopened]
 
 permissions: {}
 

--- a/.github/workflows/edited.yml
+++ b/.github/workflows/edited.yml
@@ -1,0 +1,49 @@
+# Some workflows depend on the base branch of the PR, but changing the base branch is not included in the default trigger events, which would be `opened`, `synchronize` or `reopened`.
+# Instead it causes an `edited` event.
+# Since `edited` is also triggered when PR title/body is changed, we use this wrapper workflow, to run the other workflows conditionally only.
+# There are already feature requests for adding a `base_changed` event:
+# - https://github.com/orgs/community/discussions/35058
+# - https://github.com/orgs/community/discussions/64119
+#
+# Instead of adding this to each workflow's pull_request_target event, we trigger this in a separate workflow.
+# This has the advantage, that we can actually skip running those jobs for simple edits like changing the title or description.
+# The actual trigger happens by closing and re-opening the pull request, which triggers the default pull_request_target events.
+# This is much simpler and reliable than other approaches.
+
+name: "Edited base branch"
+
+on:
+  pull_request_target:
+    types: [edited]
+
+permissions: {}
+
+jobs:
+  base:
+    name: Trigger jobs
+    runs-on: ubuntu-24.04
+    if: github.event.changes.base.ref.from && github.event.changes.base.ref.from != github.event.pull_request.base.ref
+    steps:
+      # Use a GitHub App to create the PR so that CI gets triggered
+      # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs
+      # We only need Pull Requests: write here, but the app is also used for backports.
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        id: app-token
+        with:
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+          permission-pull-requests: write
+
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+        run: |
+          gh api \
+            --method PATCH \
+            /repos/"$REPOSITORY"/pulls/"$NUMBER" \
+            -f "state=closed"
+          gh api \
+            --method PATCH \
+            /repos/"$REPOSITORY"/pulls/"$NUMBER" \
+            -f "state=open"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,7 +7,6 @@ name: "Label PR"
 
 on:
   pull_request_target:
-    types: [edited, opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/nixpkgs-vet.yml
+++ b/.github/workflows/nixpkgs-vet.yml
@@ -7,11 +7,6 @@ name: Vet nixpkgs
 
 on:
   pull_request_target:
-    # This workflow depends on the base branch of the PR, but changing the base branch is not included in the default trigger events, which would be `opened`, `synchronize` or `reopened`.
-    # Instead it causes an `edited` event, so we need to add it explicitly here.
-    # While `edited` is also triggered when the PR title/body is changed, this PR action is fairly quick, and PRs don't get edited **that** often, so it shouldn't be a problem.
-    # There is a feature request for adding a `base_changed` event: https://github.com/orgs/community/discussions/35058
-    types: [opened, synchronize, reopened, edited]
 
 permissions: {}
 

--- a/.github/workflows/no-channel.yml
+++ b/.github/workflows/no-channel.yml
@@ -2,8 +2,6 @@ name: "No channel PR"
 
 on:
   pull_request_target:
-    # Re-run should be triggered when the base branch is updated, instead of silently failing
-    types: [opened, synchronize, reopened, edited]
 
 permissions: {}
 


### PR DESCRIPTION
This is based on #371216, so the biggest chunk of commits is from that PR and should be reviewed / commented on there.

Only the last two commits are relevant for this PR. Here, we first change the way we react to the "edited" event for pull_request_target. This avoids running jobs when only title or description of a PR change. This then allows us to run eval on base branch changes as well, without triggering those on small edits all the time.

Tested the concepts, but not the final PR in that constellation, yet.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
