### PR TITLE
treewide: replace substituteAll with replaceVars (part 2)

### DIFF
--- a/pkgs/applications/audio/espeak-ng/default.nix
+++ b/pkgs/applications/audio/espeak-ng/default.nix
@@ -9,7 +9,7 @@
   libtool,
   pkg-config,
   ronn,
-  substituteAll,
+  replaceVars,
   buildPackages,
   mbrolaSupport ? true,
   mbrola,
@@ -45,8 +45,7 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals mbrolaSupport [
       # Hardcode correct mbrola paths.
-      (substituteAll {
-        src = ./mbrola.patch;
+      (replaceVars ./mbrola.patch {
         inherit mbrola;
       })
     ];

--- a/pkgs/applications/display-managers/lightdm/default.nix
+++ b/pkgs/applications/display-managers/lightdm/default.nix
@@ -4,7 +4,7 @@
   buildPackages,
   fetchFromGitHub,
   nix-update-script,
-  substituteAll,
+  replaceVars,
   plymouth,
   pam,
   pkg-config,
@@ -85,8 +85,7 @@ stdenv.mkDerivation rec {
     # Hardcode plymouth to fix transitions.
     # For some reason it can't find `plymouth`
     # even when it's in PATH in environment.systemPackages.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       plymouth = "${plymouth}/bin/plymouth";
     })
   ];

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/codeium/default.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/codeium/default.nix
@@ -3,7 +3,7 @@
   codeium,
   fetchFromGitHub,
   melpaBuild,
-  substituteAll,
+  replaceVars,
   gitUpdater,
 }:
 
@@ -19,8 +19,7 @@ melpaBuild {
   };
 
   patches = [
-    (substituteAll {
-      src = ./0000-set-codeium-command-executable.patch;
+    (replaceVars ./0000-set-codeium-command-executable.patch {
       codeium = lib.getExe' codeium "codeium_language_server";
     })
   ];

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -11,7 +11,6 @@
   fetchurl,
   neovimUtils,
   replaceVars,
-  substituteAll,
   # Language dependencies
   fetchYarnDeps,
   mkYarnModules,
@@ -181,8 +180,7 @@ in
 
   aw-watcher-vim = super.aw-watcher-vim.overrideAttrs {
     patches = [
-      (substituteAll {
-        src = ./patches/aw-watcher-vim/program_paths.patch;
+      (replaceVars ./patches/aw-watcher-vim/program_paths.patch {
         curl = lib.getExe curl;
       })
     ];
@@ -1096,8 +1094,7 @@ in
     super.fruzzy.overrideAttrs (old: {
       buildInputs = [ nim1 ];
       patches = [
-        (substituteAll {
-          src = ./patches/fruzzy/get_version.patch;
+        (replaceVars ./patches/fruzzy/get_version.patch {
           inherit (old) version;
         })
       ];
@@ -1236,8 +1233,7 @@ in
 
   gx-nvim = super.gx-nvim.overrideAttrs {
     patches = lib.optionals stdenv.hostPlatform.isLinux [
-      (substituteAll {
-        src = ./patches/gx-nvim/fix-paths.patch;
+      (replaceVars ./patches/gx-nvim/fix-paths.patch {
         inherit xdg-utils;
       })
     ];
@@ -1523,10 +1519,7 @@ in
     # https://github.com/NixOS/nixpkgs/pull/105810#issuecomment-740007985
     # https://github.com/camspiers/lens.vim/pull/40/files
     patches = [
-      (substituteAll {
-        src = ./patches/lens-vim/remove_duplicate_g_lens_animate.patch;
-        inherit languagetool;
-      })
+      ./patches/lens-vim/remove_duplicate_g_lens_animate.patch
     ];
   };
 
@@ -1655,8 +1648,7 @@ in
     in
     super.markdown-preview-nvim.overrideAttrs {
       patches = [
-        (substituteAll {
-          src = ./markdown-preview-nvim/fix-node-paths.patch;
+        (replaceVars ./markdown-preview-nvim/fix-node-paths.patch {
           node = "${nodejs}/bin/node";
         })
       ];
@@ -2566,8 +2558,7 @@ in
       "openscad.utilities"
     ];
     patches = [
-      (substituteAll {
-        src = ./patches/openscad.nvim/program_paths.patch;
+      (replaceVars ./patches/openscad.nvim/program_paths.patch {
         htop = lib.getExe htop;
         openscad = lib.getExe openscad;
         zathura = lib.getExe zathura;
@@ -2676,8 +2667,7 @@ in
 
   Preview-nvim = super.Preview-nvim.overrideAttrs {
     patches = [
-      (substituteAll {
-        src = ./patches/preview-nvim/hardcode-mdt-binary-path.patch;
+      (replaceVars ./patches/preview-nvim/hardcode-mdt-binary-path.patch {
         mdt = lib.getExe md-tui;
       })
     ];
@@ -3521,8 +3511,7 @@ in
     #   let g:grammarous#show_first_error = 1
     # see https://github.com/rhysd/vim-grammarous/issues/39
     patches = [
-      (substituteAll {
-        src = ./patches/vim-grammarous/set_default_languagetool.patch;
+      (replaceVars ./patches/vim-grammarous/set_default_languagetool.patch {
         inherit languagetool;
       })
     ];

--- a/pkgs/applications/emulators/wine/packages.nix
+++ b/pkgs/applications/emulators/wine/packages.nix
@@ -5,7 +5,7 @@
   pkgsi686Linux,
   pkgsCross,
   callPackage,
-  substituteAll,
+  replaceVars,
   moltenvk,
   wineRelease ? "stable",
   supportFlags,
@@ -80,8 +80,7 @@ with src;
       mingwW64.buildPackages.gcc
     ];
     monos = [ mono ];
-    buildScript = substituteAll {
-      src = ./builder-wow.sh;
+    buildScript = replaceVars ./builder-wow.sh {
       # pkgconfig has trouble picking the right architecture
       pkgconfig64remove = lib.makeSearchPathOutput "dev" "lib/pkgconfig" [
         pkgs.glib

--- a/pkgs/applications/graphics/gimp/default.nix
+++ b/pkgs/applications/graphics/gimp/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchurl,
-  substituteAll,
+  replaceVars,
   autoreconfHook,
   pkg-config,
   intltool,
@@ -74,8 +74,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # to remove compiler from the runtime closure, reference was retained via
     # gimp --version --verbose output
-    (substituteAll {
-      src = ./remove-cc-reference.patch;
+    (replaceVars ./remove-cc-reference.patch {
       cc_version = stdenv.cc.cc.name;
     })
 

--- a/pkgs/applications/graphics/inkscape/default.nix
+++ b/pkgs/applications/graphics/inkscape/default.nix
@@ -41,7 +41,7 @@
 , potrace
 , python3
 , runCommand
-, substituteAll
+, replaceVars
 , wrapGAppsHook3
 , libepoxy
 , zlib
@@ -92,15 +92,13 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/inkscape/inkscape/-/commit/eb6dadcf1a5c660167ba43f3606c8e7cc6529787.patch";
       hash = "sha256-FvbJV/YrBwhHg0kFdbhyd/Y9g7YV2nPIrRqZt7yJ50Q=";
     })
-    (substituteAll {
-      src = ./fix-python-paths.patch;
+    (replaceVars ./fix-python-paths.patch {
       # Python is used at run-time to execute scripts,
       # e.g., those from the "Effects" menu.
       python3 = lib.getExe python3Env;
     })
-    (substituteAll {
+    (replaceVars ./fix-ps2pdf-path.patch {
       # Fix path to ps2pdf binary
-      src = ./fix-ps2pdf-path.patch;
       inherit ghostscript;
     })
   ];

--- a/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
+++ b/pkgs/applications/graphics/inkscape/extensions/textext/default.nix
@@ -2,7 +2,7 @@
   lib,
   writeScript,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   inkscape,
   pdflatex,
   lualatex,
@@ -33,8 +33,7 @@ python3.pkgs.buildPythonApplication rec {
   patches = [
     # Make sure we can point directly to pdflatex in the extension,
     # instead of relying on the PATH (which might not have it)
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit pdflatex lualatex;
     })
 

--- a/pkgs/applications/virtualization/virtualbox/default.nix
+++ b/pkgs/applications/virtualization/virtualbox/default.nix
@@ -38,7 +38,7 @@
   libvpx,
   nettools,
   dbus,
-  substituteAll,
+  replaceVars,
   gsoap,
   zlib,
   xz,
@@ -235,10 +235,11 @@ stdenv.mkDerivation (finalAttrs: {
     # these issues by patching the code to set QT_PLUGIN_PATH to the necessary paths,
     # after the code that unsets it. Note that qtsvg is included so that SVG icons from
     # the user's icon theme can be loaded.
-    ++ optional (!headless && enableHardening) (substituteAll {
-      src = ./qt-env-vars.patch;
-      qtPluginPath = "${qtbase}/bin/${qtbase.qtPluginPrefix}:${qtsvg}/bin/${qtbase.qtPluginPrefix}:${qtwayland}/bin/${qtbase.qtPluginPrefix}";
-    })
+    ++ optional (!headless && enableHardening) (
+      replaceVars ./qt-env-vars.patch {
+        qtPluginPath = "${qtbase}/bin/${qtbase.qtPluginPrefix}:${qtsvg}/bin/${qtbase.qtPluginPrefix}:${qtwayland}/bin/${qtbase.qtPluginPrefix}";
+      }
+    )
     # While the KVM patch should not break any other behavior if --with-kvm is not specified,
     # we don't take any chances and only apply it if people actually want to use KVM support.
     ++ optional enableKvm (

--- a/pkgs/build-support/mitm-cache/default.nix
+++ b/pkgs/build-support/mitm-cache/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   callPackage,
   rustPlatform,
-  substituteAll,
+  replaceVars,
   openssl,
   Security,
   python3Packages,
@@ -27,8 +27,7 @@ rustPlatform.buildRustPackage rec {
 
   cargoHash = "sha256-6eYOSSlswJGR2IrFo17qVnwI+h2FkyTjLFvwf62nG2c=";
 
-  setupHook = substituteAll {
-    src = ./setup-hook.sh;
+  setupHook = replaceVars ./setup-hook.sh {
     inherit openssl;
     ephemeral_port_reserve = python3Packages.ephemeral-port-reserve;
   };

--- a/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
+++ b/pkgs/desktops/deepin/go-package/dde-daemon/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   buildGoModule,
   pkg-config,
   deepin-gettext-tools,
@@ -48,12 +48,10 @@ buildGoModule rec {
 
   patches = [
     ./0001-dont-set-PATH.diff
-    (substituteAll {
-      src = ./0002-fix-custom-wallpapers-path.diff;
+    (replaceVars ./0002-fix-custom-wallpapers-path.diff {
       inherit coreutils;
     })
-    (substituteAll {
-      src = ./0003-aviod-use-hardcode-path.diff;
+    (replaceVars ./0003-aviod-use-hardcode-path.diff {
       inherit dbus;
     })
   ];

--- a/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
+++ b/pkgs/desktops/gnome/extensions/EasyScreenCast/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   glib,
   gnome-shell,
   gettext,
@@ -22,8 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-gi-path.patch;
+    (replaceVars ./fix-gi-path.patch {
       gnomeShell = gnome-shell;
     })
   ];

--- a/pkgs/desktops/gnome/extensions/arcmenu/default.nix
+++ b/pkgs/desktops/gnome/extensions/arcmenu/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitLab,
   glib,
   gettext,
-  substituteAll,
+  replaceVars,
   gnome-menus,
 }:
 
@@ -20,8 +20,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix_gmenu.patch;
+    (replaceVars ./fix_gmenu.patch {
       gmenu_path = "${gnome-menus}/lib/girepository-1.0";
     })
   ];

--- a/pkgs/desktops/gnome/extensions/drop-down-terminal/default.nix
+++ b/pkgs/desktops/gnome/extensions/drop-down-terminal/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   gjs,
   vte,
   gnome,
@@ -25,8 +25,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix_vte_and_gjs.patch;
+    (replaceVars ./fix_vte_and_gjs.patch {
       inherit gjs vte;
     })
   ];

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -17,7 +17,7 @@
 , nvme-cli
 , procps
 , smartmontools
-, substituteAll
+, replaceVars
 , touchegg
 , util-linux
 , vte
@@ -72,8 +72,7 @@ super: lib.trivial.pipe super [
   (patchExtension "eepresetselector@ulville.github.io" (old: {
     patches = [
       # Needed to find the currently set preset
-      (substituteAll {
-        src = ./extensionOverridesPatches/eepresetselector_at_ulville.github.io.patch;
+      (replaceVars ./extensionOverridesPatches/eepresetselector_at_ulville.github.io.patch {
         easyeffects_gsettings_path = "${glib.getSchemaPath easyeffects}";
       })
     ];
@@ -81,8 +80,7 @@ super: lib.trivial.pipe super [
 
   (patchExtension "freon@UshakovVasilii_Github.yahoo.com" (old: {
     patches = [
-      (substituteAll {
-        src = ./extensionOverridesPatches/freon_at_UshakovVasilii_Github.yahoo.com.patch;
+      (replaceVars ./extensionOverridesPatches/freon_at_UshakovVasilii_Github.yahoo.com.patch {
         inherit hddtemp liquidctl lm_sensors procps smartmontools;
         netcat = netcat-gnu;
         nvmecli = nvme-cli;
@@ -103,11 +101,10 @@ super: lib.trivial.pipe super [
   (patchExtension "gtk4-ding@smedius.gitlab.com" (old: {
     nativeBuildInputs = [ wrapGAppsHook3 ];
     patches = [
-      (substituteAll {
+      (replaceVars ./extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch {
         inherit gjs;
         util_linux = util-linux;
         xdg_utils = xdg-utils;
-        src = ./extensionOverridesPatches/gtk4-ding_at_smedius.gitlab.com.patch;
         nautilus_gsettings_path = "${glib.getSchemaPath nautilus}";
       })
     ];
@@ -129,8 +126,7 @@ super: lib.trivial.pipe super [
 
   (patchExtension "system-monitor@gnome-shell-extensions.gcampax.github.com" (old: {
     patches = [
-      (substituteAll {
-        src = ./extensionOverridesPatches/system-monitor_at_gnome-shell-extensions.gcampax.github.com.patch;
+      (replaceVars ./extensionOverridesPatches/system-monitor_at_gnome-shell-extensions.gcampax.github.com.patch {
         gtop_path = "${libgtop}/lib/girepository-1.0";
       })
     ];
@@ -138,8 +134,7 @@ super: lib.trivial.pipe super [
 
   (patchExtension "system-monitor-next@paradoxxx.zero.gmail.com" (old: {
     patches = [
-      (substituteAll {
-        src = ./extensionOverridesPatches/system-monitor-next_at_paradoxxx.zero.gmail.com.patch;
+      (replaceVars ./extensionOverridesPatches/system-monitor-next_at_paradoxxx.zero.gmail.com.patch {
         gtop_path = "${libgtop}/lib/girepository-1.0";
       })
     ];
@@ -148,8 +143,7 @@ super: lib.trivial.pipe super [
 
   (patchExtension "Vitals@CoreCoding.com" (old: {
     patches = [
-      (substituteAll {
-        src = ./extensionOverridesPatches/vitals_at_corecoding.com.patch;
+      (replaceVars ./extensionOverridesPatches/vitals_at_corecoding.com.patch {
         gtop_path = "${libgtop}/lib/girepository-1.0";
       })
     ];

--- a/pkgs/desktops/gnome/extensions/no-title-bar/default.nix
+++ b/pkgs/desktops/gnome/extensions/no-title-bar/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   glib,
   gettext,
   xorg,
@@ -25,8 +25,7 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       xprop = "${xorg.xprop}/bin/xprop";
       xwininfo = "${xorg.xwininfo}/bin/xwininfo";
     })

--- a/pkgs/desktops/gnome/extensions/sound-output-device-chooser/default.nix
+++ b/pkgs/desktops/gnome/extensions/sound-output-device-chooser/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   fetchFromGitHub,
   libpulseaudio,
   python3,
@@ -21,8 +21,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Fix paths to libpulse and python
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       libpulse = "${libpulseaudio}/lib/libpulse.so";
       python = python3.interpreter;
     })

--- a/pkgs/desktops/lomiri/applications/lomiri/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri/default.nix
@@ -6,7 +6,7 @@
   fetchpatch2,
   gitUpdater,
   linkFarm,
-  substituteAll,
+  replaceVars,
   nixosTests,
   ayatana-indicator-datetime,
   bash,
@@ -117,8 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     ./9901-lomiri-Disable-Wizard.patch
-    (substituteAll {
-      src = ./9902-Layout-fallback-file.patch;
+    (replaceVars ./9902-Layout-fallback-file.patch {
       nixosLayoutFile = "/etc/" + finalAttrs.finalPackage.passthru.etcLayoutsFile;
     })
   ];

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/datetime/default.nix
@@ -5,7 +5,7 @@
   nix-update-script,
   meson,
   ninja,
-  substituteAll,
+  replaceVars,
   pkg-config,
   vala,
   libadwaita,
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       tzdata = tzdata;
     })
   ];

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/keyboard/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , nix-update-script
-, substituteAll
+, replaceVars
 , meson
 , ninja
 , pkg-config
@@ -37,8 +37,7 @@ stdenv.mkDerivation rec {
     # https://github.com/elementary/switchboard-plug-keyboard/issues/324
     ./hide-install-unlisted-engines-button.patch
 
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit onboard libgnomekbd;
     })
   ];

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/mouse-touchpad/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   pkg-config,
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       touchegg = touchegg;
     })
   ];

--- a/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
+++ b/pkgs/desktops/pantheon/apps/switchboard-plugs/network/default.nix
@@ -6,7 +6,7 @@
   meson,
   ninja,
   pkg-config,
-  substituteAll,
+  replaceVars,
   vala,
   libadwaita,
   libgee,
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit networkmanagerapplet;
     })
   ];

--- a/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-greeter/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , nix-update-script
 , linkFarm
-, substituteAll
+, replaceVars
 , elementary-greeter
 , pkg-config
 , meson
@@ -43,8 +43,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./sysconfdir-install.patch
     # Needed until https://github.com/elementary/greeter/issues/360 is fixed
-    (substituteAll {
-      src = ./hardcode-fallback-background.patch;
+    (replaceVars ./hardcode-fallback-background.patch {
       default_wallpaper = "${nixos-artwork.wallpapers.simple-dark-gray.gnomeFilePath}";
     })
   ];

--- a/pkgs/desktops/pantheon/desktop/file-roller-contract/default.nix
+++ b/pkgs/desktops/pantheon/desktop/file-roller-contract/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   unstableGitUpdater,
-  substituteAll,
+  replaceVars,
   file-roller,
 }:
 
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./exec-path.patch;
+    (replaceVars ./exec-path.patch {
       file_roller = file-roller;
     })
   ];

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/applications-menu/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchFromGitHub
 , nix-update-script
-, substituteAll
+, replaceVars
 , meson
 , ninja
 , pkg-config
@@ -32,8 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       bc = "${bc}/bin/bc";
     })
   ];

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/datetime/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nix-update-script,
-  substituteAll,
+  replaceVars,
   pkg-config,
   meson,
   ninja,
@@ -32,8 +32,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       elementary_calendar = elementary-calendar;
     })
   ];

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/keyboard/default.nix
@@ -6,7 +6,7 @@
   pkg-config,
   meson,
   ninja,
-  substituteAll,
+  replaceVars,
   vala,
   gtk3,
   granite,
@@ -30,8 +30,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       gkbd_keyboard_display = "${libgnomekbd}/bin/gkbd-keyboard-display";
     })
   ];

--- a/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
+++ b/pkgs/desktops/pantheon/desktop/wingpanel-indicators/power/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   nix-update-script,
   gnome-power-manager,
   pkg-config,
@@ -31,8 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       gnome_power_manager = gnome-power-manager;
     })
   ];

--- a/pkgs/desktops/plasma-5/plasma-nm/default.nix
+++ b/pkgs/desktops/plasma-5/plasma-nm/default.nix
@@ -1,6 +1,6 @@
 {
   mkDerivation,
-  substituteAll,
+  replaceVars,
   extra-cmake-modules,
   kdoctools,
   kcmutils,
@@ -75,8 +75,7 @@ mkDerivation {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./0002-openvpn-binary-path.patch;
+    (replaceVars ./0002-openvpn-binary-path.patch {
       inherit openvpn;
     })
   ];

--- a/pkgs/kde/gear/audiocd-kio/default.nix
+++ b/pkgs/kde/gear/audiocd-kio/default.nix
@@ -5,7 +5,7 @@
   flac,
   libogg,
   libvorbis,
-  substituteAll,
+  replaceVars,
   lame,
   opusTools,
 }:
@@ -13,8 +13,7 @@ mkKdeDerivation {
   pname = "audiocd-kio";
 
   patches = [
-    (substituteAll {
-      src = ./encoder-paths.patch;
+    (replaceVars ./encoder-paths.patch {
       lame = lib.getExe lame;
       opusenc = "${opusTools}/bin/opusenc";
     })

--- a/pkgs/kde/gear/kdeconnect-kde/default.nix
+++ b/pkgs/kde/gear/kdeconnect-kde/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   mkKdeDerivation,
-  substituteAll,
+  replaceVars,
   sshfs,
   qtconnectivity,
   qtmultimedia,
@@ -15,8 +15,7 @@ mkKdeDerivation {
   pname = "kdeconnect-kde";
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-sshfs-path.patch;
+    (replaceVars ./hardcode-sshfs-path.patch {
       sshfs = lib.getExe sshfs;
     })
   ];

--- a/pkgs/kde/gear/kdenetwork-filesharing/default.nix
+++ b/pkgs/kde/gear/kdenetwork-filesharing/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   mkKdeDerivation,
-  substituteAll,
+  replaceVars,
   samba,
   shadow,
   qtdeclarative,
@@ -10,8 +10,7 @@ mkKdeDerivation {
   pname = "kdenetwork-filesharing";
 
   patches = [
-    (substituteAll {
-      src = ./dependency-paths.patch;
+    (replaceVars ./dependency-paths.patch {
       inherit samba;
       usermod = lib.getExe' shadow "usermod";
     })

--- a/pkgs/kde/gear/kdenlive/default.nix
+++ b/pkgs/kde/gear/kdenlive/default.nix
@@ -1,6 +1,6 @@
 {
   mkKdeDerivation,
-  substituteAll,
+  replaceVars,
   qtsvg,
   qtmultimedia,
   qtnetworkauth,
@@ -17,8 +17,7 @@ mkKdeDerivation {
   pname = "kdenlive";
 
   patches = [
-    (substituteAll {
-      src = ./dependency-paths.patch;
+    (replaceVars ./dependency-paths.patch {
       inherit mediainfo mlt glaxnimate;
       ffmpeg = ffmpeg-full;
     })

--- a/pkgs/kde/plasma/drkonqi/default.nix
+++ b/pkgs/kde/plasma/drkonqi/default.nix
@@ -4,7 +4,7 @@
   systemd,
   gdb,
   python3,
-  substituteAll,
+  replaceVars,
 }:
 let
   gdb' = gdb.override {
@@ -20,8 +20,7 @@ mkKdeDerivation {
   pname = "drkonqi";
 
   patches = [
-    (substituteAll {
-      src = ./gdb-path.patch;
+    (replaceVars ./gdb-path.patch {
       gdb = "${gdb'}/bin/gdb";
     })
   ];

--- a/pkgs/kde/plasma/kde-gtk-config/default.nix
+++ b/pkgs/kde/plasma/kde-gtk-config/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   mkKdeDerivation,
-  substituteAll,
+  replaceVars,
   procps,
   xsettingsd,
   pkg-config,
@@ -17,8 +17,7 @@ mkKdeDerivation {
   # aren't found.
   patches = [
     ./0001-gsettings-schemas-path.patch
-    (substituteAll {
-      src = ./dependency-paths.patch;
+    (replaceVars ./dependency-paths.patch {
       pgrep = lib.getExe' procps "pgrep";
       xsettingsd = lib.getExe xsettingsd;
     })

--- a/pkgs/kde/plasma/krdp/default.nix
+++ b/pkgs/kde/plasma/krdp/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   mkKdeDerivation,
-  substituteAll,
+  replaceVars,
   openssl,
   pkg-config,
   qtkeychain,
@@ -14,8 +14,7 @@ mkKdeDerivation {
   pname = "krdp";
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-openssl-path.patch;
+    (replaceVars ./hardcode-openssl-path.patch {
       openssl = lib.getExe openssl;
     })
   ];

--- a/pkgs/kde/plasma/plasma-desktop/default.nix
+++ b/pkgs/kde/plasma/plasma-desktop/default.nix
@@ -5,7 +5,7 @@
   makeWrapper,
   glib,
   gsettings-desktop-schemas,
-  substituteAll,
+  replaceVars,
   util-linux,
   pkg-config,
   qtsvg,
@@ -31,18 +31,15 @@ mkKdeDerivation {
   pname = "plasma-desktop";
 
   patches = [
-    (substituteAll {
-      src = ./hwclock-path.patch;
+    (replaceVars ./hwclock-path.patch {
       hwclock = "${lib.getBin util-linux}/bin/hwclock";
     })
-    (substituteAll {
-      src = ./kcm-access.patch;
+    (replaceVars ./kcm-access.patch {
       gsettings = "${gsettings-wrapper}/bin/gsettings";
     })
     ./tzdir.patch
     ./no-discover-shortcut.patch
-    (substituteAll {
-      src = ./wallpaper-paths.patch;
+    (replaceVars ./wallpaper-paths.patch {
       wallpapers = "${lib.getBin breeze}/share/wallpapers";
     })
   ];

--- a/pkgs/kde/plasma/plasma-disks/default.nix
+++ b/pkgs/kde/plasma/plasma-disks/default.nix
@@ -1,16 +1,15 @@
 {
   mkKdeDerivation,
   lib,
-  substituteAll,
+  replaceVars,
   smartmontools,
 }:
 mkKdeDerivation {
   pname = "plasma-disks";
 
   patches = [
-    (substituteAll {
+    (replaceVars ./smartctl-path.patch {
       smartctl = lib.getExe smartmontools;
-      src = ./smartctl-path.patch;
     })
   ];
 }

--- a/pkgs/kde/plasma/plasma-nm/default.nix
+++ b/pkgs/kde/plasma/plasma-nm/default.nix
@@ -1,6 +1,6 @@
 {
   mkKdeDerivation,
-  substituteAll,
+  replaceVars,
   pkg-config,
   qtwebengine,
   mobile-broadband-provider-info,
@@ -11,8 +11,7 @@ mkKdeDerivation {
   pname = "plasma-nm";
 
   patches = [
-    (substituteAll {
-      src = ./0002-openvpn-binary-path.patch;
+    (replaceVars ./0002-openvpn-binary-path.patch {
       inherit openvpn;
     })
   ];


### PR DESCRIPTION
On the road again, driving #237216 forward. Continuation of #365440. Same approach: Auto-generated changes, removed all of those that would require adjustments.

The number of changed packages should still allow to build this via nixpkgs-review.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
