### PR TITLE
python313Packages.beartype: disable broken test

### DIFF
--- a/pkgs/development/python-modules/beartype/default.nix
+++ b/pkgs/development/python-modules/beartype/default.nix
@@ -5,6 +5,7 @@
   fetchFromGitHub,
   hatchling,
   pytestCheckHook,
+  pythonAtLeast,
   typing-extensions,
 }:
 
@@ -28,6 +29,11 @@ buildPythonPackage rec {
   ];
 
   pythonImportsCheck = [ "beartype" ];
+
+  # this test is not run upstream, and broke in 3.13 (_nparams removed)
+  disabledTests = lib.optionals (pythonAtLeast "3.13") [
+    "test_door_is_subhint"
+  ];
 
   meta = {
     description = "Fast runtime type checking for Python";


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).