### PR TITLE
nixos/public-inbox: fix test by creating Gitolite repositories

### DIFF
--- a/nixos/tests/public-inbox.nix
+++ b/nixos/tests/public-inbox.nix
@@ -193,11 +193,11 @@ import ./make-test-python.nix (
       )
 
       # List inboxes through public-inbox-httpd
+      machine.wait_for_unit("public-inbox-httpd.socket")
       machine.wait_for_unit("nginx.service")
       machine.succeed("curl -L https://machine.${domain} | grep repo1@${domain}")
       # The repo2 inbox is hidden
       machine.fail("curl -L https://machine.${domain} | grep repo2@${domain}")
-      machine.wait_for_unit("public-inbox-httpd.service")
 
       # Send a mail and read it through public-inbox-httpd
       # Must work too when using a recipientDelimiter.
@@ -216,8 +216,7 @@ import ./make-test-python.nix (
       machine.succeed("curl -L 'https://machine.${domain}/inbox/repo1/repo1@root-1/T/#u' | grep 'This is a testing mail.'")
 
       # Read a mail through public-inbox-imapd
-      machine.wait_for_open_port(993)
-      machine.wait_for_unit("public-inbox-imapd.service")
+      machine.wait_for_unit("public-inbox-imapd.socket")
       machine.succeed("openssl s_client -ign_eof -crlf -connect machine.${domain}:993 <${pkgs.writeText "imap-commands" ''
         tag login anonymous@${domain} anonymous
         tag SELECT INBOX.comp.${orga}.repo1.0
@@ -226,8 +225,7 @@ import ./make-test-python.nix (
       ''} | grep '^Message-ID: <repo1@root-1>'")
 
       # TODO: Read a mail through public-inbox-nntpd
-      #machine.wait_for_open_port(563)
-      #machine.wait_for_unit("public-inbox-nntpd.service")
+      #machine.wait_for_unit("public-inbox-nntpd.socket")
 
       # Delete a mail.
       # Note that the use of an extension not listed in the addresses


### PR DESCRIPTION
Previously in https://github.com/NixOS/nixpkgs/pull/308740 `BindReadOnlyPaths=` was fixed, but remained mounting non-existing Git repositories:

> vm-test-run-public-inbox> machine # [   19.503051] (ox-httpd)[1489]:
> public-inbox-httpd.service: Failed to set up mount namespacing:
> /var/lib/gitolite/repositories/user/repo1.git: No such file or directory


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- [X] Create Git repositories (**without** using gitolite anymore).
- [X] Fix race condition between `curl` and `public-inbox-httpd.socket`

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

Ping @alyssais 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
