### PR TITLE
perlPackages.GraphicsTIFF: fix strictDeps build

### DIFF
--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -11127,6 +11127,7 @@ with self; {
       url = "mirror://cpan/authors/id/R/RA/RATCLIFFE/Graphics-TIFF-20.tar.gz";
       hash = "sha256-PlXMIJRl4GQBmiFaUvBf9RBAKX0CA5P+n7PeJ60CDjU=";
     };
+    nativeBuildInputs = [ pkgs.pkg-config ];
     buildInputs = [ pkgs.libtiff ExtUtilsDepends ExtUtilsPkgConfig ];
     propagatedBuildInputs = [ Readonly ];
     nativeCheckInputs = [ TestRequires TestDeep pkgs.hexdump ];


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

Cross is broken due to broken dependency.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).