### PR TITLE
python312Packages.zarr: 2.18.7 -> 3.1.0

### DIFF
--- a/pkgs/development/python-modules/anndata/default.nix
+++ b/pkgs/development/python-modules/anndata/default.nix
@@ -12,6 +12,7 @@
   hatchling,
   joblib,
   lib,
+  legacy-api-wrap,
   natsort,
   numba,
   numpy,
@@ -32,14 +33,14 @@
 
 buildPythonPackage rec {
   pname = "anndata";
-  version = "0.11.4";
+  version = "0.12.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "scverse";
     repo = "anndata";
     tag = version;
-    hash = "sha256-9RDR0veZ8n2sq0kUbAkS2nP57u47cQxmubzuWWYBKBY=";
+    hash = "sha256-uGkeSlYcphRnIFfe9UcLvnupKeMzAIm5wT8fp3gmPKw=";
   };
 
   build-system = [
@@ -50,6 +51,7 @@ buildPythonPackage rec {
   dependencies = [
     array-api-compat
     h5py
+    legacy-api-wrap
     natsort
     numpy
     pandas
@@ -92,18 +94,24 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
+    # requires data from a previous test execution:
+    "test_no_diff"
+
     # doctests that require scanpy, creating a circular dependency chain. These
     # do not work in disabledTestPaths for some reason.
     "anndata._core.anndata.AnnData.concatenate"
     "anndata._core.anndata.AnnData.obs_names_make_unique"
     "anndata._core.anndata.AnnData.var_names_make_unique"
+    "anndata._core.extensions.register_anndata_namespac"
     "anndata._core.merge.concat"
     "anndata._core.merge.gen_reindexer"
     "anndata._core.sparse_dataset.sparse_dataset"
     "anndata._io.specs.registry.read_elem_as_dask"
+    "anndata._io.specs.registry.read_elem_lazy"
     "anndata._io.utils.report_read_key_on_error"
     "anndata._io.utils.report_write_key_on_error"
     "anndata._warnings.ImplicitModificationWarning"
+    "anndata.experimental.backed._io.read_lazy"
     "anndata.experimental.merge.concat_on_disk"
     "anndata.experimental.multi_files._anncollection.AnnCollection"
     "anndata.utils.make_index_unique"

--- a/pkgs/development/python-modules/legacy-api-wrap/default.nix
+++ b/pkgs/development/python-modules/legacy-api-wrap/default.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  hatch-docstring-description,
+  hatch-vcs,
+  hatchling,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "legacy-api-wrap";
+  version = "1.4.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "flying-sheep";
+    repo = "legacy-api-wrap";
+    tag = "v${version}";
+    hash = "sha256-ySkhfUyRBd4QS3f46KlaA5NrHxHr+dlkgmD4fGk2KsA=";
+  };
+
+  build-system = [
+    hatch-docstring-description
+    hatch-vcs
+    hatchling
+  ];
+
+  pythonImportsCheck = [
+    "legacy_api_wrap"
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  meta = {
+    description = "Wrap legacy APIs in python projects";
+    homepage = "https://github.com/flying-sheep/legacy-api-wrap";
+    changelog = "https://github.com/flying-sheep/legacy-api-wrap/releases/tag/${src.tag}";
+    license = lib.licenses.mpl20;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/multiscale-spatial-image/default.nix
+++ b/pkgs/development/python-modules/multiscale-spatial-image/default.nix
@@ -9,6 +9,7 @@
   python-dateutil,
   spatial-image,
   xarray,
+  xarray-dataclass,
   zarr,
   dask-image,
   fsspec,
@@ -22,7 +23,7 @@
 
 buildPythonPackage rec {
   pname = "multiscale-spatial-image";
-  version = "2.0.2";
+  version = "2.0.3";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -31,7 +32,7 @@ buildPythonPackage rec {
     owner = "spatial-image";
     repo = "multiscale-spatial-image";
     tag = "v${version}";
-    hash = "sha256-aJp9RrCy88XFpM5GU7jADHQZFNZgXvlqSsCbmay3gww=";
+    hash = "sha256-wKSzhlNXIXOFEK8+xfKF6zTFr0+mdFhhvjWiHAKphk0=";
   };
 
   build-system = [ hatchling ];
@@ -42,6 +43,7 @@ buildPythonPackage rec {
     python-dateutil
     spatial-image
     xarray
+    xarray-dataclass
     zarr
   ];
 

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "numcodecs";
-  version = "0.15.1";
+  version = "0.16.0";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-7u135NZjZkGizGBfvGB4x6jyzEDz36Kz9h5S5gkbBP8=";
+    hash = "sha256-9xIpqVHEmRqyJt9BR/N4DJiNHOzxMJ44jZ5XvLqCc4c=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/numcodecs/default.nix
+++ b/pkgs/development/python-modules/numcodecs/default.nix
@@ -26,14 +26,14 @@
 
 buildPythonPackage rec {
   pname = "numcodecs";
-  version = "0.16.0";
+  version = "0.16.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-9xIpqVHEmRqyJt9BR/N4DJiNHOzxMJ44jZ5XvLqCc4c=";
+    hash = "sha256-xH8g1lZFRWjGtGl84CCB5ru1EvGYc4xqVvr+gCnJf7E=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/ome-zarr/default.nix
+++ b/pkgs/development/python-modules/ome-zarr/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "ome-zarr";
-  version = "0.11.1";
+  version = "0.12rc1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ome";
     repo = "ome-zarr-py";
     tag = "v${version}";
-    hash = "sha256-3RXkz+UQvLixfYYhm5y/5vu9r0ga6s3xKx1azbmKFgg=";
+    hash = "sha256-uwAcICrFHZYYULfacWII5C3Y+Rs2Bf8ZLQEijfkldn8=";
   };
 
   build-system = [
@@ -78,6 +78,9 @@ buildPythonPackage rec {
     "tests/test_starting_points.py::TestStartingPoints::test_label"
     "tests/test_starting_points.py::TestStartingPoints::test_labels"
     "tests/test_starting_points.py::TestStartingPoints::test_top_level"
+
+    # tries to access network:
+    "ome_zarr/io.py"
   ];
 
   pythonImportsCheck = [

--- a/pkgs/development/python-modules/spatial-image/default.nix
+++ b/pkgs/development/python-modules/spatial-image/default.nix
@@ -7,12 +7,12 @@
   pytestCheckHook,
   numpy,
   xarray,
-  xarray-dataclasses,
+  xarray-dataclass,
 }:
 
 buildPythonPackage rec {
   pname = "spatial-image";
-  version = "1.2.1";
+  version = "1.2.3";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -21,7 +21,7 @@ buildPythonPackage rec {
     owner = "spatial-image";
     repo = "spatial-image";
     tag = "v${version}";
-    hash = "sha256-PGc2uey2xcfE0PcYDaCp7U0lgeGL1I6MMP3vbTN+Alk=";
+    hash = "sha256-mhT86v4/5s4dFw9sDYm5Ba7sM0ME9ifN9KEzhxVigOc=";
   };
 
   build-system = [ hatchling ];
@@ -29,7 +29,7 @@ buildPythonPackage rec {
   dependencies = [
     numpy
     xarray
-    xarray-dataclasses
+    xarray-dataclass
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -14,14 +14,14 @@
 
 buildPythonPackage rec {
   pname = "tifffile";
-  version = "2025.5.10";
+  version = "2025.6.11";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-AYM100KDqj/YwmO65cPCtmHrxFVI/eMVBAFvyue/EQM=";
+    hash = "sha256-Ds5MLnoQZWlX1Wigk7B1E8ByjTDBvYzBJyWQH//bcUM=";
   };
 
   build-system = [ setuptools ];

--- a/pkgs/development/python-modules/tifffile/default.nix
+++ b/pkgs/development/python-modules/tifffile/default.nix
@@ -58,11 +58,11 @@ buildPythonPackage rec {
   # flaky, often killed due to OOM or timeout
   env.SKIP_LARGE = "1";
 
-  meta = with lib; {
+  meta = {
     description = "Read and write image data from and to TIFF files";
     homepage = "https://github.com/cgohlke/tifffile/";
     changelog = "https://github.com/cgohlke/tifffile/blob/v${version}/CHANGES.rst";
-    license = licenses.bsd3;
-    maintainers = with maintainers; [ lebastr ];
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ lebastr ];
   };
 }

--- a/pkgs/development/python-modules/xarray-dataclass/default.nix
+++ b/pkgs/development/python-modules/xarray-dataclass/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pythonOlder,
+  hatchling,
+  pytestCheckHook,
+  numpy,
+  typing-extensions,
+  xarray,
+}:
+
+buildPythonPackage rec {
+  pname = "xarray-dataclass";
+  version = "3.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xarray-contrib";
+    repo = "xarray-dataclass";
+    tag = "v${version}";
+    hash = "sha256-NHJvrkoRhq5cPSBBMWzrWVn+3sPvveMRgTXc/NdLfuA=";
+  };
+
+  build-system = [
+    hatchling
+  ];
+
+  pythonRelaxDeps = [ "xarray" ];
+
+  dependencies = [
+    numpy
+    typing-extensions
+    xarray
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "xarray_dataclass" ];
+
+  meta = with lib; {
+    description = "Xarray data creation made easy by dataclass";
+    homepage = "https://xarray-contrib.github.io/xarray-dataclass";
+    changelog = "https://github.com/xarray-contrib/xarray-dataclass/releases/tag/v${version}";
+    license = licenses.mit;
+    maintainers = with maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -29,14 +29,14 @@
 
 buildPythonPackage rec {
   pname = "zarr";
-  version = "3.0.2";
+  version = "3.0.4";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-A2stq/+p8BSMrVenvmxp2XYfazuDO2G30pwu6Kg2tGw=";
+    hash = "sha256-br5tZdH26vteu45DT8bld7DQwDOv6/G7XNHv1GeU05g=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -70,6 +70,13 @@ buildPythonPackage rec {
     ++ moto.optional-dependencies.s3
     ++ moto.optional-dependencies.server
     ++ optional-dependencies.remote;
+  pytestFlagsArray = [
+    # Don't measure the time it takes for hypothesis related tests to succeed.
+    # See https://github.com/astropy/astropy/issues/17649 for a similar
+    # discussion, and see:
+    # https://github.com/zarr-developers/zarr-python/blob/v3.0.4/tests/conftest.py#L182C1-L187C2
+    "--hypothesis-profile=ci"
+  ];
 
   pythonImportsCheck = [ "zarr" ];
 

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -25,18 +25,21 @@
   fsspec,
   moto,
   requests,
+  tomlkit,
+  uv,
+  writableTmpDirAsHomeHook,
 }:
 
 buildPythonPackage rec {
   pname = "zarr";
-  version = "3.0.4";
+  version = "3.1.0";
   pyproject = true;
 
   disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-br5tZdH26vteu45DT8bld7DQwDOv6/G7XNHv1GeU05g=";
+    hash = "sha256-rOWxEdxp1TFcsWVd/Q+BbFrPl5jSrZL0O2CKUsjIrCs=";
   };
 
   build-system = [
@@ -51,31 +54,40 @@ buildPythonPackage rec {
     fasteners
     numcodecs
     typing-extensions
-  ] ++ numcodecs.optional-dependencies.crc32c;
+  ]
+  ++ numcodecs.optional-dependencies.crc32c;
 
   optional-dependencies = {
     remote = [ fsspec ];
   };
 
-  nativeCheckInputs =
-    [
-      pytestCheckHook
-      pytest-asyncio
-      pytest-cov-stub
-      hypothesis
-      aiohttp
-      moto
-      requests
-    ]
-    ++ moto.optional-dependencies.s3
-    ++ moto.optional-dependencies.server
-    ++ optional-dependencies.remote;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-asyncio
+    pytest-cov-stub
+    hypothesis
+    aiohttp
+    moto
+    requests
+    tomlkit
+    uv
+    writableTmpDirAsHomeHook
+  ]
+  ++ moto.optional-dependencies.s3
+  ++ moto.optional-dependencies.server
+  ++ optional-dependencies.remote;
   pytestFlagsArray = [
     # Don't measure the time it takes for hypothesis related tests to succeed.
     # See https://github.com/astropy/astropy/issues/17649 for a similar
     # discussion, and see:
     # https://github.com/zarr-developers/zarr-python/blob/v3.0.4/tests/conftest.py#L182C1-L187C2
     "--hypothesis-profile=ci"
+  ];
+  disabledTests = [
+    # 3 tests that require multiple Python versions to co-exist
+    "test_scripts_can_run"
+    "test_roundtrip_v2"
+    "test_roundtrip_v3"
   ];
 
   pythonImportsCheck = [ "zarr" ];

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -5,50 +5,73 @@
   pythonOlder,
 
   # build-system
-  setuptools-scm,
+  hatchling,
+  hatch-vcs,
 
   # dependencies
   asciitree,
+  donfig,
   numpy,
   fasteners,
   numcodecs,
+  typing-extensions,
 
   # tests
   pytestCheckHook,
+  pytest-asyncio,
+  pytest-cov-stub,
+  hypothesis,
+  aiohttp,
+  fsspec,
+  moto,
+  requests,
 }:
 
 buildPythonPackage rec {
   pname = "zarr";
-  version = "2.18.7";
+  version = "3.0.2";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-srj2bxTaxK9msYDSM4gZmBuYH3Dhlsmmbmv6qeWVcvU=";
+    hash = "sha256-A2stq/+p8BSMrVenvmxp2XYfazuDO2G30pwu6Kg2tGw=";
   };
 
   build-system = [
-    setuptools-scm
+    hatchling
+    hatch-vcs
   ];
 
   dependencies = [
     asciitree
+    donfig
     numpy
     fasteners
     numcodecs
-  ]
-  ++ numcodecs.optional-dependencies.msgpack;
+    typing-extensions
+  ] ++ numcodecs.optional-dependencies.crc32c;
 
-  nativeCheckInputs = [
-    pytestCheckHook
-  ];
+  optional-dependencies = {
+    remote = [ fsspec ];
+  };
+
+  nativeCheckInputs =
+    [
+      pytestCheckHook
+      pytest-asyncio
+      pytest-cov-stub
+      hypothesis
+      aiohttp
+      moto
+      requests
+    ]
+    ++ moto.optional-dependencies.s3
+    ++ moto.optional-dependencies.server
+    ++ optional-dependencies.remote;
 
   pythonImportsCheck = [ "zarr" ];
-
-  # FIXME remove once zarr's reverse dependencies support v3
-  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Implementation of chunked, compressed, N-dimensional arrays for Python";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -19804,6 +19804,8 @@ self: super: with self; {
 
   xarray = callPackage ../development/python-modules/xarray { };
 
+  xarray-dataclass = callPackage ../development/python-modules/xarray-dataclass { };
+
   xarray-dataclasses = callPackage ../development/python-modules/xarray-dataclasses { };
 
   xarray-einstats = callPackage ../development/python-modules/xarray-einstats { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -8003,6 +8003,8 @@ self: super: with self; {
 
   ledgerwallet = callPackage ../development/python-modules/ledgerwallet { };
 
+  legacy-api-wrap = callPackage ../development/python-modules/legacy-api-wrap { };
+
   legacy-cgi = callPackage ../development/python-modules/legacy-cgi { };
 
   leidenalg = callPackage ../development/python-modules/leidenalg { igraph-c = pkgs.igraph; };


### PR DESCRIPTION
The following packages need to be updated upstream to the Zarr 3.x. API:

 - [x] `python312Packages.tifffile`: https://github.com/cgohlke/tifffile/issues/282
 - [x] `python312Packages.multiscale-spatial-image`: https://github.com/spatial-image/multiscale-spatial-image/pull/108
 - [ ] `python312Packages.ome-zarr`: https://github.com/ome/ome-zarr-py/issues/463
 - [x] `python312Packages.reproject`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
