### PR TITLE
pass: fix strictDeps build

### DIFF
--- a/pkgs/tools/security/pass/default.nix
+++ b/pkgs/tools/security/pass/default.nix
@@ -3,6 +3,7 @@
   lib,
   pkgs,
   fetchurl,
+  bash,
   buildEnv,
   coreutils,
   findutils,
@@ -91,6 +92,8 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional stdenv.hostPlatform.isDarwin ./no-darwin-getopt.patch;
 
   nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [ bash ];
 
   installFlags = [
     "PREFIX=$(out)"


### PR DESCRIPTION
bash is required since `pass` is a shell script.

Failing check without this change https://paste.fliegendewurst.eu/g502Ed.log

Probably this also fixes the cross build. 
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).