### PR TITLE
mate.mate-panel: fix cross build

### DIFF
--- a/pkgs/desktops/mate/mate-panel/default.nix
+++ b/pkgs/desktops/mate/mate-panel/default.nix
@@ -37,6 +37,7 @@ stdenv.mkDerivation rec {
     gobject-introspection
     gettext
     itstool
+    libxml2 # xmllint
     pkg-config
     wrapGAppsHook3
   ];
@@ -46,7 +47,6 @@ stdenv.mkDerivation rec {
     libmateweather
     libwnck
     librsvg
-    libxml2
     dconf
     mate-desktop
     mate-menus


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).