### PR TITLE
treewide: directly pass cargoRoot to fetcher

### DIFF
--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -605,8 +605,8 @@ In some projects, the Rust crate is not in the main Python source
 directory.  In such cases, the `cargoRoot` attribute can be used to
 specify the crate's directory relative to `sourceRoot`. In the
 following example, the crate is in `src/rust`, as specified in the
-`cargoRoot` attribute. Note that we also need to specify the correct
-path for `fetchCargoVendor`.
+`cargoRoot` attribute. Note that we also need to pass in `cargoRoot`
+to `fetchCargoVendor`.
 
 ```nix
 {
@@ -627,8 +627,12 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    sourceRoot = "${pname}-${version}/${cargoRoot}";
+    inherit
+      pname
+      version
+      src
+      cargoRoot
+      ;
     hash = "sha256-ctUt8maCjnGddKPf+Ii++wKsAXA1h+JM6zKQNXXwJqQ=";
   };
 

--- a/pkgs/applications/misc/openbangla-keyboard/default.nix
+++ b/pkgs/applications/misc/openbangla-keyboard/default.nix
@@ -62,11 +62,7 @@ stdenv.mkDerivation rec {
     ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    postPatch = ''
-      cp ${./Cargo.lock} Cargo.lock
-    '';
-    sourceRoot = "${src.name}/${cargoRoot}";
+    inherit src cargoRoot postPatch;
     hash = "sha256-qZMTZi7eqEp5kSmVx7qdS7eDKOzSv9fMjWT0h/MGyeY=";
   };
 

--- a/pkgs/applications/science/electronics/librepcb/default.nix
+++ b/pkgs/applications/science/electronics/librepcb/default.nix
@@ -42,8 +42,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ qtbase ];
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit src;
-    sourceRoot = "source/${cargoRoot}";
+    inherit src cargoRoot;
     hash = "sha256-1td3WjxbDq2lX7c0trpYRhO82ChNAG/ZABBRsekYtq4=";
   };
 

--- a/pkgs/by-name/cc/ccextractor/package.nix
+++ b/pkgs/by-name/cc/ccextractor/package.nix
@@ -49,10 +49,8 @@ stdenv.mkDerivation (finalAttrs: {
   cargoRoot = "src/rust";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
+    inherit (finalAttrs) src cargoRoot;
     patches = [ ./use-rsmpeg-0.15.patch ];
-    patchFlags = [ "-p3" ];
     hash = "sha256-7v3gQghByUDWZLJRRGa/7X2ivUumirq6BbexNQcCXCk=";
   };
 

--- a/pkgs/by-name/op/opengamepadui/package.nix
+++ b/pkgs/by-name/op/opengamepadui/package.nix
@@ -35,8 +35,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    sourceRoot = "source/${finalAttrs.cargoRoot}";
+    inherit (finalAttrs) src cargoRoot;
     hash = "sha256-T79G2bShJuFRfaCqG3IDHqW0s68yAdGyv58kdDYg6kg=";
   };
   cargoRoot = "extensions";

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -60,8 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) src;
-    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
+    inherit (finalAttrs) src cargoRoot;
     hash = "sha256-Su9ZOPIskV5poeS8pgtri+sZANBpdgnuCsQqE4WKFdA=";
   };
 

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -36,8 +36,12 @@ stdenv.mkDerivation (finalAttrs: {
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit (finalAttrs) pname version src;
-    sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      cargoRoot
+      ;
     hash = "sha256-MmdvEutdkX98DgX1aVuxs4gabuMX5aM8yC4eqgvd8Q4=";
   };
 

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -216,8 +216,7 @@ let
           cargoDeps =
             if yjitSupport then
               rustPlatform.fetchCargoVendor {
-                inherit (finalAttrs) src;
-                sourceRoot = "${finalAttrs.pname}-${version}/${finalAttrs.cargoRoot}";
+                inherit (finalAttrs) src cargoRoot;
                 hash =
                   assert cargoHash != null;
                   cargoHash;

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -33,8 +33,12 @@ buildPythonPackage rec {
 
   cargoRoot = "src/_bcrypt";
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    sourceRoot = "${pname}-${version}/${cargoRoot}";
+    inherit
+      pname
+      version
+      src
+      cargoRoot
+      ;
     hash = "sha256-HgHvfMBspPsSYhllnKBg5XZB6zxFIqJj+4//xKG8HwA=";
   };
 

--- a/pkgs/development/python-modules/biliass/default.nix
+++ b/pkgs/development/python-modules/biliass/default.nix
@@ -28,8 +28,9 @@ buildPythonPackage rec {
       pname
       version
       src
+      sourceRoot
+      cargoRoot
       ;
-    sourceRoot = "${sourceRoot}/${cargoRoot}";
     hash = "sha256-tkHl6z0En+od//fCGJXK/p8Dz5KDOXltHrXhxHmHL6U=";
   };
 

--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -33,8 +33,12 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    sourceRoot = "${src.name}/${cargoRoot}";
+    inherit
+      pname
+      version
+      src
+      cargoRoot
+      ;
     hash = "sha256-K8hug7JeLPIvrqgVaONKfixu8XRvn+pnqS0fHV+nTqg=";
   };
 

--- a/pkgs/development/python-modules/temporalio/default.nix
+++ b/pkgs/development/python-modules/temporalio/default.nix
@@ -33,8 +33,12 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    sourceRoot = "${src.name}/${cargoRoot}";
+    inherit
+      pname
+      version
+      src
+      cargoRoot
+      ;
     hash = "sha256-9hP+zN6jcRmRhPmcZ4Zgp61IeS7gDPfsOvweAxKHnHM=";
   };
 

--- a/pkgs/kde/gear/akonadi-search/default.nix
+++ b/pkgs/kde/gear/akonadi-search/default.nix
@@ -14,9 +14,8 @@ mkKdeDerivation rec {
   cargoRoot = "agent/rs/htmlparser";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version;
+    inherit pname version cargoRoot;
     src = sources.${pname};
-    sourceRoot = "${pname}-${version}/${cargoRoot}";
     hash = "sha256-hdm4LfQcs4TTfBLzlZYJ0uzqfLxMXuYQExLGJg81W2U=";
   };
 

--- a/pkgs/kde/gear/kdepim-addons/default.nix
+++ b/pkgs/kde/gear/kdepim-addons/default.nix
@@ -17,9 +17,8 @@ mkKdeDerivation rec {
   cargoRoot = "plugins/webengineurlinterceptor/adblock";
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version;
+    inherit pname version cargoRoot;
     src = sources.${pname};
-    sourceRoot = "${pname}-${version}/${cargoRoot}";
     hash = "sha256-66FqoD3JoPbtg6zc32uaPYaTo4zHxywiN8wPI2jtcjc=";
   };
 

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -243,8 +243,12 @@ let
           };
           cargoRoot = "src/_bcrypt";
           cargoDeps = rustPlatform.fetchCargoVendor {
-            inherit pname version src;
-            sourceRoot = "${pname}-${version}/${cargoRoot}";
+            inherit
+              pname
+              version
+              src
+              cargoRoot
+              ;
             hash = "sha256-8PyCgh/rUO8uynzGdgylAsb5k55dP9fCnf40UOTCR/M=";
           };
         });

--- a/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
+++ b/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
@@ -42,8 +42,12 @@ buildPythonPackage rec {
   };
 
   cargoDeps = rustPlatform.fetchCargoVendor {
-    inherit pname version src;
-    sourceRoot = "${pname}-${version}/${cargoRoot}";
+    inherit
+      pname
+      version
+      src
+      cargoRoot
+      ;
     hash = "sha256-pZHu3Oo9DWRAtldU0UvrH1FIg0bEvyfizPUhj9IBL58=";
   };
 


### PR DESCRIPTION
Followup to https://github.com/NixOS/nixpkgs/pull/350541

You can run the following to test that it actually still can re-generate the FODs.

```
nix build .#{ccextractor,ibus-engines.openbangla-keyboard,kdePackages.akonadi-search,kdePackages.kdepim-addons,librepcb,opengamepadui,python313Packages.bcrypt,python313Packages.biliass,python313Packages.libcst,python313Packages.temporalio,ruby,surrealist,wealthfolio}.cargoDeps.vendorStaging --rebuild
```

(I have left out `ceph`'s inner derivations from this command because they are not exposed directly)

Note: I have split this PR into separate commits in case some parts need backporting.

Question: should the docs follow the formatting rules, or can it stay in a format that's more readable (single-line)?
*Edit: was answered in comments*

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
