### PR TITLE
postgresql: fix build if pythonSupport is enabled

### DIFF
--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -247,9 +247,11 @@ let
       # flags will remove unused sections from all shared libraries and binaries - including
       # those paths. This avoids a lot of circular dependency problems with different outputs,
       # and allows splitting them cleanly.
-      env.CFLAGS =
-        "-fdata-sections -ffunction-sections"
-        + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
+      env = {
+        CFLAGS =
+          "-fdata-sections -ffunction-sections"
+          + (if stdenv'.cc.isClang then " -flto" else " -fmerge-constants -Wl,--gc-sections");
+      } // lib.optionalAttrs pythonSupport { PYTHON = "${python3}/bin/python"; };
 
       configureFlags =
         let

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -380,10 +380,14 @@ let
             --replace-fail '-bundle_loader $(bindir)/postgres' "-bundle_loader $out/bin/postgres"
         '';
 
-      postFixup = lib.optionalString stdenv'.hostPlatform.isGnu ''
-        # initdb needs access to "locale" command from glibc.
-        wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
-      '';
+      postFixup =
+        lib.optionalString stdenv'.hostPlatform.isGnu ''
+          # initdb needs access to "locale" command from glibc.
+          wrapProgram $out/bin/initdb --prefix PATH ":" ${glibc.bin}/bin
+        ''
+        + lib.optionalString pythonSupport ''
+          wrapProgram "$out/bin/postgres" --set PYTHONPATH "${python3}/${python3.sitePackages}"
+        '';
 
       # Running tests as "install check" to work around SIP issue on macOS:
       # https://www.postgresql.org/message-id/flat/4D8E1BC5-BBCF-4B19-8226-359201EA8305%40gmail.com


### PR DESCRIPTION
Hi everyone,

this is a fix for https://github.com/NixOS/nixpkgs/issues/372333

It includes two commits:

### postgresql: fix build if pythonSupport is enabled

Since https://github.com/NixOS/nixpkgs/commit/445371f309a62e9107ad78fb3c65fff768efb43c (which added `strictDeps = true;`) the build of PostgreSQL is broken if python support is enabled (via argument `pythonSupport = true`). The problem seems to be that PostgreSQL’s build system is unable to find the supplied Python installation.

This commit fixes the build by setting the `PYTHON` environment variable within the build environment, as document here:

https://www.postgresql.org/docs/current/install-make.html#CONFIGURE-ENVVARS-PYTHON

### postgresql: add PYTHONPATH via wrapProgram

Currently `PYTHONPATH` is not set when building PostgreSQL. This results in Python modules not being available within `pl/python3u`.

This commit adds `PYTHONPATH` of the supplied `python3` via `wrapProgram`, which is especially useful when supplying a custom Python env.

Here is a minimal flake to test everything:

```
{
  # offending commit, which does not build
  # inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=445371f309a62e9107ad78fb3c65fff768efb43c";

  # this pull request
  inputs.nixpkgs.url = "github:nixos/nixpkgs?ref=pull/372655/head";

  outputs =
    { self, nixpkgs }:
    let
      pkgs = nixpkgs.legacyPackages.x86_64-linux;
    in
    {
      packages.x86_64-linux.default = pkgs.postgresql_16.override {
        pythonSupport = true;

        // optionally supply a custom python env:
        python3 = pkgs.python3.withPackages (ps: with ps; [ base58 ]);
      };
    };
}
```

### Note

I have tested the compilation on both NixOS (`x86_64-linux`) and `aarch64-darwin` and noticed that several extensions (pg_cron, pgvector, postgis) don’t build on Darwin due linking errors. Others (pgjwt, pgtap) do, so presumably this is unrelated to this commit. Further I only tested the functionality on NixOS. I only have a Darwin machine for testing since a few days, will try to look into it, but everything is still very complicated on MacOS for me… so any help is appreciated.

@wolfgangwalther (author of offending commit)
@thoughtpolice
@Ma27
@eclairevoyant

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
