### PR TITLE
osmium-tool: 1.16.0 → 1.17.0

### DIFF
--- a/pkgs/by-name/os/osmium-tool/package.nix
+++ b/pkgs/by-name/os/osmium-tool/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   installShellFiles,
   pandoc,
@@ -11,37 +10,21 @@
   expat,
   libosmium,
   lz4,
+  nlohmann_json,
   protozero,
   zlib,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "osmium-tool";
-  version = "1.16.0";
+  version = "1.17.0";
 
   src = fetchFromGitHub {
     owner = "osmcode";
     repo = "osmium-tool";
-    rev = "v${version}";
-    sha256 = "sha256-DObqbzdPA4RlrlcZhqA0MQtWBE+D6GRD1pd9U4DARIk=";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-l6C2DGGKcbMUkKDruM8QzpriqFMvDnsi4OE99a2EzhA=";
   };
-
-  patches = [
-    # Work around https://github.com/osmcode/osmium-tool/issues/276
-    # by applying changes from https://github.com/Tencent/rapidjson/pull/719
-    (fetchpatch {
-      url = "https://github.com/Tencent/rapidjson/commit/3b2441b87f99ab65f37b141a7b548ebadb607b96.patch";
-      hash = "sha256-Edmq+hdJQFQ4hT3Oz1cv5gX95qQxPLD4aY8QMTonDe8=";
-    })
-    (fetchpatch {
-      url = "https://github.com/Tencent/rapidjson/commit/862c39be371278a45a88d4d1d75164be57bb7e2d.patch";
-      hash = "sha256-V5zbq/THUY75p1RdEPKJK2NVnxbZs07MMwJBAH7nAMg=";
-    })
-    (fetchpatch {
-      url = "https://github.com/osmcode/osmium-tool/commit/1c62771a62f260b07c1b9a52338a24a978dcd967.patch";
-      hash = "sha256-/2HUu4tLRZzoCcGVEM61gE4RjiA2XGalr9OnhCUhKj8=";
-    })
-  ];
 
   nativeBuildInputs = [
     cmake
@@ -55,6 +38,7 @@ stdenv.mkDerivation rec {
     expat
     libosmium
     lz4
+    nlohmann_json
     protozero
     zlib
   ];
@@ -65,16 +49,16 @@ stdenv.mkDerivation rec {
     installShellCompletion --zsh ../zsh_completion/_osmium
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Multipurpose command line tool for working with OpenStreetMap data based on the Osmium library";
     homepage = "https://osmcode.org/osmium-tool/";
-    changelog = "https://github.com/osmcode/osmium-tool/blob/v${version}/CHANGELOG.md";
-    license = with licenses; [
+    changelog = "https://github.com/osmcode/osmium-tool/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
       gpl3Plus
       mit
       bsd3
     ];
-    maintainers = with maintainers; teams.geospatial.members ++ [ das-g ];
+    maintainers = lib.teams.geospatial.members ++ (with lib.maintainers; [ das-g ]);
     mainProgram = "osmium";
   };
-}
+})


### PR DESCRIPTION
https://github.com/osmcode/osmium-tool/releases/tag/v1.17.0

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
