### PR TITLE
ejabberd: use beamPackages for rebar3WithPlugins

### DIFF
--- a/pkgs/by-name/ej/ejabberd/package.nix
+++ b/pkgs/by-name/ej/ejabberd/package.nix
@@ -17,10 +17,8 @@
   gd,
   autoreconfHook,
   gawk,
-  rebar3WithPlugins,
   fetchFromGitHub,
   fetchgit,
-  fetchHex,
   beamPackages,
   nixosTests,
   withMysql ? false,
@@ -40,6 +38,8 @@
 }:
 
 let
+  inherit (beamPackages) buildRebar3 fetchHex rebar3WithPlugins;
+
   ctlpath = lib.makeBinPath [
     bash
     gnused
@@ -50,7 +50,7 @@ let
     procps
   ];
 
-  provider_asn1 = beamPackages.buildRebar3 {
+  provider_asn1 = buildRebar3 {
     name = "provider_asn1";
     version = "0.3.0";
     src = fetchHex {
@@ -60,7 +60,7 @@ let
     };
     beamDeps = [ ];
   };
-  rebar3_hex = beamPackages.buildRebar3 {
+  rebar3_hex = buildRebar3 {
     name = "rebar3_hex";
     version = "7.0.7";
     src = fetchHex {
@@ -73,7 +73,7 @@ let
 
   allBeamDeps = import ./rebar-deps.nix {
     inherit fetchHex fetchgit fetchFromGitHub;
-    builder = lib.makeOverridable beamPackages.buildRebar3;
+    builder = lib.makeOverridable buildRebar3;
 
     overrides = final: prev: {
       jiffy = prev.jiffy.override { buildPlugins = [ beamPackages.pc ]; };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Missed one place in my previous PR. This did not cause a rebuild, showing nothing actually changes, but is necessary for cases where the beam version is changed. 

I may look into removing rebar3 from the top-level attribute set. It's much cleaner to use it from a beamPackages set, especially now that we have multiple versions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
