### PR TITLE
aerc: 0.18.2 -> 0.19.0

### DIFF
--- a/pkgs/by-name/ae/aerc/package.nix
+++ b/pkgs/by-name/ae/aerc/package.nix
@@ -14,17 +14,17 @@
 
 buildGoModule rec {
   pname = "aerc";
-  version = "0.18.2";
+  version = "0.19.0";
 
   src = fetchFromSourcehut {
     owner = "~rjarry";
     repo = "aerc";
     rev = version;
-    hash = "sha256-J4W7ynJ5DpE97sILENNt6eya04aiq9DWBhlytsVmZHg=";
+    hash = "sha256-YlpR85jB6Il3UW4MTaf8pkilRVjkO0q/D/Yu+OiBX6Y=";
   };
 
   proxyVendor = true;
-  vendorHash = "sha256-STQzc25gRozNHKjjYb8J8CL5WMhnx+nTJOGbuFmUYSU=";
+  vendorHash = "sha256-WowRlAzyrfZi27JzskIDberiYt9PQkuS6H3hKqUP9qo=";
 
   nativeBuildInputs = [
     scdoc
@@ -33,18 +33,13 @@ buildGoModule rec {
 
   patches = [
     ./runtime-libexec.patch
-
-    # patch to fix a encoding problem with gpg signed messages
-    (fetchpatch {
-      url = "https://git.sr.ht/~rjarry/aerc/commit/7346d20.patch";
-      hash = "sha256-OCm8BcovYN2IDSgslZklQxkGVkSYQ8HLCrf2+DRB2mM=";
-    })
   ];
 
   postPatch = ''
     substituteAllInPlace config/aerc.conf
     substituteAllInPlace config/config.go
     substituteAllInPlace doc/aerc-config.5.scd
+    substituteAllInPlace doc/aerc-templates.7.scd
 
     # Prevent buildGoModule from trying to build this
     rm contrib/linters.go

--- a/pkgs/by-name/ae/aerc/runtime-libexec.patch
+++ b/pkgs/by-name/ae/aerc/runtime-libexec.patch
@@ -1,8 +1,8 @@
 diff --git a/config/aerc.conf b/config/aerc.conf
-index 7d33b43..4315f0e 100644
+index fbc1f3ba..9eea2b81 100644
 --- a/config/aerc.conf
 +++ b/config/aerc.conf
-@@ -202,8 +202,7 @@
+@@ -301,8 +301,7 @@
  #
  #   ${XDG_CONFIG_HOME:-~/.config}/aerc/stylesets
  #   ${XDG_DATA_HOME:-~/.local/share}/aerc/stylesets
@@ -12,7 +12,18 @@ index 7d33b43..4315f0e 100644
  #
  #stylesets-dirs=
  
-@@ -547,8 +546,7 @@ message/rfc822=colorize
+@@ -741,8 +740,8 @@
+ #   ${XDG_DATA_HOME:-~/.local/share}/aerc/filters
+ #   $PREFIX/libexec/aerc/filters
+ #   $PREFIX/share/aerc/filters
+-#   /usr/libexec/aerc/filters
+-#   /usr/share/aerc/filters
++#   @out@/libexec/aerc/filters
++#   @out@/share/aerc/filters
+ #
+ # If you want to run a program in your default $PATH which has the same name
+ # as a builtin filter (e.g. /usr/bin/colorize), use its absolute path.
+@@ -845,8 +844,7 @@ text/html=! html
  #
  #   ${XDG_CONFIG_HOME:-~/.config}/aerc/templates
  #   ${XDG_DATA_HOME:-~/.local/share}/aerc/templates
@@ -23,10 +34,10 @@ index 7d33b43..4315f0e 100644
  #template-dirs=
  
 diff --git a/config/config.go b/config/config.go
-index d70bcfe..c19e59a 100644
+index 14c4b233..9f305ffd 100644
 --- a/config/config.go
 +++ b/config/config.go
-@@ -54,10 +54,8 @@ func buildDefaultDirs() []string {
+@@ -46,10 +46,8 @@ func buildDefaultDirs() []string {
  	}
  
  	// Add fixed fallback locations
@@ -40,10 +51,19 @@ index d70bcfe..c19e59a 100644
  	return defaultDirs
  }
 diff --git a/doc/aerc-config.5.scd b/doc/aerc-config.5.scd
-index 9e1f8a3..694abbc 100644
+index 1e3daaa9..cd118be0 100644
 --- a/doc/aerc-config.5.scd
 +++ b/doc/aerc-config.5.scd
-@@ -300,8 +300,7 @@ These options are configured in the *[ui]* section of _aerc.conf_.
+@@ -13,7 +13,7 @@ _aerc_, which defaults to _~/.config/aerc_. Alternate files can be specified via
+ command line arguments, see *aerc*(1).
+ 
+ Examples of these config files are typically included with your installation of
+-aerc and are usually installed in _/usr/share/aerc_.
++aerc and are usually installed in _@out@/share/aerc_.
+ 
+ Each file uses the ini format, and consists of sections with keys and values.
+ A line beginning with _#_ is considered a comment and ignored, as are empty
+@@ -386,8 +386,7 @@ These options are configured in the *[ui]* section of _aerc.conf_.
  	```
  	${XDG_CONFIG_HOME:-~/.config}/aerc/stylesets
  	${XDG_DATA_HOME:-~/.local/share}/aerc/stylesets
@@ -53,7 +73,36 @@ index 9e1f8a3..694abbc 100644
  	```
  
  *styleset-name* = _<string>_
-@@ -900,8 +899,7 @@ These options are configured in the *[templates]* section of _aerc.conf_.
+@@ -1019,7 +1018,7 @@ will be set to the terminal TTY. The filter is expected to implement its own
+ paging.
+ 
+ aerc ships with some default filters installed in the libexec directory (usually
+-_/usr/libexec/aerc/filters_). Note that these may have additional dependencies
++_@out@/libexec/aerc/filters_). Note that these may have additional dependencies
+ that aerc does not have alone.
+ 
+ The filter commands are invoked with _sh -c command_. The following folders are
+@@ -1031,8 +1030,8 @@ ${XDG_CONFIG_HOME:-~/.config}/aerc/filters
+ ${XDG_DATA_HOME:-~/.local/share}/aerc/filters
+ $PREFIX/libexec/aerc/filters
+ $PREFIX/share/aerc/filters
+-/usr/libexec/aerc/filters
+-/usr/share/aerc/filters
++@out@/libexec/aerc/filters
++@out@/share/aerc/filters
+ ```
+ 
+ If you want to run a program in your default *$PATH* which has the same
+@@ -1370,7 +1369,7 @@ of the template name. The available symbols and functions are described in
+ *aerc-templates*(7).
+ 
+ aerc ships with some default templates installed in the share directory (usually
+-_/usr/share/aerc/templates_).
++_@out@/share/aerc/templates_).
+ 
+ These options are configured in the *[templates]* section of _aerc.conf_.
+ 
+@@ -1382,8 +1381,7 @@ These options are configured in the *[templates]* section of _aerc.conf_.
  	```
  	${XDG_CONFIG_HOME:-~/.config}/aerc/templates
  	${XDG_DATA_HOME:-~/.local/share}/aerc/templates
@@ -64,19 +113,19 @@ index 9e1f8a3..694abbc 100644
  
  *new-message* = _<template_name>_
 diff --git a/doc/aerc-templates.7.scd b/doc/aerc-templates.7.scd
-index ae9bc6d..5f42b14 100644
+index a6deb584..4f91869c 100644
 --- a/doc/aerc-templates.7.scd
 +++ b/doc/aerc-templates.7.scd
-@@ -319,7 +319,7 @@ aerc provides the following additional functions:
- 	Execute external command, provide the second argument to its stdin.
+@@ -398,7 +398,7 @@ aerc provides the following additional functions:
+ 	Attaches a file to the message being composed.
  
  	```
--	{{exec `/usr/libexec/aerc/filters/html` .OriginalText}}
-+	{{exec `@out@/libexec/aerc/filters/html` .OriginalText}}
+-	{{.Attach '/usr/libexec/aerc/filters/html'}}
++	{{.Attach '@out@/libexec/aerc/filters/html'}}
  	```
  
- *.Local*
-@@ -425,7 +425,7 @@ aerc provides the following additional functions:
+ *exec*
+@@ -581,7 +581,7 @@ aerc provides the following additional functions:
  
  	```
  	{{if eq .OriginalMIMEType "text/html"}}


### PR DESCRIPTION
## Description of changes

https://git.sr.ht/~rjarry/aerc/refs/0.19.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
