### PR TITLE
vimPlugins: add missing dependencies

### DIFF
--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -745,6 +745,14 @@ in
     ];
   };
 
+  conjure = super.conjure.overrideAttrs {
+    dependencies = [ self.plenary-nvim ];
+    nvimSkipModule = [
+      # Test mismatch of directory because of nix generated path
+      "conjure-spec.client.fennel.nfnl_spec"
+    ];
+  };
+
   context-vim = super.context-vim.overrideAttrs {
     # Vim plugin with optional lua highlight module
     nvimSkipModule = "context.highlight";
@@ -1832,9 +1840,20 @@ in
       neotest
       nvim-nio
       plenary-nvim
+      nvim-treesitter-parsers.cpp
     ];
-    # broken
-    # nvimRequireCheck = "neotest-gtest";
+    nvimSkipModule = [
+      # lua/plenary/path.lua:511: FileNotFoundError from mkdir because of stdpath parent path missing
+      "neotest-gtest.executables.global_registry"
+      "neotest-gtest.executables.init"
+      "neotest-gtest.executables.registry"
+      "neotest-gtest.executables.ui"
+      "neotest-gtest"
+      "neotest-gtest.neotest_adapter"
+      "neotest-gtest.report"
+      "neotest-gtest.storage"
+      "neotest-gtest.utils"
+    ];
   };
 
   neotest-haskell = super.neotest-haskell.overrideAttrs {
@@ -1865,6 +1884,7 @@ in
   neotest-minitest = super.neotest-minitest.overrideAttrs {
     dependencies = with self; [
       neotest
+      nvim-nio
       plenary-nvim
     ];
   };
@@ -1918,6 +1938,7 @@ in
   neotest-rspec = super.neotest-rspec.overrideAttrs {
     dependencies = with self; [
       neotest
+      nvim-nio
       plenary-nvim
     ];
   };
@@ -2171,6 +2192,10 @@ in
     ];
   };
 
+  nvim-java-test = super.nvim-java-test.overrideAttrs {
+    dependencies = [ self.nvim-java-core ];
+  };
+
   nvim-lsp-file-operations = super.nvim-lsp-file-operations.overrideAttrs {
     dependencies = [ self.plenary-nvim ];
     nvimRequireCheck = "lsp-file-operations";
@@ -2353,6 +2378,29 @@ in
   nvim-trevJ-lua = super.nvim-trevJ-lua.overrideAttrs {
     dependencies = [ self.nvim-treesitter ];
     nvimRequireCheck = "trevj";
+  };
+
+  nvim-test = super.nvim-test.overrideAttrs {
+    dependencies = with self; [
+      nvim-treesitter
+      nvim-treesitter-parsers.c_sharp
+      nvim-treesitter-parsers.go
+      nvim-treesitter-parsers.haskell
+      nvim-treesitter-parsers.javascript
+      nvim-treesitter-parsers.python
+      nvim-treesitter-parsers.ruby
+      nvim-treesitter-parsers.rust
+      nvim-treesitter-parsers.typescript
+      nvim-treesitter-parsers.zig
+    ];
+    nvimSkipModule = [
+      # Optional toggleterm integration
+      "nvim-test.terms.toggleterm"
+      # Broken runners
+      "nvim-test.runners.zig"
+      "nvim-test.runners.hspec"
+      "nvim-test.runners.stack"
+    ];
   };
 
   nvim-ufo = super.nvim-ufo.overrideAttrs {
@@ -2575,6 +2623,8 @@ in
     nvimSkipModule = [
       # rainbow-delimiters.types.lua
       "rainbow-delimiters.types"
+      # Test that requires an unpackaged dependency
+      "rainbow-delimiters._test.highlight"
     ];
   };
 
@@ -3151,6 +3201,14 @@ in
       '';
       meta.maintainers = with lib.maintainers; [ enderger ];
     };
+
+  typescript-nvim = super.typescript-nvim.overrideAttrs {
+    dependencies = with self; [
+      nvim-lspconfig
+    ];
+    # Optional null-ls integration
+    nvimSkipModule = [ "typescript.extensions.null-ls.code-actions.init" ];
+  };
 
   typescript-tools-nvim = super.typescript-tools-nvim.overrideAttrs {
     dependencies = with self; [


### PR DESCRIPTION
Discovered during fixing neovimRequireCheckHook ignores.

Discovered in https://github.com/NixOS/nixpkgs/pull/372552


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
