### PR TITLE
indicator-application-gtk{2,3}: fix cross build

### DIFF
--- a/pkgs/development/libraries/indicator-application/gtk2.nix
+++ b/pkgs/development/libraries/indicator-application/gtk2.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoconf
+    dbus-glib # dbus-binding-tool
   ];
 
   buildInputs = [

--- a/pkgs/development/libraries/indicator-application/gtk3.nix
+++ b/pkgs/development/libraries/indicator-application/gtk3.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    dbus-glib # dbus-binding-tool
   ];
 
   buildInputs = [


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).