### PR TITLE
rerun: support `web_viewer` and `nasm` feature

### DIFF
--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -9,6 +9,7 @@
   pkg-config,
   protobuf,
   rustfmt,
+  nasm,
   # buildInputs
   freetype,
   glib,
@@ -48,6 +49,7 @@ rustPlatform.buildRustPackage rec {
   buildFeatures = [
     "native_viewer"
     "web_viewer"
+    "nasm"
   ];
 
   # When web_viewer is compiled, the wasm webviewer first needs to be built
@@ -77,6 +79,7 @@ rustPlatform.buildRustPackage rec {
     pkg-config
     protobuf
     rustfmt
+    nasm
   ];
 
   buildInputs = [

--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -57,17 +57,13 @@ rustPlatform.buildRustPackage rec {
   # The command is taken from https://github.com/rerun-io/rerun/blob/dd025f1384f9944d785d0fb75ca4ca1cd1792f17/pixi.toml#L198C72-L198C187
   # Note that cargoBuildFeatures reference what buildFeatures is set to in stdenv.mkDerivation,
   # so that user can easily create an overlay to set cargoBuildFeatures to what he needs
-  configurePhase = ''
-    runHook preConfigure
-
+  preBuild = ''
     if [[ " $cargoBuildFeatures " == *" web_viewer "* ]]; then
       echo "Building with web_viewer feature..."
       cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --release -g
     else
       echo "web_viewer feature not enabled, skipping web viewer build."
     fi
-
-    runHook postConfigure
   '';
 
   nativeBuildInputs = [

--- a/pkgs/by-name/re/rerun/package.nix
+++ b/pkgs/by-name/re/rerun/package.nix
@@ -22,6 +22,15 @@
   # passthru
   nix-update-script,
   python3Packages,
+  # Expose features to the user for the wasm web viewer build
+  # So he can easily override them
+  # We omit the "analytics" feature because it is opt-out and not opt-in.
+  # More information can be found in there README:
+  # https://raw.githubusercontent.com/rerun-io/rerun/5a9794990c4903c088ad77174e65eb2573162d97/crates/utils/re_analytics/README.md
+  buildWebViewerFeatures ? [
+    "grpc"
+    "map_view"
+  ],
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -52,6 +61,9 @@ rustPlatform.buildRustPackage rec {
     "nasm"
   ];
 
+  # Forward as a bash environment variable to the preBuild hook
+  inherit buildWebViewerFeatures;
+
   # When web_viewer is compiled, the wasm webviewer first needs to be built
   # If this doesn't exist, the build will fail. More information: https://github.com/rerun-io/rerun/issues/6028
   # The command is taken from https://github.com/rerun-io/rerun/blob/dd025f1384f9944d785d0fb75ca4ca1cd1792f17/pixi.toml#L198C72-L198C187
@@ -59,8 +71,18 @@ rustPlatform.buildRustPackage rec {
   # so that user can easily create an overlay to set cargoBuildFeatures to what he needs
   preBuild = ''
     if [[ " $cargoBuildFeatures " == *" web_viewer "* ]]; then
-      echo "Building with web_viewer feature..."
-      cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --release -g
+      # transform the environment variable that is a space separated list into a comma separated list
+      buildWebViewerFeatures=$(echo $buildWebViewerFeatures | tr ' ' ',')
+      # Create the features option only if there are features to pass
+      buildWebViewerFeaturesCargoOption=""
+      if [[ ! -z "$buildWebViewerFeatures" ]]; then
+        buildWebViewerFeaturesCargoOption="--features $buildWebViewerFeatures"
+        echo "Features passed to the web viewer build: $buildWebViewerFeatures"
+      else
+        echo "No features will be passed to the web viewer build"
+      fi
+      echo "Building the wasm web viewer for rerun's web_viewer feature"
+      cargo run -p re_dev_tools -- build-web-viewer --no-default-features $buildWebViewerFeaturesCargoOption --release -g
     else
       echo "web_viewer feature not enabled, skipping web viewer build."
     fi


### PR DESCRIPTION
When web_viewer is compiled, the wasm webviewer first needs to be built
If this doesn't exist, the build will fail. More information: https://github.com/rerun-io/rerun/issues/6028
The command is taken from https://github.com/rerun-io/rerun/blob/dd025f1384f9944d785d0fb75ca4ca1cd1792f17/pixi.toml#L198C72-L198C187
Note that cargoBuildFeatures reference what buildFeatures is set to in stdenv.mkDerivation,
so that user can easily create an overlay to set cargoBuildFeatures to what he needs.

This PR also introduce overwritable `buildWebViewerFeatures` that is an array of string:
```
buildWebViewerFeatures ? [
    "grpc"
    "map_view"
  ],
```

So you can control which features are used for the web viewer wasm build