### PR TITLE
jellyseerr: revert to original config directory (/var/lib/jellyseerr)

### DIFF
--- a/nixos/modules/services/misc/jellyseerr.nix
+++ b/nixos/modules/services/misc/jellyseerr.nix
@@ -23,7 +23,7 @@ in
 
     configDir = lib.mkOption {
       type = lib.types.path;
-      default = "/var/lib/jellyseerr/config";
+      default = "/var/lib/jellyseerr";
       description = "Config data directory";
     };
   };


### PR DESCRIPTION
Recent change moved default config directory to `/var/lib/jellyseerr/config`. This sets it back to `/var/lib/jellyseerr`.

fixes #372423

