### PR TITLE
Revert "ddns-updater: disable updates"

### DIFF
--- a/pkgs/by-name/dd/ddns-updater/package.nix
+++ b/pkgs/by-name/dd/ddns-updater/package.nix
@@ -29,9 +29,6 @@ buildGoModule rec {
     tests = {
       inherit (nixosTests) ddns-updater;
     };
-    # nixpkgs-update: no auto update
-    # Necessary only as rryantm keeps getting confused and thinks 2.6.1 is newer than 2.7.0
-    # TODO remove once version newer than 2.7.0 is released
     updateScript = nix-update-script { };
   };
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#334215

Original pr was to disable updates for package as nixpkgs-update was trying to update it to an older version.

Newer versions have now been released, and so automatic updates can be re enabled.