### PR TITLE
treewide: replace substituteAll with replaceVars (part 3)

### DIFF
--- a/pkgs/by-name/ac/accountsservice/package.nix
+++ b/pkgs/by-name/ac/accountsservice/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  substituteAll,
+  replaceVars,
   pkg-config,
   glib,
   shadow,
@@ -36,8 +36,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Hardcode dependency paths.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit shadow coreutils;
     })
 

--- a/pkgs/by-name/al/alvr/package.nix
+++ b/pkgs/by-name/al/alvr/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   nix-update-script,
   pkg-config,
   autoAddDriverRunpath,
@@ -59,8 +59,7 @@ rustPlatform.buildRustPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-finding-libs.patch;
+    (replaceVars ./fix-finding-libs.patch {
       ffmpeg = lib.getDev ffmpeg;
       x264 = lib.getDev x264;
     })

--- a/pkgs/by-name/ap/appstream-glib/package.nix
+++ b/pkgs/by-name/ap/appstream-glib/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   docbook_xml_dtd_42,
   docbook_xsl,
   fontconfig,
@@ -74,8 +74,7 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       pngquant = "${pngquant}/bin/pngquant";
     })
   ];

--- a/pkgs/by-name/cc/ccache/package.nix
+++ b/pkgs/by-name/cc/ccache/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   binutils,
   asciidoctor,
   cmake,
@@ -54,8 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Darwin.
     # Additionally, when cross compiling, the correct target prefix
     # needs to be set.
-    (substituteAll {
-      src = ./fix-objdump-path.patch;
+    (replaceVars ./fix-objdump-path.patch {
       objdump = "${binutils.bintools}/bin/${binutils.targetPrefix}objdump";
     })
   ];

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchurl
-, substituteAll
+, replaceVars
 , buildPackages
 , bzip2
 , curlMinimal
@@ -75,8 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
   ++ lib.optional stdenv.hostPlatform.isDarwin ./006-darwin-always-set-runtime-c-flag.diff
   # On platforms where ps is not part of stdenv, patch the invocation of ps to use an absolute path.
   ++ lib.optional (stdenv.hostPlatform.isDarwin || stdenv.hostPlatform.isFreeBSD) (
-    substituteAll {
-      src = ./007-darwin-bsd-ps-abspath.diff;
+    replaceVars ./007-darwin-bsd-ps-abspath.diff {
       ps = lib.getExe ps;
     })
   ++ [

--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -46,7 +46,7 @@
   python3,
   shared-mime-info,
   socat,
-  substituteAll,
+  replaceVars,
   systemd,
   testers,
   valgrind,
@@ -84,8 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Hardcode paths used by tests and change test runtime generation to use files from Nix store.
     # https://github.com/flatpak/flatpak/issues/1460
-    (substituteAll {
-      src = ./fix-test-paths.patch;
+    (replaceVars ./fix-test-paths.patch {
       inherit
         coreutils
         gettext
@@ -98,8 +97,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     # Hardcode paths used by Flatpak itself.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       p11kit = "${p11-kit.bin}/bin/p11-kit";
     })
 
@@ -235,8 +233,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   passthru = {
-    icon-validator-patch = substituteAll {
-      src = ./fix-icon-validation.patch;
+    icon-validator-patch = replaceVars ./fix-icon-validation.patch {
       inherit (builtins) storeDir;
     };
 

--- a/pkgs/by-name/fo/formatter/package.nix
+++ b/pkgs/by-name/fo/formatter/package.nix
@@ -9,7 +9,7 @@
   pkg-config,
   pantheon,
   python3,
-  substituteAll,
+  replaceVars,
   glib,
   gtk3,
   dosfstools,
@@ -33,8 +33,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       ext4 = "${e2fsprogs}/bin/mkfs.ext4";
       exfat = "${exfat}/bin/mkfs.exfat";
       fat = "${dosfstools}/bin/mkfs.fat";

--- a/pkgs/by-name/gd/gdm/package.nix
+++ b/pkgs/by-name/gd/gdm/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   fetchpatch,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   pkg-config,
@@ -35,8 +35,7 @@
 
 let
 
-  override = substituteAll {
-    src = ./org.gnome.login-screen.gschema.override;
+  override = replaceVars ./org.gnome.login-screen.gschema.override {
     icon = "${nixos-icons}/share/icons/hicolor/scalable/apps/nix-snowflake-white.svg";
   };
 
@@ -105,8 +104,7 @@ stdenv.mkDerivation (finalAttrs: {
     })
 
     # Change hardcoded paths to nix store paths.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit
         coreutils
         plymouth

--- a/pkgs/by-name/gl/glib-networking/package.nix
+++ b/pkgs/by-name/gl/glib-networking/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchurl,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   nixosTests,
@@ -33,8 +33,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-gsettings.patch;
+    (replaceVars ./hardcode-gsettings.patch {
       gds_gsettings_path = glib.getSchemaPath gsettings-desktop-schemas;
     })
 

--- a/pkgs/by-name/gn/gnome-control-center/package.nix
+++ b/pkgs/by-name/gn/gnome-control-center/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   accountsservice,
   adwaita-icon-theme,
   colord,
@@ -82,8 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       gcm = gnome-color-manager;
       inherit glibc tzdata shadow;
       inherit cups networkmanagerapplet;

--- a/pkgs/by-name/gn/gnome-desktop/package.nix
+++ b/pkgs/by-name/gn/gnome-desktop/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  substituteAll,
+  replaceVars,
   pkg-config,
   libxslt,
   ninja,
@@ -44,8 +44,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = lib.optionals stdenv.hostPlatform.isLinux [
-    (substituteAll {
-      src = ./bubblewrap-paths.patch;
+    (replaceVars ./bubblewrap-paths.patch {
       bubblewrap_bin = "${bubblewrap}/bin/bwrap";
       inherit (builtins) storeDir;
     })

--- a/pkgs/by-name/gn/gnome-initial-setup/package.nix
+++ b/pkgs/by-name/gn/gnome-initial-setup/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchurl,
-  substituteAll,
+  replaceVars,
   dconf,
   gettext,
   meson,
@@ -45,8 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./0001-fix-paths.patch;
+    (replaceVars ./0001-fix-paths.patch {
       inherit tzdata;
       tecla = gnome-tecla;
     })

--- a/pkgs/by-name/gn/gnome-pomodoro/package.nix
+++ b/pkgs/by-name/gn/gnome-pomodoro/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   pkg-config,
@@ -36,8 +36,7 @@ stdenv.mkDerivation rec {
   patches = [
     # Our glib setup hooks moves GSettings schemas to a subdirectory to prevent conflicts.
     # We need to patch the build script so that the extension can find them.
-    (substituteAll {
-      src = ./fix-schema-path.patch;
+    (replaceVars ./fix-schema-path.patch {
       inherit pname version;
     })
   ];

--- a/pkgs/by-name/gn/gnome-session/package.nix
+++ b/pkgs/by-name/gn/gnome-session/package.nix
@@ -2,7 +2,7 @@
   fetchurl,
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   pkg-config,
@@ -47,8 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       gsettings = "${glib.bin}/bin/gsettings";
       dbusLaunch = "${dbus.lib}/bin/dbus-launch";
       bash = "${bash}/bin/bash";

--- a/pkgs/by-name/gn/gnome-settings-daemon/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  substituteAll,
+  replaceVars,
   buildPackages,
   fetchurl,
   meson,
@@ -54,8 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
     # https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/202
     ./add-gnome-session-ctl-option.patch
 
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit tzdata;
     })
   ];

--- a/pkgs/by-name/gn/gnome-settings-daemon46/package.nix
+++ b/pkgs/by-name/gn/gnome-settings-daemon46/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  substituteAll,
+  replaceVars,
   fetchurl,
   meson,
   ninja,
@@ -51,8 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     # https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/202
     ./add-gnome-session-ctl-option.patch
 
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit tzdata;
     })
   ];

--- a/pkgs/by-name/gn/gnome-shell-extensions/package.nix
+++ b/pkgs/by-name/gn/gnome-shell-extensions/package.nix
@@ -10,7 +10,7 @@
   glib,
   gnome,
   gnome-menus,
-  substituteAll,
+  replaceVars,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -23,12 +23,10 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix_gmenu.patch;
+    (replaceVars ./fix_gmenu.patch {
       gmenu_path = "${gnome-menus}/lib/girepository-1.0";
     })
-    (substituteAll {
-      src = ./fix_gtop.patch;
+    (replaceVars ./fix_gtop.patch {
       gtop_path = "${libgtop}/lib/girepository-1.0";
     })
   ];

--- a/pkgs/by-name/gn/gnome-shell/package.nix
+++ b/pkgs/by-name/gn/gnome-shell/package.nix
@@ -1,7 +1,7 @@
 {
   fetchurl,
   fetchpatch,
-  substituteAll,
+  replaceVars,
   lib,
   stdenv,
   docutils,
@@ -84,8 +84,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Hardcode paths to various dependencies so that they can be found at runtime.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       glib_compile_schemas = "${glib.dev}/bin/glib-compile-schemas";
       gsettings = "${glib.bin}/bin/gsettings";
       tecla = "${lib.getBin gnome-tecla}/bin/tecla";

--- a/pkgs/by-name/gn/gnome-software/package.nix
+++ b/pkgs/by-name/gn/gnome-software/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  substituteAll,
+  replaceVars,
   pkg-config,
   meson,
   ninja,
@@ -56,8 +56,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit isocodes;
     })
   ];

--- a/pkgs/by-name/go/google-cloud-cpp/package.nix
+++ b/pkgs/by-name/go/google-cloud-cpp/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   c-ares,
   cmake,
   crc32c,
@@ -43,8 +43,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-googleapis-path.patch;
+    (replaceVars ./hardcode-googleapis-path.patch {
       url = googleapis;
     })
   ];

--- a/pkgs/by-name/gp/gparted/package.nix
+++ b/pkgs/by-name/gp/gparted/package.nix
@@ -20,7 +20,7 @@
   util-linux,
   polkit,
   wrapGAppsHook3,
-  substituteAll,
+  replaceVars,
   mtools,
   dosfstools,
   xhost,
@@ -39,8 +39,7 @@ stdenv.mkDerivation rec {
   # however the binary won't be suid so it returns
   # an error preventing the program from detection
   patches = [
-    (substituteAll {
-      src = ./polkit.patch;
+    (replaceVars ./polkit.patch {
       polkit_version = polkit.version;
     })
   ];

--- a/pkgs/by-name/gu/gusb/package.nix
+++ b/pkgs/by-name/gu/gusb/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   pkg-config,
@@ -46,8 +46,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-python-path.patch;
+    (replaceVars ./fix-python-path.patch {
       python = "${pythonEnv}/bin/python3";
     })
   ];

--- a/pkgs/by-name/gv/gvfs/package.nix
+++ b/pkgs/by-name/gv/gvfs/package.nix
@@ -5,7 +5,7 @@
   meson,
   ninja,
   pkg-config,
-  substituteAll,
+  replaceVars,
   gettext,
   dbus,
   glib,
@@ -55,8 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-ssh-path.patch;
+    (replaceVars ./hardcode-ssh-path.patch {
       ssh_program = "${lib.getBin openssh}/bin/ssh";
     })
   ];

--- a/pkgs/by-name/ha/hare/package.nix
+++ b/pkgs/by-name/ha/hare/package.nix
@@ -6,7 +6,7 @@
   scdoc,
   tzdata,
   mailcap,
-  substituteAll,
+  replaceVars,
   callPackage,
   enableCrossCompilation ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.is64bit),
   pkgsCross,
@@ -92,22 +92,19 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Replace FHS paths with nix store
-    (substituteAll {
-      src = ./001-tzdata.patch;
+    (replaceVars ./001-tzdata.patch {
       inherit tzdata;
     })
     # Don't build haredoc since it uses the build `hare` bin, which breaks
     # cross-compilation.
     ./002-dont-build-haredoc.patch
     # Hardcode harec and qbe.
-    (substituteAll {
-      src = ./003-hardcode-qbe-and-harec.patch;
+    (replaceVars ./003-hardcode-qbe-and-harec.patch {
       harec_bin = lib.getExe harec;
       qbe_bin = lib.getExe qbe;
     })
     # Use mailcap `/etc/mime.types` for Hare's mime module
-    (substituteAll {
-      src = ./004-use-mailcap-for-mimetypes.patch;
+    (replaceVars ./004-use-mailcap-for-mimetypes.patch {
       inherit mailcap;
     })
   ];

--- a/pkgs/by-name/ha/haredo/package.nix
+++ b/pkgs/by-name/ha/haredo/package.nix
@@ -7,7 +7,7 @@
   nix-update-script,
   makeWrapper,
   bash,
-  substituteAll,
+  replaceVars,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "haredo";
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Use nix store's bash instead of sh. `@bash@/bin/sh` is used, since haredo expects a posix shell.
-    (substituteAll {
-      src = ./001-use-nix-store-sh.patch;
+    (replaceVars ./001-use-nix-store-sh.patch {
       inherit bash;
     })
   ];

--- a/pkgs/by-name/ho/howard-hinnant-date/package.nix
+++ b/pkgs/by-name/ho/howard-hinnant-date/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, cmake, tzdata, fetchpatch, substituteAll }:
+{ lib, stdenv, fetchFromGitHub, cmake, tzdata, fetchpatch, replaceVars }:
 
 stdenv.mkDerivation rec {
   pname = "howard-hinnant-date";
@@ -22,8 +22,7 @@ stdenv.mkDerivation rec {
     # Without this patch, this library will drop a `tzdata` directory into
     # `~/Downloads` if it cannot find `/usr/share/zoneinfo`. Make the path it
     # searches for `zoneinfo` be the one from the `tzdata` package.
-    (substituteAll {
-      src = ./make-zoneinfo-available.diff;
+    (replaceVars ./make-zoneinfo-available.diff {
       inherit tzdata;
     })
   ];

--- a/pkgs/by-name/in/iniparser/package.nix
+++ b/pkgs/by-name/in/iniparser/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitLab,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   symlinkJoin,
   cmake,
   doxygen,
@@ -24,9 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = lib.optionals finalAttrs.finalPackage.doCheck [
-    (substituteAll {
+    (replaceVars ./remove-fetchcontent-usage.patch {
       # Do not let cmake's fetchContent download unity
-      src = ./remove-fetchcontent-usage.patch;
       unitySrc = symlinkJoin {
         name = "unity-with-iniparser-config";
         paths = [

--- a/pkgs/by-name/is/isc-cron/package.nix
+++ b/pkgs/by-name/is/isc-cron/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchurl,
   stdenv,
-  substituteAll,
+  replaceVars,
   vim,
   sendmailPath ? "/usr/sbin/sendmail",
 }:
@@ -17,8 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./0000-nixpkgs-specific.diff;
+    (replaceVars ./0000-nixpkgs-specific.diff {
       inherit sendmailPath;
       viPath = lib.getExe' vim "vim";
       defPath = lib.concatStringsSep ":" [

--- a/pkgs/by-name/jo/john/package.nix
+++ b/pkgs/by-name/jo/john/package.nix
@@ -19,7 +19,7 @@
   ocl-icd,
   # include non-free ClamAV unrar code
   enableUnfree ? false,
-  substituteAll,
+  replaceVars,
   makeWrapper,
 }:
 
@@ -35,8 +35,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = lib.optionals withOpenCL [
-    (substituteAll {
-      src = ./opencl.patch;
+    (replaceVars ./opencl.patch {
       ocl_icd = ocl-icd;
     })
   ];

--- a/pkgs/by-name/ke/keepass/package.nix
+++ b/pkgs/by-name/ke/keepass/package.nix
@@ -6,7 +6,7 @@
   mono,
   makeWrapper,
   icoutils,
-  substituteAll,
+  replaceVars,
   xsel,
   xorg,
   xdotool,
@@ -37,8 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ icoutils ];
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       xsel = "${xsel}/bin/xsel";
       xprop = "${xorg.xprop}/bin/xprop";
       xdotool = "${xdotool}/bin/xdotool";

--- a/pkgs/by-name/la/lalrpop/package.nix
+++ b/pkgs/by-name/la/lalrpop/package.nix
@@ -2,7 +2,7 @@
   lib,
   rustPlatform,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   stdenv,
 }:
 
@@ -20,8 +20,7 @@ rustPlatform.buildRustPackage rec {
   cargoHash = "sha256-zkPLas+fQQzm7LlWNpTooUR/e30KMS9OET6PMwQ2yAA=";
 
   patches = [
-    (substituteAll {
-      src = ./use-correct-binary-path-in-tests.patch;
+    (replaceVars ./use-correct-binary-path-in-tests.patch {
       target_triple = stdenv.hostPlatform.rust.rustcTarget;
     })
   ];

--- a/pkgs/by-name/li/libosinfo/package.nix
+++ b/pkgs/by-name/li/libosinfo/package.nix
@@ -19,7 +19,7 @@
   perl,
   hwdata,
   osinfo-db,
-  substituteAll,
+  replaceVars,
   vala ? null,
 }:
 
@@ -61,8 +61,7 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./osinfo-db-data-dir.patch;
+    (replaceVars ./osinfo-db-data-dir.patch {
       osinfo_db_data_dir = "${osinfo-db}/share";
     })
 

--- a/pkgs/by-name/me/metacity/package.nix
+++ b/pkgs/by-name/me/metacity/package.nix
@@ -13,7 +13,7 @@
   libstartup_notification,
   libxml2,
   pkg-config,
-  substituteAll,
+  replaceVars,
   wrapGAppsHook3,
   zenity,
 }:
@@ -28,8 +28,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit zenity;
     })
   ];

--- a/pkgs/by-name/mi/minigalaxy/package.nix
+++ b/pkgs/by-name/mi/minigalaxy/package.nix
@@ -8,7 +8,7 @@
   libnotify,
   python3Packages,
   steam-run,
-  substituteAll,
+  replaceVars,
   unzip,
   webkitgtk_4_0,
   wrapGAppsHook3,
@@ -26,8 +26,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./inject-launcher-steam-run.diff;
+    (replaceVars ./inject-launcher-steam-run.diff {
       steamrun = lib.getExe steam-run;
     })
   ];

--- a/pkgs/by-name/mi/mirakurun/package.nix
+++ b/pkgs/by-name/mi/mirakurun/package.nix
@@ -7,7 +7,7 @@
   installShellFiles,
   makeWrapper,
   nodejs,
-  substituteAll,
+  replaceVars,
   v4l-utils,
   which,
 }:
@@ -46,8 +46,7 @@ buildNpmPackage rec {
         nodejs
         which
       ] ++ lib.optionals stdenv.hostPlatform.isLinux [ v4l-utils ];
-      crc32Patch = substituteAll {
-        src = ./fix-musl-detection.patch;
+      crc32Patch = replaceVars ./fix-musl-detection.patch {
         isMusl = if stdenv.hostPlatform.isMusl then "true" else "false";
       };
     in

--- a/pkgs/by-name/mu/muffin/package.nix
+++ b/pkgs/by-name/mu/muffin/package.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   cairo,
   cinnamon-desktop,
   dbus,
@@ -58,8 +58,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit zenity;
     })
   ];

--- a/pkgs/by-name/mu/music-assistant/package.nix
+++ b/pkgs/by-name/mu/music-assistant/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   ffmpeg-headless,
   nixosTests,
-  substituteAll,
+  replaceVars,
   providers ? [ ],
 }:
 
@@ -38,8 +38,7 @@ python.pkgs.buildPythonApplication rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./ffmpeg.patch;
+    (replaceVars ./ffmpeg.patch {
       ffmpeg = "${lib.getBin ffmpeg-headless}/bin/ffmpeg";
       ffprobe = "${lib.getBin ffmpeg-headless}/bin/ffprobe";
     })

--- a/pkgs/by-name/na/nautilus-python/package.nix
+++ b/pkgs/by-name/na/nautilus-python/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  substituteAll,
+  replaceVars,
   fetchurl,
   meson,
   ninja,
@@ -32,8 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Make PyGObject’s gi library available.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       pythonPaths = lib.concatMapStringsSep ", " (pkg: "'${pkg}/${python3.sitePackages}'") [
         python3.pkgs.pygobject3
       ];

--- a/pkgs/by-name/nu/nut/package.nix
+++ b/pkgs/by-name/nu/nut/package.nix
@@ -17,7 +17,7 @@
   net-snmp,
   openssl,
   pkg-config,
-  substituteAll,
+  replaceVars,
   systemd,
   udev,
   gnused,
@@ -40,8 +40,7 @@ stdenv.mkDerivation rec {
     # trying to install directly into /etc/nut which predictably fails
     ./nutshutdown-conf-default.patch
 
-    (substituteAll {
-      src = ./hardcode-paths.patch;
+    (replaceVars ./hardcode-paths.patch {
       avahi = "${avahi}/lib";
       freeipmi = "${freeipmi}/lib";
       libgpiod = "${libgpiod_1}/lib";

--- a/pkgs/by-name/oc/octoprint/package.nix
+++ b/pkgs/by-name/oc/octoprint/package.nix
@@ -6,7 +6,7 @@
   fetchFromGitHub,
   fetchPypi,
   python3,
-  substituteAll,
+  replaceVars,
   nix-update-script,
   nixosTests,
   # To include additional plugins, pass them here as an overlay.
@@ -194,14 +194,12 @@ let
 
           patches = [
             # substitute pip and let it find out, that it can't write anywhere
-            (substituteAll {
-              src = ./pip-path.patch;
+            (replaceVars ./pip-path.patch {
               pip = "${self.pip}/bin/pip";
             })
 
             # hardcore path to ffmpeg and hide related settings
-            (substituteAll {
-              src = ./ffmpeg-path.patch;
+            (replaceVars ./ffmpeg-path.patch {
               ffmpeg = "${pkgs.ffmpeg}/bin/ffmpeg";
             })
           ];

--- a/pkgs/by-name/on/onboard/package.nix
+++ b/pkgs/by-name/on/onboard/package.nix
@@ -3,7 +3,7 @@
   fetchpatch,
   stdenv,
   lib,
-  substituteAll,
+  replaceVars,
   aspellWithDicts,
   at-spi2-core ? null,
   atspiSupport ? true,
@@ -51,8 +51,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit mousetweaks;
     })
     # Allow loading hunspell dictionaries installed in NixOS system path

--- a/pkgs/by-name/or/orca/package.nix
+++ b/pkgs/by-name/or/orca/package.nix
@@ -12,7 +12,7 @@
   python3,
   gtk3,
   gnome,
-  substituteAll,
+  replaceVars,
   at-spi2-atk,
   at-spi2-core,
   dbus,
@@ -39,8 +39,7 @@ python3.pkgs.buildPythonApplication rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       cat = "${coreutils}/bin/cat";
       lsof = "${lsof}/bin/lsof";
       pgrep = "${procps}/bin/pgrep";

--- a/pkgs/by-name/pa/patchPpdFilesHook/test.nix
+++ b/pkgs/by-name/pa/patchPpdFilesHook/test.nix
@@ -1,21 +1,19 @@
 {
-  substituteAll,
+  replaceVars,
   diffutils,
   stdenv,
   patchPpdFilesHook,
 }:
 
 let
-  input = substituteAll {
-    src = ./test.ppd;
+  input = replaceVars ./test.ppd {
     keep = "cmp";
     patch = "cmp";
     pathkeep = "/bin/cmp";
     pathpatch = "/bin/cmp";
   };
 
-  output = substituteAll {
-    src = ./test.ppd;
+  output = replaceVars ./test.ppd {
     keep = "cmp";
     patch = "${diffutils}/bin/cmp";
     pathkeep = "/bin/cmp";

--- a/pkgs/by-name/pl/plymouth/package.nix
+++ b/pkgs/by-name/pl/plymouth/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitLab,
   writeText,
-  substituteAll,
+  replaceVars,
   meson,
   pkg-config,
   ninja,
@@ -44,8 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     # add support for loading plugins from /run to assist NixOS module
     ./add-runtime-plugin-path.patch
     # fix FHS hardcoded paths
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       fcmatch = "${fontconfig}/bin/fc-match";
     })
   ];

--- a/pkgs/by-name/po/podman/package.nix
+++ b/pkgs/by-name/po/podman/package.nix
@@ -19,7 +19,7 @@
   makeWrapper,
   runtimeShell,
   symlinkJoin,
-  substituteAll,
+  replaceVars,
   extraPackages ? [ ],
   crun,
   runc,
@@ -85,8 +85,7 @@ buildGoModule rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-paths.patch;
+    (replaceVars ./hardcode-paths.patch {
       bin_path = helpersBin;
     })
 

--- a/pkgs/by-name/pr/pretix/plugins/passbook.nix
+++ b/pkgs/by-name/pr/pretix/plugins/passbook.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
 
   # build-system
   pretix-plugin-build,
@@ -29,8 +29,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./passbook-openssl.patch;
+    (replaceVars ./passbook-openssl.patch {
       openssl = lib.getExe openssl;
     })
   ];

--- a/pkgs/by-name/st/streamlink/package.nix
+++ b/pkgs/by-name/st/streamlink/package.nix
@@ -2,7 +2,7 @@
   lib,
   python3Packages,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   ffmpeg,
 }:
 
@@ -17,8 +17,7 @@ python3Packages.buildPythonApplication rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./ffmpeg-path.patch;
+    (replaceVars ./ffmpeg-path.patch {
       ffmpeg = lib.getExe ffmpeg;
     })
   ];

--- a/pkgs/by-name/sw/sway-unwrapped/package.nix
+++ b/pkgs/by-name/sw/sway-unwrapped/package.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, fetchFromGitHub, fetchpatch, substituteAll, swaybg
+{ lib, stdenv, fetchFromGitHub, fetchpatch, replaceVars, swaybg
 , meson, ninja, pkg-config, wayland-scanner, scdoc
 , libGL, wayland, libxkbcommon, pcre2, json_c, libevdev
 , pango, cairo, libinput, gdk-pixbuf, librsvg
@@ -26,8 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./load-configuration-from-etc.patch
 
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit swaybg;
     })
 

--- a/pkgs/by-name/sw/swayfx-unwrapped/package.nix
+++ b/pkgs/by-name/sw/swayfx-unwrapped/package.nix
@@ -4,7 +4,7 @@
   stdenv,
   systemd,
   meson,
-  substituteAll,
+  replaceVars,
   swaybg,
   ninja,
   pkg-config,
@@ -57,8 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       ./load-configuration-from-etc.patch
 
-      (substituteAll {
-        src = ./fix-paths.patch;
+      (replaceVars ./fix-paths.patch {
         inherit swaybg;
       })
     ]

--- a/pkgs/by-name/um/umockdev/package.nix
+++ b/pkgs/by-name/um/umockdev/package.nix
@@ -13,7 +13,7 @@
   ninja,
   pkg-config,
   python3,
-  substituteAll,
+  replaceVars,
   systemdMinimal,
   usbutils,
   vala,
@@ -44,8 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Replace references to udevadm with an absolute paths, so programs using
     # umockdev will just work without having to provide it in their test environment
     # $PATH.
-    (substituteAll {
-      src = ./substitute-udevadm.patch;
+    (replaceVars ./substitute-udevadm.patch {
       udevadm = "${systemdMinimal}/bin/udevadm";
     })
   ];

--- a/pkgs/by-name/xs/xscreensaver/package.nix
+++ b/pkgs/by-name/xs/xscreensaver/package.nix
@@ -29,7 +29,7 @@
   forceInstallAllHacks ? true,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   nixosTests,
-  substituteAll,
+  replaceVars,
   wrapperPrefix ? "/run/wrappers/bin",
 }:
 
@@ -83,8 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   patches = [
-    (substituteAll {
-      src = ./xscreensaver-wrapper-prefix.patch;
+    (replaceVars ./xscreensaver-wrapper-prefix.patch {
       inherit wrapperPrefix;
     })
   ];


### PR DESCRIPTION
On the road again, driving #237216 forward. Continuation of https://github.com/NixOS/nixpkgs/pull/365440. Same approach: Auto-generated changes, removed all of those that would require adjustments.

The number of rebuilds is higher here, so targeting staging. But since this PR only contains changes in `by-name/`, it's easy to generate a build command to target the actually changed packages:

```
git diff-tree --no-commit-id --name-only HEAD -r | cut -d'/' -f 4 | sed -e 's/^/-A /g' | NIXPKGS_ALLOW_UNFREE=1 xargs nix-build
```

I ran this on a checkout of the PR, thus building all touched files. We probably need to double-check that none of the changes are behind a conditional which wouldn't be reached that way.

Edit: I tested this on the merge-base of master and staging, but there was a conflict here for one package. Thus rebased on latest staging - unfortunately, this causes about 3k builds for me now. So probably better tested by applying the changes to master first...

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
