### PR TITLE
Add osv and parquet derivations

### DIFF
--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -629,6 +629,57 @@ in
     '';
   };
 
+  osv = attrs: {
+    # Basic config
+    dontBuild = false;
+    CARGO_HOME = "${placeholder "out"}/.cargo";
+
+    # Build inputs
+    nativeBuildInputs = [
+      cargo
+      rustc
+      rustPlatform.cargoSetupHook
+      rustPlatform.bindgenHook
+    ];
+
+    # Cargo dependencies
+    cargoDeps = rustPlatform.fetchCargoTarball {
+      pname = "osv-deps-cargo-tarball";
+      version = attrs.version;
+      hash = "sha256-4foO8KxVhbi/8mFn9fMxBg0JwFCdevIbdyseG40K1+U=";
+      src = stdenv.mkDerivation {
+        inherit (buildRubyGem {
+          inherit (attrs) gemName version source;
+        })
+          name
+          src
+          unpackPhase
+          nativeBuildInputs
+          ;
+        installPhase = ''
+          mkdir -p $out/ext/osv/.cargo
+          cp -R ./Cargo.* $out/
+          cp -R ./ext/osv/* $out/ext/osv/
+        '';
+      };
+    };
+
+    # Build hooks
+    preBuild = ''
+      mkdir -p $CARGO_HOME/.cargo
+      cp ../.cargo/config.toml $CARGO_HOME/config.toml
+    '';
+
+    postInstall = ''
+      find $out -type f -name .rustc_info.json -delete
+    '';
+
+    # Cleanup
+    disallowedReferences = [
+      rustc.unwrapped
+    ];
+  };
+
   ovirt-engine-sdk = attrs: {
     buildInputs = [ curl libxml2 ];
     dontBuild = false;
@@ -646,6 +697,57 @@ in
 
   patron = attrs: {
     buildInputs = [ curl ];
+  };
+
+  parquet = attrs: {
+    # Basic config
+    dontBuild = false;
+    CARGO_HOME = "${placeholder "out"}/.cargo";
+
+    # Build inputs
+    nativeBuildInputs = [
+      cargo
+      rustc
+      rustPlatform.cargoSetupHook
+      rustPlatform.bindgenHook
+    ];
+
+    # Cargo dependencies
+    cargoDeps = rustPlatform.fetchCargoTarball {
+      pname = "parquet-deps-cargo-tarball";
+      version = attrs.version;
+      hash = "sha256-jfx6cpu11rkwBhhh37cWI/6hrzsw/YCWW9+5aoezzww=";
+      src = stdenv.mkDerivation {
+        inherit (buildRubyGem {
+          inherit (attrs) gemName version source;
+        })
+          name
+          src
+          unpackPhase
+          nativeBuildInputs
+          ;
+        installPhase = ''
+          mkdir -p $out/ext/parquet/.cargo
+          cp -R ./Cargo.* $out/
+          cp -R ./ext/parquet/* $out/ext/parquet/
+        '';
+      };
+    };
+
+    # Build hooks
+    preBuild = ''
+      mkdir -p $CARGO_HOME/.cargo
+      cp ../.cargo/config.toml $CARGO_HOME/config.toml
+    '';
+
+    postInstall = ''
+      find $out -type f -name .rustc_info.json -delete
+    '';
+
+    # Cleanup
+    disallowedReferences = [
+      rustc.unwrapped
+    ];
   };
 
   pcaprub = attrs: {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

- Adding default derivations for the `osv` and `parquet` gems. They're trickier than most to get setup properly, and this is the file I check when I'm looking to add a tricky gem to my derivations, so I want to contribute this as a reference. It's likely that people will need to override the default hash here as the versions change, but that's much better than having to figure out a derivation for it.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
