### PR TITLE
digimend: Backport fix to enable building with Linux 6.12

### DIFF
--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -16,6 +16,8 @@ stdenv.mkDerivation rec {
     hash = "sha256-YYCxTyoZGMnqC2nKkRi5Z1uofldGvJDGY2/sO9iMNIo=";
   };
 
+  patches = [ ./fix-linux-6.12-build.patch ];
+
   postPatch = ''
     sed 's/udevadm /true /' -i Makefile
     sed 's/depmod /true /' -i Makefile

--- a/pkgs/os-specific/linux/digimend/fix-linux-6.12-build.patch
+++ b/pkgs/os-specific/linux/digimend/fix-linux-6.12-build.patch
@@ -1,0 +1,243 @@
+From b9ef432e2b93c31d2e39be13f22c61f4c2e8b5cb Mon Sep 17 00:00:00 2001
+From: Stroopwafe1 <48443491+Stroopwafe1@users.noreply.github.com>
+Date: Mon, 25 Nov 2024 08:15:40 +0100
+Subject: [PATCH 1/2] Update to Linux 6.12
+
+---
+ hid-kye.c            | 2 +-
+ hid-polostar.c       | 2 +-
+ hid-uclogic-core.c   | 2 +-
+ hid-uclogic-params.c | 2 +-
+ hid-uclogic-rdesc.c  | 2 +-
+ hid-viewsonic.c      | 2 +-
+ 6 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/hid-kye.c b/hid-kye.c
+index 5fde67f..5353405 100644
+--- a/hid-kye.c
++++ b/hid-kye.c
+@@ -579,7 +579,7 @@ static __u8 *kye_consumer_control_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 	return rdesc;
+ }
+ 
+-static __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++static const __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 		unsigned int *rsize)
+ {
+ 	switch (hdev->product) {
+diff --git a/hid-polostar.c b/hid-polostar.c
+index ecbe02c..92a0085 100644
+--- a/hid-polostar.c
++++ b/hid-polostar.c
+@@ -149,7 +149,7 @@ static __u8 pt1001_rdesc_fixed[] = {
+ 	0xC0,               /*  End Collection                          */
+ };
+ 
+-static __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++static const __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 				   unsigned int *rsize)
+ {
+ 	struct usb_interface *iface = to_usb_interface(hdev->dev.parent);
+diff --git a/hid-uclogic-core.c b/hid-uclogic-core.c
+index 06298ac..efc7575 100644
+--- a/hid-uclogic-core.c
++++ b/hid-uclogic-core.c
+@@ -53,7 +53,7 @@ static void uclogic_inrange_timeout(struct timer_list *t)
+ 	input_sync(input);
+ }
+ 
+-static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++static const __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 					unsigned int *rsize)
+ {
+ 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+diff --git a/hid-uclogic-params.c b/hid-uclogic-params.c
+index 7f7cc36..4b6b08b 100644
+--- a/hid-uclogic-params.c
++++ b/hid-uclogic-params.c
+@@ -19,7 +19,7 @@
+ #include "hid-ids.h"
+ #include <linux/ctype.h>
+ #include <linux/string.h>
+-#include <asm/unaligned.h>
++#include <linux/unaligned.h>
+ 
+ #include <linux/version.h>
+ 
+diff --git a/hid-uclogic-rdesc.c b/hid-uclogic-rdesc.c
+index c26bfb1..4505633 100644
+--- a/hid-uclogic-rdesc.c
++++ b/hid-uclogic-rdesc.c
+@@ -16,7 +16,7 @@
+ 
+ #include "hid-uclogic-rdesc.h"
+ #include <linux/slab.h>
+-#include <asm/unaligned.h>
++#include <linux/unaligned.h>
+ 
+ /* Fixed WP4030U report descriptor */
+ __u8 uclogic_rdesc_wp4030u_fixed_arr[] = {
+diff --git a/hid-viewsonic.c b/hid-viewsonic.c
+index d887ac1..621f11f 100644
+--- a/hid-viewsonic.c
++++ b/hid-viewsonic.c
+@@ -71,7 +71,7 @@ static __u8 pd1011_rdesc_fixed[] = {
+ 	0xC0                    /*  End Collection                      */
+ };
+ 
+-static __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++static const __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 				    unsigned int *rsize)
+ {
+ 	switch (hdev->product) {
+
+From a9f3496b317cf27240533bc51910736d36837d8c Mon Sep 17 00:00:00 2001
+From: Stroopwafe1 <48443491+Stroopwafe1@users.noreply.github.com>
+Date: Mon, 16 Dec 2024 11:55:54 +0100
+Subject: [PATCH 2/2] Feat: Implemented feedback on keeping backwards
+ compatibility
+
+---
+ hid-kye.c            | 7 +++++++
+ hid-polostar.c       | 6 ++++++
+ hid-uclogic-core.c   | 5 +++++
+ hid-uclogic-params.c | 7 ++++++-
+ hid-uclogic-rdesc.c  | 6 ++++++
+ hid-viewsonic.c      | 6 ++++++
+ 6 files changed, 36 insertions(+), 1 deletion(-)
+
+diff --git a/hid-kye.c b/hid-kye.c
+index 5353405..ac14d1a 100644
+--- a/hid-kye.c
++++ b/hid-kye.c
+@@ -18,6 +18,8 @@
+ #include <linux/hid.h>
+ #include <linux/module.h>
+ 
++#include <linux/version.h>
++
+ #include "hid-ids.h"
+ 
+ /* Original EasyPen i405X report descriptor size */
+@@ -579,8 +581,13 @@ static __u8 *kye_consumer_control_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 	return rdesc;
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++static __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++		unsigned int *rsize)
++#else
+ static const __u8 *kye_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 		unsigned int *rsize)
++#endif
+ {
+ 	switch (hdev->product) {
+ 	case USB_DEVICE_ID_KYE_ERGO_525V:
+diff --git a/hid-polostar.c b/hid-polostar.c
+index 92a0085..df51069 100644
+--- a/hid-polostar.c
++++ b/hid-polostar.c
+@@ -16,6 +16,7 @@
+ #include <linux/hid.h>
+ #include <linux/module.h>
+ #include <linux/usb.h>
++#include <linux/version.h>
+ 
+ #include "hid-ids.h"
+ 
+@@ -149,8 +150,13 @@ static __u8 pt1001_rdesc_fixed[] = {
+ 	0xC0,               /*  End Collection                          */
+ };
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++static __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++				   unsigned int *rsize)
++#else
+ static const __u8 *polostar_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 				   unsigned int *rsize)
++#endif
+ {
+ 	struct usb_interface *iface = to_usb_interface(hdev->dev.parent);
+ 	__u8 iface_num = iface->cur_altsetting->desc.bInterfaceNumber;
+diff --git a/hid-uclogic-core.c b/hid-uclogic-core.c
+index efc7575..72680dd 100644
+--- a/hid-uclogic-core.c
++++ b/hid-uclogic-core.c
+@@ -53,8 +53,13 @@ static void uclogic_inrange_timeout(struct timer_list *t)
+ 	input_sync(input);
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++static __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++				unsigned int *rsize)
++#else
+ static const __u8 *uclogic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 					unsigned int *rsize)
++#endif
+ {
+ 	struct uclogic_drvdata *drvdata = hid_get_drvdata(hdev);
+ 
+diff --git a/hid-uclogic-params.c b/hid-uclogic-params.c
+index 4b6b08b..97f9dc6 100644
+--- a/hid-uclogic-params.c
++++ b/hid-uclogic-params.c
+@@ -19,9 +19,14 @@
+ #include "hid-ids.h"
+ #include <linux/ctype.h>
+ #include <linux/string.h>
++#include <linux/version.h>
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++#include <asm/unaligned.h>
++#else
+ #include <linux/unaligned.h>
++#endif
+ 
+-#include <linux/version.h>
+ 
+ /**
+  * uclogic_params_pen_inrange_to_str() - Convert a pen in-range reporting type
+diff --git a/hid-uclogic-rdesc.c b/hid-uclogic-rdesc.c
+index 4505633..c9d7230 100644
+--- a/hid-uclogic-rdesc.c
++++ b/hid-uclogic-rdesc.c
+@@ -16,7 +16,13 @@
+ 
+ #include "hid-uclogic-rdesc.h"
+ #include <linux/slab.h>
++#include <linux/version.h>
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++#include <asm/unaligned.h>
++#else
+ #include <linux/unaligned.h>
++#endif
+ 
+ /* Fixed WP4030U report descriptor */
+ __u8 uclogic_rdesc_wp4030u_fixed_arr[] = {
+diff --git a/hid-viewsonic.c b/hid-viewsonic.c
+index 621f11f..0d526c3 100644
+--- a/hid-viewsonic.c
++++ b/hid-viewsonic.c
+@@ -16,6 +16,7 @@
+ #include <linux/hid.h>
+ #include <linux/module.h>
+ #include <linux/usb.h>
++#include <linux/version.h>
+ 
+ #include "hid-ids.h"
+ 
+@@ -71,8 +72,13 @@ static __u8 pd1011_rdesc_fixed[] = {
+ 	0xC0                    /*  End Collection                      */
+ };
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++static __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
++				    unsigned int *rsize)
++#else
+ static const __u8 *viewsonic_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 				    unsigned int *rsize)
++#endif
+ {
+ 	switch (hdev->product) {
+ 	case USB_DEVICE_ID_VIEWSONIC_PD1011:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR has landed in upstream, however a new release is yet to be made. Resolves #363873 

Upstream PR: https://github.com/DIGImend/digimend-kernel-drivers/pull/707

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
