### PR TITLE
mattermostLatest: init at 10.4.1; mattermost: 9.11.6 -> 9.11.7

### DIFF
--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -8,21 +8,31 @@
   fetchNpmDeps,
   jq,
   nixosTests,
+
+  versionInfo ? {
+    # ESR releases only.
+    # See https://docs.mattermost.com/upgrade/extended-support-release.html
+    # When a new ESR version is available (e.g. 8.1.x -> 9.5.x), update
+    # the version regex here as well.
+    #
+    # Ensure you also check ../mattermostLatest/package.nix.
+    regex = "^v(9\.11\.[0-9]+)$";
+    version = "9.11.6";
+    srcHash = "sha256-G9RYktnnVXdhNWp8q+bNbdlHB9ZOGtnESnZVOA7lDvE=";
+    vendorHash = "sha256-Gwv6clnq7ihoFC8ox8iEM5xp/us9jWUrcmqA9/XbxBE=";
+    npmDepsHash = "sha256-ysz38ywGxJ5DXrrcDmcmezKbc5Y7aug9jOWUzHRAs/0=";
+  },
 }:
 
 buildGoModule rec {
   pname = "mattermost";
-  # ESR releases only.
-  # See https://docs.mattermost.com/upgrade/extended-support-release.html
-  # When a new ESR version is available (e.g. 8.1.x -> 9.5.x), update
-  # the version regex in passthru.updateScript as well.
-  version = "9.11.6";
+  inherit (versionInfo) version;
 
   src = fetchFromGitHub {
     owner = "mattermost";
     repo = "mattermost";
-    rev = "v${version}";
-    hash = "sha256-G9RYktnnVXdhNWp8q+bNbdlHB9ZOGtnESnZVOA7lDvE=";
+    tag = "v${version}";
+    hash = versionInfo.srcHash;
     postFetch = ''
       cd $out/webapp
 
@@ -54,7 +64,7 @@ buildGoModule rec {
   npmDeps = fetchNpmDeps {
     inherit src;
     sourceRoot = "${src.name}/webapp";
-    hash = "sha256-ysz38ywGxJ5DXrrcDmcmezKbc5Y7aug9jOWUzHRAs/0=";
+    hash = versionInfo.npmDepsHash;
     makeCacheWritable = true;
     forceGitDeps = true;
   };
@@ -99,7 +109,7 @@ buildGoModule rec {
     '';
   };
 
-  vendorHash = "sha256-Gwv6clnq7ihoFC8ox8iEM5xp/us9jWUrcmqA9/XbxBE=";
+  inherit (versionInfo) vendorHash;
 
   modRoot = "./server";
   preBuild = ''
@@ -142,10 +152,15 @@ buildGoModule rec {
 
   passthru = {
     updateScript = nix-update-script {
-      extraArgs = [
-        "--version-regex"
-        "^v(9\.11\.[0-9]+)$"
-      ];
+      extraArgs =
+        [
+          "--version-regex"
+          versionInfo.regex
+        ]
+        ++ lib.optionals (versionInfo.autoUpdate or null != null) [
+          "--override-filename"
+          versionInfo.autoUpdate
+        ];
     };
     tests.mattermost = nixosTests.mattermost;
   };

--- a/pkgs/by-name/ma/mattermost/package.nix
+++ b/pkgs/by-name/ma/mattermost/package.nix
@@ -17,9 +17,9 @@
     #
     # Ensure you also check ../mattermostLatest/package.nix.
     regex = "^v(9\.11\.[0-9]+)$";
-    version = "9.11.6";
-    srcHash = "sha256-G9RYktnnVXdhNWp8q+bNbdlHB9ZOGtnESnZVOA7lDvE=";
-    vendorHash = "sha256-Gwv6clnq7ihoFC8ox8iEM5xp/us9jWUrcmqA9/XbxBE=";
+    version = "9.11.7";
+    srcHash = "sha256-KeGpYy3jr7/B2mtBk9em2MXJBJR2+Wajmvtz/yT4SG8=";
+    vendorHash = "sha256-alLPBfnA1o6bUUgPRqvYW/98UKR9wltmFTzKIGtVEm4=";
     npmDepsHash = "sha256-ysz38ywGxJ5DXrrcDmcmezKbc5Y7aug9jOWUzHRAs/0=";
   },
 }:

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -10,7 +10,7 @@ mattermost.override {
     # See https://docs.mattermost.com/about/mattermost-server-releases.html
     # and make sure the version regex is up to date here.
     # Ensure you also check ../mattermost/package.nix for ESR releases.
-    regex = "^v(10\.4\.[0-9]+)$";
+    regex = "^v(10\.[0-9]+\.[0-9]+)$";
     version = "10.4.1";
     srcHash = "sha256-e7uT30tWhJpEQzlcDUY2huFcupDbe4l8B19Dgub2pg0=";
     vendorHash = "sha256-AcemUxcBoytE/ZoXqaIlxkzAnmGV/C1laDqziMuE+XE=";

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -11,10 +11,13 @@ mattermost.override {
     # and make sure the version regex is up to date here.
     # Ensure you also check ../mattermost/package.nix for ESR releases.
     regex = "^v(10\.4\.[0-9]+)$";
-    version = "10.3.1";
-    srcHash = "sha256-nghwf9FgdqEDLkm8dKqhvY1SvALSZ8dasTDwMwbL5AI=";
-    vendorHash = "sha256-G2IhU8/XSITjJKNu1Iwwoabm+hG9r3kLPtZnlzuKBD8=";
-    npmDepsHash = "sha256-Dc+ZFQzRQoUnsZDnPs55gr6O82WwyuBEmCZYFAwW50M=";
+    version = "10.4.1";
+    srcHash = "sha256-e7uT30tWhJpEQzlcDUY2huFcupDbe4l8B19Dgub2pg0=";
+    vendorHash = "sha256-AcemUxcBoytE/ZoXqaIlxkzAnmGV/C1laDqziMuE+XE=";
+    npmDepsHash = "sha256-HABPwdhtev9DZLhWJQsyU4g2ZueYgsX+tUduMsc74YY=";
+    lockfileOverlay = ''
+      unlock(.; "@floating-ui/react"; "channels/node_modules/@floating-ui/react")
+    '';
     autoUpdate = ./package.nix;
   };
 }

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -10,7 +10,7 @@ mattermost.override {
     # See https://docs.mattermost.com/about/mattermost-server-releases.html
     # and make sure the version regex is up to date here.
     # Ensure you also check ../mattermost/package.nix for ESR releases.
-    regex = "^v(10\.3\.[0-9]+)$";
+    regex = "^v(10\.4\.[0-9]+)$";
     version = "10.3.1";
     srcHash = "sha256-nghwf9FgdqEDLkm8dKqhvY1SvALSZ8dasTDwMwbL5AI=";
     vendorHash = "sha256-G2IhU8/XSITjJKNu1Iwwoabm+hG9r3kLPtZnlzuKBD8=";

--- a/pkgs/by-name/ma/mattermostLatest/package.nix
+++ b/pkgs/by-name/ma/mattermostLatest/package.nix
@@ -1,0 +1,20 @@
+{
+  mattermost,
+}:
+
+mattermost.override {
+  versionInfo = {
+    # Latest, non-RC releases only.
+    # If the latest is an ESR (Extended Support Release),
+    # duplicate it here to facilitate the update script.
+    # See https://docs.mattermost.com/about/mattermost-server-releases.html
+    # and make sure the version regex is up to date here.
+    # Ensure you also check ../mattermost/package.nix for ESR releases.
+    regex = "^v(10\.3\.[0-9]+)$";
+    version = "10.3.1";
+    srcHash = "sha256-nghwf9FgdqEDLkm8dKqhvY1SvALSZ8dasTDwMwbL5AI=";
+    vendorHash = "sha256-G2IhU8/XSITjJKNu1Iwwoabm+hG9r3kLPtZnlzuKBD8=";
+    npmDepsHash = "sha256-Dc+ZFQzRQoUnsZDnPs55gr6O82WwyuBEmCZYFAwW50M=";
+    autoUpdate = ./package.nix;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Create `mattermostLatest` to pull in the latest Mattermost. This works fine with all the NixOS tests, but that won't be PRed here. Instead, we will do it in #208181 which will not be backported. If people choose the latest Mattermost, they are accepting a little less stability (in general, but especially for now).

Depends-on: #373085

Backport label this since it affects the autoupdate.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
