### PR TITLE
telepresence: fix compilation error

### DIFF
--- a/pkgs/tools/networking/telepresence/default.nix
+++ b/pkgs/tools/networking/telepresence/default.nix
@@ -29,6 +29,10 @@ pythonPackages.buildPythonPackage rec {
     sha256 = "1ccc8bzcdxp6rh6llk7grcnmyc05fq7dz5w0mifdzjv3a473hsky";
   };
 
+  patches = [
+    ./fix-versioneer.patch
+  ];
+
   nativeBuildInputs = [ makeWrapper ];
 
   postInstall = ''

--- a/pkgs/tools/networking/telepresence/fix-versioneer.patch
+++ b/pkgs/tools/networking/telepresence/fix-versioneer.patch
@@ -1,0 +1,16 @@
+diff --git a/versioneer.py b/versioneer.py
+index 7e5bb402e..60d65ef76 100644
+--- a/versioneer.py
++++ b/versioneer.py
+@@ -339,9 +339,9 @@ def get_config_from_root(root):
+     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
+     # the top of versioneer.py for instructions on writing your setup.cfg .
+     setup_cfg = os.path.join(root, "setup.cfg")
+-    parser = configparser.SafeConfigParser()
++    parser = configparser.ConfigParser()
+     with open(setup_cfg, "r") as f:
+-        parser.readfp(f)
++        parser.read_file(f)
+     VCS = parser.get("versioneer", "VCS")  # mandatory
+
+     def get(parser, name):


### PR DESCRIPTION
`telepresence` compilation fails because of a couple of deprecated calls. This small patch updates these so that the package builds successful.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).