### PR TITLE
am32-config-tool: init at 0-unstable-2024-12-29

### DIFF
--- a/pkgs/by-name/am/am32-config-tool/logo.nix
+++ b/pkgs/by-name/am/am32-config-tool/logo.nix
@@ -1,0 +1,34 @@
+{
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  name = "am32-logo.svg";
+
+  src = fetchFromGitHub {
+    owner = "am32-firmware";
+    repo = "am32-configurator";
+    rev = "9cf7a8434b22d2d0d941c96fca1e3ed0661d2936";
+    hash = "sha256-szlPKuVZldIV+J0o4a6SBOPEVvCnA9EaNuzW0uKAeRU=";
+  };
+
+  # Apply styling like how it's displayed at https://am32.ca/
+  # Note: not exact, as the rounding radius depends on the browser default font size (why do you do this to me?!?!)
+  postPatch = ''
+    width=$(sed -n 's/.*width="\([0-9]\+\)".*/\1/p' assets/icons/am32-logo.svg)
+    rx=$(( width * 16 / 180 ))
+    sed -i -z "s|\(<svg[^>]*>\)|\1<rect width='100%' height='100%' fill='#991b1b' rx='$rx' ry='$rx'/>|" assets/icons/am32-logo.svg
+  '';
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    cp assets/icons/am32-logo.svg $out
+
+    runHook postInstall
+  '';
+})

--- a/pkgs/by-name/am/am32-config-tool/package.nix
+++ b/pkgs/by-name/am/am32-config-tool/package.nix
@@ -1,0 +1,79 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  librsvg,
+  qmake ? qt6.qmake,
+  wrapQtAppsHook ? qt6.wrapQtAppsHook,
+  qtbase ? qt6.qtbase,
+  qtserialport ? qt6.qtserialport,
+  nix-update-script,
+  qt6,
+}:
+
+stdenv.mkDerivation {
+  pname = "am32-config-tool";
+  version = "0-unstable-2024-12-29";
+
+  src = fetchFromGitHub {
+    owner = "am32-firmware";
+    repo = "ConfigTool";
+    rev = "3dc3b25b17c88a30e147c1c7c15279c586b6f3fa";
+    hash = "sha256-bADGdIe1Mw/j/Vh7/ecuEloOyMlietUMLEHltt101dQ=";
+  };
+
+  # Replace hardcoded install path
+  postPatch = ''
+    substituteInPlace SerialPortConnector.pro \
+      --replace-fail '/opt/$''${TARGET}/bin' "$out/bin"
+  '';
+
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+    copyDesktopItems
+    librsvg # For converting the svg logo to png
+  ];
+
+  buildInputs = [
+    qtbase
+    qtserialport
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "AM32 Configurator";
+      exec = "SerialPortConnector";
+      icon = "am32";
+      desktopName = "AM32 Configurator";
+      comment = "AM32 Offline Configuration Tool";
+      categories = [ "Development" ];
+    })
+  ];
+
+  qmakeFlags = [
+    "./SerialPortConnector.pro"
+  ];
+
+  logo = callPackage ./logo.nix { };
+
+  postInstall = ''
+    mkdir -p $out/share/pixmaps
+    rsvg-convert -w 256 -h 256 -o $out/share/pixmaps/am32.png $logo
+    cp $logo $out/share/pixmaps/am32.svg
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "AM32 Offline Configuration Tool";
+    homepage = "https://github.com/am32-firmware/ConfigTool";
+    mainProgram = "SerialPortConnector";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+}

--- a/pkgs/by-name/am/am32-config-tool/package.nix
+++ b/pkgs/by-name/am/am32-config-tool/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  callPackage,
+  fetchFromGitHub,
+  makeDesktopItem,
+  copyDesktopItems,
+  librsvg,
+  qmake ? qt6.qmake,
+  wrapQtAppsHook ? qt6.wrapQtAppsHook,
+  qtbase ? qt6.qtbase,
+  qtserialport ? qt6.qtserialport,
+  nix-update-script,
+  qt6,
+}:
+
+stdenv.mkDerivation {
+  pname = "am32-config-tool";
+  version = "0-unstable-2024-12-29";
+
+  src = fetchFromGitHub {
+    owner = "am32-firmware";
+    repo = "ConfigTool";
+    rev = "3dc3b25b17c88a30e147c1c7c15279c586b6f3fa";
+    hash = "sha256-bADGdIe1Mw/j/Vh7/ecuEloOyMlietUMLEHltt101dQ=";
+  };
+
+  # Replace hardcoded install path
+  postPatch = ''
+    substituteInPlace SerialPortConnector.pro \
+      --replace-fail '/opt/$''${TARGET}/bin' "$out/bin"
+  '';
+
+  __structuredAttrs = true;
+  strictDeps = true;
+  separateDebugInfo = true;
+  nativeBuildInputs = [
+    qmake
+    wrapQtAppsHook
+    copyDesktopItems
+    librsvg # For converting the svg logo to png
+  ];
+  buildInputs = [
+    qtbase
+    qtserialport
+  ];
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "AM32 Configurator";
+      exec = "SerialPortConnector";
+      icon = "am32";
+      desktopName = "AM32 Configurator";
+      comment = "AM32 Offline Configuration Tool";
+      categories = [ "Development" ];
+    })
+  ];
+
+  qmakeFlags = [
+    "./SerialPortConnector.pro"
+  ];
+
+  logo = callPackage ./logo.nix { };
+
+  postInstall = ''
+    mkdir -p $out/share/pixmaps
+    rsvg-convert -w 256 -h 256 -o $out/share/pixmaps/am32.png $logo
+    cp $logo $out/share/pixmaps/am32.svg
+  '';
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  meta = {
+    description = "AM32 Offline Configuration Tool";
+    homepage = "https://github.com/am32-firmware/ConfigTool";
+    mainProgram = "SerialPortConnector";
+    license = lib.licenses.gpl3Plus;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [ pandapip1 ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
