### PR TITLE
OWNERS: Change ownership of pkgs-lib

### DIFF
--- a/ci/OWNERS
+++ b/ci/OWNERS
@@ -60,10 +60,9 @@
 /pkgs/build-support/setup-hooks                  @Ericson2314
 /pkgs/build-support/setup-hooks/auto-patchelf.sh @layus
 /pkgs/by-name/au/auto-patchelf                   @layus
-/pkgs/pkgs-lib                                   @infinisil
+
 ## Format generators/serializers
-/pkgs/pkgs-lib/formats/libconfig                 @h7x4
-/pkgs/pkgs-lib/formats/hocon                     @h7x4
+/pkgs/pkgs-lib                                   @Stunkymonkey @h7x4
 
 # Nixpkgs build-support
 /pkgs/build-support/writers @lassulus @Profpatsch


### PR DESCRIPTION
I'd like to pass off maintainership of `pkgs-lib` and therefore `pkgs.formats` to others, so that I can focus on other things. There aren't a lot of PRs for that part of the code, but it adds up.

Here I'm proposing @Stunkymonkey and @h7x4 based on past engagement, let me know if you're okay with that!

Overall I recommend following the [lib PR guidelines](https://github.com/NixOS/nixpkgs/tree/master/lib#pr-guidelines) for maintenance. Note that:
- The [docs](https://nixos.org/manual/nixos/stable/#sec-settings-nix-representable) are easy to forget to update since they're far away from the code (ideally that would be improved).
- Make sure that formats only have `generate`, `type` and optionally `lib` as defined in the docs.

And you're always welcome to ask me if you're unsure about something.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
