### PR TITLE
tldr: 1.6.1 -> 3.3.0; switch to tldr-python-client

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -186,6 +186,8 @@
 
 - `sm64ex-coop` has been removed as it was archived upstream. Consider migrating to `sm64coopdx`.
 
+- `tldr` now uses [`tldr-python-client`](https://github.com/tldr-pages/tldr-python-client) instead of [`tldr-c-client`](https://github.com/tldr-pages/tldr-c-client) which is unmaintained.
+
 - `renovate` was updated to v39. See the [upstream release notes](https://docs.renovatebot.com/release-notes-for-major-versions/#version-39) for breaking changes.
   Like upstream's docker images, renovate now runs on NodeJS 22.
 

--- a/pkgs/by-name/tl/tldr/package.nix
+++ b/pkgs/by-name/tl/tldr/package.nix
@@ -1,60 +1,68 @@
 {
-  lib,
   stdenv,
+  lib,
   fetchFromGitHub,
-  curl,
-  libzip,
-  pkg-config,
   installShellFiles,
+  python3Packages,
 }:
 
-stdenv.mkDerivation rec {
+python3Packages.buildPythonApplication rec {
   pname = "tldr";
-  version = "1.6.1";
+  version = "3.3.0";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "tldr-pages";
-    repo = "tldr-c-client";
-    rev = "v${version}";
-    sha256 = "sha256-1L9frURnzfq0XvPBs8D+hBikybAw8qkb0DyZZtkZleY=";
+    repo = "tldr-python-client";
+    tag = version;
+    hash = "sha256-lc0Jen8vW4BNg784td1AZa2GTYvXC1d83FnAe5RZqpY=";
   };
 
-  buildInputs = [
-    curl
-    libzip
-  ];
-  nativeBuildInputs = [
-    pkg-config
-    installShellFiles
+  build-system = with python3Packages; [
+    setuptools
+    wheel
   ];
 
-  makeFlags = [
-    "CC=${stdenv.cc.targetPrefix}cc"
-    "LD=${stdenv.cc.targetPrefix}cc"
-    "CFLAGS="
+  dependencies = with python3Packages; [
+    termcolor
+    colorama
+    shtab
   ];
 
-  installFlags = [ "PREFIX=$(out)" ];
+  nativeBuildInputs = [ installShellFiles ];
 
-  postInstall = ''
-    installShellCompletion --cmd tldr autocomplete/complete.{bash,fish,zsh}
+  nativeCheckInputs = with python3Packages; [
+    pytest
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    pytest -k 'not test_error_message'
+    runHook postCheck
   '';
 
-  meta = with lib; {
+  doCheck = true;
+
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    installShellCompletion --cmd tldr \
+      --bash <($out/bin/tldr --print-completion bash) \
+      --zsh <($out/bin/tldr --print-completion zsh)
+  '';
+
+  meta = {
     description = "Simplified and community-driven man pages";
     longDescription = ''
       tldr pages gives common use cases for commands, so you don't need to hunt
       through a man page for the correct flags.
     '';
     homepage = "https://tldr.sh";
-    changelog = "https://github.com/tldr-pages/tldr-c-client/blob/v${version}/CHANGELOG.md";
-    license = licenses.mit;
-    maintainers = with maintainers; [
+    changelog = "https://github.com/tldr-pages/tldr-python-client/blob/${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [
       taeer
       carlosdagos
       kbdharun
     ];
-    platforms = platforms.all;
     mainProgram = "tldr";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

**Note**: This replaces [tldr-c-client](https://github.com/tldr-pages/tldr-c-client) for [tldr-python-client](https://github.com/tldr-pages/tldr-python-client). The c client is unmaintained; it is recommended to use other implementations of `tldr`. The last update of `tldr-c-client` was on Dec 13, 2023. The python client is mostly compatible with the c client (there is a client specification these implementations follow).

Some repology links:

  - https://repology.org/project/tldr-python-client/versions
  - https://repology.org/project/tldr-c-client/versions
  - https://repology.org/project/tldr-unclassified/versions

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
