### PR TITLE
bitwarden-desktop: fix browser biometrics

### DIFF
--- a/pkgs/by-name/bi/bitwarden-desktop/firefox-native-messaging-host.json
+++ b/pkgs/by-name/bi/bitwarden-desktop/firefox-native-messaging-host.json
@@ -1,0 +1,7 @@
+{
+  "name": "com.8bit.bitwarden",
+  "description": "Bitwarden desktop <-> browser bridge",
+  "path": "@out@/bin/desktop_proxy",
+  "type": "stdio",
+  "allowed_extensions": ["{446900e4-71c2-419f-a6a7-df9c091e268b}"]
+}

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -115,6 +115,10 @@ buildNpmPackage rec {
     pushd apps/desktop/desktop_native/napi
     npm run build
     popd
+
+    pushd apps/desktop/desktop_native/proxy
+    cargo build --bin desktop_proxy --release
+    popd
   '';
 
   postBuild = ''
@@ -154,7 +158,8 @@ buildNpmPackage rec {
   installPhase = ''
     runHook preInstall
 
-    mkdir $out
+    mkdir -p $out/bin
+    cp -r apps/desktop/desktop_native/target/release/desktop_proxy $out/bin
 
     pushd apps/desktop/dist/linux-${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked
     mkdir -p $out/opt/Bitwarden

--- a/pkgs/by-name/bi/bitwarden-desktop/package.nix
+++ b/pkgs/by-name/bi/bitwarden-desktop/package.nix
@@ -161,6 +161,9 @@ buildNpmPackage rec {
     mkdir -p $out/bin
     cp -r apps/desktop/desktop_native/target/release/desktop_proxy $out/bin
 
+    mkdir -p $out/lib/mozilla/native-messaging-hosts
+    substituteAll ${./firefox-native-messaging-host.json} $out/lib/mozilla/native-messaging-hosts/com.8bit.bitwarden.json
+
     pushd apps/desktop/dist/linux-${lib.optionalString stdenv.hostPlatform.isAarch64 "arm64-"}unpacked
     mkdir -p $out/opt/Bitwarden
     cp -r locales resources{,.pak} $out/opt/Bitwarden


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Add `desktop_proxy` to `$out/bin`
and expose `com.8bit.bitwarden.json` to `$out/lib/mozilla/native-messaging-hosts/com.8bit.bitwarden.json` so the user can symlink to their home directory (in the same way as [keepassxc](https://github.com/NixOS/nixpkgs/blob/78c33f2b13419227692b3aeebd37215ee9d4536d/pkgs/applications/misc/keepassxc/firefox-native-messaging-host.json))
Should fix [#347350](https://github.com/NixOS/nixpkgs/issues/347350)
note that if you have firefox sandboxed, you must allow access to `~/.cache/com.bitwarden.desktop/app.bitwarden` socket

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
