### PR TITLE
pantheon.elementary-default-settings: fix cross build

### DIFF
--- a/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-default-settings/default.nix
@@ -34,12 +34,15 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
-    accountsservice
-    dbus
-    glib # polkit requires
+    glib # glib-compile-schemas
     meson
     ninja
     pkg-config
+  ];
+
+  buildInputs = [
+    accountsservice
+    dbus
     polkit
   ];
 


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).