### PR TITLE
zxing-cpp: 2.2.1 -> 2.3.0

### DIFF
--- a/pkgs/by-name/zx/zxing-cpp/package.nix
+++ b/pkgs/by-name/zx/zxing-cpp/package.nix
@@ -1,38 +1,37 @@
 {
   lib,
-  stdenv,
-  fetchFromGitHub,
   cmake,
-  pkg-config,
-  python3,
+  fetchFromGitHub,
   gitUpdater,
+  python3,
+  stdenv,
+  zint,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "zxing-cpp";
-  version = "2.2.1";
+  version = "2.3.0";
 
   src = fetchFromGitHub {
     owner = "zxing-cpp";
     repo = "zxing-cpp";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-teFspdATn9M7Z1vSr/7PdJx/xAv+TVai8rIekxqpBZk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-e3nSxjg8p+1DEUbZOh4C2zfnA6iGhNJMPiIe2oJEbRo=";
   };
-
-  # c++ 20 needed for char8_t or clang-19 build fails
-  postPatch = ''
-    substituteInPlace CMakeLists.txt \
-      --replace-fail "CMAKE_CXX_STANDARD 17" "CMAKE_CXX_STANDARD 20"
-  '';
 
   nativeBuildInputs = [
     cmake
-    pkg-config
+  ];
+
+  buildInputs = [
+    zint
   ];
 
   cmakeFlags = [
-    "-DBUILD_EXAMPLES=OFF"
-    "-DBUILD_BLACKBOX_TESTS=OFF"
+    "-DZXING_BLACKBOX_TESTS=OFF"
+    "-DZXING_DEPENDENCIES=LOCAL"
+    "-DZXING_EXAMPLES=OFF"
+    "-DZXING_USE_BUNDLED_ZINT=OFF"
   ];
 
   passthru = {

--- a/pkgs/development/python-modules/zxing-cpp/default.nix
+++ b/pkgs/development/python-modules/zxing-cpp/default.nix
@@ -7,6 +7,7 @@
   pybind11,
   libzxing-cpp,
   pytestCheckHook,
+  zint,
 }:
 
 buildPythonPackage rec {
@@ -20,19 +21,27 @@ buildPythonPackage rec {
   # https://pybind11.readthedocs.io/en/stable/installing.html#include-with-pypi
   postPatch = ''
     substituteInPlace pyproject.toml \
-      --replace "pybind11[global]" "pybind11"
+      --replace-fail "pybind11[global]" "pybind11"
+
+    substituteInPlace setup.py \
+      --replace-fail "cfg = 'Debug' if self.debug else 'Release'" "cfg = 'Release'" \
+      --replace-fail " '-DVERSION_INFO=' + self.distribution.get_version()]" " '-DVERSION_INFO=' + self.distribution.get_version(), '-DZXING_DEPENDENCIES=LOCAL', '-DZXING_USE_BUNDLED_ZINT=OFF']"
   '';
 
   dontUseCmakeConfigure = true;
 
-  propagatedBuildInputs = [ numpy ];
+  build-system = [
+    setuptools-scm
+    pybind11
+  ];
 
-  buildInputs = [ pybind11 ];
+  dependencies = [ numpy ];
 
   nativeBuildInputs = [
     cmake
-    setuptools-scm
   ];
+
+  buildInputs = [ zint ];
 
   nativeCheckInputs = [
     pillow


### PR DESCRIPTION
Changelog: https://github.com/zxing-cpp/zxing-cpp/releases/tag/v2.3.0
Diff: https://github.com/zxing-cpp/zxing-cpp/compare/v2.2.1...v2.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
