### PR TITLE
mudlet: fix strictDeps build

### DIFF
--- a/pkgs/games/mudlet/default.nix
+++ b/pkgs/games/mudlet/default.nix
@@ -77,6 +77,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     git
+    luaEnv
     pkg-config
     qttools
     which


### PR DESCRIPTION
Lua is required to generate some JSON files. Reuse the `luaEnv` for simplicity. (Cross-build is broken anyway due to Qt.)
ref. #178468

Previous failing build log: https://paste.fliegendewurst.eu/fLeEEb.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).