### PR TITLE
xfce.tumbler, xfce.ristretto: Add HEIF support

### DIFF
--- a/pkgs/desktops/xfce/applications/ristretto/default.nix
+++ b/pkgs/desktops/xfce/applications/ristretto/default.nix
@@ -5,6 +5,7 @@
   glib,
   gnome,
   libexif,
+  libheif,
   libjxl,
   librsvg,
   libxfce4ui,
@@ -31,11 +32,12 @@ mkXfceDerivation {
   ];
 
   postInstall = ''
-    # Pull in JXL and WebP support for ristretto.
+    # Pull in HEIF, JXL and WebP support for ristretto.
     # In postInstall to run before gappsWrapperArgsHook.
     export GDK_PIXBUF_MODULE_FILE="${
       gnome._gdkPixbufCacheBuilder_DO_NOT_USE {
         extraLoaders = [
+          libheif.out
           libjxl
           librsvg
           webp-pixbuf-loader

--- a/pkgs/desktops/xfce/core/tumbler/default.nix
+++ b/pkgs/desktops/xfce/core/tumbler/default.nix
@@ -1,17 +1,19 @@
-{ lib
-, mkXfceDerivation
-, ffmpegthumbnailer
-, gdk-pixbuf
-, glib
-, freetype
-, libgepub
-, libgsf
-, libjxl
-, librsvg
-, poppler
-, gst_all_1
-, webp-pixbuf-loader
-, libxfce4util
+{
+  lib,
+  mkXfceDerivation,
+  ffmpegthumbnailer,
+  gdk-pixbuf,
+  glib,
+  freetype,
+  libgepub,
+  libgsf,
+  libheif,
+  libjxl,
+  librsvg,
+  poppler,
+  gst_all_1,
+  webp-pixbuf-loader,
+  libxfce4util,
 }:
 
 # TODO: add libopenraw
@@ -38,13 +40,22 @@ mkXfceDerivation {
   preFixup = ''
     gappsWrapperArgs+=(
       # Thumbnailers
-      --prefix XDG_DATA_DIRS : "${lib.makeSearchPath "share" [ libjxl librsvg webp-pixbuf-loader ]}"
+      --prefix XDG_DATA_DIRS : "${
+        lib.makeSearchPath "share" [
+          libheif.out
+          libjxl
+          librsvg
+          webp-pixbuf-loader
+        ]
+      }"
+      # For heif-thumbnailer in heif.thumbnailer
+      --prefix PATH : "${lib.makeBinPath [ libheif ]}"
     )
   '';
 
   # WrapGAppsHook won't touch this binary automatically, so we wrap manually.
   postFixup = ''
-    wrapProgram $out/lib/tumbler-1/tumblerd "''${gappsWrapperArgs[@]}"
+    wrapGApp $out/lib/tumbler-1/tumblerd
   '';
 
   meta = with lib; {


### PR DESCRIPTION
See also #340364.

Sample file: https://nokiatech.github.io/heif/content/images/crowd_1440x960.heic

<img src="https://github.com/user-attachments/assets/515b7f9e-03a4-4f93-aabd-a8c43d986498" width=50%>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

