### PR TITLE
auto-cpufreq: 2.4.0 -> 2.5.0

### DIFF
--- a/pkgs/by-name/au/auto-cpufreq/package.nix
+++ b/pkgs/by-name/au/auto-cpufreq/package.nix
@@ -11,14 +11,14 @@
 }:
 python3Packages.buildPythonPackage rec {
   pname = "auto-cpufreq";
-  version = "2.4.0";
+  version = "2.5.0";
   format = "pyproject";
 
   src = fetchFromGitHub {
     owner = "AdnanHodzic";
     repo = "auto-cpufreq";
     tag = "v${version}";
-    hash = "sha256-Xsh3d7rQY7RKzZ7J0swrgxZEyITb7B3oX5F/tcBGjfk=";
+    hash = "sha256-iDvgL5dQerQnu2ERKAWGvWppG7cQ/0uKEfVY93ItvO4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/au/auto-cpufreq/prevent-install-and-copy.patch
+++ b/pkgs/by-name/au/auto-cpufreq/prevent-install-and-copy.patch
@@ -1,8 +1,8 @@
-diff --git c/auto_cpufreq/bin/auto_cpufreq.py i/auto_cpufreq/bin/auto_cpufreq.py
-index 7192366..96289e1 100755
---- c/auto_cpufreq/bin/auto_cpufreq.py
-+++ i/auto_cpufreq/bin/auto_cpufreq.py
-@@ -134,20 +134,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
+diff --git a/auto_cpufreq/bin/auto_cpufreq.py b/auto_cpufreq/bin/auto_cpufreq.py
+index d9fcd37..7436a7e 100755
+--- a/auto_cpufreq/bin/auto_cpufreq.py
++++ b/auto_cpufreq/bin/auto_cpufreq.py
+@@ -136,20 +136,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                  except KeyboardInterrupt: break
              conf.notifier.stop()
          elif install:
@@ -24,7 +24,7 @@ index 7192366..96289e1 100755
          elif update:
              root_check()
              custom_dir = "/opt/auto-cpufreq/source"
-@@ -185,21 +172,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
+@@ -187,21 +174,7 @@ def main(monitor, live, daemon, install, update, remove, force, config, stats, g
                      run(["auto-cpufreq", "--version"])
                  else: print("Aborted")
          elif remove:
@@ -47,96 +47,3 @@ index 7192366..96289e1 100755
          elif stats:
              not_running_daemon_check()
              config_info_dialog()
-diff --git c/auto_cpufreq/core.py i/auto_cpufreq/core.py
-index b51d55d..4e4b5d3 100755
---- c/auto_cpufreq/core.py
-+++ i/auto_cpufreq/core.py
-@@ -277,18 +277,12 @@ def get_current_gov():
-     )
- 
- def cpufreqctl():
--    """
--    deploy cpufreqctl.auto-cpufreq script
--    """
--    if not (IS_INSTALLED_WITH_SNAP or os.path.isfile("/usr/local/bin/cpufreqctl.auto-cpufreq")):
--        copy(SCRIPTS_DIR / "cpufreqctl.sh", "/usr/local/bin/cpufreqctl.auto-cpufreq")
-+    # scripts are already in the correct place
-+    pass
- 
- def cpufreqctl_restore():
--    """
--    remove cpufreqctl.auto-cpufreq script
--    """
--    if not IS_INSTALLED_WITH_SNAP and os.path.isfile("/usr/local/bin/cpufreqctl.auto-cpufreq"):
--        os.remove("/usr/local/bin/cpufreqctl.auto-cpufreq")
-+    # no need to restore
-+    pass
- 
- def footer(l=79): print("\n" + "-" * l + "\n")
- 
-@@ -306,27 +300,8 @@ def remove_complete_msg():
-     footer()
- 
- def deploy_daemon():
--    print("\n" + "-" * 21 + " Deploying auto-cpufreq as a daemon " + "-" * 22 + "\n")
--
--    cpufreqctl() # deploy cpufreqctl script func call
--
--    bluetooth_disable() # turn off bluetooth on boot
--
--    auto_cpufreq_stats_path.touch(exist_ok=True)
--
--    print("\n* Deploy auto-cpufreq install script")
--    copy(SCRIPTS_DIR / "auto-cpufreq-install.sh", "/usr/local/bin/auto-cpufreq-install")
--
--    print("\n* Deploy auto-cpufreq remove script")
--    copy(SCRIPTS_DIR / "auto-cpufreq-remove.sh", "/usr/local/bin/auto-cpufreq-remove")
--
--    # output warning if gnome power profile is running
--    gnome_power_detect_install()
--    gnome_power_svc_disable()
--
--    tlp_service_detect() # output warning if TLP service is detected
--
--    call("/usr/local/bin/auto-cpufreq-install", shell=True)
-+    # prevent needless copying and system changes
-+    pass
- 
- def deploy_daemon_performance():
-     print("\n" + "-" * 21 + " Deploying auto-cpufreq as a daemon (performance) " + "-" * 22 + "\n")
-@@ -359,34 +334,7 @@ def deploy_daemon_performance():
-     call("/usr/local/bin/auto-cpufreq-install", shell=True)
- 
- def remove_daemon():
--    # check if auto-cpufreq is installed
--    if not os.path.exists("/usr/local/bin/auto-cpufreq-remove"):
--        print("\nauto-cpufreq daemon is not installed.\n")
--        sys.exit(1)
--
--    print("\n" + "-" * 21 + " Removing auto-cpufreq daemon " + "-" * 22 + "\n")
--
--    bluetooth_enable() # turn on bluetooth on boot
--
--    # output warning if gnome power profile is stopped
--    gnome_power_rm_reminder()
--    gnome_power_svc_enable()
--
--    # run auto-cpufreq daemon remove script
--    call("/usr/local/bin/auto-cpufreq-remove", shell=True)
--
--    # remove auto-cpufreq-remove
--    os.remove("/usr/local/bin/auto-cpufreq-remove")
--
--    # delete override pickle if it exists
--    if os.path.exists(governor_override_state):  os.remove(governor_override_state)
--
--    # delete stats file
--    if auto_cpufreq_stats_path.exists():
--        if auto_cpufreq_stats_file is not None: auto_cpufreq_stats_file.close()
--        auto_cpufreq_stats_path.unlink()
--
--    cpufreqctl_restore() # restore original cpufrectl script
-+    pass
- 
- def gov_check():
-     for gov in AVAILABLE_GOVERNORS:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

closes https://github.com/NixOS/nixpkgs/issues/372796

updated the prevent-install-and-copy.patch to work with the latest revision as without it would create a conflict when attempting to apply the patch to the new version

https://github.com/AdnanHodzic/auto-cpufreq/releases/tag/v2.5.0 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
