### PR TITLE
python312Packages.fuse: fix cross build, cleanup, 1.0.7 -> 1.0.9

### DIFF
--- a/pkgs/development/python-modules/fuse-python/default.nix
+++ b/pkgs/development/python-modules/fuse-python/default.nix
@@ -4,21 +4,30 @@
   buildPythonPackage,
   fetchPypi,
   pkg-config,
+  setuptools,
   fuse,
 }:
 
 buildPythonPackage rec {
   pname = "fuse-python";
   version = "1.0.7";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-MhiAY2UkCM1HKuu2+S0135LIu0IAk3H4yJJ7s35r3Rs=";
   };
 
-  buildInputs = [ fuse ];
+  postPatch = ''
+    substituteInPlace setup.py \
+      --replace-fail 'pkg-config' "${stdenv.cc.targetPrefix}pkg-config"
+  '';
+
   nativeBuildInputs = [ pkg-config ];
+
+  build-system = [ setuptools ];
+
+  buildInputs = [ fuse ];
 
   # no tests implemented
   doCheck = false;

--- a/pkgs/development/python-modules/fuse-python/default.nix
+++ b/pkgs/development/python-modules/fuse-python/default.nix
@@ -10,12 +10,13 @@
 
 buildPythonPackage rec {
   pname = "fuse-python";
-  version = "1.0.7";
+  version = "1.0.9";
   pyproject = true;
 
   src = fetchPypi {
-    inherit pname version;
-    hash = "sha256-MhiAY2UkCM1HKuu2+S0135LIu0IAk3H4yJJ7s35r3Rs=";
+    inherit version;
+    pname = "fuse_python";
+    hash = "sha256-ntWVd8NqshjXAKooOfAh8SwlKzVxhgV1crmOGbwqhYk=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Additionally fix strictDeps for dependent bup, mark the cross build as broken.
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).