### PR TITLE
pmount: add debian patches; fix gcc-14 build

### DIFF
--- a/pkgs/by-name/pm/pmount/package.nix
+++ b/pkgs/by-name/pm/pmount/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   intltool,
   ntfs3g,
   util-linux,
@@ -21,6 +22,35 @@ stdenv.mkDerivation rec {
     url = "mirror://debian/pool/main/p/pmount/pmount_${version}.orig.tar.bz2";
     sha256 = "db38fc290b710e8e9e9d442da2fb627d41e13b3ee80326c15cc2595ba00ea036";
   };
+
+  patches =
+    let
+      # https://salsa.debian.org/debian/pmount/-/tree/debian/master/debian/patches
+      fetchDebPatch =
+        { name, hash }:
+        fetchpatch {
+          inherit name hash;
+          url = "https://salsa.debian.org/debian/pmount/-/raw/ba05283d4a53aba5349d4397a98d9f45206fb29f/debian/patches/${name}";
+        };
+    in
+    map fetchDebPatch [
+      {
+        name = "10_fix-spelling-binary-errors.patch";
+        hash = "sha256-G4GsUe1ZdYB7Qv333X1hUjOELITR8A2pqyfEnMDTwHI=";
+      }
+      {
+        name = "20_fix-spelling-manpage-error.patch";
+        hash = "sha256-9phF8s7MFSjkhPP24cipeBUps5W1L7YmAE0B1QPx5jk=";
+      }
+      {
+        name = "fix-implicit-function-declaration.patch";
+        hash = "sha256-kdwdS9G1X5RtQFKzF6oMIUubGNP7n1ZQNHu8sN1oV4Q=";
+      }
+      {
+        name = "30_exfat-support.patch";
+        hash = "sha256-kg9gLhOtdrEDlZfUnT910xI5rNR1zgKKRx2kvFQjbi8=";
+      }
+    ];
 
   nativeBuildInputs = [
     intltool


### PR DESCRIPTION
https://salsa.debian.org/debian/pmount/-/tree/debian/master/debian/patches

fixes: #374181

ref. #356812

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
