### PR TITLE
libcap: use correct cross golang cross compiler

### DIFF
--- a/pkgs/by-name/li/libcap/package.nix
+++ b/pkgs/by-name/li/libcap/package.nix
@@ -1,7 +1,8 @@
 { stdenv, lib, buildPackages, fetchurl, runtimeShell
+, pkgsBuildHost
 , usePam ? !isStatic, pam ? null
 , isStatic ? stdenv.hostPlatform.isStatic
-, withGo ? go.meta.available, go
+, withGo ? pkgsBuildHost.go.meta.available
 
 # passthru.tests
 , bind
@@ -35,7 +36,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = lib.optionals withGo [
-    go
+    pkgsBuildHost.go
   ];
 
   buildInputs = lib.optional usePam pam;
@@ -50,8 +51,8 @@ stdenv.mkDerivation rec {
     "GOLANG=yes"
     ''GOCACHE=''${TMPDIR}/go-cache''
     "GOFLAGS=-trimpath"
-    "GOARCH=${go.GOARCH}"
-    "GOOS=${go.GOOS}"
+    "GOARCH=${pkgsBuildHost.go.GOARCH}"
+    "GOOS=${pkgsBuildHost.go.GOOS}"
   ] ++ lib.optionals isStatic [ "SHARED=no" "LIBCSTATIC=yes" ];
 
   postPatch = ''
@@ -87,7 +88,7 @@ stdenv.mkDerivation rec {
   strictDeps = true;
 
   disallowedReferences = lib.optionals withGo [
-    go
+    pkgsBuildHost.go
   ];
 
   passthru.tests = {


### PR DESCRIPTION
Since we want the compiler to run at build time and produce stuff for the host platform I believe we want pkgsBuildHost. I observed some issues when building e.g. pkgsCross.whatever.buildPackages.openssh.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
