### PR TITLE
rsync: apply patches for 6 vulnerabilities

### DIFF
--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12084/0001-Some-checksum-buffer-fixes.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12084/0001-Some-checksum-buffer-fixes.patch
@@ -1,0 +1,151 @@
+From 0902b52f6687b1f7952422080d50b93108742e53 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayne@opencoder.net>
+Date: Tue, 29 Oct 2024 22:55:29 -0700
+Subject: [PATCH 1/2] Some checksum buffer fixes.
+
+- Put sum2_array into sum_struct to hold an array of sum2 checksums
+  that are each xfer_sum_len bytes.
+- Remove sum2 buf from sum_buf.
+- Add macro sum2_at() to access each sum2 array element.
+- Throw an error if a sums header has an s2length larger than
+  xfer_sum_len.
+---
+ io.c     | 3 ++-
+ match.c  | 8 ++++----
+ rsync.c  | 5 ++++-
+ rsync.h  | 4 +++-
+ sender.c | 4 +++-
+ 5 files changed, 16 insertions(+), 8 deletions(-)
+
+diff --git a/io.c b/io.c
+index a99ac0ec..bb60eeca 100644
+--- a/io.c
++++ b/io.c
+@@ -55,6 +55,7 @@ extern int read_batch;
+ extern int compat_flags;
+ extern int protect_args;
+ extern int checksum_seed;
++extern int xfer_sum_len;
+ extern int daemon_connection;
+ extern int protocol_version;
+ extern int remove_source_files;
+@@ -1977,7 +1978,7 @@ void read_sum_head(int f, struct sum_struct *sum)
+ 		exit_cleanup(RERR_PROTOCOL);
+ 	}
+ 	sum->s2length = protocol_version < 27 ? csum_length : (int)read_int(f);
+-	if (sum->s2length < 0 || sum->s2length > MAX_DIGEST_LEN) {
++	if (sum->s2length < 0 || sum->s2length > xfer_sum_len) {
+ 		rprintf(FERROR, "Invalid checksum length %d [%s]\n",
+ 			sum->s2length, who_am_i());
+ 		exit_cleanup(RERR_PROTOCOL);
+diff --git a/match.c b/match.c
+index cdb30a15..36e78ed2 100644
+--- a/match.c
++++ b/match.c
+@@ -232,7 +232,7 @@ static void hash_search(int f,struct sum_struct *s,
+ 				done_csum2 = 1;
+ 			}
+ 
+-			if (memcmp(sum2,s->sums[i].sum2,s->s2length) != 0) {
++			if (memcmp(sum2, sum2_at(s, i), s->s2length) != 0) {
+ 				false_alarms++;
+ 				continue;
+ 			}
+@@ -252,7 +252,7 @@ static void hash_search(int f,struct sum_struct *s,
+ 					if (i != aligned_i) {
+ 						if (sum != s->sums[aligned_i].sum1
+ 						 || l != s->sums[aligned_i].len
+-						 || memcmp(sum2, s->sums[aligned_i].sum2, s->s2length) != 0)
++						 || memcmp(sum2, sum2_at(s, aligned_i), s->s2length) != 0)
+ 							goto check_want_i;
+ 						i = aligned_i;
+ 					}
+@@ -271,7 +271,7 @@ static void hash_search(int f,struct sum_struct *s,
+ 						if (sum != s->sums[i].sum1)
+ 							goto check_want_i;
+ 						get_checksum2((char *)map, l, sum2);
+-						if (memcmp(sum2, s->sums[i].sum2, s->s2length) != 0)
++						if (memcmp(sum2, sum2_at(s, i), s->s2length) != 0)
+ 							goto check_want_i;
+ 						/* OK, we have a re-alignment match.  Bump the offset
+ 						 * forward to the new match point. */
+@@ -290,7 +290,7 @@ static void hash_search(int f,struct sum_struct *s,
+ 			 && (!updating_basis_file || s->sums[want_i].offset >= offset
+ 			  || s->sums[want_i].flags & SUMFLG_SAME_OFFSET)
+ 			 && sum == s->sums[want_i].sum1
+-			 && memcmp(sum2, s->sums[want_i].sum2, s->s2length) == 0) {
++			 && memcmp(sum2, sum2_at(s, want_i), s->s2length) == 0) {
+ 				/* we've found an adjacent match - the RLL coder
+ 				 * will be happy */
+ 				i = want_i;
+diff --git a/rsync.c b/rsync.c
+index cd288f57..b130aba5 100644
+--- a/rsync.c
++++ b/rsync.c
+@@ -437,7 +437,10 @@ int read_ndx_and_attrs(int f_in, int f_out, int *iflag_ptr, uchar *type_ptr, cha
+   */
+ void free_sums(struct sum_struct *s)
+ {
+-	if (s->sums) free(s->sums);
++	if (s->sums) {
++		free(s->sums);
++		free(s->sum2_array);
++	}
+ 	free(s);
+ }
+ 
+diff --git a/rsync.h b/rsync.h
+index d3709fe0..8ddbe702 100644
+--- a/rsync.h
++++ b/rsync.h
+@@ -958,12 +958,12 @@ struct sum_buf {
+ 	uint32 sum1;	        /**< simple checksum */
+ 	int32 chain;		/**< next hash-table collision */
+ 	short flags;		/**< flag bits */
+-	char sum2[SUM_LENGTH];	/**< checksum  */
+ };
+ 
+ struct sum_struct {
+ 	OFF_T flength;		/**< total file length */
+ 	struct sum_buf *sums;	/**< points to info for each chunk */
++	char *sum2_array;	/**< checksums of length xfer_sum_len */
+ 	int32 count;		/**< how many chunks */
+ 	int32 blength;		/**< block_length */
+ 	int32 remainder;	/**< flength % block_length */
+@@ -982,6 +982,8 @@ struct map_struct {
+ 	int status;		/* first errno from read errors		*/
+ };
+ 
++#define sum2_at(s, i)	((s)->sum2_array + ((OFF_T)(i) * xfer_sum_len))
++
+ #define NAME_IS_FILE		(0)    /* filter name as a file */
+ #define NAME_IS_DIR		(1<<0) /* filter name as a dir */
+ #define NAME_IS_XATTR		(1<<2) /* filter name as an xattr */
+diff --git a/sender.c b/sender.c
+index 3d4f052e..ab205341 100644
+--- a/sender.c
++++ b/sender.c
+@@ -31,6 +31,7 @@ extern int log_before_transfer;
+ extern int stdout_format_has_i;
+ extern int logfile_format_has_i;
+ extern int want_xattr_optim;
++extern int xfer_sum_len;
+ extern int csum_length;
+ extern int append_mode;
+ extern int copy_links;
+@@ -94,10 +95,11 @@ static struct sum_struct *receive_sums(int f)
+ 		return(s);
+ 
+ 	s->sums = new_array(struct sum_buf, s->count);
++	s->sum2_array = new_array(char, s->count * xfer_sum_len);
+ 
+ 	for (i = 0; i < s->count; i++) {
+ 		s->sums[i].sum1 = read_int(f);
+-		read_buf(f, s->sums[i].sum2, s->s2length);
++		read_buf(f, sum2_at(s, i), s->s2length);
+ 
+ 		s->sums[i].offset = offset;
+ 		s->sums[i].flags = 0;
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12084/0002-Another-cast-when-multiplying-integers.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12084/0002-Another-cast-when-multiplying-integers.patch
@@ -1,0 +1,39 @@
+From 42e2b56c4ede3ab164f9a5c6dae02aa84606a6c1 Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayne@opencoder.net>
+Date: Tue, 5 Nov 2024 11:01:03 -0800
+Subject: [PATCH 2/2] Another cast when multiplying integers.
+
+---
+ rsync.h  | 2 +-
+ sender.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/rsync.h b/rsync.h
+index 8ddbe702..0f9e277f 100644
+--- a/rsync.h
++++ b/rsync.h
+@@ -982,7 +982,7 @@ struct map_struct {
+ 	int status;		/* first errno from read errors		*/
+ };
+ 
+-#define sum2_at(s, i)	((s)->sum2_array + ((OFF_T)(i) * xfer_sum_len))
++#define sum2_at(s, i)	((s)->sum2_array + ((size_t)(i) * xfer_sum_len))
+ 
+ #define NAME_IS_FILE		(0)    /* filter name as a file */
+ #define NAME_IS_DIR		(1<<0) /* filter name as a dir */
+diff --git a/sender.c b/sender.c
+index ab205341..2bbff2fa 100644
+--- a/sender.c
++++ b/sender.c
+@@ -95,7 +95,7 @@ static struct sum_struct *receive_sums(int f)
+ 		return(s);
+ 
+ 	s->sums = new_array(struct sum_buf, s->count);
+-	s->sum2_array = new_array(char, s->count * xfer_sum_len);
++	s->sum2_array = new_array(char, (size_t)s->count * xfer_sum_len);
+ 
+ 	for (i = 0; i < s->count; i++) {
+ 		s->sums[i].sum1 = read_int(f);
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12085/0001-prevent-information-leak-off-the-stack.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12085/0001-prevent-information-leak-off-the-stack.patch
@@ -1,0 +1,27 @@
+From cf620065502f065d4ea44f5df4f81295a738aa21 Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Thu, 14 Nov 2024 09:57:08 +1100
+Subject: [PATCH] prevent information leak off the stack
+
+prevent leak of uninitialised stack data in hash_search
+---
+ match.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/match.c b/match.c
+index 36e78ed2..dfd6af2c 100644
+--- a/match.c
++++ b/match.c
+@@ -147,6 +147,9 @@ static void hash_search(int f,struct sum_struct *s,
+ 	int more;
+ 	schar *map;
+ 
++	// prevent possible memory leaks
++	memset(sum2, 0, sizeof sum2);
++
+ 	/* want_i is used to encourage adjacent matches, allowing the RLL
+ 	 * coding of the output to work more efficiently. */
+ 	want_i = 0;
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0001-refuse-fuzzy-options-when-fuzzy-not-selected.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0001-refuse-fuzzy-options-when-fuzzy-not-selected.patch
@@ -1,0 +1,37 @@
+From 3feb8669d875d03c9ceb82e208ef40ddda8eb908 Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Sat, 23 Nov 2024 11:08:03 +1100
+Subject: [PATCH 1/4] refuse fuzzy options when fuzzy not selected
+
+this prevents a malicious server providing a file to compare to when
+the user has not given the fuzzy option
+---
+ receiver.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/receiver.c b/receiver.c
+index 6b4b369e..2d7f6033 100644
+--- a/receiver.c
++++ b/receiver.c
+@@ -66,6 +66,7 @@ extern char sender_file_sum[MAX_DIGEST_LEN];
+ extern struct file_list *cur_flist, *first_flist, *dir_flist;
+ extern filter_rule_list daemon_filter_list;
+ extern OFF_T preallocated_len;
++extern int fuzzy_basis;
+ 
+ extern struct name_num_item *xfer_sum_nni;
+ extern int xfer_sum_len;
+@@ -716,6 +717,10 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 				fnamecmp = get_backup_name(fname);
+ 				break;
+ 			case FNAMECMP_FUZZY:
++				if (fuzzy_basis == 0) {
++					rprintf(FERROR_XFER, "rsync: refusing malicious fuzzy operation for %s\n", xname);
++					exit_cleanup(RERR_PROTOCOL);
++				}
+ 				if (file->dirname) {
+ 					pathjoin(fnamecmpbuf, sizeof fnamecmpbuf, file->dirname, xname);
+ 					fnamecmp = fnamecmpbuf;
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0002-added-secure_relative_open.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0002-added-secure_relative_open.patch
@@ -1,0 +1,103 @@
+From 33385aefe4773e7a3982d41995681eb079c92d12 Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Sat, 23 Nov 2024 12:26:10 +1100
+Subject: [PATCH 2/4] added secure_relative_open()
+
+this is an open that enforces no symlink following for all path
+components in a relative path
+---
+ syscall.c | 74 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 74 insertions(+)
+
+diff --git a/syscall.c b/syscall.c
+index d92074aa..a4b7f542 100644
+--- a/syscall.c
++++ b/syscall.c
+@@ -33,6 +33,8 @@
+ #include <sys/syscall.h>
+ #endif
+ 
++#include "ifuncs.h"
++
+ extern int dry_run;
+ extern int am_root;
+ extern int am_sender;
+@@ -712,3 +714,75 @@ int do_open_nofollow(const char *pathname, int flags)
+ 
+ 	return fd;
+ }
++
++/*
++  open a file relative to a base directory. The basedir can be NULL,
++  in which case the current working directory is used. The relpath
++  must be a relative path, and the relpath must not contain any
++  elements in the path which follow symlinks (ie. like O_NOFOLLOW, but
++  applies to all path components, not just the last component)
++*/
++int secure_relative_open(const char *basedir, const char *relpath, int flags, mode_t mode)
++{
++	if (!relpath || relpath[0] == '/') {
++		// must be a relative path
++		errno = EINVAL;
++		return -1;
++	}
++
++#if !defined(O_NOFOLLOW) || !defined(O_DIRECTORY)
++	// really old system, all we can do is live with the risks
++	if (!basedir) {
++		return open(relpath, flags, mode);
++	}
++	char fullpath[MAXPATHLEN];
++	pathjoin(fullpath, sizeof fullpath, basedir, relpath);
++	return open(fullpath, flags, mode);
++#else
++	int dirfd = AT_FDCWD;
++	if (basedir != NULL) {
++		dirfd = openat(AT_FDCWD, basedir, O_RDONLY | O_DIRECTORY);
++		if (dirfd == -1) {
++			return -1;
++		}
++	}
++	int retfd = -1;
++
++	char *path_copy = my_strdup(relpath, __FILE__, __LINE__);
++	if (!path_copy) {
++		return -1;
++	}
++	
++	for (const char *part = strtok(path_copy, "/");
++	     part != NULL;
++	     part = strtok(NULL, "/"))
++	{
++		int next_fd = openat(dirfd, part, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
++		if (next_fd == -1 && errno == ENOTDIR) {
++			if (strtok(NULL, "/") != NULL) {
++				// this is not the last component of the path
++				errno = ELOOP;
++				goto cleanup;
++			}
++			// this could be the last component of the path, try as a file
++			retfd = openat(dirfd, part, flags | O_NOFOLLOW, mode);
++			goto cleanup;
++		}
++		if (next_fd == -1) {
++			goto cleanup;
++		}
++		if (dirfd != AT_FDCWD) close(dirfd);
++		dirfd = next_fd;
++	}
++
++	// the path must be a directory
++	errno = EINVAL;
++
++cleanup:
++	free(path_copy);
++	if (dirfd != AT_FDCWD) {
++		close(dirfd);
++	}
++	return retfd;
++#endif // O_NOFOLLOW, O_DIRECTORY
++}
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0003-receiver-use-secure_relative_open-for-basis-file.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0003-receiver-use-secure_relative_open-for-basis-file.patch
@@ -1,0 +1,103 @@
+From e59ef9939d3f0ccc8f9bab51442989a81be0c914 Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Sat, 23 Nov 2024 12:28:13 +1100
+Subject: [PATCH 3/4] receiver: use secure_relative_open() for basis file
+
+this prevents attacks where the basis file is manipulated by a
+malicious sender to gain information about files outside the
+destination tree
+---
+ receiver.c | 42 ++++++++++++++++++++++++++----------------
+ 1 file changed, 26 insertions(+), 16 deletions(-)
+
+diff --git a/receiver.c b/receiver.c
+index 2d7f6033..8031b8f4 100644
+--- a/receiver.c
++++ b/receiver.c
+@@ -552,6 +552,8 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 	progress_init();
+ 
+ 	while (1) {
++		const char *basedir = NULL;
++
+ 		cleanup_disable();
+ 
+ 		/* This call also sets cur_flist. */
+@@ -722,27 +724,29 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 					exit_cleanup(RERR_PROTOCOL);
+ 				}
+ 				if (file->dirname) {
+-					pathjoin(fnamecmpbuf, sizeof fnamecmpbuf, file->dirname, xname);
+-					fnamecmp = fnamecmpbuf;
+-				} else
+-					fnamecmp = xname;
++					basedir = file->dirname;
++				}
++				fnamecmp = xname;
+ 				break;
+ 			default:
+ 				if (fnamecmp_type > FNAMECMP_FUZZY && fnamecmp_type-FNAMECMP_FUZZY <= basis_dir_cnt) {
+ 					fnamecmp_type -= FNAMECMP_FUZZY + 1;
+ 					if (file->dirname) {
+-						stringjoin(fnamecmpbuf, sizeof fnamecmpbuf,
+-							   basis_dir[fnamecmp_type], "/", file->dirname, "/", xname, NULL);
+-					} else
+-						pathjoin(fnamecmpbuf, sizeof fnamecmpbuf, basis_dir[fnamecmp_type], xname);
++						pathjoin(fnamecmpbuf, sizeof fnamecmpbuf, basis_dir[fnamecmp_type], file->dirname);
++						basedir = fnamecmpbuf;
++					} else {
++						basedir = basis_dir[fnamecmp_type];
++					}
++					fnamecmp = xname;
+ 				} else if (fnamecmp_type >= basis_dir_cnt) {
+ 					rprintf(FERROR,
+ 						"invalid basis_dir index: %d.\n",
+ 						fnamecmp_type);
+ 					exit_cleanup(RERR_PROTOCOL);
+-				} else
+-					pathjoin(fnamecmpbuf, sizeof fnamecmpbuf, basis_dir[fnamecmp_type], fname);
+-				fnamecmp = fnamecmpbuf;
++				} else {
++					basedir = basis_dir[fnamecmp_type];
++					fnamecmp = fname;
++				}
+ 				break;
+ 			}
+ 			if (!fnamecmp || (daemon_filter_list.head
+@@ -765,7 +769,7 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 		}
+ 
+ 		/* open the file */
+-		fd1 = do_open(fnamecmp, O_RDONLY, 0);
++		fd1 = secure_relative_open(basedir, fnamecmp, O_RDONLY, 0);
+ 
+ 		if (fd1 == -1 && protocol_version < 29) {
+ 			if (fnamecmp != fname) {
+@@ -776,14 +780,20 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 
+ 			if (fd1 == -1 && basis_dir[0]) {
+ 				/* pre-29 allowed only one alternate basis */
+-				pathjoin(fnamecmpbuf, sizeof fnamecmpbuf,
+-					 basis_dir[0], fname);
+-				fnamecmp = fnamecmpbuf;
++				basedir = basis_dir[0];
++				fnamecmp = fname;
+ 				fnamecmp_type = FNAMECMP_BASIS_DIR_LOW;
+-				fd1 = do_open(fnamecmp, O_RDONLY, 0);
++				fd1 = secure_relative_open(basedir, fnamecmp, O_RDONLY, 0);
+ 			}
+ 		}
+ 
++		if (basedir) {
++			// for the following code we need the full
++			// path name as a single string
++			pathjoin(fnamecmpbuf, sizeof fnamecmpbuf, basedir, fnamecmp);
++			fnamecmp = fnamecmpbuf;
++		}
++
+ 		one_inplace = inplace_partial && fnamecmp_type == FNAMECMP_PARTIAL_DIR;
+ 		updating_basis_or_equiv = one_inplace
+ 		    || (inplace && (fnamecmp == fname || fnamecmp_type == FNAMECMP_BACKUP));
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0004-disallow-.-elements-in-relpath-for-secure_relative_o.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12086/0004-disallow-.-elements-in-relpath-for-secure_relative_o.patch
@@ -1,0 +1,37 @@
+From c78e53edb802d04f7e4e070fe8314f2544749e7a Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Tue, 26 Nov 2024 09:16:31 +1100
+Subject: [PATCH 4/4] disallow ../ elements in relpath for secure_relative_open
+
+---
+ syscall.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/syscall.c b/syscall.c
+index a4b7f542..47c5ea57 100644
+--- a/syscall.c
++++ b/syscall.c
+@@ -721,6 +721,8 @@ int do_open_nofollow(const char *pathname, int flags)
+   must be a relative path, and the relpath must not contain any
+   elements in the path which follow symlinks (ie. like O_NOFOLLOW, but
+   applies to all path components, not just the last component)
++
++  The relpath must also not contain any ../ elements in the path
+ */
+ int secure_relative_open(const char *basedir, const char *relpath, int flags, mode_t mode)
+ {
+@@ -729,6 +731,11 @@ int secure_relative_open(const char *basedir, const char *relpath, int flags, mo
+ 		errno = EINVAL;
+ 		return -1;
+ 	}
++	if (strncmp(relpath, "../", 3) == 0 || strstr(relpath, "/../")) {
++		// no ../ elements allowed in the relpath
++		errno = EINVAL;
++		return -1;
++	}
+ 
+ #if !defined(O_NOFOLLOW) || !defined(O_DIRECTORY)
+ 	// really old system, all we can do is live with the risks
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12087/0001-Refuse-a-duplicate-dirlist.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12087/0001-Refuse-a-duplicate-dirlist.patch
@@ -1,0 +1,45 @@
+From 0ebc19ee486a8e928a68d8f98d07d40f176770aa Mon Sep 17 00:00:00 2001
+From: Wayne Davison <wayne@opencoder.net>
+Date: Thu, 14 Nov 2024 15:46:50 -0800
+Subject: [PATCH 1/2] Refuse a duplicate dirlist.
+
+---
+ flist.c | 9 +++++++++
+ rsync.h | 1 +
+ 2 files changed, 10 insertions(+)
+
+diff --git a/flist.c b/flist.c
+index 464d556e..847b1054 100644
+--- a/flist.c
++++ b/flist.c
+@@ -2584,6 +2584,15 @@ struct file_list *recv_file_list(int f, int dir_ndx)
+ 		init_hard_links();
+ #endif
+ 
++	if (inc_recurse && dir_ndx >= 0) {
++		struct file_struct *file = dir_flist->files[dir_ndx];
++		if (file->flags & FLAG_GOT_DIR_FLIST) {
++			rprintf(FERROR_XFER, "rsync: refusing malicious duplicate flist for dir %d\n", dir_ndx);
++			exit_cleanup(RERR_PROTOCOL);
++		}
++		file->flags |= FLAG_GOT_DIR_FLIST;
++	}
++
+ 	flist = flist_new(0, "recv_file_list");
+ 	flist_expand(flist, FLIST_START_LARGE);
+ 
+diff --git a/rsync.h b/rsync.h
+index 0f9e277f..b9a7101a 100644
+--- a/rsync.h
++++ b/rsync.h
+@@ -84,6 +84,7 @@
+ #define FLAG_DUPLICATE (1<<4)	/* sender */
+ #define FLAG_MISSING_DIR (1<<4)	/* generator */
+ #define FLAG_HLINKED (1<<5)	/* receiver/generator (checked on all types) */
++#define FLAG_GOT_DIR_FLIST (1<<5)/* sender/receiver/generator - dir_flist only */
+ #define FLAG_HLINK_FIRST (1<<6)	/* receiver/generator (w/FLAG_HLINKED) */
+ #define FLAG_IMPLIED_DIR (1<<6)	/* sender/receiver/generator (dirs only) */
+ #define FLAG_HLINK_LAST (1<<7)	/* receiver/generator */
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12087/0002-range-check-dir_ndx-before-use.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12087/0002-range-check-dir_ndx-before-use.patch
@@ -1,0 +1,27 @@
+From b3e16be18d582dac1513c0a932d146b36e867b1b Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Tue, 26 Nov 2024 16:12:45 +1100
+Subject: [PATCH 2/2] range check dir_ndx before use
+
+---
+ flist.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/flist.c b/flist.c
+index 847b1054..087f9da6 100644
+--- a/flist.c
++++ b/flist.c
+@@ -2585,6 +2585,10 @@ struct file_list *recv_file_list(int f, int dir_ndx)
+ #endif
+ 
+ 	if (inc_recurse && dir_ndx >= 0) {
++		if (dir_ndx >= dir_flist->used) {
++			rprintf(FERROR_XFER, "rsync: refusing invalid dir_ndx %u >= %u\n", dir_ndx, dir_flist->used);
++			exit_cleanup(RERR_PROTOCOL);
++		}
+ 		struct file_struct *file = dir_flist->files[dir_ndx];
+ 		if (file->flags & FLAG_GOT_DIR_FLIST) {
+ 			rprintf(FERROR_XFER, "rsync: refusing malicious duplicate flist for dir %d\n", dir_ndx);
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12088/0001-make-safe-links-stricter.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12088/0001-make-safe-links-stricter.patch
@@ -1,0 +1,136 @@
+From 535f8f816539ba681ef0f12015d2cb587ae61b6d Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Sat, 23 Nov 2024 15:15:53 +1100
+Subject: [PATCH] make --safe-links stricter
+
+when --safe-links is used also reject links where a '../' component is
+included in the destination as other than the leading part of the
+filename
+---
+ testsuite/safe-links.test    | 55 ++++++++++++++++++++++++++++++++++++
+ testsuite/unsafe-byname.test |  2 +-
+ util1.c                      | 26 ++++++++++++++++-
+ 3 files changed, 81 insertions(+), 2 deletions(-)
+ create mode 100644 testsuite/safe-links.test
+
+diff --git a/testsuite/safe-links.test b/testsuite/safe-links.test
+new file mode 100644
+index 00000000..6e95a4b9
+--- /dev/null
++++ b/testsuite/safe-links.test
+@@ -0,0 +1,55 @@
++#!/bin/sh
++
++. "$suitedir/rsync.fns"
++
++test_symlink() {
++	is_a_link "$1" || test_fail "File $1 is not a symlink"
++}
++
++test_regular() {
++	if [ ! -f "$1" ]; then
++		test_fail "File $1 is not regular file or not exists"
++	fi
++}
++
++test_notexist() {
++        if [ -e "$1" ]; then
++                test_fail "File $1 exists"
++	fi
++        if [ -h "$1" ]; then
++                test_fail "File $1 exists as a symlink"
++	fi
++}
++
++cd "$tmpdir"
++
++mkdir from
++
++mkdir "from/safe"
++mkdir "from/unsafe"
++
++mkdir "from/safe/files"
++mkdir "from/safe/links"
++
++touch "from/safe/files/file1"
++touch "from/safe/files/file2"
++touch "from/unsafe/unsafefile"
++
++ln -s ../files/file1 "from/safe/links/"
++ln -s ../files/file2 "from/safe/links/"
++ln -s ../../unsafe/unsafefile "from/safe/links/"
++ln -s a/a/a/../../../unsafe2 "from/safe/links/"
++
++#echo "LISTING FROM"
++#ls -lR from
++
++echo "rsync with relative path and just -a"
++$RSYNC -avv --safe-links from/safe/ to
++
++#echo "LISTING TO"
++#ls -lR to
++
++test_symlink to/links/file1
++test_symlink to/links/file2
++test_notexist to/links/unsafefile
++test_notexist to/links/unsafe2
+diff --git a/testsuite/unsafe-byname.test b/testsuite/unsafe-byname.test
+index 75e72014..d2e318ef 100644
+--- a/testsuite/unsafe-byname.test
++++ b/testsuite/unsafe-byname.test
+@@ -40,7 +40,7 @@ test_unsafe ..//../dest 		from/dir			unsafe
+ test_unsafe ..				from/file			safe
+ test_unsafe ../..			from/file			unsafe
+ test_unsafe ..//..			from//file			unsafe
+-test_unsafe dir/..			from				safe
++test_unsafe dir/..			from				unsafe
+ test_unsafe dir/../..			from				unsafe
+ test_unsafe dir/..//..			from				unsafe
+ 
+diff --git a/util1.c b/util1.c
+index da50ff1e..f260d398 100644
+--- a/util1.c
++++ b/util1.c
+@@ -1318,7 +1318,14 @@ int handle_partial_dir(const char *fname, int create)
+  *
+  * "src" is the top source directory currently applicable at the level
+  * of the referenced symlink.  This is usually the symlink's full path
+- * (including its name), as referenced from the root of the transfer. */
++ * (including its name), as referenced from the root of the transfer.
++ *
++ * NOTE: this also rejects dest names with a .. component in other
++ * than the first component of the name ie. it rejects names such as
++ * a/b/../x/y. This needs to be done as the leading subpaths 'a' or
++ * 'b' could later be replaced with symlinks such as a link to '.'
++ * resulting in the link being transferred now becoming unsafe
++ */
+ int unsafe_symlink(const char *dest, const char *src)
+ {
+ 	const char *name, *slash;
+@@ -1328,6 +1335,23 @@ int unsafe_symlink(const char *dest, const char *src)
+ 	if (!dest || !*dest || *dest == '/')
+ 		return 1;
+ 
++	// reject destinations with /../ in the name other than at the start of the name
++	const char *dest2 = dest;
++	while (strncmp(dest2, "../", 3) == 0) {
++	    dest2 += 3;
++	    while (*dest2 == '/') {
++		// allow for ..//..///../foo
++		dest2++;
++	    }
++	}
++	if (strstr(dest2, "/../"))
++	    return 1;
++
++	// reject if the destination ends in /..
++	const size_t dlen = strlen(dest);
++	if (dlen > 3 && strcmp(&dest[dlen-3], "/..") == 0)
++	    return 1;
++
+ 	/* find out what our safety margin is */
+ 	for (name = src; (slash = strchr(name, '/')) != 0; name = slash+1) {
+ 		/* ".." segment starts the count over.  "." segment is ignored. */
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/CVE-2024-12747/0001-fixed-symlink-race-condition-in-sender.patch
+++ b/pkgs/applications/networking/sync/rsync/CVE-2024-12747/0001-fixed-symlink-race-condition-in-sender.patch
@@ -1,0 +1,187 @@
+From f45f48055e548851bc7230f454dfeba139be6c04 Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Wed, 18 Dec 2024 08:59:42 +1100
+Subject: [PATCH] fixed symlink race condition in sender
+
+when we open a file that we don't expect to be a symlink use
+O_NOFOLLOW to prevent a race condition where an attacker could change
+a file between being a normal file and a symlink
+---
+ checksum.c  |  2 +-
+ flist.c     |  2 +-
+ generator.c |  4 ++--
+ receiver.c  |  2 +-
+ sender.c    |  2 +-
+ syscall.c   | 20 ++++++++++++++++++++
+ t_unsafe.c  |  3 +++
+ tls.c       |  3 +++
+ trimslash.c |  2 ++
+ util1.c     |  2 +-
+ 10 files changed, 35 insertions(+), 7 deletions(-)
+
+diff --git a/checksum.c b/checksum.c
+index cb21882c..66e80896 100644
+--- a/checksum.c
++++ b/checksum.c
+@@ -406,7 +406,7 @@ void file_checksum(const char *fname, const STRUCT_STAT *st_p, char *sum)
+ 	int32 remainder;
+ 	int fd;
+ 
+-	fd = do_open(fname, O_RDONLY, 0);
++	fd = do_open_checklinks(fname);
+ 	if (fd == -1) {
+ 		memset(sum, 0, file_sum_len);
+ 		return;
+diff --git a/flist.c b/flist.c
+index 087f9da6..17832533 100644
+--- a/flist.c
++++ b/flist.c
+@@ -1390,7 +1390,7 @@ struct file_struct *make_file(const char *fname, struct file_list *flist,
+ 
+ 	if (copy_devices && am_sender && IS_DEVICE(st.st_mode)) {
+ 		if (st.st_size == 0) {
+-			int fd = do_open(fname, O_RDONLY, 0);
++			int fd = do_open_checklinks(fname);
+ 			if (fd >= 0) {
+ 				st.st_size = get_device_size(fd, fname);
+ 				close(fd);
+diff --git a/generator.c b/generator.c
+index 110db28f..3f13bb95 100644
+--- a/generator.c
++++ b/generator.c
+@@ -1798,7 +1798,7 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+ 
+ 	if (write_devices && IS_DEVICE(sx.st.st_mode) && sx.st.st_size == 0) {
+ 		/* This early open into fd skips the regular open below. */
+-		if ((fd = do_open(fnamecmp, O_RDONLY, 0)) >= 0)
++		if ((fd = do_open_nofollow(fnamecmp, O_RDONLY)) >= 0)
+ 			real_sx.st.st_size = sx.st.st_size = get_device_size(fd, fnamecmp);
+ 	}
+ 
+@@ -1867,7 +1867,7 @@ static void recv_generator(char *fname, struct file_struct *file, int ndx,
+ 	}
+ 
+ 	/* open the file */
+-	if (fd < 0 && (fd = do_open(fnamecmp, O_RDONLY, 0)) < 0) {
++	if (fd < 0 && (fd = do_open_checklinks(fnamecmp)) < 0) {
+ 		rsyserr(FERROR, errno, "failed to open %s, continuing",
+ 			full_fname(fnamecmp));
+ 	  pretend_missing:
+diff --git a/receiver.c b/receiver.c
+index 8031b8f4..edfbb210 100644
+--- a/receiver.c
++++ b/receiver.c
+@@ -775,7 +775,7 @@ int recv_files(int f_in, int f_out, char *local_name)
+ 			if (fnamecmp != fname) {
+ 				fnamecmp = fname;
+ 				fnamecmp_type = FNAMECMP_FNAME;
+-				fd1 = do_open(fnamecmp, O_RDONLY, 0);
++				fd1 = do_open_nofollow(fnamecmp, O_RDONLY);
+ 			}
+ 
+ 			if (fd1 == -1 && basis_dir[0]) {
+diff --git a/sender.c b/sender.c
+index 2bbff2fa..a4d46c39 100644
+--- a/sender.c
++++ b/sender.c
+@@ -350,7 +350,7 @@ void send_files(int f_in, int f_out)
+ 			exit_cleanup(RERR_PROTOCOL);
+ 		}
+ 
+-		fd = do_open(fname, O_RDONLY, 0);
++		fd = do_open_checklinks(fname);
+ 		if (fd == -1) {
+ 			if (errno == ENOENT) {
+ 				enum logcode c = am_daemon && protocol_version < 28 ? FERROR : FWARNING;
+diff --git a/syscall.c b/syscall.c
+index 081357bb..8cea2900 100644
+--- a/syscall.c
++++ b/syscall.c
+@@ -45,6 +45,8 @@ extern int preallocate_files;
+ extern int preserve_perms;
+ extern int preserve_executability;
+ extern int open_noatime;
++extern int copy_links;
++extern int copy_unsafe_links;
+ 
+ #ifndef S_BLKSIZE
+ # if defined hpux || defined __hpux__ || defined __hpux
+@@ -788,3 +790,21 @@ cleanup:
+ 	return retfd;
+ #endif // O_NOFOLLOW, O_DIRECTORY
+ }
++
++/*
++  varient of do_open/do_open_nofollow which does do_open() if the
++  copy_links or copy_unsafe_links options are set and does
++  do_open_nofollow() otherwise
++
++  This is used to prevent a race condition where an attacker could be
++  switching a file between being a symlink and being a normal file
++
++  The open is always done with O_RDONLY flags
++ */
++int do_open_checklinks(const char *pathname)
++{
++	if (copy_links || copy_unsafe_links) {
++		return do_open(pathname, O_RDONLY, 0);
++	}
++	return do_open_nofollow(pathname, O_RDONLY);
++}
+diff --git a/t_unsafe.c b/t_unsafe.c
+index 010cac50..e10619a2 100644
+--- a/t_unsafe.c
++++ b/t_unsafe.c
+@@ -28,6 +28,9 @@ int am_root = 0;
+ int am_sender = 1;
+ int read_only = 0;
+ int list_only = 0;
++int copy_links = 0;
++int copy_unsafe_links = 0;
++
+ short info_levels[COUNT_INFO], debug_levels[COUNT_DEBUG];
+ 
+ int
+diff --git a/tls.c b/tls.c
+index e6b0708a..858f8f10 100644
+--- a/tls.c
++++ b/tls.c
+@@ -49,6 +49,9 @@ int list_only = 0;
+ int link_times = 0;
+ int link_owner = 0;
+ int nsec_times = 0;
++int safe_symlinks = 0;
++int copy_links = 0;
++int copy_unsafe_links = 0;
+ 
+ #ifdef SUPPORT_XATTRS
+ 
+diff --git a/trimslash.c b/trimslash.c
+index 1ec928ca..f2774cd7 100644
+--- a/trimslash.c
++++ b/trimslash.c
+@@ -26,6 +26,8 @@ int am_root = 0;
+ int am_sender = 1;
+ int read_only = 1;
+ int list_only = 0;
++int copy_links = 0;
++int copy_unsafe_links = 0;
+ 
+ int
+ main(int argc, char **argv)
+diff --git a/util1.c b/util1.c
+index f260d398..d84bc414 100644
+--- a/util1.c
++++ b/util1.c
+@@ -365,7 +365,7 @@ int copy_file(const char *source, const char *dest, int tmpfilefd, mode_t mode)
+ 	int len;   /* Number of bytes read into `buf'. */
+ 	OFF_T prealloc_len = 0, offset = 0;
+ 
+-	if ((ifd = do_open(source, O_RDONLY, 0)) < 0) {
++	if ((ifd = do_open_nofollow(source, O_RDONLY)) < 0) {
+ 		int save_errno = errno;
+ 		rsyserr(FERROR_XFER, errno, "open %s", full_fname(source));
+ 		errno = save_errno;
+-- 
+2.34.1
+

--- a/pkgs/applications/networking/sync/rsync/default.nix
+++ b/pkgs/applications/networking/sync/rsync/default.nix
@@ -38,6 +38,18 @@ stdenv.mkDerivation rec {
   patches = [
     # https://github.com/WayneD/rsync/pull/558
     ./configure.ac-fix-failing-IPv6-check.patch
+    ./CVE-2024-12084/0001-Some-checksum-buffer-fixes.patch
+    ./CVE-2024-12084/0002-Another-cast-when-multiplying-integers.patch
+    ./CVE-2024-12085/0001-prevent-information-leak-off-the-stack.patch
+    ./CVE-2024-12086/0001-refuse-fuzzy-options-when-fuzzy-not-selected.patch
+    ./CVE-2024-12086/0002-added-secure_relative_open.patch
+    ./CVE-2024-12086/0003-receiver-use-secure_relative_open-for-basis-file.patch
+    ./CVE-2024-12086/0004-disallow-.-elements-in-relpath-for-secure_relative_o.patch
+    ./CVE-2024-12087/0001-Refuse-a-duplicate-dirlist.patch
+    ./CVE-2024-12087/0002-range-check-dir_ndx-before-use.patch
+    ./CVE-2024-12088/0001-make-safe-links-stricter.patch
+    ./CVE-2024-12747/0001-fixed-symlink-race-condition-in-sender.patch
+    ./raise-protocol-version-to-32.patch
   ];
 
   buildInputs =

--- a/pkgs/applications/networking/sync/rsync/raise-protocol-version-to-32.patch
+++ b/pkgs/applications/networking/sync/rsync/raise-protocol-version-to-32.patch
@@ -1,0 +1,26 @@
+From 163e05b1680c4a3b448fa68d03c3fca9589f3bc4 Mon Sep 17 00:00:00 2001
+From: Andrew Tridgell <andrew@tridgell.net>
+Date: Tue, 10 Dec 2024 13:34:01 +1100
+Subject: [PATCH 1/3] raise protocol version to 32
+
+make it easier to spot unpatched servers
+---
+ rsync.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rsync.h b/rsync.h
+index b9a7101a..9be1297b 100644
+--- a/rsync.h
++++ b/rsync.h
+@@ -111,7 +111,7 @@
+ 
+ /* Update this if you make incompatible changes and ALSO update the
+  * SUBPROTOCOL_VERSION if it is not a final (official) release. */
+-#define PROTOCOL_VERSION 31
++#define PROTOCOL_VERSION 32
+ 
+ /* This is used when working on a new protocol version or for any unofficial
+  * protocol tweaks.  It should be a non-zero value for each pre-release repo
+-- 
+2.34.1
+


### PR DESCRIPTION
Fixes CVE-2024-12084, CVE-2024-12085, CVE-2024-12086, CVE-2024-12087, CVE-2024-12088 and CVE-2024-12747.

https://www.kb.cert.org/vuls/id/952657


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
