### PR TITLE
doc: Cross-reference roles syntax doc & implementation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -108,6 +108,7 @@ A few markups for other kinds of literals are also available:
 These literal kinds are used mostly in NixOS option documentation.
 
 This syntax is taken from [MyST](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html#roles-an-in-line-extension-point). Though, the feature originates from [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-manpage) with slightly different syntax.
+They are handled by `myst_role` defined per renderer. <!-- reverse references in code -->
 
 #### Admonitions
 

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/asciidoc.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/asciidoc.py
@@ -182,6 +182,7 @@ class AsciiDocRenderer(Renderer):
         self._leave_block()
         return "\n"
     def myst_role(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        # NixOS-specific roles are documented at <nixpkgs>/doc/README.md (with reverse reference)
         self._parstack[-1].continuing = True
         content = asciidoc_escape(token.content)
         if token.meta['name'] == 'manpage' and (url := self._manpage_urls.get(token.content)):

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/commonmark.py
@@ -159,6 +159,7 @@ class CommonMarkRenderer(Renderer):
         self._leave_block()
         return ""
     def myst_role(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        # NixOS-specific roles are documented at <nixpkgs>/doc/README.md (with reverse reference)
         self._parstack[-1].continuing = True
         content = md_make_code(token.content)
         if token.meta['name'] == 'manpage' and (url := self._manpage_urls.get(token.content)):

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/html.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/html.py
@@ -136,6 +136,7 @@ class HTMLRenderer(Renderer):
     def dd_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         return "</dd>"
     def myst_role(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        # NixOS-specific roles are documented at <nixpkgs>/doc/README.md (with reverse reference)
         if token.meta['name'] == 'command':
             return f'<span class="command"><strong>{escape(token.content)}</strong></span>'
         if token.meta['name'] == 'file':

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manpage.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/manpage.py
@@ -253,6 +253,7 @@ class ManpageRenderer(Renderer):
         self._leave_block()
         return ".RE"
     def myst_role(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        # NixOS-specific roles are documented at <nixpkgs>/doc/README.md (with reverse reference)
         if token.meta['name'] in [ 'command', 'env', 'option' ]:
             return f'\\fB{man_escape(token.content)}\\fP'
         elif token.meta['name'] in [ 'file', 'var' ]:

--- a/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/md.py
+++ b/pkgs/by-name/ni/nixos-render-docs/src/nixos_render_docs/md.py
@@ -228,6 +228,7 @@ class Renderer:
     def dd_close(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         raise RuntimeError("md token not supported", token)
     def myst_role(self, token: Token, tokens: Sequence[Token], i: int) -> str:
+        # NixOS-specific roles are documented at <nixpkgs>/doc/README.md (with reverse reference)
         raise RuntimeError("md token not supported", token)
     def attr_span_begin(self, token: Token, tokens: Sequence[Token], i: int) -> str:
         raise RuntimeError("md token not supported", token)


### PR DESCRIPTION
reasoning:
- (doc -> code) make it easier to find where those are implemented
  - to get easier insight if/what a specific renderer does with it
  - in case one wants to improve them, which seems likely as they are rather Nix/NixOS-specific
  - (took me too long to find their implementation)
- (code -> doc) ensure changes to the code can be reflected in the doc
  - code authors might not know about the reference documentation or how to find it

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
