### PR TITLE
goxel: 0.15.1 -> 0.15.1-unstable-2024-12-27

### DIFF
--- a/pkgs/by-name/go/goxel/package.nix
+++ b/pkgs/by-name/go/goxel/package.nix
@@ -12,13 +12,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "goxel";
-  version = "0.15.1";
+  version = "0.15.1-unstable-2024-12-27";
 
   src = fetchFromGitHub {
     owner = "guillaumechereau";
     repo = "goxel";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-mNSkQisWL3wXb+IsClWFTMbpeiRC4xteePXNP+GkUnU=";
+    rev = "60ec064a144295b17dfece85bb778dad19eaa8dc";
+    hash = "sha256-H5ErFfYsGmU2KsWJyUoozlrpf/JhgFimMxyFHt+czdg=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Fixes build error with GCC 14 https://paste.fliegendewurst.eu/s4myXd.log

ref. #356812

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).