### PR TITLE
clapboard: add new maintainer

### DIFF
--- a/pkgs/by-name/cl/clapboard/package.nix
+++ b/pkgs/by-name/cl/clapboard/package.nix
@@ -21,7 +21,10 @@ rustPlatform.buildRustPackage rec {
     description = "Wayland clipboard manager that will make you clap";
     homepage = "https://github.com/bjesus/clapboard";
     license = licenses.mit;
-    maintainers = with maintainers; [ dit7ya ];
+    maintainers = with maintainers; [
+      dit7ya
+      bjesus
+    ];
     platforms = platforms.linux;
     mainProgram = "clapboard";
   };


### PR DESCRIPTION
I have added myself as a maintainer for `clapboard`, as I am the author of the software and I'd like to help make sure that the nixpkg is up-to-date.