### PR TITLE
duckstation: Fix build on aarch64-linux

### DIFF
--- a/pkgs/by-name/du/duckstation/003-fix-NEON-intrinsics.patch
+++ b/pkgs/by-name/du/duckstation/003-fix-NEON-intrinsics.patch
@@ -1,0 +1,70 @@
+From 19e094e5c7aaaf375a13424044521701e85c8313 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 9 Jan 2025 17:46:25 +0100
+Subject: [PATCH] Fix usage of NEON intrinsics
+
+---
+ src/common/gsvector_neon.h | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/common/gsvector_neon.h b/src/common/gsvector_neon.h
+index e4991af5e..61b8dc09b 100644
+--- a/src/common/gsvector_neon.h
++++ b/src/common/gsvector_neon.h
+@@ -867,7 +867,7 @@ public:
+ 
+   ALWAYS_INLINE int mask() const
+   {
+-    const uint32x2_t masks = vshr_n_u32(vreinterpret_u32_s32(v2s), 31);
++    const uint32x2_t masks = vshr_n_u32(vreinterpret_u32_f32(v2s), 31);
+     return (vget_lane_u32(masks, 0) | (vget_lane_u32(masks, 1) << 1));
+   }
+ 
+@@ -2882,7 +2882,7 @@ public:
+   ALWAYS_INLINE GSVector4 gt64(const GSVector4& v) const
+   {
+ #ifdef CPU_ARCH_ARM64
+-    return GSVector4(vreinterpretq_f32_f64(vcgtq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
++    return GSVector4(vreinterpretq_f32_u64(vcgtq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
+ #else
+     GSVector4 ret;
+     ret.U64[0] = (F64[0] > v.F64[0]) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+@@ -2894,7 +2894,7 @@ public:
+   ALWAYS_INLINE GSVector4 eq64(const GSVector4& v) const
+   {
+ #ifdef CPU_ARCH_ARM64
+-    return GSVector4(vreinterpretq_f32_f64(vceqq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
++    return GSVector4(vreinterpretq_f32_u64(vceqq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
+ #else
+     GSVector4 ret;
+     ret.U64[0] = (F64[0] == v.F64[0]) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+@@ -2906,7 +2906,7 @@ public:
+   ALWAYS_INLINE GSVector4 lt64(const GSVector4& v) const
+   {
+ #ifdef CPU_ARCH_ARM64
+-    return GSVector4(vreinterpretq_f32_f64(vcgtq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
++    return GSVector4(vreinterpretq_f32_u64(vcgtq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
+ #else
+     GSVector4 ret;
+     ret.U64[0] = (F64[0] < v.F64[0]) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+@@ -2918,7 +2918,7 @@ public:
+   ALWAYS_INLINE GSVector4 ge64(const GSVector4& v) const
+   {
+ #ifdef CPU_ARCH_ARM64
+-    return GSVector4(vreinterpretq_f32_f64(vcgeq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
++    return GSVector4(vreinterpretq_f32_u64(vcgeq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
+ #else
+     GSVector4 ret;
+     ret.U64[0] = (F64[0] >= v.F64[0]) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+@@ -2930,7 +2930,7 @@ public:
+   ALWAYS_INLINE GSVector4 le64(const GSVector4& v) const
+   {
+ #ifdef CPU_ARCH_ARM64
+-    return GSVector4(vreinterpretq_f32_f64(vcleq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
++    return GSVector4(vreinterpretq_f32_u64(vcleq_f64(vreinterpretq_f64_f32(v4s), vreinterpretq_f64_f32(v.v4s))));
+ #else
+     GSVector4 ret;
+     ret.U64[0] = (F64[0] <= v.F64[0]) ? 0xFFFFFFFFFFFFFFFFULL : 0;
+-- 
+2.47.0
+

--- a/pkgs/by-name/du/duckstation/package.nix
+++ b/pkgs/by-name/du/duckstation/package.nix
@@ -40,6 +40,8 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     ./001-fix-test-inclusion.diff
     # Patching yet another script that fills data based on git commands . . .
     ./002-hardcode-vars.diff
+    # Fix NEON intrinsics usage
+    ./003-fix-NEON-intrinsics.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/365429#issuecomment-2580730714

I haven't checked if/how this was fixed upstream, because I didn't want to figure out if that whole licensing situation means that we may not apply newer upstream commits to the last GPL release. If that should be fine from a licensing perspective, then I'll submit it upstream as well, so we can eventually just `fetchpatch` it.

Tested by playing a round of yu-gi-oh forbidden memories, there was only a seemingly non-critical error at runtime about missing/mismatched ffmpeg. Not sure if this should be addressed, but likely not an aarch64-specific issue:
```
[   25.1688] E(GetCodecListForContainer): FFmpeg load failed: You may be missing one or more files, or are using the incorrect version. This build of DuckStation requires:
  libavcodec: 61
  libavformat: 61
  libavutil: 59
  libswscale: 8
  libswresample: 5
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
