### PR TITLE
kitty: 0.38.1 → 0.39.0

### DIFF
--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -250,7 +250,7 @@ buildPythonApplication rec {
 
   meta = with lib; {
     homepage = "https://github.com/kovidgoyal/kitty";
-    description = "Modern, hackable, featureful, OpenGL based terminal emulator";
+    description = "The fast, feature-rich, GPU based terminal emulator";
     license = licenses.gpl3Only;
     changelog = [
       "https://sw.kovidgoyal.net/kitty/changelog/"

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -1,35 +1,54 @@
-{ lib, stdenv, fetchFromGitHub, python3Packages, libunistring
-, harfbuzz, fontconfig, pkg-config, ncurses, imagemagick
-, libstartup_notification, libGL, libX11, libXrandr, libXinerama, libXcursor
-, libxkbcommon, libXi, libXext, wayland-protocols, wayland, xxHash
-, nerd-fonts
-, lcms2
-, librsync
-, openssl
-, installShellFiles
-, dbus
-, sudo
-, Libsystem
-, Cocoa
-, Kernel
-, UniformTypeIdentifiers
-, UserNotifications
-, libcanberra
-, libicns
-, wayland-scanner
-, libpng
-, python3
-, zlib
-, simde
-, bashInteractive
-, zsh
-, fish
-, nixosTests
-, go_1_23
-, buildGo123Module
-, nix-update-script
-, makeBinaryWrapper
-, autoSignDarwinBinariesHook
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  python3Packages,
+  libunistring,
+  harfbuzz,
+  fontconfig,
+  pkg-config,
+  ncurses,
+  imagemagick,
+  libstartup_notification,
+  libGL,
+  libX11,
+  libXrandr,
+  libXinerama,
+  libXcursor,
+  libxkbcommon,
+  libXi,
+  libXext,
+  wayland-protocols,
+  wayland,
+  xxHash,
+  nerd-fonts,
+  lcms2,
+  librsync,
+  openssl,
+  installShellFiles,
+  dbus,
+  sudo,
+  Libsystem,
+  Cocoa,
+  Kernel,
+  UniformTypeIdentifiers,
+  UserNotifications,
+  libcanberra,
+  libicns,
+  wayland-scanner,
+  libpng,
+  python3,
+  zlib,
+  simde,
+  bashInteractive,
+  zsh,
+  fish,
+  nixosTests,
+  go_1_23,
+  buildGo123Module,
+  nix-update-script,
+  makeBinaryWrapper,
+  autoSignDarwinBinariesHook,
 }:
 
 with python3Packages;
@@ -45,60 +64,84 @@ buildPythonApplication rec {
     hash = "sha256-4JlsIwQzCxs1i8Pvsj9KcJZpXbVkSzWtW7klatA0FOM";
   };
 
-  goModules = (buildGo123Module {
-    pname = "kitty-go-modules";
-    inherit src version;
-    vendorHash = "sha256-Yahn+nlarPy4Yf1QmDminnHDqbe0+iJ6IsUKF0tioK4=";
-  }).goModules;
+  goModules =
+    (buildGo123Module {
+      pname = "kitty-go-modules";
+      inherit src version;
+      vendorHash = "sha256-Yahn+nlarPy4Yf1QmDminnHDqbe0+iJ6IsUKF0tioK4=";
+    }).goModules;
 
-  buildInputs = [
-    harfbuzz
-    ncurses
-    simde
-    lcms2
-    librsync
-    matplotlib
-    openssl.dev
-    xxHash
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    Cocoa
-    Kernel
-    UniformTypeIdentifiers
-    UserNotifications
-    libpng
-    python3
-    zlib
-  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
-    Libsystem
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    fontconfig libunistring libcanberra libX11
-    libXrandr libXinerama libXcursor libxkbcommon libXi libXext
-    wayland-protocols wayland dbus libGL
-  ];
+  buildInputs =
+    [
+      harfbuzz
+      ncurses
+      simde
+      lcms2
+      librsync
+      matplotlib
+      openssl.dev
+      xxHash
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      Cocoa
+      Kernel
+      UniformTypeIdentifiers
+      UserNotifications
+      libpng
+      python3
+      zlib
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) [
+      Libsystem
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      fontconfig
+      libunistring
+      libcanberra
+      libX11
+      libXrandr
+      libXinerama
+      libXcursor
+      libxkbcommon
+      libXi
+      libXext
+      wayland-protocols
+      wayland
+      dbus
+      libGL
+    ];
 
-  nativeBuildInputs = [
-    installShellFiles
-    ncurses
-    pkg-config
-    sphinx
-    furo
-    sphinx-copybutton
-    sphinxext-opengraph
-    sphinx-inline-tabs
-    go_1_23
-    fontconfig
-    makeBinaryWrapper
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-    imagemagick
-    libicns  # For the png2icns tool.
-    autoSignDarwinBinariesHook
-  ] ++ lib.optionals stdenv.hostPlatform.isLinux [
-    wayland-scanner
-  ];
+  nativeBuildInputs =
+    [
+      installShellFiles
+      ncurses
+      pkg-config
+      sphinx
+      furo
+      sphinx-copybutton
+      sphinxext-opengraph
+      sphinx-inline-tabs
+      go_1_23
+      fontconfig
+      makeBinaryWrapper
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      imagemagick
+      libicns # For the png2icns tool.
+      autoSignDarwinBinariesHook
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      wayland-scanner
+    ];
 
   depsBuildBuild = [ pkg-config ];
 
-  outputs = [ "out" "terminfo" "shell_integration" "kitten" ];
+  outputs = [
+    "out"
+    "terminfo"
+    "shell_integration"
+    "kitten"
+  ];
 
   patches = [
     # Gets `test_ssh_env_vars` to pass when `bzip2` is in the output of `env`.
@@ -130,49 +173,58 @@ buildPythonApplication rec {
     cp -r --reflink=auto $goModules vendor
   '';
 
-  buildPhase = let
-    commonOptions = ''
-      --update-check-interval=0 \
-      --shell-integration=enabled\ no-rc
+  buildPhase =
+    let
+      commonOptions = ''
+        --update-check-interval=0 \
+        --shell-integration=enabled\ no-rc
+      '';
+      darwinOptions = ''
+        --disable-link-time-optimization \
+        ${commonOptions}
+      '';
+    in
+    ''
+      runHook preBuild
+
+      # Add the font by hand because fontconfig does not finds it in darwin
+      mkdir ./fonts/
+      cp "${nerd-fonts.symbols-only}/share/fonts/truetype/NerdFonts/Symbols/SymbolsNerdFontMono-Regular.ttf" ./fonts/
+
+      ${
+        if stdenv.hostPlatform.isDarwin then
+          ''
+            ${python.pythonOnBuildForHost.interpreter} setup.py build ${darwinOptions}
+            make docs
+            ${python.pythonOnBuildForHost.interpreter} setup.py kitty.app ${darwinOptions}
+          ''
+        else
+          ''
+            ${python.pythonOnBuildForHost.interpreter} setup.py linux-package \
+            --egl-library='${lib.getLib libGL}/lib/libEGL.so.1' \
+            --startup-notification-library='${libstartup_notification}/lib/libstartup-notification-1.so' \
+            --canberra-library='${libcanberra}/lib/libcanberra.so' \
+            --fontconfig-library='${fontconfig.lib}/lib/libfontconfig.so' \
+            ${commonOptions}
+            ${python.pythonOnBuildForHost.interpreter} setup.py build-launcher
+          ''
+      }
+      runHook postBuild
     '';
-    darwinOptions = ''
-      --disable-link-time-optimization \
-      ${commonOptions}
-    '';
-  in ''
-    runHook preBuild
 
-    # Add the font by hand because fontconfig does not finds it in darwin
-    mkdir ./fonts/
-    cp "${nerd-fonts.symbols-only}/share/fonts/truetype/NerdFonts/Symbols/SymbolsNerdFontMono-Regular.ttf" ./fonts/
+  nativeCheckInputs =
+    [
+      pillow
 
-    ${if stdenv.hostPlatform.isDarwin then ''
-      ${python.pythonOnBuildForHost.interpreter} setup.py build ${darwinOptions}
-      make docs
-      ${python.pythonOnBuildForHost.interpreter} setup.py kitty.app ${darwinOptions}
-    '' else ''
-      ${python.pythonOnBuildForHost.interpreter} setup.py linux-package \
-      --egl-library='${lib.getLib libGL}/lib/libEGL.so.1' \
-      --startup-notification-library='${libstartup_notification}/lib/libstartup-notification-1.so' \
-      --canberra-library='${libcanberra}/lib/libcanberra.so' \
-      --fontconfig-library='${fontconfig.lib}/lib/libfontconfig.so' \
-      ${commonOptions}
-      ${python.pythonOnBuildForHost.interpreter} setup.py build-launcher
-    ''}
-    runHook postBuild
-  '';
-
-  nativeCheckInputs = [
-    pillow
-
-    # Shells needed for shell integration tests
-    bashInteractive
-    zsh
-    fish
-  ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    # integration tests need sudo
-    sudo
-  ];
+      # Shells needed for shell integration tests
+      bashInteractive
+      zsh
+      fish
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
+      # integration tests need sudo
+      sudo
+    ];
 
   # skip failing tests due to darwin sandbox
   preCheck = lib.optionalString stdenv.hostPlatform.isDarwin ''
@@ -186,49 +238,61 @@ buildPythonApplication rec {
   '';
 
   checkPhase = ''
-      runHook preCheck
+    runHook preCheck
 
-      # Fontconfig error: Cannot load default config file: No such file: (null)
-      export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
+    # Fontconfig error: Cannot load default config file: No such file: (null)
+    export FONTCONFIG_FILE=${fontconfig.out}/etc/fonts/fonts.conf
 
-      # Required for `test_ssh_shell_integration` to pass.
-      export TERM=kitty
+    # Required for `test_ssh_shell_integration` to pass.
+    export TERM=kitty
 
-      make test
-      runHook postCheck
-    '';
+    make test
+    runHook postCheck
+  '';
 
   installPhase = ''
     runHook preInstall
     mkdir -p "$out"
     mkdir -p "$kitten/bin"
-    ${if stdenv.hostPlatform.isDarwin then ''
-    mkdir "$out/bin"
-    ln -s ../Applications/kitty.app/Contents/MacOS/kitty "$out/bin/kitty"
-    ln -s ../Applications/kitty.app/Contents/MacOS/kitten "$out/bin/kitten"
-    cp ./kitty.app/Contents/MacOS/kitten "$kitten/bin/kitten"
-    mkdir "$out/Applications"
-    cp -r kitty.app "$out/Applications/kitty.app"
+    ${
+      if stdenv.hostPlatform.isDarwin then
+        ''
+          mkdir "$out/bin"
+          ln -s ../Applications/kitty.app/Contents/MacOS/kitty "$out/bin/kitty"
+          ln -s ../Applications/kitty.app/Contents/MacOS/kitten "$out/bin/kitten"
+          cp ./kitty.app/Contents/MacOS/kitten "$kitten/bin/kitten"
+          mkdir "$out/Applications"
+          cp -r kitty.app "$out/Applications/kitty.app"
 
-    installManPage 'docs/_build/man/kitty.1'
-    '' else ''
-    cp -r linux-package/{bin,share,lib} "$out"
-    cp linux-package/bin/kitten "$kitten/bin/kitten"
-    ''}
+          installManPage 'docs/_build/man/kitty.1'
+        ''
+      else
+        ''
+          cp -r linux-package/{bin,share,lib} "$out"
+          cp linux-package/bin/kitten "$kitten/bin/kitten"
+        ''
+    }
 
     # dereference the `kitty` symlink to make sure the actual executable
     # is wrapped on macOS as well (and not just the symlink)
-    wrapProgram $(realpath "$out/bin/kitty") --prefix PATH : "$out/bin:${lib.makeBinPath [ imagemagick ncurses.dev ]}"
+    wrapProgram $(realpath "$out/bin/kitty") --prefix PATH : "$out/bin:${
+      lib.makeBinPath [
+        imagemagick
+        ncurses.dev
+      ]
+    }"
 
     installShellCompletion --cmd kitty \
       --bash <("$out/bin/kitty" +complete setup bash) \
       --fish <("$out/bin/kitty" +complete setup fish2) \
       --zsh  <("$out/bin/kitty" +complete setup zsh)
 
-    terminfo_src=${if stdenv.hostPlatform.isDarwin then
-      ''"$out/Applications/kitty.app/Contents/Resources/terminfo"''
+    terminfo_src=${
+      if stdenv.hostPlatform.isDarwin then
+        ''"$out/Applications/kitty.app/Contents/Resources/terminfo"''
       else
-      "$out/share/terminfo"}
+        "$out/share/terminfo"
+    }
 
     mkdir -p $terminfo/share
     mv "$terminfo_src" $terminfo/share/terminfo
@@ -245,7 +309,7 @@ buildPythonApplication rec {
     tests = lib.optionalAttrs stdenv.hostPlatform.isLinux {
       default = nixosTests.terminal-emulators.kitty;
     };
-    updateScript = nix-update-script {};
+    updateScript = nix-update-script { };
   };
 
   meta = with lib; {
@@ -258,6 +322,11 @@ buildPythonApplication rec {
     ];
     platforms = platforms.darwin ++ platforms.linux;
     mainProgram = "kitty";
-    maintainers = with maintainers; [ tex rvolosatovs Luflosi kashw2 ];
+    maintainers = with maintainers; [
+      tex
+      rvolosatovs
+      Luflosi
+      kashw2
+    ];
   };
 }

--- a/pkgs/applications/terminal-emulators/kitty/default.nix
+++ b/pkgs/applications/terminal-emulators/kitty/default.nix
@@ -35,20 +35,20 @@
 with python3Packages;
 buildPythonApplication rec {
   pname = "kitty";
-  version = "0.38.1";
+  version = "0.39.0";
   format = "other";
 
   src = fetchFromGitHub {
     owner = "kovidgoyal";
     repo = "kitty";
     tag = "v${version}";
-    hash = "sha256-0M4Bvhh3j9vPedE/d+8zaiZdET4mXcrSNUgLllhaPJw=";
+    hash = "sha256-4JlsIwQzCxs1i8Pvsj9KcJZpXbVkSzWtW7klatA0FOM";
   };
 
   goModules = (buildGo123Module {
     pname = "kitty-go-modules";
     inherit src version;
-    vendorHash = "sha256-K12P81jE7oOU7qX2yQ+VtVHX/igKG0nPMSBkZ7wsR0o=";
+    vendorHash = "sha256-Yahn+nlarPy4Yf1QmDminnHDqbe0+iJ6IsUKF0tioK4=";
   }).goModules;
 
   buildInputs = [


### PR DESCRIPTION
## Package Information

- Package name: kitty
- Latest released version: 0.39.0
- Current version on the unstable channel: 0.38.1
- Current version on the stable/release channel: 0.38.1

**Note: Formatted to nixfmt-rfc-style**

**Changed description according to official [website](https://sw.kovidgoyal.net/kitty/)**

## Maintainer Ping
@tex @rvolosatovs @Luflosi @kashw2

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
