### PR TITLE
liblangtag: fix cross build

### DIFF
--- a/pkgs/by-name/li/liblangtag/package.nix
+++ b/pkgs/by-name/li/liblangtag/package.nix
@@ -43,9 +43,13 @@ stdenv.mkDerivation rec {
     cp "${language_subtag_registry}" data/language-subtag-registry
   '';
 
-  configureFlags = lib.optional (
-    stdenv.hostPlatform.libc == "glibc"
-  ) "--with-locale-alias=${stdenv.cc.libc}/share/locale/locale.alias";
+  configureFlags =
+    [
+      "ac_cv_va_copy=1"
+    ]
+    ++ lib.optional (
+      stdenv.hostPlatform.libc == "glibc"
+    ) "--with-locale-alias=${stdenv.cc.libc}/share/locale/locale.alias";
 
   buildInputs = [
     gettext


### PR DESCRIPTION
Also fix regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).