### PR TITLE
[Backport release-24.11] electron-source: copy node_headers.tar to new 'header' output

### DIFF
--- a/pkgs/development/tools/electron/common.nix
+++ b/pkgs/development/tools/electron/common.nix
@@ -3,7 +3,6 @@
   stdenv,
   chromium,
   nodejs,
-  python3,
   fetchYarnDeps,
   fetchNpmDeps,
   fixup-yarn-lock,
@@ -35,7 +34,15 @@ in
 ((chromium.override { upstream-info = info.chromium; }).mkDerivation (base: {
   packageName = "electron";
   inherit (info) version;
-  buildTargets = [ "electron:electron_dist_zip" ];
+  buildTargets = [
+    "electron:copy_node_headers"
+    "electron:electron_dist_zip"
+  ];
+
+  outputs = [
+    "out"
+    "headers"
+  ];
 
   nativeBuildInputs = base.nativeBuildInputs ++ [
     nodejs
@@ -214,6 +221,12 @@ in
     mkdir -p $libExecPath
     unzip -d $libExecPath out/Release/dist.zip
 
+    # Create reproducible tarball, per instructions at https://reproducible-builds.org/docs/archives/
+    tar --sort=name \
+      --mtime="@$SOURCE_DATE_EPOCH" \
+      --owner=0 --group=0 --numeric-owner \
+      -czf $headers -C out/Release/gen node_headers
+
     runHook postInstall
   '';
 
@@ -239,21 +252,6 @@ in
 
   passthru = {
     inherit info fetchedDeps;
-    headers = stdenv.mkDerivation rec {
-      name = "node-v${info.node}-headers.tar.gz";
-      nativeBuildInputs = [ python3 ];
-      src = fetchedDeps."src/third_party/electron_node";
-      buildPhase = ''
-        runHook preBuild
-        make tar-headers
-        runHook postBuild
-      '';
-      installPhase = ''
-        runHook preInstall
-        mv ${name} $out
-        runHook postInstall
-      '';
-    };
   };
 
   meta = with lib; {


### PR DESCRIPTION
Manual backport of #371189, as the automatic one failed due to a merge conflict caused by not having backported #368966.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
