### PR TITLE
himalaya: 1.0.0-beta.4 -> 1.1.0

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -174,6 +174,8 @@
 
 - `nodePackages.copy-webpack-plugin` has been removed, as it should be installed in projects that use it instead.
 
+- `himalaya` has been updated from `v1.0.0-beta.4` to `v1.1.0`, which introduces breaking changes. Check out the [release notes](https://github.com/pimalaya/himalaya/releases) for details.
+
 - `linuxPackages.nvidiaPackages.dc_520` has been removed since it is marked broken and there are better newer alternatives.
 
 - `programs.less.lessopen` is now null by default. To restore the previous behaviour, set it to `''|${lib.getExe' pkgs.lesspipe "lesspipe.sh"} %s''`.

--- a/pkgs/by-name/hi/himalaya/package.nix
+++ b/pkgs/by-name/hi/himalaya/package.nix
@@ -2,8 +2,9 @@
 , rustPlatform
 , fetchFromGitHub
 , stdenv
+, buildPackages
 , pkg-config
-, darwin
+, apple-sdk
 , installShellFiles
 , installShellCompletions ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
 , installManPages ? stdenv.buildPlatform.canExecute stdenv.hostPlatform
@@ -11,56 +12,72 @@
 , gpgme
 , buildNoDefaultFeatures ? false
 , buildFeatures ? []
-}:
+, withNoDefaultFeatures ? buildNoDefaultFeatures
+, withFeatures ? buildFeatures
+}@args:
 
-rustPlatform.buildRustPackage rec {
-  # Learn more about available cargo features at:
-  #  - <https://pimalaya.org/himalaya/cli/latest/installation.html#cargo>
-  inherit buildNoDefaultFeatures buildFeatures;
+let
+  version = "1.1.0";
+  hash = "sha256-gdrhzyhxRHZkALB3SG/aWOdA5iMYkel3Cjk5VBy3E4M=";
+  cargoHash = "sha256-MLPXcPA90YZY55jwC7XUZ6KVJf4Pn8w19iT5E2HqZV0=";
+
+  noDefaultFeatures = lib.warnIf
+    (args ? buildNoDefaultFeatures)
+    "buildNoDefaultFeatures is deprecated in favour of withNoDefaultFeatures and will be removed in the next release"
+    withNoDefaultFeatures;
+
+  features = lib.warnIf
+    (args ? buildFeatures)
+    "buildFeatures is deprecated in favour of withFeatures and will be removed in the next release"
+    withFeatures;
+in
+
+rustPlatform.buildRustPackage {
+  inherit version cargoHash;
 
   pname = "himalaya";
-  version = "1.0.0-beta.4";
 
   src = fetchFromGitHub {
-    owner = "soywod";
-    repo = pname;
+    inherit hash;
+    owner = "pimalaya";
+    repo = "himalaya";
     rev = "v${version}";
-    hash = "sha256-NrWBg0sjaz/uLsNs8/T4MkUgHOUvAWRix1O5usKsw6o=";
   };
 
-  cargoHash = "sha256-YS8IamapvmdrOPptQh2Ef9Yold0IK1XIeGs0kDIQ5b8=";
-
-  NIX_LDFLAGS = lib.optionals stdenv.hostPlatform.isDarwin [
-    "-F${darwin.apple_sdk.frameworks.AppKit}/Library/Frameworks"
-    "-framework"
-    "AppKit"
-  ];
+  buildNoDefaultFeatures = noDefaultFeatures;
+  buildFeatures = features;
 
   nativeBuildInputs = [ pkg-config ]
-    ++ lib.optional (builtins.elem "pgp-gpg" buildFeatures) pkg-config
     ++ lib.optional (installManPages || installShellCompletions) installShellFiles;
 
   buildInputs = [ ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [ AppKit Cocoa Security ])
-    ++ lib.optional (builtins.elem "notmuch" buildFeatures) notmuch
-    ++ lib.optional (builtins.elem "pgp-gpg" buildFeatures) gpgme;
+    ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk
+    ++ lib.optional (builtins.elem "notmuch" withFeatures) notmuch
+    ++ lib.optional (builtins.elem "pgp-gpg" withFeatures) gpgme;
 
-  postInstall = lib.optionalString installManPages ''
-    mkdir -p $out/man
-    $out/bin/himalaya man $out/man
-    installManPage $out/man/*
+  # most of the tests are lib side
+  doCheck = false;
+
+  postInstall = let emulator = stdenv.hostPlatform.emulator buildPackages; in ''
+    mkdir -p $out/share/{applications,completions,man}
+    cp assets/himalaya.desktop "$out"/share/applications/
+    ${emulator} "$out"/bin/himalaya man "$out"/share/man
+    ${emulator} "$out"/bin/himalaya completion bash > "$out"/share/completions/himalaya.bash
+    ${emulator} "$out"/bin/himalaya completion elvish > "$out"/share/completions/himalaya.elvish
+    ${emulator} "$out"/bin/himalaya completion fish > "$out"/share/completions/himalaya.fish
+    ${emulator} "$out"/bin/himalaya completion powershell > "$out"/share/completions/himalaya.powershell
+    ${emulator} "$out"/bin/himalaya completion zsh > "$out"/share/completions/himalaya.zsh
+  '' + lib.optionalString installManPages ''
+    installManPage "$out"/share/man/*
   '' + lib.optionalString installShellCompletions ''
-    installShellCompletion --cmd himalaya \
-      --bash <($out/bin/himalaya completion bash) \
-      --fish <($out/bin/himalaya completion fish) \
-      --zsh <($out/bin/himalaya completion zsh)
+    installShellCompletion "$out"/share/completions/himalaya.{bash,fish,zsh}
   '';
 
   meta = with lib; {
     description = "CLI to manage emails";
     mainProgram = "himalaya";
-    homepage = "https://pimalaya.org/himalaya/cli/latest/";
-    changelog = "https://github.com/soywod/himalaya/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/pimalaya/himalaya";
+    changelog = "https://github.com/pimalaya/himalaya/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
     maintainers = with maintainers; [ soywod toastal yanganto ];
   };

--- a/pkgs/by-name/hi/himalaya/package.nix
+++ b/pkgs/by-name/hi/himalaya/package.nix
@@ -79,6 +79,6 @@ rustPlatform.buildRustPackage {
     homepage = "https://github.com/pimalaya/himalaya";
     changelog = "https://github.com/pimalaya/himalaya/blob/v${version}/CHANGELOG.md";
     license = licenses.mit;
-    maintainers = with maintainers; [ soywod toastal yanganto ];
+    maintainers = with maintainers; [ soywod yanganto ];
   };
 }


### PR DESCRIPTION
- Bumped version to `v1.1.0`, see [release notes](https://github.com/pimalaya/himalaya/releases)
- Made the derivation compatible with the new apple API

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
