### PR TITLE
taglib: 1.13.1 -> 2.0.2, taglib_1: init at 1.13.1

### DIFF
--- a/pkgs/applications/audio/ardour/7.nix
+++ b/pkgs/applications/audio/ardour/7.nix
@@ -52,7 +52,7 @@
   soundtouch,
   sratom,
   suil,
-  taglib,
+  taglib_1,
   vamp-plugin-sdk,
   wafHook,
   xjadeo,
@@ -166,7 +166,7 @@ stdenv.mkDerivation rec {
       soundtouch
       sratom
       suil
-      taglib
+      taglib_1
       vamp-plugin-sdk
     ]
     ++ lib.optionals videoSupport [

--- a/pkgs/applications/audio/clementine/default.nix
+++ b/pkgs/applications/audio/clementine/default.nix
@@ -11,7 +11,7 @@
   qtbase,
   qtx11extras,
   qttools,
-  taglib,
+  taglib_1,
   fftw,
   glew,
   qjson,
@@ -92,7 +92,7 @@ stdenv.mkDerivation (finalAttrs: {
       qtx11extras
       qttools
       sqlite
-      taglib
+      taglib_1
       alsa-lib
     ]
     # gst_plugins needed for setup-hooks

--- a/pkgs/applications/audio/soundkonverter/default.nix
+++ b/pkgs/applications/audio/soundkonverter/default.nix
@@ -19,7 +19,7 @@
   kxmlgui,
   qtbase,
   phonon,
-  taglib,
+  taglib_1,
   # optional backends
   withCD ? true,
   cdparanoia,
@@ -131,7 +131,7 @@ mkDerivation rec {
     qtbase
     phonon
   ];
-  buildInputs = [ taglib ] ++ runtimeDeps;
+  buildInputs = [ taglib_1 ] ++ runtimeDeps;
   # encoder plugins go to ${out}/lib so they're found by kbuildsycoca5
   cmakeFlags = [ "-DCMAKE_INSTALL_PREFIX=$out" ];
   sourceRoot = "${src.name}/src";

--- a/pkgs/applications/video/obs-studio/plugins/obs-tuna/default.nix
+++ b/pkgs/applications/video/obs-studio/plugins/obs-tuna/default.nix
@@ -6,7 +6,6 @@
   cmake,
   zlib,
   curl,
-  taglib,
   dbus,
   pkg-config,
   qtbase,
@@ -27,7 +26,6 @@ stdenv.mkDerivation (finalAttrs: {
     qtbase
     zlib
     curl
-    taglib
     dbus
   ];
 

--- a/pkgs/by-name/ca/cantata/package.nix
+++ b/pkgs/by-name/ca/cantata/package.nix
@@ -19,7 +19,7 @@
   libmusicbrainz5,
 
   withTaglib ? true,
-  taglib,
+  taglib_1,
   taglib_extras,
   withHttpStream ? true,
   withReplaygain ? true,
@@ -139,7 +139,7 @@ let
       ];
       enable = withTaglib;
       pkgs = [
-        taglib
+        taglib_1
         taglib_extras
       ];
     }

--- a/pkgs/by-name/ea/easytag/package.nix
+++ b/pkgs/by-name/ea/easytag/package.nix
@@ -8,7 +8,7 @@
   glib,
   libid3tag,
   id3lib,
-  taglib,
+  taglib_1,
   libvorbis,
   libogg,
   opusfile,
@@ -54,7 +54,7 @@ stdenv.mkDerivation rec {
     glib
     libid3tag
     id3lib
-    taglib
+    taglib_1
     libvorbis
     libogg
     opusfile

--- a/pkgs/by-name/lo/loudgain/package.nix
+++ b/pkgs/by-name/lo/loudgain/package.nix
@@ -7,7 +7,7 @@
   ffmpeg,
   libebur128,
   libresample,
-  taglib,
+  taglib_1,
   zlib,
 }:
 
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     ffmpeg
     libebur128
     libresample
-    taglib
+    taglib_1
     zlib
   ];
 

--- a/pkgs/by-name/ta/taglib_1/package.nix
+++ b/pkgs/by-name/ta/taglib_1/package.nix
@@ -3,33 +3,33 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  utf8cpp,
   zlib,
   testers,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "taglib";
-  version = "2.0.2";
+  version = "1.13.1";
 
   src = fetchFromGitHub {
     owner = "taglib";
     repo = "taglib";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-3cJwCo2nUSRYkk8H8dzyg7UswNPhjfhyQ704Fn9yNV8=";
+    hash = "sha256-QX0EpHGT36UsgIfRf5iALnwxe0jjLpZvCTbk8vSMFF4=";
   };
 
   strictDeps = true;
 
   nativeBuildInputs = [ cmake ];
 
-  buildInputs = [
-    zlib
-    utf8cpp
-  ];
+  buildInputs = [ zlib ];
 
   cmakeFlags = [
     (lib.cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    # Workaround unconditional ${prefix} until upstream is fixed:
+    #   https://github.com/taglib/taglib/issues/1098
+    (lib.cmakeFeature "CMAKE_INSTALL_LIBDIR" "lib")
+    (lib.cmakeFeature "CMAKE_INSTALL_INCLUDEDIR" "include")
   ];
 
   passthru.tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;

--- a/pkgs/by-name/ta/taglib_extras/package.nix
+++ b/pkgs/by-name/ta/taglib_extras/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   cmake,
   taglib,
   zlib,
@@ -11,9 +12,18 @@ stdenv.mkDerivation rec {
   pname = "taglib-extras";
   version = "1.0.1";
   src = fetchurl {
-    url = "https://ftp.rz.uni-wuerzburg.de/pub/unix/kde/taglib-extras/${version}/src/${pname}-${version}.tar.gz";
+    url = "https://download.kde.org/stable/taglib-extras/${version}/src/taglib-extras-${version}.tar.gz";
     sha256 = "0cln49ws9svvvals5fzxjxlzqm0fzjfymn7yfp4jfcjz655nnm7y";
   };
+
+  patches = [
+    (fetchurl {
+      name = "2001-taglib-extras-Fix-taglib-2.x-compat.patch";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/taglib-2.0.diff?h=taglib-extras&id=5826657b841b138c501e0633d1c9333fe9197b00";
+      hash = "sha256-yhme2KcIS5SPXz+mx/R2OiLV57WHz6WW8LJtYab4h5I=";
+    })
+  ];
+
   buildInputs = [ taglib ];
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/vl/vlc/package.nix
+++ b/pkgs/by-name/vl/vlc/package.nix
@@ -81,7 +81,7 @@
   srt,
   stdenv,
   systemd,
-  taglib,
+  taglib_1,
   unzip,
   wayland,
   wayland-protocols,
@@ -194,7 +194,7 @@ stdenv.mkDerivation (finalAttrs: {
       speex
       srt
       systemd
-      taglib
+      taglib_1
       xcbutilkeysyms
       wayland-scanner # only required for configure script
       zlib

--- a/pkgs/desktops/deepin/apps/deepin-music/default.nix
+++ b/pkgs/desktops/deepin/apps/deepin-music/default.nix
@@ -12,7 +12,7 @@
   ffmpeg_6,
   libvlc,
   qt6Packages,
-  taglib,
+  taglib_1,
   SDL2,
   gst_all_1,
 }:
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
       qt6Packages.qtmultimedia
       ffmpeg_6
       libvlc
-      taglib
+      taglib_1
       SDL2
     ]
     ++ (with gst_all_1; [

--- a/pkgs/desktops/deepin/core/dde-grand-search/default.nix
+++ b/pkgs/desktops/deepin/core/dde-grand-search/default.nix
@@ -11,7 +11,7 @@
   deepin-pdfium,
   qt5integration,
   qt5platform-plugins,
-  taglib,
+  taglib_1,
   ffmpeg,
   ffmpegthumbnailer,
   pcre,
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     deepin-pdfium
     qt5integration
     qt5platform-plugins
-    taglib
+    taglib_1
     ffmpeg
     ffmpegthumbnailer
     pcre

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
+  fetchpatch,
   gitUpdater,
   nixosTests,
   testers,
@@ -48,6 +49,14 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
+    # Fix compat with taglib 2.x
+    # Remove when version > 3.0.4
+    (fetchpatch {
+      name = "0001-lomiri-thumbnailer-Fix-taglib-2.x-compat.patch";
+      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/b7f1055e36cd6e33314bb9f6648f93e977a33267.patch";
+      hash = "sha256-9RHtxqsgdMkgIyswaeL5yS6+o/YvzT+HgRD8KL/RfNM=";
+    })
+
     # Remove when https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/23 merged & in release
     ./1001-doc-liblomiri-thumbnailer-qt-Honour-CMAKE_INSTALL_DO.patch
     ./1002-Re-enable-documentation.patch

--- a/pkgs/desktops/lomiri/services/mediascanner2/default.nix
+++ b/pkgs/desktops/lomiri/services/mediascanner2/default.nix
@@ -52,6 +52,14 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/core/mediascanner2/-/commit/1e65b32e32a0536b9e2f283ba563fa78b6ef6d61.patch";
       hash = "sha256-Xhm5+/E/pP+mn+4enqdsor1oRqfYTzabg1ODVfIhra4=";
     })
+
+    # Fix taglib 2.x compat
+    # Remove when version > 0.117
+    (fetchpatch {
+      name = "0002-mediascanner2-Fix-taglib-2.x-compat.patch";
+      url = "https://gitlab.com/ubports/development/core/mediascanner2/-/commit/0ce744ecb32abb39516d1b9f98d47c3e86690158.patch";
+      hash = "sha256-hz/EB83yNoxhxkEcg7ZMezknpKajhH1BNkYD3wrf/eY=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/development/compilers/chicken/5/overrides.nix
+++ b/pkgs/development/compilers/chicken/5/overrides.nix
@@ -188,10 +188,10 @@ in
     old: (addToBuildInputs [ pkgs.ncurses pkgs.stfl ] old) // (addToCscOptions "-L -lncurses" old);
   taglib =
     old:
-    (addToBuildInputs [ pkgs.zlib pkgs.taglib ] old)
+    (addToBuildInputs [ pkgs.zlib pkgs.taglib_1 ] old)
     // (
       # needed for tablib-config to be in PATH
-      addToNativeBuildInputs pkgs.taglib old
+      addToNativeBuildInputs pkgs.taglib_1 old
     );
   uuid-lib = addToBuildInputs pkgs.libuuid;
   webview = addToBuildInputsWithPkgConfig pkgs.webkitgtk_4_0;

--- a/pkgs/development/ocaml-modules/taglib/default.nix
+++ b/pkgs/development/ocaml-modules/taglib/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   dune-configurator,
   pkg-config,
-  taglib,
+  taglib_1,
   zlib,
 }:
 
@@ -24,7 +24,7 @@ buildDunePackage rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [
-    taglib
+    taglib_1
     zlib
   ];
 

--- a/pkgs/development/python-modules/pytaglib/default.nix
+++ b/pkgs/development/python-modules/pytaglib/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  taglib,
+  taglib_1,
   cython,
   pytestCheckHook,
   pythonOlder,
@@ -24,7 +24,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     cython
-    taglib
+    taglib_1
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -23,7 +23,7 @@
 , cmake, libssh2, openssl, openssl_1_1, libmysqlclient, git, perl, pcre2, gecode_3, curl
 , libsodium, snappy, libossp_uuid, lxc, libpcap, xorg, gtk3, lerc, buildRubyGem
 , cairo, expat, re2, rake, gobject-introspection, gdk-pixbuf, zeromq, czmq, graphicsmagick, libcxx
-, file, libvirt, glib, vips, taglib, libopus, linux-pam, libidn, protobuf, fribidi, harfbuzz
+, file, libvirt, glib, vips, taglib_1, libopus, linux-pam, libidn, protobuf, fribidi, harfbuzz
 , bison, flex, pango, python3, patchelf, binutils, freetds, wrapGAppsHook3, atk
 , bundler, libsass, dart-sass, libexif, libselinux, libsepol, shared-mime-info, libthai, libdatrie
 , CoreServices, DarwinTools, cctools, libtool, discount, exiv2, libepoxy, libxkbcommon, libmaxminddb, libyaml
@@ -848,7 +848,7 @@ in
   };
 
   taglib-ruby = attrs: {
-    buildInputs = [ taglib ];
+    buildInputs = [ taglib_1 ];
   };
 
   timfel-krb5-auth = attrs: {

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1834,7 +1834,7 @@ let
     ### T ###
 
     taglib = callPackage ../development/ocaml-modules/taglib {
-      inherit (pkgs) taglib;
+      inherit (pkgs) taglib_1;
     };
 
     tar = callPackage ../development/ocaml-modules/tar { };


### PR DESCRIPTION
(Based on & including some initial housekeeping in #373233, hence draft)

Closes #295648

New taglib major version released ~ a year ago, and it dropped some interfaces that were previously warned to be obsolete. Not every codebase so far has fixed their compatibility with this, so we'll need to keep around a 1.x taglib for those.

Doing a proper review for the bump was not possible for me, fetching all the deps & rebuilding everything that relies on `gst-plugins-good` is too much for my drive. I've instead just grepped for `taglib`, identified & built the derivations as best as I could, and fixed them / pinned them to the older `taglib` as needed.

- `dsf2flac` is borked on master, for unrelated reasons (deprecation of an interface in `Boost.Timer` breaks the config check).
- `obs-studio-plugins.obs-tuna` uses a vendored taglib and has no built-in way of building & linking against an external one, drop it from the package
- `taglib_extras` has a *seemingly* official source upload, fetch it from there. it's also seemingly an inactive project and doesn't support taglib 2.x OOTB, so fetch & apply a patch from the AUR(?) to fix that

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
