### PR TITLE
ocamlPackages.bigstringaf: 0.9.0 -> 0.10.0

### DIFF
--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -4,23 +4,25 @@
   buildDunePackage,
   alcotest,
   pkg-config,
+  dune-configurator,
 }:
 
 buildDunePackage rec {
   pname = "bigstringaf";
-  version = "0.9.0";
+  version = "0.10.0";
 
   minimalOCamlVersion = "4.08";
-  duneVersion = "3";
 
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = pname;
     rev = version;
-    hash = "sha256-HXPjnE56auy2MI6HV2XuBX/VeqsO50HFzTul17lKEqE=";
+    hash = "sha256-p1hdB3ArOd2UX7S6YvXCFbYjEiXdMDmBaC/lFQgua7Q=";
   };
 
   nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
+
   checkInputs = [ alcotest ];
   doCheck = true;
 

--- a/pkgs/development/ocaml-modules/bigstringaf/default.nix
+++ b/pkgs/development/ocaml-modules/bigstringaf/default.nix
@@ -16,7 +16,7 @@ buildDunePackage rec {
   src = fetchFromGitHub {
     owner = "inhabitedtype";
     repo = pname;
-    rev = version;
+    tag = version;
     hash = "sha256-p1hdB3ArOd2UX7S6YvXCFbYjEiXdMDmBaC/lFQgua7Q=";
   };
 
@@ -28,6 +28,18 @@ buildDunePackage rec {
 
   meta = {
     description = "Bigstring intrinsics and fast blits based on memcpy/memmove";
+    longDescription = ''
+      Bigstring intrinsics and fast blits based on memcpy/memmove
+
+      The OCaml compiler has a bunch of intrinsics for Bigstrings, but they're not
+      widely-known, sometimes misused, and so programs that use Bigstrings are slower
+      than they have to be. And even if a library got that part right and exposed the
+      intrinsics properly, the compiler doesn't have any fast blits between
+      Bigstrings and other string-like types.
+
+      So here they are. Go crazy.
+    '';
+    changelog = "https://github.com/inhabitedtype/bigstringaf/releases/tag/${version}";
     license = lib.licenses.bsd3;
     maintainers = [ lib.maintainers.vbgl ];
     inherit (src.meta) homepage;


### PR DESCRIPTION
Changelog: https://github.com/inhabitedtype/bigstringaf/releases/tag/0.10.0
Diff: https://github.com/inhabitedtype/bigstringaf/compare/0.9.0...0.10.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
