### PR TITLE
mecab: fix cross build

### DIFF
--- a/pkgs/tools/text/mecab/ipadic.nix
+++ b/pkgs/tools/text/mecab/ipadic.nix
@@ -1,7 +1,9 @@
 {
+  lib,
   stdenv,
   fetchurl,
   mecab-nodic,
+  buildPackages,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -16,8 +18,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [ mecab-nodic ];
 
-  configureFlags = [
-    "--with-charset=utf8"
-    "--with-dicdir=${placeholder "out"}"
-  ];
+  configureFlags =
+    [
+      "--with-charset=utf8"
+      "--with-dicdir=${placeholder "out"}"
+    ]
+    ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "--with-mecab-config=${lib.getExe' buildPackages.mecab "mecab-config"}"
+    ]
+    ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      "--with-mecab-config=${lib.getExe' (lib.getDev mecab-nodic) "mecab-config"}"
+    ];
 })


### PR DESCRIPTION
Bit ugly but it works. Cross build output does not depend on build platform stuff.
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).