### PR TITLE
rke2: fix update script and update all rke2 packages

### DIFF
--- a/pkgs/applications/networking/cluster/rke2/latest/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/latest/versions.nix
@@ -1,14 +1,14 @@
 {
-  rke2Version = "1.31.1+rke2r1";
-  rke2Commit = "909d20d6a28cd7656b7177190f06f69f57927613";
-  rke2TarballHash = "sha256-9ZryOX6QMNpjDtsOXLOVNPjCc6AMAa+XDLOn1EpyCcg=";
-  rke2VendorHash = "sha256-7nWbWi4oJTOWZ5iZr9ptECDJJakPg4qZ7hW+tU7LBsI=";
-  k8sVersion = "v1.31.1";
-  k8sImageTag = "v1.31.1-rke2r1-build20240912";
-  etcdVersion = "v3.5.13-k3s1-build20240910";
+  rke2Version = "1.32.0+rke2r1";
+  rke2Commit = "1182e7eb91b27b1686e69306eb2e227928a27a38";
+  rke2TarballHash = "sha256-mmHQxiNcfgZTTdYPJPO7WTIlaCRM4CWsWwfRUcAR8ho=";
+  rke2VendorHash = "sha256-6Y3paEQJ8yHzONqalzoe15TjWhF3zGsM92LS1AcJ2GM=";
+  k8sVersion = "v1.32.0";
+  k8sImageTag = "v1.32.0-rke2r1-build20241212";
+  etcdVersion = "v3.5.16-k3s1-build20241106";
   pauseVersion = "3.6";
-  ccmVersion = "v1.31.0-build20240910";
-  dockerizedVersion = "v1.31.1-rke2r1";
-  golangVersion = "go1.22.6";
-  eol = "2025-10-28";
+  ccmVersion = "v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101";
+  dockerizedVersion = "v1.32.0-rke2r1";
+  golangVersion = "go1.23.3";
+  eol = "2026-02-28";
 }

--- a/pkgs/applications/networking/cluster/rke2/stable/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/stable/versions.nix
@@ -1,14 +1,14 @@
 {
-  rke2Version = "1.30.5+rke2r1";
-  rke2Commit = "0c83bc82315cd61664880d0b52a7e070e9fbd623";
-  rke2TarballHash = "sha256-K5e7TNlL97PQ13IYnr4PSrXb4XaGJT9bPq55iWL0m1g=";
-  rke2VendorHash = "sha256-QIcVyWnedKNF10OqJ2WmZqZeKA+8hvwDQ4Pl+WUOEJY=";
-  k8sVersion = "v1.30.5";
-  k8sImageTag = "v1.30.5-rke2r1-build20240912";
-  etcdVersion = "v3.5.13-k3s1-build20240910";
+  rke2Version = "1.31.4+rke2r1";
+  rke2Commit = "5142beec71f7a61804840df5b434c2fd7137ce82";
+  rke2TarballHash = "sha256-Lebi3a7kNA9IQCVVkYfUoGEeEiLScqpOx1aTCFElDvw=";
+  rke2VendorHash = "sha256-DGmu1vFNcu1O2wuEwRZRBTL/TP2lJ9ggQ2M/Ix+jknM=";
+  k8sVersion = "v1.31.4";
+  k8sImageTag = "v1.31.4-rke2r1-build20241212";
+  etcdVersion = "v3.5.16-k3s1-build20241106";
   pauseVersion = "3.6";
-  ccmVersion = "v1.30.4-build20240910";
-  dockerizedVersion = "v1.30.5-rke2r1";
-  golangVersion = "go1.22.6";
-  eol = "2025-06-28";
+  ccmVersion = "v1.31.2-0.20241016053446-0955fa330f90-build20241016";
+  dockerizedVersion = "v1.31.4-rke2r1";
+  golangVersion = "go1.22.9";
+  eol = "2025-10-28";
 }

--- a/pkgs/applications/networking/cluster/rke2/testing/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/testing/versions.nix
@@ -1,14 +1,14 @@
 {
-  rke2Version = "1.31.1-rc3+rke2r1";
-  rke2Commit = "909d20d6a28cd7656b7177190f06f69f57927613";
-  rke2TarballHash = "sha256-9ZryOX6QMNpjDtsOXLOVNPjCc6AMAa+XDLOn1EpyCcg=";
-  rke2VendorHash = "sha256-7nWbWi4oJTOWZ5iZr9ptECDJJakPg4qZ7hW+tU7LBsI=";
-  k8sVersion = "v1.31.1";
-  k8sImageTag = "v1.31.1-rke2r1-build20240912";
-  etcdVersion = "v3.5.13-k3s1-build20240910";
+  rke2Version = "1.31.4-rc3+rke2r1";
+  rke2Commit = "b2d8003d79075e7331ab8f2d1e1a3c494ed944b9";
+  rke2TarballHash = "sha256-eTA+/fF6HuXDT4EUnvPIaJtLfbNGk9BXG+z3zCRPh9s=";
+  rke2VendorHash = "sha256-akP6XLkeBtVVGgaLBcn+e1bwFtMPRs1/NGR9VN5UuCo=";
+  k8sVersion = "v1.31.4";
+  k8sImageTag = "v1.31.4-rke2r1-build20241212";
+  etcdVersion = "v3.5.16-k3s1-build20241106";
   pauseVersion = "3.6";
-  ccmVersion = "v1.31.0-build20240910";
-  dockerizedVersion = "v1.31.1-rc3-rke2r1";
-  golangVersion = "go1.22.6";
+  ccmVersion = "v1.31.2-0.20241016053446-0955fa330f90-build20241016";
+  dockerizedVersion = "v1.31.4-rc3-rke2r1";
+  golangVersion = "go1.22.9";
   eol = "2025-10-28";
 }

--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p curl git gnugrep gnused yq-go nix-prefetch go
+#!nix-shell -i bash -p curl git gnugrep gnused yq-go nurl go
 
 SHELL_FLAGS=$(set +o)
 set -x -eu -o pipefail
@@ -54,8 +54,7 @@ cat << EOF > "${WORKDIR}/${CHANNEL_NAME}/versions.nix"
 EOF
 
 set +e
-RKE2_VENDOR_HASH=$(nix-prefetch -I nixpkgs=$(git rev-parse --show-toplevel) \
-        "{ sha256 }: rke2_${CHANNEL_NAME}.goModules.overrideAttrs (_: { vendorHash = sha256; })")
+RKE2_VENDOR_HASH=$(nurl -e "(import $(git rev-parse --show-toplevel) {}).rke2_${CHANNEL_NAME}.goModules")
 set -e
 
 if [ -n "${RKE2_VENDOR_HASH:-}" ]; then


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The update script was failing because of `nix-prefetch`, we had the same problem in k3s (https://github.com/NixOS/nixpkgs/pull/356772). I replaced it with [nurl](https://github.com/nix-community/nurl), as we did in k3s.

Additionally, the `testing` release channel returns a really old version from 2020, which also leads to the update script failing. I set the testing version manually to the latest rke2 pre-release, but I also asked in https://github.com/rancher/rke2/issues/7610 what's going on with the testing release channel.

The version updates are:

- rke2_testing: 1.31.1-rc3+rke2r1 -> 1.31.4-rc3+rke2r1
- rke2_latest: 1.31.1+rke2r1 -> 1.32.0+rke2r1
- rke2_stable: 1.30.5+rke2r1 -> 1.31.4+rke2r1

I build all packages locally and run `./result/bin/rke2 --version`, which worked fine. I guess the rke2 tests have never worked correctly (but that's another topic), so I didn't rely on them that much.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@zimbatm @stefan-bordei 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
