### PR TITLE
flexget: 3.13.6 -> 3.13.25

### DIFF
--- a/pkgs/by-name/fl/flexget/package.nix
+++ b/pkgs/by-name/fl/flexget/package.nix
@@ -7,21 +7,22 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "flexget";
-  version = "3.13.6";
+  version = "3.13.10";
   pyproject = true;
 
-  # Fetch from GitHub in order to use `requirements.in`
   src = fetchFromGitHub {
     owner = "Flexget";
     repo = "Flexget";
     tag = "v${version}";
-    hash = "sha256-I6AQtoGk/YUDM5DzegvLi8QmVvoma16zJGZ8BMUUN3c=";
+    hash = "sha256-WiCWvANsVi0j0AWt5mcYTVBKW7BHBZP2ozfMeaAOKeE=";
   };
 
-  # relax dep constrains, keep environment constraints
   pythonRelaxDeps = true;
 
-  build-system = with python3Packages; [ setuptools ];
+  build-system = with python3Packages; [
+    hatchling
+    hatch-requirements-txt
+  ];
 
   dependencies = with python3Packages; [
     # See https://github.com/Flexget/Flexget/blob/master/pyproject.toml

--- a/pkgs/by-name/fl/flexget/package.nix
+++ b/pkgs/by-name/fl/flexget/package.nix
@@ -7,14 +7,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "flexget";
-  version = "3.13.10";
+  version = "3.13.25";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "Flexget";
     repo = "Flexget";
     tag = "v${version}";
-    hash = "sha256-WiCWvANsVi0j0AWt5mcYTVBKW7BHBZP2ozfMeaAOKeE=";
+    hash = "sha256-4VDMVJPzp6mCiO092iRn9e/3Jed3g29tLZa+TNYkYoI=";
   };
 
   pythonRelaxDeps = true;


### PR DESCRIPTION
Changelog: 
https://github.com/Flexget/Flexget/releases/tag/v3.13.25
https://github.com/Flexget/Flexget/releases/tag/v3.13.24
https://github.com/Flexget/Flexget/releases/tag/v3.13.23
https://github.com/Flexget/Flexget/releases/tag/v3.13.22
https://github.com/Flexget/Flexget/releases/tag/v3.13.21
https://github.com/Flexget/Flexget/releases/tag/v3.13.20
https://github.com/Flexget/Flexget/releases/tag/v3.13.19
https://github.com/Flexget/Flexget/releases/tag/v3.13.18
https://github.com/Flexget/Flexget/releases/tag/v3.13.17
https://github.com/Flexget/Flexget/releases/tag/v3.13.16
https://github.com/Flexget/Flexget/releases/tag/v3.13.15
https://github.com/Flexget/Flexget/releases/tag/v3.13.14
https://github.com/Flexget/Flexget/releases/tag/v3.13.13
https://github.com/Flexget/Flexget/releases/tag/v3.13.12
https://github.com/Flexget/Flexget/releases/tag/v3.13.11
https://github.com/Flexget/Flexget/releases/tag/v3.13.10
https://github.com/Flexget/Flexget/releases/tag/v3.13.9
https://github.com/Flexget/Flexget/releases/tag/v3.13.8
https://github.com/Flexget/Flexget/releases/tag/v3.13.7

Diff: https://github.com/Flexget/Flexget/compare/refs/tags/v3.13.6...v3.13.25


Currently the package violates the dep requirement `urllib3 <2`, so lets await merging until this check passes upstream

* https://github.com/Flexget/Flexget/pull/4115

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
