### PR TITLE
workflows: switch to NIXPKGS_CI specific variables

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
         id: app-token
         with:
-          app-id: ${{ vars.BACKPORT_APP_ID }}
-          private-key: ${{ secrets.BACKPORT_PRIVATE_KEY }}
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -37,3 +37,4 @@ jobs:
     with:
       from: ${{ matrix.pairs.from }}
       into: ${{ matrix.pairs.into }}
+    secrets: inherit

--- a/.github/workflows/periodic-merge-24h.yml
+++ b/.github/workflows/periodic-merge-24h.yml
@@ -14,9 +14,7 @@ on:
     - cron:  '0 0 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write  # for devmasx/merge-branch to merge branches
-  pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
+permissions: {}
 
 jobs:
   periodic-merge:

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -14,9 +14,7 @@ on:
     - cron:  '0 */6 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write  # for devmasx/merge-branch to merge branches
-  pull-requests: write  # for peter-evans/create-or-update-comment to create or update comment
+permissions: {}
 
 jobs:
   periodic-merge:

--- a/.github/workflows/periodic-merge-6h.yml
+++ b/.github/workflows/periodic-merge-6h.yml
@@ -35,3 +35,4 @@ jobs:
     with:
       from: ${{ matrix.pairs.from }}
       into: ${{ matrix.pairs.into }}
+    secrets: inherit

--- a/.github/workflows/periodic-merge.yml
+++ b/.github/workflows/periodic-merge.yml
@@ -17,6 +17,14 @@ jobs:
     runs-on: ubuntu-24.04
     name: ${{ inputs.from }} → ${{ inputs.into }}
     steps:
+      # Use a GitHub App to create the PR so that CI gets triggered
+      # The App is scoped to Repository > Contents and Pull Requests: write for Nixpkgs
+      - uses: actions/create-github-app-token@c1a285145b9d317df6ced56c09f525b5c2b6f755 # v1.11.1
+        id: app-token
+        with:
+          app-id: ${{ vars.NIXPKGS_CI_APP_ID }}
+          private-key: ${{ secrets.NIXPKGS_CI_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Find merge base between two branches
@@ -38,7 +46,7 @@ jobs:
           type: now
           from_branch: ${{ steps.merge_base.outputs.merge_base || inputs.from }}
           target_branch: ${{ inputs.into }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - name: Comment on failure
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
@@ -47,3 +55,4 @@ jobs:
           issue-number: 105153
           body: |
             Periodic merge from `${{ inputs.from }}` into `${{ inputs.into }}` has [failed](https://github.com/NixOS/nixpkgs/actions/runs/${{ github.run_id }}).
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
This will allow GitHub to run actions on those commits, specifically Eval action. Currently as these merges are commited by `github-actions`, Eval doesn't run on the commits. 

ie, https://github.com/NixOS/nixpkgs/actions/runs/12646467735/job/35237397411?pr=371701 Processing failed due to https://github.com/NixOS/nixpkgs/commit/fa2d66f36366a6f04bdd3beec4936001f9a623ad commit was done by github-actions.

With this every periodic merge will be authored and commited by the nixpkgs-ci bot.

Supercedes https://github.com/NixOS/nixpkgs/pull/372041 

Relevant org discussion: https://github.com/NixOS/org/issues/54

PR created from a NixOS/nixpkgs branch as to make it easier to test.