### PR TITLE
gnome-applets: fix cross build

### DIFF
--- a/pkgs/by-name/gn/gnome-applets/package.nix
+++ b/pkgs/by-name/gn/gnome-applets/package.nix
@@ -34,6 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     gettext
+    glib # glib-compile-resources
     itstool
     pkg-config
     libxml2


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).