### PR TITLE
sonic-lineup: fix and enable strictDeps

### DIFF
--- a/pkgs/applications/audio/sonic-lineup/default.nix
+++ b/pkgs/applications/audio/sonic-lineup/default.nix
@@ -72,9 +72,12 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [
+    capnproto # capnp
     pkg-config
     wrapQtAppsHook
   ];
+
+  strictDeps = true;
 
   enableParallelBuilding = true;
 


### PR DESCRIPTION
ref. #178468

Can't test cross due to Qt not cross-compiling.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).