### PR TITLE
traefik: 3.2.2 -> 3.3.1

### DIFF
--- a/pkgs/by-name/tr/traefik/package.nix
+++ b/pkgs/by-name/tr/traefik/package.nix
@@ -7,21 +7,23 @@
 
 buildGo123Module rec {
   pname = "traefik";
-  version = "3.2.2";
+  version = "3.3.1";
 
   # Archive with static assets for webui
   src = fetchzip {
     url = "https://github.com/traefik/traefik/releases/download/v${version}/traefik-v${version}.src.tar.gz";
-    hash = "sha256-DTgpoJvk/rxzMAIBgKJPT70WW8W/aBhOEoyw3cK+JrM=";
+    hash = "sha256-EvFphlxsNfmccgRw85B0xCFJRC1DKmIcD2467n8XOVI=";
     stripRoot = false;
   };
 
-  vendorHash = "sha256-+sL0GJhWMlFdNEsRdgRJ42aGedOfn76gg70wH6/a+qQ=";
+  vendorHash = "sha256-9WuhQjl+lWRZBvEP8qjBQUbEQC1SG9J+3xNpmIieOo8=";
 
   subPackages = [ "cmd/traefik" ];
 
+  env.CGO_ENABLED = 0;
+
   preBuild = ''
-    GOOS= GOARCH= CGO_ENABLED=0 go generate
+    GOOS= GOARCH= go generate
 
     CODENAME=$(grep -Po "CODENAME \?=\s\K.+$" Makefile)
 


### PR DESCRIPTION
https://github.com/traefik/traefik/releases/tag/v3.3.1
