### PR TITLE
sway-easyfocus: 0.2.0 -> 0.2.0-unstable-2025-01-15

### DIFF
--- a/pkgs/by-name/sw/sway-easyfocus/package.nix
+++ b/pkgs/by-name/sw/sway-easyfocus/package.nix
@@ -15,16 +15,17 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "sway-easyfocus";
-  version = "0.2.0";
+  version = "0.2.0-unstable-2025-01-15";
 
   src = fetchFromGitHub {
     owner = "edzdez";
     repo = "sway-easyfocus";
-    tag = version;
-    hash = "sha256-ogqstgJqUczn0LDwpOAppC1J/Cs0IEOAXjNAnbiKn6M=";
+
+    rev = "4c1df53f630ac8791479eabfc9656b57de5e32e6";
+    hash = "sha256-c3vDtettZuwopI/3ShIPIAokzYqPL9Q9hDXS6xmxm8c=";
   };
 
-  cargoHash = "sha256-lAyKW6tjb4lVNA8xtvXLYYiLeKxSe/yfyY6h/f/WuP4=";
+  cargoHash = "sha256-+7CRl3KPFJ6PMMb2kmby08SiF0KlUcHc8qZtoxrc0Po=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Update sway-easyfocus to `2025-01-15`. Adds new feature: `swap windows`
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested, as applicable:
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
