### PR TITLE
naja: 0-unstable-2024-08-27 -> 0-unstable-2025-01-13, fix cross

### DIFF
--- a/pkgs/by-name/na/naja/package.nix
+++ b/pkgs/by-name/na/naja/package.nix
@@ -12,16 +12,17 @@
   pkg-config,
   python3,
   tbb_2021_11,
+  buildPackages,
 }:
 stdenv.mkDerivation {
   pname = "naja";
-  version = "0-unstable-2024-08-27";
+  version = "0-unstable-2025-01-13";
 
   src = fetchFromGitHub {
     owner = "najaeda";
     repo = "naja";
-    rev = "ca7a544d16abb31d6992e702ccbd97be3a644c08";
-    hash = "sha256-lmgXv2nmmjKph0Tf9ZvV3kQBtbiGXYA7jrE77cgM+KU=";
+    rev = "ffc29daa22e02565b2a0a108f8e65236cdee413a";
+    hash = "sha256-XGlgSUHSpHxNrms50pOQ9eoGZ6y79Rbm/sDYW2C4qsg=";
     fetchSubmodules = true;
   };
 
@@ -31,17 +32,32 @@ stdenv.mkDerivation {
     "dev"
   ];
 
+  # disable building tests for cross build
+  postPatch =
+    lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      substituteInPlace CMakeLists.txt \
+        --replace-fail 'enable_testing()' "" \
+        --replace-fail 'add_subdirectory(test)' ""
+      substituteInPlace thirdparty/yosys-liberty/CMakeLists.txt \
+        --replace-fail 'add_subdirectory(test)' ""
+    ''
+    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+      patchShebangs --build test/test_utils/diff_files.py
+    '';
+
   strictDeps = true;
 
-  nativeBuildInputs = [
-    bison
-    capnproto
-    cmake
-    doxygen
-    flex
-    pkg-config
-    python3
-  ];
+  nativeBuildInputs =
+    [
+      bison
+      cmake
+      doxygen
+      flex
+      pkg-config
+    ]
+    ++ lib.optionals (stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      python3 # test scripts
+    ];
 
   buildInputs = [
     boost
@@ -49,14 +65,24 @@ stdenv.mkDerivation {
     flex # include dir
     libdwarf-lite
     tbb_2021_11
+    python3
   ];
 
   cmakeFlags = [
     (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_LIBDWARF" true)
     (lib.cmakeBool "CPPTRACE_USE_EXTERNAL_ZSTD" true)
+    # provide correct executables for cross
+    (lib.cmakeFeature "Python3_EXECUTABLE" (lib.getExe python3.pythonOnBuildForHost))
+    # TODO: remove these once capnp cross is fixed properly
+    (lib.cmakeFeature "CAPNP_EXECUTABLE" (lib.getExe' buildPackages.capnproto "capnp"))
+    (lib.cmakeFeature "CAPNPC_CXX_EXECUTABLE" (lib.getExe' buildPackages.capnproto "capnpc-c++"))
   ];
 
   doCheck = true;
+
+  postInstall = ''
+    moveToOutput lib/libnaja_bne.so $lib
+  '';
 
   meta = {
     description = "Structural Netlist API (and more) for EDA post synthesis flow development";


### PR DESCRIPTION
Simple update with some fixes for cross-compiling.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).