### PR TITLE
nixos/hostapd: enable dynamic_vlan automatically if necessary

### DIFF
--- a/nixos/modules/services/networking/hostapd.nix
+++ b/nixos/modules/services/networking/hostapd.nix
@@ -8,6 +8,7 @@
 let
   inherit
     (lib)
+    any
     attrNames
     attrValues
     concatLists
@@ -781,7 +782,8 @@ in {
                         that any client can use.
 
                         An optional key identifier can be added by prefixing the line with `keyid=<keyid_string>`
-                        An optional VLAN ID can be specified by prefixing the line with `vlanid=<VLAN ID>`.
+                        An optional VLAN ID can be specified by prefixing the line with `vlanid=<VLAN ID>`,
+                        this requires you to also set `settings.dynamic_vlan = 1`.
                         An optional WPS tag can be added by prefixing the line with `wps=<0/1>` (default: 0).
                         Any matching entry with that tag will be used when generating a PSK for a WPS Enrollee
                         instead of generating a new random per-Enrollee PSK.
@@ -931,6 +933,11 @@ in {
                     # Always enable QoS, which is required for 802.11n and above
                     wmm_enabled = mkDefault true;
                     ap_isolate = bssCfg.apIsolate;
+
+                    # Enable dynamic_vlan which is required when using the |vlanid= selector in sae_passwords.
+                    # Not doing so does NOT result in any error but instead silently fails without any logs tracing back to this.
+                    # Authentication of clients just fails with a misleading message "bad password" as soon as at least two |vlanid= selectors are present.
+                    dynamic_vlan = mkIf (any (entry: entry.vlanid != null) bssCfg.authentication.saePasswords) 1;
 
                     sae_password = flip map bssCfg.authentication.saePasswords (
                       entry:


### PR DESCRIPTION
This automatically sets `dynamic_vlan=1` when using the sae `|vlanid=` selector,
which when forgotten results in rejected authentication with "bad password" which is misleading.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
