### PR TITLE
rofi-file-browser: Fix build error & warnings

### DIFF
--- a/pkgs/by-name/ro/rofi-file-browser/fix_build_on_i686.patch
+++ b/pkgs/by-name/ro/rofi-file-browser/fix_build_on_i686.patch
@@ -1,0 +1,13 @@
+diff --git a/src/icons.c b/src/icons.c
+index eee00a4..ae476de 100644
+--- a/src/icons.c
++++ b/src/icons.c
+@@ -48,7 +48,7 @@ void request_icons_for_file ( FBFile *fbfile, int icon_size, FileBrowserIconData
+         }
+     }
+ 
+-    unsigned long num_icon_names;
++    gsize num_icon_names;
+     char** icon_names_raw = g_array_steal ( icon_names, &num_icon_names );
+ 
+     /* Create icon fetcher requests. */

--- a/pkgs/by-name/ro/rofi-file-browser/fix_incompatible_pointer_type.patch
+++ b/pkgs/by-name/ro/rofi-file-browser/fix_incompatible_pointer_type.patch
@@ -1,0 +1,27 @@
+diff --git a/src/filebrowser.c b/src/filebrowser.c
+index a5a19af..59f0140 100644
+--- a/src/filebrowser.c
++++ b/src/filebrowser.c
+@@ -256,21 +256,21 @@ static char *file_browser_get_display_value ( const Mode *sw, unsigned int selec
+         FBCmd *fbcmd = &pd->cmds[selected_line];
+         char* name = fbcmd->name != NULL ? fbcmd->name : fbcmd->cmd;
+         return rofi_force_utf8 ( name, strlen ( name ) );
+     } else {
+         int index = pd->open_custom ? pd->open_custom_index : selected_line;
+         FBFile *fbfile = &fd->files[index];
+         return rofi_force_utf8 ( fbfile->name, strlen ( fbfile->name ) );
+     }
+ }
+ 
+-static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, int height )
++static cairo_surface_t *file_browser_get_icon ( const Mode *sw, unsigned int selected_line, unsigned int height )
+ {
+     FileBrowserModePrivateData *pd = ( FileBrowserModePrivateData * ) mode_get_private_data ( sw );
+     FileBrowserFileData *fd = &pd->file_data;
+     FileBrowserIconData *id = &pd->icon_data;
+ 
+     if ( ! id->show_icons ) {
+         return NULL;
+     }
+ 
+     if ( pd->open_custom && pd->show_cmds ) {

--- a/pkgs/by-name/ro/rofi-file-browser/fix_recent_glib_deprecation_warning.patch
+++ b/pkgs/by-name/ro/rofi-file-browser/fix_recent_glib_deprecation_warning.patch
@@ -1,0 +1,83 @@
+diff --git a/src/cmds.c b/src/cmds.c
+index b2f61d7..16554d8 100644
+--- a/src/cmds.c
++++ b/src/cmds.c
+@@ -108,21 +108,21 @@ void search_path_for_cmds ( FileBrowserModePrivateData *pd )
+         fbcmd->cmd = cmdstr;
+         fbcmd->name = NULL;
+         fbcmd->icon_name = NULL;
+ 
+         num_cmds++;
+     }
+ 
+     g_hash_table_steal_all ( table );
+     g_hash_table_destroy ( table );
+ 
+-    g_qsort_with_data ( cmds, num_cmds, sizeof ( FBCmd ), compare_cmds, NULL );
++    g_sort_array ( cmds, num_cmds, sizeof ( FBCmd ), compare_cmds, NULL );
+ 
+     add_cmds(cmds, num_cmds, pd);
+ 
+     g_free ( cmds );
+ }
+ 
+ void destroy_cmds ( FileBrowserModePrivateData *pd )
+ {
+     for ( int i = 0; i < pd->num_cmds; i++ ) {
+         g_free( pd->cmds[i].cmd );
+diff --git a/src/files.c b/src/files.c
+index 29a5f9c..6a15b2e 100644
+--- a/src/files.c
++++ b/src/files.c
+@@ -135,46 +135,46 @@ void load_files ( FileBrowserFileData *fd )
+     FBFile *sort_files = fd->files;
+     int num_sort_files = fd->num_files;
+     if ( ! fd->hide_parent ) {
+         sort_files++;
+         num_sort_files--;
+     }
+ 
+     /* Sort all but the parent dir. */
+     if ( fd->sort_by_type ) {
+         if ( fd->sort_by_depth ) {
+-            g_qsort_with_data ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files_depth_type, NULL );
++            g_sort_array ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files_depth_type, NULL );
+         } else {
+-            g_qsort_with_data ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files_type, NULL );
++            g_sort_array ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files_type, NULL );
+         }
+     } else {
+         if ( fd->sort_by_depth ) {
+-            g_qsort_with_data ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files_depth, NULL );
++            g_sort_array ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files_depth, NULL );
+         } else {
+-            g_qsort_with_data ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files, NULL );
++            g_sort_array ( sort_files, num_sort_files, sizeof ( FBFile ), compare_files, NULL );
+         }
+     }
+ }
+ 
+ void change_dir ( char *path, FileBrowserFileData *pd )
+ {
+     char* new_dir = get_canonical_abs_path ( path, pd->current_dir );
+     g_free ( pd->current_dir );
+     pd->current_dir = new_dir;
+     g_chdir ( new_dir );
+ }
+ 
+ static bool match_glob_patterns ( const char *basename, FileBrowserFileData *fd )
+ {
+     int len = strlen ( basename );
+     for ( int i = 0; i < fd->num_exclude_patterns; i++ ) {
+-        if ( g_pattern_match ( fd->exclude_patterns[i], len, basename, NULL ) ) {
++        if ( g_pattern_spec_match ( fd->exclude_patterns[i], len, basename, NULL ) ) {
+             return false;
+         }
+     }
+     return true;
+ }
+ 
+ static int add_file ( const char *fpath, G_GNUC_UNUSED const struct stat *sb, int typeflag, struct FTW *ftwbuf )
+ {
+     FileBrowserFileData *fd = global_fd;
+ 

--- a/pkgs/by-name/ro/rofi-file-browser/package.nix
+++ b/pkgs/by-name/ro/rofi-file-browser/package.nix
@@ -20,6 +20,12 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
+  patches = [
+    ./fix_incompatible_pointer_type.patch
+    ./fix_build_on_i686.patch
+    ./fix_recent_glib_deprecation_warning.patch
+  ];
+
   prePatch = ''
     substituteInPlace ./CMakeLists.txt \
       --replace ' ''${ROFI_PLUGINS_DIR}' " $out/lib/rofi" \

--- a/pkgs/by-name/ro/rofi-file-browser/package.nix
+++ b/pkgs/by-name/ro/rofi-file-browser/package.nix
@@ -49,6 +49,9 @@ stdenv.mkDerivation rec {
     description = "Use rofi to quickly open files";
     homepage = "https://github.com/marvinkreis/rofi-file-browser-extended";
     license = licenses.mit;
-    maintainers = with maintainers; [ jluttine ];
+    maintainers = with maintainers; [
+      bew
+      jluttine
+    ];
   };
 }


### PR DESCRIPTION
Fix build error we've been having for a while:
```
error: builder for '/nix/store/9pc8vm8sy9lh6cj9yxppjplp0gjpsfl0-rofi-file-browser-extended-1.3.1.drv' failed with exit code 2;
       last 10 log lines:
       >    52 | gboolean      g_pattern_match          (GPatternSpec *pspec,
       >       |               ^~~~~~~~~~~~~~~
       > /build/source/src/filebrowser.c:380:27: error: initialization of 'cairo_surface_t * (*)(const Mode *, unsigned int,  unsigned int)' {aka 'struct _cairo_surface * (*
)(const struct rofi_mode *, unsigned int,  unsigned int)'} from incompatible pointer type 'cairo_surface_t * (*)(const Mode *, unsigned int,  int)' {aka 'struct _cairo_surfa
ce * (*)(const struct rofi_mode *, unsigned int,  int)'} [-Wincompatible-pointer-types]
       >   380 |     ._get_icon          = file_browser_get_icon,
       >       |                           ^~~~~~~~~~~~~~~~~~~~~
       > /build/source/src/filebrowser.c:380:27: note: (near initialization for 'mode._get_icon')
       > make[2]: *** [CMakeFiles/filebrowser.dir/build.make:90: CMakeFiles/filebrowser.dir/src/filebrowser.c.o] Error 1
       > make[2]: *** Waiting for unfinished jobs....
       > make[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/filebrowser.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2
       For full logs, run 'nix log /nix/store/9pc8vm8sy9lh6cj9yxppjplp0gjpsfl0-rofi-file-browser-extended-1.3.1.drv'.
```
A patch was made to fix the build for gentoo (https://github.com/marvinkreis/rofi-file-browser-extended/commit/6f62a2d0784a6937d35ac8f6df2e22c23bbfc8f4) but no official patch was ever released.

I tested the change using:
```sh
nix build --impure --expr 'with import ./. {}; rofi.override { plugins = [ rofi-file-browser ]; }'
./result/bin/rofi -modi file-browser-extended -show file-browser-extended
```

I also added myself as maintainer since I'm the maintainer for rofi (even though I don't use it anymore 👀).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
