### PR TITLE
[Backport release-24.11] pingvin-share: 1.1.3 -> 1.8.0

### DIFF
--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
     prisma
   ];
 
-  npmDepsHash = "sha256-IeryDlBFG+fu0FyqlNujkF+O+YwfQm0hoMMvp/vN0IQ=";
+  npmDepsHash = "sha256-2q+3NgXkpqdljW/AnBU44002arMc0K/Rl15eqr+oa9E=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
     prisma
   ];
 
-  npmDepsHash = "sha256-2q+3NgXkpqdljW/AnBU44002arMc0K/Rl15eqr+oa9E=";
+  npmDepsHash = "sha256-BkwFQVHpg7PuMU5MaW73S6R+wbdGOJ62PR9EE2ghQFg=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
     prisma
   ];
 
-  npmDepsHash = "sha256-F+pYEsaU4Rsiq1z3rwGeKznZqpITF+AoFgswhTFeXf8=";
+  npmDepsHash = "sha256-RedMH3zWXTNOu/15UDeATP+gWBfDvt4vhKVahL/sEKM=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
     prisma
   ];
 
-  npmDepsHash = "sha256-RedMH3zWXTNOu/15UDeATP+gWBfDvt4vhKVahL/sEKM=";
+  npmDepsHash = "sha256-/tzYrPzfB2TDy+o5ZGlUUbLKaEuu+YesnWFWF+VEaCM=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
     prisma
   ];
 
-  npmDepsHash = "sha256-/tzYrPzfB2TDy+o5ZGlUUbLKaEuu+YesnWFWF+VEaCM=";
+  npmDepsHash = "sha256-IeryDlBFG+fu0FyqlNujkF+O+YwfQm0hoMMvp/vN0IQ=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
     prisma
   ];
 
-  npmDepsHash = "sha256-SBVkrrNKD3hCf1dT4ZWXYcQCat+wVQ9+ti1d0hfpWIw=";
+  npmDepsHash = "sha256-zzN4r2hednmm5DFnK/RRTKPq0vWiGhG+WyNTPNNP1vc=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/backend.nix
+++ b/pkgs/servers/pingvin-share/backend.nix
@@ -31,7 +31,7 @@ buildNpmPackage {
     prisma
   ];
 
-  npmDepsHash = "sha256-BkwFQVHpg7PuMU5MaW73S6R+wbdGOJ62PR9EE2ghQFg=";
+  npmDepsHash = "sha256-SBVkrrNKD3hCf1dT4ZWXYcQCat+wVQ9+ti1d0hfpWIw=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/default.nix
+++ b/pkgs/servers/pingvin-share/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "1.4.0";
+  version = "1.6.1";
   src = fetchFromGitHub {
     owner = "stonith404";
     repo = "pingvin-share";
     rev = "v${version}";
-    hash = "sha256-5tu81kB9UDui2/n5KJLRug4IHeDihuv8+HWeo0saqAM=";
+    hash = "sha256-uoOkr5awBa7MQA4tNUzFp7we5zVnBpjX6V6fNcTI84o=";
   };
 in
 

--- a/pkgs/servers/pingvin-share/default.nix
+++ b/pkgs/servers/pingvin-share/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "1.6.1";
+  version = "1.7.0";
   src = fetchFromGitHub {
     owner = "stonith404";
     repo = "pingvin-share";
     rev = "v${version}";
-    hash = "sha256-uoOkr5awBa7MQA4tNUzFp7we5zVnBpjX6V6fNcTI84o=";
+    hash = "sha256-wZV3PKnGoD3g4PjSDPwMm4ftUTlEZykNkWlwLCDJfuM=";
   };
 in
 

--- a/pkgs/servers/pingvin-share/default.nix
+++ b/pkgs/servers/pingvin-share/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "1.1.3";
+  version = "1.2.4";
   src = fetchFromGitHub {
     owner = "stonith404";
     repo = "pingvin-share";
     rev = "v${version}";
-    hash = "sha256-n3EwmS8uKrhEuNOh55eAkEtibAerAy6AduszW4leJuI=";
+    hash = "sha256-hGM7xTgB+XTytnNdGNKQYd7YLAIMbBczxsrcNE3EXkc=";
   };
 in
 

--- a/pkgs/servers/pingvin-share/default.nix
+++ b/pkgs/servers/pingvin-share/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "1.3.0";
+  version = "1.4.0";
   src = fetchFromGitHub {
     owner = "stonith404";
     repo = "pingvin-share";
     rev = "v${version}";
-    hash = "sha256-OCAuntdOdIQ3hFOoSQxoPzNSg1mz1qrNhtayXZ0Hl8o=";
+    hash = "sha256-5tu81kB9UDui2/n5KJLRug4IHeDihuv8+HWeo0saqAM=";
   };
 in
 

--- a/pkgs/servers/pingvin-share/default.nix
+++ b/pkgs/servers/pingvin-share/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "1.2.4";
+  version = "1.3.0";
   src = fetchFromGitHub {
     owner = "stonith404";
     repo = "pingvin-share";
     rev = "v${version}";
-    hash = "sha256-hGM7xTgB+XTytnNdGNKQYd7YLAIMbBczxsrcNE3EXkc=";
+    hash = "sha256-OCAuntdOdIQ3hFOoSQxoPzNSg1mz1qrNhtayXZ0Hl8o=";
   };
 in
 

--- a/pkgs/servers/pingvin-share/default.nix
+++ b/pkgs/servers/pingvin-share/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "1.7.1";
+  version = "1.8.0";
   src = fetchFromGitHub {
     owner = "stonith404";
     repo = "pingvin-share";
     rev = "v${version}";
-    hash = "sha256-XchwPP573z4tzwAlSdWwi0aZwNlLcL1wGGgGyYgJAWg=";
+    hash = "sha256-cgB2cnpWdQFqdz9Lxyl87MOvhELge0YwwY0AoKqL8BU=";
   };
 in
 

--- a/pkgs/servers/pingvin-share/default.nix
+++ b/pkgs/servers/pingvin-share/default.nix
@@ -5,12 +5,12 @@
 }:
 
 let
-  version = "1.7.0";
+  version = "1.7.1";
   src = fetchFromGitHub {
     owner = "stonith404";
     repo = "pingvin-share";
     rev = "v${version}";
-    hash = "sha256-wZV3PKnGoD3g4PjSDPwMm4ftUTlEZykNkWlwLCDJfuM=";
+    hash = "sha256-XchwPP573z4tzwAlSdWwi0aZwNlLcL1wGGgGyYgJAWg=";
   };
 in
 

--- a/pkgs/servers/pingvin-share/frontend.nix
+++ b/pkgs/servers/pingvin-share/frontend.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [ pkg-config ];
 
-  npmDepsHash = "sha256-G9UzA/laXEiU101ehFwhi0i6PAeErNWqmb1fu4W+cII=";
+  npmDepsHash = "sha256-TC3I3suUJTCmKykitpf2vvO6aGUSoYWOnB3jFwV2W/4=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/frontend.nix
+++ b/pkgs/servers/pingvin-share/frontend.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [ pkg-config ];
 
-  npmDepsHash = "sha256-TC3I3suUJTCmKykitpf2vvO6aGUSoYWOnB3jFwV2W/4=";
+  npmDepsHash = "sha256-uu/JX039QjVwMtGI8lOjuzPC7kM1knhKycbJ/4cc1o4=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/frontend.nix
+++ b/pkgs/servers/pingvin-share/frontend.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [ pkg-config ];
 
-  npmDepsHash = "sha256-laVAVwx/A/6TunCmmZYQKAuYqv1xTG3e1DIonj2S9IU=";
+  npmDepsHash = "sha256-aTarzVt+9Sn0xvAfPyoXFoHqPVjKDGv/OfLO8/RdkQw=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/frontend.nix
+++ b/pkgs/servers/pingvin-share/frontend.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [ pkg-config ];
 
-  npmDepsHash = "sha256-RBeKjljFnUwdVdIMd+huqKXvrsDp4weSgcCAIOSxeeM=";
+  npmDepsHash = "sha256-G9UzA/laXEiU101ehFwhi0i6PAeErNWqmb1fu4W+cII=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/frontend.nix
+++ b/pkgs/servers/pingvin-share/frontend.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [ pkg-config ];
 
-  npmDepsHash = "sha256-aTarzVt+9Sn0xvAfPyoXFoHqPVjKDGv/OfLO8/RdkQw=";
+  npmDepsHash = "sha256-RBeKjljFnUwdVdIMd+huqKXvrsDp4weSgcCAIOSxeeM=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/frontend.nix
+++ b/pkgs/servers/pingvin-share/frontend.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [ pkg-config ];
 
-  npmDepsHash = "sha256-TC5yMvAXO3oKRhyVgGAiXT213vvv+cOxY4z6vQU1gX4=";
+  npmDepsHash = "sha256-wQIQHRVj8weUh/VOBdYVr8Q4ZE9u4rGJbQr0+NE6XG0=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 

--- a/pkgs/servers/pingvin-share/frontend.nix
+++ b/pkgs/servers/pingvin-share/frontend.nix
@@ -23,7 +23,7 @@ buildNpmPackage {
   buildInputs = [ vips ];
   nativeBuildInputs = [ pkg-config ];
 
-  npmDepsHash = "sha256-uu/JX039QjVwMtGI8lOjuzPC7kM1knhKycbJ/4cc1o4=";
+  npmDepsHash = "sha256-TC5yMvAXO3oKRhyVgGAiXT213vvv+cOxY4z6vQU1gX4=";
   makeCacheWritable = true;
   npmFlags = [ "--legacy-peer-deps" ];
 


### PR DESCRIPTION
Manual backport of

https://github.com/NixOS/nixpkgs/pull/354105
https://github.com/NixOS/nixpkgs/pull/356551
https://github.com/NixOS/nixpkgs/pull/361751
https://github.com/NixOS/nixpkgs/pull/366607
https://github.com/NixOS/nixpkgs/pull/368297
https://github.com/NixOS/nixpkgs/pull/368297

Fixes https://github.com/stonith404/pingvin-share/security/advisories/GHSA-rjwx-p44f-mcrv

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
