### PR TITLE
gcl: 2.6.14 -> 2.7.0pre34

### DIFF
--- a/pkgs/development/compilers/gcl/default.nix
+++ b/pkgs/development/compilers/gcl/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchgit,
   mpfr,
   m4,
   binutils,
@@ -26,11 +26,13 @@ assert stdenv.cc.libc != null;
 
 stdenv.mkDerivation rec {
   pname = "gcl";
-  version = "2.6.14";
+  version = "2.7.0pre34";
 
-  src = fetchurl {
-    url = "mirror://gnu/gcl/gcl-${version}.tar.gz";
-    hash = "sha256-CfNBfFEqoXM6Y4gJ06Y6wpDuuUSL6CeV9bZoG9MHNFo=";
+  src = fetchgit {
+    # url = "mirror://gnu/gcl/gcl-${version}.tar.gz";
+    url = "git://git.savannah.gnu.org/gcl.git/";
+    rev = "Version_" + (lib.replaceStrings [ "." ] [ "_" ] version);
+    hash = "sha256-9ftolkgr458yycV0BzCuUQkuDkFMcSdr2LdMgb5NXdc=";
   };
 
   buildInputs = [
@@ -50,6 +52,10 @@ stdenv.mkDerivation rec {
     which
     texinfo
   ];
+
+  strictDeps = true;
+
+  sourceRoot = "gcl/gcl";
 
   configureFlags = [
     "--enable-ansi"


### PR DESCRIPTION
Fixing the build

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
