### PR TITLE
gitui: refactor, add `passthru.updateScript`, 0.26.3 -> 0.27.0

### DIFF
--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -9,10 +9,12 @@
   xclip,
   darwin,
 }:
-
-rustPlatform.buildRustPackage rec {
+let
   pname = "gitui";
   version = "0.26.3";
+in
+rustPlatform.buildRustPackage {
+  inherit pname version;
 
   src = fetchFromGitHub {
     owner = "extrawurst";
@@ -55,11 +57,11 @@ rustPlatform.buildRustPackage rec {
   ];
 
   meta = {
+    changelog = "https://github.com/extrawurst/gitui/blob/v${version}/CHANGELOG.md";
     description = "Blazing fast terminal-ui for Git written in Rust";
     homepage = "https://github.com/extrawurst/gitui";
-    changelog = "https://github.com/extrawurst/gitui/blob/v${version}/CHANGELOG.md";
-    mainProgram = "gitui";
     license = lib.licenses.mit;
+    mainProgram = "gitui";
     maintainers = with lib.maintainers; [
       Br1ght0ne
       yanganto

--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -6,13 +6,14 @@
   libiconv,
   openssl,
   pkg-config,
+  cmake,
   xclip,
   darwin,
   nix-update-script,
 }:
 let
   pname = "gitui";
-  version = "0.26.3";
+  version = "0.27.0";
 in
 rustPlatform.buildRustPackage {
   inherit pname version;
@@ -21,12 +22,15 @@ rustPlatform.buildRustPackage {
     owner = "extrawurst";
     repo = "gitui";
     rev = "v${version}";
-    hash = "sha256-j3y+KjC+o9p2omf4bN8+XevwU7WqiaQ0sfPqHySD2ik=";
+    hash = "sha256-jKJ1XnF6S7clyFGN2o3bHnYpC4ckl/lNXscmf6GRLbI=";
   };
 
-  cargoHash = "sha256-vVEo0kSghOQsH3T6ZTAzN7gIUku0n7rDbKwNmOM9GZc=";
+  cargoHash = "sha256-T00TqxR2EWnDkZo3MUQhiG0oAUf1PgpkUMZLt7f4FH0=";
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    pkg-config
+    cmake
+  ];
 
   buildInputs =
     [ openssl ]
@@ -57,9 +61,7 @@ rustPlatform.buildRustPackage {
     "--skip=keys::key_config::tests::test_symbolic_links"
   ];
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [ "--version=unstable" ];
-  };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     changelog = "https://github.com/extrawurst/gitui/blob/v${version}/CHANGELOG.md";

--- a/pkgs/by-name/gi/gitui/package.nix
+++ b/pkgs/by-name/gi/gitui/package.nix
@@ -8,6 +8,7 @@
   pkg-config,
   xclip,
   darwin,
+  nix-update-script,
 }:
 let
   pname = "gitui";
@@ -55,6 +56,10 @@ rustPlatform.buildRustPackage {
   checkFlags = [
     "--skip=keys::key_config::tests::test_symbolic_links"
   ];
+
+  passthru.updateScript = nix-update-script {
+    extraArgs = [ "--version=unstable" ];
+  };
 
   meta = {
     changelog = "https://github.com/extrawurst/gitui/blob/v${version}/CHANGELOG.md";


### PR DESCRIPTION
# Breaking Changes

- use default shell instead of bash on Unix-like OS [@yerke](https://github.com/yerke) (https://github.com/extrawurst/gitui/pull/2343)

----

Changelog: https://github.com/extrawurst/gitui/releases/tag/v0.27.0-rc.1
Diff: https://github.com/extrawurst/gitui/compare/v0.26.3...v0.27.0-rc.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
