### PR TITLE
code-cursor: add aarch64-linux

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -9,21 +9,32 @@
 let
   pname = "cursor";
   version = "0.44.11";
-  appKey = "230313mzl4w4u92";
-  src = fetchurl {
-    url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.11-build-250103fqxdt5u9z-x86_64.AppImage";
-    hash = "sha256-eOZuofnpED9F6wic0S9m933Tb7Gq7cb/v0kRDltvFVg=";
+
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.11-build-250103fqxdt5u9z-x86_64.AppImage";
+      hash = "sha256-eOZuofnpED9F6wic0S9m933Tb7Gq7cb/v0kRDltvFVg=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.11-build-250103fqxdt5u9z-arm64.AppImage";
+      hash = "sha256-mxq7tQJfDccE0QsZDZbaFUKO0Xc141N00ntX3oEYRcc=";
+    };
   };
-  appimageContents = appimageTools.extractType2 { inherit version pname src; };
-in
-stdenvNoCC.mkDerivation {
-  inherit pname version;
 
-  src = appimageTools.wrapType2 { inherit version pname src; };
+  supportedPlatforms = [
+    "x86_64-linux"
+    "aarch64-linux"
+  ];
 
-  nativeBuildInputs = [ makeWrapper ];
+  src = sources.${stdenvNoCC.hostPlatform.system};
 
-  installPhase = ''
+  appimageContents = appimageTools.extractType2 {
+    inherit version pname src;
+  };
+
+  wrappedAppImage = appimageTools.wrapType2 { inherit version pname src; };
+
+  appimageInstall = ''
     runHook preInstall
 
     mkdir -p $out/
@@ -43,21 +54,47 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = writeScript "update.sh" ''
-    #!/usr/bin/env nix-shell
-    #!nix-shell -i bash -p curl yq coreutils gnused common-updater-scripts
-    set -eu -o pipefail
-    latestLinux="$(curl -s https://download.todesktop.com/${appKey}/latest-linux.yml)"
-    version="$(echo "$latestLinux" | yq -r .version)"
-    filename="$(echo "$latestLinux" | yq -r '.files[] | .url | select(. | endswith(".AppImage"))')"
-    url="https://download.todesktop.com/${appKey}/$filename"
-    currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version;
 
-    if [[ "$version" != "$currentVersion" ]]; then
-      hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$url")")
-      update-source-version code-cursor "$version" "$hash" "$url" --source-key=src.src
-    fi
-  '';
+  src = wrappedAppImage;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = appimageInstall;
+
+  passthru = {
+    inherit sources;
+    updateScript = writeScript "update.sh" ''
+      #!/usr/bin/env nix-shell
+      #!nix-shell -i bash -p curl yq coreutils gnused common-updater-scripts
+      set -eu -o pipefail
+      baseUrl="https://download.todesktop.com/230313mzl4w4u92"
+      latestLinux="$(curl -s $baseUrl/latest-linux.yml)"
+      version="$(echo "$latestLinux" | yq -r .version)"
+      filename="$(echo "$latestLinux" | yq -r '.files[] | .url | select(. | endswith(".AppImage"))')"
+      linuxStem="$(echo "$filename" | sed -E s/^\(cursor-.+-build-.*\)-.+$/\\1/)"
+
+      currentVersion=$(nix-instantiate --eval -E "with import ./. {}; code-cursor.version or (lib.getVersion code-cursor)" | tr -d '"')
+
+      if [[ "$version" != "$currentVersion" ]]; then
+        for platform in ${lib.escapeShellArgs supportedPlatforms}; do
+          if [ $platform = "x86_64-linux" ]; then
+            url="$baseUrl/$linuxStem-x86_64.AppImage"
+          elif [ $platform = "aarch64-linux" ]; then
+            url="$baseUrl/$linuxStem-arm64.AppImage"
+          else
+            echo "Unsupported platform: $platform"
+            exit 1
+          fi
+
+          hash=$(nix-hash --to-sri --type sha256 "$(nix-prefetch-url "$url")")
+          update-source-version code-cursor $version $hash $url --system=$platform --ignore-same-version --source-key="sources.$platform"
+        done
+      fi
+    '';
+  };
 
   meta = {
     description = "AI-powered code editor built on vscode";
@@ -66,7 +103,7 @@ stdenvNoCC.mkDerivation {
     license = lib.licenses.unfree;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
     maintainers = with lib.maintainers; [ sarahec ];
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.platforms.linux;
     mainProgram = "cursor";
   };
 }


### PR DESCRIPTION
## Changes

1. Added aarch64-linux to supported platforms
2. Altered `update.sh` to collect new platform
3. Refactored the AppImage packaging step into a function
4. Refactored the AppImage install step into a function

This will facilitate adding Darwin in #373494 

## Tests

1. Confirmed update.sh works for both linux platforms
2. Confirmed that x86_64-linux builds the same binary as before the change

## For reviewers

1. Please confirm that aarch64-linux builds. Note: This is an unfree package.
2. The unusual structure (defining the input source to the derivation and the install phase in the upper `let` block) is so we can add Darwin installation easily. Darwin uses a different file format (.dmg disk images) and will need its own repack and install phases. We can assign these conditionally to `src` and `installPhase` based on platform class. 
 