### PR TITLE
lm_sensors: fix build, split outputs, modernize and remove perl from library closure

### DIFF
--- a/pkgs/by-name/fa/fan2go/package.nix
+++ b/pkgs/by-name/fa/fan2go/package.nix
@@ -18,18 +18,17 @@ buildGo123Module rec {
 
   vendorHash = "sha256-ad0e/cxbcU/KfPDOdD46KdCcvns83dgGDAyLLQiGyiA=";
 
+  buildInputs = [ lm_sensors ];
+
   postConfigure = ''
     substituteInPlace vendor/github.com/md14454/gosensors/gosensors.go \
-      --replace-fail '"/etc/sensors3.conf"' '"${lm_sensors}/etc/sensors3.conf"'
+      --replace-fail '"/etc/sensors3.conf"' '"${lib.getLib lm_sensors}/etc/sensors3.conf"'
 
     # Uses /usr/bin/echo, and even if we patch that, it refuses to execute any
     # binary without being able to confirm that it's owned by root, which isn't
     # possible under the sandbox.
     rm internal/fans/cmd_test.go
   '';
-
-  CGO_CFLAGS = "-I ${lm_sensors}/include";
-  CGO_LDFLAGS = "-L ${lm_sensors}/lib";
 
   meta = with lib; {
     description = "Simple daemon providing dynamic fan speed control based on temperature sensors";

--- a/pkgs/by-name/lm/lm_sensors/package.nix
+++ b/pkgs/by-name/lm/lm_sensors/package.nix
@@ -17,7 +17,7 @@ let
   tag = lib.replaceStrings [ "." ] [ "-" ] version;
 in
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "lm-sensors";
   inherit version;
 
@@ -84,8 +84,8 @@ stdenv.mkDerivation rec {
   # complicated, it is easier to remove them post-install.
   postInstall =
     ''
-      mkdir -p $doc/share/doc/${pname}
-      cp -r configs doc/* $doc/share/doc/${pname}
+      mkdir -p $doc/share/doc/lm_sensors
+      cp -r configs doc/* $doc/share/doc/lm_sensors
     ''
     + lib.optionalString stdenv.hostPlatform.isStatic ''
       rm $out/lib/*.so*

--- a/pkgs/by-name/lm/lm_sensors/package.nix
+++ b/pkgs/by-name/lm/lm_sensors/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation {
     hash = "sha256-9lfHCcODlS7sZMjQhK0yQcCBEoGyZOChx/oM0CU37sY=";
   };
 
-  patches = lib.optionals sensord [
+  patches = [
     # Fix compile failure on GCC 14 with `sensord` enabled.
     # From: https://github.com/lm-sensors/lm-sensors/pull/483
     (fetchpatch {

--- a/pkgs/by-name/lm/lm_sensors/package.nix
+++ b/pkgs/by-name/lm/lm_sensors/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   bash,
   bison,
   flex,
@@ -26,6 +27,15 @@ stdenv.mkDerivation rec {
     inherit tag;
     hash = "sha256-9lfHCcODlS7sZMjQhK0yQcCBEoGyZOChx/oM0CU37sY=";
   };
+
+  patches = lib.optionals sensord [
+    # Fix compile failure on GCC 14 with `sensord` enabled.
+    # From: https://github.com/lm-sensors/lm-sensors/pull/483
+    (fetchpatch {
+      url = "https://github.com/lm-sensors/lm-sensors/pull/483/commits/7a6170f07d05cc6601b4668f211e9389f2e75286.patch";
+      hash = "sha256-Q49quv3eXeMvY3jgZFs/F7Rljbq4YyehIDIlsgmloBQ=";
+    })
+  ];
 
   outputs = [
     "bin"

--- a/pkgs/tools/system/htop/default.nix
+++ b/pkgs/tools/system/htop/default.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
       optionalPatch = pred: so: lib.optionalString pred "patchelf --add-needed ${so} $out/bin/htop";
     in
     lib.optionalString (!stdenv.hostPlatform.isStatic) ''
-      ${optionalPatch sensorsSupport "${lm_sensors}/lib/libsensors.so"}
+      ${optionalPatch sensorsSupport "${lib.getLib lm_sensors}/lib/libsensors.so"}
       ${optionalPatch systemdSupport "${systemd}/lib/libsystemd.so"}
     '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Fix build with `sensord = true` on GCC 14.
- Split outputs, so the library no longer depends on `perl`, removing `perl` from closure of its dependents (especially, htop).
- Use `tag = ` for `fetchFromGitHub`.
- Use `--replace-fail` for `substituteInPlace`.
- `enableParallelBuilding = true` 

Unresolved:

- Should we rename the package to `lm-sensors` (dash instead of underscore), because of the [upstream project name](https://github.com/lm-sensors/lm-sensors)? The code and docs seem to use lm_sensors and lm-sensors interchangeable. For reference, [Arch](https://archlinux.org/packages/extra/x86_64/lm_sensors/) and [Fedora](https://packages.fedoraproject.org/pkgs/lm_sensors/lm_sensors/) both use `lm_sensors` (underscore). I don't have a strong opinion about it.
- Is the `doc` output really useful? It's done by manually `cp -r configs doc/* <outdir>` and it's not installed by upstream Makefile. [The arch package](https://archlinux.org/packages/extra/x86_64/lm_sensors/) does not install these files either. cc the introducer @peterhoeg
 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
