### PR TITLE
gallery-dl: 1.28.3 -> 1.28.4, refactor

### DIFF
--- a/pkgs/by-name/ga/gallery-dl/package.nix
+++ b/pkgs/by-name/ga/gallery-dl/package.nix
@@ -1,20 +1,23 @@
 {
   lib,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   yt-dlp,
   python3Packages,
 }:
 
-python3Packages.buildPythonApplication rec {
+let
   pname = "gallery-dl";
   version = "1.28.4";
+in
+python3Packages.buildPythonApplication {
+  inherit pname version;
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mikf";
     repo = "gallery-dl";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-bfE3QUu+ytxd4YkWxsnQ3hTEDE1OgJN8zJxSah2u08I=";
   };
 
@@ -43,17 +46,17 @@ python3Packages.buildPythonApplication rec {
 
   pythonImportsCheck = [ "gallery_dl" ];
 
-  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
+    changelog = "https://github.com/mikf/gallery-dl/blob/v${version}/CHANGELOG.md";
     description = "Command-line program to download image-galleries and -collections from several image hosting sites";
     homepage = "https://github.com/mikf/gallery-dl";
-    changelog = "https://github.com/mikf/gallery-dl/blob/v${version}/CHANGELOG.md";
     license = lib.licenses.gpl2Only;
     mainProgram = "gallery-dl";
-    maintainers = [
-      lib.maintainers.dawidsowa
-      lib.maintainers.lucasew
+    maintainers = with lib.maintainers; [
+      dawidsowa
+      lucasew
     ];
   };
 }

--- a/pkgs/by-name/ga/gallery-dl/package.nix
+++ b/pkgs/by-name/ga/gallery-dl/package.nix
@@ -8,14 +8,14 @@
 
 python3Packages.buildPythonApplication rec {
   pname = "gallery-dl";
-  version = "1.28.3";
+  version = "1.28.4";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mikf";
     repo = "gallery-dl";
     rev = "v${version}";
-    hash = "sha256-OV+4BJmJNvkNmDsogI9V7SLmnc5HJkZd5xqsFoZCHEk=";
+    hash = "sha256-bfE3QUu+ytxd4YkWxsnQ3hTEDE1OgJN8zJxSah2u08I=";
   };
 
   build-system = [ python3Packages.setuptools ];


### PR DESCRIPTION
Changelog: https://github.com/mikf/gallery-dl/releases/tag/v1.28.4
Diff: https://github.com/mikf/gallery-dl/compare/v1.28.3...v1.28.4

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc