### PR TITLE
nixos/matomo: fix service failure when not fully set up

### DIFF
--- a/nixos/modules/services/web-apps/matomo.nix
+++ b/nixos/modules/services/web-apps/matomo.nix
@@ -183,7 +183,10 @@ in {
             chmod -R u+rwX,g+rwX,o-rwx "${dataDir}"
 
             # check whether user setup has already been done
-            if test -f "${dataDir}/config/config.ini.php"; then
+            if test -f "${dataDir}/config/config.ini.php" &&
+              # since matomo-5.2.0, the config.ini.php is already created at first
+              # installer page access https://github.com/matomo-org/matomo/issues/22932
+              grep -q -F "[database]" "${dataDir}/config/config.ini.php"; then
               # then execute possibly pending database upgrade
               matomo-console core:update --yes
             fi

--- a/nixos/tests/matomo.nix
+++ b/nixos/tests/matomo.nix
@@ -37,11 +37,25 @@ let
         machine.wait_for_unit("phpfpm-matomo.service")
         machine.wait_for_unit("nginx.service")
 
+        with subtest("matomo.js reachable via HTTP"):
+          machine.succeed("curl -sSfk http://machine/matomo.js")
+
+        with subtest("js/piwik.js reachable via HTTP"):
+          machine.succeed("curl -sSfk http://machine/js/piwik.js")
+
+        with subtest("matomo.php (API) reachable via HTTP"):
+          machine.succeed("curl -sSfk http://machine/matomo.php")
+
         # without the grep the command does not produce valid utf-8 for some reason
         with subtest("welcome screen loads"):
             machine.succeed(
                 "curl -sSfL http://localhost/ | grep '<title>Matomo[^<]*Installation'"
             )
+
+        with subtest("killing the phpfpm process should trigger an automatic restart"):
+          machine.succeed("systemctl kill -s KILL phpfpm-matomo")
+          machine.sleep(1)
+          machine.wait_for_unit("phpfpm-matomo.service")
       '';
     };
 in


### PR DESCRIPTION
Since matomo-5.2.0, the config.php.ini is already created when first
accessing the installer page without completing it. This breaks our
discovery of whether to run database migrations.

Attempting to run DB migrations without provided database credentials
causes a crash -> causing matomo-setup-update.service to fail -> causing
phpfpm-matomo.service to fail.
This is a problem when the service (or the whole system) is restarted during the start, but before the end of the setup process of the web installer. With the `phpfpm-matomo.service` failing to start due to a failing dependency, finishing up the setup process won't be possible anymore.

I have also extended the corresponding NixOS tests to cover aspects we have already been covering in a more detailed downstream test for our own matomo module.
The last test with the `systemctl kill` was actually the one revealing the issue fixed here.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
