### PR TITLE
nixos/garage: add user-given path to ReadWritePaths

### DIFF
--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -11,13 +11,6 @@ let
   cfg = config.services.garage;
   toml = pkgs.formats.toml { };
   configFile = toml.generate "garage.toml" cfg.settings;
-
-  anyHasPrefix =
-    prefix: strOrList:
-    if isString strOrList then
-      hasPrefix prefix strOrList
-    else
-      any ({ path, ... }: hasPrefix prefix path) strOrList;
 in
 {
   meta = {
@@ -44,13 +37,13 @@ in
     };
 
     logLevel = mkOption {
-      type = types.enum ([
+      type = types.enum [
         "error"
         "warn"
         "info"
         "debug"
         "trace"
-      ]);
+      ];
       default = "info";
       example = "debug";
       description = "Garage log level, see <https://garagehq.deuxfleurs.fr/documentation/quick-start/#launching-the-garage-server> for examples.";
@@ -125,18 +118,32 @@ in
       restartTriggers = [
         configFile
       ] ++ (lib.optional (cfg.environmentFile != null) cfg.environmentFile);
-      serviceConfig = {
-        ExecStart = "${cfg.package}/bin/garage server";
+      serviceConfig =
+        let
+          paths = lib.flatten (
+            with cfg.settings;
+            [
+              metadata_dir
+            ]
+            # data_dir can either be a string or a list of attrs
+            # if data_dir is a list, the actual path will in in the `path` attribute of each item
+            # see https://garagehq.deuxfleurs.fr/documentation/reference-manual/configuration/#data_dir
+            ++ lib.optional (lib.isList data_dir) (map (item: item.path) data_dir)
+            ++ lib.optional (lib.isString data_dir) [ data_dir ]
+          );
+          isDefault = lib.hasPrefix "/var/lib/garage";
+          isDefaultStateDirectory = lib.any isDefault paths;
+        in
+        {
+          ExecStart = "${cfg.package}/bin/garage server";
 
-        StateDirectory = mkIf (
-          anyHasPrefix "/var/lib/garage" cfg.settings.data_dir
-          || hasPrefix "/var/lib/garage" cfg.settings.metadata_dir
-        ) "garage";
-        DynamicUser = lib.mkDefault true;
-        ProtectHome = true;
-        NoNewPrivileges = true;
-        EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
-      };
+          StateDirectory = lib.mkIf isDefaultStateDirectory "garage";
+          DynamicUser = lib.mkDefault true;
+          ProtectHome = true;
+          NoNewPrivileges = true;
+          EnvironmentFile = lib.optional (cfg.environmentFile != null) cfg.environmentFile;
+          ReadWritePaths = lib.filter (x: !(isDefault x)) (lib.flatten [ paths ]);
+        };
       environment = {
         RUST_LOG = lib.mkDefault "garage=${cfg.logLevel}";
       } // cfg.extraEnvironment;

--- a/nixos/modules/services/web-servers/garage.nix
+++ b/nixos/modules/services/web-servers/garage.nix
@@ -15,7 +15,10 @@ in
 {
   meta = {
     doc = ./garage.md;
-    maintainers = [ maintainers.mjm ];
+    maintainers = with lib.maintainers; [
+      mjm
+      cything
+    ];
   };
 
   options.services.garage = {


### PR DESCRIPTION
If the user has specified a custom `data_dir` or `meta_dir`, this results in garage service failing with read-only filesystem error since the service runs with `DynamicUser` by default.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
