### PR TITLE
gnome-terminal: fix cross build

### DIFF
--- a/pkgs/by-name/gn/gnome-terminal/package.nix
+++ b/pkgs/by-name/gn/gnome-terminal/package.nix
@@ -54,7 +54,6 @@ stdenv.mkDerivation (finalAttrs: {
     vala
     desktop-file-utils
     wrapGAppsHook3
-    pcre2
     python3
   ];
 
@@ -67,6 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
     vte
     libuuid
     nautilus # For extension
+    pcre2
   ];
 
   postPatch = ''


### PR DESCRIPTION
meson claims pcre2 is a run-time dependency.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).