### PR TITLE
sile: fix strictDeps build

### DIFF
--- a/pkgs/by-name/si/sile/package.nix
+++ b/pkgs/by-name/si/sile/package.nix
@@ -45,6 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     zstd
     pkg-config
+    fontconfig # fc-match
     jq
     cargo
     rustc
@@ -101,6 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
       gentium
     ];
   };
+  strictDeps = true;
+  env.LUA = "${finalAttrs.finalPackage.passthru.luaEnv}/bin/lua";
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
ref. #178468

Cross-build unfortunately still broken due to build-time Lua detection stuff.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).