### PR TITLE
dvdauthor: fix cross build

### DIFF
--- a/pkgs/by-name/dv/dvdauthor/package.nix
+++ b/pkgs/by-name/dv/dvdauthor/package.nix
@@ -37,11 +37,18 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    libxml2 # xml2-config (only checked for, not used)
+  ];
+
+  # set *-config for cross builds
+  configureFlags = [
+    "FREETYPECONFIG=${lib.getExe' (lib.getDev freetype) "freetype-config"}"
+    "XML2_CONFIG=${lib.getExe' (lib.getDev libxml2) "xml2-config"}"
   ];
 
   meta = with lib; {
     description = "Tools for generating DVD files to be played on standalone DVD players";
-    homepage = "https://dvdauthor.sourceforge.net/";
+    homepage = "https://dvdauthor.sourceforge.net/"; # or https://github.com/ldo/dvdauthor
     license = licenses.gpl2;
     platforms = platforms.linux ++ platforms.darwin;
   };


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

Previous failing build log https://paste.fliegendewurst.eu/KBBD8b.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).