### PR TITLE
meme-bingo-web: 1.1.0 → 1.2.0

### DIFF
--- a/nixos/modules/services/web-apps/meme-bingo-web.nix
+++ b/nixos/modules/services/web-apps/meme-bingo-web.nix
@@ -36,6 +36,14 @@ in
         default = "http://localhost:41678/";
         example = "https://bingo.example.com/";
       };
+      address = mkOption {
+        description = ''
+          The address the webserver will bind to.
+        '';
+        type = types.str;
+        default = "localhost";
+        example = "::";
+      };
       port = mkOption {
         description = ''
           Port to be used for the web server.
@@ -44,16 +52,22 @@ in
         default = 41678;
         example = 21035;
       };
+      openFirewall = mkEnableOption ''
+        Opens the specified port in the firewall.
+      '';
     };
   };
 
   config = mkIf cfg.enable {
+    networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.port ];
+
     systemd.services.meme-bingo-web = {
       description = "A web app for playing meme bingos";
       wantedBy = [ "multi-user.target" ];
 
       environment = {
         MEME_BINGO_BASE = cfg.baseUrl;
+        MEME_BINGO_ADDRESS = cfg.address;
         MEME_BINGO_PORT = toString cfg.port;
       };
       path = [ cfg.package ];

--- a/nixos/modules/services/web-apps/meme-bingo-web.nix
+++ b/nixos/modules/services/web-apps/meme-bingo-web.nix
@@ -89,6 +89,9 @@ in
         InaccessiblePaths = [
           "/dev/shm"
           "/sys"
+          "/run/dbus"
+          "/run/user"
+          "/run/nscd"
         ];
         LockPersonality = true;
         PrivateDevices = true;
@@ -124,6 +127,8 @@ in
         RemoveIPC = true;
         NoNewPrivileges = true;
         MemoryDenyWriteExecute = true;
+        ExecPaths = [ "/nix/store" ];
+        NoExecPaths = [ "/" ];
       };
     };
   };

--- a/pkgs/by-name/me/meme-bingo-web/package.nix
+++ b/pkgs/by-name/me/meme-bingo-web/package.nix
@@ -8,14 +8,14 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "meme-bingo-web";
-  version = "1.1.0";
+  version = "1.2.0";
 
   src = fetchFromGitea {
     domain = "codeberg.org";
     owner = "annaaurora";
     repo = "meme-bingo-web";
     rev = "v${version}";
-    hash = "sha256-AKY0EjeoOnliRN3XSnlCgzCvnWOkZPQz/9QIcr8+hQM=";
+    hash = "sha256-0ahyyuihpwmAmaBwZv7lNmjuy8UsAm1a9XUhWcYq76w=";
   };
 
   useFetchCargoVendor = true;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Updated meme-bingo-web package and updated nixos module accordingly. the nixos module also has a some more hardening and a new convenience option (openFirewall).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
