### PR TITLE
i3: fix tests with strictDeps

### DIFF
--- a/pkgs/applications/window-managers/i3/default.nix
+++ b/pkgs/applications/window-managers/i3/default.nix
@@ -66,36 +66,27 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.mesonBool "mans" true)
   ];
 
-  buildInputs =
-    [
-      libxcb
-      xcbutilkeysyms
-      xcbutil
-      xcbutilwm
-      xcbutilxrm
-      libxkbcommon
-      libstartup_notification
-      libX11
-      pcre2
-      libev
-      yajl
-      xcb-util-cursor
-      perl
-      pango
-      perlPackages.AnyEventI3
-      perlPackages.X11XCB
-      perlPackages.IPCRun
-      perlPackages.ExtUtilsPkgConfig
-      perlPackages.InlineC
-    ]
-    ++ lib.optionals finalAttrs.doCheck [
-      xorgserver
-      xvfb-run
-      xdotool
-      xorg.setxkbmap
-      xorg.xrandr
-      which
-    ];
+  buildInputs = [
+    libxcb
+    xcbutilkeysyms
+    xcbutil
+    xcbutilwm
+    xcbutilxrm
+    libxkbcommon
+    libstartup_notification
+    libX11
+    pcre2
+    libev
+    yajl
+    xcb-util-cursor
+    perl
+    pango
+    perlPackages.AnyEventI3
+    perlPackages.X11XCB
+    perlPackages.IPCRun
+    perlPackages.ExtUtilsPkgConfig
+    perlPackages.InlineC
+  ];
 
   postPatch = ''
     patchShebangs .
@@ -110,6 +101,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   # xvfb-run is available only on Linux
   doCheck = stdenv.hostPlatform.isLinux;
+
+  nativeCheckInputs = lib.optionals finalAttrs.doCheck [
+    xorgserver
+    xvfb-run
+    xdotool
+    xorg.setxkbmap
+    xorg.xrandr
+    which
+  ];
 
   checkPhase = ''
     runHook preCheck


### PR DESCRIPTION
Put executables used for tests in the correct input. ref. #178468

Failing log previously https://paste.fliegendewurst.eu/9t1A1d.log

Diff noise due to https://github.com/NixOS/nixfmt/issues/228

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).