### PR TITLE
haskellPackages: use upstream version for reflex-dom(-core)

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1661,6 +1661,17 @@ self: super: {
   # Tests disabled because they assume to run in the whole jsaddle repo and not the hackage tarball of jsaddle-warp.
   jsaddle-warp = dontCheck super.jsaddle-warp;
 
+  # https://github.com/ghcjs/jsaddle/issues/151
+  jsaddle-webkit2gtk = overrideCabal (drv: {
+    postPatch = drv.postPatch or "" + ''
+      substituteInPlace jsaddle-webkit2gtk.cabal --replace-fail gi-gtk gi-gtk3
+      substituteInPlace jsaddle-webkit2gtk.cabal --replace-fail gi-javascriptcore gi-javascriptcore4
+    '';
+  }) (super.jsaddle-webkit2gtk.override {
+    gi-gtk = self.gi-gtk3;
+    gi-javascriptcore = self.gi-javascriptcore4;
+  });
+
   # 2020-06-24: Jailbreaking because of restrictive test dep bounds
   # Upstream issue: https://github.com/kowainik/trial/issues/62
   trial = doJailbreak super.trial;

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -1880,21 +1880,16 @@ self: super: {
   # https://github.com/adnelson/semver-range/issues/15
   semver-range = dontCheck super.semver-range;
 
-  reflex = lib.pipe super.reflex [
-    doJailbreak
-    # Until hackage release has https://github.com/reflex-frp/reflex/pull/517
-    (overrideCabal (drv: {
-      postPatch = drv.postPatch or "" + ''
-        substituteInPlace \
-          src/Data/AppendMap.hs \
-          src/Reflex/Class.hs \
-          src/Reflex/FunctorMaybe.hs \
-          src/Reflex/Spider/Internal.hs \
-          test/DebugCycles.hs \
-          --replace-fail Data.Witherable Witherable
-      '';
-    }))
-  ];
+  reflex = lib.warnIf (lib.versionAtLeast super.reflex.version "0.9.3.2") "reflex version override is no longer needed and should be removed"
+    (overrideSrc rec {
+      version = "0.9.3.2";
+      src = (pkgs.fetchFromGitHub {
+        owner = "reflex-frp";
+        repo = "reflex";
+        rev = "v0.9.3.2";
+        hash = "sha256-IJMoYoIN8OWOmyOMSvr1aFXofWsyEetCUY7hO141ThE=";
+      });
+    } super.reflex);
 
   # 2024-03-02: vty <5.39 - https://github.com/reflex-frp/reflex-ghci/pull/33
   reflex-ghci = assert super.reflex-ghci.version == "0.2.0.1"; doJailbreak super.reflex-ghci;

--- a/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghcjs-9.x.nix
@@ -25,6 +25,7 @@ with haskellLib;
 
   # https://gitlab.haskell.org/ghc/ghc/-/issues/25083#note_578275
   patch = haskellLib.disableParallelBuilding super.patch;
+  reflex-dom-core = haskellLib.disableParallelBuilding super.reflex-dom-core;
 
   reflex-dom = super.reflex-dom.override (drv: {
     jsaddle-webkit2gtk = null;


### PR DESCRIPTION
This fixes the `reflex-dom-core` build while we wait for the hackage release to propagate, but weird things happen with the deps of `reflex-dom`
```
these 6 derivations will be built:
  /nix/store/jnn0nhi5ddpjyc8mgvgggwg58lj9lg4p-gi-javascriptcore6-6.0.5.drv
  /nix/store/38ryddi3bsdq4zb3r8nf5lbg9qpmmvwg-gi-javascriptcore-6.0.5.drv
  /nix/store/66d98cgs16j2pgvv70413l09nkhlksc8-gi-javascriptcore4-4.0.29.drv
  /nix/store/ikd3398z8vfwz3796j86jxwcb5g500p3-gi-webkit2-4.0.32.drv
  /nix/store/bgkha8bxq60c1kns1kazhq61nz92wzqx-jsaddle-webkit2gtk-0.9.9.0.drv
  /nix/store/aj04snrxpcbsqgmxd9i60w141jhv6zya-reflex-dom-0.8.1.1.drv
```

[jsaddle-webkit2gtk-0.9.9.0](https://hackage.haskell.org/package/jsaddle-webkit2gtk-0.9.9.0) -> [gi-javascriptcore](https://hackage.haskell.org/package/gi-javascriptcore) (>=4.0.14 && <4.1), [gi-webkit2](https://hackage.haskell.org/package/gi-webkit2) (>=4.0.14 && <4.1)
[gi-webkit2-4.0.31](https://hackage.haskell.org/package/gi-webkit2-4.0.31) ->  [gi-javascriptcore (>=4.0 && <4.1)](https://hackage.haskell.org/package/gi-javascriptcore),
[gi-webkit2-4.0.32](https://hackage.haskell.org/package/gi-webkit2-4.0.32) ->  [gi-javascriptcore4](https://hackage.haskell.org/package/gi-javascriptcore4)

It seems `gi-webkit2` started using separate packages but `jsaddle-webkit2gtk` hasn't yet adjusted to the change?
IIUC until then we want to force `jsaddle-webkit2gtk` to use `gi-javascriptcore4` ?
```nix
  jsaddle-webkit2gtk = super.jsaddle-webkit2gtk.override {
    gi-javascriptcore = self.gi-javascriptcore4;
  };
``` 
That simplifies things to 
```
these 4 derivations will be built:
  /nix/store/66d98cgs16j2pgvv70413l09nkhlksc8-gi-javascriptcore4-4.0.29.drv
  /nix/store/ikd3398z8vfwz3796j86jxwcb5g500p3-gi-webkit2-4.0.32.drv
  /nix/store/51q2x4y18abxy8r994rai5wphmvmqcp4-jsaddle-webkit2gtk-0.9.9.0.drv
  /nix/store/z3mdc0jlclx0lcpamf01ya942ikfnkz2-reflex-dom-0.8.1.1.drv
```
but then `gi-javascriptcore4` fails to build with 

```
Using tar found on system at:
/nix/store/9cwwj1c9csmc85l2cqzs3h9hbf1vwl6c-gnutar-1.35/bin/tar
No uhc found
Error: Setup: Missing dependencies on foreign libraries:
* Missing (or bad) C libraries: javascriptcoregtk-4.0, gobject-2.0, glib-2.0
This problem can usually be solved by installing the system packages that
provide these libraries (you may need the "-dev" versions). If the libraries
are already installed but in a non-standard location then you can use the
flags --extra-include-dirs= and --extra-lib-dirs= to specify where they are.If
the library files do exist, it may contain errors that are caught by the C
compiler at the preprocessing stage. In this case you can re-run configure
with the verbosity flag -v3 to see the error messages.
```
and I can't seem to make it happy messing with `*PkgconfigDepends`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
