### PR TITLE
jsc: init at unstable-2026-02-19

### DIFF
--- a/pkgs/by-name/js/jsc/package.nix
+++ b/pkgs/by-name/js/jsc/package.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  clangStdenv,
+  autoPatchelfHook,
+  fetchgit,
+  cmakeMinimal,
+  ninja,
+  icu,
+  perl,
+  ruby,
+  python3,
+  rsync,
+  enableStatic ? clangStdenv.hostPlatform.isStatic,
+}:
+
+clangStdenv.mkDerivation {
+  pname = "javascriptcore";
+  version = "unstable-2026-02-19";
+
+  src = fetchgit {
+    url = "https://github.com/WebKit/WebKit";
+    rev = "e2639ef69577f28d66dc711233148970ba221657";
+    hash = "sha256-J54SZ2uKWaXPJp2A8RATGzg2FgqDlZ0zoM8mmaxXY+c=";
+    deepClone = false;
+    fetchSubmodules = false;
+  };
+
+  nativeBuildInputs = [
+    cmakeMinimal
+    ninja
+    perl
+    ruby
+    python3
+    rsync
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    icu
+  ];
+
+  cmakeFlags = [
+    "-GNinja"
+    "-DPORT=JSCOnly"
+    "-DENABLE_C_LOOP=OFF"
+    "-DUSE_SYSTEM_MALLOC=ON"
+    "-DENABLE_C_LOOP=OFF"
+    "-DDEVELOPER_MODE=ON"
+    "-DENABLE_API_TESTS=ON"
+    "-DCMAKE_SKIP_BUILD_RPATH=ON"
+    (lib.cmakeBool "ENABLE_STATIC_JSC" enableStatic)
+  ];
+
+  # WebKit doesn't have a CMake install target
+  installPhase = ''
+    mkdir -p $out/{bin,lib,include}
+
+    # 1. Copy all headers from Source/JavaScriptCore while preserving directory structure
+    # This will create $out/include/Source/JavaScriptCore/...
+    find ../Source/JavaScriptCore -name "*.h" -exec cp --parents {} $out/include/ \;
+
+    # 2. Move them to the standard include path and clean up the extra nesting
+    mv $out/include/../Source/JavaScriptCore $out/include/JavaScriptCore
+    rm -rf $out/include/../Source
+
+    # 3. Copy WTF and bmalloc (straightforward paths)
+    cp -r ../Source/WTF/wtf $out/include/
+    mkdir -p $out/include/bmalloc
+    cp -r ../Source/bmalloc/bmalloc/*.h $out/include/bmalloc/
+
+    # 4. Copy Generated/Derived headers (InternalPromise, etc. live here)
+    # These are usually in the build directory, not the source directory
+    cp -r JavaScriptCore/DerivedSources/*.h $out/include/JavaScriptCore/ 2>/dev/null || true
+
+    # 5. Binaries and Libraries
+    cp bin/jsc $out/bin/
+    cp lib/libJavaScriptCore* $out/lib/
+  '';
+
+  meta = {
+    description = "The built-in JavaScript engine for WebKit, which implements ECMAScript as in ECMA-262 specification.";
+    homepage = "https://docs.webkit.org/Deep%20Dive/JSC/JavaScriptCore.html";
+    license = [
+      lib.licenses.lgpl2Plus
+      lib.licenses.bsd2
+    ];
+    maintainers = [ lib.maintainers.theoparis ];
+    platforms = lib.platforms.all;
+    mainProgram = "jsc";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

1. Webkit doesn't have releases or tags (not for JSC either), it only seems to have tags for the full GTK port. Please let me know if this should be pulled from one of the tags instead of using an unstable version.
2. WebKit doesn't have CMake install targets so you can't install all of the headers for JSC, and it doesn't come with pkg-config files either. It would be great to fix this upstream but for now I've added rsync commands. See https://bugs.webkit.org/show_bug.cgi?id=272010
3. The JSC tests currently need the vendored libgtest.so to be found at runtime. Even after building gtest as a static library the tests fail.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
