### PR TITLE
libnids: fix cross build

### DIFF
--- a/pkgs/by-name/li/libnids/package.nix
+++ b/pkgs/by-name/li/libnids/package.nix
@@ -14,6 +14,12 @@ stdenv.mkDerivation {
     url = "mirror://sourceforge/libnids/libnids-1.24.tar.gz";
     sha256 = "1cblklfdfxcmy0an6xyyzx4l877xdawhjd28daqfsvrh81mb07k1";
   };
+
+  postPatch = ''
+    substituteInPlace src/Makefile.in \
+      --replace-fail ar '${stdenv.cc.targetPrefix}ar'
+  '';
+
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     libpcap


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).