### PR TITLE
gitwatch package - possible lacking of gnugrep and gnused dependencies

### DIFF
--- a/pkgs/by-name/gi/gitwatch/package.nix
+++ b/pkgs/by-name/gi/gitwatch/package.nix
@@ -5,6 +5,8 @@
   fetchFromGitHub,
 
   git,
+  gnugrep,
+  gnused,
   openssh,
   inotify-tools,
 }:
@@ -42,6 +44,8 @@ runCommand "gitwatch"
       --prefix PATH ';' ${
         lib.makeBinPath [
           git
+          gnugrep
+          gnused
           inotify-tools
           openssh
         ]


### PR DESCRIPTION
As I have described on [discourse thread](https://discourse.nixos.org/t/i-think-i-found-a-bug-in-gitwatch-package-but-i-dont-know-how-to-verify-and-possibly-fix-it/58167):

1. I have installed this packages system-wide on NixOS stable 24.11
2. when using `gitwatch` program from interactive shell it worked fine
3. I have then tried to put in under control of user-spaced *systemd* service unit to make it start automatically; this however could not happen due to errors:

```
Dec 31 22:34:50 hosthost gitwatch[3688627]: /nix/store/vabiazsm1vk3mcjhfx7cq31p211icx7s-gitwatch/bin/.gitwatch-wrapped: line 225: sed: command not found
Dec 31 22:34:50 hosthost gitwatch[3688629]: /nix/store/vabiazsm1vk3mcjhfx7cq31p211icx7s-gitwatch/bin/.gitwatch-wrapped: line 273: grep: command not found
```

## Things done

I have blindly added `gnused` and `gnugrep` to the `package.nix` script, **but I have not tested it** because I don't know how to do it in the "easy way" (I have tried cloning the nixpkgs repo though, but I have failed upon system update).