### PR TITLE
ccze: fix cross build

### DIFF
--- a/pkgs/by-name/cc/ccze/package.nix
+++ b/pkgs/by-name/cc/ccze/package.nix
@@ -39,6 +39,9 @@ stdenv.mkDerivation (finalAttrs: {
     autoconf
   '';
 
+  # provide correct pcre2-config for cross
+  env.PCRE_CONFIG = lib.getExe' (lib.getDev pcre2) "pcre2-config";
+
   meta = with lib; {
     mainProgram = "ccze";
     description = "Fast, modular log colorizer";


### PR DESCRIPTION
Also fixes regular strictDeps build
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).