### PR TITLE
mate.marco: fix cross build

### DIFF
--- a/pkgs/desktops/mate/marco/default.nix
+++ b/pkgs/desktops/mate/marco/default.nix
@@ -34,11 +34,11 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     itstool
+    libxml2 # xmllint
     wrapGAppsHook3
   ];
 
   buildInputs = [
-    libxml2
     libcanberra-gtk3
     libgtop
     libXdamage
@@ -53,10 +53,11 @@ stdenv.mkDerivation rec {
 
   postPatch = ''
     substituteInPlace src/core/util.c \
-      --replace-fail 'argvl[i++] = "zenity"' 'argvl[i++] = "${zenity}/bin/zenity"'
+      --replace-fail 'argvl[i++] = "zenity"' 'argvl[i++] = "${lib.getExe zenity}"'
   '';
 
   env.NIX_CFLAGS_COMPILE = "-I${glib.dev}/include/gio-unix-2.0";
+  env.ZENITY = lib.getExe zenity;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).