### PR TITLE
ci/request-reviews: request codeowners from parent folders

### DIFF
--- a/ci/request-reviews/default.nix
+++ b/ci/request-reviews/default.nix
@@ -3,7 +3,7 @@
   stdenvNoCC,
   makeWrapper,
   coreutils,
-  codeowners,
+  gnused,
   jq,
   curl,
   github-cli,
@@ -32,7 +32,7 @@ stdenvNoCC.mkDerivation {
         --set PATH ${
           lib.makeBinPath [
             coreutils
-            codeowners
+            gnused
             jq
             curl
             github-cli

--- a/ci/request-reviews/get-code-owners.sh
+++ b/ci/request-reviews/get-code-owners.sh
@@ -33,62 +33,70 @@ git -C "$gitRepo" show "$baseRef":"$ownersFile" > "$tmp"/codeowners
 # Make sure to always lowercase keys to avoid duplicates with different casings
 declare -A users=()
 
-for file in "${touchedFiles[@]}"; do
-    result=$(codeowners --file "$tmp"/codeowners "$file")
+for path in "${touchedFiles[@]}"; do
+    while true; do
+        result="$(grep -oP "(?<=^|/)\Q$file\E\s.*$" "$tmp"/codeowners || echo "$file (unowned)")"
 
-    # Remove the file prefix and trim the surrounding spaces
-    read -r owners <<< "${result#"$file"}"
-    if [[ "$owners" == "(unowned)" ]]; then
-        log "File $file is unowned"
-        continue
-    fi
-    log "File $file is owned by $owners"
-
-    # Split up multiple owners, separated by arbitrary amounts of spaces
-    IFS=" " read -r -a entries <<< "$owners"
-
-    for entry in "${entries[@]}"; do
-        # GitHub technically also supports Emails as code owners,
-        # but we can't easily support that, so let's not
-        if [[ ! "$entry" =~ @(.*) ]]; then
-            warn -e "\e[33mCodeowner \"$entry\" for file $file is not valid: Must start with \"@\"\e[0m" >&2
-            # Don't fail, because the PR for which this script runs can't fix it,
-            # it has to be fixed in the base branch
-            continue
-        fi
-        # The first regex match is everything after the @
-        entry=${BASH_REMATCH[1]}
-
-        if [[ "$entry" =~ (.*)/(.*) ]]; then
-            # Teams look like $org/$team
-            org=${BASH_REMATCH[1]}
-            team=${BASH_REMATCH[2]}
-
-            # Instead of requesting a review from the team itself,
-            # we request reviews from the individual users.
-            # This is because once somebody from a team reviewed the PR,
-            # the API doesn't expose that the team was already requested for a review,
-            # so we wouldn't be able to avoid rerequesting reviews
-            # without saving some some extra state somewhere
-
-            # We could also consider implementing a more advanced heuristic
-            # in the future that e.g. only pings one team member,
-            # but escalates to somebody else if that member doesn't respond in time.
-            gh api \
-                --cache=1h \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                "/orgs/$org/teams/$team/members" \
-                --jq '.[].login' > "$tmp/team-members"
-            readarray -t members < "$tmp/team-members"
-            log "Team $entry has these members: ${members[*]}"
-
-            for user in "${members[@]}"; do
-                users[${user,,}]=
-            done
+        # Remove the file prefix and trim the surrounding spaces
+        read -r owners <<< "${result#"$file"}"
+        if [[ "$owners" == "(unowned)" ]]; then
+            log "File $file is unowned"
         else
-            # Everything else is a user
-            users[${entry,,}]=
+            log "File $file is owned by $owners"
+
+            # Split up multiple owners, separated by arbitrary amounts of spaces
+            IFS=" " read -r -a entries <<< "$owners"
+
+            for entry in "${entries[@]}"; do
+                # GitHub technically also supports Emails as code owners,
+                # but we can't easily support that, so let's not
+                if [[ ! "$entry" =~ @(.*) ]]; then
+                    warn -e "\e[33mCodeowner \"$entry\" for file $file is not valid: Must start with \"@\"\e[0m" >&2
+                    # Don't fail, because the PR for which this script runs can't fix it,
+                    # it has to be fixed in the base branch
+                    continue
+                fi
+                # The first regex match is everything after the @
+                entry=${BASH_REMATCH[1]}
+
+                if [[ "$entry" =~ (.*)/(.*) ]]; then
+                    # Teams look like $org/$team
+                    org=${BASH_REMATCH[1]}
+                    team=${BASH_REMATCH[2]}
+
+                    # Instead of requesting a review from the team itself,
+                    # we request reviews from the individual users.
+                    # This is because once somebody from a team reviewed the PR,
+                    # the API doesn't expose that the team was already requested for a review,
+                    # so we wouldn't be able to avoid rerequesting reviews
+                    # without saving some some extra state somewhere
+
+                    # We could also consider implementing a more advanced heuristic
+                    # in the future that e.g. only pings one team member,
+                    # but escalates to somebody else if that member doesn't respond in time.
+                    gh api \
+                        --cache=1h \
+                        -H "Accept: application/vnd.github+json" \
+                        -H "X-GitHub-Api-Version: 2022-11-28" \
+                        "/orgs/$org/teams/$team/members" \
+                        --jq '.[].login' > "$tmp/team-members"
+                    readarray -t members < "$tmp/team-members"
+                    log "Team $entry has these members: ${members[*]}"
+
+                    for user in "${members[@]}"; do
+                        users[${user,,}]=
+                    done
+                else
+                    # Everything else is a user
+                    users[${entry,,}]=
+                fi
+            done
+        fi
+
+        # Check all parent paths, too.
+        file="$(dirname "$file")"
+        if [[ "$file" == "." ]]; then
+            break
         fi
     done
 

--- a/ci/request-reviews/get-code-owners.sh
+++ b/ci/request-reviews/get-code-owners.sh
@@ -35,14 +35,14 @@ declare -A users=()
 
 for path in "${touchedFiles[@]}"; do
     while true; do
-        result="$(grep -oP "(?<=^|/)\Q$file\E\s.*$" "$tmp"/codeowners || echo "$file (unowned)")"
+        result="$(grep -oP "(?<=^|/)\Q$path\E\s.*$" "$tmp"/codeowners || echo "$path (unowned)")"
 
-        # Remove the file prefix and trim the surrounding spaces
-        read -r owners <<< "${result#"$file"}"
+        # Remove the path prefix and trim the surrounding spaces
+        read -r owners <<< "${result#"$path"}"
         if [[ "$owners" == "(unowned)" ]]; then
-            log "File $file is unowned"
+            log "Path $path is unowned"
         else
-            log "File $file is owned by $owners"
+            log "Path $path is owned by $owners"
 
             # Split up multiple owners, separated by arbitrary amounts of spaces
             IFS=" " read -r -a entries <<< "$owners"
@@ -51,7 +51,7 @@ for path in "${touchedFiles[@]}"; do
                 # GitHub technically also supports Emails as code owners,
                 # but we can't easily support that, so let's not
                 if [[ ! "$entry" =~ @(.*) ]]; then
-                    warn -e "\e[33mCodeowner \"$entry\" for file $file is not valid: Must start with \"@\"\e[0m" >&2
+                    echo -e "\e[33mCodeowner \"$entry\" for path $path is not valid: Must start with \"@\"\e[0m" >&2
                     # Don't fail, because the PR for which this script runs can't fix it,
                     # it has to be fixed in the base branch
                     continue
@@ -94,8 +94,8 @@ for path in "${touchedFiles[@]}"; do
         fi
 
         # Check all parent paths, too.
-        file="$(dirname "$file")"
-        if [[ "$file" == "." ]]; then
+        path="$(dirname "$path")"
+        if [[ "$path" == "." ]]; then
             break
         fi
     done


### PR DESCRIPTION
As discussed in https://github.com/NixOS/nixpkgs/pull/360286#pullrequestreview-2547347632.

To check codeowners for the codeowners-v2.yml workflow file, run this:

```
ci/request-reviews/get-code-owners.sh . ci/OWNERS 973017d9{~1,}
```

Before this PR:
```
This PR touches 1 files
File .github/workflows/codeowners-v2.yml is owned by @infinisil
infinisil
```

After:

```
This PR touches 1 files
Path .github/workflows/codeowners-v2.yml is owned by @infinisil
Path .github/workflows is owned by @NixOS/Security @Mic92 @zowoq @infinisil @azuwis
Team NixOS/Security has these members: mweinelt LeSuisse risicle
Path .github is unowned
mic92
risicle
lesuisse
zowoq
mweinelt
azuwis
infinisil
```

Unfortunately, the `codeowners` binary only returns a single line, not the parent lines. Thus we resort to grepping the OWNERS file ourselves. Not pretty, but works.

Lots of whitespace noise, review with whitespace changes invisible.

## Things done

- [x] Tested basic functionality
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
