### PR TITLE
deepin.docparser: fix strictDeps build

### DIFF
--- a/pkgs/desktops/deepin/library/docparser/default.nix
+++ b/pkgs/desktops/deepin/library/docparser/default.nix
@@ -8,6 +8,7 @@
   pugixml,
   libzip,
   libuuid,
+  libxml2,
   tinyxml-2,
 }:
 
@@ -34,6 +35,7 @@ stdenv.mkDerivation rec {
     pugixml
     libzip
     libuuid
+    libxml2
     tinyxml-2
   ];
 


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468
Cross build probably broken due to qmake

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).