### PR TITLE
octopus: fix build

### DIFF
--- a/pkgs/by-name/oc/octopus/package.nix
+++ b/pkgs/by-name/oc/octopus/package.nix
@@ -40,6 +40,11 @@ stdenv.mkDerivation rec {
     hash = "sha256-vG1HUkuNUZkhBumoJJy3AyFU6cZOo1YGmaOYcU6bPOM=";
   };
 
+  patches = [
+    # Discover all MPI languages components to avoid scalpack discovery failure
+    ./scalapack-mpi-alias.patch
+  ];
+
   nativeBuildInputs = [
     which
     perl

--- a/pkgs/by-name/oc/octopus/scalapack-mpi-alias.patch
+++ b/pkgs/by-name/oc/octopus/scalapack-mpi-alias.patch
@@ -1,0 +1,13 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 70d89efb5e..47ba750d7a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -131,7 +131,7 @@ set(Octopus_ext_libs)
+ find_package(GSL)
+ if (OCTOPUS_MPI)
+ 	set(MPI_DETERMINE_LIBRARY_VERSION ON)
+-	find_package(MPI 3 COMPONENTS Fortran)
++	find_package(MPI 3)
+ 	# Further set MKL variables
+ 	if (MPI_Fortran_LIBRARY_VERSION_STRING MATCHES Intel)
+ 		set(MKL_MPI intelmpi CACHE STRING "Octopus: Overloaded")


### PR DESCRIPTION
Fix fallout of https://github.com/NixOS/nixpkgs/pull/373686

scalapack has started to use target aliases  in the form of MPI::MPI_lang. Octopus only discovers MPI's Fortran component and does not set MPI::MPI_C. Scalapack discovery fails with unset MPI::MPI_C.

## Things done
* Re-introduce fix for cmake files in scalapack, which has been removed in the update.
* Patch scalapack to show correct version (the respective commit was made after the scalapack release).
* Patch octopus cmake files to work with scalapack 2.2.2 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
