### PR TITLE
pantheon.elementary-terminal: 6.3.0 -> 6.3.1

### DIFF
--- a/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
+++ b/pkgs/desktops/pantheon/apps/elementary-terminal/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   nix-update-script,
   pkg-config,
   meson,
@@ -22,29 +21,14 @@
 
 stdenv.mkDerivation rec {
   pname = "elementary-terminal";
-  version = "6.3.0";
+  version = "6.3.1";
 
   src = fetchFromGitHub {
     owner = "elementary";
     repo = "terminal";
     rev = version;
-    sha256 = "sha256-Pr2Jm37vuw1DOx63BXKT3oPK6C7i5v9ObYFNR6Hvhns=";
+    sha256 = "sha256-W06J+QqouoZBWGm/w5aBuL009IO4odmSKHoeJkXnVpA=";
   };
-
-  patches = [
-    # Fix clear and reset actions when ongoing foreground process
-    # https://github.com/elementary/terminal/pull/823
-    (fetchpatch {
-      url = "https://github.com/elementary/terminal/commit/3c84bcb98ecdadb4d5e0c7a8f52fb5238f5e92f0.patch";
-      hash = "sha256-XViJR+vj+qy2A1nZa3Pdo8uY24tS4ZqZKjTAyPN9sPA=";
-    })
-    # Only reset/clear screen when <Shift> is pressed
-    # https://github.com/elementary/terminal/pull/827
-    (fetchpatch {
-      url = "https://github.com/elementary/terminal/commit/91b93d883c2b8a8549d9743292d6a564e3b2d3cb.patch";
-      hash = "sha256-3opiRhQLJCYFDwDjEbm0CZ9y8CF/6biU+cJk1Ideyks=";
-    })
-  ];
 
   nativeBuildInputs = [
     desktop-file-utils


### PR DESCRIPTION
https://github.com/elementary/terminal/compare/6.3.0...6.3.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

