### PR TITLE
pantheon.switchboard-plug-*: fix strictDeps / cross build

### DIFF
--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/about/default.nix
@@ -12,6 +12,8 @@
   libgtop,
   libgudev,
   libsoup_3,
+  gettext,
+  glib,
   granite7,
   gtk4,
   packagekit,
@@ -35,6 +37,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
+    glib # glib-compile-resources
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/applications/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
+  gettext,
   meson,
   ninja,
   pkg-config,
@@ -27,6 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/bluetooth/default.nix
@@ -9,6 +9,7 @@
   vala,
   libadwaita,
   libgee,
+  gettext,
   granite7,
   gtk4,
   bluez,
@@ -28,6 +29,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
@@ -12,6 +12,7 @@
   libgee,
   libical,
   granite7,
+  gettext,
   gtk4,
   libxml2,
   switchboard,
@@ -37,6 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    gettext # msgfmt
     libxml2
     meson
     ninja

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/display/default.nix
@@ -9,6 +9,8 @@
   vala,
   libadwaita,
   libgee,
+  gettext,
+  glib,
   granite7,
   gtk4,
   switchboard,
@@ -26,6 +28,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
+    glib # glib-compile-resources
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -9,6 +9,7 @@
 , vala
 , libadwaita
 , libgee
+, gettext
 , gnome-settings-daemon
 , granite7
 , gsettings-desktop-schemas
@@ -44,6 +45,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    gettext # msgfmt
     libxml2
     meson
     ninja

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -13,6 +13,7 @@
   granite7,
   gtk4,
   switchboard,
+  gettext,
   gnome-settings-daemon,
   glib,
   gala, # needed for gestures support
@@ -38,6 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/notifications/default.nix
@@ -9,6 +9,8 @@
   vala,
   libadwaita,
   libgee,
+  gettext,
+  glib,
   granite7,
   gtk4,
   switchboard,
@@ -27,6 +29,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
+    glib # glib-compile-resources
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/onlineaccounts/default.nix
@@ -27,6 +27,8 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    glib # glib-compile-resources
+    gtk4 # gtk-update-icon-cache
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/power/default.nix
@@ -9,6 +9,7 @@
   vala,
   libadwaita,
   libgee,
+  gettext,
   gnome-settings-daemon,
   granite7,
   gtk4,
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/printers/default.nix
@@ -9,6 +9,7 @@
   vala,
   libadwaita,
   libgee,
+  gettext,
   granite7,
   gtk4,
   cups,
@@ -27,6 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/security-privacy/default.nix
@@ -9,6 +9,7 @@
   vala,
   elementary-settings-daemon,
   libgee,
+  gettext,
   granite7,
   gsettings-desktop-schemas,
   gala,
@@ -31,6 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/sharing/default.nix
@@ -9,6 +9,7 @@
   vala,
   elementary-bluetooth-daemon,
   libgee,
+  gettext,
   granite7,
   gtk4,
   switchboard,
@@ -26,6 +27,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/wacom/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/wacom/default.nix
@@ -7,6 +7,7 @@
   ninja,
   pkg-config,
   vala,
+  gettext,
   glib,
   granite7,
   gtk4,
@@ -30,6 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
@@ -10,6 +10,7 @@
   ninja,
   vala,
   elementary-settings-daemon,
+  gettext,
   gtk3,
   granite,
   libgtop,
@@ -38,6 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    gettext # msgfmt
     meson
     ninja
     pkg-config


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64 (where applicable, since `bamf` and others do not cross-compile)
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).