### PR TITLE
deepdwn: init at 0.41.0

### DIFF
--- a/pkgs/by-name/de/deepdwn/package.nix
+++ b/pkgs/by-name/de/deepdwn/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  requireFile,
+  appimageTools,
+}:
+
+let
+  pname = "deepdwn";
+  version = source.version;
+
+  source = lib.importJSON ./source.json;
+
+  src = requireFile {
+    name = "Deepdwn-${version}.AppImage";
+    hash = source.hash;
+    url = "https://www.deepdwn.com/";
+  };
+
+  appimageContents = appimageTools.extractType2 {
+    inherit pname version src;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/deepdwn.desktop $out/share/applications/deepdwn.desktop
+    install -m 444 -D ${appimageContents}/deepdwn.png $out/share/icons/hicolor/512x512/apps/deepdwn.png
+    substituteInPlace $out/share/applications/deepdwn.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=deepdwn'
+  '';
+
+  passthru.updateScript = ./update.sh;
+
+  meta = {
+    description = "Markdown editor and organizer for Windows, Mac and Linux";
+    homepage = "https://www.deepdwn.com/";
+    downloadPage = "https://billiam.itch.io/deepdwn";
+    license = lib.licenses.unfree;
+    maintainers = with lib.maintainers; [ ymstnt ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "deepdwn";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/de/deepdwn/source.json
+++ b/pkgs/by-name/de/deepdwn/source.json
@@ -1,0 +1,4 @@
+{
+  "version": "0.41.0",
+  "hash": "sha256-kMv8GDOFuqjkNyehkj/onKJgbWKc4WuHAMeBM/xzWDQ="
+}

--- a/pkgs/by-name/de/deepdwn/update.sh
+++ b/pkgs/by-name/de/deepdwn/update.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env nix-shell
+#!nix-shell --pure -i bash -p nix jq
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+package=(~/.config/itch/apps/deepdwn/Deepdwn-*.AppImage)
+
+if [ ! -e "${package[0]}" ]; then
+  echo "No matching file found.";
+  exit 1
+fi
+
+hash=$(nix hash file --type sha256 --sri "${package[0]}")
+filename=$(basename "${package[0]}")
+version="${filename#Deepdwn-}"
+version="${version%.AppImage}"
+
+jq -n "{version: \"$version\", hash: \"$hash\"}" > source.json
+
+nix-store --add-fixed sha256 "${package[0]}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Deepdwn is a proprietary Markdown editor and organizer for Windows, Mac and Linux.
Homepage: https://www.deepdwn.com/

It is a paid app, so this package only provides the necessary build instructions and not the program itself, the user needs to supply their own AppImage, which can be purchased here: https://billiam.itch.io/deepdwn

I've also made an updater script which can be run locally and expects the program's AppImage to be downloaded from Itch (`pkgs.itch`) to the default path given.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
