### PR TITLE
freesweep: 1.0.2 -> 1.0.2-unstable-2024-04-19

### DIFF
--- a/pkgs/by-name/fr/freesweep/0001-include-strings.h.patch
+++ b/pkgs/by-name/fr/freesweep/0001-include-strings.h.patch
@@ -1,0 +1,15 @@
+diff --git a/sweep.h b/sweep.h
+index 198349d..549f39f 100644
+--- a/sweep.h
++++ b/sweep.h
+@@ -32,6 +32,10 @@
+ #include <string.h>
+ #endif /* HAVE_STRING_H */
+ 
++#ifdef HAVE_STRINGS_H
++#include <strings.h>
++#endif /* HAVE_STRINGS_H */
++
+ #ifdef HAVE_GETOPT_H
+ #include <getopt.h>
+ #endif /* HAVE_GETOPT_H */

--- a/pkgs/by-name/fr/freesweep/0002-fix-Wformat-security.patch
+++ b/pkgs/by-name/fr/freesweep/0002-fix-Wformat-security.patch
@@ -1,0 +1,13 @@
+diff --git a/logs.c b/logs.c
+index 5e87f52..29ad433 100644
+--- a/logs.c
++++ b/logs.c
+@@ -128,7 +128,7 @@ static void log_display(const char *mesg) {
+   // Display the message on the screen.
+   if (log_win) {
+     wclear(log_win);
+-    mvwprintw(log_win, 0, 0, mesg);
++    mvwprintw(log_win, 0, 0, "%s", mesg);
+     wnoutrefresh(log_win);
+     wrefresh(log_win);
+   }

--- a/pkgs/by-name/fr/freesweep/0003-remove-ac_func_malloc.patch
+++ b/pkgs/by-name/fr/freesweep/0003-remove-ac_func_malloc.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index ae08308..5262e56 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -32,7 +32,6 @@ AC_TYPE_SIZE_T
+ AC_TYPE_UID_T
+ 
+ # Checks for library functions.
+-AC_FUNC_MALLOC
+ AC_CHECK_FUNCS([alarm getcwd memset mkdir setlocale strdup strncasecmp
+                 fileno flock lockf getopt getopt_long])
+ 

--- a/pkgs/by-name/fr/freesweep/package.nix
+++ b/pkgs/by-name/fr/freesweep/package.nix
@@ -55,12 +55,12 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  meta = with lib; {
+  meta = {
     description = "Console minesweeper-style game written in C for Unix-like systems";
     mainProgram = "freesweep";
     homepage = "https://github.com/rwestlund/freesweep";
-    license = licenses.gpl2Only;
-    maintainers = with maintainers; [ ];
-    platforms = platforms.unix;
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ sanana ];
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/fr/freesweep/package.nix
+++ b/pkgs/by-name/fr/freesweep/package.nix
@@ -3,30 +3,49 @@
   ncurses,
   lib,
   stdenv,
-  updateAutotoolsGnuConfigScriptsHook,
+  autoconf,
+  automake,
+  pkg-config,
   installShellFiles,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "freesweep";
-  version = "1.0.2";
+  version = "1.0.2-unstable-2024-04-19";
 
   src = fetchFromGitHub {
     owner = "rwestlund";
     repo = "freesweep";
-    rev = "v${version}";
-    hash = "sha256-iuu81yHbNrjdPsimBrPK58PJ0d8i3ySM7rFUG/d8NJM";
+    rev = "68c0ee5b29d1087d216d95875a7036713cd25fc0";
+    hash = "sha256-ZnAH7mIuBMFLdrtJOY8PzNbxv+GDEFAgyEtWCpTH2Us=";
   };
 
+  # These patches are sent upstream in github:rwestlund/freesweep#18
+  patches = [
+    # strncasecmp and friends are declared in strings.h and not string.h on
+    # systems with HAVE_STRINGS_H
+    ./0001-include-strings.h.patch
+    # Fixes a potential format string vulnerability and makes it compile with
+    # -Wformat-security
+    ./0002-fix-Wformat-security.patch
+    # autoconf believes systems that handle malloc(0) differently from glibc
+    # have a bad malloc implementation and will replace calls to malloc with
+    # rpl_malloc. freesweep does not define rpl_malloc so this macro prevents
+    # building for such systems, the easiest solution is to remove this macro
+    ./0003-remove-ac_func_malloc.patch
+  ];
+
   nativeBuildInputs = [
-    updateAutotoolsGnuConfigScriptsHook
+    autoconf
+    automake
+    pkg-config
     installShellFiles
   ];
   buildInputs = [ ncurses ];
 
-  configureFlags = [ "--with-prefsdir=$out/share" ];
-
   enableParallelBuilding = true;
+
+  preConfigure = "./autogen.sh";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
freesweep has a new version in development and it seems to be usable, let's update to it. I added myself as a maintainer and included a few patches to allow it to build with and without mlibc (which I'm working on in #371092).
The patches are sent upstream but upstream seems to be inactive. 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
