### PR TITLE
[Backport release-24.11] tests.overriding: format with nixfmt-rfc-style and categorize

### DIFF
--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -1,9 +1,15 @@
-{ lib, pkgs, stdenvNoCC }:
+{
+  lib,
+  pkgs,
+  stdenvNoCC,
+}:
 
 let
   tests =
     let
-      p = pkgs.python3Packages.xpybutil.overridePythonAttrs (_: { dontWrapPythonPrograms = true; });
+      p = pkgs.python3Packages.xpybutil.overridePythonAttrs (_: {
+        dontWrapPythonPrograms = true;
+      });
     in
     {
       overridePythonAttrs = {
@@ -24,31 +30,45 @@ let
       };
       overriding-using-only-attrset-no-final-attrs = {
         name = "overriding-using-only-attrset-no-final-attrs";
-        expr = ((stdenvNoCC.mkDerivation { pname = "hello-no-final-attrs"; }).overrideAttrs { pname = "hello-no-final-attrs-overridden"; }).pname == "hello-no-final-attrs-overridden";
+        expr =
+          ((stdenvNoCC.mkDerivation { pname = "hello-no-final-attrs"; }).overrideAttrs {
+            pname = "hello-no-final-attrs-overridden";
+          }).pname == "hello-no-final-attrs-overridden";
         expected = true;
       };
       buildGoModule-overrideAttrs = {
-        expr = lib.all (
-          attrPath:
-          let
-            attrPathPretty = lib.concatStringsSep "." attrPath;
-            valueNative = lib.getAttrFromPath attrPath pet_0_4_0;
-            valueOverridden = lib.getAttrFromPath attrPath pet_0_4_0-overridden;
-          in
-          lib.warnIfNot
-            (valueNative == valueOverridden)
-            "pet_0_4_0.${attrPathPretty} (${valueNative}) does not equal pet_0_4_0-overridden.${attrPathPretty} (${valueOverridden})"
-            true
-        ) [
-          [ "drvPath" ]
-          [ "name" ]
-          [ "pname" ]
-          [ "version" ]
-          [ "vendorHash" ]
-          [ "goModules" "drvPath" ]
-          [ "goModules" "name" ]
-          [ "goModules" "outputHash" ]
-        ];
+        expr =
+          lib.all
+            (
+              attrPath:
+              let
+                attrPathPretty = lib.concatStringsSep "." attrPath;
+                valueNative = lib.getAttrFromPath attrPath pet_0_4_0;
+                valueOverridden = lib.getAttrFromPath attrPath pet_0_4_0-overridden;
+              in
+              lib.warnIfNot (valueNative == valueOverridden)
+                "pet_0_4_0.${attrPathPretty} (${valueNative}) does not equal pet_0_4_0-overridden.${attrPathPretty} (${valueOverridden})"
+                true
+            )
+            [
+              [ "drvPath" ]
+              [ "name" ]
+              [ "pname" ]
+              [ "version" ]
+              [ "vendorHash" ]
+              [
+                "goModules"
+                "drvPath"
+              ]
+              [
+                "goModules"
+                "name"
+              ]
+              [
+                "goModules"
+                "outputHash"
+              ]
+            ];
         expected = true;
       };
       buildGoModule-goModules-overrideAttrs = {
@@ -61,28 +81,37 @@ let
       };
     };
 
-  addEntangled = origOverrideAttrs: f:
+  addEntangled =
+    origOverrideAttrs: f:
     origOverrideAttrs (
-      lib.composeExtensions f (self: super: {
-        passthru = super.passthru // {
-          entangled = super.passthru.entangled.overrideAttrs f;
-          overrideAttrs = addEntangled self.overrideAttrs;
-        };
-      })
+      lib.composeExtensions f (
+        self: super: {
+          passthru = super.passthru // {
+            entangled = super.passthru.entangled.overrideAttrs f;
+            overrideAttrs = addEntangled self.overrideAttrs;
+          };
+        }
+      )
     );
 
-  entangle = pkg1: pkg2: pkg1.overrideAttrs (self: super: {
-    passthru = super.passthru // {
-      entangled = pkg2;
-      overrideAttrs = addEntangled self.overrideAttrs;
-    };
-  });
+  entangle =
+    pkg1: pkg2:
+    pkg1.overrideAttrs (
+      self: super: {
+        passthru = super.passthru // {
+          entangled = pkg2;
+          overrideAttrs = addEntangled self.overrideAttrs;
+        };
+      }
+    );
 
   example = entangle pkgs.hello pkgs.figlet;
 
   overrides1 = example.overrideAttrs (_: super: { pname = "a-better-${super.pname}"; });
 
-  repeatedOverrides = overrides1.overrideAttrs (_: super: { pname = "${super.pname}-with-blackjack"; });
+  repeatedOverrides = overrides1.overrideAttrs (
+    _: super: { pname = "${super.pname}-with-blackjack"; }
+  );
 
   pet_0_3_4 = pkgs.buildGoModule rec {
     pname = "pet";
@@ -126,17 +155,19 @@ let
     };
   };
 
-  pet_0_4_0-overridden = pet_0_3_4.overrideAttrs (finalAttrs: previousAttrs: {
-  version = "0.4.0";
+  pet_0_4_0-overridden = pet_0_3_4.overrideAttrs (
+    finalAttrs: previousAttrs: {
+      version = "0.4.0";
 
-  src = pkgs.fetchFromGitHub {
-    inherit (previousAttrs.src) owner repo;
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-gVTpzmXekQxGMucDKskGi+e+34nJwwsXwvQTjRO6Gdg=";
-  };
+      src = pkgs.fetchFromGitHub {
+        inherit (previousAttrs.src) owner repo;
+        rev = "v${finalAttrs.version}";
+        hash = "sha256-gVTpzmXekQxGMucDKskGi+e+34nJwwsXwvQTjRO6Gdg=";
+      };
 
-  vendorHash = "sha256-dUvp7FEW09V0xMuhewPGw3TuAic/sD7xyXEYviZ2Ivs=";
-  });
+      vendorHash = "sha256-dUvp7FEW09V0xMuhewPGw3TuAic/sD7xyXEYviZ2Ivs=";
+    }
+  );
 
   pet-foo = pet_0_3_4.overrideAttrs (
     finalAttrs: previousAttrs: {
@@ -156,7 +187,16 @@ in
 stdenvNoCC.mkDerivation {
   name = "test-overriding";
   passthru = { inherit tests; };
-  buildCommand = ''
-    touch $out
-  '' + lib.concatStringsSep "\n" (lib.attrValues (lib.mapAttrs (name: t: "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${name} success') || (echo '${name} fail' && exit 1)") tests));
+  buildCommand =
+    ''
+      touch $out
+    ''
+    + lib.concatStringsSep "\n" (
+      lib.attrValues (
+        lib.mapAttrs (
+          name: t:
+          "([[ ${lib.boolToString t.expr} == ${lib.boolToString t.expected} ]] && echo '${name} success') || (echo '${name} fail' && exit 1)"
+        ) tests
+      )
+    );
 }

--- a/pkgs/test/overriding.nix
+++ b/pkgs/test/overriding.nix
@@ -5,17 +5,43 @@
 }:
 
 let
-  tests =
+  tests = tests-stdenv // tests-go // tests-python;
+
+  tests-stdenv =
     let
-      p = pkgs.python3Packages.xpybutil.overridePythonAttrs (_: {
-        dontWrapPythonPrograms = true;
-      });
+      addEntangled =
+        origOverrideAttrs: f:
+        origOverrideAttrs (
+          lib.composeExtensions f (
+            self: super: {
+              passthru = super.passthru // {
+                entangled = super.passthru.entangled.overrideAttrs f;
+                overrideAttrs = addEntangled self.overrideAttrs;
+              };
+            }
+          )
+        );
+
+      entangle =
+        pkg1: pkg2:
+        pkg1.overrideAttrs (
+          self: super: {
+            passthru = super.passthru // {
+              entangled = pkg2;
+              overrideAttrs = addEntangled self.overrideAttrs;
+            };
+          }
+        );
+
+      example = entangle pkgs.hello pkgs.figlet;
+
+      overrides1 = example.overrideAttrs (_: super: { pname = "a-better-${super.pname}"; });
+
+      repeatedOverrides = overrides1.overrideAttrs (
+        _: super: { pname = "${super.pname}-with-blackjack"; }
+      );
     in
     {
-      overridePythonAttrs = {
-        expr = !lib.hasInfix "wrapPythonPrograms" p.postFixup;
-        expected = true;
-      };
       repeatedOverrides-pname = {
         expr = repeatedOverrides.pname == "a-better-hello-with-blackjack";
         expected = true;
@@ -36,6 +62,81 @@ let
           }).pname == "hello-no-final-attrs-overridden";
         expected = true;
       };
+    };
+
+  tests-go =
+    let
+      pet_0_3_4 = pkgs.buildGoModule rec {
+        pname = "pet";
+        version = "0.3.4";
+
+        src = pkgs.fetchFromGitHub {
+          owner = "knqyf263";
+          repo = "pet";
+          rev = "v${version}";
+          hash = "sha256-Gjw1dRrgM8D3G7v6WIM2+50r4HmTXvx0Xxme2fH9TlQ=";
+        };
+
+        vendorHash = "sha256-ciBIR+a1oaYH+H1PcC8cD8ncfJczk1IiJ8iYNM+R6aA=";
+
+        meta = {
+          description = "Simple command-line snippet manager, written in Go";
+          homepage = "https://github.com/knqyf263/pet";
+          license = lib.licenses.mit;
+          maintainers = with lib.maintainers; [ kalbasit ];
+        };
+      };
+
+      pet_0_4_0 = pkgs.buildGoModule rec {
+        pname = "pet";
+        version = "0.4.0";
+
+        src = pkgs.fetchFromGitHub {
+          owner = "knqyf263";
+          repo = "pet";
+          rev = "v${version}";
+          hash = "sha256-gVTpzmXekQxGMucDKskGi+e+34nJwwsXwvQTjRO6Gdg=";
+        };
+
+        vendorHash = "sha256-dUvp7FEW09V0xMuhewPGw3TuAic/sD7xyXEYviZ2Ivs=";
+
+        meta = {
+          description = "Simple command-line snippet manager, written in Go";
+          homepage = "https://github.com/knqyf263/pet";
+          license = lib.licenses.mit;
+          maintainers = with lib.maintainers; [ kalbasit ];
+        };
+      };
+
+      pet_0_4_0-overridden = pet_0_3_4.overrideAttrs (
+        finalAttrs: previousAttrs: {
+          version = "0.4.0";
+
+          src = pkgs.fetchFromGitHub {
+            inherit (previousAttrs.src) owner repo;
+            rev = "v${finalAttrs.version}";
+            hash = "sha256-gVTpzmXekQxGMucDKskGi+e+34nJwwsXwvQTjRO6Gdg=";
+          };
+
+          vendorHash = "sha256-dUvp7FEW09V0xMuhewPGw3TuAic/sD7xyXEYviZ2Ivs=";
+        }
+      );
+
+      pet-foo = pet_0_3_4.overrideAttrs (
+        finalAttrs: previousAttrs: {
+          passthru = previousAttrs.passthru // {
+            overrideModAttrs = lib.composeExtensions previousAttrs.passthru.overrideModAttrs (
+              finalModAttrs: previousModAttrs: {
+                FOO = "foo";
+              }
+            );
+          };
+        }
+      );
+
+      pet-vendored = pet-foo.overrideAttrs { vendorHash = null; };
+    in
+    {
       buildGoModule-overrideAttrs = {
         expr =
           lib.all
@@ -81,107 +182,18 @@ let
       };
     };
 
-  addEntangled =
-    origOverrideAttrs: f:
-    origOverrideAttrs (
-      lib.composeExtensions f (
-        self: super: {
-          passthru = super.passthru // {
-            entangled = super.passthru.entangled.overrideAttrs f;
-            overrideAttrs = addEntangled self.overrideAttrs;
-          };
-        }
-      )
-    );
-
-  entangle =
-    pkg1: pkg2:
-    pkg1.overrideAttrs (
-      self: super: {
-        passthru = super.passthru // {
-          entangled = pkg2;
-          overrideAttrs = addEntangled self.overrideAttrs;
-        };
-      }
-    );
-
-  example = entangle pkgs.hello pkgs.figlet;
-
-  overrides1 = example.overrideAttrs (_: super: { pname = "a-better-${super.pname}"; });
-
-  repeatedOverrides = overrides1.overrideAttrs (
-    _: super: { pname = "${super.pname}-with-blackjack"; }
-  );
-
-  pet_0_3_4 = pkgs.buildGoModule rec {
-    pname = "pet";
-    version = "0.3.4";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "knqyf263";
-      repo = "pet";
-      rev = "v${version}";
-      hash = "sha256-Gjw1dRrgM8D3G7v6WIM2+50r4HmTXvx0Xxme2fH9TlQ=";
-    };
-
-    vendorHash = "sha256-ciBIR+a1oaYH+H1PcC8cD8ncfJczk1IiJ8iYNM+R6aA=";
-
-    meta = {
-      description = "Simple command-line snippet manager, written in Go";
-      homepage = "https://github.com/knqyf263/pet";
-      license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ kalbasit ];
-    };
-  };
-
-  pet_0_4_0 = pkgs.buildGoModule rec {
-    pname = "pet";
-    version = "0.4.0";
-
-    src = pkgs.fetchFromGitHub {
-      owner = "knqyf263";
-      repo = "pet";
-      rev = "v${version}";
-      hash = "sha256-gVTpzmXekQxGMucDKskGi+e+34nJwwsXwvQTjRO6Gdg=";
-    };
-
-    vendorHash = "sha256-dUvp7FEW09V0xMuhewPGw3TuAic/sD7xyXEYviZ2Ivs=";
-
-    meta = {
-      description = "Simple command-line snippet manager, written in Go";
-      homepage = "https://github.com/knqyf263/pet";
-      license = lib.licenses.mit;
-      maintainers = with lib.maintainers; [ kalbasit ];
-    };
-  };
-
-  pet_0_4_0-overridden = pet_0_3_4.overrideAttrs (
-    finalAttrs: previousAttrs: {
-      version = "0.4.0";
-
-      src = pkgs.fetchFromGitHub {
-        inherit (previousAttrs.src) owner repo;
-        rev = "v${finalAttrs.version}";
-        hash = "sha256-gVTpzmXekQxGMucDKskGi+e+34nJwwsXwvQTjRO6Gdg=";
+  tests-python =
+    let
+      p = pkgs.python3Packages.xpybutil.overridePythonAttrs (_: {
+        dontWrapPythonPrograms = true;
+      });
+    in
+    {
+      overridePythonAttrs = {
+        expr = !lib.hasInfix "wrapPythonPrograms" p.postFixup;
+        expected = true;
       };
-
-      vendorHash = "sha256-dUvp7FEW09V0xMuhewPGw3TuAic/sD7xyXEYviZ2Ivs=";
-    }
-  );
-
-  pet-foo = pet_0_3_4.overrideAttrs (
-    finalAttrs: previousAttrs: {
-      passthru = previousAttrs.passthru // {
-        overrideModAttrs = lib.composeExtensions previousAttrs.passthru.overrideModAttrs (
-          finalModAttrs: previousModAttrs: {
-            FOO = "foo";
-          }
-        );
-      };
-    }
-  );
-
-  pet-vendored = pet-foo.overrideAttrs { vendorHash = null; };
+    };
 in
 
 stdenvNoCC.mkDerivation {


### PR DESCRIPTION
This PR backports the chore changes of #366583 that format the Nix expression of `tests.overriding` according to Nix RFC 166 and categorise the test cases according to the build helpers they are testing.

This PR enables automatic backport of subsequent PRs that add new test cases under `tests.overriding`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
