### PR TITLE
git: 2.47.2 -> 2.48.1

### DIFF
--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -138,8 +138,13 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
 
-  postBuild = ''
-    make -C contrib/subtree
+  postBuild = (lib.optionalString withManual ''
+    # Need to build the main Git documentation before building the
+    # contrib/subtree documentation, as the latter depends on the
+    # asciidoc.conf file created by the former.
+    make -C Documentation
+  '') + ''
+    make -C contrib/subtree all ${lib.optionalString withManual "doc"}
   '' + (lib.optionalString perlSupport ''
     make -C contrib/diff-highlight
   '') + (lib.optionalString osxkeychainSupport ''

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -138,20 +138,20 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
 
-  postBuild = (lib.optionalString withManual ''
+  postBuild = lib.optionalString withManual ''
     # Need to build the main Git documentation before building the
     # contrib/subtree documentation, as the latter depends on the
     # asciidoc.conf file created by the former.
     make -C Documentation
-  '') + ''
+  '' + ''
     make -C contrib/subtree all ${lib.optionalString withManual "doc"}
-  '' + (lib.optionalString perlSupport ''
+  '' + lib.optionalString perlSupport ''
     make -C contrib/diff-highlight
-  '') + (lib.optionalString osxkeychainSupport ''
+  '' + lib.optionalString osxkeychainSupport ''
     make -C contrib/credential/osxkeychain
-  '') + (lib.optionalString withLibsecret ''
+  '' + lib.optionalString withLibsecret ''
     make -C contrib/credential/libsecret
-  '');
+  '';
 
 
   ## Install
@@ -161,15 +161,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   installFlags = [ "NO_INSTALL_HARDLINKS=1" ];
 
-  preInstall = (lib.optionalString osxkeychainSupport ''
+  preInstall = lib.optionalString osxkeychainSupport ''
     mkdir -p $out/bin
     ln -s $out/share/git/contrib/credential/osxkeychain/git-credential-osxkeychain $out/bin/
     rm -f $PWD/contrib/credential/osxkeychain/git-credential-osxkeychain.o
-  '') + (lib.optionalString withLibsecret ''
+  '' + lib.optionalString withLibsecret ''
     mkdir -p $out/bin
     ln -s $out/share/git/contrib/credential/libsecret/git-credential-libsecret $out/bin/
     rm -f $PWD/contrib/credential/libsecret/git-credential-libsecret.o
-  '');
+  '';
 
   postInstall =
     ''

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -30,7 +30,7 @@ assert sendEmailSupport -> perlSupport;
 assert svnSupport -> perlSupport;
 
 let
-  version = "2.47.2";
+  version = "2.48.1";
   svn = subversionClient.override { perlBindings = perlSupport; };
   gitwebPerlLibs = with perlPackages; [ CGI HTMLParser CGIFast FCGI FCGIProcManager HTMLTagCloud ];
 in
@@ -43,7 +43,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   src = fetchurl {
     url = "https://www.kernel.org/pub/software/scm/git/git-${version}.tar.xz";
-    hash = "sha256-sZJovmtvFVa0ep3YNCcuFn06dXQM3NKDzzgS7f/jkw8=";
+    hash = "sha256-HF1UX13B61HpXSxQ2Y/fiLGja6H6MOmuXVOFxgJPgq0=";
   };
 
   outputs = [ "out" ] ++ lib.optional withManual "doc";

--- a/pkgs/build-support/fetchgit/tests.nix
+++ b/pkgs/build-support/fetchgit/tests.nix
@@ -33,7 +33,7 @@
     name = "leave-git-nix-source";
     url = "https://github.com/NixOS/nix";
     rev = "9d9dbe6ed05854e03811c361a3380e09183f4f4a";
-    sha256 = "sha256-zZxDxqaeWvuWuzwPizBLR7d59zP24+zqnWllNICenko=";
+    sha256 = "sha256-3YYVIeaeu6zO7bBkZxF+1d5VS0K2GHYEZwChB3tPJ4s=";
     leaveDotGit = true;
   };
 
@@ -49,7 +49,7 @@
     name = "submodule-leave-git-source";
     url = "https://github.com/pineapplehunter/nix-test-repo-with-submodule";
     rev = "26473335b84ead88ee0a3b649b1c7fa4a91cfd4a";
-    sha256 = "sha256-+uXIClcRJ4S1rdgx2Oyww+Jv4h1VXp8tfeh9lb07Fhk=";
+    sha256 = "sha256-0pwleO/m4Iws3BF9ewyWbYMcGfEJLS3BYzWfDSYtXs8=";
     leaveDotGit = true;
     fetchSubmodules = true;
   };
@@ -58,7 +58,7 @@
     name = "submodule-deep-source";
     url = "https://github.com/pineapplehunter/nix-test-repo-with-submodule";
     rev = "26473335b84ead88ee0a3b649b1c7fa4a91cfd4a";
-    sha256 = "sha256-LL7uhXQk3N3DcvBBxwjmfVx55tTXCGQ19T91tknopzw=";
+    sha256 = "sha256-eRHOwolRZDJS/5zk88e7SdoO7nKKtjDXMLVsyFPFgk8=";
     deepClone = true;
     fetchSubmodules = true;
   };
@@ -67,7 +67,7 @@
     name = "submodule-leave-git-deep-source";
     url = "https://github.com/pineapplehunter/nix-test-repo-with-submodule";
     rev = "26473335b84ead88ee0a3b649b1c7fa4a91cfd4a";
-    sha256 = "sha256-LL7uhXQk3N3DcvBBxwjmfVx55tTXCGQ19T91tknopzw=";
+    sha256 = "sha256-eRHOwolRZDJS/5zk88e7SdoO7nKKtjDXMLVsyFPFgk8=";
     deepClone = true;
     leaveDotGit = true;
     fetchSubmodules = true;


### PR DESCRIPTION
Changelogs: 

-   https://github.com/gitster/git/blob/v2.48.1/Documentation/RelNotes/2.48.0.txt
-   https://github.com/gitster/git/blob/v2.48.1/Documentation/RelNotes/2.48.1.txt

This also includes one commit from #370888, which is necessary for the build to complete.

No substantial changes that affect backwards compatibility AFAICS, so I don't think there's a need for a release note.

Haven't tested all executables in `bin/`, but I did check `git --version` as a quick test on top of the test suite and that's fine. Builds of `nixosTests.gitdaemon`, `git.passthru.tests` and `tests.fetchgit`, as safety checks, are on my system now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
