### PR TITLE
maa-assistant-arknights: 5.10.2 -> 5.12.0-beta-1

### DIFF
--- a/pkgs/by-name/ma/maa-assistant-arknights/pin.json
+++ b/pkgs/by-name/ma/maa-assistant-arknights/pin.json
@@ -1,10 +1,10 @@
 {
   "stable": {
-    "version": "5.10.2",
-    "hash": "sha256-Qyhl6uZy70208j07vaWdwN5GGmX66kkOpA3Ny48PdtI="
+    "version": "5.12.0-beta.1",
+    "hash": "sha256-ZiC6UCXsB+Czb+RAuvv3zENDxgaOKtNZQUEQuV86ggI="
   },
   "beta": {
-    "version": "5.11.0-beta.1",
-    "hash": "sha256-qpzbnfAd7P4f2jFgnCx7gTmZXYUUGreEHRY3/HGbZco="
+    "version": "5.12.0-beta.1",
+    "hash": "sha256-ZiC6UCXsB+Czb+RAuvv3zENDxgaOKtNZQUEQuV86ggI="
   }
 }


### PR DESCRIPTION
Temporarily updated to beta version to fix build errors on gcc14. The next time it will be automatically switched back to the stable channel by the update script.

I sign this commit both as the upstream committer and as the package's maintainer in nixpkgs.

Upstream commit: https://github.com/MaaAssistantArknights/MaaAssistantArknights/commit/86d422087fd7a97b75519d3f21326c34bca06b4f

Reported-by: https://hydra.nixos.org/build/282160825/nixlog/4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
