### PR TITLE
Don't use hostPackages.{autoconf,automake} as build tools

### DIFF
--- a/pkgs/applications/audio/ladspa-plugins/default.nix
+++ b/pkgs/applications/audio/ladspa-plugins/default.nix
@@ -3,7 +3,6 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
-  automake,
   fftw,
   ladspaH,
   libxml2,
@@ -25,19 +24,20 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    perlPackages.perl
+    perlPackages.XMLParser
   ];
   buildInputs = [
     fftw
     ladspaH
     libxml2
-    perlPackages.perl
-    perlPackages.XMLParser
   ];
 
-  patchPhase = ''
+  postPatch = ''
     patchShebangs .
-    patchShebangs ./metadata/
-    cp ${automake}/share/automake-*/mkinstalldirs .
+    substituteInPlace util/Makefile.am --replace-fail "ranlib" "$RANLIB"
+    substituteInPlace gsm/Makefile.am --replace-fail "ranlib" "$RANLIB"
+    substituteInPlace gverb/Makefile.am --replace-fail "ranlib" "$RANLIB"
   '';
 
   meta = with lib; {

--- a/pkgs/by-name/if/iftop/package.nix
+++ b/pkgs/by-name/if/iftop/package.nix
@@ -4,7 +4,6 @@
   fetchurl,
   ncurses,
   libpcap,
-  automake,
   nixosTests,
 }:
 
@@ -20,10 +19,6 @@ stdenv.mkDerivation rec {
   # Explicitly link against libgcc_s, to work around the infamous
   # "libgcc_s.so.1 must be installed for pthread_cancel to work".
   LDFLAGS = lib.optionalString stdenv.hostPlatform.isLinux "-lgcc_s";
-
-  preConfigure = ''
-    cp ${automake}/share/automake*/config.{sub,guess} config
-  '';
 
   buildInputs = [
     ncurses

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -468,7 +468,7 @@ self: super:
   transset = addMainProgram super.transset { };
 
   utilmacros = super.utilmacros.overrideAttrs (attrs: { # not needed for releases, we propagate the needed tools
-    propagatedBuildInputs = attrs.propagatedBuildInputs or [] ++ [ automake autoconf libtool ];
+    propagatedNativeBuildInputs = attrs.propagatedNativeBuildInputs or [] ++ [ automake autoconf libtool ];
   });
 
   viewres = addMainProgram super.viewres { };
@@ -725,7 +725,7 @@ self: super:
     '';
   in
     xorg.xkeyboardconfig.overrideAttrs (old: {
-      buildInputs = old.buildInputs ++ [ automake ];
+      nativeBuildInputs = old.nativeBuildInputs ++ [ automake ];
       postPatch   = lib.concatStrings (lib.mapAttrsToList patchIn layouts);
     });
 


### PR DESCRIPTION
Clean up automake/autoconf usage which cause build autotools for target during cross compiling, which cause
unnessesary build of `automake-aarch64-linux` during cross-compilation

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
