### PR TITLE
trilium-next-desktop: fix Darwin build

### DIFF
--- a/pkgs/by-name/tr/trilium-next-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-next-desktop/package.nix
@@ -115,12 +115,16 @@ let
   darwin = stdenv.mkDerivation {
     inherit pname version meta;
 
-    src = fetchzip darwinSource;
+    src = fetchurl darwinSource;
+
+    nativeBuildInputs = [
+      unzip
+    ];
 
     installPhase = ''
       runHook preInstall
-      mkdir -p $out/Applications
-      cp -r *.app $out/Applications
+      mkdir -p "$out/Applications/TriliumNext Notes.app"
+      cp -r * "$out/Applications/TriliumNext Notes.app/"
       runHook postInstall
     '';
   };


### PR DESCRIPTION
Seems no one tested the original Darwin build.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).