### PR TITLE
luaPackages.argparse: fix strictDeps build

### DIFF
--- a/pkgs/development/lua-modules/overrides.nix
+++ b/pkgs/development/lua-modules/overrides.nix
@@ -69,7 +69,7 @@ in
   argparse = prev.argparse.overrideAttrs(oa: {
 
     doCheck = true;
-    checkInputs = [ final.busted ];
+    nativeCheckInputs = [ final.busted ];
 
     checkPhase = ''
       runHook preCheck


### PR DESCRIPTION
busted is a binary to execute -> nativeCheckInputs

Otherwise the check fails https://paste.fliegendewurst.eu/gnXfPc.log

ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).