### PR TITLE
ocamlPackages.cohttp: manual update 5.3.1 -> 6.0.0, cohttp-eio, cohtt-http: init at 6.0.0

### DIFF
--- a/pkgs/development/ocaml-modules/cohttp/default.nix
+++ b/pkgs/development/ocaml-modules/cohttp/default.nix
@@ -3,6 +3,8 @@
   fetchurl,
   buildDunePackage,
   ppx_sexp_conv,
+  cohttp-http,
+  logs,
   base64,
   jsonm,
   re,
@@ -10,18 +12,19 @@
   uri-sexp,
   fmt,
   alcotest,
+  ppx_expect,
   crowbar,
 }:
 
 buildDunePackage rec {
   pname = "cohttp";
-  version = "5.3.1";
+  version = "6.0.0";
 
   minimalOCamlVersion = "4.08";
 
   src = fetchurl {
     url = "https://github.com/mirage/ocaml-cohttp/releases/download/v${version}/cohttp-${version}.tbz";
-    hash = "sha256-9eJz08Lyn/R71+Ftsj4fPWzQGkC+ACCJhbxDTIjUV2s=";
+    hash = "sha256-VMw0rxKLNC9K5gimaWUNZmYf/dUDJQ5N6ToaXvHvIqk=";
   };
 
   postPatch = ''
@@ -38,6 +41,8 @@ buildDunePackage rec {
     re
     stringext
     uri-sexp
+    cohttp-http
+    logs
   ];
 
   doCheck = true;
@@ -45,6 +50,7 @@ buildDunePackage rec {
     fmt
     alcotest
     crowbar
+    ppx_expect
   ];
 
   meta = {

--- a/pkgs/development/ocaml-modules/cohttp/eio.nix
+++ b/pkgs/development/ocaml-modules/cohttp/eio.nix
@@ -1,0 +1,35 @@
+{
+  buildDunePackage,
+  cohttp,
+  eio,
+  uri,
+  ppx_sexp_conv,
+  logs,
+  sexplib0,
+  ptime,
+}:
+
+buildDunePackage {
+  pname = "cohttp-eio";
+  inherit (cohttp)
+    version
+    src
+    ;
+
+  duneVersion = "3";
+
+  buildInputs = [ ppx_sexp_conv ];
+
+  propagatedBuildInputs = [
+    cohttp
+    eio
+    logs
+    sexplib0
+    uri
+    ptime
+  ];
+
+  meta = cohttp.meta // {
+    description = "CoHTTP implementation using the Lwt concurrency library";
+  };
+}

--- a/pkgs/development/ocaml-modules/cohttp/http.nix
+++ b/pkgs/development/ocaml-modules/cohttp/http.nix
@@ -1,0 +1,35 @@
+{
+  buildDunePackage,
+  cohttp,
+  base_quickcheck,
+  alcotest,
+  ppx_expect,
+  crowbar,
+}:
+
+buildDunePackage {
+  pname = "http";
+  inherit (cohttp)
+    version
+    src
+    ;
+
+  duneVersion = "3";
+
+  buildInputs = [ ];
+
+  doCheck = true;
+
+  propagatedBuildInputs = [ ];
+
+  checkInputs = [
+    base_quickcheck
+    alcotest
+    ppx_expect
+    crowbar
+  ];
+
+  meta = cohttp.meta // {
+    description = "Type definitions of HTTP essentials";
+  };
+}

--- a/pkgs/development/ocaml-modules/cohttp/lwt-jsoo.nix
+++ b/pkgs/development/ocaml-modules/cohttp/lwt-jsoo.nix
@@ -9,6 +9,7 @@
   js_of_ocaml-lwt,
   nodejs,
   lwt_ppx,
+  ppx_expect
 }:
 
 buildDunePackage {
@@ -31,6 +32,7 @@ buildDunePackage {
   checkInputs = [
     nodejs
     lwt_ppx
+    ppx_expect
   ];
 
   meta = cohttp-lwt.meta // {

--- a/pkgs/development/ocaml-modules/cohttp/top.nix
+++ b/pkgs/development/ocaml-modules/cohttp/top.nix
@@ -1,4 +1,8 @@
-{ buildDunePackage, cohttp }:
+{
+  buildDunePackage,
+  cohttp,
+  ppx_expect,
+}:
 
 buildDunePackage {
   pname = "cohttp-top";
@@ -7,6 +11,8 @@ buildDunePackage {
   duneVersion = "3";
 
   propagatedBuildInputs = [ cohttp ];
+
+  checkInputs = [ ppx_expect ];
 
   doCheck = true;
 

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -225,6 +225,10 @@ let
 
     cohttp-async = callPackage ../development/ocaml-modules/cohttp/async.nix { };
 
+    cohttp-eio = callPackage ../development/ocaml-modules/cohttp/eio.nix { };
+
+    cohttp-http = callPackage ../development/ocaml-modules/cohttp/http.nix { };
+
     cohttp-lwt = callPackage ../development/ocaml-modules/cohttp/lwt.nix { };
 
     cohttp-lwt-jsoo = callPackage ../development/ocaml-modules/cohttp/lwt-jsoo.nix { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
updates cohttp to 6.0.0 and adds the new cohttp-http base package and the new cohttp-eio package.

in 6.0.0, there are [more subpackages](https://github.com/mirage/ocaml-cohttp/tree/v6.0.0) which are not yet packaged.

the cohttp-http package is named "http" in opam but i've used cohttp-http here to be more explicit.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
