### PR TITLE
vala-panel-appmenu: init at 25.04

### DIFF
--- a/pkgs/by-name/va/vala-panel-appmenu/package.nix
+++ b/pkgs/by-name/va/vala-panel-appmenu/package.nix
@@ -1,0 +1,137 @@
+# to prevent bloating this package, please choose what integration you want
+# to use manually, like this:
+#   vala-panel-appmenu.override { enableMate = true; }
+# the package compiles very quickly, so there is no sense to have every
+# single combination to be build by hydra
+{
+  lib,
+  budgie-desktop,
+  fetchFromGitLab,
+  glib,
+  gobject-introspection,
+  gtk3,
+  jdk,
+  libdbusmenu,
+  libwnck,
+  libxkbcommon,
+  mate,
+  meson,
+  ninja,
+  nix-update-script,
+  pkg-config,
+  stdenv,
+  stripJavaArchivesHook,
+  vala,
+  vala-panel-appmenu,
+  wrapGAppsHook3,
+  xfce,
+
+  enableXfce ? false,
+  enableBudgie ? false,
+  enableValapanel ? false, # NOTE: requires https://github.com/rilian-la-te/vala-panel which is not packaged
+  enableMate ? false,
+  enableJayatana ? false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vala-panel-appmenu";
+  version = "25.04";
+
+  src = fetchFromGitLab {
+    owner = "vala-panel-project";
+    repo = "vala-panel-appmenu";
+    tag = finalAttrs.version;
+    fetchSubmodules = true;
+    hash = "sha256-v5J3nwViNiSKRPdJr+lhNUdKaPG82fShPDlnmix5tlY=";
+  };
+
+  patches = [
+    # for some weird reason, upstream tries to install its content
+    # into library files that it uses. this is not allowed on linux
+    ./proper-install-dirs.patch
+  ];
+
+  nativeBuildInputs =
+    [
+      meson
+      ninja
+
+      pkg-config
+      vala
+      wrapGAppsHook3
+    ]
+    ++ lib.optionals enableXfce [
+      xfce.xfce4-panel
+      xfce.xfconf
+    ]
+    ++ lib.optional enableBudgie budgie-desktop
+    ++ lib.optional enableMate mate.mate-panel-with-applets
+    ++ lib.optionals enableJayatana [
+      jdk
+      stripJavaArchivesHook
+    ];
+
+  buildInputs =
+    [
+      glib
+      gobject-introspection
+      gtk3
+      libwnck
+    ]
+    ++ lib.optionals enableJayatana [
+      libdbusmenu
+      libxkbcommon
+    ];
+
+  mesonAutoFeatures = "auto";
+  mesonFlags = [
+    (lib.mesonEnable "xfce" enableXfce)
+    (lib.mesonEnable "budgie" enableBudgie)
+    (lib.mesonEnable "valapanel" enableValapanel)
+    (lib.mesonEnable "mate" enableMate)
+    (lib.mesonEnable "jayatana" enableJayatana)
+    (lib.mesonEnable "appmenu-gtk-module" true)
+    (lib.mesonOption "appmenu-gtk-module:gtk" "3")
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { };
+
+    # this just generates all possible combinations for `enable*` flags
+    tests =
+      let
+        combinations =
+          n: items:
+          if n == 0 then
+            [ [ ] ]
+          else
+            builtins.concatMap (b: map (l: [ b ] ++ l) (combinations (n - 1) items)) items;
+        allArgs = combinations 4 [
+          true
+          false
+        ];
+      in
+      lib.listToAttrs (
+        lib.forEach allArgs (args: {
+          name = lib.foldl (acc: a: acc + lib.boolToString a + "-") "" args;
+          value = vala-panel-appmenu.override {
+            enableXfce = builtins.elemAt args 0;
+            enableBudgie = builtins.elemAt args 1;
+            enableValapanel = false;
+            enableMate = builtins.elemAt args 2;
+            enableJayatana = builtins.elemAt args 3;
+          };
+        })
+      );
+  };
+
+  meta = {
+    description = "Global Menu for Vala Panel/XFCE/Budgie/Mate";
+    homepage = "https://gitlab.com/vala-panel-project/vala-panel-appmenu";
+    license = lib.licenses.lgpl3;
+    maintainers = with lib.maintainers; [ perchun ];
+    platforms = lib.platforms.linux;
+    # needs https://github.com/rilian-la-te/vala-panel
+    broken = enableValapanel;
+  };
+})

--- a/pkgs/by-name/va/vala-panel-appmenu/proper-install-dirs.patch
+++ b/pkgs/by-name/va/vala-panel-appmenu/proper-install-dirs.patch
@@ -1,0 +1,95 @@
+diff --git a/applets/meson.build b/applets/meson.build
+index fd29a9f..56f89dd 100644
+--- a/applets/meson.build
++++ b/applets/meson.build
+@@ -4,7 +4,6 @@ if vala_panel_found
+     vpp = shared_module('appmenu', vp_sources, libres,
+                     dependencies: [appmenu_dep, vp],
+                     install: true,
+-                    install_dir: vp_applets_libdir
+                   )
+ endif
+ 
+@@ -14,7 +13,6 @@ if mate_found
+     mpp = shared_module('appmenu-mate', mp_sources, libres,
+                     dependencies: [appmenu_dep, mp],
+                     install: true,
+-                    install_dir: mate_applet_libdir
+                   )
+ endif
+ 
+@@ -24,7 +22,6 @@ if xfce_found
+     xpp = shared_module('appmenu-xfce', xp_sources, libres,
+                     dependencies: [appmenu_dep, xc,xp],
+                     install: true,
+-                    install_dir: xfce_applet_libdir
+                   )
+ endif
+ 
+@@ -34,6 +31,5 @@ if budgie_found
+     bpp = shared_module('appmenu-budgie', bp_sources, libres,
+                     dependencies: [appmenu_dep, bp],
+                     install: true,
+-                    install_dir: budgie_applet_libdir
+                   )
+ endif
+diff --git a/data/meson.build b/data/meson.build
+index fa3df0c..18470ad 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -3,7 +3,7 @@ cdata.set('CMAKE_INSTALL_FULL_LIBDIR', join_paths(prefix,get_option('libdir')))
+ cdata.set('CMAKE_INSTALL_FULL_DATAROOTDIR', join_paths(prefix,datadir))
+ 
+ if vala_panel_found
+-    vp_applets_datadir = vp.get_variable(pkgconfig:'applets_data')
++    vp_applets_datadir = get_option('datadir') / 'vala-panel' / 'applications'
+     desktop = vcs_tag(
+ 	    command : ['git','describe','--tags'],
+ 	    input: 'appmenu.plugin.desktop.in',
+@@ -19,7 +19,7 @@ if vala_panel_found
+ endif
+ 
+ if mate_found
+-    mate_applet_datadir = join_paths(mp.get_variable(pkgconfig:'prefix'),datadir,'mate-panel','applets')
++    mate_applet_datadir = get_option('datadir') / 'mate-panel' / 'applications'
+     mate_desktop = configure_file(input : 'appmenu-mate.plugin.desktop.in',
+                output : 'appmenu-mate.desktop.in',
+ 			   configuration : cdata)
+@@ -32,7 +32,7 @@ if mate_found
+ endif
+ 
+ if xfce_found
+-    xfce_applet_datadir = join_paths(xp.get_variable(pkgconfig:'prefix'),datadir,'xfce4','panel','plugins')
++    xfce_applet_datadir = get_option('datadir') / 'xfce' / 'panel' / 'plugins'
+     i18n.merge_file(
+       input: 'appmenu.desktop.in',
+       output: 'appmenu.desktop',
+@@ -46,7 +46,7 @@ if budgie_found
+       input: 'appmenu-budgie.desktop.in',
+       output: 'appmenu-budgie.plugin',
+       kwargs: desktop_kwargs,
+-      install_dir: budgie_applet_libdir
++      install_dir: get_option('datadir') / 'budgie-desktop' / 'plugins' / 'budgie-appmenu-plugin'
+     )
+ endif
+ 
+diff --git a/subprojects/appmenu-gtk-module/src/gtk-2.0/meson.build b/subprojects/appmenu-gtk-module/src/gtk-2.0/meson.build
+index 505d547..43e1714 100644
+--- a/subprojects/appmenu-gtk-module/src/gtk-2.0/meson.build
++++ b/subprojects/appmenu-gtk-module/src/gtk-2.0/meson.build
+@@ -3,5 +3,4 @@ gtk2_module = shared_module(
+     dependencies: gtk2_parser_dep,
+     c_args: '-Wno-deprecated-declarations',
+     install: true,
+-    install_dir: join_paths(gtk2.get_variable(pkgconfig:'libdir'),'gtk-2.0','modules')
+ )
+diff --git a/subprojects/appmenu-gtk-module/src/gtk-3.0/meson.build b/subprojects/appmenu-gtk-module/src/gtk-3.0/meson.build
+index dff3bf3..cb90daf 100644
+--- a/subprojects/appmenu-gtk-module/src/gtk-3.0/meson.build
++++ b/subprojects/appmenu-gtk-module/src/gtk-3.0/meson.build
+@@ -2,5 +2,4 @@ gtk3_module = shared_module(
+     'appmenu-gtk-module', module_sources,
+     dependencies: gtk3_parser_dep,
+     install: true,
+-    install_dir: join_paths(gtk3.get_variable(pkgconfig:'libdir'),'gtk-3.0','modules')
+ )

--- a/pkgs/development/libraries/astal/modules/tray.nix
+++ b/pkgs/development/libraries/astal/modules/tray.nix
@@ -1,10 +1,13 @@
 {
   buildAstalModule,
   json-glib,
+  vala-panel-appmenu,
 }:
 buildAstalModule {
   name = "tray";
-  buildInputs = [ json-glib ];
+  buildInputs = [
+    json-glib
+    vala-panel-appmenu
+  ];
   meta.description = "Astal module for StatusNotifierItem";
-  meta.broken = true; # https://github.com/NixOS/nixpkgs/issues/337630
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

https://gitlab.com/vala-panel-project/vala-panel-appmenu: Global Menu for Vala Panel/XFCE/Budgie/Mate

This is required for `astal.tray`
https://github.com/NixOS/nixpkgs/blob/ffeebf0acf3ae8b29f8c7049cd911b9636efd7e7/pkgs/development/libraries/astal/modules/tray.nix#L9

Closes https://github.com/NixOS/nixpkgs/issues/337630

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
