### PR TITLE
xsw: fix GCC 14 build

### DIFF
--- a/pkgs/applications/misc/xsw/default.nix
+++ b/pkgs/applications/misc/xsw/default.nix
@@ -39,15 +39,18 @@ stdenv.mkDerivation rec {
     SDL_gfx
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString (makeSDLFlags [
-    SDL
-    SDL_image
-    SDL_ttf
-    SDL_gfx
-  ]);
+  env.NIX_CFLAGS_COMPILE =
+    toString (makeSDLFlags [
+      SDL
+      SDL_image
+      SDL_ttf
+      SDL_gfx
+    ])
+    + " -lSDL";
 
   patches = [
     ./parse.patch # Fixes compilation error by avoiding redundant definitions.
+    ./sdl-error.patch # Adds required include for SDL_GetError.
   ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/xsw/sdl-error.patch
+++ b/pkgs/applications/misc/xsw/sdl-error.patch
@@ -1,0 +1,11 @@
+diff --git a/src/presenter.c b/src/presenter.c
+index a082541..74bfbec 100644
+--- a/src/presenter.c
++++ b/src/presenter.c
+@@ -5,5 +5,6 @@
+ #include <stdlib.h>
+ #include "SDL_ttf.h"
++#include <SDL/SDL_error.h>
+ #include "presenter.h"
+ #include "execute.h"
+ #include "list.h"


### PR DESCRIPTION
ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).