### PR TITLE
json-sort-cli: init at 2.0.2

### DIFF
--- a/pkgs/by-name/js/json-sort-cli/package.nix
+++ b/pkgs/by-name/js/json-sort-cli/package.nix
@@ -13,7 +13,7 @@ buildNpmPackage rec {
   src = fetchFromGitHub {
     owner = "tillig";
     repo = "json-sort-cli";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-h7RlAFSb2pFolkd+0M5tddPxM5RgZJtNLLAoTuYNdIQ=";
   };
 

--- a/pkgs/by-name/js/json-sort-cli/package.nix
+++ b/pkgs/by-name/js/json-sort-cli/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs,
+  nix-update-script,
+}:
+
+buildNpmPackage rec {
+  pname = "json-sort-cli";
+  version = "2.0.2";
+
+  src = fetchFromGitHub {
+    owner = "tillig";
+    repo = "json-sort-cli";
+    rev = "v${version}";
+    hash = "sha256-h7RlAFSb2pFolkd+0M5tddPxM5RgZJtNLLAoTuYNdIQ=";
+  };
+
+  npmDepsHash = "sha256-g+6yLvEnZ2Zi7+4M+KDVSL2Qf3COWGgiBtpYrwG4HRM=";
+  dontNpmBuild = true;
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    npm run test
+    runHook postCheck
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "CLI interface to json-stable-stringify.";
+    homepage = "https://github.com/tillig/json-sort-cli";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ hasnep ];
+    inherit (nodejs.meta) platforms;
+    mainProgram = "json-sort";
+  };
+}


### PR DESCRIPTION
Adds [`json-sort`](https://github.com/tillig/json-sort-cli), a CLI tool to sort JSON files

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
