### PR TITLE
lib/cli: add wrappingValueString option to `toGNUCommandLineShell`

### DIFF
--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -137,6 +137,7 @@ rec {
         in
         if v == null then
           [ ]
+        # We need the option and its value in different list elements, to play nice with `lib.escapeShellArgs`
         else if optionValueSeparator == null then
           [
             (mkOptionName k)

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -84,6 +84,13 @@ rec {
     By default, there is no separator, so option `-c` and value `5` would become ["-c" "5"].
     This is useful if the command requires equals, for example, `-c=5`.
 
+    `wrappingValueString`
+
+    : The string to surround an option's value with.
+    Values aren't quoted by default, so option `foo` and value `bar` would become ["--foo bar"]
+    This is useful if your value could be misinterpreted by your shell without quoting.
+    For example, if you wanted a result of `["--foo \"bar\" "]`, you could set `wrappingValueString` to a literal quote.
+
     # Examples
     :::{.example}
     ## `lib.cli.toGNUCommandLine` usage example
@@ -120,21 +127,27 @@ rec {
 
       optionValueSeparator ? null,
 
+      wrappingValueString ? "",
+
       mkOption ?
         k: v:
+        let
+          surroundedString =
+            wrappingValueString + lib.generators.mkValueStringDefault { } v + wrappingValueString;
+        in
         if v == null then
           [ ]
         else if optionValueSeparator == null then
           [
             (mkOptionName k)
-            (lib.generators.mkValueStringDefault { } v)
+            surroundedString
           ]
         else
           [
             (lib.concatStrings [
               (mkOptionName k)
               optionValueSeparator
-              (lib.generators.mkValueStringDefault { } v)
+              surroundedString
             ])
           ],
     }:

--- a/lib/cli.nix
+++ b/lib/cli.nix
@@ -118,6 +118,8 @@ rec {
 
       mkList ? k: v: lib.concatMap (mkOption k) v,
 
+      optionValueSeparator ? null,
+
       mkOption ?
         k: v:
         if v == null then
@@ -128,9 +130,13 @@ rec {
             (lib.generators.mkValueStringDefault { } v)
           ]
         else
-          [ "${mkOptionName k}${optionValueSeparator}${lib.generators.mkValueStringDefault { } v}" ],
-
-      optionValueSeparator ? null,
+          [
+            (lib.concatStrings [
+              (mkOptionName k)
+              optionValueSeparator
+              (lib.generators.mkValueStringDefault { } v)
+            ])
+          ],
     }:
     options:
     let

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -1832,6 +1832,27 @@ runTests {
     ];
   };
 
+  testToGNUCommandLineWrapped = {
+    expr = cli.toGNUCommandLine { wrappingValueString = "\""; } {
+      data = builtins.toJSON { id = 0; };
+      X = "PUT";
+      retry = 3;
+      retry-delay = null;
+      url = [ "https://example.com/foo" "https://example.com/bar" ];
+      silent = false;
+      verbose = true;
+    };
+
+    expected = [
+      "-X" "\"PUT\""
+      "--data" "\"{\"id\":0}\""
+      "--retry" "\"3\""
+      "--url" "\"https://example.com/foo\""
+      "--url" "\"https://example.com/bar\""
+      "--verbose"
+    ];
+  };
+
   testToGNUCommandLineShell = {
     expr = cli.toGNUCommandLineShell {} {
       data = builtins.toJSON { id = 0; };


### PR DESCRIPTION
Closes #373291.
The function currently doesn't provide a way to create a result like `--foo "bar"` or `--foo="bar"`, where the argument is quoted. This new option resolves that. We set it to an empty string by default, so we can always interpolate it into the string, even if the user didn't set it.

Included in this PR is also a very small change to the original behavior. Now, the input `foo = "bar"` with `optionValueSeparator` unset will be transformed into `[ "--foo bar" ]`, instead of `[ "--foo" "bar" ]`. This resulted in cleaner code, and I think it's more intuitive anyways.

`nixpkgs-review` is running right now on my system as I write this. There could be some packages that rely on this buggy behavior as mentioned above. I'll add the results in a comment when it finishes.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
