### PR TITLE
lomiri.lomiri-thumbnailer: 3.0.3 -> 3.0.4

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1001-doc-liblomiri-thumbnailer-qt-Honour-CMAKE_INSTALL_DO.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1001-doc-liblomiri-thumbnailer-qt-Honour-CMAKE_INSTALL_DO.patch
@@ -1,0 +1,25 @@
+From e8893fcae7e732c9e15ccd6d54a62b5b3862e445 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 16 Jan 2025 17:12:36 +0100
+Subject: [PATCH 1/5] doc/liblomiri-thumbnailer-qt: Honour CMAKE_INSTALL_DOCDIR
+
+---
+ doc/liblomiri-thumbnailer-qt/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/doc/liblomiri-thumbnailer-qt/CMakeLists.txt b/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
+index 91e12a0..3e96f80 100644
+--- a/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
++++ b/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
+@@ -28,7 +28,7 @@ add_doxygen(
+ )
+ 
+ install(DIRECTORY ${PROJECT_BINARY_DIR}/doc/liblomiri-thumbnailer-qt/html
+-        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/doc/liblomiri-thumbnailer-qt)
++        DESTINATION ${CMAKE_INSTALL_DOCDIR})
+ 
+ add_subdirectory(examples)
+ 
+-- 
+2.47.0
+

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1002-Re-enable-documentation.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1002-Re-enable-documentation.patch
@@ -1,0 +1,97 @@
+From 37687a195052186432923276bc2c2358b3622ab1 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 16 Jan 2025 17:12:44 +0100
+Subject: [PATCH 2/5] Re-enable documentation
+
+---
+ CMakeLists.txt                                |  6 +++++-
+ debian/liblomiri-thumbnailer-qt-doc.install   |  1 +
+ ...lomiri-thumbnailer-qt-doc.install.disabled |  1 -
+ doc/liblomiri-thumbnailer-qt/CMakeLists.txt   | 21 ++++++++-----------
+ 4 files changed, 15 insertions(+), 14 deletions(-)
+ create mode 100644 debian/liblomiri-thumbnailer-qt-doc.install
+ delete mode 100644 debian/liblomiri-thumbnailer-qt-doc.install.disabled
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 464ac70..cade10f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -184,7 +184,11 @@ if (${BUILD_TESTING})
+ endif()
+ add_subdirectory(include)
+ add_subdirectory(man)
+-#add_subdirectory(doc)
++
++option(ENABLE_DOC "Build documentation" ON)
++if(ENABLE_DOC)
++    add_subdirectory(doc)
++endif()
+ 
+ #enable_coverage_report(
+ #    TARGETS
+diff --git a/debian/liblomiri-thumbnailer-qt-doc.install b/debian/liblomiri-thumbnailer-qt-doc.install
+new file mode 100644
+index 0000000..ff56aee
+--- /dev/null
++++ b/debian/liblomiri-thumbnailer-qt-doc.install
+@@ -0,0 +1 @@
++usr/share/doc/lomiri-thumbnailer/*
+diff --git a/debian/liblomiri-thumbnailer-qt-doc.install.disabled b/debian/liblomiri-thumbnailer-qt-doc.install.disabled
+deleted file mode 100644
+index db055cf..0000000
+--- a/debian/liblomiri-thumbnailer-qt-doc.install.disabled
++++ /dev/null
+@@ -1 +0,0 @@
+-usr/share/doc/liblomiri-thumbnailer-qt/*
+diff --git a/doc/liblomiri-thumbnailer-qt/CMakeLists.txt b/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
+index 3e96f80..fe98e4c 100644
+--- a/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
++++ b/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
+@@ -1,35 +1,32 @@
+-include(UseDoxygen OPTIONAL)
++find_package(DoxygenBuilder REQUIRED)
+ 
+ file(GLOB libthumbnailer_headers "${PROJECT_SOURCE_DIR}/include/lomiri/thumbnailer/qt/*.h")
+ 
+ add_doxygen(
+     liblomiri-thumbnailer-qt-doc
++    PROJECT_NAME
++        "Thumbnailer Qt API"
+     INPUT
+         ${CMAKE_CURRENT_SOURCE_DIR}/tutorial.dox
+         ${libthumbnailer_headers}
+-    OUTPUT_DIRECTORY
+-        ${CMAKE_BINARY_DIR}/doc/liblomiri-thumbnailer-qt
++    EXAMPLE_PATH
++        ${CMAKE_CURRENT_SOURCE_DIR}
+     STRIP_FROM_PATH
+         "${CMAKE_SOURCE_DIR}/src"
+     STRIP_FROM_INC_PATH
+         "${CMAKE_SOURCE_DIR}/include"
++    DOXYFILE_IN
++        ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
+     EXCLUDE_PATTERNS
+         */internal/*
+     EXCLUDE_SYMBOLS
+         *::internal*
+         *::Priv
+-    EXAMPLE_PATH
+-        ${CMAKE_CURRENT_SOURCE_DIR}
+-    DOXYFILE_IN
+-        ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
+-    PROJECT_NAME
+-        "Thumbnailer Qt API"
++    INSTALL
++        ${CMAKE_INSTALL_DOCDIR}
+     ALL
+ )
+ 
+-install(DIRECTORY ${PROJECT_BINARY_DIR}/doc/liblomiri-thumbnailer-qt/html
+-        DESTINATION ${CMAKE_INSTALL_DOCDIR})
+-
+ add_subdirectory(examples)
+ 
+ list(APPEND UNIT_TEST_TARGETS qt_example_test)
+-- 
+2.47.0
+

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1003-doc-liblomiri-thumbnailer-qt-examples-Drop-qt5_use_m.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1003-doc-liblomiri-thumbnailer-qt-examples-Drop-qt5_use_m.patch
@@ -1,0 +1,25 @@
+From 010d19f85f4f8d73f96f054e5d293951fae1f9de Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 16 Jan 2025 17:12:45 +0100
+Subject: [PATCH 3/5] doc/liblomiri-thumbnailer-qt/examples: Drop
+ qt5_use_modules usage
+
+Leftover from a0d81863f3f48717507cfa181030a8ffb0c4e881
+---
+ doc/liblomiri-thumbnailer-qt/examples/CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/doc/liblomiri-thumbnailer-qt/examples/CMakeLists.txt b/doc/liblomiri-thumbnailer-qt/examples/CMakeLists.txt
+index db8139f..825a821 100644
+--- a/doc/liblomiri-thumbnailer-qt/examples/CMakeLists.txt
++++ b/doc/liblomiri-thumbnailer-qt/examples/CMakeLists.txt
+@@ -1,6 +1,5 @@
+ include_directories(${CMAKE_BINARY_DIR}/tests ${CMAKE_SOURCE_DIR}/tests)
+ add_executable(qt_example_test qt_example_test.cpp)
+-qt5_use_modules(qt_example_test Core Gui Network Test)
+ target_link_libraries(qt_example_test
+     gtest
+     Qt5::Core
+-- 
+2.47.0
+

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1004-Re-enable-coverge-reporting.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1004-Re-enable-coverge-reporting.patch
@@ -1,0 +1,131 @@
+From ffec02835aa44e93c96c48b7a33be3f51a3571a1 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 16 Jan 2025 17:12:46 +0100
+Subject: [PATCH 4/5] Re-enable coverge reporting
+
+---
+ CMakeLists.txt                              | 51 +++++++++++++--------
+ doc/CMakeLists.txt                          |  6 ++-
+ doc/liblomiri-thumbnailer-qt/CMakeLists.txt |  8 ++--
+ tests/CMakeLists.txt                        |  2 -
+ 4 files changed, 40 insertions(+), 27 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cade10f..cbfd9c0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -134,7 +134,14 @@ endif()
+ 
+ include(CTest)
+ 
+-#include(EnableCoverageReport)
++if (cmake_build_type_lower MATCHES coverage)
++    find_package(CoverageReport REQUIRED)
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftest-coverage -fprofile-arcs" )
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftest-coverage -fprofile-arcs" )
++    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -coverage" )
++    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -coverage" )
++endif()
++
+ 
+ include(cmake/UseGSettings.cmake)
+ 
+@@ -169,6 +176,8 @@ include_directories(${TAGLIB_DEPS_INCLUDE_DIRS})
+ include_directories(include)
+ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
+ 
++set(UNIT_TEST_TARGETS "")
++
+ add_subdirectory(src)
+ add_subdirectory(data)
+ add_subdirectory(plugins/Lomiri/Thumbnailer.0.1)
+@@ -190,22 +199,24 @@ if(ENABLE_DOC)
+     add_subdirectory(doc)
+ endif()
+ 
+-#enable_coverage_report(
+-#    TARGETS
+-#        recovery_test         # Need to turn on coverage for this, to get the helper template instrumented.
+-#        testutils
+-#        test-seq
+-#        thumbnailer-admin
+-#        thumbnailer-qml
+-#        thumbnailer-qml-static
+-#        lomiri-thumbnailer-qt
+-#        thumbnailer-service
+-#        thumbnailer-static
+-#        vs-thumb
+-#        vs-thumb-static
+-#    FILTER
+-#        ${CMAKE_SOURCE_DIR}/tests/*
+-#        ${CMAKE_BINARY_DIR}/*
+-#    TESTS
+-#        ${UNIT_TEST_TARGETS}
+-#)
++if (cmake_build_type_lower MATCHES coverage)
++    enable_coverage_report(
++        TARGETS
++            recovery_test         # Need to turn on coverage for this, to get the helper template instrumented.
++            testutils
++            test-seq
++            lomiri-thumbnailer-admin
++            LomiriThumbnailer-qml
++            thumbnailer-qml-static
++            lomiri-thumbnailer-qt
++            thumbnailer-service
++            thumbnailer-static
++            vs-thumb
++            vs-thumb-static
++        FILTER
++            ${CMAKE_SOURCE_DIR}/tests/*
++            ${CMAKE_BINARY_DIR}/*
++        TESTS
++            ${UNIT_TEST_TARGETS}
++    )
++endif()
+diff --git a/doc/CMakeLists.txt b/doc/CMakeLists.txt
+index 11f4449..249f5e0 100644
+--- a/doc/CMakeLists.txt
++++ b/doc/CMakeLists.txt
+@@ -1,4 +1,6 @@
+ add_subdirectory(liblomiri-thumbnailer-qt)
+ 
+-list(APPEND UNIT_TEST_TARGETS qt_example_test)
+-set(UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} PARENT_SCOPE)
++if(BUILD_TESTING)
++    list(APPEND UNIT_TEST_TARGETS qt_example_test)
++    set(UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} PARENT_SCOPE)
++endif()
+diff --git a/doc/liblomiri-thumbnailer-qt/CMakeLists.txt b/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
+index fe98e4c..078be07 100644
+--- a/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
++++ b/doc/liblomiri-thumbnailer-qt/CMakeLists.txt
+@@ -27,7 +27,9 @@ add_doxygen(
+     ALL
+ )
+ 
+-add_subdirectory(examples)
++if(BUILD_TESTING)
++    add_subdirectory(examples)
+ 
+-list(APPEND UNIT_TEST_TARGETS qt_example_test)
+-set(UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} PARENT_SCOPE)
++    list(APPEND UNIT_TEST_TARGETS qt_example_test)
++    set(UNIT_TEST_TARGETS ${UNIT_TEST_TARGETS} PARENT_SCOPE)
++endif()
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 03a4900..97cb3a1 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -42,8 +42,6 @@ set(slow_test_dirs
+     stress
+ )
+ 
+-set(UNIT_TEST_TARGETS "")
+-
+ foreach(dir ${unit_test_dirs})
+     add_subdirectory(${dir})
+     list(APPEND UNIT_TEST_TARGETS "${dir}_test")
+-- 
+2.47.0
+

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1005-Make-GTest-available-to-example-test.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/1005-Make-GTest-available-to-example-test.patch
@@ -1,0 +1,38 @@
+From d9152f5e1f77a6c3bbc759eec58811410de7b85a Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 16 Jan 2025 17:12:49 +0100
+Subject: [PATCH 5/5] Make GTest available to example test
+
+---
+ CMakeLists.txt       | 2 ++
+ tests/CMakeLists.txt | 1 -
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cbfd9c0..0663b44 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -189,6 +189,8 @@ if (${BUILD_TESTING})
+     find_package(Qt5QuickTest REQUIRED)
+     find_package(Qt5Network REQUIRED)
+ 
++    find_package(GMock REQUIRED)
++
+     add_subdirectory(tests)
+ endif()
+ add_subdirectory(include)
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 97cb3a1..92eae14 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -3,7 +3,6 @@
+ 
+ set(old_cxx_flags ${CMAKE_CXX_FLAGS})
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wno-old-style-cast -Wno-missing-field-initializers")
+-find_package(GMock)
+ set(CMAKE_CXX_FLAGS ${old_cxx_flags})
+ 
+ set(TESTDATADIR ${CMAKE_CURRENT_SOURCE_DIR}/media)
+-- 
+2.47.0
+

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -2,7 +2,6 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  fetchpatch,
   gitUpdater,
   testers,
   boost,
@@ -32,13 +31,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "lomiri-thumbnailer";
-  version = "3.0.3";
+  version = "3.0.4";
 
   src = fetchFromGitLab {
     owner = "ubports";
     repo = "development/core/lomiri-thumbnailer";
-    rev = finalAttrs.version;
-    hash = "sha256-BE/U4CT4z4WzEJXrVhX8ME/x9q7w8wNnJKTbfVku2VQ=";
+    tag = finalAttrs.version;
+    hash = "sha256-pf/bzpooCcoIGb5JtSnowePcobcfVSzHyBaEkb51IOg=";
   };
 
   outputs = [
@@ -48,74 +47,35 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/19 merged & in release
-    (fetchpatch {
-      name = "0001-lomiri-thumbnailer-Add-more-better-GNUInstallDirs-variables-usage.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/0b9795a6313fd025d5646f2628a2cbb3104b0ebc.patch";
-      hash = "sha256-br99n2nDLjUfnjbjhOsWlvP62VmVjYeZ6yPs1dhPN/s=";
-    })
-
-    # Remove when https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/22 merged & in release
-    (fetchpatch {
-      name = "0002-lomiri-thumbnailer-Make-tests-optional.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/df7a3d1689f875d207a90067b957e888160491b9.patch";
-      hash = "sha256-gVxigpSL/3fXNdJBjh8Ex3/TYmQUiwRji/NmLW/uhE4=";
-    })
-
     # Remove when https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/merge_requests/23 merged & in release
-    (fetchpatch {
-      name = "0003-lomiri-thumbnailer-doc-liblomiri-thumbnailer-qt-Honour-CMAKE_INSTALL_DOCDIR.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/930a3b57e899f6eb65a96d096edaea6a6f6b242a.patch";
-      hash = "sha256-klYycUoQqA+Dfk/4fRQgdS4/G4o0sC1k98mbtl0iHkE=";
-    })
-    (fetchpatch {
-      name = "0004-lomiri-thumbnailer-Re-enable-documentation.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/2f9186f71fdd25e8a0852073f1da59ba6169cf3f.patch";
-      hash = "sha256-youaJfCeYVpLmruHMupuUdl0c/bSDPWqKPLgu5plBrw=";
-    })
-    (fetchpatch {
-      name = "0005-lomiri-thumbnailer-doc-liblomiri-thumbnailer-qt-examples-Drop-qt5_use_modules-usage.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/9e5cf09de626e73e6b8f180cbc1160ebd2f169e7.patch";
-      hash = "sha256-vfNCN7tqq6ngzNmb3qqHDHaDx/kI8/UXyyv7LqUWya0=";
-    })
-    (fetchpatch {
-      name = "0006-lomiri-thumbnailer-Re-enable-coverge-reporting.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/6a48831f042cd3ad34200f32800393d4eec2f84b.patch";
-      hash = "sha256-HZd4K0R1W6adOjKy7tODfQAD+9IKPcK0DnH1uKNd/Ak=";
-    })
-    (fetchpatch {
-      name = "0007-lomiri-thumbnailer-Make-GTest-available-to-example-test.patch";
-      url = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/commit/657be3bd1aeb227edc04e26b597b2fe97b2dc51a.patch";
-      hash = "sha256-XEvdWV3JJujG16+87iewYor0jFK7NTeE5459iT96SkU=";
-    })
-    (fetchpatch {
-      name = "0008-fix-googletest-1-13.patch";
-      url = "https://salsa.debian.org/ubports-team/lomiri-thumbnailer/-/raw/debian/3.0.3-1/debian/patches/0001_fix_googletest_1_13.patch";
-      hash = "sha256-oBcdspQMhCxh4L/XotG9NRp/Ij2YzIjpC8xg/jdiptw=";
-    })
+    ./1001-doc-liblomiri-thumbnailer-qt-Honour-CMAKE_INSTALL_DO.patch
+    ./1002-Re-enable-documentation.patch
+    ./1003-doc-liblomiri-thumbnailer-qt-examples-Drop-qt5_use_m.patch
+    ./1004-Re-enable-coverge-reporting.patch
+    ./1005-Make-GTest-available-to-example-test.patch
   ];
 
   postPatch = ''
     patchShebangs tools/{parse-settings.py,run-xvfb.sh} tests/{headers,whitespace,server}/*.py
 
     substituteInPlace tests/thumbnailer-admin/thumbnailer-admin_test.cpp \
-      --replace '/usr/bin/test' 'test'
+      --replace-fail '/usr/bin/test' 'test'
 
     substituteInPlace plugins/*/Thumbnailer*/CMakeLists.txt \
-      --replace "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
+      --replace-fail "\''${CMAKE_INSTALL_LIBDIR}/qt5/qml" "\''${CMAKE_INSTALL_PREFIX}/${qtbase.qtQmlPrefix}"
 
     # I think this variable fails to be populated because of our toolchain, while upstream uses Debian / Ubuntu where this works fine
     # https://cmake.org/cmake/help/v3.26/variable/CMAKE_LIBRARY_ARCHITECTURE.html
     # > If the <LANG> compiler passes to the linker an architecture-specific system library search directory such as
     # > <prefix>/lib/<arch> this variable contains the <arch> name if/as detected by CMake.
     substituteInPlace tests/qml/CMakeLists.txt \
-      --replace 'CMAKE_LIBRARY_ARCHITECTURE' 'CMAKE_SYSTEM_PROCESSOR' \
-      --replace 'powerpc-linux-gnu' 'ppc' \
-      --replace 's390x-linux-gnu' 's390x'
+      --replace-fail 'CMAKE_LIBRARY_ARCHITECTURE' 'CMAKE_SYSTEM_PROCESSOR' \
+      --replace-fail 'powerpc-linux-gnu' 'ppc' \
+      --replace-fail 's390x-linux-gnu' 's390x'
 
     # Tests run in parallel to other builds, don't suck up cores
     substituteInPlace tests/headers/compile_headers.py \
-      --replace 'max_workers=multiprocessing.cpu_count()' "max_workers=1"
+      --replace-fail 'max_workers=multiprocessing.cpu_count()' "max_workers=1"
   '';
 
   strictDeps = true;
@@ -213,17 +173,17 @@ stdenv.mkDerivation (finalAttrs: {
     updateScript = gitUpdater { };
   };
 
-  meta = with lib; {
+  meta = {
     description = "D-Bus service for out of process thumbnailing";
     mainProgram = "lomiri-thumbnailer-admin";
     homepage = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer";
     changelog = "https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/blob/${finalAttrs.version}/ChangeLog";
-    license = with licenses; [
+    license = with lib.licenses; [
       gpl3Only
       lgpl3Only
     ];
-    maintainers = teams.lomiri.members;
-    platforms = platforms.linux;
+    maintainers = lib.teams.lomiri.members;
+    platforms = lib.platforms.linux;
     pkgConfigModules = [
       "liblomiri-thumbnailer-qt"
     ];


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-thumbnailer/-/blob/3.0.4/ChangeLog

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
