### PR TITLE
nixos/mobilizon: update nginx config, mobilizon: fix media proxy

### DIFF
--- a/nixos/modules/services/web-apps/mobilizon.nix
+++ b/nixos/modules/services/web-apps/mobilizon.nix
@@ -5,9 +5,17 @@
   ...
 }:
 
-with lib;
-
 let
+  inherit (lib)
+    mkEnableOption
+    mkPackageOption
+    mkOption
+    mkDefault
+    mkIf
+    types
+    literalExpression
+    ;
+
   cfg = config.services.mobilizon;
 
   user = "mobilizon";
@@ -20,7 +28,7 @@ let
   # Make a package containing launchers with the correct envirenment, instead of
   # setting it with systemd services, so that the user can also use them without
   # troubles
-  launchers = pkgs.stdenv.mkDerivation rec {
+  launchers = pkgs.stdenv.mkDerivation {
     pname = "${cfg.package.pname}-launchers";
     inherit (cfg.package) version;
 

--- a/nixos/modules/services/web-apps/mobilizon.nix
+++ b/nixos/modules/services/web-apps/mobilizon.nix
@@ -455,7 +455,6 @@ in
               add_header Cache-Control "public, max-age=31536000, s-maxage=31536000, immutable";
             '';
           };
-
         };
       };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -615,7 +615,7 @@ in {
   misc = handleTest ./misc.nix {};
   misskey = handleTest ./misskey.nix {};
   mjolnir = handleTest ./matrix/mjolnir.nix {};
-  mobilizon = handleTest ./mobilizon.nix {};
+  mobilizon = runTest ./mobilizon.nix;
   mod_perl = handleTest ./mod_perl.nix {};
   molly-brown = handleTest ./molly-brown.nix {};
   mollysocket = handleTest ./mollysocket.nix { };

--- a/nixos/tests/mobilizon.nix
+++ b/nixos/tests/mobilizon.nix
@@ -1,49 +1,47 @@
-import ./make-test-python.nix (
-  { lib, ... }:
-  let
-    certs = import ./common/acme/server/snakeoil-certs.nix;
-    mobilizonDomain = certs.domain;
-    port = 41395;
-  in
+{ lib, ... }:
+let
+  certs = import ./common/acme/server/snakeoil-certs.nix;
+  mobilizonDomain = certs.domain;
+  port = 41395;
+in
 
-  {
-    name = "mobilizon";
-    meta.maintainers = with lib.maintainers; [
-      minijackson
-      erictapen
-    ];
+{
+  name = "mobilizon";
+  meta.maintainers = with lib.maintainers; [
+    minijackson
+    erictapen
+  ];
 
-    nodes.server =
-      { ... }:
-      {
-        services.mobilizon = {
-          enable = true;
-          settings = {
-            ":mobilizon" = {
-              ":instance" = {
-                name = "Test Mobilizon";
-                hostname = mobilizonDomain;
-              };
-              "Mobilizon.Web.Endpoint".http.port = port;
+  nodes.server =
+    { ... }:
+    {
+      services.mobilizon = {
+        enable = true;
+        settings = {
+          ":mobilizon" = {
+            ":instance" = {
+              name = "Test Mobilizon";
+              hostname = mobilizonDomain;
             };
+            "Mobilizon.Web.Endpoint".http.port = port;
           };
         };
-
-        security.pki.certificateFiles = [ certs.ca.cert ];
-
-        services.nginx.virtualHosts."${mobilizonDomain}" = {
-          enableACME = lib.mkForce false;
-          sslCertificate = certs.${mobilizonDomain}.cert;
-          sslCertificateKey = certs.${mobilizonDomain}.key;
-        };
-
-        networking.hosts."::1" = [ mobilizonDomain ];
       };
 
-    testScript = ''
-      server.wait_for_unit("mobilizon.service")
-      server.wait_for_open_port(${toString port})
-      server.succeed("curl --fail https://${mobilizonDomain}/")
-    '';
-  }
-)
+      security.pki.certificateFiles = [ certs.ca.cert ];
+
+      services.nginx.virtualHosts."${mobilizonDomain}" = {
+        enableACME = lib.mkForce false;
+        sslCertificate = certs.${mobilizonDomain}.cert;
+        sslCertificateKey = certs.${mobilizonDomain}.key;
+      };
+
+      networking.hosts."::1" = [ mobilizonDomain ];
+    };
+
+  testScript = ''
+    server.wait_for_unit("mobilizon.service")
+    server.wait_for_open_port(${toString port})
+    server.succeed("curl --fail https://${mobilizonDomain}/")
+  '';
+}

--- a/pkgs/servers/mobilizon/0002-fix-media-proxy.patch
+++ b/pkgs/servers/mobilizon/0002-fix-media-proxy.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/web/proxy/reverse_proxy.ex b/lib/web/proxy/reverse_proxy.ex
+index 8a78ef27..788ccc30 100644
+--- a/lib/web/proxy/reverse_proxy.ex
++++ b/lib/web/proxy/reverse_proxy.ex
+@@ -187,9 +187,13 @@ defmodule Mobilizon.Web.ReverseProxy do
+   @spec response(Plug.Conn.t(), any(), String.t(), pos_integer(), list(tuple()), Keyword.t()) ::
+           Plug.Conn.t()
+   defp response(conn, client, url, status, headers, opts) do
++    headers = build_resp_headers(headers, opts)
++    # Fix HTTP/1.1 protocol violation: content-length can't be combined with chunked encoding
++    headers = Enum.reject(headers, fn {k, _} -> k == "content-length" end)
++
+     result =
+       conn
+-      |> put_resp_headers(build_resp_headers(headers, opts))
++      |> put_resp_headers(headers)
+       |> send_chunked(status)
+       |> chunk_reply(client, opts)
+ 

--- a/pkgs/servers/mobilizon/default.nix
+++ b/pkgs/servers/mobilizon/default.nix
@@ -19,10 +19,19 @@ in
 mixRelease rec {
   inherit (common) pname version src;
 
-  # Version 5.1.1 failed to bump their internal package version,
-  # which causes issues with static file serving in the NixOS module.
-  # See https://github.com/NixOS/nixpkgs/pull/370277
-  patches = [ ./0001-fix-version.patch ];
+  patches = [
+    # Version 5.1.1 failed to bump their internal package version,
+    # which causes issues with static file serving in the NixOS module.
+    # See https://github.com/NixOS/nixpkgs/pull/370277
+    ./0001-fix-version.patch
+    # Mobilizon uses chunked Transfer-Encoding for the media proxy but also
+    # sets the Content-Length header. This is a HTTP/1.1 protocol violation
+    # and results in nginx >=1.24 rejecting the response with this error:
+    # 'upstream sent "Content-Length" and "Transfer-Encoding" headers at the same
+    # time while reading response header from upstream'
+    # Upstream PR: https://framagit.org/framasoft/mobilizon/-/merge_requests/1604
+    ./0002-fix-media-proxy.patch
+  ];
 
   nativeBuildInputs = [
     git


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The nginx config of the NixOS Mobilizon module still is using the settings from Mobilizon's [development config](https://framagit.org/framasoft/mobilizon/-/blob/main/support/nginx/mobilizon-source.conf), while a proper [release config](https://framagit.org/framasoft/mobilizon/-/blob/main/support/nginx/mobilizon-release.conf) has been introduced since.
This PR adopts these changes from the Mobilizon release config.

I also took this opportunity to remove the use of `with lib;` and an unused `rec`, and migrated the tests from `handleTest` to `runTest`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
