### PR TITLE
gnumeric: fix cross build

### DIFF
--- a/pkgs/by-name/gn/gnumeric/package.nix
+++ b/pkgs/by-name/gn/gnumeric/package.nix
@@ -2,13 +2,17 @@
   lib,
   stdenv,
   fetchurl,
+  autoconf,
+  automake,
   pkg-config,
   intltool,
+  libxml2,
   perlPackages,
   goffice,
   gnome,
   adwaita-icon-theme,
   wrapGAppsHook3,
+  glib,
   gtk3,
   bison,
   python3Packages,
@@ -30,14 +34,20 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--disable-component" ];
 
   nativeBuildInputs = [
+    autoconf
+    automake
     pkg-config
     intltool
     bison
     itstool
+    glib # glib-compile-resources
+    libxml2 # xmllint
+    python.pythonOnBuildForHost
     wrapGAppsHook3
   ];
 
   # ToDo: optional libgda, introspection?
+  # TODO: fix Perl plugin when cross-compiling
   buildInputs =
     [
       goffice
@@ -52,6 +62,11 @@ stdenv.mkDerivation rec {
     ]);
 
   enableParallelBuilding = true;
+
+  postPatch = ''
+    substituteInPlace configure.ac \
+      --replace-fail 'GLIB_COMPILE_RESOURCES=' 'GLIB_COMPILE_RESOURCES="glib-compile-resources"#'
+  '';
 
   passthru = {
     updateScript = gnome.updateScript {


### PR DESCRIPTION
Unfortunately the configure logic for the Perl stuff doesn't work when cross-compiling.

Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).