### PR TITLE
liberation-sans-narrow: fix cross build

### DIFF
--- a/pkgs/by-name/li/liberation-sans-narrow/package.nix
+++ b/pkgs/by-name/li/liberation-sans-narrow/package.nix
@@ -18,15 +18,17 @@ stdenv.mkDerivation rec {
     sha256 = "1qw554jbdnqkg6pjjl4cqkgsalq3398kzvww2naw30vykcz752bm";
   };
 
-  buildInputs = [
+  nativeBuildInputs = [
     fontforge
     python3Packages.fonttools
     python3
   ];
 
   installPhase = ''
+    runHook preInstall
     find . -name '*Narrow*.ttf' -exec install -m444 -Dt $out/share/fonts/truetype {} \;
     install -m444 -Dt $out/doc/${pname}-${version} AUTHORS ChangeLog COPYING License.txt README.rst
+    runHook postInstall
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).