### PR TITLE
klick: fix cross build

### DIFF
--- a/pkgs/by-name/kl/klick/package.nix
+++ b/pkgs/by-name/kl/klick/package.nix
@@ -25,16 +25,22 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     pkg-config
-    rubberband
     scons
   ];
   buildInputs = [
+    rubberband
     libsamplerate
     libsndfile
     liblo
     libjack2
     boost
   ];
+
+  preBuild = ''
+    substituteInPlace SConstruct \
+      --replace-fail 'pkg-config' "${stdenv.cc.targetPrefix}pkg-config"
+  '';
+
   prefixKey = "PREFIX=";
 
   meta = {


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

Previously failed https://paste.fliegendewurst.eu/yepvbd.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).