### PR TITLE
libskk: fix cross build

### DIFF
--- a/pkgs/by-name/li/libskk/package.nix
+++ b/pkgs/by-name/li/libskk/package.nix
@@ -55,9 +55,7 @@ stdenv.mkDerivation rec {
     json-glib
   ];
 
-  preConfigure = ''
-    ./autogen.sh
-  '';
+  configureScript = "./autogen.sh";
 
   # link SKK-JISYO.L from skkdicts for the bundled tool `skk`
   preInstall = ''


### PR DESCRIPTION
This ensures the proper configureFlags are passed to autogen.sh

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).