### PR TITLE
epson-escpr: restore correct install layout

### DIFF
--- a/pkgs/by-name/ep/epson-escpr/package.nix
+++ b/pkgs/by-name/ep/epson-escpr/package.nix
@@ -5,8 +5,6 @@
   cups,
   fetchpatch,
   dos2unix,
-  automake115x,
-  autoconf,
 }:
 
 let
@@ -29,17 +27,10 @@ stdenv.mkDerivation {
     ];
     sha256 = "sha256-hVbX4OXPe4y37Szju3uVdXlVdjX4DFSN/A2Emz3eCcQ=";
   };
-  # DOS Line Endings in /lib directory and UNIX Line endings in /src directory.
-  # So convert everything to UNIX style line endings.
-  # Since the files are modified, autoconf and automake is required
-  postUnpack = ''
-    dir=''${src%-*}
-    cd ''${dir#*-}
-    local f
-    for f in $(find ./ -type f || die); do
-      ${dos2unix}/bin/dos2unix $f
-    done
-    cd ..
+  # the patches above are expecting unix line endings, but one of the files
+  # being patched has dos line endings in the source tarball
+  prePatch = ''
+    ${dos2unix}/bin/dos2unix lib/epson-escpr-api.h
   '';
 
   patches = [
@@ -59,10 +50,6 @@ stdenv.mkDerivation {
     "-p1"
   ];
   buildInputs = [ cups ];
-  nativeBuildInputs = [
-    automake115x
-    autoconf
-  ];
 
   meta = with lib; {
     homepage = "http://download.ebz.epson.net/dsc/search/01/search/";


### PR DESCRIPTION
in 75ad85225676171bb0743533f156b58b5023c35c, some new patches were added (to deal with gcc 14, among other things).  these patches disagree with the source tarball about the line endings of the files being patches.  in that commit, the solution was to run dos2unix across the entire source tree.

however, that produced this failure:

WARNING: 'aclocal-1.15' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.

so in that same commit, automake and autoconf were added to nativeBuildInputs.  this fixed that error, but it meant that the 'configure' script was regenerated.  and that's a problem, because cups-filter-ppd-dirs.patch patches the 'configure' script to ensure that the installPhase doesn't introduce weird partial store paths under $out.

as it turns out, there is only one file that is both touched by the new patches and comes with dos line endings in the source tarball. so, we can be much more focused with our invocation of dos2unix.  this prevents the build from seeing unexpected modifications and deciding to try to clobber our patch to the 'configure' script.

further, if we shift our invocation of dos2unix from the unpack phase to the patch phase, we've already cd'd into the unpacked source directory, so we don't need any obscure bash voodoo to figure out its name.

---

I have testing that `ensure-printers` no longer complains, but I don't have an epson printer at my current location so can't test that this actually still works.

follows on to https://github.com/NixOS/nixpkgs/pull/369304#issuecomment-2574174656

cc @andrevmatos @Ekleog 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
