### PR TITLE
mujoco: 3.2.6 -> 3.2.7

### DIFF
--- a/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
+++ b/pkgs/by-name/mu/mujoco/mujoco-system-deps-dont-fetch.patch
@@ -1,17 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index eea180c0..efb39178 100644
+index aaac4e38..fe4e9932 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -93,7 +93,7 @@ add_subdirectory(src/render)
- add_subdirectory(src/thread)
- add_subdirectory(src/ui)
- 
--target_compile_definitions(mujoco PRIVATE _GNU_SOURCE CCD_STATIC_DEFINE MUJOCO_DLL_EXPORTS -DMC_IMPLEM_ENABLE)
-+target_compile_definitions(mujoco PRIVATE _GNU_SOURCE MUJOCO_DLL_EXPORTS -DMC_IMPLEM_ENABLE)
- if(MUJOCO_ENABLE_AVX_INTRINSICS)
-   target_compile_definitions(mujoco PUBLIC mjUSEPLATFORMSIMD)
- endif()
-@@ -118,7 +118,7 @@ target_link_libraries(
+@@ -120,7 +120,7 @@ target_link_libraries(
            lodepng
            qhullstatic_r
            tinyobjloader
@@ -21,7 +12,7 @@ index eea180c0..efb39178 100644
  
  set_target_properties(
 diff --git a/cmake/MujocoDependencies.cmake b/cmake/MujocoDependencies.cmake
-index 44962272..656beeb8 100644
+index 23e4e71e..33081e00 100644
 --- a/cmake/MujocoDependencies.cmake
 +++ b/cmake/MujocoDependencies.cmake
 @@ -93,28 +93,36 @@ set(BUILD_SHARED_LIBS
@@ -75,7 +66,7 @@ index 44962272..656beeb8 100644
    )
  
    FetchContent_GetProperties(marchingcubecpp)
-@@ -124,119 +132,158 @@ if(NOT TARGET marchingcubecpp)
+@@ -124,119 +132,157 @@ if(NOT TARGET marchingcubecpp)
    endif()
  endif()
  
@@ -196,7 +187,6 @@ index 44962272..656beeb8 100644
  option(SDFLIB_USE_ASSIMP OFF)
  option(SDFLIB_USE_OPENMP OFF)
  option(SDFLIB_USE_ENOKI OFF)
-+
  findorfetch(
    USE_SYSTEM_PACKAGE
 -  OFF
@@ -285,7 +275,7 @@ index 44962272..656beeb8 100644
    set(ABSL_PROPAGATE_CXX_STD ON)
  
    # This specific version of Abseil does not have the following variable. We need to work with BUILD_TESTING
-@@ -249,15 +296,11 @@ if(MUJOCO_BUILD_TESTS)
+@@ -249,15 +295,11 @@ if(MUJOCO_BUILD_TESTS)
    set(ABSL_BUILD_TESTING OFF)
    findorfetch(
      USE_SYSTEM_PACKAGE
@@ -302,7 +292,7 @@ index 44962272..656beeb8 100644
      TARGETS
      absl::core_headers
      EXCLUDE_FROM_ALL
-@@ -268,6 +311,9 @@ if(MUJOCO_BUILD_TESTS)
+@@ -268,6 +310,9 @@ if(MUJOCO_BUILD_TESTS)
        CACHE BOOL "Build tests." FORCE
    )
  
@@ -312,7 +302,7 @@ index 44962272..656beeb8 100644
    # Avoid linking errors on Windows by dynamically linking to the C runtime.
    set(gtest_force_shared_crt
        ON
-@@ -276,22 +322,20 @@ if(MUJOCO_BUILD_TESTS)
+@@ -276,22 +321,20 @@ if(MUJOCO_BUILD_TESTS)
  
    findorfetch(
      USE_SYSTEM_PACKAGE
@@ -341,7 +331,7 @@ index 44962272..656beeb8 100644
    set(BENCHMARK_EXTRA_FETCH_ARGS "")
    if(WIN32 AND NOT MSVC)
      set(BENCHMARK_EXTRA_FETCH_ARGS
-@@ -310,15 +354,11 @@ if(MUJOCO_BUILD_TESTS)
+@@ -310,15 +353,11 @@ if(MUJOCO_BUILD_TESTS)
  
    findorfetch(
      USE_SYSTEM_PACKAGE
@@ -358,7 +348,7 @@ index 44962272..656beeb8 100644
      TARGETS
      benchmark::benchmark
      benchmark::benchmark_main
-@@ -328,15 +368,18 @@ if(MUJOCO_BUILD_TESTS)
+@@ -328,15 +367,18 @@ if(MUJOCO_BUILD_TESTS)
  endif()
  
  if(MUJOCO_TEST_PYTHON_UTIL)
@@ -382,7 +372,7 @@ index 44962272..656beeb8 100644
      )
  
      FetchContent_GetProperties(Eigen3)
-@@ -348,6 +391,19 @@ if(MUJOCO_TEST_PYTHON_UTIL)
+@@ -348,6 +390,19 @@ if(MUJOCO_TEST_PYTHON_UTIL)
        set_target_properties(
          Eigen3::Eigen PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${eigen3_SOURCE_DIR}"
        )
@@ -479,19 +469,10 @@ index 5141406c..75ff7884 100644
    glfw
    EXCLUDE_FROM_ALL
 diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
-index 122760a9..ddd90819 100644
+index 0f92803d..da9dce4c 100644
 --- a/test/CMakeLists.txt
 +++ b/test/CMakeLists.txt
-@@ -30,7 +30,7 @@ macro(mujoco_test name)
-   )
- 
-   add_executable(${name} ${name}.cc)
--  target_link_libraries(${name} gtest_main mujoco)
-+  target_link_libraries(${name} GTest::gtest_main mujoco)
-   target_include_directories(${name} PRIVATE ${MUJOCO_TEST_INCLUDE})
-   set_target_properties(${name} PROPERTIES BUILD_RPATH ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
-   # gtest_discover_tests is recommended over gtest_add_tests, but has some issues in Windows.
-@@ -60,20 +60,20 @@ target_link_libraries(
+@@ -81,8 +81,8 @@ target_link_libraries(
           absl::synchronization
           absl::flat_hash_map
           absl::flat_hash_set
@@ -502,18 +483,3 @@ index 122760a9..ddd90819 100644
           mujoco::mujoco
  )
  target_include_directories(fixture PRIVATE ${mujoco_SOURCE_DIR}/include gmock)
- 
- mujoco_test(fixture_test)
--target_link_libraries(fixture_test fixture gmock)
-+target_link_libraries(fixture_test fixture GTest::gmock)
- 
- mujoco_test(header_test)
--target_link_libraries(header_test fixture gmock)
-+target_link_libraries(fixture_test fixture GTest::gmock)
- 
- mujoco_test(pipeline_test)
--target_link_libraries(pipeline_test fixture gmock)
-+target_link_libraries(fixture_test fixture GTest::gmock)
- 
- add_subdirectory(benchmark)
- add_subdirectory(engine)

--- a/pkgs/by-name/mu/mujoco/package.nix
+++ b/pkgs/by-name/mu/mujoco/package.nix
@@ -1,13 +1,14 @@
 {
-  cereal_1_3_2,
-  cmake,
+  lib,
+  stdenv,
   fetchFromGitHub,
+  cmake,
   fetchFromGitLab,
   glfw,
   glm,
-  lib,
   spdlog,
-  stdenv,
+  cereal_1_3_2,
+  python3Packages,
 }:
 
 let
@@ -35,8 +36,8 @@ let
     eigen3 = fetchFromGitLab {
       owner = "libeigen";
       repo = "eigen";
-      rev = "d34b100c137ac931379ae5e1b888f16a9c8d6c72";
-      hash = "sha256-GYjENtobSWCJqRw2GJbxAJDZSdyBNqWkobn2Vm5H53Q=";
+      rev = "7f2377859377da6f22152015c28b12c04752af77";
+      hash = "sha256-SmyvY/WlU9jryD9ZpSw73dQEc9jI4ySQPRnplg/BC4w=";
     };
     googletest = fetchFromGitHub {
       owner = "google";
@@ -131,7 +132,7 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "mujoco";
-  version = "3.2.6";
+  version = "3.2.7";
 
   # Bumping version? Make sure to look though the MuJoCo's commit
   # history for bumped dependency pins!
@@ -139,7 +140,7 @@ stdenv.mkDerivation rec {
     owner = "google-deepmind";
     repo = "mujoco";
     tag = version;
-    hash = "sha256-n1H9e+GMqHYsimypF7AiVzHC2dXkL+4FWDEHB5B2ZIE=";
+    hash = "sha256-TAhgu3h7tCflIMscVS+jYuUfMmIYcCcI3JFxUlj8g9E=";
   };
 
   patches = [ ./mujoco-system-deps-dont-fetch.patch ];
@@ -177,8 +178,13 @@ stdenv.mkDerivation rec {
     ln -s ${pin.marchingcubecpp} build/_deps/marchingcubecpp-src
   '';
 
-  passthru.pin = {
-    inherit (pin) lodepng eigen3 abseil-cpp;
+  passthru = {
+    pin = {
+      inherit (pin) lodepng eigen3 abseil-cpp;
+    };
+    tests = {
+      pythonMujoco = python3Packages.mujoco;
+    };
   };
 
   meta = {

--- a/pkgs/development/python-modules/mujoco/default.nix
+++ b/pkgs/development/python-modules/mujoco/default.nix
@@ -37,7 +37,7 @@ buildPythonPackage rec {
   # in the project's CI.
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-kl7+5cMvaAaILEARKs5KPtdLE7Kv8J7NddZnj6oLwk8=";
+    hash = "sha256-a0ATRmtFV11J3T2HSNCZhfc0kAOu8yaHIW0rkCrHsTg=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/python-modules/torchrl/default.nix
+++ b/pkgs/development/python-modules/torchrl/default.nix
@@ -175,7 +175,8 @@ buildPythonPackage rec {
       "test_gae_param_as_tensor"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-      # Flaky (AssertionError)
+      # Flaky
+      # AssertionError: assert tensor([51.]) == ((5 * 11) + 2)
       "test_vecnorm_parallel_auto"
     ];
 


### PR DESCRIPTION
## Things done

Changelog: https://github.com/google-deepmind/mujoco/releases/tag/3.2.7

cc @tmplt @samuela

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
