### PR TITLE
lomiri.biometryd: pin Boost 1.86 for now

### DIFF
--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -4,7 +4,8 @@
   fetchFromGitLab,
   gitUpdater,
   testers,
-  boost,
+  # Pin Boost 1.86 due to use of boost::asio::io_service.
+  boost186,
   cmake,
   cmake-extras,
   dbus,
@@ -65,7 +66,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost
+    boost186
     cmake-extras
     dbus
     dbus-cpp


### PR DESCRIPTION
ref. #369118

This is a no-op on master.

Failing build with Boost 1.87 https://paste.fliegendewurst.eu/vK0pFc.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).