### PR TITLE
nexttrace: 1.3.5 -> 1.3.7

### DIFF
--- a/pkgs/by-name/ne/nexttrace/package.nix
+++ b/pkgs/by-name/ne/nexttrace/package.nix
@@ -6,15 +6,15 @@
 
 buildGo122Module rec {
   pname = "nexttrace";
-  version = "1.3.5";
+  version = "1.3.7";
 
   src = fetchFromGitHub {
     owner = "nxtrace";
     repo = "NTrace-core";
     rev = "v${version}";
-    sha256 = "sha256-32QFgmvXQ+8ix1N9I6pJaIJGWOT67/FG0VVEhftwQQw=";
+    sha256 = "sha256-UmViXxyOvzs2ifG7y+OA+/BjzbF6YIc6sjDUN+ttS8w=";
   };
-  vendorHash = "sha256-WRH9doQavcdH1sd2fS8QoFSmlirBMZgSzB/sj1q6cUQ=";
+  vendorHash = "sha256-rSCg6TeCVdYldghmFCXtv2R9mQ97b3DogZhFcSTzt4o=";
 
   doCheck = false; # Tests require a network connection.
 


### PR DESCRIPTION
https://github.com/nxtrace/NTrace-core/releases/tag/v1.3.7

Did not update to Go 1.23 since the upstream recommendation of `-checklinkname=0` seems like a bad idea.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).