### PR TITLE
endless-sky: fix cross build

### DIFF
--- a/pkgs/by-name/en/endless-sky/package.nix
+++ b/pkgs/by-name/en/endless-sky/package.nix
@@ -41,13 +41,16 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
+  nativeBuildInputs = [
+    scons
+  ];
+
   buildInputs = [
     SDL2
     libpng
     libjpeg
     glew
     openal
-    scons
     libmad
     libuuid
   ];


### PR DESCRIPTION
Also fixes regular strictDeps build , ref. #178468

Previously failed https://paste.fliegendewurst.eu/-WqSWa.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).