### PR TITLE
libsixel: make linking against gd a choosable option.

### DIFF
--- a/pkgs/by-name/li/libsixel/package.nix
+++ b/pkgs/by-name/li/libsixel/package.nix
@@ -7,19 +7,33 @@
   gdk-pixbuf,
   gd,
   pkg-config,
+
+  # Enable linking against image loading libraries as part of the
+  # implementation of the sixel_helper_{load,write}_image_file() functions.
+  # These helper functions are not needed for the main functionality of the
+  # library to encode image buffers to sixels.
+  #
+  # libsixel already uses vendored stb image loading to provide basic
+  # implementations, but also allows for the "gd" library to be linked for
+  # a wider set of image formats.
+  # This pulls in a large amount of deps bloating the resulting library.
+  #
+  # Default off, but configurable in case you really need it.
+  withGd ? false,
 }:
-stdenv.mkDerivation rec {
+
+stdenv.mkDerivation (finalAttrs: {
   pname = "libsixel";
   version = "1.10.5";
 
   src = fetchFromGitHub {
     owner = "libsixel";
     repo = "libsixel";
-    rev = "v${version}";
+    rev = "v${finalAttrs.version}";
     hash = "sha256-obzBZAknN3N7+Bvtd0+JHuXcemVb7wRv+Pt4VjS6Bck=";
   };
 
-  buildInputs = [
+  buildInputs = lib.optionals withGd [
     gdk-pixbuf
     gd
   ];
@@ -34,8 +48,14 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dtests=enabled"
-    # build system seems to be broken here, it still seems to handle jpeg
-    # through some other ways.
+    "-Dimg2sixel=enabled"
+    "-Dsixel2png=enabled"
+
+    (lib.mesonEnable "gd" withGd)
+
+    # build system seems to be broken here; error message indicates pkconfig
+    # issue.
+    # Not to worry: jpeg and png are handled by the built-in stb and/or gd lib.
     "-Djpeg=disabled"
     "-Dpng=disabled"
   ];
@@ -47,4 +67,4 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     platforms = platforms.unix;
   };
-}
+})


### PR DESCRIPTION
Libgd was linked with libsixel, but it is not needed for the main functionality. Make this an option, default off.
(explanation at the option). This reduces unnecessary bloat on the linked libraries.

Before:
```
$ ldd result/lib/libsixel.so
        linux-vdso.so.1 (0x00007ffea4b60000)
        libm.so.6 => /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libm.so.6 (0x00007fb8d60e4000)
        libgd.so.3 => /nix/store/lrkwzgmd9h56z3lwm9kgvgiwixzil0h4-gd-2.3.3/lib/libgd.so.3 (0x00007fb8d6074000)
        libc.so.6 => /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6 (0x00007fb8d5e00000)
        /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib64/ld-linux-x86-64.so.2 (0x00007fb8d6240000)
        libz.so.1 => /nix/store/cqlaa2xf6lslnizyj9xqa8j0ii1yqw0x-zlib-1.3.1/lib/libz.so.1 (0x00007fb8d6053000)
        libpng16.so.16 => /nix/store/ayk2mh02j7wrvgx17155xcwvpmgrzzka-libpng-apng-1.6.43/lib/libpng16.so.16 (0x00007fb8d6017000)
        libfontconfig.so.1 => /nix/store/rbv8d3qlvfij22qiarxbfy4z8b4j9dr6-fontconfig-2.15.0-lib/lib/libfontconfig.so.1 (0x00007fb8d5db1000)
        libfreetype.so.6 => /nix/store/6h3h8437bqlcc54awn05jpswgps35j5r-freetype-2.13.3/lib/libfreetype.so.6 (0x00007fb8d5cdc000)
        libjpeg.so.62 => /nix/store/jiiih03zpspc2lgcihz79yq0gd28zqqv-libjpeg-turbo-3.0.4/lib/libjpeg.so.62 (0x00007fb8d5c08000)
        libXpm.so.4 => /nix/store/asdigqj9794rvlgrmsqj6gpp7p95d3ip-libXpm-3.5.17/lib/libXpm.so.4 (0x00007fb8d5bf2000)
        libX11.so.6 => /nix/store/nlqind4szw3amcmhgy4pd2n0894558gg-libX11-1.8.10/lib/libX11.so.6 (0x00007fb8d5aa2000)
        libtiff.so.6 => /nix/store/bq3k3dc1zmb4apnsz8l8z4lwlb8kh2lf-libtiff-4.7.0/lib/libtiff.so.6 (0x00007fb8d5a08000)
        libwebp.so.7 => /nix/store/75v06fahb45kf0rcq37957n93jxka2cf-libwebp-1.4.0/lib/libwebp.so.7 (0x00007fb8d5958000)
        libavif.so.16 => /nix/store/78jlv74754csh7kvjg2nli4jqwafj9yr-libavif-1.1.1/lib/libavif.so.16 (0x00007fb8d5923000)
        libpthread.so.0 => /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libpthread.so.0 (0x00007fb8d600e000)
        libbz2.so.1 => /nix/store/ivl2v8rgg7qh1jkj5pwpqycax3rc2hnl-bzip2-1.0.8/lib/libbz2.so.1 (0x00007fb8d590f000)
        libbrotlidec.so.1 => /nix/store/8zvalh0pmrmzypynv2gh8mw1vkkys19i-brotli-1.1.0-lib/lib/libbrotlidec.so.1 (0x00007fb8d5900000)
        libexpat.so.1 => /nix/store/5ayb629gzbkc3amm6zd5jp1aciprb2zs-expat-2.6.4/lib/libexpat.so.1 (0x00007fb8d58d3000)
        libxcb.so.1 => /nix/store/2j3c18398phz5c1376x2qvva8gx9g551-libxcb-1.17.0/lib/libxcb.so.1 (0x00007fb8d58a6000)
        libzstd.so.1 => /nix/store/s0zynhz13rhg0gg8cy0ga4c0lnv3yqdn-zstd-1.5.6/lib/libzstd.so.1 (0x00007fb8d57d2000)
        liblzma.so.5 => /nix/store/c2njy6bv84kw1i4bjf5k5gn7gz8hn57n-xz-5.6.3/lib/liblzma.so.5 (0x00007fb8d57a1000)
        libLerc.so.4 => /nix/store/1hpi9rlpw4n3790bs75d4dkb8kb2iv72-lerc-4.0.0/lib/libLerc.so.4 (0x00007fb8d56d3000)
        libdeflate.so.0 => /nix/store/03vb8v0mmr98b2rh11klsyd5xhmk0wd2-libdeflate-1.22/lib/libdeflate.so.0 (0x00007fb8d56bb000)
        libsharpyuv.so.0 => /nix/store/75v06fahb45kf0rcq37957n93jxka2cf-libwebp-1.4.0/lib/libsharpyuv.so.0 (0x00007fb8d56b1000)
        libyuv.so => /nix/store/04ddm1wyyh5qcsxw65r0snack4ghi02z-libyuv-1787/lib/libyuv.so (0x00007fb8d55b9000)
        libdav1d.so.7 => /nix/store/2zq6mih79zkr2qssby2pxqh47g69az0s-dav1d-1.5.0/lib/libdav1d.so.7 (0x00007fb8d53d6000)
        libdl.so.2 => /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libdl.so.2 (0x00007fb8d53d1000)
        libaom.so.3 => /nix/store/cgw63wf51z3vlzaddcdkvqiflns1kbz8-libaom-3.11.0/lib/libaom.so.3 (0x00007fb8d4a00000)
        libstdc++.so.6 => /nix/store/bpq1s72cw9qb2fs8mnmlw6hn2c7iy0ss-gcc-14-20241116-lib/lib/libstdc++.so.6 (0x00007fb8d4600000)
        libgcc_s.so.1 => /nix/store/bpq1s72cw9qb2fs8mnmlw6hn2c7iy0ss-gcc-14-20241116-lib/lib/libgcc_s.so.1 (0x00007fb8d53a3000)
        libbrotlicommon.so.1 => /nix/store/8zvalh0pmrmzypynv2gh8mw1vkkys19i-brotli-1.1.0-lib/lib/libbrotlicommon.so.1 (0x00007fb8d5380000)
        libXau.so.6 => /nix/store/hjbxiwsc587b8dc6v6pisa34aj10hq23-libXau-1.0.11/lib/libXau.so.6 (0x00007fb8d537b000)
        libXdmcp.so.6 => /nix/store/c9gk656q2x8av467r06hcjag31drjfzh-libXdmcp-1.1.5/lib/libXdmcp.so.6 (0x00007fb8d5373000)
        libvmaf.so.3 => /nix/store/wvrxszldz4jcmpcxkl5rzvb3709kr0gk-libvmaf-3.0.0/lib/libvmaf.so.3 (0x00007fb8d5266000)
```

After:
```
$ ldd result/lib/libsixel.so
        linux-vdso.so.1 (0x00007ffc02d9e000)
        libm.so.6 => /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libm.so.6 (0x00007f4635b43000)
        libc.so.6 => /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6 (0x00007f4635800000)
        /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib64/ld-linux-x86-64.so.2 (0x00007f4635c9f000)
```

While at it, implement the finalAttrs pattern.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux  (tested with and without option enabled)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
