### PR TITLE
rar2hashcat: init at 1.0

### DIFF
--- a/pkgs/by-name/ra/rar2hashcat/darwin-support.patch
+++ b/pkgs/by-name/ra/rar2hashcat/darwin-support.patch
@@ -1,0 +1,24 @@
+diff --git a/Makefile b/Makefile
+index eca86a9..f11931b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,5 +1,5 @@
+ # Common variables
+-CFLAGS = -g -static -O2 -D_GNU_SOURCE -DARCH_LITTLE_ENDIAN=1
++CFLAGS = -g -O2 -D_GNU_SOURCE -DARCH_LITTLE_ENDIAN=1
+ TARGET = rar2hashcat
+ 
+ # Variables for Linux target
+diff --git a/base64_convert.c b/base64_convert.c
+index 0d2635d..b101e3c 100644
+--- a/base64_convert.c
++++ b/base64_convert.c
+@@ -163,7 +163,7 @@ static char *strnzcpy(char *dst, const char *src, int size)
+ 	return dst;
+ }
+ 
+-#ifdef __linux__
++#if defined(__linux__) || defined(__APPLE__)
+ static char *strupr(char *s)
+ {
+ 	unsigned char *ptr = (unsigned char *)s;

--- a/pkgs/by-name/ra/rar2hashcat/package.nix
+++ b/pkgs/by-name/ra/rar2hashcat/package.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "rar2hashcat";
+  version = "1.0";
+
+  src = fetchFromGitHub {
+    owner = "hashstation";
+    repo = "rar2hashcat";
+    rev = finalAttrs.version;
+    hash = "sha256-GVh4Gyjn84xAwO7wKXYe2DPnpb8gnxGIMH5Szce+XpY=";
+  };
+
+  patches = [
+    ./darwin-support.patch
+  ];
+
+  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-error=implicit-function-declaration -Wno-error=int-conversion";
+
+  makeFlags = [
+    "CC_LINUX=${stdenv.cc.targetPrefix}cc"
+    "rar2hashcat"
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D rar2hashcat $out/bin/rar2hashcat
+
+    runHook postInstall
+  '';
+
+  meta = {
+    changelog = "https://github.com/hashstation/rar2hashcat/releases/tag/${finalAttrs.version}";
+    description = "Processes input RAR files into a format suitable for use with hashcat";
+    homepage = "https://github.com/hashstation/rar2hashcat";
+    license = lib.licenses.mit;
+    mainProgram = "rar2hashcat";
+    maintainers = with lib.maintainers; [ emilytrau ];
+    platforms = lib.platforms.unix;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Processes input RAR files into a format suitable for use with hashcat https://github.com/hashstation/rar2hashcat

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
