### PR TITLE
libabw: fix cross build

### DIFF
--- a/pkgs/by-name/li/libabw/package.nix
+++ b/pkgs/by-name/li/libabw/package.nix
@@ -27,14 +27,16 @@ stdenv.mkDerivation rec {
     sed -i 's,^CPPFLAGS.*,\0 -DBOOST_ERROR_CODE_HEADER_ONLY -DBOOST_SYSTEM_NO_DEPRECATED,' src/lib/Makefile.in
   '';
 
-  nativeBuildInputs = [ pkg-config ];
-  buildInputs = [
-    boost
+  nativeBuildInputs = [
     doxygen
     gperf
+    perl
+    pkg-config
+  ];
+  buildInputs = [
+    boost
     librevenge
     libxml2
-    perl
     zlib
   ];
 


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).