### PR TITLE
lvm2: put the profile scripts into `etc/profile.d`

### DIFF
--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -24,6 +24,7 @@
   enableMultipath ? false,
   multipath-tools,
   nixosTests,
+  buildFHSEnv,
   recurseIntoAttrs,
 }:
 
@@ -183,6 +184,12 @@ stdenv.mkDerivation rec {
   passthru.tests = {
     installer = nixosTests.installer.lvm;
     lvm2 = recurseIntoAttrs nixosTests.lvm2;
+
+    # https://github.com/NixOS/nixpkgs/issues/369732
+    lvm2-fhs-env = buildFHSEnv {
+      name = "lvm2-fhs-env-test";
+      targetPkgs = p: [ p.lvm2 ];
+    };
   };
 
   meta = with lib; {

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -1,29 +1,39 @@
 { version, hash }:
 
-{ lib, stdenv
-, fetchurl
-, pkg-config
-, coreutils
-, libuuid
-, libaio
-, replaceVars
-, enableCmdlib ? false
-, enableDmeventd ? false
-, udevSupport ? !stdenv.hostPlatform.isStatic, udev
-, onlyLib ? stdenv.hostPlatform.isStatic
+{
+  lib,
+  stdenv,
+  fetchurl,
+  pkg-config,
+  coreutils,
+  libuuid,
+  libaio,
+  replaceVars,
+  enableCmdlib ? false,
+  enableDmeventd ? false,
+  udevSupport ? !stdenv.hostPlatform.isStatic,
+  udev,
+  onlyLib ? stdenv.hostPlatform.isStatic,
   # Otherwise we have a infinity recursion during static compilation
-, enableUtilLinux ? !stdenv.hostPlatform.isStatic, util-linux
-, enableVDO ? false, vdo
-, enableMdadm ? false, mdadm
-, enableMultipath ? false, multipath-tools
-, nixosTests
+  enableUtilLinux ? !stdenv.hostPlatform.isStatic,
+  util-linux,
+  enableVDO ? false,
+  vdo,
+  enableMdadm ? false,
+  mdadm,
+  enableMultipath ? false,
+  multipath-tools,
+  nixosTests,
 }:
 
 # configure: error: --enable-dmeventd requires --enable-cmdlib to be used as well
 assert enableDmeventd -> enableCmdlib;
 
 stdenv.mkDerivation rec {
-  pname = "lvm2" + lib.optionalString enableDmeventd "-with-dmeventd" + lib.optionalString enableVDO "-with-vdo";
+  pname =
+    "lvm2"
+    + lib.optionalString enableDmeventd "-with-dmeventd"
+    + lib.optionalString enableVDO "-with-vdo";
   inherit version;
 
   src = fetchurl {
@@ -35,44 +45,55 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    libaio
-  ] ++ lib.optionals udevSupport [
-    udev
-  ] ++ lib.optionals (!onlyLib) [
-    libuuid
-  ] ++ lib.optionals enableVDO [
-    vdo
-  ];
+  buildInputs =
+    [
+      libaio
+    ]
+    ++ lib.optionals udevSupport [
+      udev
+    ]
+    ++ lib.optionals (!onlyLib) [
+      libuuid
+    ]
+    ++ lib.optionals enableVDO [
+      vdo
+    ];
 
-  configureFlags = [
-    "--disable-readline"
-    "--enable-pkgconfig"
-    "--with-default-locking-dir=/run/lock/lvm"
-    "--with-default-run-dir=/run/lvm"
-    "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
-    "--with-systemd-run=/run/current-system/systemd/bin/systemd-run"
-  ] ++ lib.optionals (!enableCmdlib && !onlyLib) [
-    "--bindir=${placeholder "bin"}/bin"
-    "--sbindir=${placeholder "bin"}/bin"
-    "--libdir=${placeholder "lib"}/lib"
-    "--with-libexecdir=${placeholder "lib"}/libexec"
-  ] ++ lib.optional enableCmdlib "--enable-cmdlib"
-  ++ lib.optionals enableDmeventd [
-    "--enable-dmeventd"
-    "--with-dmeventd-pidfile=/run/dmeventd/pid"
-    "--with-default-dm-run-dir=/run/dmeventd"
-  ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
-    "ac_cv_func_malloc_0_nonnull=yes"
-    "ac_cv_func_realloc_0_nonnull=yes"
-  ] ++ lib.optionals udevSupport [
-    "--enable-udev_rules"
-    "--enable-udev_sync"
-  ] ++ lib.optionals enableVDO [
-    "--enable-vdo"
-  ] ++ lib.optionals stdenv.hostPlatform.isStatic [
-    "--enable-static_link"
-  ];
+  configureFlags =
+    [
+      "--disable-readline"
+      "--enable-pkgconfig"
+      "--with-default-locking-dir=/run/lock/lvm"
+      "--with-default-run-dir=/run/lvm"
+      "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+      "--with-systemd-run=/run/current-system/systemd/bin/systemd-run"
+    ]
+    ++ lib.optionals (!enableCmdlib && !onlyLib) [
+      "--bindir=${placeholder "bin"}/bin"
+      "--sbindir=${placeholder "bin"}/bin"
+      "--libdir=${placeholder "lib"}/lib"
+      "--with-libexecdir=${placeholder "lib"}/libexec"
+    ]
+    ++ lib.optional enableCmdlib "--enable-cmdlib"
+    ++ lib.optionals enableDmeventd [
+      "--enable-dmeventd"
+      "--with-dmeventd-pidfile=/run/dmeventd/pid"
+      "--with-default-dm-run-dir=/run/dmeventd"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      "ac_cv_func_malloc_0_nonnull=yes"
+      "ac_cv_func_realloc_0_nonnull=yes"
+    ]
+    ++ lib.optionals udevSupport [
+      "--enable-udev_rules"
+      "--enable-udev_sync"
+    ]
+    ++ lib.optionals enableVDO [
+      "--enable-vdo"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isStatic [
+      "--enable-static_link"
+    ];
 
   preConfigure = ''
     sed -i /DEFAULT_SYS_DIR/d Makefile.in
@@ -91,36 +112,47 @@ stdenv.mkDerivation rec {
 
   patches = [
     # fixes paths to and checks for tools
-    (replaceVars ./fix-blkdeactivate.patch (let
-      optionalTool = cond: pkg: if cond then pkg else "/run/current-system/sw";
-    in {
-      inherit coreutils;
-      util_linux = optionalTool enableUtilLinux util-linux;
-      mdadm = optionalTool enableMdadm mdadm;
-      multipath_tools = optionalTool enableMultipath multipath-tools;
-      vdo = optionalTool enableVDO vdo;
-      SBINDIR = null; # part of original source code in the patch's context
-    }))
+    (replaceVars ./fix-blkdeactivate.patch (
+      let
+        optionalTool = cond: pkg: if cond then pkg else "/run/current-system/sw";
+      in
+      {
+        inherit coreutils;
+        util_linux = optionalTool enableUtilLinux util-linux;
+        mdadm = optionalTool enableMdadm mdadm;
+        multipath_tools = optionalTool enableMultipath multipath-tools;
+        vdo = optionalTool enableVDO vdo;
+        SBINDIR = null; # part of original source code in the patch's context
+      }
+    ))
     ./fix-stdio-usage.patch
   ];
 
   doCheck = false; # requires root
 
-  makeFlags = lib.optionals udevSupport [
-    "SYSTEMD_GENERATOR_DIR=${placeholder "out"}/lib/systemd/system-generators"
-  ] ++ lib.optionals onlyLib [
-    "libdm.device-mapper"
-  ];
+  makeFlags =
+    lib.optionals udevSupport [
+      "SYSTEMD_GENERATOR_DIR=${placeholder "out"}/lib/systemd/system-generators"
+    ]
+    ++ lib.optionals onlyLib [
+      "libdm.device-mapper"
+    ];
 
   # To prevent make install from failing.
-  installFlags = [ "OWNER=" "GROUP=" "confdir=$(out)/etc" ];
+  installFlags = [
+    "OWNER="
+    "GROUP="
+    "confdir=$(out)/etc"
+  ];
 
   # Install systemd stuff.
-  installTargets = [ "install" ] ++ lib.optionals udevSupport [
-    "install_systemd_generators"
-    "install_systemd_units"
-    "install_tmpfiles_configuration"
-  ];
+  installTargets =
+    [ "install" ]
+    ++ lib.optionals udevSupport [
+      "install_systemd_generators"
+      "install_systemd_units"
+      "install_tmpfiles_configuration"
+    ];
 
   installPhase = lib.optionalString onlyLib ''
     make -C libdm install_${if stdenv.hostPlatform.isStatic then "static" else "dynamic"}
@@ -129,15 +161,18 @@ stdenv.mkDerivation rec {
   '';
 
   # only split bin and lib out from out if cmdlib isn't enabled
-  outputs = [
-    "out"
-  ] ++ lib.optionals (!onlyLib) [
-    "dev"
-    "man"
-  ] ++ lib.optionals (!onlyLib && !enableCmdlib) [
-    "bin"
-    "lib"
-  ];
+  outputs =
+    [
+      "out"
+    ]
+    ++ lib.optionals (!onlyLib) [
+      "dev"
+      "man"
+    ]
+    ++ lib.optionals (!onlyLib && !enableCmdlib) [
+      "bin"
+      "lib"
+    ];
 
   postInstall = lib.optionalString (enableCmdlib != true) ''
     moveToOutput lib/libdevmapper.so $lib
@@ -152,7 +187,14 @@ stdenv.mkDerivation rec {
     homepage = "http://sourceware.org/lvm2/";
     description = "Tools to support Logical Volume Management (LVM) on Linux";
     platforms = platforms.linux;
-    license = with licenses; [ gpl2Only bsd2 lgpl21 ];
-    maintainers = with maintainers; [ raskin ajs124 ];
+    license = with licenses; [
+      gpl2Only
+      bsd2
+      lgpl21
+    ];
+    maintainers = with maintainers; [
+      raskin
+      ajs124
+    ];
   };
 }

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation rec {
       "--with-default-run-dir=/run/lvm"
       "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
       "--with-systemd-run=/run/current-system/systemd/bin/systemd-run"
+      "--with-default-profile-subdir=profile.d"
     ]
     ++ lib.optionals (!enableCmdlib && !onlyLib) [
       "--bindir=${placeholder "bin"}/bin"

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -24,6 +24,7 @@
   enableMultipath ? false,
   multipath-tools,
   nixosTests,
+  recurseIntoAttrs,
 }:
 
 # configure: error: --enable-dmeventd requires --enable-cmdlib to be used as well
@@ -181,7 +182,7 @@ stdenv.mkDerivation rec {
 
   passthru.tests = {
     installer = nixosTests.installer.lvm;
-    lvm2 = nixosTests.lvm2;
+    lvm2 = recurseIntoAttrs nixosTests.lvm2;
   };
 
   meta = with lib; {


### PR DESCRIPTION
Motivation: #369732

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https:// github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
