### PR TITLE
python312Packages.priority: cleanup

### DIFF
--- a/pkgs/development/python-modules/priority/default.nix
+++ b/pkgs/development/python-modules/priority/default.nix
@@ -5,18 +5,24 @@
   fetchPypi,
   hypothesis,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "priority";
   version = "2.0.0";
-  format = "setuptools";
-  disabled = pythonOlder "3.6.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.6";
 
   src = fetchPypi {
     inherit pname version;
     sha256 = "c965d54f1b8d0d0b19479db3924c7c36cf672dbf2aec92d43fbdaf4492ba18c0";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   pythonImportsCheck = [ "priority" ];
 


### PR DESCRIPTION
pythonOlder only compares major + minor version.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).