### PR TITLE
ocelot-desktop: init at 1.13.1

### DIFF
--- a/pkgs/by-name/oc/ocelot-desktop/package.nix
+++ b/pkgs/by-name/oc/ocelot-desktop/package.nix
@@ -1,0 +1,149 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  makeBinaryWrapper,
+  makeDesktopItem,
+  copyDesktopItems,
+
+  jre,
+
+  # deps
+  alsa-lib,
+  libjack2,
+  libpulseaudio,
+  pipewire,
+  libGL,
+  libX11,
+  libXcursor,
+  libXext,
+  libXrandr,
+  libXxf86vm,
+
+  # runtime (path)
+  xrandr,
+
+  # native
+  unzip,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ocelot-desktop";
+  version = "1.13.1";
+
+  __darwinAllowLocalNetworking = true;
+
+  # Cannot build from source because sbt/scala support is completely non-existent in nixpkgs
+  src = fetchurl {
+    url = "https://gitlab.com/api/v4/projects/9941848/packages/generic/ocelot-desktop/v${finalAttrs.version}/ocelot-desktop-v${finalAttrs.version}.jar";
+    hash = "sha256-aXjz2H4vO8D7BGHxhanbmpxqd8op31v1Gwk/si4CBfg=";
+  };
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+
+  preferLocal = true;
+
+  nativeBuildInputs = [
+    makeBinaryWrapper
+    copyDesktopItems
+    unzip
+  ];
+
+  installPhase =
+    let
+      # does darwin need any deps?
+      runtimeLibs = lib.optionals stdenv.hostPlatform.isLinux [
+        # openal
+        alsa-lib
+        libjack2
+        libpulseaudio
+        pipewire
+
+        # lwjgl
+        libGL
+        libX11
+        libXcursor
+        libXext
+        libXrandr
+        libXxf86vm
+      ];
+      runtimePrograms = lib.optionals stdenv.hostPlatform.isLinux [
+        # https://github.com/LWJGL/lwjgl/issues/128
+        xrandr
+      ];
+    in
+    ''
+      runHook preInstall
+
+      mkdir -p $out/{bin,share/${finalAttrs.pname}}
+      install -Dm644 ${finalAttrs.src} $out/share/${finalAttrs.pname}/ocelot-desktop.jar
+
+      makeBinaryWrapper ${jre}/bin/java $out/bin/ocelot-desktop \
+        --set JAVA_HOME ${jre.home} \
+        --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath runtimeLibs}" \
+        --prefix PATH : "${lib.makeBinPath runtimePrograms}" \
+        --add-flags "-jar $out/share/${finalAttrs.pname}/ocelot-desktop.jar"
+
+      # copy icons from zip file
+      # ocelot/desktop/images/icon*.png
+      # 16,32,64,128,256
+
+      for size in 16 32 64 128 256; do
+        mkdir -p $out/share/icons/hicolor/"$size"x"$size"/apps
+        unzip -p $out/share/${finalAttrs.pname}/ocelot-desktop.jar \
+          ocelot/desktop/images/icon"$size".png > $out/share/icons/hicolor/"$size"x"$size"/apps/ocelot-desktop.png
+      done
+
+      runHook postInstall
+    '';
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "ocelot-desktop";
+      desktopName = "Ocelot Desktop";
+      genericName = "OpenComputers Emulator";
+      comment = "An advanced OpenComputers emulator";
+      tryExec = "ocelot-desktop";
+      exec = "ocelot-desktop -w %f";
+      icon = "ocelot-desktop";
+      startupNotify = true;
+      startupWMClass = "Ocelot Desktop"; # (maybe broken)
+      terminal = false;
+      keywords = [
+        "Ocelot"
+        "OpenComputers"
+        "Emulator"
+        "oc"
+        "lua"
+        "OpenOS"
+        "ocemu"
+        "mc"
+        "Minecraft"
+      ];
+      categories = [
+        "Development"
+        "Emulator"
+      ];
+      mimeTypes = [
+        "inode/directory"
+      ];
+    })
+  ];
+
+  meta = {
+    description = "An advanced OpenComputers emulator";
+    homepage = "https://ocelot.fomalhaut.me/desktop";
+    changelog = "https://gitlab.com/cc-ru/ocelot/ocelot-desktop/-/releases/v${finalAttrs.version}";
+    license = lib.licenses.mit;
+    mainProgram = "ocelot-desktop";
+    platforms = with lib.platforms; linux ++ darwin;
+    badPlatforms = [
+      # missing compatible lwjgl.dylib
+      "aarch64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ griffi-gh ];
+    sourceProvenance = with lib.sourceTypes; [ binaryBytecode ];
+  };
+})


### PR DESCRIPTION
closes #374407

An advanced OpenComputers emulator

![Screenshot_20250117_174007](https://github.com/user-attachments/assets/a5aac9c1-d26d-4521-a1e5-eca4c242b1a9)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
