### PR TITLE
stellarsolver: switch to qt6, by-name path, add myself to maintainers; kstars: switch to qt6, by-name path, add myself to maintainers, 3.7.4 -> 3.7.5

### DIFF
--- a/pkgs/by-name/ks/kstars/package.nix
+++ b/pkgs/by-name/ks/kstars/package.nix
@@ -53,11 +53,11 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "kstars";
-  version = "3.7.4";
+  version = "3.7.5";
 
   src = fetchurl {
     url = "mirror://kde/stable/kstars/${finalAttrs.version}/kstars-${finalAttrs.version}.tar.xz";
-    hash = "sha256-WdVsPCwDQWW/NIRehuqk5f8rgtucAbGLSbmwZLMLiHM=";
+    hash = "sha256-L9hyVfdgFlFfM6MyjR4bUa86FHPbVg7xBWPY8YSHUXw=";
   };
 
   nativeBuildInputs = with kdePackages; [

--- a/pkgs/by-name/ks/kstars/package.nix
+++ b/pkgs/by-name/ks/kstars/package.nix
@@ -121,6 +121,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with maintainers; [
       timput
       hjones2199
+      returntoreality
     ];
   };
 })

--- a/pkgs/by-name/ks/kstars/package.nix
+++ b/pkgs/by-name/ks/kstars/package.nix
@@ -1,41 +1,25 @@
 {
   lib,
   stdenv,
-  extra-cmake-modules,
   fetchurl,
   fetchFromGitLab,
   fetchpatch,
-  kconfig,
-  kdoctools,
-  kguiaddons,
-  ki18n,
-  kinit,
-  kiconthemes,
-  kio,
-  knewstuff,
-  kplotting,
-  kwidgetsaddons,
-  kxmlgui,
-  knotifyconfig,
-  qtx11extras,
-  qtwebsockets,
-  qtkeychain,
-  qtdatavis3d,
-  wrapQtAppsHook,
-  breeze-icons,
-  libsecret,
-  eigen,
-  zlib,
   cfitsio,
+  cmake,
+  curl,
+  eigen,
+  gsl,
   indi-full,
-  xplanet,
+  kdePackages,
   libnova,
   libraw,
-  gsl,
-  wcslib,
-  stellarsolver,
+  libsecret,
   libxisf,
-  curl,
+  opencv,
+  stellarsolver,
+  wcslib,
+  xplanet,
+  zlib,
 }:
 
 let
@@ -76,47 +60,51 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-WdVsPCwDQWW/NIRehuqk5f8rgtucAbGLSbmwZLMLiHM=";
   };
 
-  nativeBuildInputs = [
+  nativeBuildInputs = with kdePackages; [
     extra-cmake-modules
     kdoctools
     wrapQtAppsHook
+    cmake
   ];
-  buildInputs = [
+  buildInputs = with kdePackages; [
+    breeze-icons
+    cfitsio
+    curl
+    eigen'
+    gsl
+    indi-full
     kconfig
     kdoctools
     kguiaddons
     ki18n
-    kinit
     kiconthemes
     kio
     knewstuff
+    knotifyconfig
     kplotting
     kwidgetsaddons
     kxmlgui
-    knotifyconfig
-    qtx11extras
-    qtwebsockets
-    qtkeychain
-    qtdatavis3d
-    breeze-icons
-    libsecret
-    eigen'
-    zlib
-    cfitsio
-    indi-full
-    xplanet
     libnova
     libraw
-    gsl
-    wcslib
-    stellarsolver
+    libsecret
     libxisf
-    curl
+    opencv
+    qtdatavis3d
+    qtkeychain
+    qtsvg
+    qtwayland
+    qtwebsockets
+    stellarsolver
+    wcslib
+    xplanet
+    zlib
   ];
 
-  cmakeFlags = [
-    "-DINDI_PREFIX=${indi-full}"
-    "-DXPLANET_PREFIX=${xplanet}"
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "BUILD_QT5" false)
+    (cmakeFeature "INDI_PREFIX" "${indi-full}")
+    (cmakeFeature "XPLANET_PREFIX" "${xplanet}")
+    (cmakeFeature "DATA_INSTALL_DIR" "$out/share/kstars/")
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/st/stellarsolver/package.nix
+++ b/pkgs/by-name/st/stellarsolver/package.nix
@@ -40,7 +40,10 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/rlancaste/stellarsolver";
     description = "Astrometric plate solving library";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ hjones2199 ];
+    maintainers = with maintainers; [
+      hjones2199
+      returntoreality
+    ];
     platforms = platforms.unix;
   };
 })

--- a/pkgs/by-name/st/stellarsolver/package.nix
+++ b/pkgs/by-name/st/stellarsolver/package.nix
@@ -1,37 +1,39 @@
 {
   lib,
-  mkDerivation,
+  stdenv,
   fetchFromGitHub,
   cmake,
-  qtbase,
+  qt6,
   cfitsio,
   gsl,
   wcslib,
   withTester ? false,
 }:
-
-mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "stellarsolver";
   version = "2.6";
 
   src = fetchFromGitHub {
     owner = "rlancaste";
-    repo = pname;
-    rev = version;
+    repo = finalAttrs.pname;
+    rev = finalAttrs.version;
     sha256 = "sha256-6WDiHaBhi9POtXynGU/eTeuqZSK81JJeuZv4SxOeVoE=";
   };
 
   nativeBuildInputs = [ cmake ];
 
+  dontWrapQtApps = true;
+
   buildInputs = [
-    qtbase
+    qt6.qtbase
     cfitsio
     gsl
     wcslib
   ];
 
   cmakeFlags = [
-    "-DBUILD_TESTER=${if withTester then "on" else "off"}"
+    (lib.strings.cmakeBool "BUILD_TESTER" withTester)
+    (lib.strings.cmakeBool "USE_QT5" false)
   ];
 
   meta = with lib; {
@@ -41,4 +43,4 @@ mkDerivation rec {
     maintainers = with maintainers; [ hjones2199 ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -3868,8 +3868,6 @@ with pkgs;
 
   ksmoothdock = libsForQt5.callPackage ../applications/misc/ksmoothdock { };
 
-  kstars = libsForQt5.callPackage ../applications/science/astronomy/kstars { };
-
   ligo =
     let ocaml_p = ocaml-ng.ocamlPackages_4_14.overrideScope (self: super: {
       zarith = super.zarith.override { version = "1.13"; };
@@ -17277,8 +17275,6 @@ with pkgs;
   spyder = with python3.pkgs; toPythonApplication spyder;
 
   stellarium = qt6Packages.callPackage ../applications/science/astronomy/stellarium { };
-
-  stellarsolver = libsForQt5.callPackage ../development/libraries/science/astronomy/stellarsolver { };
 
   tulip = libsForQt5.callPackage ../applications/science/misc/tulip { };
 


### PR DESCRIPTION
This PR changes kstars and stellarsolver to build against Qt6 (support was added in their last releases). And updates kstars to the latest release. I also added myself to the maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
