### PR TITLE
waypipe: 0.92 -> 0.10.0

### DIFF
--- a/pkgs/by-name/wa/waypipe/package.nix
+++ b/pkgs/by-name/wa/waypipe/package.nix
@@ -1,50 +1,79 @@
 {
   lib,
-  stdenv,
+  rustPlatform,
   fetchFromGitLab,
   meson,
   ninja,
   pkg-config,
   scdoc,
-  libgbm,
+  mesa,
   lz4,
   zstd,
   ffmpeg,
   libva,
+  cargo,
+  rustc,
+  git,
+  vulkan-headers,
+  vulkan-loader,
+  shaderc,
+  vulkan-tools,
+  llvmPackages,
+  autoPatchelfHook,
   wayland,
   wayland-scanner,
+  rust-bindgen,
+  egl-wayland,
 }:
-
-stdenv.mkDerivation rec {
+llvmPackages.stdenv.mkDerivation rec {
   pname = "waypipe";
-  version = "0.9.2";
+  version = "0.10.0";
 
   src = fetchFromGitLab {
     domain = "gitlab.freedesktop.org";
     owner = "mstoeckl";
     repo = "waypipe";
-    rev = "v${version}";
-    hash = "sha256-DW+WWwuav0lxnoV55L8RrX0enRURRnHMljtwEC0+9t4=";
+    tag = "v${version}";
+    hash = "sha256-OV0FHieHce83W2O379VpGmUMrtID7NdtIrxIe+IJfF0=";
+  };
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit pname version src;
+    hash = "sha256-pC1m1P4wJOT3jARGlpc86u7GdyPXX+YHsFLOcWRqdxI=";
   };
 
   strictDeps = true;
+  LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   depsBuildBuild = [ pkg-config ];
   nativeBuildInputs = [
     meson
     ninja
     pkg-config
     scdoc
+    cargo
+    git
+    vulkan-headers
+    vulkan-loader
+    shaderc
+    rustc
     wayland-scanner
+    rustPlatform.cargoSetupHook
+    autoPatchelfHook
+    rust-bindgen
   ];
   buildInputs = [
     # Optional dependencies:
-    libgbm
+    mesa
     lz4
     zstd
     ffmpeg
     libva
-
+    vulkan-headers
+  ];
+  runtimeDependencies = [
+    vulkan-tools
+    vulkan-loader
     wayland
+    egl-wayland
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Added cargo meson build as waypipe now uses rust. Waypipe v0.10.0 is a major upgrade from 0.9.2, greatly improving network performance for streaming data.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
