### PR TITLE
nixos/nixpkgs-flake: enable flakes in systems built from flakes, make ISO behave well

### DIFF
--- a/nixos/modules/installer/cd-dvd/channel.nix
+++ b/nixos/modules/installer/cd-dvd/channel.nix
@@ -42,12 +42,15 @@ in
   options.system.installer.channel.enable =
     (lib.mkEnableOption "bundling NixOS/Nixpkgs channel in the installer")
     // {
-      default = true;
+      # Don't ship a channel if we are already providing nixpkgs through the
+      # flake registry
+      default = config.nixpkgs.flake.source == null;
     };
   config = lib.mkIf config.system.installer.channel.enable {
     # Pin the nixpkgs flake in the installer to our cleaned up nixpkgs source.
     # FIXME: this might be surprising and is really only needed for offline installations,
     # see discussion in https://github.com/NixOS/nixpkgs/pull/204178#issuecomment-1336289021
+    # N.B. also hits https://github.com/NixOS/nix/issues/7075
     nix.registry.nixpkgs.to = {
       type = "path";
       path = "${channelSources}/nixos";

--- a/nixos/modules/misc/nixpkgs-flake.nix
+++ b/nixos/modules/misc/nixpkgs-flake.nix
@@ -106,6 +106,12 @@ in
           [ "nixpkgs=flake:nixpkgs" ]
           ++ lib.optional config.nix.channel.enable "/nix/var/nix/profiles/per-user/root/channels"
         );
+        # Nix will not accept a NIX_PATH with `flake:foo` in it unless flakes
+        # are enabled in the resulting configuration, and this is kind of surprising behaviour.
+        nix.settings.experimental-features = lib.mkDefault [
+          "nix-command"
+          "flakes"
+        ];
       })
     ]
   );


### PR DESCRIPTION
This makes `<nixpkgs>` work.

If you don't enable flakes and you use a flake reference in NIX_PATH, you get this:

```
~ » NIX_PATH=nixpkgs=flake:nixpkgs nix-instantiate --experimental-features '' --eval --expr 'with import <nixpkgs> {}; hello'
error:
       … while calling the 'import' builtin
         at «string»:1:6:
            1| with import <nixpkgs> {}; hello
             |      ^

       … while calling the 'findFile' builtin
         at «string»:1:14:
            1| with import <nixpkgs> {}; hello
             |              ^

       error: experimental Lix feature 'flakes' is disabled; use '--extra-experimental-features flakes' to override
```

The thing with this is that auto-enabling flakes in the resulting system isn't so silly if you are building the system from a flake such that `<nixpkgs>` is not from a channel, and it is quite bad UX for `<nixpkgs>` to not work.

Fixes: https://github.com/NixOS/nixpkgs/issues/292465


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
