### PR TITLE
treewide: remove `nixfmt-classic` from `updateScript`

### DIFF
--- a/pkgs/applications/editors/nano/default.nix
+++ b/pkgs/applications/editors/nano/default.nix
@@ -9,7 +9,6 @@
   common-updater-scripts,
   git,
   nix,
-  nixfmt-classic,
   coreutils,
   gnused,
   callPackage,
@@ -75,7 +74,6 @@ stdenv.mkDerivation rec {
         lib.makeBinPath [
           common-updater-scripts
           git
-          nixfmt-classic
           nix
           coreutils
           gnused
@@ -87,9 +85,6 @@ stdenv.mkDerivation rec {
 
       if [ ! "$oldVersion" = "$latestTag" ]; then
         update-source-version ${pname} "$latestTag" --version-key=version --print-changes
-        nixpkgs="$(git rev-parse --show-toplevel)"
-        default_nix="$nixpkgs/pkgs/applications/editors/nano/default.nix"
-        nixfmt "$default_nix"
       else
         echo "${pname} is already up-to-date"
       fi

--- a/pkgs/by-name/je/jenkins/package.nix
+++ b/pkgs/by-name/je/jenkins/package.nix
@@ -8,7 +8,6 @@
   gnused,
   makeWrapper,
   nix,
-  nixfmt-classic,
   openjdk,
   writeScript,
   nixosTests,
@@ -57,7 +56,6 @@ stdenv.mkDerivation rec {
           gnused
           jq
           nix
-          nixfmt-classic
         ]
       }
 
@@ -70,9 +68,6 @@ stdenv.mkDerivation rec {
 
       if [ ! "$oldVersion" = "$version" ]; then
         update-source-version jenkins "$version" "$hash"
-        nixpkgs="$(git rev-parse --show-toplevel)"
-        default_nix="$nixpkgs/pkgs/by-name/je/jenkins/package.nix"
-        nixfmt "$default_nix"
       else
         echo "jenkins is already up-to-date"
       fi

--- a/pkgs/by-name/oh/oh-my-zsh/package.nix
+++ b/pkgs/by-name/oh/oh-my-zsh/package.nix
@@ -10,7 +10,6 @@
   common-updater-scripts,
   git,
   nix,
-  nixfmt-classic,
   jq,
   coreutils,
   gnused,
@@ -99,7 +98,6 @@ stdenv.mkDerivation rec {
           curl
           cacert
           git
-          nixfmt-classic
           nix
           jq
           coreutils
@@ -111,11 +109,8 @@ stdenv.mkDerivation rec {
       latestSha="$(curl -L -s https://api.github.com/repos/ohmyzsh/ohmyzsh/commits\?sha\=master\&since\=$oldVersion | jq -r '.[0].sha')"
 
       if [ ! "null" = "$latestSha" ]; then
-        nixpkgs="$(git rev-parse --show-toplevel)"
-        default_nix="$nixpkgs/pkgs/shells/zsh/oh-my-zsh/default.nix"
         latestDate="$(curl -L -s https://api.github.com/repos/ohmyzsh/ohmyzsh/commits/$latestSha | jq '.commit.committer.date' | sed 's|"\(.*\)T.*|\1|g')"
         update-source-version oh-my-zsh "$latestDate" --rev="$latestSha"
-        nixfmt "$default_nix"
       else
         echo "${pname} is already up-to-date"
       fi

--- a/pkgs/by-name/sb/sbt-extras/package.nix
+++ b/pkgs/by-name/sb/sbt-extras/package.nix
@@ -10,7 +10,6 @@
   common-updater-scripts,
   cacert,
   git,
-  nixfmt-classic,
   nix,
   jq,
   coreutils,
@@ -66,7 +65,6 @@ stdenv.mkDerivation rec {
          curl
          cacert
          git
-         nixfmt-classic
          nix
          jq
          coreutils
@@ -76,12 +74,9 @@ stdenv.mkDerivation rec {
     oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
      latestSha="$(curl -L -s https://api.github.com/repos/paulp/sbt-extras/commits\?sha\=master\&since\=$oldVersion | jq -r '.[0].sha')"
     if [ ! "null" = "$latestSha" ]; then
-       nixpkgs="$(git rev-parse --show-toplevel)"
-       default_nix="$nixpkgs/pkgs/development/tools/build-managers/sbt-extras/default.nix"
        latestDate="$(curl -L -s https://api.github.com/repos/paulp/sbt-extras/commits/$latestSha | jq '.commit.committer.date' | sed 's|"\(.*\)T.*|\1|g')"
        update-source-version ${pname} "$latestSha" --version-key=rev
        update-source-version ${pname} "$latestDate" --ignore-same-hash
-       nixfmt "$default_nix"
      else
        echo "${pname} is already up-to-date"
      fi

--- a/pkgs/development/compilers/scala/2.x.nix
+++ b/pkgs/development/compilers/scala/2.x.nix
@@ -11,7 +11,6 @@
   git,
   gnused,
   nix,
-  nixfmt-classic,
   majorVersion,
 }:
 
@@ -98,17 +97,13 @@ stdenv.mkDerivation rec {
           git
           gnused
           nix
-          nixfmt-classic
         ]
       }
       versionSelect='v${lib.versions.major version}.${lib.versions.minor version}.*'
       oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
       latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags ${repo} "$versionSelect" | tail --lines=1 | cut --delimiter='/' --fields=3 | sed 's|^v||g')"
       if [ "$oldVersion" != "$latestTag" ]; then
-        nixpkgs="$(git rev-parse --show-toplevel)"
-        default_nix="$nixpkgs/pkgs/development/compilers/scala/2.x.nix"
         update-source-version ${pname} "$latestTag" --version-key=version --print-changes
-        nixfmt "$default_nix"
       else
         echo "${pname} is already up-to-date"
       fi

--- a/pkgs/development/python-modules/types-aiobotocore/update.sh
+++ b/pkgs/development/python-modules/types-aiobotocore/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p nix-update nixfmt-classic curl jq
+#!nix-shell -i bash -p nix-update curl jq
 
 set -eu -o pipefail
 
@@ -392,5 +392,3 @@ for package in "${packages[@]}"; do
   }' ${source_file}
 
 done
-
-nixfmt ${source_file}

--- a/pkgs/development/tools/ammonite/default.nix
+++ b/pkgs/development/tools/ammonite/default.nix
@@ -6,7 +6,6 @@
   writeScript,
   common-updater-scripts,
   git,
-  nixfmt-classic,
   nix,
   coreutils,
   gnused,
@@ -51,18 +50,14 @@ let
               git
               gnused
               nix
-              nixfmt-classic
             ]
           }
           oldVersion="$(nix-instantiate --eval -E "with import ./. {}; lib.getVersion ${pname}" | tr -d '"')"
           latestTag="$(git -c 'versionsort.suffix=-' ls-remote --exit-code --refs --sort='version:refname' --tags ${repo} '*.*.*' | tail --lines=1 | cut --delimiter='/' --fields=3)"
           if [ "$oldVersion" != "$latestTag" ]; then
-            nixpkgs="$(git rev-parse --show-toplevel)"
-            default_nix="$nixpkgs/pkgs/development/tools/ammonite/default.nix"
             update-source-version ${pname}_2_12 "$latestTag" --version-key=version --print-changes
-            sed -i "s|$latestTag|$oldVersion|g" "$default_nix"
+            sed -i "s|$latestTag|$oldVersion|g" "$(git rev-parse --show-toplevel)/pkgs/development/tools/ammonite/default.nix"
             update-source-version ${pname}_2_13 "$latestTag" --version-key=version --print-changes
-            nixfmt "$default_nix"
           else
             echo "${pname} is already up-to-date"
           fi


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/373528

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
