### PR TITLE
m4ri: do not autodetect some SIMD cpuflags

### DIFF
--- a/pkgs/by-name/m4/m4ri/package.nix
+++ b/pkgs/by-name/m4/m4ri/package.nix
@@ -19,6 +19,35 @@ stdenv.mkDerivation rec {
     hash = "sha256-untwo0go8O8zNO0EyZ4n/n7mngSXLr3Z/FSkXA8ptnU=";
   };
 
+  # based on the list in m4/m4_ax_ext.m4
+  configureFlags = builtins.map (s: "ax_cv_have_${s}_cpu_ext=no") (
+    [
+      "sha"
+      "xop"
+    ]
+    ++ lib.optional (!stdenv.hostPlatform.sse3Support) "sse3"
+    ++ lib.optional (!stdenv.hostPlatform.ssse3Support) "ssse3"
+    ++ lib.optional (!stdenv.hostPlatform.sse4_1Support) "sse41"
+    ++ lib.optional (!stdenv.hostPlatform.sse4_2Support) "sse42"
+    ++ lib.optional (!stdenv.hostPlatform.sse4_aSupport) "sse4a"
+    ++ lib.optional (!stdenv.hostPlatform.aesSupport) "aes"
+    ++ lib.optional (!stdenv.hostPlatform.avxSupport) "avx"
+    ++ lib.optional (!stdenv.hostPlatform.fmaSupport) "fma3"
+    ++ lib.optional (!stdenv.hostPlatform.fma4Support) "fma4"
+    ++ lib.optional (!stdenv.hostPlatform.avx2Support) "avx2"
+    ++ lib.optionals (!stdenv.hostPlatform.avx512Support) [
+      "avx512f"
+      "avx512cd"
+      "avx512pf"
+      "avx512er"
+      "avx512vl"
+      "avx512bw"
+      "avx512dq"
+      "avx512ifma"
+      "avx512vbmi"
+    ]
+  );
+
   doCheck = true;
 
   nativeBuildInputs = [


### PR DESCRIPTION
This is similar to the AVX troubles way back in #36437: The Hydra builder may have extra CPU extensions which aren't supposed to be used in the compiled binary. We disable autodetection for those by pre-filling the relevant variables used by `m4/m4_ax_ext.m4` to `no`, resulting in this output on x86_64:

<details>
<summary>Configure output on x86_64</summary>

```
checking for x86 cpuid  output... unknown
checking for x86-AVX xgetbv  output... unknown
checking for x86 cpuid 0x00000000 output... 10:68747541:444d4163:69746e65
checking for x86 cpuid 0x80000000 output... 80000020:68747541:444d4163:69746e65
checking for x86 cpuid 0x00000001 output... 860f01:80800:7ed8320b:178bfbff
checking for x86 cpuid 0x00000007 output... 0:219c91a9:400004:0
checking for x86 cpuid 0x80000001 output... 860f01:0:75c237ff:2fd3fbff
checking for x86-AVX xgetbv 0x00000000 output... 7:0
checking whether RDRND is supported by the processor... yes
checking whether RDRND is supported by the processor and OS... yes
checking whether C compiler accepts -mrdrnd... yes
checking whether BMI1 is supported by the processor... yes
checking whether BMI1 is supported by the processor and OS... yes
checking whether C compiler accepts -mbmi... yes
checking whether BMI2 is supported by the processor... yes
checking whether BMI2 is supported by the processor and OS... yes
checking whether C compiler accepts -mbmi2... yes
checking whether ADX is supported by the processor... yes
checking whether ADX is supported by the processor and OS... yes
checking whether C compiler accepts -madx... yes
checking whether MPX is supported by the processor... no
checking whether PREFETCHWT1 is supported by the processor... no
checking whether ABM is supported by the processor... yes
checking whether ABM is supported by the processor and OS... yes
checking whether C compiler accepts -mabm... yes
checking whether MMX is supported by the processor... yes
checking whether MMX is supported by the processor and OS... yes
checking whether C compiler accepts -mmmx... yes
checking whether SSE is supported by the processor... yes
checking whether SSE is supported by the processor and OS... yes
checking whether C compiler accepts -msse... yes
checking whether SSE2 is supported by the processor... yes
checking whether SSE2 is supported by the processor and OS... yes
checking whether C compiler accepts -msse2... yes
checking whether SSE3 is supported by the processor... (cached) no
checking whether SSSE3 is supported by the processor... (cached) no
checking whether SSE4.1 is supported by the processor... (cached) no
checking whether SSE4.2 is supported by the processor... (cached) no
checking whether SSE4a is supported by the processor... (cached) no
checking whether SHA is supported by the processor... (cached) no
checking whether AES is supported by the processor... (cached) no
checking whether AVX is supported by the processor... (cached) no
checking whether FMA3 is supported by the processor... (cached) no
checking whether FMA4 is supported by the processor... (cached) no
checking whether XOP is supported by the processor... (cached) no
checking whether AVX2 is supported by the processor... (cached) no
checking whether AVX512-F is supported by the processor... (cached) no
checking whether AVX512-CD is supported by the processor... (cached) no
checking whether AVX512-PF is supported by the processor... (cached) no
checking whether AVX512-ER is supported by the processor... (cached) no
checking whether AVX512-VL is supported by the processor... (cached) no
checking whether AVX512-BW is supported by the processor... (cached) no
checking whether AVX512-DQ is supported by the processor... (cached) no
checking whether AVX512-IFMA is supported by the processor... (cached) no
checking whether AVX512-VBMI is supported by the processor... (cached) no
```
</details>

cc @paparodeo (see also https://github.com/NixOS/nixpkgs/pull/370480#issuecomment-2585619244)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
