### PR TITLE
network: make network setup service do not depend on udev, and fix typo with greTunnels

### DIFF
--- a/nixos/modules/tasks/network-interfaces-scripted.nix
+++ b/nixos/modules/tasks/network-interfaces-scripted.nix
@@ -77,6 +77,7 @@ let
              (hasAttr dev cfg.macvlans) ||
              (hasAttr dev cfg.sits) ||
              (hasAttr dev cfg.vlans) ||
+             (hasAttr dev cfg.greTunnels) ||
              (hasAttr dev cfg.vswitches)
           then [ "${dev}-netdev.service" ]
           else optional (!config.boot.isContainer) (subsystemDevice dev);
@@ -94,7 +95,7 @@ let
         networkSetup = lib.mkIf needNetworkSetup
           { description = "Networking Setup";
 
-            after = [ "network-pre.target" "systemd-udevd.service" "systemd-sysctl.service" ];
+            after = [ "network-pre.target" ];
             before = [ "network.target" "shutdown.target" ];
             wants = [ "network.target" ];
             # exclude bridges from the partOf relationship to fix container networking bug #47210


### PR DESCRIPTION
Otherwise, when doing nixos switch to major changes (typically when stdenv changes), udevd service gets loaded after addresses service, which causes addresses service to wait for the device until failed.
This is separate bug from #352523 , though in our case it appeared together.

To test  this you can follow Reproduction steps from #352523 but instead of (or together with) changing tunnel settings you can switch between nixpkgs revisions that have changing stdenv (https://discourse.nixos.org/t/how-to-determine-why-nixos-rebuild-restarted-systemd-services/10921), for example I tested on switching back and forth between 1dab772dd4a68a7bba5d9460685547ff8e17d899 and fddbd3e9800c214f83674791a883716c168a8539 . 

Before patch:
```
reloading the following units: dbus.service, firewall.service, reload-systemd-vconsole-setup.service
restarting the following units: dhcpcd.service, network-addresses-alt0.service, network-addresses-enp11s0.service, network-addresses-enp4s0.service, network-addresses-enp5s0f1.service, network-addresses-henet0.service, network-addresses-vlan0.service, network-addresses-wlp6s0.service, nginx.service, nix-daemon.service, rt-server.service, sshd.service, systemd-journald.service
A dependency job for network-addresses-alt0.service failed. See 'journalctl -xe' for details.
```
And in journalctl it just waited for that virtual device (thus happens slower) and failed.

After patch all services start without errors and services restart happens faster.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - [x] nixosTests.networking.networkd
    - [x] nixosTests.networking.scripted
    - [x] nixosTests.containers-restart_networking -> already broken in master
    - [x] nixosTests.containers-bridge
    - [x] nixosTests.containers-macvlans
    - [x] nixosTests.containers-extra_veth
    - [x] nixosTests.containers-hosts
    - [x] nixosTests.containers-physical_interfaces
    - [x] nixosTests.libreswan
    - [x] nixosTests.libreswan-nat
    - [ ] nixosTests.systemd-initrd-bridge -> already broken in master
    - [x] nixosTests.yggdrasil

@rnhmjoj and @fpletz, I hope on your review 🙏

Also consider backporting it to the current release 24.11.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
