### PR TITLE
telepathy-mission-control: fix cross build

### DIFF
--- a/pkgs/by-name/te/telepathy-mission-control/package.nix
+++ b/pkgs/by-name/te/telepathy-mission-control/package.nix
@@ -27,13 +27,13 @@ stdenv.mkDerivation rec {
     sha256 = "0ibs575pfr0wmhfcw6ln6iz7gw2y45l3bah11rksf6g9jlwsxy1d";
   };
 
-  buildInputs = [
-    python3
-  ]; # ToDo: optional stuff missing
+  # TODO: optional build inputs missing
 
   nativeBuildInputs =
     [
+      telepathy-glib # glib-genmarshal
       pkg-config
+      python3
       libxslt
       makeWrapper
     ]


### PR DESCRIPTION
It seems Python is only used at build time. 
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).