### PR TITLE
hoarder: init at 0.21.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -23027,6 +23027,12 @@
     githubId = 1391883;
     name = "Tom Hall";
   };
+  three = {
+    email = "eric@ericroberts.dev";
+    github = "three";
+    githubId = 1761259;
+    name = "Eric Roberts";
+  };
   thtrf = {
     email = "thtrf@proton.me";
     github = "thtrf";

--- a/pkgs/by-name/ho/hoarder/helpers/hoarder-cli
+++ b/pkgs/by-name/ho/hoarder/helpers/hoarder-cli
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+HOARDER_LIB_PATH=
+NODEJS=
+exec "$NODEJS/bin/node" "$HOARDER_LIB_PATH/apps/cli/dist/index.mjs" "$@"

--- a/pkgs/by-name/ho/hoarder/helpers/migrate
+++ b/pkgs/by-name/ho/hoarder/helpers/migrate
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+HOARDER_LIB_PATH=
+RELEASE=
+NODE_ENV=production
+
+[[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
+
+export RELEASE NODE_ENV
+exec "$HOARDER_LIB_PATH/node_modules/.bin/tsx" "$HOARDER_LIB_PATH/packages/db/migrate.ts" "$@"

--- a/pkgs/by-name/ho/hoarder/helpers/start-web
+++ b/pkgs/by-name/ho/hoarder/helpers/start-web
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+HOARDER_LIB_PATH=
+RELEASE=
+NODEJS=
+NODE_ENV=production
+
+[[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
+
+export RELEASE NODE_ENV
+exec "$NODEJS/bin/node" "$HOARDER_LIB_PATH/apps/web/.next/standalone/apps/web/server.js"

--- a/pkgs/by-name/ho/hoarder/helpers/start-workers
+++ b/pkgs/by-name/ho/hoarder/helpers/start-workers
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+HOARDER_LIB_PATH=
+RELEASE=
+NODE_ENV=production
+NODE_PATH="$HOARDER_LIB_PATH/apps/workers"
+
+[[ -d "$DATA_DIR" ]]	# Ensure DATA_DIR is defined and exists
+
+export RELEASE NODE_ENV NODE_PATH
+exec "$HOARDER_LIB_PATH/node_modules/.bin/tsx" "$HOARDER_LIB_PATH/apps/workers/index.ts"

--- a/pkgs/by-name/ho/hoarder/package.nix
+++ b/pkgs/by-name/ho/hoarder/package.nix
@@ -1,0 +1,143 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  nodejs,
+  node-gyp,
+  inter,
+  python3,
+  srcOnly,
+  removeReferencesTo,
+  pnpm_9,
+}:
+let
+  pnpm = pnpm_9;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hoarder";
+  version = "0.21.0";
+
+  src = fetchFromGitHub {
+    owner = "hoarder-app";
+    repo = "hoarder";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-3xgpiqq+BV0a/OlcQiGDt59fYNF+zP0+HPeBCRiZj48=";
+  };
+
+  patches = [
+    ./patches/use-local-font.patch
+    ./patches/fix-migrations-path.patch
+    ./patches/dont-lock-pnpm-version.patch
+  ];
+  postPatch = ''
+    ln -s ${inter}/share/fonts/truetype ./apps/landing/app/fonts
+    ln -s ${inter}/share/fonts/truetype ./apps/web/app/fonts
+  '';
+
+  nativeBuildInputs = [
+    python3
+    nodejs
+    node-gyp
+    pnpm.configHook
+  ];
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs) pname version;
+
+    # We need to pass the patched source code, so pnpm sees the patched version
+    src = stdenv.mkDerivation {
+      name = "${finalAttrs.pname}-patched-source";
+      phases = [
+        "unpackPhase"
+        "patchPhase"
+        "installPhase"
+      ];
+      src = finalAttrs.src;
+      patches = finalAttrs.patches;
+      installPhase = "cp -pr --reflink=auto -- . $out";
+    };
+
+    hash = "sha256-U2wrjBhklP7c8S3QQoUtOPTYyJr7MBOwm0R/76FjhqE=";
+  };
+  buildPhase = ''
+    runHook preBuild
+
+    # Based on matrix-appservice-discord
+    pushd node_modules/better-sqlite3
+    npm run build-release --offline "--nodedir=${srcOnly nodejs}"
+    find build -type f -exec ${removeReferencesTo}/bin/remove-references-to -t "${srcOnly nodejs}" {} \;
+    popd
+
+    export CI=true
+
+    echo "Compiling apps/web..."
+    pushd apps/web
+    pnpm run build
+    popd
+
+    echo "Building apps/cli"
+    pushd apps/cli
+    pnpm run build
+    popd
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share/doc/hoarder
+    cp README.md LICENSE $out/share/doc/hoarder
+
+    # Copy necessary files into lib/hoarder while keeping the directory structure
+    LIB_TO_COPY="node_modules apps/web/.next/standalone apps/cli/dist apps/workers packages/db packages/shared packages/trpc"
+    HOARDER_LIB_PATH="$out/lib/hoarder"
+    for DIR in $LIB_TO_COPY; do
+      mkdir -p "$HOARDER_LIB_PATH/$DIR"
+      cp -a $DIR/{.,}* "$HOARDER_LIB_PATH/$DIR"
+      chmod -R u+w "$HOARDER_LIB_PATH/$DIR"
+    done
+
+    # NextJS requires static files are copied in a specific way
+    # https://nextjs.org/docs/pages/api-reference/config/next-config-js/output#automatically-copying-traced-files
+    cp -r ./apps/web/public "$HOARDER_LIB_PATH/apps/web/.next/standalone/apps/web/"
+    cp -r ./apps/web/.next/static "$HOARDER_LIB_PATH/apps/web/.next/standalone/apps/web/.next/"
+
+    # Copy and patch helper scripts
+    for HELPER_SCRIPT in ${./helpers}/*; do
+      HELPER_SCRIPT_NAME="$(basename "$HELPER_SCRIPT")"
+      cp "$HELPER_SCRIPT" "$HOARDER_LIB_PATH/"
+      substituteInPlace "$HOARDER_LIB_PATH/$HELPER_SCRIPT_NAME" \
+        --replace-warn "HOARDER_LIB_PATH=" "HOARDER_LIB_PATH=$HOARDER_LIB_PATH" \
+        --replace-warn "RELEASE=" "RELEASE=${finalAttrs.version}" \
+        --replace-warn "NODEJS=" "NODEJS=${nodejs}"
+      chmod +x "$HOARDER_LIB_PATH/$HELPER_SCRIPT_NAME"
+      patchShebangs "$HOARDER_LIB_PATH/$HELPER_SCRIPT_NAME"
+    done
+
+    # The cli should be in bin/
+    mkdir -p $out/bin
+    mv "$HOARDER_LIB_PATH/hoarder-cli" $out/bin/
+
+    runHook postInstall
+  '';
+
+  fixupPhase = ''
+    runHook preFixup
+
+    # Remove large dependencies that are not necessary during runtime
+    rm -rf $out/lib/hoarder/node_modules/{@next,next,@swc,react-native,monaco-editor,faker,@typescript-eslint,@microsoft,@typescript-eslint,pdfjs-dist}
+
+    # Remove broken symlinks
+    find $out -type l ! -exec test -e {} \; -delete
+
+    runHook postFixup
+  '';
+
+  meta = {
+    homepage = "https://github.com/hoarder-app/hoarder";
+    description = "Self-hostable bookmark-everything app with a touch of AI for the data hoarders out there";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.three ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/by-name/ho/hoarder/patches/dont-lock-pnpm-version.patch
+++ b/pkgs/by-name/ho/hoarder/patches/dont-lock-pnpm-version.patch
@@ -1,0 +1,24 @@
+The Hoarder project uses a very specific version of pnpm (9.0.0-alpha.8) and
+will fail to build with other pnpm versions. Instead of adding this pnpm
+version to nixpkgs, we override this requirement and use the latest v9 release.
+
+---
+--- a/package.json
++++ b/package.json
+@@ -33,7 +33,7 @@
+     "turbo": "^2.1.2"
+   },
+   "prettier": "@hoarder/prettier-config",
+-  "packageManager": "pnpm@9.0.0-alpha.8+sha256.a433a59569b00389a951352956faf25d1fdf43b568213fbde591c36274d4bc30",
++  "packageManager": "pnpm",
+   "pnpm": {
+     "patchedDependencies": {
+       "xcode@3.0.1": "patches/xcode@3.0.1.patch"
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -1,4 +1,4 @@
+-lockfileVersion: '7.0'
++lockfileVersion: '9.0'
+ 
+ settings:
+   autoInstallPeers: true

--- a/pkgs/by-name/ho/hoarder/patches/fix-migrations-path.patch
+++ b/pkgs/by-name/ho/hoarder/patches/fix-migrations-path.patch
@@ -1,0 +1,15 @@
+Without this change the migrations script will fail if the working directory
+isn't the same directory this file is located in. To improve usability we
+specify the migrations folder relative to __dirname, which doesn't depend on the
+working directory.
+
+---
+--- a/packages/db/migrate.ts
++++ b/packages/db/migrate.ts
+@@ -1,4 +1,5 @@
+ import { db } from "./drizzle";
+ import { migrate } from "drizzle-orm/better-sqlite3/migrator";
++import path from "path";
+
+-migrate(db, { migrationsFolder: "./drizzle" });
++migrate(db, { migrationsFolder: path.join(__dirname, "./drizzle") });

--- a/pkgs/by-name/ho/hoarder/patches/use-local-font.patch
+++ b/pkgs/by-name/ho/hoarder/patches/use-local-font.patch
@@ -1,0 +1,47 @@
+Prevents NextJS from attempting to download fonts during build. The fonts
+directory will be created in the derivation script.
+
+See similar patches:
+ pkgs/by-name/cr/crabfit-frontend/01-localfont.patch
+ pkgs/by-name/al/alcom/use-local-fonts.patch
+ pkgs/by-name/ne/nextjs-ollama-llm-ui/0002-use-local-google-fonts.patch
+
+---
+--- a/apps/landing/app/layout.tsx
++++ b/apps/landing/app/layout.tsx
+@@ -1,11 +1,14 @@
+ import type { Metadata } from "next";
+-import { Inter } from "next/font/google";
++import localFont from 'next/font/local';
+
+ import "@hoarder/tailwind-config/globals.css";
+
+ import React from "react";
+
+-const inter = Inter({ subsets: ["latin"] });
++const inter = localFont({
++  subsets: ["latin"],
++  src: "./fonts/InterVariable.ttf",
++});
+
+ export const metadata: Metadata = {
+   title: "Hoarder",
+--- a/apps/web/app/layout.tsx
++++ b/apps/web/app/layout.tsx
+@@ -1,5 +1,5 @@
+ import type { Metadata } from "next";
+-import { Inter } from "next/font/google";
++import localFont from 'next/font/local';
+
+ import "@hoarder/tailwind-config/globals.css";
+
+@@ -13,7 +13,8 @@
+
+ import { clientConfig } from "@hoarder/shared/config";
+
+-const inter = Inter({
++const inter = localFont({
++  src: "./fonts/InterVariable.ttf",
+   subsets: ["latin"],
+   fallback: ["sans-serif"],
+ });


### PR DESCRIPTION
fixes #359226

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

This PR packages the Hoarder bookmarking app (homepage: https://hoarder.app/) and resolves https://github.com/NixOS/nixpkgs/issues/359226.

Project Homepage: https://hoarder.app/

Project v0.21.0 Release: https://github.com/hoarder-app/hoarder/releases/tag/v0.21.0

This package is the sum of multiple related components:

- The app web server
- The workers process, meant to be run in the background and support the web server
- Migration script, necessary to setup the db and start the web server
- A cli to interact with hoarder via its API

I am not affiliated with the upstream project.

<details>

<summary>Basic server test script</summary>

Script to test basic server functionality after running `nix build .#hoarder`. This isn't as full-featured as the NixOS configuration below.

```bash
#!/usr/bin/env bash
set -x

export DATA_DIR=/tmp/test-data-dir
mkdir -p $DATA_DIR
export NEXTAUTH_SECRET=deadbeefdeadbeefdeadbeef

rm -rf $DATA_DIR/*

./result/lib/hoarder/migrate

./result/lib/hoarder/start-workers & sleep 1
./result/lib/hoarder/start-web &

# Function to clean up background processes
cleanup() {
  echo "Cleaning up..."
  # Query all child PIDs of this script and kill them
  CHILD_PIDS=$(pgrep -P $$)
  if [[ -n "$CHILD_PIDS" ]]; then
    kill $CHILD_PIDS
  fi
}

# Trap Ctrl-C (SIGINT) and call cleanup
trap cleanup SIGINT

wait
```

</details>

<details>

<summary>Example NixOS configuration and video demonstrating basic functionality</summary>

This example config demonstrates how this package might be used,

This configuration supports the following features,

- Sign in and sign up functionality
- Adding new articles
- The Cached Content, Screenshot (fullscreen), Archive and Video scrapers
- AI functionality via ollama running on the same server
- Search via meilisearch

```nix
{ config, lib, pkgs, ... }:

let
  hoarderEnv = [
    "DATA_DIR=/var/lib/hoarder"
    "NEXTAUTH_URL=https://localhost"
    "NEXTAUTH_SECRET=deadbeefdeadbeefdeadbeef"
    "DISABLE_NEW_RELEASE_CHECK=true"
    "OLLAMA_BASE_URL=http://127.0.0.1:11434"
    "INFERENCE_TEXT_MODEL=llama3.2:3b"         # Must be downloaded manually after ollama enabled
    "BROWSER_WEB_URL=http://127.0.0.1:9222"
    "NEXT_CACHE_DIR=/var/tmp/hoarder"
    "MEILI_ADDR=http://127.0.0.1:7700"
    "MEILI_MASTER_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

    "CRAWLER_FULL_PAGE_SCREENSHOT=true"
    "CRAWLER_FULL_PAGE_ARCHIVE=true"
    "CRAWLER_VIDEO_DOWNLOAD=true"
  ];
in
  {
    nixpkgs.overlays = [
      (self: super: {
        hoarder = pkgs.callPackage "${
          pkgs.fetchgit {
            url = "https://github.com/three/nixpkgs.git";
            rev = "add-hoarder-app-pr";
            sha256 = "";
          }
        }/pkgs/by-name/ho/hoarder/package.nix" {};
      })
    ];

    services.meilisearch.enable = true;
    services.ollama.enable = true;

    users.groups.hoarder = {};
    users.users.hoarder = {
      description = "hoarder user";
      isSystemUser = true;
      group = "hoarder";
    };

   environment.systemPackages = [ pkgs.hoarder ];

   systemd.services.hoarder-init = {
     serviceConfig = {
       User = "hoarder";
       Group = "hoarder";
       ExecStart = "${pkgs.hoarder}/lib/hoarder/migrate";
       Type = "oneshot";
       RemainAfterExit = true;
       StateDirectory = "hoarder";
       Environment = hoarderEnv;
     };
     wantedBy = [ "multi-user.target" ];
   };
   systemd.services.hoarder-workers = {
     path = [ pkgs.monlith pkgs.yt-dlp ];
     serviceConfig = {
       User = "hoarder";
       Group = "hoarder";
       Restart="on-failure";
       ExecStart = "${pkgs.hoarder}/lib/hoarder/start-workers";
       Type = "simple";
       StateDirectory = "hoarder";
       Environment = hoarderEnv;

       After = [ "network.target" "hoarder-init.service" ];
     };
     wantedBy = [ "multi-user.target" ];
   };
   systemd.services.hoarder-web = {
     serviceConfig = {
       User = "hoarder";
       Group = "hoarder";
       Restart = "on-failure";
       ExecStart = "${pkgs.hoarder}/lib/hoarder/start-web";
       Type = "simple";
       StateDirectory = "hoarder";
       Environment = hoarderEnv;
       After = [ "network.target" "hoarder-init.service" "hoarder-workers.service" ];
     };
     wantedBy = [ "multi-user.target" ];
   };
   systemd.services.hoarder-browser = {
     serviceConfig = {
       User = "nobody";
       Group = "nobody";
       Restart="on-failure";
       TimeoutStopSec=5;
       ExecStart = "${pkgs.chromium}/bin/chromium --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --remote-debugging-address=127.0.0.1 --remote-debugging-port=9222 --hide-scrollbars";
       Type = "simple";
       Environment = hoarderEnv;
       After = [ "network.target" ];
     };
     wantedBy = [ "multi-user.target" ];
   };
  }
```

Here is a video demonstrating this functionality,

https://github.com/user-attachments/assets/739e3d98-d51f-4f81-8f2a-f2f4559d8c41

</details>

<details>

<summary>Known Cache Issue</summary>

Caching does not seem to work properly. The following types of errors get regularly logged during normal usage,

```
Jan 16 13:58:52 server start-web[783]:  ⨯ Failed to write image to cache M0Ukvr+LGSQPpdca8soE5S76+B3PA0Qd14LKSWOWkss= Error: ENOENT: no such file or directory, mkdir '/nix/store/jcnpr8qz40fikn747gz21fv0nv1a7i7q-hoarder-0.21.0/lib/hoarder/apps/web/.next/standalone/apps/web/.next/cache'
Jan 16 13:58:52 server start-web[783]:     at async Object.mkdir (node:internal/fs/promises:858:10)
Jan 16 13:58:52 server start-web[783]:     at async writeToCacheDir (/nix/store/jcnpr8qz40fikn747gz21fv0nv1a7i7q-hoarder-0.21.0/lib/hoarder/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js:178:5)
Jan 16 13:58:52 server start-web[783]:     at async ImageOptimizerCache.set (/nix/store/jcnpr8qz40fikn747gz21fv0nv1a7i7q-hoarder-0.21.0/lib/hoarder/apps/web/.next/standalone/node_modules/next/dist/server/image-optimizer.js:440:13)
Jan 16 13:58:52 server start-web[783]:     at async /nix/store/jcnpr8qz40fikn747gz21fv0nv1a7i7q-hoarder-0.21.0/lib/hoarder/apps/web/.next/standalone/node_modules/next/dist/server/response-cache/index.js:121:25
Jan 16 13:58:52 server start-web[783]:     at async /nix/store/jcnpr8qz40fikn747gz21fv0nv1a7i7q-hoarder-0.21.0/lib/hoarder/apps/web/.next/standalone/node_modules/next/dist/lib/batcher.js:45:32 {
Jan 16 13:58:52 server start-web[783]:   errno: -2,
Jan 16 13:58:52 server start-web[783]:   code: 'ENOENT',
Jan 16 13:58:52 server start-web[783]:   syscall: 'mkdir',
Jan 16 13:58:52 server start-web[783]:   path: '/nix/store/jcnpr8qz40fikn747gz21fv0nv1a7i7q-hoarder-0.21.0/lib/hoarder/apps/web/.next/standalone/apps/web/.next/cache'
Jan 16 13:58:52 server start-web[783]: }
```

I don't believe this is possible to fix without changing the upstream project. This does not seem to effect functionality.

</details>

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
