### PR TITLE
vdrift: fix cross build, misc. cleanup

### DIFF
--- a/pkgs/by-name/vd/vdrift/package.nix
+++ b/pkgs/by-name/vd/vdrift/package.nix
@@ -34,6 +34,11 @@ let
       sha256 = "sha256-DrzRF4WzwEXCNALq0jz8nHWZ1oYTEsdrvSYVYI1WkTI=";
     };
 
+    postPatch = ''
+      substituteInPlace src/SConscript \
+        --replace-fail sdl2-config "${lib.getExe' (lib.getDev SDL2) "sdl2-config"}"
+    '';
+
     nativeBuildInputs = [
       pkg-config
       scons
@@ -54,16 +59,19 @@ let
     ];
 
     buildPhase = ''
-      sed -i -e s,/usr/local,$out, SConstruct
-      export CXXFLAGS="$(pkg-config --cflags SDL2_image)"
+      runHook preBuild
+      substituteInPlace SConstruct \
+        --replace-fail /usr/local "$out" \
+        --replace-fail pkg-config "${stdenv.cc.targetPrefix}pkg-config"
+      export CXXFLAGS="$(${stdenv.cc.targetPrefix}pkg-config --cflags SDL2_image)"
       scons -j$NIX_BUILD_CORES
+      runHook postBuild
     '';
-    installPhase = "scons install";
 
     meta = {
       description = "Car racing game";
       mainProgram = "vdrift";
-      homepage = "http://vdrift.net/";
+      homepage = "https://vdrift.net/";
       license = lib.licenses.gpl2Plus;
       maintainers = [ ];
       platforms = lib.platforms.linux;


### PR DESCRIPTION
Also fixes regular strictDeps, ref. #178468

Previously failed https://paste.fliegendewurst.eu/44mUid.log

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).