### PR TITLE
nixos/nixpkgs: add option to specify Nixpkgs source path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,7 @@
                 # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
                 ({ config, pkgs, lib, ... }: {
                   config.nixpkgs.source = self.outPath;
+                  config.system.build.usingFlakes = true;
                 })
               ];
             } // builtins.removeAttrs args [ "modules" ]

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
                 # See: failed attempt to make pkgs.path not copy when using flakes:
                 # https://github.com/NixOS/nixpkgs/pull/153594#issuecomment-1023287913
                 ({ config, pkgs, lib, ... }: {
-                  config.nixpkgs.flake.source = self.outPath;
+                  config.nixpkgs.source = self.outPath;
                 })
               ];
             } // builtins.removeAttrs args [ "modules" ]

--- a/nixos/doc/manual/release-notes/rl-2405.section.md
+++ b/nixos/doc/manual/release-notes/rl-2405.section.md
@@ -24,7 +24,7 @@ In addition to numerous new and upgraded packages, this release has the followin
 
   This may be undesirable if Nix commands are not going to be run on the built system since it adds nixpkgs to the system closure. For such closure-size-constrained non-interactive systems, this setting should be disabled.
 
-  To disable it, set [nixpkgs.flake.setNixPath](#opt-nixpkgs.flake.setNixPath) and [nixpkgs.flake.setFlakeRegistry](#opt-nixpkgs.flake.setFlakeRegistry) to false.
+  To disable it, set `nixpkgs.flake.setNixPath` and `nixpkgs.flake.setFlakeRegistry` to false.
 
 - NixOS AMIs are now uploaded regularly to a new AWS Account.
   Instructions on how to use them can be found on <https://nixos.github.io/amis>.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -29,6 +29,8 @@
 - A `nixos-rebuild build-image` sub-command has been added.
   It allows users to build platform-specific (disk) images from their NixOS configurations. `nixos-rebuild build-image` works similar to the popular [nix-community/nixos-generators](https://github.com/nix-community/nixos-generators) project. See new [section on image building in the nixpkgs manual](https://nixos.org/manual/nixpkgs/unstable/#sec-image-nixos-rebuild-build-image). It is also available for `nixos-rebuild-ng`.
 
+- Using the new `nixpkgs.source` option it is finally possible to build NixOS with a specific Nixpkgs version declaratively, without depending on nix-channel or flakes.
+
 - `nixos-option` has been rewritten to a Nix expression called by a simple bash script. This lowers our maintenance threshold, makes eval errors less verbose, adds support for flake-based configurations, descending into `attrsOf` and `listOf` submodule options, and `--show-trace`.
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/misc/nixpkgs-pin.nix
+++ b/nixos/modules/misc/nixpkgs-pin.nix
@@ -7,7 +7,7 @@
 }:
 let
   cfg = config.nixpkgs;
-  usingFlakes = lib ? nixosSystem;
+  usingFlakes = config.system.build.usingFlakes;
 in
 {
 

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -140,7 +140,7 @@
   ./misc/meta.nix
   ./misc/nixops-autoluks.nix
   ./misc/nixpkgs.nix
-  ./misc/nixpkgs-flake.nix
+  ./misc/nixpkgs-pin.nix
   ./misc/passthru.nix
   ./misc/version.nix
   ./misc/wordlist.nix

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -145,6 +145,12 @@ in
           You can read this path in a custom deployment tool for example.
         '';
       };
+      usingFlakes = mkOption {
+        type = types.bool;
+        default = false;
+        readOnly = true;
+        description = "Whether the NixOS system is being built using flakes.";
+      };
     };
 
 


### PR DESCRIPTION
A non-breaking and (IMHO) simpler alternative to https://github.com/NixOS/nixpkgs/pull/333788 for setting the Nixpkgs versions declaratively from configuration.nix.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change (`nixos-rebuild`, `nixos-rebuild-ng`)
- [x] Tested basic functionality of all binary files
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
