### PR TITLE
gitwatch: add missing runtime dependencies

### DIFF
--- a/pkgs/by-name/gi/gitwatch/package.nix
+++ b/pkgs/by-name/gi/gitwatch/package.nix
@@ -4,7 +4,10 @@
   makeWrapper,
   fetchFromGitHub,
 
+  coreutils,
   git,
+  gnugrep,
+  gnused,
   openssh,
   inotify-tools,
 }:
@@ -41,7 +44,10 @@ runCommand "gitwatch"
     wrapProgram $dest \
       --prefix PATH ';' ${
         lib.makeBinPath [
+          coreutils
           git
+          gnugrep
+          gnused
           inotify-tools
           openssh
         ]


### PR DESCRIPTION
As I have described on [discourse thread](https://discourse.nixos.org/t/i-think-i-found-a-bug-in-gitwatch-package-but-i-dont-know-how-to-verify-and-possibly-fix-it/58167):

1. I have installed this packages system-wide on NixOS stable 24.11
2. when using `gitwatch` program from interactive shell it worked fine
3. I have then tried to put in under control of user-spaced *systemd* service unit to make it start automatically; this however could not happen due to errors:

```
Dec 31 22:34:50 hosthost gitwatch[3688625]: /nix/store/vabiazsm1vk3mcjhfx7cq31p211icx7s-gitwatch/bin/.gitwatch-wrapped: line 210: readlink: command not found
Dec 31 22:34:50 hosthost gitwatch[3688627]: /nix/store/vabiazsm1vk3mcjhfx7cq31p211icx7s-gitwatch/bin/.gitwatch-wrapped: line 225: sed: command not found
Dec 31 22:34:50 hosthost gitwatch[3688629]: /nix/store/vabiazsm1vk3mcjhfx7cq31p211icx7s-gitwatch/bin/.gitwatch-wrapped: line 273: grep: command not found
```

## Things done

I have added `gnused`, `gnugrep` and `coreutils` to the `package.nix` script.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin

- [x] Tested using `nixos-rebuild switch`