### PR TITLE
anthy: fix cross build

### DIFF
--- a/pkgs/by-name/an/anthy/package.nix
+++ b/pkgs/by-name/an/anthy/package.nix
@@ -2,11 +2,33 @@
   lib,
   stdenv,
   fetchurl,
+  buildPackages,
 }:
 
 stdenv.mkDerivation rec {
   pname = "anthy";
   version = "9100h";
+
+  postPatch = lib.optionalString (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    # for cross builds, copy build tools from the native package
+    cp -r "${buildPackages.anthy}"/lib/internals/{mkdepgraph,.libs} depgraph/
+    cp -r "${buildPackages.anthy}"/lib/internals/{mkworddic,.libs} mkworddic/
+    cp -r "${buildPackages.anthy}"/lib/internals/{calctrans,.libs} calctrans/
+    cp -r "${buildPackages.anthy}"/lib/internals/{mkfiledic,.libs} mkanthydic/
+    substituteInPlace mkworddic/Makefile.in \
+      --replace-fail 'anthy.wdic : mkworddic' 'anthy.wdic : ' \
+      --replace-fail 'all: ' 'all: anthy.wdic #'
+    substituteInPlace calctrans/Makefile.in \
+      --replace-fail '$(dict_source_files): $(srcdir)/corpus_info $(srcdir)/weak_words calctrans' \
+                     '$(dict_source_files): $(srcdir)/corpus_info $(srcdir)/weak_words' \
+      --replace-fail 'all-am: Makefile $(PROGRAMS) $(DATA)' 'all-am: $(DATA)'
+    substituteInPlace depgraph/Makefile.in \
+      --replace-fail 'anthy.dep : mkdepgraph' 'anthy.dep : ' \
+      --replace-fail 'all-am: Makefile $(PROGRAMS) $(DATA)' 'all-am: $(DATA)'
+    substituteInPlace mkanthydic/Makefile.in \
+      --replace-fail 'anthy.dic : mkfiledic' 'anthy.dic : ' \
+      --replace-fail 'all-am: Makefile $(PROGRAMS) $(SCRIPTS) $(DATA)' 'all-am: $(DATA)'
+  '';
 
   meta = with lib; {
     description = "Hiragana text to Kana Kanji mixed text Japanese input method";
@@ -15,6 +37,11 @@ stdenv.mkDerivation rec {
     maintainers = with maintainers; [ ericsagnes ];
     platforms = platforms.unix;
   };
+
+  postFixup = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    mkdir "$out/lib/internals"
+    cp -r depgraph/{mkdepgraph,.libs} mkworddic/{mkworddic,.libs} calctrans/{calctrans,.libs} mkanthydic/{mkfiledic,.libs} "$out/lib/internals"
+  '';
 
   src = fetchurl {
     url = "mirror://osdn/anthy/37536/anthy-${version}.tar.gz";


### PR DESCRIPTION
Bit hacky but it works.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).