### PR TITLE
[24.11] asterisk_18: 18.24.3 -> 18.26.1, asterisk_20: 20.9.3 -> 20.11.1

### DIFF
--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,14 +1,18 @@
 {
   "asterisk_18": {
-    "sha256": "70af95d1067a5afec7acbf98a242d853ae5dc8637c8f20d1f30d0dcf96eadb29",
-    "version": "18.24.3"
+    "sha256": "5da6fbd94f668115ae85aabf484a8b584faac72d75ed98bbb2bb800eeb17db3e",
+    "version": "18.26.0"
   },
   "asterisk_20": {
-    "sha256": "3d3d3c558f0ca9c3209a6aa7c561c2b85a1ab1b4099d4995f33c917b4cff9ee4",
-    "version": "20.9.3"
+    "sha256": "69325bf5ae0b38b361c9fd2f936fafdf2387be9812e857bdeb379cbec252bcca",
+    "version": "20.11.0"
   },
   "asterisk_21": {
-    "sha256": "bd9f492d3a9e6a5c9f0a69440402be61285d14df9dc7049377f29f9cbecfeeda",
-    "version": "21.4.3"
+    "sha256": "a46e22478b891b2e6d7ce9ba7b1908c6a7f1c4095c013d95415864da80ab2831",
+    "version": "21.6.0"
+  },
+  "asterisk_22": {
+    "sha256": "c892e9a51919d62bee2bed8b7c6f59ec79dfd48768ae289df61dba2da83f4413",
+    "version": "22.1.0"
   }
 }

--- a/pkgs/servers/asterisk/versions.json
+++ b/pkgs/servers/asterisk/versions.json
@@ -1,18 +1,18 @@
 {
   "asterisk_18": {
-    "sha256": "5da6fbd94f668115ae85aabf484a8b584faac72d75ed98bbb2bb800eeb17db3e",
-    "version": "18.26.0"
+    "sha256": "5df5d1c3885428b8bf03e78d7b8c3079d4512679137ef1d47e865dc2058aa825",
+    "version": "18.26.1"
   },
   "asterisk_20": {
-    "sha256": "69325bf5ae0b38b361c9fd2f936fafdf2387be9812e857bdeb379cbec252bcca",
-    "version": "20.11.0"
+    "sha256": "5ad25c136c7772f0ad10ae02d59f19b32c0cf64027278e3de6a6314ee24d5ff9",
+    "version": "20.11.1"
   },
   "asterisk_21": {
-    "sha256": "a46e22478b891b2e6d7ce9ba7b1908c6a7f1c4095c013d95415864da80ab2831",
-    "version": "21.6.0"
+    "sha256": "8df00a37b448fdaf63ffe25be0df02112211c1617efcb00b21cdb58f1baed89d",
+    "version": "21.6.1"
   },
   "asterisk_22": {
-    "sha256": "c892e9a51919d62bee2bed8b7c6f59ec79dfd48768ae289df61dba2da83f4413",
-    "version": "22.1.0"
+    "sha256": "e697740d91c33bf02d506d4da04635da48bfb0b5bb79bf8863c1a9b8f791264f",
+    "version": "22.1.1"
   }
 }


### PR DESCRIPTION
Fixes CVE-2024-53566

Changes:
https://github.com/asterisk/asterisk/releases/tag/20.11.1
https://github.com/asterisk/asterisk/releases/tag/20.11.0
https://github.com/asterisk/asterisk/releases/tag/20.10.0
https://github.com/asterisk/asterisk/releases/tag/18.26.1
https://github.com/asterisk/asterisk/releases/tag/18.26.0
https://github.com/asterisk/asterisk/releases/tag/18.25.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 373859`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>asterisk (asterisk-stable ,asterisk_20)</li>
    <li>asterisk-ldap</li>
    <li>asterisk_18 (asterisk-lts)</li>
    <li>asterisk-module-sccp</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
