### PR TITLE
nixos/aerospike: remove obsolete parameter "paxos-single-replica-limit"

### DIFF
--- a/nixos/modules/services/databases/aerospike.nix
+++ b/nixos/modules/services/databases/aerospike.nix
@@ -13,7 +13,7 @@ let
     service {
       user aerospike
       group aerospike
-      paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
+#      paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
       proto-fd-max 15000
       work-directory ${cfg.workDir}
     }


### PR DESCRIPTION
> “paxos-single-replica-limit” configuration parameter is removed in the server version 6.0. 
-- [discuss.aerospike.com/t/removal-of-paxos-single-replica-limit-and-fail-on-cluster-change/10329](https://discuss.aerospike.com/t/removal-of-paxos-single-replica-limit-and-fail-on-cluster-change/10329)