### PR TITLE
uboot: 2024.10 -> 2025.01

### DIFF
--- a/pkgs/misc/uboot/0002-HACK-add-HOST_ARCH-detection-for-armv5tel-and-armv6l.patch
+++ b/pkgs/misc/uboot/0002-HACK-add-HOST_ARCH-detection-for-armv5tel-and-armv6l.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ZHANG Yuntian <yt@radxa.com>
+Date: Wed, 22 Jan 2025 16:45:36 +0800
+Subject: [PATCH] HACK: add HOST_ARCH detection for armv5tel and armv6l
+
+In 9fd623afede63a7049b498bbc285f3555eb2bf26@v2025.01, `HOST_ARCH` was introduced
+to EFI library. However, our `CROSS_COMPILE=armv6l-unknown-linux-gnueabihf-`
+does not have a match in `Makefile` so it is undefined, and thus breaks the
+build.
+
+Same issue can potentially affect `armv5tel-linux` targets. However, their
+defconfig do not define `CONFIG_EFI_LOADER`, so that code is not complied, and
+we happen to build the target normally.
+
+Add both to fix the armv6l build, in case if we want to support EFI on armv5tel
+targets.
+
+Signed-off-by: ZHANG Yuntian <yt@radxa.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index f67aac72b9f..544b23402b7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -30,7 +30,7 @@ else ifneq (,$(findstring $(MK_ARCH), "i386" "i486" "i586" "i686"))
+   export HOST_ARCH=$(HOST_ARCH_X86)
+ else ifneq (,$(findstring $(MK_ARCH), "aarch64" "armv8l"))
+   export HOST_ARCH=$(HOST_ARCH_AARCH64)
+-else ifneq (,$(findstring $(MK_ARCH), "arm" "armv7" "armv7a" "armv7l"))
++else ifneq (,$(findstring $(MK_ARCH), "arm" "armv5tel" "armv6l" "armv7" "armv7a" "armv7l"))
+   export HOST_ARCH=$(HOST_ARCH_ARM)
+ else ifeq ("riscv32", $(MK_ARCH))
+   export HOST_ARCH=$(HOST_ARCH_RISCV32)
+-- 
+2.48.1
+

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -29,10 +29,10 @@
 }:
 
 let
-  defaultVersion = "2024.10";
+  defaultVersion = "2025.01";
   defaultSrc = fetchurl {
     url = "https://ftp.denx.de/pub/u-boot/u-boot-${defaultVersion}.tar.bz2";
-    hash = "sha256-so2vSsF+QxVjYweL9RApdYQTf231D87ZsS3zT2GpL7A=";
+    hash = "sha256-ze99UHyT8bvZ8BXqm8IfoHQmhIFAVQGUWrxvhU1baG8=";
   };
 
   # Dependencies for the tools need to be included as either native or cross,

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -65,6 +65,7 @@ let
 
     patches = [
       ./0001-configs-rpi-allow-for-bigger-kernels.patch
+      ./0002-HACK-add-HOST_ARCH-detection-for-armv5tel-and-armv6l.patch
     ] ++ extraPatches;
 
     postPatch = ''

--- a/pkgs/misc/uboot/default.nix
+++ b/pkgs/misc/uboot/default.nix
@@ -1,31 +1,32 @@
-{ stdenv
-, lib
-, bc
-, bison
-, dtc
-, fetchFromGitHub
-, fetchpatch
-, fetchurl
-, flex
-, gnutls
-, installShellFiles
-, libuuid
-, meson-tools
-, ncurses
-, openssl
-, rkbin
-, swig
-, which
-, python3
-, perl
-, armTrustedFirmwareAllwinner
-, armTrustedFirmwareAllwinnerH6
-, armTrustedFirmwareAllwinnerH616
-, armTrustedFirmwareRK3328
-, armTrustedFirmwareRK3399
-, armTrustedFirmwareRK3588
-, armTrustedFirmwareS905
-, buildPackages
+{
+  stdenv,
+  lib,
+  bc,
+  bison,
+  dtc,
+  fetchFromGitHub,
+  fetchpatch,
+  fetchurl,
+  flex,
+  gnutls,
+  installShellFiles,
+  libuuid,
+  meson-tools,
+  ncurses,
+  openssl,
+  rkbin,
+  swig,
+  which,
+  python3,
+  perl,
+  armTrustedFirmwareAllwinner,
+  armTrustedFirmwareAllwinnerH6,
+  armTrustedFirmwareAllwinnerH616,
+  armTrustedFirmwareRK3328,
+  armTrustedFirmwareRK3399,
+  armTrustedFirmwareRK3588,
+  armTrustedFirmwareS905,
+  buildPackages,
 }:
 
 let
@@ -44,115 +45,142 @@ let
     openssl # tools/mkimage
   ];
 
-  buildUBoot = lib.makeOverridable ({
-    version ? null
-  , src ? null
-  , filesToInstall
-  , pythonScriptsToInstall ? { }
-  , installDir ? "$out"
-  , defconfig
-  , extraConfig ? ""
-  , extraPatches ? []
-  , extraMakeFlags ? []
-  , extraMeta ? {}
-  , crossTools ? false
-  , ... } @ args: stdenv.mkDerivation ({
-    pname = "uboot-${defconfig}";
+  buildUBoot = lib.makeOverridable (
+    {
+      version ? null,
+      src ? null,
+      filesToInstall,
+      pythonScriptsToInstall ? { },
+      installDir ? "$out",
+      defconfig,
+      extraConfig ? "",
+      extraPatches ? [ ],
+      extraMakeFlags ? [ ],
+      extraMeta ? { },
+      crossTools ? false,
+      ...
+    }@args:
+    stdenv.mkDerivation (
+      {
+        pname = "uboot-${defconfig}";
 
-    version = if src == null then defaultVersion else version;
+        version = if src == null then defaultVersion else version;
 
-    src = if src == null then defaultSrc else src;
+        src = if src == null then defaultSrc else src;
 
-    patches = [
-      ./0001-configs-rpi-allow-for-bigger-kernels.patch
-      ./0002-HACK-add-HOST_ARCH-detection-for-armv5tel-and-armv6l.patch
-    ] ++ extraPatches;
+        patches = [
+          ./0001-configs-rpi-allow-for-bigger-kernels.patch
+          ./0002-HACK-add-HOST_ARCH-detection-for-armv5tel-and-armv6l.patch
+        ] ++ extraPatches;
 
-    postPatch = ''
-      ${lib.concatMapStrings (script: ''
-        substituteInPlace ${script} \
-        --replace "#!/usr/bin/env python3" "#!${pythonScriptsToInstall.${script}}/bin/python3"
-      '') (builtins.attrNames pythonScriptsToInstall)}
-      patchShebangs tools
-      patchShebangs scripts
-    '';
+        postPatch = ''
+          ${lib.concatMapStrings (script: ''
+            substituteInPlace ${script} \
+            --replace "#!/usr/bin/env python3" "#!${pythonScriptsToInstall.${script}}/bin/python3"
+          '') (builtins.attrNames pythonScriptsToInstall)}
+          patchShebangs tools
+          patchShebangs scripts
+        '';
 
-    nativeBuildInputs = [
-      ncurses # tools/kwboot
-      bc
-      bison
-      flex
-      installShellFiles
-      (buildPackages.python3.withPackages (p: [
-        p.libfdt
-        p.setuptools # for pkg_resources
-        p.pyelftools
-      ]))
-      swig
-      which # for scripts/dtc-version.sh
-      perl # for oid build (secureboot)
-    ] ++ lib.optionals (!crossTools) toolsDeps;
-    depsBuildBuild = [ buildPackages.stdenv.cc ];
-    buildInputs = lib.optionals crossTools toolsDeps;
+        nativeBuildInputs = [
+          ncurses # tools/kwboot
+          bc
+          bison
+          flex
+          installShellFiles
+          (buildPackages.python3.withPackages (p: [
+            p.libfdt
+            p.setuptools # for pkg_resources
+            p.pyelftools
+          ]))
+          swig
+          which # for scripts/dtc-version.sh
+          perl # for oid build (secureboot)
+        ] ++ lib.optionals (!crossTools) toolsDeps;
+        depsBuildBuild = [ buildPackages.stdenv.cc ];
+        buildInputs = lib.optionals crossTools toolsDeps;
 
-    hardeningDisable = [ "all" ];
+        hardeningDisable = [ "all" ];
 
-    enableParallelBuilding = true;
+        enableParallelBuilding = true;
 
-    makeFlags = [
-      "DTC=${lib.getExe buildPackages.dtc}"
-      "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
-    ] ++ extraMakeFlags;
+        makeFlags = [
+          "DTC=${lib.getExe buildPackages.dtc}"
+          "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
+        ] ++ extraMakeFlags;
 
-    passAsFile = [ "extraConfig" ];
+        passAsFile = [ "extraConfig" ];
 
-    configurePhase = ''
-      runHook preConfigure
+        configurePhase = ''
+          runHook preConfigure
 
-      make ${defconfig}
+          make ${defconfig}
 
-      cat $extraConfigPath >> .config
+          cat $extraConfigPath >> .config
 
-      runHook postConfigure
-    '';
+          runHook postConfigure
+        '';
 
-    installPhase = ''
-      runHook preInstall
+        installPhase = ''
+          runHook preInstall
 
-      mkdir -p ${installDir}
-      cp ${lib.concatStringsSep " " (filesToInstall ++ builtins.attrNames pythonScriptsToInstall)} ${installDir}
+          mkdir -p ${installDir}
+          cp ${
+            lib.concatStringsSep " " (filesToInstall ++ builtins.attrNames pythonScriptsToInstall)
+          } ${installDir}
 
-      mkdir -p "$out/nix-support"
-      ${lib.concatMapStrings (file: ''
-        echo "file binary-dist ${installDir}/${builtins.baseNameOf file}" >> "$out/nix-support/hydra-build-products"
-      '') (filesToInstall ++ builtins.attrNames pythonScriptsToInstall)}
+          mkdir -p "$out/nix-support"
+          ${lib.concatMapStrings (file: ''
+            echo "file binary-dist ${installDir}/${builtins.baseNameOf file}" >> "$out/nix-support/hydra-build-products"
+          '') (filesToInstall ++ builtins.attrNames pythonScriptsToInstall)}
 
-      runHook postInstall
-    '';
+          runHook postInstall
+        '';
 
-    dontStrip = true;
+        dontStrip = true;
 
-    meta = with lib; {
-      homepage = "https://www.denx.de/wiki/U-Boot/";
-      description = "Boot loader for embedded systems";
-      license = licenses.gpl2Plus;
-      maintainers = with maintainers; [ bartsch dezgeg lopsided98 ];
-    } // extraMeta;
-  } // removeAttrs args [ "extraMeta" "pythonScriptsToInstall" ]));
-in {
+        meta =
+          with lib;
+          {
+            homepage = "https://www.denx.de/wiki/U-Boot/";
+            description = "Boot loader for embedded systems";
+            license = licenses.gpl2Plus;
+            maintainers = with maintainers; [
+              bartsch
+              dezgeg
+              lopsided98
+            ];
+          }
+          // extraMeta;
+      }
+      // removeAttrs args [
+        "extraMeta"
+        "pythonScriptsToInstall"
+      ]
+    )
+  );
+in
+{
   inherit buildUBoot;
 
   ubootTools = buildUBoot {
     defconfig = "tools-only_defconfig";
     installDir = "$out/bin";
-    hardeningDisable = [];
+    hardeningDisable = [ ];
     dontStrip = false;
     extraMeta.platforms = lib.platforms.linux;
 
     crossTools = true;
-    extraMakeFlags = [ "HOST_TOOLS_ALL=y" "NO_SDL=1" "cross_tools" ];
+    extraMakeFlags = [
+      "HOST_TOOLS_ALL=y"
+      "NO_SDL=1"
+      "cross_tools"
+    ];
 
-    outputs = [ "out" "man" ];
+    outputs = [
+      "out"
+      "man"
+    ];
 
     postInstall = ''
       installManPage doc/*.1
@@ -172,47 +200,50 @@ in {
 
   ubootA20OlinuxinoLime = buildUBoot {
     defconfig = "A20-OLinuXino-Lime_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootA20OlinuxinoLime2EMMC = buildUBoot {
     defconfig = "A20-OLinuXino-Lime2-eMMC_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootAmx335xEVM = buildUBoot {
     defconfig = "am335x_evm_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["MLO" "u-boot.img"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [
+      "MLO"
+      "u-boot.img"
+    ];
   };
 
   ubootBananaPi = buildUBoot {
     defconfig = "Bananapi_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootBananaPim3 = buildUBoot {
     defconfig = "Sinovoip_BPI_M3_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootBananaPim64 = buildUBoot {
     defconfig = "bananapi_m64_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   # http://git.denx.de/?p=u-boot.git;a=blob;f=board/solidrun/clearfog/README;hb=refs/heads/master
   ubootClearfog = buildUBoot {
     defconfig = "clearfog_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-with-spl.kwb"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-with-spl.kwb" ];
   };
 
   ubootCM3588NAS = buildUBoot {
@@ -220,25 +251,34 @@ in {
     extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
     ROCKCHIP_TPL = rkbin.TPL_RK3588;
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+    ];
   };
 
   ubootCubieboard2 = buildUBoot {
     defconfig = "Cubieboard2_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootGuruplug = buildUBoot {
     defconfig = "guruplug_defconfig";
-    extraMeta.platforms = ["armv5tel-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "armv5tel-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootJetsonTK1 = buildUBoot {
     defconfig = "jetson-tk1_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot" "u-boot.dtb" "u-boot-dtb-tegra.bin" "u-boot-nodtb-tegra.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [
+      "u-boot"
+      "u-boot.dtb"
+      "u-boot-dtb-tegra.bin"
+      "u-boot-nodtb-tegra.bin"
+    ];
     # tegra-uboot-flasher expects this exact directory layout, sigh...
     postInstall = ''
       mkdir -p $out/spl
@@ -249,43 +289,44 @@ in {
   # Flashing instructions:
   # dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=512 skip=1 seek=1
   # dd if=u-boot.gxl.sd.bin of=<sdcard> conv=fsync,notrunc bs=1 count=444
-  ubootLibreTechCC = let
-    firmwareImagePkg = fetchFromGitHub {
-      owner = "LibreELEC";
-      repo = "amlogic-boot-fip";
-      rev = "4369a138ca24c5ab932b8cbd1af4504570b709df";
-      sha256 = "sha256-mGRUwdh3nW4gBwWIYHJGjzkezHxABwcwk/1gVRis7Tc=";
-      meta.license = lib.licenses.unfreeRedistributableFirmware;
+  ubootLibreTechCC =
+    let
+      firmwareImagePkg = fetchFromGitHub {
+        owner = "LibreELEC";
+        repo = "amlogic-boot-fip";
+        rev = "4369a138ca24c5ab932b8cbd1af4504570b709df";
+        sha256 = "sha256-mGRUwdh3nW4gBwWIYHJGjzkezHxABwcwk/1gVRis7Tc=";
+        meta.license = lib.licenses.unfreeRedistributableFirmware;
+      };
+    in
+    assert stdenv.buildPlatform.system == "x86_64-linux"; # aml_encrypt_gxl is a x86_64 binary
+    buildUBoot {
+      defconfig = "libretech-cc_defconfig";
+      extraMeta.platforms = [ "aarch64-linux" ];
+      filesToInstall = [ "u-boot.bin" ];
+      postBuild = ''
+        # Copy binary files & tools from LibreELEC/amlogic-boot-fip, and u-boot build to working dir
+        mkdir $out tmp
+        cp ${firmwareImagePkg}/lepotato/{acs.bin,bl2.bin,bl21.bin,bl30.bin,bl301.bin,bl31.img} \
+           ${firmwareImagePkg}/lepotato/{acs_tool.py,aml_encrypt_gxl,blx_fix.sh} \
+           u-boot.bin tmp/
+        cd tmp
+        python3 acs_tool.py bl2.bin bl2_acs.bin acs.bin 0
+
+        bash -e blx_fix.sh bl2_acs.bin zero bl2_zero.bin bl21.bin bl21_zero.bin bl2_new.bin bl2
+        [ -f zero ] && rm zero
+
+        bash -e blx_fix.sh bl30.bin zero bl30_zero.bin bl301.bin bl301_zero.bin bl30_new.bin bl30
+        [ -f zero ] && rm zero
+
+        ./aml_encrypt_gxl --bl2sig --input bl2_new.bin --output bl2.n.bin.sig
+        ./aml_encrypt_gxl --bl3enc --input bl30_new.bin --output bl30_new.bin.enc
+        ./aml_encrypt_gxl --bl3enc --input bl31.img --output bl31.img.enc
+        ./aml_encrypt_gxl --bl3enc --input u-boot.bin --output bl33.bin.enc
+        ./aml_encrypt_gxl --bootmk --output $out/u-boot.gxl \
+          --bl2 bl2.n.bin.sig --bl30 bl30_new.bin.enc --bl31 bl31.img.enc --bl33 bl33.bin.enc
+      '';
     };
-  in
-  assert stdenv.buildPlatform.system == "x86_64-linux"; # aml_encrypt_gxl is a x86_64 binary
-  buildUBoot {
-    defconfig = "libretech-cc_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
-    filesToInstall = ["u-boot.bin"];
-    postBuild = ''
-      # Copy binary files & tools from LibreELEC/amlogic-boot-fip, and u-boot build to working dir
-      mkdir $out tmp
-      cp ${firmwareImagePkg}/lepotato/{acs.bin,bl2.bin,bl21.bin,bl30.bin,bl301.bin,bl31.img} \
-         ${firmwareImagePkg}/lepotato/{acs_tool.py,aml_encrypt_gxl,blx_fix.sh} \
-         u-boot.bin tmp/
-      cd tmp
-      python3 acs_tool.py bl2.bin bl2_acs.bin acs.bin 0
-
-      bash -e blx_fix.sh bl2_acs.bin zero bl2_zero.bin bl21.bin bl21_zero.bin bl2_new.bin bl2
-      [ -f zero ] && rm zero
-
-      bash -e blx_fix.sh bl30.bin zero bl30_zero.bin bl301.bin bl301_zero.bin bl30_new.bin bl30
-      [ -f zero ] && rm zero
-
-      ./aml_encrypt_gxl --bl2sig --input bl2_new.bin --output bl2.n.bin.sig
-      ./aml_encrypt_gxl --bl3enc --input bl30_new.bin --output bl30_new.bin.enc
-      ./aml_encrypt_gxl --bl3enc --input bl31.img --output bl31.img.enc
-      ./aml_encrypt_gxl --bl3enc --input u-boot.bin --output bl33.bin.enc
-      ./aml_encrypt_gxl --bootmk --output $out/u-boot.gxl \
-        --bl2 bl2.n.bin.sig --bl30 bl30_new.bin.enc --bl31 bl31.img.enc --bl33 bl33.bin.enc
-    '';
-  };
 
   ubootNanoPCT4 = buildUBoot rec {
     rkbin = fetchFromGitHub {
@@ -298,11 +339,14 @@ in {
     defconfig = "nanopc-t4-rk3399_defconfig";
 
     extraMeta = {
-      platforms = ["aarch64-linux"];
+      platforms = [ "aarch64-linux" ];
       license = lib.licenses.unfreeRedistributableFirmware;
     };
-    BL31="${armTrustedFirmwareRK3399}/bl31.elf";
-    filesToInstall = ["u-boot.itb" "idbloader.img"];
+    BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+    ];
     postBuild = ''
       ./tools/mkimage -n rk3399 -T rksd -d ${rkbin}/rk33/rk3399_ddr_800MHz_v1.24.bin idbloader.img
       cat ${rkbin}/rk33/rk3399_miniloader_v1.19.bin >> idbloader.img
@@ -311,209 +355,241 @@ in {
 
   ubootNanoPCT6 = buildUBoot {
     defconfig = "nanopc-t6-rk3588_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
     ROCKCHIP_TPL = rkbin.TPL_RK3588;
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" "u-boot-rockchip-spi.bin" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+      "u-boot-rockchip-spi.bin"
+    ];
   };
 
   ubootNovena = buildUBoot {
     defconfig = "novena_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-dtb.img" "SPL"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [
+      "u-boot-dtb.img"
+      "SPL"
+    ];
   };
 
   # Flashing instructions:
   # dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=1 count=442
   # dd if=bl1.bin.hardkernel of=<device> conv=fsync bs=512 skip=1 seek=1
   # dd if=u-boot.gxbb of=<device> conv=fsync bs=512 seek=97
-  ubootOdroidC2 = let
-    firmwareBlobs = fetchFromGitHub {
-      owner = "armbian";
-      repo = "odroidc2-blobs";
-      rev = "47c5aac4bcac6f067cebe76e41fb9924d45b429c";
-      sha256 = "1ns0a130yxnxysia8c3q2fgyjp9k0nkr689dxk88qh2vnibgchnp";
-      meta.license = lib.licenses.unfreeRedistributableFirmware;
+  ubootOdroidC2 =
+    let
+      firmwareBlobs = fetchFromGitHub {
+        owner = "armbian";
+        repo = "odroidc2-blobs";
+        rev = "47c5aac4bcac6f067cebe76e41fb9924d45b429c";
+        sha256 = "1ns0a130yxnxysia8c3q2fgyjp9k0nkr689dxk88qh2vnibgchnp";
+        meta.license = lib.licenses.unfreeRedistributableFirmware;
+      };
+    in
+    buildUBoot {
+      defconfig = "odroid-c2_defconfig";
+      extraMeta.platforms = [ "aarch64-linux" ];
+      filesToInstall = [
+        "u-boot.bin"
+        "u-boot.gxbb"
+        "${firmwareBlobs}/bl1.bin.hardkernel"
+      ];
+      postBuild = ''
+        # BL301 image needs at least 64 bytes of padding after it to place
+        # signing headers (with amlbootsig)
+        truncate -s 64 bl301.padding.bin
+        cat '${firmwareBlobs}/gxb/bl301.bin' bl301.padding.bin > bl301.padded.bin
+        # The downstream fip_create tool adds a custom TOC entry with UUID
+        # AABBCCDD-ABCD-EFEF-ABCD-12345678ABCD for the BL301 image. It turns out
+        # that the firmware blob does not actually care about UUIDs, only the
+        # order the images appear in the file. Because fiptool does not know
+        # about the BL301 UUID, we would have to use the --blob option, which adds
+        # the image to the end of the file, causing the boot to fail. Instead, we
+        # take advantage of the fact that UUIDs are ignored and just put the
+        # images in the right order with the wrong UUIDs. In the command below,
+        # --tb-fw is really --scp-fw and --scp-fw is the BL301 image.
+        #
+        # See https://github.com/afaerber/meson-tools/issues/3 for more
+        # information.
+        '${buildPackages.armTrustedFirmwareTools}/bin/fiptool' create \
+          --align 0x4000 \
+          --tb-fw '${firmwareBlobs}/gxb/bl30.bin' \
+          --scp-fw bl301.padded.bin \
+          --soc-fw '${armTrustedFirmwareS905}/bl31.bin' \
+          --nt-fw u-boot.bin \
+          fip.bin
+        cat '${firmwareBlobs}/gxb/bl2.package' fip.bin > boot_new.bin
+        '${buildPackages.meson-tools}/bin/amlbootsig' boot_new.bin u-boot.img
+        dd if=u-boot.img of=u-boot.gxbb bs=512 skip=96
+      '';
     };
-  in buildUBoot {
-    defconfig = "odroid-c2_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
-    filesToInstall = ["u-boot.bin" "u-boot.gxbb" "${firmwareBlobs}/bl1.bin.hardkernel"];
-    postBuild = ''
-      # BL301 image needs at least 64 bytes of padding after it to place
-      # signing headers (with amlbootsig)
-      truncate -s 64 bl301.padding.bin
-      cat '${firmwareBlobs}/gxb/bl301.bin' bl301.padding.bin > bl301.padded.bin
-      # The downstream fip_create tool adds a custom TOC entry with UUID
-      # AABBCCDD-ABCD-EFEF-ABCD-12345678ABCD for the BL301 image. It turns out
-      # that the firmware blob does not actually care about UUIDs, only the
-      # order the images appear in the file. Because fiptool does not know
-      # about the BL301 UUID, we would have to use the --blob option, which adds
-      # the image to the end of the file, causing the boot to fail. Instead, we
-      # take advantage of the fact that UUIDs are ignored and just put the
-      # images in the right order with the wrong UUIDs. In the command below,
-      # --tb-fw is really --scp-fw and --scp-fw is the BL301 image.
-      #
-      # See https://github.com/afaerber/meson-tools/issues/3 for more
-      # information.
-      '${buildPackages.armTrustedFirmwareTools}/bin/fiptool' create \
-        --align 0x4000 \
-        --tb-fw '${firmwareBlobs}/gxb/bl30.bin' \
-        --scp-fw bl301.padded.bin \
-        --soc-fw '${armTrustedFirmwareS905}/bl31.bin' \
-        --nt-fw u-boot.bin \
-        fip.bin
-      cat '${firmwareBlobs}/gxb/bl2.package' fip.bin > boot_new.bin
-      '${buildPackages.meson-tools}/bin/amlbootsig' boot_new.bin u-boot.img
-      dd if=u-boot.img of=u-boot.gxbb bs=512 skip=96
-    '';
-  };
 
   ubootOdroidXU3 = buildUBoot {
     defconfig = "odroid-xu3_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-dtb.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-dtb.bin" ];
   };
 
   ubootOlimexA64Olinuxino = buildUBoot {
     defconfig = "a64-olinuxino-emmc_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOlimexA64Teres1 = buildUBoot {
     defconfig = "teres_i_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     # Using /dev/null here is upstream-specified way that disables the inclusion of crust-firmware as it's not yet packaged and without which the build will fail -- https://docs.u-boot.org/en/latest/board/allwinner/sunxi.html#building-the-crust-management-processor-firmware
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOrangePi5 = buildUBoot {
     defconfig = "orangepi-5-rk3588s_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
     ROCKCHIP_TPL = rkbin.TPL_RK3588;
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" "u-boot-rockchip-spi.bin" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+      "u-boot-rockchip-spi.bin"
+    ];
   };
 
   ubootOrangePi5Plus = buildUBoot {
     defconfig = "orangepi-5-plus-rk3588_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
     ROCKCHIP_TPL = rkbin.TPL_RK3588;
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" "u-boot-rockchip-spi.bin" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+      "u-boot-rockchip-spi.bin"
+    ];
   };
 
   ubootOrangePiPc = buildUBoot {
     defconfig = "orangepi_pc_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOrangePiZeroPlus2H5 = buildUBoot {
     defconfig = "orangepi_zero_plus2_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOrangePiZero = buildUBoot {
     defconfig = "orangepi_zero_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOrangePiZero2 = buildUBoot {
     defconfig = "orangepi_zero2_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinnerH616}/bl31.bin";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOrangePiZero3 = buildUBoot {
     defconfig = "orangepi_zero3_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     # According to https://linux-sunxi.org/H616 the H618 "is a minor update with a larger (1MB) L2 cache" (compared to the H616)
     # but "does require extra support in U-Boot, TF-A and sunxi-fel. Support for that has been merged in mainline releases."
     # But no extra support seems to be in TF-A.
     BL31 = "${armTrustedFirmwareAllwinnerH616}/bl31.bin";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOrangePi3 = buildUBoot {
     defconfig = "orangepi_3_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinnerH6}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootOrangePi3B = buildUBoot {
     defconfig = "orangepi-3b-rk3566_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     ROCKCHIP_TPL = rkbin.TPL_RK3568;
     BL31 = rkbin.BL31_RK3568;
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" "u-boot-rockchip-spi.bin" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+      "u-boot-rockchip-spi.bin"
+    ];
   };
 
   ubootPcduino3Nano = buildUBoot {
     defconfig = "Linksprite_pcDuino3_Nano_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootPine64 = buildUBoot {
     defconfig = "pine64_plus_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootPine64LTS = buildUBoot {
     defconfig = "pine64-lts_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootPinebook = buildUBoot {
     defconfig = "pinebook_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootPinebookPro = buildUBoot {
     defconfig = "pinebook-pro-rk3399_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+    ];
   };
 
   ubootQemuAarch64 = buildUBoot {
     defconfig = "qemu_arm64_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootQemuArm = buildUBoot {
     defconfig = "qemu_arm_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootQemuRiscv64Smode = buildUBoot {
     defconfig = "qemu-riscv64_smode_defconfig";
-    extraMeta.platforms = ["riscv64-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "riscv64-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootQemuX86 = buildUBoot {
@@ -524,72 +600,87 @@ in {
       CONFIG_USB_EHCI_GENERIC=y
       CONFIG_USB_XHCI_HCD=y
     '';
-    extraMeta.platforms = [ "i686-linux" "x86_64-linux" ];
+    extraMeta.platforms = [
+      "i686-linux"
+      "x86_64-linux"
+    ];
     filesToInstall = [ "u-boot.rom" ];
   };
 
   ubootRaspberryPi = buildUBoot {
     defconfig = "rpi_defconfig";
-    extraMeta.platforms = ["armv6l-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "armv6l-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootRaspberryPi2 = buildUBoot {
     defconfig = "rpi_2_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootRaspberryPi3_32bit = buildUBoot {
     defconfig = "rpi_3_32b_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootRaspberryPi3_64bit = buildUBoot {
     defconfig = "rpi_3_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootRaspberryPi4_32bit = buildUBoot {
     defconfig = "rpi_4_32b_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootRaspberryPi4_64bit = buildUBoot {
     defconfig = "rpi_4_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootRaspberryPiZero = buildUBoot {
     defconfig = "rpi_0_w_defconfig";
-    extraMeta.platforms = ["armv6l-linux"];
-    filesToInstall = ["u-boot.bin"];
+    extraMeta.platforms = [ "armv6l-linux" ];
+    filesToInstall = [ "u-boot.bin" ];
   };
 
   ubootRock4CPlus = buildUBoot {
     defconfig = "rock-4c-plus-rk3399_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+    ];
   };
 
   ubootRock5ModelB = buildUBoot {
     defconfig = "rock5b-rk3588_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
     ROCKCHIP_TPL = rkbin.TPL_RK3588;
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" "u-boot-rockchip-spi.bin" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+      "u-boot-rockchip-spi.bin"
+    ];
   };
 
   ubootRock64 = buildUBoot {
     defconfig = "rock64-rk3328_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];
-    BL31="${armTrustedFirmwareRK3328}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" ];
+    BL31 = "${armTrustedFirmwareRK3328}/bl31.elf";
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+    ];
   };
 
   # A special build with much lower memory frequency (666 vs 1600 MT/s) which
@@ -605,15 +696,23 @@ in {
     '';
     defconfig = "rock64-rk3328_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];
-    BL31="${armTrustedFirmwareRK3328}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" ];
+    BL31 = "${armTrustedFirmwareRK3328}/bl31.elf";
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+    ];
   };
 
   ubootRockPiE = buildUBoot {
     defconfig = "rock-pi-e-rk3328_defconfig";
     extraMeta.platforms = [ "aarch64-linux" ];
-    BL31="${armTrustedFirmwareRK3328}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" ];
+    BL31 = "${armTrustedFirmwareRK3328}/bl31.elf";
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+    ];
   };
 
   ubootRockPro64 = buildUBoot {
@@ -625,30 +724,37 @@ in {
       })
     ];
     defconfig = "rockpro64-rk3399_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
-    BL31="${armTrustedFirmwareRK3399}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+    extraMeta.platforms = [ "aarch64-linux" ];
+    BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+    ];
   };
 
   ubootROCPCRK3399 = buildUBoot {
     defconfig = "roc-pc-rk3399_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
-    filesToInstall = [ "spl/u-boot-spl.bin" "u-boot.itb" "idbloader.img"];
+    extraMeta.platforms = [ "aarch64-linux" ];
+    filesToInstall = [
+      "spl/u-boot-spl.bin"
+      "u-boot.itb"
+      "idbloader.img"
+    ];
     BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
   };
 
   ubootSheevaplug = buildUBoot {
     defconfig = "sheevaplug_defconfig";
-    extraMeta.platforms = ["armv5tel-linux"];
-    filesToInstall = ["u-boot.kwb"];
+    extraMeta.platforms = [ "armv5tel-linux" ];
+    filesToInstall = [ "u-boot.kwb" ];
   };
 
   ubootSopine = buildUBoot {
     defconfig = "sopine_baseboard_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareAllwinner}/bl31.bin";
     SCP = "/dev/null";
-    filesToInstall = ["u-boot-sunxi-with-spl.bin"];
+    filesToInstall = [ "u-boot-sunxi-with-spl.bin" ];
   };
 
   ubootTuringRK1 = buildUBoot {
@@ -656,13 +762,17 @@ in {
     extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3588}/bl31.elf";
     ROCKCHIP_TPL = rkbin.TPL_RK3588;
-    filesToInstall = [ "u-boot.itb" "idbloader.img" "u-boot-rockchip.bin" ];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+      "u-boot-rockchip.bin"
+    ];
   };
 
   ubootUtilite = buildUBoot {
     defconfig = "cm_fx6_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot-with-nand-spl.imx"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [ "u-boot-with-nand-spl.imx" ];
     buildFlags = [ "u-boot-with-nand-spl.imx" ];
     extraConfig = ''
       CONFIG_CMD_SETEXPR=y
@@ -673,14 +783,20 @@ in {
 
   ubootWandboard = buildUBoot {
     defconfig = "wandboard_defconfig";
-    extraMeta.platforms = ["armv7l-linux"];
-    filesToInstall = ["u-boot.img" "SPL"];
+    extraMeta.platforms = [ "armv7l-linux" ];
+    filesToInstall = [
+      "u-boot.img"
+      "SPL"
+    ];
   };
 
   ubootRockPi4 = buildUBoot {
     defconfig = "rock-pi-4-rk3399_defconfig";
-    extraMeta.platforms = ["aarch64-linux"];
+    extraMeta.platforms = [ "aarch64-linux" ];
     BL31 = "${armTrustedFirmwareRK3399}/bl31.elf";
-    filesToInstall = [ "u-boot.itb" "idbloader.img"];
+    filesToInstall = [
+      "u-boot.itb"
+      "idbloader.img"
+    ];
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Build tested with an expression based on #347188.

```nix
let
  pkgs = import ./. { };
  inherit (pkgs) lib;
in

pkgs.linkFarm "uboot-all" (
  lib.mapAttrsToList
    (name: pkg: {
      inherit name;
      path = pkg;
    })
    (
      lib.mapAttrs
        (
          name: pkg:
          let
            inherit (pkg.meta) platforms;
          in
          if builtins.elem "x86_64-linux" platforms then
            pkgs.${name}
          else if builtins.elem "aarch64-linux" platforms then
            pkgs.pkgsCross.aarch64-multiplatform.${name}
          else if builtins.elem "armv7l-linux" platforms then
            pkgs.pkgsCross.armv7l-hf-multiplatform.${name}
          else if builtins.elem "riscv64-linux" platforms then
            pkgs.pkgsCross.riscv64.${name}
          else if builtins.elem "armv6l-linux" platforms then
            pkgs.pkgsCross.raspberryPi.${name}
          else if builtins.elem "armv5tel-linux" platforms then
            pkgs.pkgsCross.sheevaplug.${name}
          else
            builtins.throw "don't know how to build ${name} on platforms ${toString platforms}"
        )
        (
          lib.filterAttrs (
            name: _:
            (builtins.match "^uboot.*" name != null)
            && (!builtins.elem name [
              "ubootBeagleboneBlack" # The target is removed. Currently it is an error throwing alias.
            ])
          ) pkgs
        )
    )
)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
