### PR TITLE
gokapi: init at 1.9.6

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -142,6 +142,8 @@
 
 - [victorialogs][https://docs.victoriametrics.com/victorialogs/], log database from VictoriaMetrics. Available as [services.victorialogs](#opt-services.victorialogs.enable)
 
+- [gokapi](https://github.com/Forceu/Gokapi), Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported. Available with [services.gokapi](options.html#opt-services.gokapi.enable)
+
 - [nostr-rs-relay](https://git.sr.ht/~gheartsfield/nostr-rs-relay/), This is a nostr relay, written in Rust. Available as [services.nostr-rs-relay](options.html#opt-services.nostr-rs-relay.enable).
 
 - [Prometheus Node Cert Exporter](https://github.com/amimof/node-cert-exporter), a prometheus exporter to check for SSL cert expiry. Available under [services.prometheus.exporters.node-cert](#opt-services.prometheus.exporters.node-cert.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1116,6 +1116,7 @@
   ./services/networking/go-neb.nix
   ./services/networking/go-shadowsocks2.nix
   ./services/networking/gobgpd.nix
+  ./services/networking/gokapi.nix
   ./services/networking/gvpe.nix
   ./services/networking/hans.nix
   ./services/networking/harmonia.nix

--- a/nixos/modules/services/networking/gokapi.nix
+++ b/nixos/modules/services/networking/gokapi.nix
@@ -1,0 +1,143 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.gokapi;
+  settingsFormat = pkgs.formats.json { };
+  userSettingsFile = settingsFormat.generate "generated-config.json" cfg.settings;
+in
+{
+  options.services.gokapi = {
+    enable = lib.mkEnableOption "Lightweight selfhosted Firefox Send alternative without public upload";
+
+    mutableSettings = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Allow changes to the program config made by the program to persist between restarts.
+        If disabled all required values must be set using nix, and all changes to config format over application updates must be resolved by user.
+      '';
+    };
+
+    package = lib.mkPackageOption pkgs "gokapi" { };
+
+    environment = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = lib.types.attrsOf (lib.types.either lib.types.str lib.types.int);
+        options = {
+          GOKAPI_CONFIG_DIR = lib.mkOption {
+            type = lib.types.str;
+            default = "%S/gokapi/config";
+            description = "Sets the directory for the config file.";
+          };
+          GOKAPI_CONFIG_FILE = lib.mkOption {
+            type = lib.types.str;
+            default = "config.json";
+            description = "Sets the filename for the config file.";
+          };
+          GOKAPI_DATA_DIR = lib.mkOption {
+            type = lib.types.str;
+            default = "%S/gokapi/data";
+            description = "Sets the directory for the data.";
+          };
+          GOKAPI_PORT = lib.mkOption {
+            type = lib.types.port;
+            default = 53842;
+            description = "Sets the port of the service.";
+          };
+        };
+      };
+      default = { };
+      description = ''
+        Environment variables to be set for the gokapi service. Can use systemd specifiers.
+        For full list see <https://gokapi.readthedocs.io/en/latest/advanced.html#environment-variables>.
+      '';
+    };
+    settings = lib.mkOption {
+      type = lib.types.submodule {
+        freeformType = settingsFormat.type;
+        options = { };
+      };
+      default = { };
+      description = ''
+        Configuration settings for the generated config json file.
+        See <https://gokapi.readthedocs.io/en/latest/advanced.html#config-json> for more information
+      '';
+    };
+    settingsFile = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = ''
+        Path to config file to parse and append to settings.
+        Largely useful for loading secrets from a file not in the nix store. Can use systemd specifiers.
+        See <https://gokapi.readthedocs.io/en/latest/advanced.html#config-json> for more information
+      '';
+    };
+
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.gokapi = {
+      wantedBy = [ "default.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      environment = lib.mapAttrs (_: value: toString value) cfg.environment;
+      unitConfig = {
+        Description = "gokapi service";
+      };
+      serviceConfig = {
+        ExecStartPre =
+          let
+            updateScript = lib.getExe (
+              pkgs.writeShellApplication {
+                name = "merge-config";
+                runtimeInputs = with pkgs; [ jq ];
+                text = ''
+                  echo "Running merge-config"
+                  mutableSettings="$1"
+                  statefulSettingsFile="$2"
+                  settingsFile="$3"
+                  if [[ "$mutableSettings" == true ]]; then
+                    if [[ -f "$statefulSettingsFile" ]]; then
+                      echo "Updating stateful config file"
+                      merged="$(jq -s '.[0] * .[1]' "$statefulSettingsFile" ${userSettingsFile})"
+                      echo "$merged" > "$statefulSettingsFile"
+                    fi
+                  else
+                    echo "Overwriting stateful config file"
+                    mkdir -p "$(dirname "$statefulSettingsFile")"
+                    cat ${userSettingsFile} > "$statefulSettingsFile"
+                  fi
+                  if [ "$settingsFile" != "null" ]; then
+                    echo "Merging settings file into current stateful settings file"
+                    merged="$(jq -s '.[0] * .[1]' "$statefulSettingsFile" "$settingsFile")"
+                    echo "$merged" > "$statefulSettingsFile"
+                  fi
+                '';
+              }
+            );
+          in
+          lib.strings.concatStringsSep " " [
+            updateScript
+            (lib.boolToString cfg.mutableSettings)
+            "${cfg.environment.GOKAPI_CONFIG_DIR}/${cfg.environment.GOKAPI_CONFIG_FILE}"
+            (if (cfg.settingsFile == null) then "null" else cfg.settingsFile)
+          ];
+        ExecStart = lib.getExe cfg.package;
+        RestartSec = 30;
+        DynamicUser = true;
+        PrivateTmp = true;
+        StateDirectory = "gokapi";
+        CacheDirectory = "gokapi";
+        Restart = "on-failure";
+      };
+    };
+  };
+  meta.maintainers = with lib.maintainers; [
+    delliott
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -479,6 +479,7 @@ in {
   gobgpd = handleTest ./gobgpd.nix {};
   gocd-agent = handleTest ./gocd-agent.nix {};
   gocd-server = handleTest ./gocd-server.nix {};
+  gokapi = runTest ./gokapi.nix;
   gollum = handleTest ./gollum.nix {};
   gonic = handleTest ./gonic.nix {};
   google-oslogin = handleTest ./google-oslogin {};

--- a/nixos/tests/gokapi.nix
+++ b/nixos/tests/gokapi.nix
@@ -1,0 +1,22 @@
+{ lib, ... }:
+let
+  port = 6000;
+in
+{
+  name = "gokapi";
+
+  meta.maintainers = with lib.maintainers; [ delliott ];
+
+  nodes.machine = {
+    services.gokapi = {
+      enable = true;
+      environment.GOKAPI_PORT = port;
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("gokapi.service")
+    machine.wait_for_open_port(${toString port})
+    machine.succeed("curl --fail http://localhost:${toString port}/")
+  '';
+}

--- a/pkgs/by-name/go/gokapi/package.nix
+++ b/pkgs/by-name/go/gokapi/package.nix
@@ -1,0 +1,72 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  nixosTests,
+  nix-update-script,
+  versionCheckHook,
+}:
+
+buildGoModule rec {
+  pname = "gokapi";
+  version = "1.9.6";
+
+  src = fetchFromGitHub {
+    owner = "Forceu";
+    repo = "Gokapi";
+    tag = "v${version}";
+    hash = "sha256-RDEvKh3tUun7wt1nhtCim95wEN9V9RlztZ9zcw9nS1o=";
+  };
+
+  vendorHash = "sha256-9GRAlgng+yq7q0VQz374jIOCjeDIIDD631BglM/FsQQ=";
+
+  preBuild = ''
+    # This is the go generate is ran in the upstream builder, but we have to run the components seperately for things to work.
+    # go generate ./...
+    # Hopefully at some point this is no longer necessary
+
+    # Enter package dir, to match behaviour of go:generate
+    cd ./cmd/gokapi/
+    go run "../../build/go-generate/updateVersionNumbers.go"
+    # Ran by go-generate, but breaks build in nix
+    # As it tries to download "golang.org/x/exp/slices"
+    # go run "../../build/go-generate/updateProtectedUrls.go"
+    go run "../../build/go-generate/buildWasm.go"
+    # Must specify go root to import wasm_exec.js
+    GOROOT="$(go env GOROOT)" go run "../../build/go-generate/copyStaticFiles.go"
+    # Return to toplevel before build
+    cd ../..
+  '';
+
+  subPackages = [
+    "cmd/gokapi"
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru = {
+    tests = {
+      inherit (nixosTests) gokapi;
+    };
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported";
+    homepage = "https://github.com/Forceu/Gokapi";
+    changelog = "https://github.com/Forceu/Gokapi/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [
+      delliott
+    ];
+    mainProgram = "gokapi";
+  };
+}

--- a/pkgs/by-name/go/gokapi/package.nix
+++ b/pkgs/by-name/go/gokapi/package.nix
@@ -20,21 +20,15 @@ buildGoModule rec {
 
   vendorHash = "sha256-9GRAlgng+yq7q0VQz374jIOCjeDIIDD631BglM/FsQQ=";
 
+  # This is the go generate is ran in the upstream builder, but we have to run the components separately for things to work.
   preBuild = ''
-    # This is the go generate is ran in the upstream builder, but we have to run the components seperately for things to work.
-    # go generate ./...
-    # Hopefully at some point this is no longer necessary
-
-    # Enter package dir, to match behaviour of go:generate
     cd ./cmd/gokapi/
-    go run "../../build/go-generate/updateVersionNumbers.go"
-    # Ran by go-generate, but breaks build in nix
-    # As it tries to download "golang.org/x/exp/slices"
-    # go run "../../build/go-generate/updateProtectedUrls.go"
-    go run "../../build/go-generate/buildWasm.go"
-    # Must specify go root to import wasm_exec.js
+    go run ../../build/go-generate/updateVersionNumbers.go
+    # Tries to download "golang.org/x/exp/slices"
+    # go run ../../build/go-generate/updateProtectedUrls.go
+    go run ../../build/go-generate/buildWasm.go
+    # Must be specify go root to import wasm_exec.js
     GOROOT="$(go env GOROOT)" go run "../../build/go-generate/copyStaticFiles.go"
-    # Return to toplevel before build
     cd ../..
   '';
 
@@ -59,7 +53,7 @@ buildGoModule rec {
   };
 
   meta = {
-    description = "Lightweight selfhosted Firefox Send alternative without public upload. AWS S3 supported";
+    description = "Lightweight selfhosted Firefox Send alternative without public upload";
     homepage = "https://github.com/Forceu/Gokapi";
     changelog = "https://github.com/Forceu/Gokapi/releases/tag/v${version}";
     license = lib.licenses.agpl3Only;


### PR DESCRIPTION
Add gokapi, a convenient service for generating links to file downloads.

Adds package derivation, module, and tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
