### PR TITLE
deepin.deepin-pdfium: fix strictDeps build

### DIFF
--- a/pkgs/desktops/deepin/library/deepin-pdfium/default.nix
+++ b/pkgs/desktops/deepin/library/deepin-pdfium/default.nix
@@ -2,9 +2,12 @@
   stdenv,
   lib,
   fetchFromGitHub,
+  freetype,
+  icu,
   libsForQt5,
   pkg-config,
   libchardet,
+  libjpeg,
   lcms2,
   openjpeg,
 }:
@@ -28,13 +31,16 @@ stdenv.mkDerivation rec {
   dontWrapQtApps = true;
 
   buildInputs = [
+    freetype
+    icu
     libchardet
+    libjpeg
     lcms2
     openjpeg
   ];
 
   meta = with lib; {
-    description = "development library for pdf on deepin";
+    description = "Development library for PDF on deepin";
     homepage = "https://github.com/linuxdeepin/deepin-pdfium";
     license = licenses.lgpl3Plus;
     platforms = platforms.linux;


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468
Cross broken due to qmake just not cooperating.

It is a bit odd that the library depends both on openjpeg and libjpeg.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).