### PR TITLE
waydroid: remove duplicate, broken d-bus service

### DIFF
--- a/pkgs/by-name/wa/waydroid/package.nix
+++ b/pkgs/by-name/wa/waydroid/package.nix
@@ -67,6 +67,11 @@ python3Packages.buildPythonApplication rec {
     "SYSCONFDIR=$(out)/etc"
   ];
 
+  postInstall = ''
+    # points to an invalid path and causes duplication with the d-bus service on NixOS
+    rm $out/share/dbus-1/system-services/id.waydro.Container.service
+  '';
+
   preFixup = ''
     makeWrapperArgs+=("''${gappsWrapperArgs[@]}")
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

_**Keeping this open for discussion on the approach.**_

Tracking issue: #303078

This prevents the message

```
dbus-broker-launch[953]: Ignoring duplicate name 'id.waydro.Container' in service file '/nix/store/pxnn1bq6sg4a9w15jn0paqibrahkmsxb-system-path/share/dbus-1/system-services/id.waydro.Container.service'
```

when using `dbus-broker`. (Note that `dbus-daemon` silently ignores such configuration issues, even though the underlying issue is still present.)

I feel most comfortable removing this file, because the contents are as follows:

```ini
[D-BUS Service]
Name=id.waydro.Container
Exec=/usr/bin/waydroid -w container start
User=root
SystemdService=waydroid-container.service
```

The `Exec` line points to an invalid path, and in any case, on NixOS we have some additional configuration that's added in that sets `Environment` and `UMask`.

https://github.com/NixOS/nixpkgs/blob/4f0dadbf38ee4cf4cc38cbc232b7708fddf965bc/nixos/modules/virtualisation/waydroid.nix#L58-L69

I'm open to trying the opposite approach of paring down the NixOS module's configuration, and patching the file in this package, if that makes more sense.

Also we may want to rename the container service as well to comply with the dbus guidelines that the service name should match the d-bus name.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
