### PR TITLE
ocamlPackages.extlib: 1.7.9 → 1.8.0

### DIFF
--- a/pkgs/development/compilers/haxe/default.nix
+++ b/pkgs/development/compilers/haxe/default.nix
@@ -53,6 +53,7 @@ let
       hash,
       version,
       prePatch ? defaultPatch,
+      patches ? [ ],
     }:
     stdenv.mkDerivation {
       pname = "haxe";
@@ -76,7 +77,7 @@ let
         inherit hash;
       };
 
-      inherit prePatch;
+      inherit prePatch patches;
 
       buildFlags = [
         "all"
@@ -165,5 +166,6 @@ in
   haxe_4_3 = generic {
     version = "4.3.6";
     hash = "sha256-m/A0xxB3fw+syPmH1GPKKCcj0a2G/HMRKOu+FKrO5jQ=";
+    patches = [ ./extlib-1.8.0.patch ];
   };
 }

--- a/pkgs/development/compilers/haxe/extlib-1.8.0.patch
+++ b/pkgs/development/compilers/haxe/extlib-1.8.0.patch
@@ -1,0 +1,26 @@
+diff --git a/src/context/typecore.ml b/src/context/typecore.ml
+index dc38a5264..0c3ebde9f 100644
+--- a/src/context/typecore.ml
++++ b/src/context/typecore.ml
+@@ -294,7 +294,7 @@ let add_local ctx k n t p =
+ 			begin try
+ 				let v' = PMap.find n ctx.locals in
+ 				(* ignore std lib *)
+-				if not (List.exists (ExtLib.String.starts_with p.pfile) ctx.com.std_path) then begin
++				if not (List.exists (ExtLib.String.starts_with ~prefix:p.pfile) ctx.com.std_path) then begin
+ 					warning ctx WVarShadow "This variable shadows a previously declared variable" p;
+ 					warning ~depth:1 ctx WVarShadow (compl_msg "Previous variable was here") v'.v_pos
+ 				end
+diff --git a/src/optimization/dce.ml b/src/optimization/dce.ml
+index 4e7b1fc98..90d8fc5d6 100644
+--- a/src/optimization/dce.ml
++++ b/src/optimization/dce.ml
+@@ -76,7 +76,7 @@ let overrides_extern_field cf c =
+ 	loop c cf
+ 
+ let is_std_file dce file =
+-	List.exists (ExtString.String.starts_with file) dce.std_dirs
++	List.exists (ExtString.String.starts_with ~prefix:file) dce.std_dirs
+ 
+ let keep_metas = [Meta.Keep;Meta.Expose]
+ 

--- a/pkgs/development/ocaml-modules/extlib/default.nix
+++ b/pkgs/development/ocaml-modules/extlib/default.nix
@@ -7,13 +7,11 @@
 
 buildDunePackage rec {
   pname = "extlib";
-  version = "1.7.9";
-
-  minimalOCamlVersion = "4.02";
+  version = "1.8.0";
 
   src = fetchurl {
-    url = "https://ygrek.org/p/release/ocaml-${pname}/${pname}-${version}.tar.gz";
-    hash = "sha512-I4asafA36lIINcBiTTmun7/+Q6ILGOJH3gMiMu1vQZ1me1PSMUxvVtxx02i/C2IBpWwvPypb39kzdmxabLmHaA==";
+    url = "https://github.com/ygrek/ocaml-extlib/releases/download/${version}/extlib-${version}.tar.gz";
+    hash = "sha256-lkJ38AEoCo7d/AjgcB1Zygxr3F0FIxOz5A5QiPbUXXA=";
   };
 
   nativeBuildInputs = [ cppo ];


### PR DESCRIPTION
Support latest OCaml:
https://raw.githubusercontent.com/ygrek/ocaml-extlib/refs/tags/1.8.0/CHANGES

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
