### PR TITLE
gtkspell2: fix cross build

### DIFF
--- a/pkgs/development/libraries/gtkspell/default.nix
+++ b/pkgs/development/libraries/gtkspell/default.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
     docbook_xsl
+    gtk2 # GLIB_GNU_GETTEXT
     gtk-doc
     intltool
     pkg-config


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).