### PR TITLE
cosmic-player: init at unstable-2025-01-14

### DIFF
--- a/pkgs/by-name/co/cosmic-player/package.nix
+++ b/pkgs/by-name/co/cosmic-player/package.nix
@@ -1,0 +1,110 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  alsa-lib,
+  ffmpeg,
+  glib,
+  gst_all_1,
+  just,
+  pkg-config,
+  libxkbcommon,
+  stdenv,
+  cosmic-icons,
+  libglvnd,
+  libgbm,
+  wayland,
+  xorg,
+  vulkan-loader,
+  makeBinaryWrapper,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "cosmic-player";
+  version = "1.0.0-alpha.5.1";
+
+  src = fetchFromGitHub {
+    owner = "pop-os";
+    repo = pname;
+    rev = "epoch-${version}";
+    hash = "sha256-IgMFKtuMAfRtbxunwrwRzFi/0PcSMWhx33uJcxiAHhI=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-VSUv4yV54fzWPhxZV/EjBrkx7tTLo6vfSHNiluWnn9A=";
+
+  postPatch = ''
+    substituteInPlace justfile --replace '#!/usr/bin/env' "#!$(command -v env)"
+  '';
+
+  nativeBuildInputs = [
+    just
+    pkg-config
+    makeBinaryWrapper
+  ];
+
+  # Largely based on lilyinstarlight's work linked below
+  # https://github.com/lilyinstarlight/nixos-cosmic/blob/main/pkgs/cosmic-player/package.nix
+
+  buildInputs = [
+    alsa-lib
+    ffmpeg
+    glib
+    gst_all_1.gstreamer
+    gst_all_1.gst-plugins-base
+    gst_all_1.gst-plugins-good
+    gst_all_1.gst-plugins-bad
+    libxkbcommon
+    libgbm
+    wayland
+    vulkan-loader
+    xorg.libX11
+    libglvnd
+  ];
+
+  dontUseJustBuild = true;
+
+  justFlags = [
+    "--set"
+    "prefix"
+    (placeholder "out")
+    "--set"
+    "bin-src"
+    "target/${stdenv.hostPlatform.rust.cargoShortTarget}/release/cosmic-player"
+  ];
+
+  # Force linking to libEGL, which is always dlopen()ed, and to
+  # libwayland-client, which is always dlopen()ed except by the
+  # obscure winit backend.
+  RUSTFLAGS = map (a: "-C link-arg=${a}") [
+    "-Wl,--push-state,--no-as-needed"
+    "-lEGL"
+    "-lwayland-client"
+    "-Wl,--pop-state"
+  ];
+
+  # LD_LIBRARY_PATH can be removed once tiny-xlib is bumped above 0.2.2
+  postInstall = ''
+    wrapProgram "$out/bin/cosmic-player" \
+      --suffix XDG_DATA_DIRS : "${cosmic-icons}/share" \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          xorg.libX11
+          xorg.libXcursor
+          xorg.libXi
+          vulkan-loader
+          libxkbcommon
+          wayland
+        ]
+      }
+  '';
+
+  meta = {
+    homepage = "https://github.com/pop-os/cosmic-player";
+    description = "Media player for the COSMIC Desktop Environment";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ ahoneybun ];
+    platforms = lib.platforms.linux;
+    mainProgram = "cosmic-player";
+  };
+}


### PR DESCRIPTION
## Things done

This is based on @lilyinstarlight work in the nixos-cosmic repo linked below.

https://github.com/lilyinstarlight/nixos-cosmic/blob/main/pkgs/cosmic-player/package.nix

This is based on the latest tag for COSMIC Player which is epoch-1.0.0-alpha.5.1

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
