### PR TITLE
frr: add optional grpc support via grpcSupport parameter

### DIFF
--- a/pkgs/by-name/fr/frr/package.nix
+++ b/pkgs/by-name/fr/frr/package.nix
@@ -1,77 +1,83 @@
-{ lib
-, stdenv
-, fetchFromGitHub
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchpatch,
 
-# build time
-, autoreconfHook
-, flex
-, bison
-, perl
-, pkg-config
-, texinfo
-, buildPackages
+  # build time
+  autoreconfHook,
+  flex,
+  bison,
+  perl,
+  pkg-config,
+  texinfo,
+  buildPackages,
+  grpc,
+  protobuf,
+  which,
 
-# runtime
-, c-ares
-, json_c
-, libcap
-, elfutils
-, libunwind
-, libyang
-, net-snmp
-, openssl
-, pam
-, pcre2
-, python3
-, readline
-, rtrlib
-, protobufc
-, zeromq
+  # runtime
+  c-ares,
+  json_c,
+  libcap,
+  elfutils,
+  libunwind,
+  libyang,
+  net-snmp,
+  openssl,
+  pam,
+  pcre2,
+  python3,
+  readline,
+  rtrlib,
+  protobufc,
+  zeromq,
 
-# tests
-, nettools
-, nixosTests
+  # tests
+  nettools,
+  nixosTests,
 
+  # general options
+  snmpSupport ? true,
+  rpkiSupport ? true,
+  numMultipath ? 64,
+  watchfrrSupport ? true,
+  cumulusSupport ? false,
+  rtadvSupport ? true,
+  irdpSupport ? true,
+  routeReplacementSupport ? true,
+  mgmtdSupport ? true,
+  # Experimental as of 10.1, reconsider if upstream changes defaults
+  grpcSupport ? false,
 
-# general options
-, snmpSupport ? true
-, rpkiSupport ? true
-, numMultipath ? 64
-, watchfrrSupport ? true
-, cumulusSupport ? false
-, rtadvSupport ? true
-, irdpSupport ? true
-, routeReplacementSupport ? true
-, mgmtdSupport ? true
+  # routing daemon options
+  bgpdSupport ? true,
+  ripdSupport ? true,
+  ripngdSupport ? true,
+  ospfdSupport ? true,
+  ospf6dSupport ? true,
+  ldpdSupport ? true,
+  nhrpdSupport ? true,
+  eigrpdSupport ? true,
+  babeldSupport ? true,
+  isisdSupport ? true,
+  pimdSupport ? true,
+  pim6dSupport ? true,
+  sharpdSupport ? true,
+  fabricdSupport ? true,
+  vrrpdSupport ? true,
+  pathdSupport ? true,
+  bfddSupport ? true,
+  pbrdSupport ? true,
+  staticdSupport ? true,
 
-# routing daemon options
-, bgpdSupport ? true
-, ripdSupport ? true
-, ripngdSupport ? true
-, ospfdSupport ? true
-, ospf6dSupport ? true
-, ldpdSupport ? true
-, nhrpdSupport ? true
-, eigrpdSupport ? true
-, babeldSupport ? true
-, isisdSupport ? true
-, pimdSupport ? true
-, pim6dSupport ? true
-, sharpdSupport ? true
-, fabricdSupport ? true
-, vrrpdSupport ? true
-, pathdSupport ? true
-, bfddSupport ? true
-, pbrdSupport ? true
-, staticdSupport ? true
+  # BGP options
+  bgpAnnounce ? true,
+  bgpBmp ? true,
+  bgpVnc ? true,
 
-# BGP options
-, bgpAnnounce ? true
-, bgpBmp ? true
-, bgpVnc ? true
-
-# OSPF options
-, ospfApi ? true
+  # OSPF options
+  ospfApi ? true,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -85,37 +91,60 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-TWqW6kI5dDl6IW2Ql6eeySDSyxp0fPgcJOOX1JxjAxs=";
   };
 
-  nativeBuildInputs = [
-    autoreconfHook
-    bison
-    flex
-    perl
-    pkg-config
-    python3.pkgs.sphinx
-    texinfo
-    protobufc
+  patches = [
+    (fetchpatch {
+      name = "CVE-2024-44070.patch";
+      url = "https://github.com/FRRouting/frr/commit/fea4ed5043b4a523921f970a39a565d2c1ca381f.patch";
+      hash = "sha256-X9FjQeOvo92+mL1z3u5W0LBhhePDAyhFAqh8sAtNNm8=";
+    })
   ];
 
-  buildInputs = [
-    c-ares
-    json_c
-    libunwind
-    libyang
-    openssl
-    pam
-    pcre2
-    protobufc
-    python3
-    readline
-    rtrlib
-    zeromq
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    libcap
-  ] ++ lib.optionals snmpSupport [
-    net-snmp
-  ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
-    elfutils
-  ];
+  # Without the std explicitly set, we may run into abseil-cpp
+  # compilation errors.
+  CXXFLAGS = "-std=gnu++23";
+
+  nativeBuildInputs =
+    [
+      autoreconfHook
+      bison
+      flex
+      perl
+      pkg-config
+      protobufc
+      python3.pkgs.sphinx
+      texinfo
+    ]
+    ++ lib.optionals grpcSupport [
+      which
+    ];
+
+  buildInputs =
+    [
+      c-ares
+      json_c
+      libunwind
+      libyang
+      openssl
+      pam
+      pcre2
+      python3
+      readline
+      rtrlib
+      zeromq
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libcap
+    ]
+    ++ lib.optionals snmpSupport [
+      net-snmp
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform elfutils) [
+      elfutils
+    ]
+    ++ lib.optionals grpcSupport [
+      grpc
+      protobuf
+    ];
 
   # otherwise in cross-compilation: "configure: error: no working python version found"
   depsBuildBuild = [
@@ -124,62 +153,68 @@ stdenv.mkDerivation (finalAttrs: {
 
   # cross-compiling: clippy is compiled with the build host toolchain, split it out to ease
   # navigation in dependency hell
-  clippy-helper = buildPackages.callPackage ./clippy-helper.nix { frrVersion = finalAttrs.version; frrSource = finalAttrs.src; };
+  clippy-helper = buildPackages.callPackage ./clippy-helper.nix {
+    frrVersion = finalAttrs.version;
+    frrSource = finalAttrs.src;
+  };
 
-  configureFlags = [
-    "--disable-silent-rules"
-    "--disable-exampledir"
-    "--enable-configfile-mask=0640"
-    "--enable-group=frr"
-    "--enable-logfile-mask=0640"
-    "--enable-multipath=${toString numMultipath}"
-    "--enable-user=frr"
-    "--enable-vty-group=frrvty"
-    "--localstatedir=/run/frr"
-    "--sbindir=${placeholder "out"}/libexec/frr"
-    "--sysconfdir=/etc/frr"
-    "--with-clippy=${finalAttrs.clippy-helper}/bin/clippy"
-    # general options
-    (lib.strings.enableFeature snmpSupport "snmp")
-    (lib.strings.enableFeature rpkiSupport "rpki")
-    (lib.strings.enableFeature watchfrrSupport "watchfrr")
-    (lib.strings.enableFeature rtadvSupport "rtadv")
-    (lib.strings.enableFeature irdpSupport "irdp")
-    (lib.strings.enableFeature routeReplacementSupport "rr-semantics")
-    (lib.strings.enableFeature mgmtdSupport "mgmtd")
+  configureFlags =
+    [
+      "--disable-silent-rules"
+      "--disable-exampledir"
+      "--enable-configfile-mask=0640"
+      "--enable-group=frr"
+      "--enable-logfile-mask=0640"
+      "--enable-multipath=${toString numMultipath}"
+      "--enable-user=frr"
+      "--enable-vty-group=frrvty"
+      "--localstatedir=/run/frr"
+      "--sbindir=${placeholder "out"}/libexec/frr"
+      "--sysconfdir=/etc/frr"
+      "--with-clippy=${finalAttrs.clippy-helper}/bin/clippy"
+      # general options
+      (lib.strings.enableFeature snmpSupport "snmp")
+      (lib.strings.enableFeature rpkiSupport "rpki")
+      (lib.strings.enableFeature watchfrrSupport "watchfrr")
+      (lib.strings.enableFeature rtadvSupport "rtadv")
+      (lib.strings.enableFeature irdpSupport "irdp")
+      (lib.strings.enableFeature routeReplacementSupport "rr-semantics")
+      (lib.strings.enableFeature mgmtdSupport "mgmtd")
+      (lib.strings.enableFeature grpcSupport "grpc")
 
-    # routing protocols
-    (lib.strings.enableFeature bgpdSupport "bgpd")
-    (lib.strings.enableFeature ripdSupport "ripd")
-    (lib.strings.enableFeature ripngdSupport "ripngd")
-    (lib.strings.enableFeature ospfdSupport "ospfd")
-    (lib.strings.enableFeature ospf6dSupport "ospf6d")
-    (lib.strings.enableFeature ldpdSupport "ldpd")
-    (lib.strings.enableFeature nhrpdSupport "nhrpd")
-    (lib.strings.enableFeature eigrpdSupport "eigrpd")
-    (lib.strings.enableFeature babeldSupport "babeld")
-    (lib.strings.enableFeature isisdSupport "isisd")
-    (lib.strings.enableFeature pimdSupport "pimd")
-    (lib.strings.enableFeature pim6dSupport "pim6d")
-    (lib.strings.enableFeature sharpdSupport "sharpd")
-    (lib.strings.enableFeature fabricdSupport "fabricd")
-    (lib.strings.enableFeature vrrpdSupport "vrrpd")
-    (lib.strings.enableFeature pathdSupport "pathd")
-    (lib.strings.enableFeature bfddSupport "bfdd")
-    (lib.strings.enableFeature pbrdSupport "pbrd")
-    (lib.strings.enableFeature staticdSupport "staticd")
-    # BGP options
-    (lib.strings.enableFeature bgpAnnounce "bgp-announce")
-    (lib.strings.enableFeature bgpBmp "bgp-bmp")
-    (lib.strings.enableFeature bgpVnc "bgp-vnc")
-    # OSPF options
-    (lib.strings.enableFeature ospfApi "ospfapi")
-    # Cumulus options
-    (lib.strings.enableFeature cumulusSupport "cumulus")
-  ] ++ lib.optionals snmpSupport [
-    # Used during build for paths, `dev` has build shebangs so can be run during build.
-    "NETSNMP_CONFIG=${lib.getDev net-snmp}/bin/net-snmp-config"
-  ];
+      # routing protocols
+      (lib.strings.enableFeature bgpdSupport "bgpd")
+      (lib.strings.enableFeature ripdSupport "ripd")
+      (lib.strings.enableFeature ripngdSupport "ripngd")
+      (lib.strings.enableFeature ospfdSupport "ospfd")
+      (lib.strings.enableFeature ospf6dSupport "ospf6d")
+      (lib.strings.enableFeature ldpdSupport "ldpd")
+      (lib.strings.enableFeature nhrpdSupport "nhrpd")
+      (lib.strings.enableFeature eigrpdSupport "eigrpd")
+      (lib.strings.enableFeature babeldSupport "babeld")
+      (lib.strings.enableFeature isisdSupport "isisd")
+      (lib.strings.enableFeature pimdSupport "pimd")
+      (lib.strings.enableFeature pim6dSupport "pim6d")
+      (lib.strings.enableFeature sharpdSupport "sharpd")
+      (lib.strings.enableFeature fabricdSupport "fabricd")
+      (lib.strings.enableFeature vrrpdSupport "vrrpd")
+      (lib.strings.enableFeature pathdSupport "pathd")
+      (lib.strings.enableFeature bfddSupport "bfdd")
+      (lib.strings.enableFeature pbrdSupport "pbrd")
+      (lib.strings.enableFeature staticdSupport "staticd")
+      # BGP options
+      (lib.strings.enableFeature bgpAnnounce "bgp-announce")
+      (lib.strings.enableFeature bgpBmp "bgp-bmp")
+      (lib.strings.enableFeature bgpVnc "bgp-vnc")
+      # OSPF options
+      (lib.strings.enableFeature ospfApi "ospfapi")
+      # Cumulus options
+      (lib.strings.enableFeature cumulusSupport "cumulus")
+    ]
+    ++ lib.optionals snmpSupport [
+      # Used during build for paths, `dev` has build shebangs so can be run during build.
+      "NETSNMP_CONFIG=${lib.getDev net-snmp}/bin/net-snmp-config"
+    ];
 
   postPatch = ''
     substituteInPlace tools/frr-reload \
@@ -221,8 +256,14 @@ stdenv.mkDerivation (finalAttrs: {
       infrastructure, web 2.0 businesses, hyperscale services, and Fortune 500
       private clouds.
     '';
-    license = with licenses; [ gpl2Plus lgpl21Plus ];
-    maintainers = with maintainers; [ woffs thillux ];
+    license = with licenses; [
+      gpl2Plus
+      lgpl21Plus
+    ];
+    maintainers = with maintainers; [
+      woffs
+      thillux
+    ];
     # adapt to platforms stated in http://docs.frrouting.org/en/latest/overview.html#supported-platforms
     platforms = (platforms.linux ++ platforms.freebsd ++ platforms.netbsd ++ platforms.openbsd);
   };


### PR DESCRIPTION
I've been running FRR with gRPC support for a while now with these changes to the upstream package in an overlay. Thought it'd be worth upstreaming. Notes:

- I'm not thrilled about adding `CXXFLAGS` to the derivation since it changes the package regardless of whether or not you enable gRPC, but it seems to behave fine. And if upstream isn't setting something like `-std` explicitly, it makes me think that adding it to the downstream nix package will probably just make it behave a little more like upstream intends.
- The parameter is set to `true` by default, but I'm happy to set this to `false` if pulling in `grpc` and `protobuf` is a little much.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
