### PR TITLE
capnproto: fix cross build of dependent packages

### DIFF
--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -1,7 +1,9 @@
 {
   lib,
   stdenv,
+  buildPackages,
   fetchFromGitHub,
+  makeSetupHook,
   cmake,
   openssl,
   zlib,
@@ -20,6 +22,16 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ];
+
+  propagatedNativeBuildInputs = lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+    (makeSetupHook {
+      name = "capnproto-setup-hook";
+      substitutions = {
+        build_capnp = buildPackages.capnproto;
+      };
+    } ./setup-hook.sh)
+  ];
+
   propagatedBuildInputs = [
     openssl
     zlib

--- a/pkgs/by-name/ca/capnproto/setup-hook.sh
+++ b/pkgs/by-name/ca/capnproto/setup-hook.sh
@@ -1,0 +1,8 @@
+CapnProtoCMakeFlags() {
+  cmakeFlagsArray+=(
+    -DCAPNP_EXECUTABLE="@build_capnp@/bin/capnp"
+    -DCAPNPC_CXX_EXECUTABLE="@build_capnp@/bin/capnpc-c++"
+  )
+}
+
+preConfigureHooks+=(CapnProtoCMakeFlags)


### PR DESCRIPTION
Fix path to these build tools. As far as I can tell these do not need to care about the hostPlatform.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).