### PR TITLE
nixos-rebuild-ng: fix --option parse, make --quiet a count

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -34,12 +34,12 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     common_flags.add_argument("--keep-failed", "-K", action="store_true")
     common_flags.add_argument("--fallback", action="store_true")
     common_flags.add_argument("--repair", action="store_true")
-    common_flags.add_argument("--option", nargs=2)
+    common_flags.add_argument("--option", nargs=2, action="append")
 
     common_build_flags = argparse.ArgumentParser(add_help=False)
     common_build_flags.add_argument("--builders")
     common_build_flags.add_argument("--include", "-I", action="append")
-    common_build_flags.add_argument("--quiet", action="store_true")
+    common_build_flags.add_argument("--quiet", action="count", default=0)
     common_build_flags.add_argument("--print-build-logs", "-L", action="store_true")
     common_build_flags.add_argument("--show-trace", action="store_true")
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -27,6 +27,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
         default=0,
         help="Enable verbose logging (includes nix)",
     )
+    common_flags.add_argument("--quiet", action="count", default=0)
     common_flags.add_argument("--max-jobs", "-j")
     common_flags.add_argument("--cores")
     common_flags.add_argument("--log-format")
@@ -39,7 +40,6 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     common_build_flags = argparse.ArgumentParser(add_help=False)
     common_build_flags.add_argument("--builders")
     common_build_flags.add_argument("--include", "-I", action="append")
-    common_build_flags.add_argument("--quiet", action="count", default=0)
     common_build_flags.add_argument("--print-build-logs", "-L", action="store_true")
     common_build_flags.add_argument("--show-trace", action="store_true")
 
@@ -55,7 +55,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     flake_common_flags.add_argument("--no-registries", action="store_true")
     flake_common_flags.add_argument("--commit-lock-file", action="store_true")
     flake_common_flags.add_argument("--update-input")
-    flake_common_flags.add_argument("--override-input", nargs=2)
+    flake_common_flags.add_argument("--override-input", nargs=2, action="append")
 
     classic_build_flags = argparse.ArgumentParser(add_help=False)
     classic_build_flags.add_argument("--no-build-output", "-Q", action="store_true")

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/__init__.py
@@ -54,7 +54,7 @@ def get_parser() -> tuple[argparse.ArgumentParser, dict[str, argparse.ArgumentPa
     flake_common_flags.add_argument("--no-write-lock-file", action="store_true")
     flake_common_flags.add_argument("--no-registries", action="store_true")
     flake_common_flags.add_argument("--commit-lock-file", action="store_true")
-    flake_common_flags.add_argument("--update-input")
+    flake_common_flags.add_argument("--update-input", action="append")
     flake_common_flags.add_argument("--override-input", nargs=2, action="append")
 
     classic_build_flags = argparse.ArgumentParser(add_help=False)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/models.py
@@ -52,7 +52,7 @@ class BuildAttr:
     attr: str | None
 
     def to_attr(self, *attrs: str) -> str:
-        return f"{self.attr + '.' if self.attr else ''}{".".join(attrs)}"
+        return f"{self.attr + '.' if self.attr else ''}{'.'.join(attrs)}"
 
     @classmethod
     def from_arg(cls, attr: str | None, file: str | None) -> Self:
@@ -68,7 +68,7 @@ class Flake:
     _re: ClassVar = re.compile(r"^(?P<path>[^\#]*)\#?(?P<attr>[^\#\"]*)$")
 
     def to_attr(self, *attrs: str) -> str:
-        return f"{self}.{".".join(attrs)}"
+        return f"{self}.{'.'.join(attrs)}"
 
     @override
     def __str__(self) -> str:
@@ -83,7 +83,7 @@ class Flake:
         m = cls._re.match(flake_str)
         assert m is not None, f"got no matches for {flake_str}"
         attr = m.group("attr")
-        nixos_attr = f"nixosConfigurations.{attr or hostname_fn() or "default"}"
+        nixos_attr = f"nixosConfigurations.{attr or hostname_fn() or 'default'}"
         path = m.group("path")
         if ":" in path:
             return cls(path, nixos_attr)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/process.py
@@ -15,7 +15,7 @@ SSH_DEFAULT_OPTS: Final = [
     "-o",
     "ControlMaster=auto",
     "-o",
-    f"ControlPath={tmpdir.TMPDIR_PATH / "ssh-%n"}",
+    f"ControlPath={tmpdir.TMPDIR_PATH / 'ssh-%n'}",
     "-o",
     "ControlPersist=60",
 ]

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/nixos_rebuild/utils.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Mapping, Sequence
 from typing import Any, assert_never, override
 
-type Arg = bool | str | list[str] | int | None
+type Arg = bool | str | list[str] | list[list[str]] | int | None
 type Args = dict[str, Arg]
 
 
@@ -43,9 +43,13 @@ def dict_to_flags(d: Args | None) -> list[str]:
                 flags.append(flag)
                 flags.append(value)
             case list():
-                for v in value:
+                for vs in value:
                     flags.append(flag)
-                    flags.append(v)
+                    if isinstance(vs, list):
+                        for v in vs:
+                            flags.append(v)
+                    else:
+                        flags.append(vs)
             case _:
                 assert_never(value)
     return flags

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -51,6 +51,10 @@ def test_parse_args() -> None:
             "--override-input",
             "override2",
             "input2",
+            "--update-input",
+            "input1",
+            "--update-input",
+            "input2",
         ]
     )
     assert nr.logger.level == logging.INFO
@@ -69,6 +73,10 @@ def test_parse_args() -> None:
         "bar2",
     ]
     assert nr.utils.dict_to_flags(vars(g1["flake_common_flags"])) == [
+        "--update-input",
+        "input1",
+        "--update-input",
+        "input2",
         "--override-input",
         "override1",
         "input1",

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -40,8 +40,17 @@ def test_parse_args() -> None:
             "--flake",
             "/etc/nixos",
             "--option",
-            "foo",
-            "bar",
+            "foo1",
+            "bar1",
+            "--option",
+            "foo2",
+            "bar2",
+            "--override-input",
+            "override1",
+            "input1",
+            "--override-input",
+            "override2",
+            "input2",
         ]
     )
     assert nr.logger.level == logging.INFO
@@ -50,8 +59,23 @@ def test_parse_args() -> None:
     assert r1.install_grub is True
     assert r1.profile_name == "system"
     assert r1.action == "switch"
-    assert r1.option == [["foo", "bar"]]
-    assert g1["common_flags"].option == [["foo", "bar"]]
+    # round-trip test (ensure that we have the same flags as parsed)
+    assert nr.utils.dict_to_flags(vars(g1["common_flags"])) == [
+        "--option",
+        "foo1",
+        "bar1",
+        "--option",
+        "foo2",
+        "bar2",
+    ]
+    assert nr.utils.dict_to_flags(vars(g1["flake_common_flags"])) == [
+        "--override-input",
+        "override1",
+        "input1",
+        "--override-input",
+        "override2",
+        "input2",
+    ]
 
     r2, g2 = nr.parse_args(
         [
@@ -63,7 +87,13 @@ def test_parse_args() -> None:
             "foo",
             "--attr",
             "bar",
+            "-I",
+            "include1",
+            "-I",
+            "include2",
             "-vvv",
+            "--quiet",
+            "--quiet",
         ]
     )
     assert nr.logger.level == logging.DEBUG
@@ -72,7 +102,18 @@ def test_parse_args() -> None:
     assert r2.action == "dry-build"
     assert r2.file == "foo"
     assert r2.attr == "bar"
-    assert g2["common_flags"].v == 3
+    # round-trip test (ensure that we have the same flags as parsed)
+    assert nr.utils.dict_to_flags(vars(g2["common_flags"])) == [
+        "-vvv",
+        "--quiet",
+        "--quiet",
+    ]
+    assert nr.utils.dict_to_flags(vars(g2["common_build_flags"])) == [
+        "--include",
+        "include1",
+        "--include",
+        "include2",
+    ]
 
 
 @patch.dict(nr.process.os.environ, {}, clear=True)

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -50,8 +50,8 @@ def test_parse_args() -> None:
     assert r1.install_grub is True
     assert r1.profile_name == "system"
     assert r1.action == "switch"
-    assert r1.option == ["foo", "bar"]
-    assert g1["common_flags"].option == ["foo", "bar"]
+    assert r1.option == [["foo", "bar"]]
+    assert g1["common_flags"].option == [["foo", "bar"]]
 
     r2, g2 = nr.parse_args(
         [
@@ -292,6 +292,10 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
             "--sudo",
             "--verbose",
             "--fast",
+            # https://github.com/NixOS/nixpkgs/issues/374050
+            "--option",
+            "narinfo-cache-negative-ttl",
+            "1200",
         ]
     )
 
@@ -307,6 +311,9 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
                     "--print-out-paths",
                     "/path/to/config#nixosConfigurations.hostname.config.system.build.toplevel",
                     "-v",
+                    "--option",
+                    "narinfo-cache-negative-ttl",
+                    "1200",
                     "--no-link",
                 ],
                 check=True,

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_utils.py
@@ -11,10 +11,11 @@ def test_dict_to_flags() -> None:
             "test_flag_2": False,
             "test_flag_3": "value",
             "test_flag_4": ["v1", "v2"],
-            "test_flag_5": None,
+            "test_flag_5": [["o1", "v1"], ["o2", "v2"]],
+            "test_flag_6": None,
             "t": True,
             "v": 5,
-            "verbose": 2,
+            "quiet": 2,
         }
     )
     assert r1 == [
@@ -25,10 +26,16 @@ def test_dict_to_flags() -> None:
         "v1",
         "--test-flag-4",
         "v2",
+        "--test-flag-5",
+        "o1",
+        "v1",
+        "--test-flag-5",
+        "o2",
+        "v2",
         "-t",
         "-vvvvv",
-        "--verbose",
-        "--verbose",
+        "--quiet",
+        "--quiet",
     ]
     r2 = u.dict_to_flags({"verbose": 0, "empty_list": []})
     assert r2 == []


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Fix #374050.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
