### PR TITLE
losslesscut-bin: 3.61.1 -> 3.64.0

### DIFF
--- a/pkgs/by-name/lo/losslesscut-bin/build-from-appimage.nix
+++ b/pkgs/by-name/lo/losslesscut-bin/build-from-appimage.nix
@@ -9,8 +9,6 @@
 }:
 
 let
-  pname = "losslesscut";
-
   src = fetchurl {
     url = "https://github.com/mifi/lossless-cut/releases/download/v${version}/LosslessCut-linux-x86_64.AppImage";
     inherit hash;

--- a/pkgs/by-name/lo/losslesscut-bin/build-from-dmg.nix
+++ b/pkgs/by-name/lo/losslesscut-bin/build-from-dmg.nix
@@ -10,17 +10,15 @@
   metaCommon ? { },
 }:
 
-let
-  pname = "losslesscut";
+stdenvNoCC.mkDerivation {
+  inherit pname version;
+
   src = fetchurl {
     url = "https://github.com/mifi/lossless-cut/releases/download/v${version}/LosslessCut-mac-${
       if isAarch64 then "arm64" else "x64"
     }.dmg";
     inherit hash;
   };
-in
-stdenvNoCC.mkDerivation {
-  inherit pname version src;
 
   nativeBuildInputs = [ _7zz ];
 

--- a/pkgs/by-name/lo/losslesscut-bin/package.nix
+++ b/pkgs/by-name/lo/losslesscut-bin/package.nix
@@ -7,7 +7,7 @@
 
 let
   pname = "losslesscut";
-  version = "3.61.1";
+  version = "3.64.0";
   metaCommon = with lib; {
     description = "Swiss army knife of lossless video/audio editing";
     homepage = "https://mifi.no/losslesscut/";
@@ -18,22 +18,22 @@ let
   };
   x86_64-appimage = callPackage ./build-from-appimage.nix {
     inherit pname version metaCommon;
-    hash = "sha256-wKhEB+MfOsBvZRTIt3hLofw37+YO+hWKowlSi1OxSAU=";
+    hash = "sha256-K90cJuJFcIkPuAQusJcOBkZ5PQ8T25q7IFIhtmK+jzc=";
     inherit (buildPackages) makeWrapper;
   };
   x86_64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-yZYmM533D9VzM+a0bnYz/aqocaEJVFOTgLWjbQGOQR0=";
+    hash = "sha256-BO2KoYAevbVL0Eix1knvaPVBkWucYI89VkueWYRTcXY=";
     isAarch64 = false;
   };
   aarch64-dmg = callPackage ./build-from-dmg.nix {
     inherit pname version metaCommon;
-    hash = "sha256-/qa2P0R7xRzDgnPKqkeKN6lrDbPg9WuZ/Nnc51NTzaM=";
+    hash = "sha256-/M5yafZQDqCoDzHpjZBC80CcL9KMO5lwvyCcq19caRg=";
     isAarch64 = true;
   };
   x86_64-windows = callPackage ./build-from-windows.nix {
     inherit pname version metaCommon;
-    hash = "sha256-0awYmSGxm8M12X0WQftlapRF9m3GGCZivNwBtRjSa4E=";
+    hash = "sha256-FYrnTiZ5ATT+Y08zceIIHbVM//5Bg2ozIEyC5UxmIno=";
   };
 in
 (


### PR DESCRIPTION
Fixes #368292

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
