### PR TITLE
dsniff: Unbreak by bumping 2.4b1+debian-30 -> 2.4b1+debian-34

### DIFF
--- a/pkgs/by-name/ds/dsniff/package.nix
+++ b/pkgs/by-name/ds/dsniff/package.nix
@@ -71,8 +71,8 @@ stdenv.mkDerivation rec {
     domain = "salsa.debian.org";
     owner = "pkg-security-team";
     repo = "dsniff";
-    rev = "debian/${version}+debian-30";
-    sha256 = "1fk2k0sfdp5g27i11g0sbzm7al52raz5yr1aibzssnysv7l9xgzh";
+    rev = "debian/${version}+debian-34";
+    sha256 = "sha256-CY0+G09KZXtAwKuaYh5/qcmZjuNhdGis3zCG14hWtqw=";
     name = "dsniff.tar.gz";
   };
 


### PR DESCRIPTION
dsniff is a collection of tools for network auditing and penetration testing.

Our current dsniff derivation does no longer build, with the following error message:

```
> ./urlsnarf.c: In function 'main':
       > ./urlsnarf.c:346:42: error: passing argument 3 of 'pcap_next_ex' from incompatible pointer type [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wincompatible-pointer-types-Wincompatible-pointer-types8;;]
       >   346 |         while ((rc = pcap_next_ex(p, &h, &d)) == 1) {
       >       |                                          ^~
       >       |                                          |
       >       |                                          u_char ** {aka unsigned char **}
       > In file included from /nix/store/r2gn5viprygwb938pksqivs5xbsh5bv1-libpcap-1.10.5/include/pcap.h:43,
       >                  from /nix/store/armsh6njg22aw7sgidglzi3hsylwsvnl-libnids-1.24/include/nids.h:14,
       >                  from ./urlsnarf.c:26:
       > /nix/store/r2gn5viprygwb938pksqivs5xbsh5bv1-libpcap-1.10.5/include/pcap/pcap.h:623:63: note: expected 'const u_char **' {aka 'const unsigned char **'} but argument is of type 'u_char **' {aka 'unsigned char **'}
       >   623 | PCAP_API int    pcap_next_ex(pcap_t *, struct pcap_pkthdr **, const u_char **);
       >       |                                                               ^~~~~~~~~~~~~~~
       > make: *** [Makefile:78: urlsnarf.o] Error 1
```

This pull request resolves this issue by bumping to the latest Debian patches, rendering dsniff compatible with modern pcap.

ref. #356812

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
