### PR TITLE
dbus-cpp: pin Boost 1.86

### DIFF
--- a/pkgs/by-name/db/dbus-cpp/package.nix
+++ b/pkgs/by-name/db/dbus-cpp/package.nix
@@ -5,7 +5,7 @@
   fetchpatch,
   gitUpdater,
   testers,
-  boost,
+  boost186,
   cmake,
   dbus,
   doxygen,
@@ -81,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost
+    boost186 # uses boost/asio/io_service.hpp
     lomiri.cmake-extras
     dbus
     libxml2


### PR DESCRIPTION
#369118 will hit eventually, pin now to prevent breakage.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).