### PR TITLE
lsd2dsl: fix build

### DIFF
--- a/pkgs/by-name/ls/lsd2dsl/package.nix
+++ b/pkgs/by-name/ls/lsd2dsl/package.nix
@@ -16,14 +16,14 @@
   qt6,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "lsd2dsl";
   version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "nongeneric";
     repo = "lsd2dsl";
-    rev = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-0UsxDNpuWpBrfjh4q3JhZnOyXhHatSa3t/cApiG2JzM=";
   };
 
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     exec = "lsd2dsl-qtgui";
     desktopName = "lsd2dsl";
     genericName = "lsd2dsl";
-    comment = meta.description;
+    comment = finalAttrs.meta.description;
     categories = [
       "Dictionary"
       "FileTools"
@@ -75,14 +75,14 @@ stdenv.mkDerivation rec {
     install -Dm755 console/lsd2dsl gui/lsd2dsl-qtgui -t $out/bin
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://rcebits.com/lsd2dsl/";
     description = "Lingvo dictionaries decompiler";
     longDescription = ''
       A decompiler for ABBYY Lingvo’s proprietary dictionaries.
     '';
-    license = licenses.mit;
-    maintainers = with maintainers; [ sikmir ];
-    platforms = platforms.unix;
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ sikmir ];
+    platforms = lib.platforms.unix;
   };
-}
+})

--- a/pkgs/by-name/ls/lsd2dsl/package.nix
+++ b/pkgs/by-name/ls/lsd2dsl/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   makeDesktopItem,
   copyDesktopItems,
   cmake,
@@ -26,6 +27,13 @@ stdenv.mkDerivation rec {
     hash = "sha256-0UsxDNpuWpBrfjh4q3JhZnOyXhHatSa3t/cApiG2JzM=";
   };
 
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/nongeneric/lsd2dsl/commit/bbda5be1b76a4a44804483d00c07d79783eceb6b.patch";
+      hash = "sha256-7is83D1cMBArXVLe5TP7D7lUcwnTMeXjkJ+cbaH5JQk=";
+    })
+  ];
+
   postPatch = ''
     substituteInPlace CMakeLists.txt --replace "-Werror" ""
   '';
@@ -48,7 +56,7 @@ stdenv.mkDerivation rec {
     qt6.qtwebengine
   ];
 
-  env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.cc.isClang "-Wno-int-conversion";
+  env.NIX_CFLAGS_COMPILE = "-Wno-int-conversion";
 
   desktopItems = lib.singleton (makeDesktopItem {
     name = "lsd2dsl";


### PR DESCRIPTION
* [x86_64-linux](https://hydra.nixos.org/build/303393010)
* [x86_64-darwin](https://hydra.nixos.org/build/303583056)

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
