### PR TITLE
pinentry-rofi: fix strictDeps build

### DIFF
--- a/pkgs/by-name/pi/pinentry-rofi/package.nix
+++ b/pkgs/by-name/pi/pinentry-rofi/package.nix
@@ -26,6 +26,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoconf-archive
     autoreconfHook
+    guile
     pkg-config
     texinfo
     makeWrapper


### PR DESCRIPTION
Cross still broken due to guile not cross-compiling.
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).