### PR TITLE
caribou: fix strictDeps build, mark cross as broken

### DIFF
--- a/pkgs/by-name/ca/caribou/package.nix
+++ b/pkgs/by-name/ca/caribou/package.nix
@@ -6,6 +6,7 @@
   gnome,
   glib,
   gtk3,
+  gobject-introspection,
   clutter,
   dbus,
   python3,
@@ -61,9 +62,11 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
+    gobject-introspection
     intltool
     libxslt
     libxml2
+    pythonEnv
     autoreconfHook
     wrapGAppsHook3
     vala
@@ -109,5 +112,8 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21;
     maintainers = [ ];
     platforms = platforms.linux;
+    # checking for a Python interpreter with version >= 2.4... none
+    # configure: error: no suitable Python interpreter found
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
ref. #178468

Cross build is a real pain to fix due to gobject-introspection.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).