### PR TITLE
nixos/rustic: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -99,6 +99,8 @@
 
 - [git-worktree-switcher](https://github.com/mateusauler/git-worktree-switcher), switch between git worktrees with speed. Available as [programs.git-worktree-switcher](#opt-programs.git-worktree-switcher.enable)
 
+- [rustic](https://github.com/rustic-rs/rustic), a Rust-based backup tool. Available as [services.rustic](#opt-services.rustic.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -429,6 +429,7 @@
   ./services/backup/restic-rest-server.nix
   ./services/backup/restic.nix
   ./services/backup/rsnapshot.nix
+  ./services/backup/rustic.nix
   ./services/backup/sanoid.nix
   ./services/backup/syncoid.nix
   ./services/backup/tarsnap.nix

--- a/nixos/modules/services/backup/rustic.nix
+++ b/nixos/modules/services/backup/rustic.nix
@@ -1,0 +1,445 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  tomlFormat = pkgs.formats.toml { };
+
+  cfg = config.services.rustic;
+  configFiles = lib.mapAttrs (k: v: tomlFormat.generate "rustic-${k}.toml" v) cfg.profiles;
+
+  commonOpts =
+    v:
+    if v ? files then
+      v.files
+    else if v ? command then
+      v.command
+    else if v ? postgres then
+      v.postgres
+    else
+      throw "unexpected: backup has none of the authorized types";
+
+  backupType =
+    v:
+    if v ? files then
+      "files"
+    else if v ? command then
+      "command"
+    else if v ? postgres then
+      "postgres"
+    else
+      throw "unexpected: backup has none of the authorized types";
+
+  backupConfigToCmd =
+    k: v:
+    let
+      o = commonOpts v;
+      profileArgs = lib.concatMapStrings (s: " -P \"${s}\"") o.useProfiles;
+      extraArgs = lib.concatMapStrings (s: " \"${s}\"") o.extraArgs;
+      genericArgs = profileArgs + extraArgs;
+
+      sourcesArgs = lib.concatMapStrings (s: " ${s}") v.files.sources;
+      asPathArg = lib.optionalString (v.files.asPath != null) " --as-path \"${v.files.asPath}\"";
+      ifFilesArgs = lib.optionalString (v ? files) (sourcesArgs + asPathArg);
+
+      commandArg = " --stdin-command \"${v.command.command}\" -"; # stdin-command requires adding `-` as a source
+      stdinFilenameArg = lib.optionalString (
+        v.command.filename != null
+      ) " --stdin-filename \"${v.command.filename}\"";
+      ifCommandArgs = lib.optionalString (v ? command) (commandArg + stdinFilenameArg);
+
+      pipeJsonIntoCmd =
+        if o.pipeJsonInto ? nothing then
+          ""
+        else if o.pipeJsonInto ? command then
+          " --json | ${o.pipeJsonInto.command} \"$1\""
+        else if o.pipeJsonInto ? prometheus then
+          " --json | ${prometheusWriteScript o.pipeJsonInto.prometheus.nodeExporterCollectorFolder} \"$1\""
+        else
+          throw "unexpected: pipeJsonInto has none of the authorized types";
+    in
+    if v ? postgres then
+      let
+        systemctl = "${config.systemd.package}/bin/systemctl";
+      in
+      pkgs.writeScript "rustic-postgres-starter-${k}" ''
+        #!${pkgs.bash}/bin/bash
+        set -euo pipefail
+
+        ${systemctl} start --no-block rustic-postgres-globals-${k}.service
+
+        ${pkgs.sudo}/bin/sudo -u postgres \
+          ${config.services.postgresql.package}/bin/psql \
+          -c 'SELECT datname FROM pg_database' \
+          --csv \
+          | tail -n +2 \
+          | grep -Ev '^template0$' \
+          | xargs -I {} \
+          ${systemctl} start --no-block rustic-postgres-db-${k}@{}.service
+      ''
+    else
+      pkgs.writeScript "rustic-backup-${k}" ''
+        #!${pkgs.bash}/bin/bash
+        set -euo pipefail
+
+        TZ="" ${cfg.package}/bin/rustic backup${ifFilesArgs + ifCommandArgs + genericArgs + pipeJsonIntoCmd}
+      '';
+
+  prometheusNumericMetrics = [
+    "files_new"
+    "files_changed"
+    "files_unmodified"
+    "total_files_processed"
+    "total_bytes_processed"
+    "dirs_new"
+    "dirs_changed"
+    "dirs_unmodified"
+    "total_dirs_processed"
+    "total_dirsize_processed"
+    "data_blobs"
+    "tree_blobs"
+    "data_added"
+    "data_added_packed"
+    "data_added_files"
+    "data_added_files_packed"
+    "data_added_trees"
+    "data_added_trees_packed"
+    "backup_duration"
+    "total_duration"
+  ];
+
+  prometheusTimeMetrics = [
+    "backup_start"
+    "backup_end"
+  ];
+
+  prometheusAllMetrics = prometheusNumericMetrics ++ prometheusTimeMetrics;
+
+  prometheusJqTemplate = lib.concatMapStrings (m: ''
+    rustic_backup_${m}{id=\"{{id}}\"} {{${m}}}
+  '') prometheusAllMetrics;
+
+  prometheusWriteScript =
+    f:
+    pkgs.writeScript "rustic-write-to-prometheus" ''
+      #!${pkgs.bash}/bin/bash
+      set -euo pipefail
+
+      ${pkgs.jq}/bin/jq -r --arg template "${prometheusJqTemplate}" '
+        . as $json
+        | $template
+        | gsub("{{id}}"; "'"$1"'")
+        ${lib.concatMapStrings (
+          m: ''| gsub("{{${m}}}"; $json.summary.${m} | tostring)''
+        ) prometheusNumericMetrics}
+        ${lib.concatMapStrings
+          # jq's `fromdate` builtins do not support sub-second accuracy (as of early 2025)
+          (
+            m:
+            ''| gsub("{{${m}}}"; $json.summary.${m} | sub(".[0-9]{0,9}Z"; "Z") | fromdateiso8601 | tostring)''
+          )
+          prometheusTimeMetrics
+        }
+      ' > "${f}/rustic-backup-$1.prom.next"
+      mv "${f}/rustic-backup-$1.prom.next" "${f}/rustic-backup-$1.prom"
+    '';
+
+  commonOptions = {
+    startAt = lib.mkOption {
+      type = with lib.types; either (listOf str) str;
+      description = ''
+        Time(s) at which to run this operation.
+
+        The format is documented in `man systemd.time`.
+      '';
+    };
+
+    useProfiles = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Config profiles to use";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Extra command-line arguments to pass to the `rustic` call.";
+    };
+  };
+
+  commonBackupOptions = commonOptions // {
+    pipeJsonInto = lib.mkOption {
+      description = "Command that will be called on the JSON result of `rustic backup`.";
+      default = {
+        nothing = { };
+      };
+      type = lib.types.attrTag {
+        nothing = lib.mkOption {
+          description = "Do nothing with the result.";
+          type = lib.types.unspecified;
+        };
+
+        command = lib.mkOption {
+          description = ''
+            Run a command on the result.
+
+            It will be called with the JSON result on standard input, and an identifier of
+            the backup section as an argument. You can pass any other arguments eg. as tags,
+            which rustic will return in its JSON output.
+          '';
+          type = lib.types.str;
+        };
+
+        prometheus = lib.mkOption {
+          description = "Write the result as prometheus metrics.";
+          type = lib.types.submodule {
+            options.nodeExporterCollectorFolder = lib.mkOption {
+              type = lib.types.path;
+              description = ''
+                Folder that is exported by the node exporter, and in which the metrics should be placed.
+
+                This should be configured in the node exporter as `--collector.textfile.directory=`.
+              '';
+            };
+          };
+        };
+      };
+    };
+  };
+in
+{
+  options.services.rustic = {
+    enable = lib.mkEnableOption "rustic";
+    package = lib.mkPackageOption pkgs "rustic" { };
+
+    checkProfiles = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        If enabled, checks that the generated rustic profiles are valid.
+
+        Note that imports that cannot be resolved are accepted. This allows
+        the recommended setup of using an imported file that only root can read
+        to store the passwords.
+      '';
+    };
+
+    profiles = lib.mkOption {
+      type = lib.types.attrsOf tomlFormat.type;
+      default = { };
+      description = ''
+        Configuration files for rustic, see
+        <https://github.com/rustic-rs/rustic/blob/main/config/README.md>
+        for supported settings.
+
+        The `rustic` profile will be the one used by default.
+
+        Note that this will be world-readable in the nix store, so do not put
+        your passwords here! Instead, you should write them somewhere safe, and
+        then set, eg. if you put it in `/root/rustic-passwords.toml`:
+        ```nix
+        global.use-profiles = ["/root/rustic-passwords"];
+        ```
+      '';
+    };
+
+    backups = lib.mkOption {
+      default = { };
+      description = ''
+        Backup configurations.
+
+        Each key is the name of the backup, and the value is the parameters
+        with which this backup will be run. This allows setting multiple backups
+        running at different intervals, and backing up different folders or
+        databases.
+      '';
+      type = lib.types.attrsOf (
+        lib.types.attrTag {
+          files = lib.mkOption {
+            description = "Backup files and directories.";
+            type = lib.types.submodule {
+              options = commonBackupOptions // {
+                sources = lib.mkOption {
+                  type = lib.types.listOf lib.types.path;
+                  default = [ ];
+                  description = ''
+                    List of sources to backup.
+
+                    Defaults to the ones defined in the relevant configuration files.
+                  '';
+                };
+
+                asPath = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = "Manually set the backup path in snapshot";
+                };
+              };
+            };
+          };
+
+          command = lib.mkOption {
+            description = "Backup the output of a command.";
+            type = lib.types.submodule {
+              options = commonBackupOptions // {
+                command = lib.mkOption {
+                  type = lib.types.str;
+                  description = "Command of which to backup the output";
+                };
+
+                filename = lib.mkOption {
+                  type = lib.types.nullOr lib.types.str;
+                  default = null;
+                  description = ''
+                    Filename to use in the backup.
+
+                    Defaults to the profile-provided filename, or `stdin`.
+                  '';
+                };
+              };
+            };
+          };
+
+          postgres = lib.mkOption {
+            description = ''
+              Backup all postgresql databases.
+
+              Use a custom `command` using `pg_dump` if you want to backup a single
+              database.
+
+              This backs up globals and individual databases in independent files.
+            '';
+            type = lib.types.submodule {
+              options = commonBackupOptions // {
+                prefix = lib.mkOption {
+                  type = lib.types.str;
+                  default = "/postgres";
+                  description = "Path prefix for the dumps.";
+                };
+              };
+            };
+          };
+        }
+      );
+    };
+
+    checks = lib.mkOption {
+      default = { };
+      description = ''
+        Check configurations.
+
+        Each key is the name of the check, and the value is the parameters
+        with which this check will be run. This allows setting multiple check
+        running at different intervals, eg. a frequent metadata-only check and
+        an infrequent full-data check.
+      '';
+      type = lib.types.attrsOf (lib.types.submodule { options = commonOptions; });
+    };
+
+    prune = commonOptions // {
+      enable = lib.mkEnableOption "rustic-prune";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    system.checks = lib.optional cfg.checkProfiles (
+      pkgs.runCommand "rustic-profiles-check" { } ''
+        ${lib.concatMapStrings (p: ''
+          ln -s ${p} ./rustic-config-for-checking.toml
+          ${cfg.package}/bin/rustic show-config -P rustic-config-for-checking > /dev/null
+          rm ./rustic-config-for-checking.toml
+        '') (lib.attrValues configFiles)}
+        touch $out
+      ''
+    );
+
+    environment.systemPackages = [ cfg.package ];
+
+    environment.etc = lib.mapAttrs' (k: v: {
+      name = "rustic/${k}.toml";
+      value.source = v;
+    }) configFiles;
+
+    systemd.services =
+      lib.concatMapAttrs (
+        k: v:
+        {
+          "rustic-backup-${k}" = {
+            serviceConfig = {
+              Type = "oneshot";
+              User = "root";
+              ExecStart = "${backupConfigToCmd k v} ${backupType v}-${k}";
+            };
+            startAt = (commonOpts v).startAt;
+          };
+        }
+        // lib.optionalAttrs (v ? postgres) {
+          "rustic-postgres-globals-${k}" = {
+            serviceConfig = {
+              Type = "oneshot";
+              User = "root";
+              ExecStart = "${
+                backupConfigToCmd k {
+                  command = v.postgres // {
+                    filename = "${v.postgres.prefix}/globals.sql";
+                    command = "${pkgs.sudo}/bin/sudo -u postgres ${config.services.postgresql.package}/bin/pg_dumpall --globals-only";
+                  };
+                }
+              } postgres-globals-${k}";
+            };
+          };
+
+          "rustic-postgres-db-${k}@" = {
+            serviceConfig = {
+              Type = "oneshot";
+              User = "root";
+              ExecStart = "${
+                backupConfigToCmd k {
+                  command = v.postgres // {
+                    filename = "$3";
+                    command = "${pkgs.sudo}/bin/sudo -u postgres ${config.services.postgresql.package}/bin/pg_dump $2";
+                  };
+                }
+              } 'postgres-db-${k}-%i' '%i' '${v.postgres.prefix}/db/%i.sql'";
+            };
+          };
+        }
+      ) cfg.backups
+      // lib.concatMapAttrs (
+        k: v:
+        let
+          profiles = lib.concatMapStrings (p: " -P \"${p}\"") v.useProfiles;
+          extraArgs = lib.concatMapStrings (a: " \"${a}\"") v.extraArgs;
+        in
+        {
+          "rustic-check-${k}" = {
+            serviceConfig = {
+              Type = "oneshot";
+              User = "root";
+              ExecStart = "${cfg.package}/bin/rustic check${profiles}${extraArgs}";
+            };
+            startAt = v.startAt;
+          };
+        }
+      ) cfg.checks
+      // lib.optionalAttrs cfg.prune.enable (
+        let
+          profiles = lib.concatMapStrings (p: " -P \"${p}\"") cfg.prune.useProfiles;
+          extraArgs = lib.concatMapStrings (a: " \"${a}\"") cfg.prune.extraArgs;
+        in
+        {
+          "rustic-prune" = {
+            serviceConfig = {
+              Type = "oneshot";
+              User = "root";
+              ExecStart = "${cfg.package}/bin/rustic forget --prune${profiles}${extraArgs}";
+            };
+            startAt = cfg.prune.startAt;
+          };
+        }
+      );
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -915,6 +915,7 @@ in {
   rsyslogd = handleTest ./rsyslogd.nix {};
   rtkit = runTest ./rtkit.nix;
   rtorrent = handleTest ./rtorrent.nix {};
+  rustic = handleTest ./rustic.nix {};
   rustls-libssl = handleTest ./rustls-libssl.nix {};
   rxe = handleTest ./rxe.nix {};
   sabnzbd = handleTest ./sabnzbd.nix {};

--- a/nixos/tests/rustic.nix
+++ b/nixos/tests/rustic.nix
@@ -1,0 +1,102 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "rustic";
+    meta.maintainers = with pkgs.lib.maintainers; [
+      ekleog
+      nobbz
+      pmw
+    ];
+
+    nodes.machine =
+      { pkgs, ... }:
+      {
+        services.rustic = {
+          enable = true;
+          profiles."rustic" = {
+            repository = {
+              repository = "/root/repo";
+              password = "foobar"; # obviously don't do that
+            };
+            forget = {
+              keep-last = 1;
+            };
+          };
+          backups.fs.files = {
+            sources = [ "/root/backup" ];
+            startAt = "minutely";
+            pipeJsonInto.prometheus.nodeExporterCollectorFolder = "/root/prometheus-text";
+          };
+          checks.regularly = {
+            startAt = "minutely";
+          };
+          prune = {
+            enable = true;
+            startAt = "minutely";
+          };
+        };
+
+        # Disable the timers, as nixos testing seems ill-adapted to timers
+        systemd.timers.rustic-backup-fs.enable = false;
+        systemd.timers.rustic-check-regularly.enable = false;
+        systemd.timers.rustic-prune.enable = false;
+      };
+
+    testScript = ''
+      # Initialize the repository
+      machine.succeed("mkdir /root/{backup,repo,prometheus-text}")
+      machine.succeed("touch /root/backup/first-file")
+      machine.succeed("rustic init")
+
+      # Make a first backup
+      machine.succeed("systemctl start rustic-backup-fs.service")
+
+      # Check we made one valid backup
+      machine.succeed("rustic snapshots") # debug
+      machine.succeed("rustic list snapshots | wc -l | egrep '^1$'")
+      machine.succeed("rustic check --read-data")
+
+      # Validate the prometheus metrics file was written
+      machine.succeed("ls /root/prometheus-text | wc -l | egrep '^1$'")
+
+      # Restore the first backup
+      machine.succeed("mkdir /root/restore-1")
+      machine.succeed("rustic restore latest /root/restore-1")
+      machine.succeed("ls /root/restore-1/root/backup | grep first-file")
+
+      # Add one file and make a new backup
+      machine.succeed("touch /root/backup/second-file")
+      machine.succeed("systemctl start rustic-backup-fs.service")
+      machine.succeed("systemctl start rustic-check-regularly.service")
+
+      # Check we have a second valid backup
+      machine.succeed("rustic snapshots") # debug
+      machine.succeed("rustic list snapshots | wc -l | egrep '^2$'")
+      machine.succeed("rustic check --read-data")
+
+      # Validate we overwrote the prometheus metrics file, without adding a new one
+      machine.succeed("ls /root/prometheus-text | wc -l | egrep '^1$'")
+
+      # Restore the second backup
+      machine.succeed("mkdir /root/restore-2")
+      machine.succeed("rustic restore latest /root/restore-2")
+      machine.succeed("ls /root/restore-2/root/backup | grep first-file")
+      machine.succeed("ls /root/restore-2/root/backup | grep second-file")
+
+      # Prune the first backup
+      machine.succeed("systemctl start rustic-prune.service")
+      machine.succeed("systemctl start rustic-check-regularly.service")
+
+      # Check we only have one backup left
+      machine.succeed("rustic snapshots") # debug
+      machine.succeed("rustic list snapshots | wc -l | egrep '^1$'")
+      machine.succeed("rustic check --read-data")
+
+      # Restore the second backup again, checking we didn't, just now, delete it
+      machine.succeed("mkdir /root/restore-3")
+      machine.succeed("rustic restore latest /root/restore-3")
+      machine.succeed("ls /root/restore-3/root/backup | grep first-file")
+      machine.succeed("ls /root/restore-3/root/backup | grep second-file")
+    '';
+  }
+)

--- a/pkgs/by-name/ru/rustic/package.nix
+++ b/pkgs/by-name/ru/rustic/package.nix
@@ -7,6 +7,7 @@
   SystemConfiguration,
   installShellFiles,
   nix-update-script,
+  nixosTests,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -38,6 +39,8 @@ rustPlatform.buildRustPackage rec {
   '';
 
   passthru.updateScript = nix-update-script { };
+
+  passthru.tests.nixos = nixosTests.rustic;
 
   meta = {
     homepage = "https://github.com/rustic-rs/rustic";


### PR DESCRIPTION
Second attempt at #372935.

This has been running smoothlessly on my 4 systems for quite a while, on both aarch64 and x86-64 linux.

Considering the complexity of the module, I'll wait for (either a very long time or) a review from another committer before landing. But I can already say I'm very happy with it personally :)

The only future work I'd see on it would be to add easy toggles to automatically run a FS-level snapshot before backing up, which I'd likely implement for ZFS and maybe BTRFS. Or maybe I'd PR that upstream directly, idk, it's not on the short-term todo-list anyway.

cc @emilylange @happysalada @NobbZ @philipmw 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
