### PR TITLE
ocamlPackages: fixes after GCC update to version 14

### DIFF
--- a/pkgs/development/ocaml-modules/lablgtk3/default.nix
+++ b/pkgs/development/ocaml-modules/lablgtk3/default.nix
@@ -13,7 +13,7 @@ buildDunePackage rec {
   version = "3.1.5";
   pname = "lablgtk3";
 
-  minimalOCamlVersion = "4.05";
+  minimalOCamlVersion = "4.06";
 
   src = fetchurl {
     url = "https://github.com/garrigue/lablgtk/releases/download/${version}/lablgtk3-${version}.tbz";

--- a/pkgs/development/ocaml-modules/labltk/default.nix
+++ b/pkgs/development/ocaml-modules/labltk/default.nix
@@ -1,5 +1,6 @@
 {
   stdenv,
+  gcc13Stdenv,
   lib,
   makeWrapper,
   fetchzip,
@@ -11,6 +12,7 @@
 }:
 
 let
+  defaultStdenv = stdenv;
   params =
     let
       mkNewParam =
@@ -18,9 +20,10 @@ let
           version,
           sha256,
           rev ? version,
+          stdenv ? defaultStdenv,
         }:
         {
-          inherit version;
+          inherit stdenv version;
           src = fetchzip {
             url = "https://github.com/garrigue/labltk/archive/${rev}.tar.gz";
             inherit sha256;
@@ -32,15 +35,18 @@ let
         version = "8.06.4";
         rev = "labltk-8.06.4";
         sha256 = "03xwnnnahb2rf4siymzqyqy8zgrx3h26qxjgbp5dh1wdl7n02c7g";
+        stdenv = gcc13Stdenv;
       };
       "4.07" = mkNewParam {
         version = "8.06.5";
         rev = "1b71e2c6f3ae6847d3d5e79bf099deb7330fb419";
         sha256 = "02vchmrm3izrk7daldd22harhgrjhmbw6i1pqw6hmfmrmrypypg2";
+        stdenv = gcc13Stdenv;
       };
       _8_06_7 = mkNewParam {
         version = "8.06.7";
         sha256 = "1cqnxjv2dvw9csiz4iqqyx6rck04jgylpglk8f69kgybf7k7xk2h";
+        stdenv = gcc13Stdenv;
       };
       "4.08" = _8_06_7;
       "4.09" = _8_06_7;
@@ -78,7 +84,7 @@ let
     or (throw "labltk is not available for OCaml ${ocaml.version}");
 in
 
-stdenv.mkDerivation rec {
+param.stdenv.mkDerivation rec {
   inherit (param) version src;
   pname = "ocaml${ocaml.version}-labltk";
 

--- a/pkgs/development/ocaml-modules/linenoise/default.nix
+++ b/pkgs/development/ocaml-modules/linenoise/default.nix
@@ -9,7 +9,7 @@ buildDunePackage rec {
   pname = "linenoise";
   version = "1.5.1";
 
-  minimalOCamlVersion = "4.03";
+  minimalOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "fxfactorial";

--- a/pkgs/development/ocaml-modules/patch/default.nix
+++ b/pkgs/development/ocaml-modules/patch/default.nix
@@ -11,6 +11,8 @@ buildDunePackage rec {
   pname = "patch";
   version = "2.0.0";
 
+  minimalOCamlVersion = "4.03";
+
   src = fetchFromGitHub {
     owner = "hannesm";
     repo = "patch";

--- a/pkgs/development/ocaml-modules/stdcompat/default.nix
+++ b/pkgs/development/ocaml-modules/stdcompat/default.nix
@@ -13,6 +13,8 @@ lib.throwIf (lib.versionAtLeast ocaml.version "5.2")
     pname = "stdcompat";
     version = "19";
 
+    minimalOCamlVersion = "4.06";
+
     src = fetchurl {
       url = "https://github.com/thierry-martinez/stdcompat/releases/download/v${version}/stdcompat-${version}.tar.gz";
       sha256 = "sha256-DKQGd4nnIN6SPls6hcA/2Jvc7ivYNpeMU6rYsVc1ClU=";

--- a/pkgs/development/ocaml-modules/z3/default.nix
+++ b/pkgs/development/ocaml-modules/z3/default.nix
@@ -7,7 +7,7 @@
   z3,
 }:
 
-if lib.versionOlder ocaml.version "4.07" then
+if lib.versionOlder ocaml.version "4.08" then
   throw "z3 is not available for OCaml ${ocaml.version}"
 else
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -452,7 +452,9 @@ let
 
     either = callPackage ../development/ocaml-modules/either { };
 
-    elina = callPackage ../development/ocaml-modules/elina { };
+    elina = callPackage ../development/ocaml-modules/elina {
+      stdenv = pkgs.gcc13Stdenv;
+    };
 
     eliom = callPackage ../development/ocaml-modules/eliom { };
 
@@ -2063,21 +2065,37 @@ in let inherit (pkgs) callPackage; in rec
 {
   inherit mkOcamlPackages;
 
-  ocamlPackages_4_00_1 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.00.1.nix { });
+  ocamlPackages_4_00_1 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.00.1.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
-  ocamlPackages_4_01_0 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.01.0.nix { });
+  ocamlPackages_4_01_0 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.01.0.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
-  ocamlPackages_4_02 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.02.nix { });
+  ocamlPackages_4_02 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.02.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
-  ocamlPackages_4_03 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.03.nix { });
+  ocamlPackages_4_03 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.03.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
-  ocamlPackages_4_04 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.04.nix { });
+  ocamlPackages_4_04 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.04.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
-  ocamlPackages_4_05 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.05.nix { });
+  ocamlPackages_4_05 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.05.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
-  ocamlPackages_4_06 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.06.nix { });
+  ocamlPackages_4_06 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.06.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
-  ocamlPackages_4_07 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.07.nix { });
+  ocamlPackages_4_07 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.07.nix {
+    stdenv = pkgs.gcc13Stdenv;
+  });
 
   ocamlPackages_4_08 = mkOcamlPackages (callPackage ../development/compilers/ocaml/4.08.nix { });
 


### PR DESCRIPTION
A few OCaml packages have been broken by the latest GCC update (to version 14), this fixes them by using GCC13 explicitly or just marking them as no longer available.

(The fix to `patch` is unrelated.)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
