### PR TITLE
libixion: fix cross build

### DIFF
--- a/pkgs/by-name/li/libixion/package.nix
+++ b/pkgs/by-name/li/libixion/package.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    python3.pythonOnBuildForHost
   ];
 
   buildInputs = [


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).