### PR TITLE
apple-sdk: use llvm-readtapi instead of tapi

### DIFF
--- a/pkgs/by-name/ap/apple-sdk/common/process-stubs.nix
+++ b/pkgs/by-name/ap/apple-sdk/common/process-stubs.nix
@@ -10,13 +10,13 @@ in
 {
   lib,
   jq,
-  libtapi,
+  llvm,
 }:
 
 self: super: {
   nativeBuildInputs = super.nativeBuildInputs or [ ] ++ [
     jq
-    libtapi
+    llvm
   ];
 
   buildPhase =
@@ -24,22 +24,18 @@ self: super: {
     + ''
       echo "Removing the following dylibs from the libSystem reexported libraries list: ${lib.escapeShellArg (lib.concatStringsSep ", " removedDylibs)}"
       for libSystem in libSystem.B.tbd libSystem.B_asan.tbd; do
-        tapi stubify --filetype=tbd-v5 usr/lib/$libSystem -o usr/lib/$libSystem # tbd-v5 is a JSON-based format.
-        jq --argjson libs ${lib.escapeShellArg (builtins.toJSON removedDylibs)} '
+        # tbd-v5 is a JSON-based format, which can be manipulated by `jq`.
+        llvm-readtapi --filetype=tbd-v5 usr/lib/$libSystem \
+        | jq --argjson libs ${lib.escapeShellArg (builtins.toJSON removedDylibs)} '
           if .libraries then
             .libraries[] |= select(.install_names[] | any([.] | inside($libs)) | not)
           else
             .
           end
           | .main_library.reexported_libraries[].names[] |= select([.] | inside($libs) | not)
-        ' usr/lib/$libSystem > usr/lib/$libSystem~
-        mv usr/lib/$libSystem~ usr/lib/$libSystem
+        ' > usr/lib/$libSystem~
+        # Convert libSystem back to tbd-v4 because not all tooling supports the JSON-based format yet.
+        llvm-readtapi -delete-input --filetype=tbd-v4 usr/lib/$libSystem~ -o usr/lib/$libSystem
       done
-
-      # Rewrite the text-based stubs to v4 using `tapi`. This ensures a consistent format between SDK versions.
-      # tbd-v4 also drops certain elements that are no longer necessary (such as GUID lists).
-      find . -name '*.tbd' -type f \
-        -exec echo "Converting {} to tbd-v4" \; \
-        -exec tapi stubify --filetype=tbd-v4 {} -o {} \;
     '';
 }

--- a/pkgs/by-name/ap/apple-sdk/package.nix
+++ b/pkgs/by-name/ap/apple-sdk/package.nix
@@ -18,6 +18,7 @@ in
   # Required by various phases
   callPackage,
   jq,
+  llvm,
 }:
 
 let
@@ -37,8 +38,10 @@ let
       (callPackage ./common/remove-disallowed-packages.nix { })
     ]
     # Only process stubs and convert them to tbd-v4 if jq is available. This can be made unconditional once
-    # the bootstrap tools have jq and libtapi.
-    ++ lib.optional (jq != null) (callPackage ./common/process-stubs.nix { })
+    # the bootstrap tools have jq and llvm-readtapi.
+    ++ lib.optional (jq != null && lib.getName llvm != "bootstrap-stage0-llvm") (
+      callPackage ./common/process-stubs.nix { }
+    )
     # Avoid infinite recursions by not propagating certain packages, so they can themselves build with the SDK.
     ++ lib.optionals (!enableBootstrap) [
       (callPackage ./common/propagate-inputs.nix { })


### PR DESCRIPTION
Newer versions of LLVM provide `llvm-readtapi`, which is functionally equivalent to `tapi` (with a slightly different CLI). Using it allows the SDK to drop `libtapi` as a dependency.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
