### PR TITLE
python312Packages.django-autocomplete-light: 3.9.4 -> 3.11.0

### DIFF
--- a/pkgs/development/python-modules/django-autocomplete-light/default.nix
+++ b/pkgs/development/python-modules/django-autocomplete-light/default.nix
@@ -1,74 +1,48 @@
 {
   lib,
   buildPythonPackage,
-  fetchFromGitHub,
-  django,
-  six,
-  pytestCheckHook,
-  django-debug-toolbar,
-  django-extensions,
   django-taggit,
-  django-tagging,
-  mock,
-  pytest-django,
-  selenium,
-  splinter,
-  sqlparse,
-  tenacity,
-  whitenoise,
+  django,
+  fetchFromGitHub,
+  pytestCheckHook,
+  pythonOlder,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "django-autocomplete-light";
-  version = "3.9.4";
-  format = "setuptools";
+  version = "3.11.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "yourlabs";
     repo = "django-autocomplete-light";
-    rev = version;
-    hash = "sha256-YUiGN6q7ARM/rg7d+ykeDEYZDYjB+DHxMCmdme6QccU=";
+    tag = version;
+    hash = "sha256-Lcl14CVmpDoEdEq49sL4GFtWWqFcVoSjOJOBU7oWeH4=";
   };
 
-  propagatedBuildInputs = [
-    django
-    six
-  ];
+  build-system = [ setuptools ];
+
+  dependencies = [ django ];
+
+  optional-dependencies = {
+    tags = [ django-taggit ];
+    # nested = [ django-nested-admin ];
+    # genericm2m = [ django-generic-m2m ];
+    # gfk = [ django-querysetsequence ];
+  };
 
   # Too many un-packaged dependencies
   doCheck = false;
-
-  nativeCheckInputs = [
-    pytestCheckHook
-    django-debug-toolbar
-    django-extensions
-    django-taggit
-    django-tagging
-    mock
-    pytest-django
-    selenium
-    splinter
-    sqlparse
-    tenacity
-    whitenoise
-
-    # FIXME: not packaged
-    # django-generic-m2m
-    # django-gm2m
-    # django-querysetsequence
-    # pytest-splinter
-    # dango-nested-admin
-    # djhacker
-  ];
-
-  # Taken from tox.ini
-  preCheck = "cd test_project";
 
   pythonImportsCheck = [ "dal" ];
 
   meta = with lib; {
     description = "Fresh approach to autocomplete implementations, specially for Django";
     homepage = "https://django-autocomplete-light.readthedocs.io";
+    changelog = "https://github.com/yourlabs/django-autocomplete-light/blob/${version}/CHANGELOG";
     license = licenses.bsd3;
     maintainers = with maintainers; [ ambroisie ];
   };


### PR DESCRIPTION
Diff: https://github.com/yourlabs/django-autocomplete-light/compare/refs/tags/3.9.4...3.11.0

Changelog: https://github.com/yourlabs/django-autocomplete-light/blob/3.11.0/CHANGELOG


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
