### PR TITLE
[staging-next-24.11] curl: apply eventfd free patch

### DIFF
--- a/pkgs/by-name/cu/curlMinimal/fix-eventfd-free.patch
+++ b/pkgs/by-name/cu/curlMinimal/fix-eventfd-free.patch
@@ -1,0 +1,33 @@
+From ff5091aa9f73802e894b1cbdf24ab84e103200e2 Mon Sep 17 00:00:00 2001
+From: Andy Pan <i@andypan.me>
+Date: Thu, 12 Dec 2024 12:48:56 +0000
+Subject: [PATCH] async-thread: avoid closing eventfd twice
+
+When employing eventfd for socketpair, there is only one file
+descriptor. Closing that fd twice might result in fd corruption.
+Thus, we should avoid closing the eventfd twice, following the
+pattern in lib/multi.c.
+
+Fixes #15725
+Closes #15727
+Reported-by: Christian Heusel
+---
+ lib/asyn-thread.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/asyn-thread.c b/lib/asyn-thread.c
+index a58e4b790494..32d496b107cb 100644
+--- a/lib/asyn-thread.c
++++ b/lib/asyn-thread.c
+@@ -195,9 +195,11 @@ void destroy_thread_sync_data(struct thread_sync_data *tsd)
+    * close one end of the socket pair (may be done in resolver thread);
+    * the other end (for reading) is always closed in the parent thread.
+    */
++#ifndef USE_EVENTFD
+   if(tsd->sock_pair[1] != CURL_SOCKET_BAD) {
+     wakeup_close(tsd->sock_pair[1]);
+   }
++#endif
+ #endif
+   memset(tsd, 0, sizeof(*tsd));
+ }

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -59,6 +59,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-x8p9tIsJCXQ+rvNCUNoCwZvGHU8dzt1mA/EJQJU2q1Y=";
   };
 
+  patches = [
+    # https://github.com/curl/curl/issues/15725
+    ./fix-eventfd-free.patch
+  ];
+
   # this could be accomplished by updateAutotoolsGnuConfigScriptsHook, but that causes infinite recursion
   # necessary for FreeBSD code path in configure
   postPatch = ''


### PR DESCRIPTION
Fixes #373540

Next scheduled release for curl is Feb 5th + the time for staging to build. I think it's better to patch this now.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
