### PR TITLE
totem: fix strictDeps build, mark cross as broken

### DIFF
--- a/pkgs/by-name/to/totem/package.nix
+++ b/pkgs/by-name/to/totem/package.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation rec {
     itstool
     gobject-introspection
     wrapGAppsHook3
+    gst_all_1.gstreamer # gst-inspect-1.0
   ];
 
   buildInputs = [
@@ -114,5 +115,7 @@ stdenv.mkDerivation rec {
     maintainers = teams.gnome.members;
     license = licenses.gpl2Plus; # with exception to allow use of non-GPL compatible plug-ins
     platforms = platforms.linux;
+    # gst-inspect-1.0 is not smart enough for cross compiling
+    broken = stdenv.buildPlatform != stdenv.hostPlatform;
   };
 }


### PR DESCRIPTION
ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).