### PR TITLE
apt, dpkg: fix cross build

### DIFF
--- a/pkgs/by-name/ap/apt/package.nix
+++ b/pkgs/by-name/ap/apt/package.nix
@@ -49,13 +49,23 @@ stdenv.mkDerivation (finalAttrs: {
     "man"
   ];
 
-  nativeBuildInputs = [
-    cmake
-    gtest
-    (lib.getBin libxslt)
-    pkg-config
-    triehash
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      dpkg # dpkg-architecture
+      gettext # msgfmt
+      gtest
+      (lib.getBin libxslt)
+      pkg-config
+      triehash
+      perlPackages.perl
+    ]
+    ++ lib.optionals withDocs [
+      docbook_xml_dtd_45
+      doxygen
+      perlPackages.Po4a
+      w3m
+    ];
 
   buildInputs =
     [
@@ -64,23 +74,17 @@ stdenv.mkDerivation (finalAttrs: {
       db
       dpkg
       gnutls
+      gtest
       libgcrypt
       libgpg-error
       libseccomp
       libtasn1
       lz4
       p11-kit
-      perlPackages.perl
       udev
       xxHash
       xz
       zstd
-    ]
-    ++ lib.optionals withDocs [
-      docbook_xml_dtd_45
-      doxygen
-      perlPackages.Po4a
-      w3m
     ]
     ++ lib.optionals withNLS [
       gettext
@@ -88,6 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags = [
     (lib.cmakeOptionType "filepath" "BERKELEY_INCLUDE_DIRS" "${lib.getDev db}/include")
+    (lib.cmakeOptionType "filepath" "DPKG_DATADIR" "${dpkg}/share/dpkg")
     (lib.cmakeOptionType "filepath" "DOCBOOK_XSL" "${docbook_xsl}/share/xml/docbook-xsl")
     (lib.cmakeOptionType "filepath" "GNUTLS_INCLUDE_DIR" "${lib.getDev gnutls}/include")
     (lib.cmakeFeature "DROOT_GROUP" "root")

--- a/pkgs/by-name/dp/dpkg/package.nix
+++ b/pkgs/by-name/dp/dpkg/package.nix
@@ -49,10 +49,14 @@ stdenv.mkDerivation rec {
     for i in $(find . -name Makefile.in); do
       substituteInPlace $i --replace "install-data-local:" "disabled:" ;
     done
+
+    # Skip check broken when cross-compiling.
+    substituteInPlace configure \
+      --replace-fail 'as_fn_error $? "cannot find a GNU tar program"' "#"
   '';
 
   postPatch = ''
-    patchShebangs .
+    patchShebangs --host .
 
     # Dpkg commands sometimes calls out to shell commands
     substituteInPlace lib/dpkg/dpkg.h \


### PR DESCRIPTION
Also fix regular strictDeps, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).