### PR TITLE
uhd: pin Boost 1.86

### DIFF
--- a/pkgs/applications/radio/uhd/default.nix
+++ b/pkgs/applications/radio/uhd/default.nix
@@ -6,7 +6,8 @@
   cmake,
   pkg-config,
   # See https://files.ettus.com/manual_archive/v3.15.0.0/html/page_build_guide.html for dependencies explanations
-  boost,
+  # Pin Boost 1.86 due to use of boost::asio::io_service.
+  boost186,
   ncurses,
   enableCApi ? true,
   enablePythonApi ? true,
@@ -162,7 +163,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs =
     finalAttrs.pythonPath
     ++ [
-      boost
+      boost186
       libusb1
     ]
     ++ optionals (enableExamples) [


### PR DESCRIPTION
This is a no-op on master. Preparation for #369118

https://paste.fliegendewurst.eu/AgwTgc.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).