### PR TITLE
nixos/minidlna: add options for user and group

### DIFF
--- a/nixos/modules/services/networking/minidlna.nix
+++ b/nixos/modules/services/networking/minidlna.nix
@@ -6,6 +6,8 @@ let
   cfg = config.services.minidlna;
   settingsFormat = pkgs.formats.keyValue { listsAsDuplicateKeys = true; };
   settingsFile = settingsFormat.generate "minidlna.conf" cfg.settings;
+  defaultUser = "minidlna";
+  defaultGroup = defaultUser;
 in
 
 {
@@ -107,6 +109,20 @@ in
     };
   };
 
+  options.services.minidlna.user = mkOption {
+    type = types.str;
+    default = defaultUser;
+    example = "yourUser";
+    description = "Overrides the default user used to run MiniDLNA.  Skips the creation of the default `${defaultUser}` user.";
+  };
+
+  options.services.minidlna.group = mkOption {
+    type = types.str;
+    default = defaultGroup;
+    example = "yourGroup";
+    description = "Overrides the default group used to run MiniDLNA.  Skips the creation of the default `${defaultGroup}` group.";
+  };
+
   imports = [
     (mkRemovedOptionModule [ "services" "minidlna" "config" ] "")
     (mkRemovedOptionModule [ "services" "minidlna" "extraConfig" ] "")
@@ -122,13 +138,18 @@ in
     networking.firewall.allowedTCPPorts = mkIf cfg.openFirewall [ cfg.settings.port ];
     networking.firewall.allowedUDPPorts = mkIf cfg.openFirewall [ 1900 ];
 
-    users.users.minidlna = {
-      description = "MiniDLNA daemon user";
-      group = "minidlna";
-      uid = config.ids.uids.minidlna;
-    };
+    users.users = mkIf (cfg.user == defaultUser) {
+      ${defaultUser} =
+        { group = cfg.group;
+          uid = config.ids.uids.minidlna;
+          description = "MiniDLNA daemon user";
+        };
+     };
 
-    users.groups.minidlna.gid = config.ids.gids.minidlna;
+    users.groups = mkIf (cfg.group == defaultGroup) {
+      ${defaultGroup}.gid =
+        config.ids.gids.minidlna;
+    };
 
     systemd.services.minidlna = {
       description = "MiniDLNA Server";
@@ -136,8 +157,8 @@ in
       after = [ "network.target" ];
 
       serviceConfig = {
-        User = "minidlna";
-        Group = "minidlna";
+        User = cfg.user;
+        Group = cfg.group;
         CacheDirectory = "minidlna";
         RuntimeDirectory = "minidlna";
         PIDFile = "/run/minidlna/pid";


### PR DESCRIPTION
###### Description of changes

This adds configuration options to specify the user/group to use for
running the MiniDLNA daemon.

The default `minidlna` user/group will not be created when a different
user/group is specified.

###### Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- Tested on NixOS (x86_64-linux) via `nixos-rebuild -I path/to/nixpkgs`
    - [x] Using the default `minidlna` user/group
    - [x] Using a custom user/group