### PR TITLE
nixos/recyclarr: init module

### DIFF
--- a/nixos/modules/services/misc/recyclarr.nix
+++ b/nixos/modules/services/misc/recyclarr.nix
@@ -1,0 +1,156 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.services.recyclarr;
+  format = pkgs.formats.yaml { };
+  stateDir = "/var/lib/recyclarr";
+  configPath = "${stateDir}/config.json";
+in
+{
+  options.services.recyclarr = {
+    enable = lib.mkEnableOption "recyclarr service";
+
+    package = lib.mkPackageOption pkgs "recyclarr" { };
+
+    configuration = lib.mkOption {
+      type = format.type;
+      default = { };
+      example = {
+        sonarr = [
+          {
+            instance_name = "main";
+            base_url = "http://localhost:8989";
+            api_key = {
+              _secret = "/run/credentials/recyclarr.service/sonarr-api_key";
+            };
+          }
+        ];
+        radarr = [
+          {
+            instance_name = "main";
+            base_url = "http://localhost:7878";
+            api_key = {
+              _secret = "/run/credentials/recyclarr.service/radarr-api_key";
+            };
+          }
+        ];
+      };
+      description = lib.mdDoc ''
+        Recyclarr YAML configuration as a Nix attribute set.
+
+        For detailed configuration options and examples, see the
+        [official configuration reference](https://recyclarr.dev/wiki/yaml/config-reference/).
+
+        The configuration is processed using [utils.genJqSecretsReplacementSnippet](https://github.com/NixOS/nixpkgs/blob/master/nixos/lib/utils.nix#L232-L331) to handle secret substitution.
+
+        To avoid permission issues, secrets should be provided via systemd's credential mechanism:
+
+        ```nix
+        systemd.services.recyclarr.serviceConfig.LoadCredential = [
+          "radarr-api_key:''${config.sops.secrets.radarr-api_key.path}"
+        ];
+      '';
+    };
+
+    schedule = lib.mkOption {
+      type = lib.types.str;
+      default = "daily";
+      description = "When to run recyclarr in systemd calendar format.";
+    };
+
+    command = lib.mkOption {
+      type = lib.types.str;
+      default = "sync";
+      description = "The recyclarr command to run (e.g., sync).";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "recyclarr";
+      description = "User account under which recyclarr runs.";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "recyclarr";
+      description = "Group under which recyclarr runs.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    users.users = lib.mkIf (cfg.user == "recyclarr") {
+      recyclarr = {
+        isSystemUser = true;
+        description = "recyclarr user";
+        home = stateDir;
+        group = cfg.group;
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "recyclarr") {
+      ${cfg.group} = { };
+    };
+
+    systemd.services.recyclarr = {
+      description = "Recyclarr Service";
+
+      # YAML is a JSON super-set
+      preStart = utils.genJqSecretsReplacementSnippet cfg.configuration configPath;
+
+      serviceConfig = {
+        Type = "oneshot";
+        User = cfg.user;
+        Group = cfg.group;
+        StateDirectory = "recyclarr";
+        ExecStart = "${lib.getExe cfg.package} ${cfg.command} --app-data ${stateDir} --config ${configPath}";
+
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectHostname = true;
+        ProtectClock = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectControlGroups = true;
+
+        PrivateNetwork = false;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+
+        NoNewPrivileges = true;
+        RestrictSUIDSGID = true;
+        RemoveIPC = true;
+
+        ReadWritePaths = [ stateDir ];
+
+        CapabilityBoundingSet = "";
+
+        LockPersonality = true;
+        RestrictRealtime = true;
+      };
+    };
+
+    systemd.timers.recyclarr = {
+      description = "Recyclarr Timer";
+      wantedBy = [ "timers.target" ];
+      partOf = [ "recyclarr.service" ];
+
+      timerConfig = {
+        OnCalendar = cfg.schedule;
+        Persistent = true;
+        RandomizedDelaySec = "5m";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds a service definition that allows to run [Recyclarr](https://recyclarr.dev/wiki/) ([nixos packge](https://search.nixos.org/packages?channel=unstable&show=recyclarr&from=0&size=50&sort=alpha_asc&type=packages&query=recyclarr)) periodically.

Executing the sync regularly ensures that the Sonarr and Radarr instances stay updated with the latest configurations from the TRaSH guides

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
