### PR TITLE
buildNpmPackage: avoid using npm config

### DIFF
--- a/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
+++ b/pkgs/build-support/node/build-npm-package/hooks/npm-config-hook.sh
@@ -81,9 +81,11 @@ npmConfigHook() {
         cachePath="$TMPDIR/cache"
     fi
 
-    npm config set cache "$cachePath"
-    npm config set offline true
-    npm config set progress false
+    echo "Setting npm_config_cache to $cachePath"
+    # do not use npm config to avoid modifying .npmrc
+    export npm_config_cache="$cachePath"
+    export npm_config_offline="true"
+    export npm_config_progress="false"
 
     echo "Installing dependencies"
 


### PR DESCRIPTION
Revival of #280623

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).