### PR TITLE
nixos/nix: add option to preface remote machines with a comment

### DIFF
--- a/nixos/modules/config/nix-remote-build.nix
+++ b/nixos/modules/config/nix-remote-build.nix
@@ -31,7 +31,7 @@ let
 
   buildMachinesText = concatMapStrings (
     machine:
-    (concatStringsSep " " (
+    ((optionalString (machine.comment != null) "# ${machine.comment}\n") + concatStringsSep " " (
       [
         "${optionalString (machine.protocol != null) "${machine.protocol}://"}${
           optionalString (machine.sshUser != null) "${machine.sshUser}@"
@@ -199,6 +199,15 @@ in
                   The (base64-encoded) public host key of this builder. The field
                   is calculated via {command}`base64 -w0 /etc/ssh/ssh_host_type_key.pub`.
                   If null, SSH will use its regular known-hosts file when connecting.
+                '';
+              };
+              comment = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                example = "This is a powerful builder located in Belgium";
+                description = ''
+                  A comment to describe the builder. Could be useful for noting the full
+                  DNS name of a machine, and using an IP address as hostName.
                 '';
               };
             };

--- a/nixos/modules/config/nix-remote-build.nix
+++ b/nixos/modules/config/nix-remote-build.nix
@@ -31,39 +31,44 @@ let
 
   buildMachinesText = concatMapStrings (
     machine:
-    ((optionalString (machine.comment != null) "# ${machine.comment}\n") + concatStringsSep " " (
-      [
-        "${optionalString (machine.protocol != null) "${machine.protocol}://"}${
-          optionalString (machine.sshUser != null) "${machine.sshUser}@"
-        }${machine.hostName}"
-        (
-          if machine.system != null then
-            machine.system
-          else if machine.systems != [ ] then
-            concatStringsSep "," machine.systems
-          else
-            "-"
+    (
+      (optionalString (machine.comment != null) ''
+        # ${machine.comment}
+      '')
+      + concatStringsSep " " (
+        [
+          "${optionalString (machine.protocol != null) "${machine.protocol}://"}${
+            optionalString (machine.sshUser != null) "${machine.sshUser}@"
+          }${machine.hostName}"
+          (
+            if machine.system != null then
+              machine.system
+            else if machine.systems != [ ] then
+              concatStringsSep "," machine.systems
+            else
+              "-"
+          )
+          (if machine.sshKey != null then machine.sshKey else "-")
+          (toString machine.maxJobs)
+          (toString machine.speedFactor)
+          (
+            let
+              res = (machine.supportedFeatures ++ machine.mandatoryFeatures);
+            in
+            if (res == [ ]) then "-" else (concatStringsSep "," res)
+          )
+          (
+            let
+              res = machine.mandatoryFeatures;
+            in
+            if (res == [ ]) then "-" else (concatStringsSep "," machine.mandatoryFeatures)
+          )
+        ]
+        ++ optional (isNixAtLeast "2.4pre") (
+          if machine.publicHostKey != null then machine.publicHostKey else "-"
         )
-        (if machine.sshKey != null then machine.sshKey else "-")
-        (toString machine.maxJobs)
-        (toString machine.speedFactor)
-        (
-          let
-            res = (machine.supportedFeatures ++ machine.mandatoryFeatures);
-          in
-          if (res == [ ]) then "-" else (concatStringsSep "," res)
-        )
-        (
-          let
-            res = machine.mandatoryFeatures;
-          in
-          if (res == [ ]) then "-" else (concatStringsSep "," machine.mandatoryFeatures)
-        )
-      ]
-      ++ optional (isNixAtLeast "2.4pre") (
-        if machine.publicHostKey != null then machine.publicHostKey else "-"
       )
-    ))
+    )
     + "\n"
   ) cfg.buildMachines;
 
@@ -256,9 +261,7 @@ in
       ];
 
     # List of machines for distributed Nix builds
-    environment.etc."nix/machines" = mkIf (cfg.buildMachines != [ ]) {
-      text = buildMachinesText;
-    };
+    environment.etc."nix/machines" = mkIf (cfg.buildMachines != [ ]) { text = buildMachinesText; };
 
     # Legacy configuration conversion.
     nix.settings = mkIf (!cfg.distributedBuilds) { builders = null; };


### PR DESCRIPTION
I recently ran into an issue where I wasn't able to use the DNS hostname of a machine inside the /etc/nix/machines file. Nothing to do with NixOS or Nix itself, just a weird networking setup I was in. This meant I had to use the plain IPv4 and IPv6 addresses of those machines in these files.

I still like to have some reference to what these machines are, so I've always put a comment above the remote machine line with the DNS name of the machine, and then use the hostName option for the IP address.

This adds the nix.buildMachines.*.comment option. Allows us to do the following.

    {
      nix.buildMachines = [
        {
          protocol = "ssh-ng";
          sshUser = "nixbld";
          hostName = "192.168.0.222";
          comment = "Some very powerful machine in Belgium";
        }
      ];
    }

Which would result in the following /etc/nix/machines entry.

    # Some very powerful machine in Belgium
    ssh-ng://nixbld@192.168.0.222 - - 1 1 - - -

I also went ahead and formatted this module with `nix run nixpkgs#nixfmt`, not sure if that's allowed.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
