### PR TITLE
handheld-daemon: 3.9.0 -> 3.10.2

### DIFF
--- a/pkgs/by-name/ha/handheld-daemon/0001-remove-selinux-fixes.patch
+++ b/pkgs/by-name/ha/handheld-daemon/0001-remove-selinux-fixes.patch
@@ -1,0 +1,37 @@
+diff --git a/src/hhd/plugins/power/power.py b/src/hhd/plugins/power/power.py
+index 5ece857..be41542 100644
+--- a/src/hhd/plugins/power/power.py
++++ b/src/hhd/plugins/power/power.py
+@@ -79,12 +79,6 @@ def create_subvol():
+         )
+         return
+ 
+-    # Fixup selinux for swap
+-    subprocess.run(
+-        ["semanage", "fcontext", "-a", "-t", "var_t", HHD_SWAP_SUBVOL],
+-    )
+-    subprocess.run(["restorecon", HHD_SWAP_SUBVOL])
+-
+     logger.info(f"Creating swap subvolume {HHD_SWAP_SUBVOL}")
+     os.system(f"btrfs subvolume create {HHD_SWAP_SUBVOL}")
+ 
+@@ -153,19 +147,6 @@ def create_temporary_swap():
+         subprocess.run(["chmod", "600", HHD_SWAP_FILE], check=True)
+         subprocess.run(["mkswap", HHD_SWAP_FILE], check=True)
+ 
+-    # Fixup selinux for swap
+-    subprocess.run(
+-        [
+-            "semanage",
+-            "fcontext",
+-            "-a",
+-            "-t",
+-            "swapfile_t",
+-            HHD_SWAP_FILE,
+-        ],
+-    )
+-    subprocess.run(["restorecon", HHD_SWAP_FILE])
+-
+     # Enable swap
+     subprocess.run(["swapon", HHD_SWAP_FILE], check=True)
+ 

--- a/pkgs/by-name/ha/handheld-daemon/package.nix
+++ b/pkgs/by-name/ha/handheld-daemon/package.nix
@@ -11,18 +11,24 @@
   efibootmgr,
   dbus,
   lsof,
+  btrfs-progs,
+  util-linux,
 }:
 python3Packages.buildPythonApplication rec {
   pname = "handheld-daemon";
-  version = "3.9.0";
+  version = "3.10.2";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "hhd-dev";
     repo = "hhd";
     tag = "v${version}";
-    hash = "sha256-y3CxdWqQEwdNYs4m1NEUeRjTvvhEpS5S739wyFlluWo=";
+    hash = "sha256-6BjXqqNe2u/rh1cnuJ13L/1KimprcyatIr53b0GOBSM=";
   };
+
+  # Handheld-daemon runs some selinux-related utils which are not in nixpkgs.
+  # NixOS doesn't support selinux so we can safely remove them
+  patches = [ ./0001-remove-selinux-fixes.patch ];
 
   # This package relies on several programs expected to be on the user's PATH.
   # We take a more reproducible approach by patching the absolute path to each of these required
@@ -41,8 +47,16 @@ python3Packages.buildPythonApplication rec {
     substituteInPlace src/hhd/controller/physical/imu.py \
       --replace-fail '"modprobe' '"${lib.getExe' kmod "modprobe"}'
 
-    substituteInPlace src/hhd/plugins/overlay/power.py \
-      --replace-fail '"efibootmgr"' '"${lib.getExe' efibootmgr "id"}"'
+    substituteInPlace src/hhd/plugins/power/power.py \
+      --replace-fail '"efibootmgr"' '"${lib.getExe' efibootmgr "id"}"' \
+      --replace-fail '"systemctl"' '"${lib.getExe' systemd "systemctl"}"' \
+      --replace-fail '"stat"' '"${lib.getExe' coreutils "stat"}"' \
+      --replace-fail '"swapon"' '"${lib.getExe' util-linux "swapon"}"' \
+      --replace-fail '"swapoff"' '"${lib.getExe' util-linux "swapoff"}"' \
+      --replace-fail '"fallocate"' '"${lib.getExe' util-linux "fallocate"}"' \
+      --replace-fail '"chmod"' '"${lib.getExe' coreutils "chmod"}"' \
+      --replace-fail '"mkswap"' '"${lib.getExe' util-linux "mkswap"}"' \
+      --replace-fail '"btrfs",' '"${lib.getExe' btrfs-progs "btrfs"}",'
 
     substituteInPlace src/hhd/device/oxp/serial.py \
       --replace-fail "udevadm" "${lib.getExe' systemd "udevadm"}"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This pr also adds a patch to remove some selinux fixes in handheld-daemon, since NixOS does not support selinux, and the fixes require packages not in nixpkgs

https://github.com/hhd-dev/hhd/releases/tag/v3.10.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
