### PR TITLE
libchewing: mark cross as broken

### DIFF
--- a/pkgs/by-name/li/libchewing/package.nix
+++ b/pkgs/by-name/li/libchewing/package.nix
@@ -30,5 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
       ShamrockLee
     ];
     platforms = platforms.all;
+    # compile time tools init_database, dump_database are built for host
+    broken = !stdenv.buildPlatform.canExecute stdenv.hostPlatform;
   };
 })


### PR DESCRIPTION
These are built via CMake and it is not obvious how to replace them with native tools.

## Things done
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).