### PR TITLE
z88dk: 2.3 -> 2.3-unstable-2025-01-08

### DIFF
--- a/pkgs/by-name/z8/z88dk/package.nix
+++ b/pkgs/by-name/z8/z88dk/package.nix
@@ -105,13 +105,13 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "z88dk";
-  version = "2.3";
+  version = "2.3-unstable-2025-01-08";
 
   src = fetchFromGitHub {
     owner = "z88dk";
     repo = "z88dk";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-CHTORgK6FYIO6n+cvTUX4huY2Ek5FuHrs40QN5NZX44=";
+    rev = "e223137af42ed0332b11fa6185268246293245c4";
+    hash = "sha256-m0ZEAfKISEqzsh4VNXwRSceBC4uWmIIdi5cw+7lEC9o=";
     fetchSubmodules = true;
   };
 
@@ -199,7 +199,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://www.z88dk.org";
     description = "z80 Development Kit";
     license = licenses.clArtistic;
-    maintainers = [ maintainers.siraben ];
+    maintainers = with maintainers; [
+      siraben
+      hzeller
+    ];
     platforms = platforms.unix;
   };
 })


### PR DESCRIPTION
Update to head. Upstream version has not been bumped in a while, but it accumulated almost 1k new changes.

So make an unstable version from current head.

All unit tests pass; also manually verified by running

```bash
echo "int main() { return 42; }" > foo.c
zcc +m100 -subtype=default -create-app foo.c -o foo.bin
z88dk-dis foo.bin
```

Adding myself to maintainers ( @siraben hinted in https://github.com/NixOS/nixpkgs/pull/329782#issuecomment-2355636328 that having more maintainers is probably good)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
