### PR TITLE
mount-zip: 1.0.15 -> 1.6

### DIFF
--- a/pkgs/by-name/mo/mount-zip/package.nix
+++ b/pkgs/by-name/mo/mount-zip/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mount-zip";
-  version = "1.0.15";
+  version = "1.6";
 
   src = fetchFromGitHub {
     owner = "google";
     repo = "mount-zip";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-7S+mZ6jejD9wCqFYfJ0mE2jCKt77S64LEAgAIV2DPqA=";
+    hash = "sha256-akiZwuwrsj+62TmZEJamlvQ1rSyFA4hrH0TcZ8T97z4=";
   };
 
   strictDeps = true;
@@ -35,22 +35,23 @@ stdenv.mkDerivation (finalAttrs: {
     libzip
   ];
 
-  makeFlags = [ "prefix=$(out)" ];
+  makeFlags = [ "PREFIX=$(out)" ];
 
-  meta = with lib; {
+  meta = {
     description = "FUSE file system for ZIP archives";
     homepage = "https://github.com/google/mount-zip";
+    changelog = "https://github.com/google/mount-zip/releases/tag/v${finalAttrs.version}";
     longDescription = ''
       mount-zip is a tool allowing to open, explore and extract ZIP archives.
 
       This project is a fork of fuse-zip.
     '';
-    license = licenses.gpl3;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
       arti5an
       progrm_jarvis
     ];
-    platforms = platforms.linux;
+    platforms = lib.platforms.linux;
     mainProgram = "mount-zip";
   };
 })

--- a/pkgs/by-name/mo/mount-zip/package.nix
+++ b/pkgs/by-name/mo/mount-zip/package.nix
@@ -8,6 +8,8 @@
   libzip,
   pandoc,
   pkg-config,
+  versionCheckHook,
+  gitUpdater,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -36,6 +38,16 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeFlags = [ "PREFIX=$(out)" ];
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru = {
+    updateScript = gitUpdater { rev-prefix = "v"; };
+  };
 
   meta = {
     description = "FUSE file system for ZIP archives";

--- a/pkgs/by-name/mo/mount-zip/package.nix
+++ b/pkgs/by-name/mo/mount-zip/package.nix
@@ -46,7 +46,10 @@ stdenv.mkDerivation (finalAttrs: {
       This project is a fork of fuse-zip.
     '';
     license = licenses.gpl3;
-    maintainers = with maintainers; [ arti5an ];
+    maintainers = with maintainers; [
+      arti5an
+      progrm_jarvis
+    ];
     platforms = platforms.linux;
     mainProgram = "mount-zip";
   };


### PR DESCRIPTION

## Things done

* Updated `mount-zip` from `1.0.15` to `1.6`.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
