### PR TITLE
libretro: updates

### DIFF
--- a/pkgs/applications/emulators/libretro/cores/dosbox-pure.nix
+++ b/pkgs/applications/emulators/libretro/cores/dosbox-pure.nix
@@ -5,13 +5,13 @@
 }:
 mkLibretroCore {
   core = "dosbox-pure";
-  version = "0-unstable-2024-12-31";
+  version = "0-unstable-2025-01-12";
 
   src = fetchFromGitHub {
     owner = "schellingb";
     repo = "dosbox-pure";
-    rev = "9e468f0087454c6c1b68975ead933977d5cf33b2";
-    hash = "sha256-tiyDXxwZapu+Ol1icOeemVQ5oAjMMx2/M4nA0CiRkMY=";
+    rev = "e69a36a83c09f6660f7683d64eb8077a2da9a487";
+    hash = "sha256-QiwkWP6fHiGASN1SpLY+pSJVsu3TsENj7oAM4pCXnsk=";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/applications/emulators/libretro/cores/fbneo.nix
+++ b/pkgs/applications/emulators/libretro/cores/fbneo.nix
@@ -5,13 +5,13 @@
 }:
 mkLibretroCore {
   core = "fbneo";
-  version = "0-unstable-2025-01-06";
+  version = "0-unstable-2025-01-13";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "fbneo";
-    rev = "b8780c057029db8768c9a057b0bc28f9a12609d8";
-    hash = "sha256-cK3ILA0Ape6rHf5dPbXOMmQ69ZPZ/qrxeKYA1LniBEk=";
+    rev = "274cdf95a16981c130015a8b4808a95ef5b46203";
+    hash = "sha256-BS+Siam2jz6mFDz0mtvWH3+Is3Il78UbWkCh2f+DSAE=";
   };
 
   makefile = "Makefile";

--- a/pkgs/applications/emulators/libretro/cores/flycast.nix
+++ b/pkgs/applications/emulators/libretro/cores/flycast.nix
@@ -8,13 +8,13 @@
 }:
 mkLibretroCore {
   core = "flycast";
-  version = "0-unstable-2025-01-09";
+  version = "0-unstable-2025-01-10";
 
   src = fetchFromGitHub {
     owner = "flyinghead";
     repo = "flycast";
-    rev = "3114344414dbd8fb08efe1d6a25dbae457a2ec44";
-    hash = "sha256-UgH8L02WkAPaMMUnes6GYLjRbkuY8+9b6LCGaaQWhjQ=";
+    rev = "2e8984804170afce31a6d85e10ee4e153bbfb5aa";
+    hash = "sha256-jOOfYZ33SZM39vaJ/OqL7OpvIjuYoSewspOWNVTOBdk=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/emulators/libretro/cores/mame2003-plus.nix
+++ b/pkgs/applications/emulators/libretro/cores/mame2003-plus.nix
@@ -5,13 +5,13 @@
 }:
 mkLibretroCore {
   core = "mame2003-plus";
-  version = "0-unstable-2025-01-10";
+  version = "0-unstable-2025-01-13";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "mame2003-plus-libretro";
-    rev = "61305d60329d6a9abf7ddad1c3657b3253c5e64d";
-    hash = "sha256-fLThBOHkX0dV0zjDuJIh1ILpWi2FNV9oOXRH4ApcGbs=";
+    rev = "0fcccae96eb722d58be329977eb49173c5c97981";
+    hash = "sha256-Dt9MVWSe9ykNUasEgANsKYuXdqD3cGuM5jQCyD1iSY0=";
   };
 
   makefile = "Makefile";

--- a/pkgs/applications/emulators/libretro/cores/mgba.nix
+++ b/pkgs/applications/emulators/libretro/cores/mgba.nix
@@ -5,13 +5,13 @@
 }:
 mkLibretroCore {
   core = "mgba";
-  version = "0-unstable-2024-11-12";
+  version = "0-unstable-2025-01-14";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "mgba";
-    rev = "747362c02d2e71ee7c363e8dcb240925be8af906";
-    hash = "sha256-dBhdS6C1H02iwdYDVvJmkPWob81vpmQJdHUHJFAq2vo=";
+    rev = "72b5a9d3c4945c381d3230d59ea484729bcfe6c7";
+    hash = "sha256-90APQtjwYh/KPrvvlnVU+3G45gaibpOEBf9MoVWOzDI=";
   };
 
   meta = {

--- a/pkgs/applications/emulators/libretro/cores/pcsx-rearmed.nix
+++ b/pkgs/applications/emulators/libretro/cores/pcsx-rearmed.nix
@@ -5,13 +5,13 @@
 }:
 mkLibretroCore {
   core = "pcsx-rearmed";
-  version = "0-unstable-2025-01-09";
+  version = "0-unstable-2025-01-14";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "pcsx_rearmed";
-    rev = "c5d1f1dd5e304dfcba2adf0de8aa9188ca35fad3";
-    hash = "sha256-4stYqeGrKtNtjbhoG8IriV41xq3urH9QMNnqYMQ7CxQ=";
+    rev = "9fec7ce05906838a4682dd0a83d0e7d6ac0336fa";
+    hash = "sha256-1t6mXucg2/2hqyM4Id5Ze2Ry5U2rWMw2ce9mPAJur8k=";
   };
 
   dontConfigure = true;

--- a/pkgs/applications/emulators/libretro/cores/pcsx2.nix
+++ b/pkgs/applications/emulators/libretro/cores/pcsx2.nix
@@ -11,13 +11,13 @@
 }:
 mkLibretroCore {
   core = "pcsx2";
-  version = "0-unstable-2025-01-09";
+  version = "0-unstable-2025-01-12";
 
   src = fetchFromGitHub {
     owner = "libretro";
     repo = "ps2";
-    rev = "397b8f54b92aeffd2dd502c2c9b601305fb1de9d";
-    hash = "sha256-zP4gOxAAWqgmGkilVijY2GF6awD7cbMICfxYSsI1wa0=";
+    rev = "3fda2d1bb58564e2c814289036a7e4b10bf53357";
+    hash = "sha256-06cbF/Mhq2Gf87EQBiptHzqayOm0BA1c2dx6fu795RI=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/emulators/libretro/cores/play.nix
+++ b/pkgs/applications/emulators/libretro/cores/play.nix
@@ -14,13 +14,13 @@
 }:
 mkLibretroCore {
   core = "play";
-  version = "0-unstable-2025-01-09";
+  version = "0-unstable-2025-01-11";
 
   src = fetchFromGitHub {
     owner = "jpd002";
     repo = "Play-";
-    rev = "2958fa6c5ada62a3150513e4d8b6c4343c1cfbb8";
-    hash = "sha256-beo3tOUW62tiZISdAAGdeSVrS8w1l8x+JIi0nDDl5wA=";
+    rev = "b35ef5663b809a449a4c89f6e9808fd0a63e7e49";
+    hash = "sha256-P3R8gV4LxorfW0qo8HVOZunK58+/SO5pvlmij/HlnKw=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/emulators/libretro/cores/ppsspp.nix
+++ b/pkgs/applications/emulators/libretro/cores/ppsspp.nix
@@ -13,13 +13,13 @@
 }:
 mkLibretroCore {
   core = "ppsspp";
-  version = "0-unstable-2025-01-10";
+  version = "0-unstable-2025-01-14";
 
   src = fetchFromGitHub {
     owner = "hrydgard";
     repo = "ppsspp";
-    rev = "aa752ade6c99ec6db4c7f7cbc6c1133738005c5f";
-    hash = "sha256-zbDXAI3VnpPQbPMAN1ie5nPFCNzBQif1S1nZnar4fvg=";
+    rev = "841eb115e224dcdaa4b97f33ee0126fa00149c2a";
+    hash = "sha256-QnD13GxwW+B5ZdRRBhBwxUELwCwrlBsxBO0//elIfM4=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/applications/emulators/libretro/cores/scummvm.nix
+++ b/pkgs/applications/emulators/libretro/cores/scummvm.nix
@@ -1,42 +1,63 @@
 {
   lib,
   fetchFromGitHub,
-  fluidsynth,
   libGL,
   libGLU,
-  libjpeg,
-  libvorbis,
+  which,
+  zip,
   mkLibretroCore,
 }:
+let
+  # https://github.com/libretro/scummvm/blob/master/backends/platform/libretro/dependencies.mk#L8-L14
+  libretro-common-src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "libretro-common";
+    rev = "70ed90c42ddea828f53dd1b984c6443ddb39dbd6";
+    hash = "sha256-ItsUNbJCK/m/3VprK/zHD2UF5MhPC8b7jM3qS/oHU2A=";
+  };
+
+  libretro-deps-src = fetchFromGitHub {
+    owner = "libretro";
+    repo = "libretro-deps";
+    rev = "abf5246b016569759e7d1b0ea91bb98c2e34d160";
+    hash = "sha256-tdGytbSNMCfMuXIAUunOSVw9qFq2rRaruELhZwEmhWE=";
+  };
+in
 mkLibretroCore {
   core = "scummvm";
-  version = "0-unstable-2022-04-06";
+  version = "0-unstable-2024-12-03";
 
-  # This is the old source code before they upstreamed the source code,
-  # so now the libretro related code lives in the scummvm/scummvm repository.
-  # However this broke the old way we were doing builds, so for now point
-  # to a mirror with the old source code until this issue is fixed.
-  # TODO: switch to libretro/scummvm since this is more up-to-date
   src = fetchFromGitHub {
-    owner = "libretro-mirrors";
+    owner = "libretro";
     repo = "scummvm";
-    rev = "2fb2e4c551c9c1510c56f6e890ee0300b7b3fca3";
-    hash = "sha256-wrlFqu+ONbYH4xMFDByOgySobGrkhVc7kYWI4JzA4ew=";
+    rev = "7310d4e9f5d11553c6c5499911bd2f9b8ff3db3b";
+    hash = "sha256-h+tnwayBhzBQrg5x1rxIJASAS43SP8emTATDG2N3ePk=";
   };
 
   extraBuildInputs = [
-    fluidsynth
-    libjpeg
-    libvorbis
-    libGLU
     libGL
+    libGLU
+    zip
   ];
+
+  extraNativeBuildInputs = [ which ];
+
+  preConfigure = "cd backends/platform/libretro";
+
+  preBuild = ''
+    mkdir -p deps/libretro-{common,deps}
+    cp -a ${libretro-common-src}/* deps/libretro-common
+    cp -a ${libretro-deps-src}/* deps/libretro-deps
+    chmod -R u+w deps/
+
+    patchShebangs ./scripts/*
+  '';
+
   makefile = "Makefile";
-  preConfigure = "cd backends/platform/libretro/build";
 
   meta = {
     description = "Libretro port of ScummVM";
-    homepage = "https://github.com/libretro-mirrors/scummvm";
+    homepage = "https://github.com/libretro/scummvm";
     license = lib.licenses.gpl2Only;
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Continuation of https://github.com/NixOS/nixpkgs/pull/372719.

This PR finally updates a few cores that were in an older version because the newer versions didn't build anymore:
- `libretro.scummvm`
- `libretro.citra`

Since we are already here, updates all the cores for their latest commits.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
