### PR TITLE
firefox: Remove support for specific native host config options (deprecated since 23.11)

### DIFF
--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -5,10 +5,7 @@
 ## various stuff that can be plugged in
 , ffmpeg, xorg, alsa-lib, libpulseaudio, libcanberra-gtk3, libglvnd, libnotify, opensc
 , adwaita-icon-theme
-, browserpass, gnome-browser-connector, uget-integrator, plasma5Packages, bukubrow, pipewire
-, tridactyl-native
-, fx-cast-bridge
-, keepassxc
+, pipewire
 , udev
 , libkrb5
 , libva
@@ -36,7 +33,6 @@ let
     , icon ? applicationName
     , wmClass ? applicationName
     , nativeMessagingHosts ? []
-    , extraNativeMessagingHosts ? []
     , pkcs11Modules ? []
     , useGlvnd ? true
     , cfg ? config.${applicationName} or {}
@@ -65,27 +61,7 @@ let
       # PCSC-Lite daemon (services.pcscd) also must be enabled for firefox to access smartcards
       smartcardSupport = cfg.smartcardSupport or false;
 
-      deprecatedNativeMessagingHost = option: pkg:
-        if (cfg.${option} or false)
-          then
-            lib.warn "The cfg.${option} argument for `firefox.override` is deprecated, please add `pkgs.${pkg.pname}` to `nativeMessagingHosts` instead"
-            [pkg]
-          else [];
-
-      allNativeMessagingHosts = builtins.map lib.getBin (
-        nativeMessagingHosts
-          ++ deprecatedNativeMessagingHost "enableBrowserpass" browserpass
-          ++ deprecatedNativeMessagingHost "enableBukubrow" bukubrow
-          ++ deprecatedNativeMessagingHost "enableTridactylNative" tridactyl-native
-          ++ deprecatedNativeMessagingHost "enableGnomeExtensions" gnome-browser-connector
-          ++ deprecatedNativeMessagingHost "enableUgetIntegrator" uget-integrator
-          ++ deprecatedNativeMessagingHost "enablePlasmaBrowserIntegration" plasma5Packages.plasma-browser-integration
-          ++ deprecatedNativeMessagingHost "enableFXCastBridge" fx-cast-bridge
-          ++ deprecatedNativeMessagingHost "enableKeePassXC" keepassxc
-          ++ (if extraNativeMessagingHosts != []
-                then lib.warn "The extraNativeMessagingHosts argument for the Firefox wrapper is deprecated, please use `nativeMessagingHosts`" extraNativeMessagingHosts
-                else [])
-       );
+      allNativeMessagingHosts = builtins.map lib.getBin nativeMessagingHosts;
 
        libs = lib.optionals stdenv.hostPlatform.isLinux (
             [ udev libva libgbm libnotify xorg.libXScrnSaver cups pciutils vulkan-loader ]

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeDesktopItem, makeWrapper, makeBinaryWrapper, lndir, config
+{ stdenv, lib, makeDesktopItem, makeWrapper, lndir, config
 , buildPackages
 , jq, xdg-utils, writeText
 


### PR DESCRIPTION
This is a cleanup. I'm planning to work on a Darwin specific wrapper for apps like Firefox and Thunderbird, so this is in anticipation of that. The wrapper is quite complex and it would be helpful to remove crust if possible.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
