### PR TITLE
simplenote: init at version 2.22.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11218,6 +11218,12 @@
     github = "jooooscha";
     githubId = 57965027;
   };
+  josephfinlayson = {
+    email = "joseph@innocentspark.com";
+    github = "josephfinlayson";
+    githubId = 1572410;
+    name = "Joseph Finlayson";
+  };
   josephst = {
     name = "Joseph Stahl";
     email = "hello@josephstahl.com";

--- a/pkgs/by-name/si/simplenote/package.nix
+++ b/pkgs/by-name/si/simplenote/package.nix
@@ -52,5 +52,6 @@ appimageTools.wrapType2 {
     homepage = "https://github.com/Automattic/simplenote-electron";
     license = licenses.gpl2Plus;
     platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ josephfinlayson ];
   };
 }

--- a/pkgs/by-name/si/simplenote/package.nix
+++ b/pkgs/by-name/si/simplenote/package.nix
@@ -23,7 +23,7 @@ appimageTools.wrapType2 {
   extraInstallCommands = ''
     install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
     substituteInPlace $out/share/applications/${pname}.desktop \
-      --replace-warn 'Exec=AppRun' 'Exec=${pname}'
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
 
     cp -r ${appimageContents}/usr/share/icons $out/share
   '';
@@ -36,7 +36,7 @@ appimageTools.wrapType2 {
     ];
 
   desktopItems = [
-  makeDesktopItem
+    makeDesktopItem
     {
       name = pname;
       exec = pname;

--- a/pkgs/by-name/si/simplenote/package.nix
+++ b/pkgs/by-name/si/simplenote/package.nix
@@ -1,0 +1,56 @@
+{
+  appimageTools,
+  lib,
+  fetchurl,
+  nix-update-script,
+  makeDesktopItem,
+}:
+
+let
+  pname = "simplenote";
+  version = "2.22.2";
+
+  src = fetchurl {
+    url = "https://github.com/Automattic/simplenote-electron/releases/download/v${version}/Simplenote-linux-${version}-x86_64.AppImage";
+    sha512 = "4aTMCbnURlJqgZqSqU/b3HTaWDp3FzFhWcES1ANxElNumfUs7IBdCGroyiumBUbQQb+4NG+Yj0kCKuVBjVXZXQ==";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+    substituteInPlace $out/share/applications/${pname}.desktop \
+      --replace-warn 'Exec=AppRun' 'Exec=${pname}'
+
+    cp -r ${appimageContents}/usr/share/icons $out/share
+  '';
+
+  extraPkgs =
+    pkgs: with pkgs; [
+      libsecret
+      libnotify
+      libappindicator-gtk3
+    ];
+
+  desktopItems = [
+  makeDesktopItem
+    {
+      name = pname;
+      exec = pname;
+      icon = "simplenote";
+      description = "The simplest way to keep notes";
+    }
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "The simplest way to keep notes";
+    homepage = "https://github.com/Automattic/simplenote-electron";
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/by-name/si/simplenote/package.nix
+++ b/pkgs/by-name/si/simplenote/package.nix
@@ -8,11 +8,11 @@
 
 let
   pname = "simplenote";
-  version = "2.22.2";
+  version = "2.23.2";
 
   src = fetchurl {
     url = "https://github.com/Automattic/simplenote-electron/releases/download/v${version}/Simplenote-linux-${version}-x86_64.AppImage";
-    sha512 = "4aTMCbnURlJqgZqSqU/b3HTaWDp3FzFhWcES1ANxElNumfUs7IBdCGroyiumBUbQQb+4NG+Yj0kCKuVBjVXZXQ==";
+    hash = "sha512-m2Z1XlIdnxMgnHu6YWKZAp4Nwe1UaOyodtiKhy4/xvPwU2c8z4iBQHjgPoeAwnWJNQ/9JazPgBoP7W5oIMHLCg==";
   };
 
   appimageContents = appimageTools.extract { inherit pname version src; };
@@ -47,11 +47,12 @@ appimageTools.wrapType2 {
 
   passthru.updateScript = nix-update-script { };
 
-  meta = with lib; {
+  meta = {
     description = "The simplest way to keep notes";
     homepage = "https://github.com/Automattic/simplenote-electron";
-    license = licenses.gpl2Plus;
+    license = lib.licenses.gpl2Plus;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ josephfinlayson ];
+    maintainers = with lib.maintainers; [ josephfinlayson ];
+    changelog = "https://github.com/Automattic/simplenote-electron/releases/tag/v${version}/RELEASE-NOTES.md";
   };
 }


### PR DESCRIPTION
This includes the package simplenote from Automattic (the wordpress company). It is a cross platform app for synchronizing notes.


## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
