### PR TITLE
doc/neovim: better document the wrappers

### DIFF
--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -55,7 +55,6 @@ You can use the new unstable wrapper but the interface may change:
 - `autoconfigure`: certain plugins need a custom configuration to work with nix.
 For instance, `sqlite-lua` needs `g:sqlite_clib_path` to be set to work. Nixpkgs historically patched these in the plugins with several drawbacks: harder maintenance and making upstream work harder. Per convention, these mandatory bits of configuration are bookmarked in nixpkgs in `passthru.initLua`. Enabling `autoconfigure` automatically adds the snippets required for the plugins to work.
 - `autowrapRuntimeDeps`: Appends plugin's runtime dependencies to `PATH`. For instance, `rest.nvim` requires `curl` to work. Enabling `autowrapRuntimeDeps` adds it to the `PATH` visible by your Neovim wrapper (but not your global `PATH`).
-  neovim wrapper.
 - `luaRcContent`: Extra lua code to add to the generated `init.lua`.
 - `neovimRcContent`: Extra vimL code sourced by the generated `init.lua`.
 - `wrapperArgs`: Extra arguments forwarded to the `makeWrapper` call.

--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -54,14 +54,14 @@ neovim-qt.override {
 You can use the new unstable wrapper but the interface may change:
 - `autoconfigure`: certain plugins need a custom configuration to work with nix.
 For instance, `sqlite-lua` needs `g:sqlite_clib_path` to be set to work. Nixpkgs historically patched these in the plugins with several drawbacks: harder maintenance and making upstream work harder. Per convention, these mandatory bits of configuration are bookmarked in nixpkgs in `passthru.initLua`. Enabling `autoconfigure` automatically adds the snippets required for the plugins to work.
-- `autowrapRuntimeDeps`: append to PATH runtime dependencies of your plugins. For instance `rest.nvim` requires `curl` to work. Enabling `autowrapRuntimeDeps` adds it to the PATH visible by your neovim wrapper (but not your global PATH).
+- `autowrapRuntimeDeps`: Appends plugin's runtime dependencies to `PATH`. For instance, `rest.nvim` requires `curl` to work. Enabling `autowrapRuntimeDeps` adds it to the `PATH` visible by your Neovim wrapper (but not your global `PATH`).
   neovim wrapper.
-- `luaRcContent`: extra lua code to add to the generated `init.lua`
-- `neovimRcContent`: extra vimL code sourced by the generated init.lua
-- `wrapperArgs`: extra arguments forwarded to the `makeWrapper` call
-- `wrapRc`: nix not being able to write in your $HOME, nixpkgs loads the
-  generated neovim configuration via its  `-u` argument, i.e. : `-u /nix/store/...generatedInit.lua`. This has sideeffects like preventing neovim to read your config in `$XDG_CONFIG_HOME` (see bullet 7 of [`:help startup`](https://neovim.io/doc/user/starting.html#_initialization) in neovim). Disable it if you want to generate your own wrapper. You can still reuse while reusing the logic of the nixpkgs wrapper and access the generated config via `neovim.passthru.initRc`.
-- `plugins`: a list of plugins to add to the wrapper.
+- `luaRcContent`: Extra lua code to add to the generated `init.lua`.
+- `neovimRcContent`: Extra vimL code sourced by the generated `init.lua`.
+- `wrapperArgs`: Extra arguments forwarded to the `makeWrapper` call.
+- `wrapRc`: Nix, not being able to write in your `$HOME`, loads the
+  generated Neovim configuration via its  `-u` argument, i.e. : `-u /nix/store/...generatedInit.lua`. This has side effects like preventing Neovim from reading your config in `$XDG_CONFIG_HOME` (see bullet 7 of [`:help startup`](https://neovim.io/doc/user/starting.html#_initialization) in Neovim). Disable it if you want to generate your own wrapper. You can still reuse while reusing the logic of the nixpkgs wrapper and access the generated config via `neovim.passthru.initRc`.
+- `plugins`: A list of plugins to add to the wrapper.
 
 ```
 wrapNeovimUnstable {
@@ -89,7 +89,7 @@ wrapNeovimUnstable {
 }
 ```
 
-You can explore the configuration in the `nix repl` to discover these options and
+You can explore the configuration with`nix repl` to discover these options and
 override them. For instance:
 ```nix
 neovim.overrideAttrs(oldAttrs: {

--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -25,7 +25,7 @@ neovim.override {
       # here your custom configuration goes!
     '';
     packages.myVimPackage = with pkgs.vimPlugins; {
-      # see examples below how to use custom packages
+      # See examples below on how to use custom packages.
       start = [ ];
       # If a Vim plugin has a dependency that is not explicitly listed in
       # opt that dependency will always be added to start to avoid confusion.

--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -53,7 +53,7 @@ neovim-qt.override {
 
 You can use the new unstable wrapper but the interface may change:
 - `autoconfigure`: certain plugins need a custom configuration to work with nix.
-For instance, `sqlite-lua` needs `g:sqlite_clib_path` to be set to work. Nixpkgs historically patched these in the plugins with several drawbacks: harder maintainance and making upstream work harder. Per convention, these mandatory bits of configuration are bookmarked in nixpkgs in `passthru.initLua`. Enabling `autoconfigure` adds automatically the snippets required for the plugins to work.
+For instance, `sqlite-lua` needs `g:sqlite_clib_path` to be set to work. Nixpkgs historically patched these in the plugins with several drawbacks: harder maintenance and making upstream work harder. Per convention, these mandatory bits of configuration are bookmarked in nixpkgs in `passthru.initLua`. Enabling `autoconfigure` automatically adds the snippets required for the plugins to work.
 - `autowrapRuntimeDeps`: append to PATH runtime dependencies of your plugins. For instance `rest.nvim` requires `curl` to work. Enabling `autowrapRuntimeDeps` adds it to the PATH visible by your neovim wrapper (but not your global PATH).
   neovim wrapper.
 - `luaRcContent`: extra lua code to add to the generated `init.lua`

--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -106,7 +106,22 @@ patch those plugins but expose the necessary configuration under
 `PLUGIN.passthru.initLua` for neovim plugins. For instance, the `unicode-vim` plugin
 needs the path towards a unicode database so we expose the following snippet `vim.g.Unicode_data_directory="${self.unicode-vim}/autoload/unicode"` under `vimPlugins.unicode-vim.passthru.initLua`.
 
-### {#neovim-luarocks-based-plugins}
+#### {#neovim-luarocks-based-plugins}
+
+In order to automatically handle plugin dependencies, several neovim plugins
+upload their package to [](www.luarocks.org). This means less work for nixpkgs maintainers in the long term as dependencies get updated automatically.
+This means several neovim plugins are first packaged as nixpkgs [lua
+packages](#packaging-a-library-on-luarocks), and converted via `buildNeovimPlugin` in
+a vim plugin. This conversion is necessary because neovim expects lua folders to be
+top-level while luarocks installs them in varous subfolders by default.
+
+For instance:
+```nix
+rtp-nvim = neovimUtils.buildNeovimPlugin {
+    luaAttr = luaPackages.rtp-nvim;
+};
+```
+To update these packages, you should use the lua updater rather than vim's.
 
 #### Treesitter {#neovim-plugin-treesitter}
 

--- a/doc/languages-frameworks/neovim.section.md
+++ b/doc/languages-frameworks/neovim.section.md
@@ -28,7 +28,7 @@ neovim.override {
       # See examples below on how to use custom packages.
       start = [ ];
       # If a Vim plugin has a dependency that is not explicitly listed in
-      # opt that dependency will always be added to start to avoid confusion.
+      # `opt`, that dependency will always be added to `start` to avoid confusion.
       opt = [ ];
     };
   };

--- a/doc/languages-frameworks/vim.section.md
+++ b/doc/languages-frameworks/vim.section.md
@@ -58,25 +58,6 @@ vim-full.customize {
 }
 ```
 
-`myVimPackage` is an arbitrary name for the generated package. You can choose any name you like.
-For Neovim the syntax is:
-
-```nix
-neovim.override {
-  configure = {
-    customRC = ''
-      # here your custom configuration goes!
-    '';
-    packages.myVimPackage = with pkgs.vimPlugins; {
-      # see examples below how to use custom packages
-      start = [ ];
-      # If a Vim plugin has a dependency that is not explicitly listed in
-      # opt that dependency will always be added to start to avoid confusion.
-      opt = [ ];
-    };
-  };
-}
-```
 
 The resulting package can be added to `packageOverrides` in `~/.nixpkgs/config.nix` to make it installable:
 
@@ -177,15 +158,6 @@ Sometimes plugins require an override that must be changed when the plugin is up
 To add a new plugin, run `nix-shell -p vimPluginsUpdater --run 'vim-plugins-updater add "[owner]/[name]"'`. **NOTE**: This script automatically commits to your git repository. Be sure to check out a fresh branch before running.
 
 Finally, there are some plugins that are also packaged in nodePackages because they have Javascript-related build steps, such as running webpack. Those plugins are not listed in `vim-plugin-names` or managed by `vimPluginsUpdater` at all, and are included separately in `overrides.nix`. Currently, all these plugins are related to the `coc.nvim` ecosystem of the Language Server Protocol integration with Vim/Neovim.
-
-
-### Plugin optional configuration {#vim-plugin-required-snippet}
-
-Some plugins require specific configuration to work. We choose not to
-patch those plugins but expose the necessary configuration under
-`PLUGIN.passthru.initLua` for neovim plugins. For instance, the `unicode-vim` plugin
-needs the path towards a unicode database so we expose the following snippet `vim.g.Unicode_data_directory="${self.unicode-vim}/autoload/unicode"` under `vimPlugins.unicode-vim.passthru.initLua`.
-
 
 ## Updating plugins in nixpkgs {#updating-plugins-in-nixpkgs}
 

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -8,6 +8,9 @@
   "neovim-custom-configuration": [
     "index.html#neovim-custom-configuration"
   ],
+  "neovim-luarocks-based-plugins": [
+    "index.html#neovim-luarocks-based-plugins"
+  ],
   "nixpkgs-manual": [
     "index.html#nixpkgs-manual"
   ],
@@ -3799,7 +3802,8 @@
   "testing-neovim-plugins-neovim-require-check": [
     "index.html#testing-neovim-plugins-neovim-require-check"
   ],
-  "vim-plugin-required-snippet": [
+  "neovim-plugin-required-snippet": [
+    "index.html#neovim-plugin-required-snippet",
     "index.html#vim-plugin-required-snippet"
   ],
   "updating-plugins-in-nixpkgs": [


### PR DESCRIPTION
there is new wrapper interface `wrapNeovimUnstable` in development intended to be easier to use than the old `wrapNeovim`. It provides new fancy features that we would like to leverage/advertise
The interface is not definitive yet so we provide a translation layer to avoid breaking user configurations such that `wrapNeovim` still works. This explains why we document both at the moment with the goal to remove the old one once we ciment the interface.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
