### PR TITLE
ladspaPlugins: fix cross build

### DIFF
--- a/pkgs/applications/audio/ladspa-plugins/default.nix
+++ b/pkgs/applications/audio/ladspa-plugins/default.nix
@@ -22,21 +22,29 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-eOtIhNcuItREUShI8JRlBVKfMfovpdfIYu+m37v4KLE=";
   };
 
+  preBuild = ''
+    shopt -s globstar
+    for f in **/Makefile; do
+      substituteInPlace "$f" \
+        --replace-quiet 'ranlib' '${stdenv.cc.targetPrefix}ranlib'
+    done
+    shopt -u globstar
+  '';
+
   nativeBuildInputs = [
     autoreconfHook
+    perlPackages.perl
+    perlPackages.XMLParser
     pkg-config
   ];
   buildInputs = [
     fftw
     ladspaH
     libxml2
-    perlPackages.perl
-    perlPackages.XMLParser
   ];
 
-  patchPhase = ''
-    patchShebangs .
-    patchShebangs ./metadata/
+  postPatch = ''
+    patchShebangs --build . ./metadata/ makestub.pl
     cp ${automake}/share/automake-*/mkinstalldirs .
   '';
 


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

https://paste.fliegendewurst.eu/T6+7Zb.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).