### PR TITLE
gpt4all: 3.4.2 -> 3.9.0

### DIFF
--- a/pkgs/by-name/du/duckx/package.nix
+++ b/pkgs/by-name/du/duckx/package.nix
@@ -1,0 +1,41 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  gitUpdater,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "duckx";
+  version = "1.2.2";
+
+  src = fetchFromGitHub {
+    owner = "amiremohamadi";
+    repo = "DuckX";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qRqYcBi/a2tUSlLAa7DKPqwQsctw5/0hjV/Og1pHPQU=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  cmakeFlags = [
+    # https://github.com/amiremohamadi/DuckX/issues/92
+    (lib.cmakeFeature "CMAKE_CXX_STANDARD" "14")
+  ];
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "C++ library for creating and modifying Microsoft Word (.docx) files";
+    homepage = "https://github.com/amiremohamadi/DuckX";
+    changelog = "https://github.com/amiremohamadi/DuckX/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ titaniumtown ];
+  };
+})

--- a/pkgs/by-name/op/optional-lite/package.nix
+++ b/pkgs/by-name/op/optional-lite/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "optional-lite";
+  version = "3.6.0";
+
+  src = fetchFromGitHub {
+    owner = "martinmoene";
+    repo = "optional-lite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-qmKuxYc0cpoOtRRb4okJZ8pYPvzQid1iqBctnhGlz6M=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  doCheck = true;
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "A C++17-like optional, a nullable object for C++98, C++11 and later in a single-file header-only library";
+    homepage = "https://github.com/martinmoene/optional-lite";
+    changelog = "https://github.com/martinmoene/optional-lite/blob/v${finalAttrs.version}/CHANGES.txt";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [ titaniumtown ];
+  };
+})

--- a/pkgs/by-name/st/string-view-lite/package.nix
+++ b/pkgs/by-name/st/string-view-lite/package.nix
@@ -1,0 +1,38 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "string-view-lite";
+  version = "1.8.0";
+
+  src = fetchFromGitHub {
+    owner = "martinmoene";
+    repo = "string-view-lite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-hXm3MLskeZzTegSj79dQV+VcwBatT1VIAUydjisd19U=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  doCheck = true;
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "A C++17-like string_view for C++98, C++11 and later in a single-file header-only library";
+    homepage = "https://github.com/martinmoene/string-view-lite";
+    changelog = "https://github.com/martinmoene/string-view-lite/blob/v${finalAttrs.version}/CHANGES.txt";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [ titaniumtown ];
+  };
+})

--- a/pkgs/by-name/va/variant-lite/package.nix
+++ b/pkgs/by-name/va/variant-lite/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  gitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "variant-lite";
+  version = "2.0.0";
+
+  src = fetchFromGitHub {
+    owner = "martinmoene";
+    repo = "variant-lite";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-zLyzNzeD0C4e7CYqCCsPzkqa2cH5pSbL9vNVIxdkEfc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  cmakeFlags = [
+    # https://github.com/martinmoene/variant-lite/issues/50
+    (lib.cmakeBool "VARIANT_LITE_OPT_BUILD_TESTS" false)
+  ];
+
+  doCheck = true;
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
+
+  meta = {
+    description = "A C++17-like variant, a type-safe union for C++98, C++11 and later in a single-file header-only library";
+    homepage = "https://github.com/martinmoene/variant-lite";
+    changelog = "https://github.com/martinmoene/variant-lite/blob/v${finalAttrs.version}/CHANGES.txt";
+    license = lib.licenses.boost;
+    maintainers = with lib.maintainers; [ titaniumtown ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Had to init these packages as they are new dependencies to gpt4all:
[variant-lite](https://github.com/martinmoene/variant-lite)
[optional-lite](https://github.com/martinmoene/optional-lite)
[string-view-lite](https://github.com/martinmoene/string-view-lite)
[duckx](https://github.com/amiremohamadi/DuckX)

Updated gpt4all to [3.9.0](https://github.com/nomic-ai/gpt4all/releases/tag/v3.9.0)
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
