### PR TITLE
libhangul: fix cross build

### DIFF
--- a/pkgs/by-name/li/libhangul/package.nix
+++ b/pkgs/by-name/li/libhangul/package.nix
@@ -13,6 +13,11 @@ stdenv.mkDerivation rec {
     sha256 = "0ni9b0v70wkm0116na7ghv03pgxsfpfszhgyj3hld3bxamfal1ar";
   };
 
+  configureFlags = [
+    # detection doesn't work for cross builds
+    "ac_cv_func_realloc_0_nonnull=yes"
+  ];
+
   meta = with lib; {
     description = "Core algorithm library for Korean input routines";
     mainProgram = "hangul";


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).