### PR TITLE
nixos/freshrss: organize tests

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -360,11 +360,7 @@ in {
   freenet = handleTest ./freenet.nix {};
   freeswitch = handleTest ./freeswitch.nix {};
   freetube = discoverTests (import ./freetube.nix);
-  freshrss-extensions = handleTest ./freshrss-extensions.nix {};
-  freshrss-sqlite = handleTest ./freshrss-sqlite.nix {};
-  freshrss-pgsql = handleTest ./freshrss-pgsql.nix {};
-  freshrss-http-auth = handleTest ./freshrss-http-auth.nix {};
-  freshrss-none-auth = handleTest ./freshrss-none-auth.nix {};
+  freshrss = handleTest ./freshrss {};
   frigate = handleTest ./frigate.nix {};
   frp = handleTest ./frp.nix {};
   frr = handleTest ./frr.nix {};

--- a/nixos/tests/freshrss/default.nix
+++ b/nixos/tests/freshrss/default.nix
@@ -1,0 +1,9 @@
+{ system, pkgs, ... }:
+
+{
+  extensions = import ./extensions.nix { inherit system pkgs; };
+  http-auth = import ./http-auth.nix { inherit system pkgs; };
+  none-auth = import ./none-auth.nix { inherit system pkgs; };
+  pgsql = import ./pgsql.nix { inherit system pkgs; };
+  sqlite = import ./sqlite.nix { inherit system pkgs; };
+}

--- a/nixos/tests/freshrss/extensions.nix
+++ b/nixos/tests/freshrss/extensions.nix
@@ -1,7 +1,7 @@
-import ./make-test-python.nix (
+import ../make-test-python.nix (
   { lib, pkgs, ... }:
   {
-    name = "freshrss";
+    name = "freshrss-extensions";
 
     nodes.machine =
       { pkgs, ... }:

--- a/nixos/tests/freshrss/http-auth.nix
+++ b/nixos/tests/freshrss/http-auth.nix
@@ -1,7 +1,7 @@
-import ./make-test-python.nix (
+import ../make-test-python.nix (
   { lib, pkgs, ... }:
   {
-    name = "freshrss";
+    name = "freshrss-http-auth";
     meta.maintainers = with lib.maintainers; [ mattchrist ];
 
     nodes.machine =

--- a/nixos/tests/freshrss/none-auth.nix
+++ b/nixos/tests/freshrss/none-auth.nix
@@ -1,7 +1,7 @@
-import ./make-test-python.nix (
+import ../make-test-python.nix (
   { lib, pkgs, ... }:
   {
-    name = "freshrss";
+    name = "freshrss-none-auth";
     meta.maintainers = with lib.maintainers; [ mattchrist ];
 
     nodes.machine =

--- a/nixos/tests/freshrss/pgsql.nix
+++ b/nixos/tests/freshrss/pgsql.nix
@@ -1,7 +1,7 @@
-import ./make-test-python.nix (
+import ../make-test-python.nix (
   { lib, pkgs, ... }:
   {
-    name = "freshrss";
+    name = "freshrss-pgsql";
     meta.maintainers = with lib.maintainers; [
       etu
       stunkymonkey

--- a/nixos/tests/freshrss/sqlite.nix
+++ b/nixos/tests/freshrss/sqlite.nix
@@ -1,7 +1,7 @@
-import ./make-test-python.nix (
+import ../make-test-python.nix (
   { lib, pkgs, ... }:
   {
-    name = "freshrss";
+    name = "freshrss-sqlite";
     meta.maintainers = with lib.maintainers; [
       etu
       stunkymonkey

--- a/pkgs/servers/web-apps/freshrss/default.nix
+++ b/pkgs/servers/web-apps/freshrss/default.nix
@@ -41,7 +41,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   passthru.tests = {
-    inherit (nixosTests) freshrss-sqlite freshrss-pgsql freshrss-http-auth freshrss-none-auth freshrss-extensions;
+    inherit (nixosTests) freshrss;
   };
 
   meta = with lib; {


### PR DESCRIPTION
this way we can not forget to run the tests in the package as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
