### PR TITLE
vvenc: Fix build on Darwin

### DIFF
--- a/pkgs/by-name/vv/vvenc/package.nix
+++ b/pkgs/by-name/vv/vvenc/package.nix
@@ -24,6 +24,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-9fWKunafTniBsY9hK09+xYwvB7IgGPhZmgqauPHgB/g=";
   };
 
+  patches = [ ./unset-darwin-cmake-flags.patch ];
+
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optionals stdenv.cc.isGNU [
       "-Wno-maybe-uninitialized"

--- a/pkgs/by-name/vv/vvenc/unset-darwin-cmake-flags.patch
+++ b/pkgs/by-name/vv/vvenc/unset-darwin-cmake-flags.patch
@@ -1,0 +1,9 @@
+--- a/source/Lib/vvenc/CMakeLists.txt	2025-01-14 23:26:14
++++ b/source/Lib/vvenc/CMakeLists.txt	2025-01-14 23:26:43
+@@ -174,6 +174,4 @@
+ set_target_properties( ${LIB_NAME} PROPERTIES
+                                    VERSION ${PROJECT_VERSION}
+                                    SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+-                                   INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib
+-                                   MACOSX_RPATH FALSE
+                                    FOLDER lib )


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

vvenc 1.13.0 introduced [changes](https://github.com/fraunhoferhhi/vvenc/pull/407) to the CMake environment which broke the build on Darwin:

```cmake
INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib
MACOSX_RPATH FALSE
```

~Setting `CMAKE_SKIP_RPATH=true` fixes the build for me.~ This broke the down stream dependencies (perhaps obviously). I opted for reverting the darwin-specific vvenc 1.13.0 changes to `CMakeLists.txt` in a patch instead.

**References:**

- See changes to `source/Lib/vvenc/CMakeLists.txt` here: https://github.com/fraunhoferhhi/vvenc/pull/407.
- https://github.com/NixOS/nixpkgs/pull/372214

Should resolve these build issues:

- https://github.com/NixOS/nixpkgs/pull/373158

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
