### PR TITLE
scipoptsuite: init at 9.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7844,6 +7844,12 @@
     githubId = 11705326;
     name = "Max Kochurov";
   };
+  fettgoenner = {
+    email = "paulmatti@protonmail.com";
+    github = "fettgoenner";
+    githubId = 92429150;
+    name = "Paul Meinhold";
+  };
   ffinkdevs = {
     email = "fink@h0st.space";
     github = "ffinkdevs";

--- a/pkgs/by-name/sc/scipopt-gcg/package.nix
+++ b/pkgs/by-name/sc/scipopt-gcg/package.nix
@@ -1,0 +1,65 @@
+{
+  lib,
+  pkgs,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  scipopt-scip,
+  cliquer,
+  gsl,
+  gmp,
+  bliss,
+  nauty,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scipopt-gcg";
+  version = "371";
+
+  # To correlate scipVersion and version, check: https://scipopt.org/#news
+  scipVersion = "9.2.1";
+
+  src = fetchFromGitHub {
+    owner = "scipopt";
+    repo = "gcg";
+    tag = "v${version}";
+    hash = "sha256-+rD8tGE49Irg9xZTD3Ay87ISSeRI4kbBpCj5ppyENbo=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    scipopt-scip
+    cliquer
+    gsl
+    gmp
+    bliss
+    nauty
+  ];
+
+  # Fixing the error
+  #   > CMake Error at CMakeLists.txt:236 (find_package):
+  #   >   By not providing "FindNAUTY.cmake" in CMAKE_MODULE_PATH this project has
+  #   >   asked CMake to find a package configuration file provided by "NAUTY", but
+  #   >   CMake did not find one.
+  # with this weird workaround of setting SCIPOptSuite_SOURCE_DIR to include the scipopt-scip source
+  # files via symlinks, so the specific nauty files are found:
+  preConfigure = ''
+    mkdir -pv $out/scip
+    ln -sv ${scipopt-scip.src}/src/ $out/scip/src
+    cmakeFlagsArray+=(
+      "-DSCIPOptSuite_SOURCE_DIR=$out"
+    )
+  '';
+  doCheck = true;
+  meta = {
+    maintainers = with lib.maintainers; [ fettgoenner ];
+    changelog = "https://scipopt.org/doc-${scipVersion}/html/RN${lib.versions.major scipVersion}.php";
+    description = "Branch-and-Price & Column Generation for Everyone";
+    license = lib.licenses.lgpl3Plus;
+    homepage = "https://gcg.zib.de";
+    mainProgram = "gcg";
+  };
+}

--- a/pkgs/by-name/sc/scipopt-papilo/package.nix
+++ b/pkgs/by-name/sc/scipopt-papilo/package.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  fetchFromGitHub,
+  boost,
+  blas,
+  gmp,
+  tbb_2021_11,
+  gfortran,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scipopt-papilo";
+  version = "2.4.1";
+
+  # To correlate scipVersion and version, check: https://scipopt.org/#news
+  scipVersion = "9.2.1";
+
+  src = fetchFromGitHub {
+    owner = "scipopt";
+    repo = "papilo";
+    tag = "v${version}";
+    hash = "sha256-oQ9iq5UkFK0ghUx6uxdJIOo5niQjniHegSZptqi2fgE=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    blas
+    gmp
+    gfortran
+    boost
+    tbb_2021_11
+  ];
+
+  cmakeFlags = [
+    # Disable automatic download of TBB.
+    (lib.cmakeBool "TBB_DOWNLOAD" false)
+
+    # Explicitly disable SoPlex as a built-in back-end solver to avoid this error:
+    #   > include/boost/multiprecision/mpfr.hpp:22: fatal error: mpfr.h: No such file or directory
+    #   > compilation terminated.
+    (lib.cmakeBool "SOPLEX" false)
+
+    # (lib.cmakeBool "GMP" true)
+    # (lib.cmakeBool "QUADMATH" true)
+    # (lib.cmakeBool "TBB" true)
+  ];
+  doCheck = true;
+  meta = {
+    maintainers = with lib.maintainers; [ fettgoenner ];
+    changelog = "https://scipopt.org/doc-${scipVersion}/html/RN${lib.versions.major scipVersion}.php";
+    description = "Parallel Presolve for Integer and Linear Optimization";
+    license = lib.licenses.lgpl3Plus;
+    homepage = "https://github.com/scipopt/papilo";
+    mainProgram = "papilo";
+  };
+}

--- a/pkgs/by-name/sc/scipopt-scip/package.nix
+++ b/pkgs/by-name/sc/scipopt-scip/package.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  fetchFromGitHub,
+  cmake,
+  zlib,
+  readline,
+  gmp,
+  scipopt-soplex,
+  scipopt-papilo,
+  scipopt-zimpl,
+  ipopt,
+  tbb_2021_11,
+  boost,
+  gfortran,
+  criterion,
+  mpfr,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scipopt-scip";
+  version = "9.2.1";
+
+  src = fetchFromGitHub {
+    owner = "scipopt";
+    repo = "scip";
+    tag = "v${lib.replaceStrings [ "." ] [ "" ] version}";
+    hash = "sha256-xYxbMZYYqFNInlct8Ju0SrksfJlwV9Q+AHjxq7xhfAs=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    scipopt-soplex
+    scipopt-papilo
+    scipopt-zimpl
+    ipopt
+    gmp
+    readline
+    zlib
+    tbb_2021_11
+    boost
+    gfortran
+    criterion
+    mpfr # if not included, throws fatal error: mpfr.h not found
+  ];
+
+  cmakeFlags = [ ];
+
+  doCheck = true;
+
+  meta = {
+    maintainers = with lib.maintainers; [ fettgoenner ];
+    changelog = "https://scipopt.org/doc-${version}/html/RN${lib.versions.major version}.php";
+    description = "Solving Constraint Integer Programs";
+    license = lib.licenses.asl20;
+    homepage = "https://github.com/scipopt/scip";
+    mainProgram = "scip";
+  };
+}

--- a/pkgs/by-name/sc/scipopt-soplex/package.nix
+++ b/pkgs/by-name/sc/scipopt-soplex/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  gmp,
+  mpfr,
+  zlib,
+  boost,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "scipopt-soplex";
+  version = "713";
+
+  # To correlate scipVersion and version, check: https://scipopt.org/#news
+  scipVersion = "9.2.1";
+
+  src = fetchFromGitHub {
+    owner = "scipopt";
+    repo = "soplex";
+    rev = "release-${builtins.replaceStrings [ "." ] [ "" ] finalAttrs.version}";
+    hash = "sha256-qI7VGPAm3ALzeiD/OgvlZ1w2GzHRYdBajTW5XdIN9pU=";
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  buildInputs = [
+    boost
+    gmp
+    mpfr
+    zlib
+  ];
+
+  strictDeps = true;
+
+  doCheck = true;
+
+  meta = {
+    homepage = "https://soplex.zib.de/";
+    description = "Sequential object-oriented simPlex";
+    license = with lib.licenses; [ asl20 ];
+    mainProgram = "soplex";
+    maintainers = with lib.maintainers; [ david-r-cox ];
+    changelog = "https://scipopt.org/doc-${finalAttrs.scipVersion}/html/RN${lib.versions.major finalAttrs.scipVersion}.php";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/pkgs/by-name/sc/scipopt-ug/package.nix
+++ b/pkgs/by-name/sc/scipopt-ug/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  cmake,
+  scipopt-scip,
+  zlib,
+  mpi,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scipopt-ug";
+  version = "1.0.0-beta6";
+
+  # To correlate scipVersion and version, check: https://scipopt.org/#news
+  scipVersion = "9.2.1";
+
+  # Take the SCIPOptSuite source since no other source exists publicly.
+  src = fetchzip {
+    url = "https://github.com/scipopt/scip/releases/download/v${
+      lib.replaceStrings [ "." ] [ "" ] scipVersion
+    }/scipoptsuite-${scipVersion}.tgz";
+    sha256 = "sha256-Hi6oDPtJZODTBIuRYE62sUMTJqfmF0flY3cGoWh2IZE=";
+  };
+
+  sourceRoot = "${src.name}/ug";
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    scipopt-scip
+    mpi
+    zlib
+  ];
+
+  meta = {
+    maintainers = with lib.maintainers; [ fettgoenner ];
+    changelog = "https://scipopt.org/doc-${scipVersion}/html/RN${lib.versions.major scipVersion}.php";
+    description = "Ubiquity Generator framework to parallelize branch-and-bound based solvers";
+    license = lib.licenses.lgpl3Plus;
+    homepage = "https://ug.zib.de";
+  };
+}

--- a/pkgs/by-name/sc/scipopt-zimpl/package.nix
+++ b/pkgs/by-name/sc/scipopt-zimpl/package.nix
@@ -1,0 +1,75 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  bison,
+  flex,
+  gmp,
+  zlib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "scipopt-zimpl";
+  version = "362";
+
+  # To correlate scipVersion and version, check: https://scipopt.org/#news
+  scipVersion = "9.2.1";
+
+  src = fetchFromGitHub {
+    owner = "scipopt";
+    repo = "zimpl";
+    tag = "v${version}";
+    sha256 = "juqAwzqBArsFXmz7L7RQaE78EhQdP5P51wQFlCoo7/o=";
+  };
+
+  postPatch = ''
+    chmod +x check/check.sh
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    bison
+    flex
+  ];
+
+  buildInputs = [
+    gmp
+    zlib
+  ];
+  doCheck = true;
+
+  checkPhase = ''
+    runHook preCheck
+    pushd ../check
+    ./check.sh ../build/bin/zimpl
+    popd
+    runHook postCheck
+  '';
+  meta = {
+    maintainers = with lib.maintainers; [ fettgoenner ];
+    changelog = "https://scipopt.org/doc-${scipVersion}/html/RN${lib.versions.major scipVersion}.php";
+    description = "Zuse Institut Mathematical Programming Language";
+    longDescription = ''
+      ZIMPL is a little language to translate the mathematical model of a
+      problem into a linear or (mixed-)integer mathematical program
+      expressed in .lp or .mps file format which can be read by a LP or MIP
+      solver.
+
+      If you use Zimpl for research and publish results, the best way
+      to refer to Zimpl is to cite my Ph.d. thesis:
+
+      @PHDTHESIS{Koch2004,
+         author      = "Thorsten Koch",
+         title       = "Rapid Mathematical Programming",
+         year        = "2004",
+         school      = "Technische {Universit\"at} Berlin",
+         url         = "http://www.zib.de/Publications/abstracts/ZR-04-58/",
+         note        = "ZIB-Report 04-58",
+      }
+    '';
+    license = lib.licenses.lgpl3Plus;
+    homepage = "https://zimpl.zib.de";
+    mainProgram = "zimpl";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Packaged all packages included in the [SCIP Optimization Suite](https://scipopt.org/),
an open-source toolbox for generating and solving mixed integer nonlinear programs.

I did not create an actual `scipoptsuite` package, just its parts. (If the PR name is confusing.)

Including these packages gives computer scientists, applied mathematicians and enthusiasts quick and easy access to this actively developed optimization suite.

~~Renamed preexisting package `soplex` to `scipopt-soplex` to fit the SCIP Optimization Suite package names and added additional necessary build inputs to it.~~
Kept old `soplex` around for now.

Added packages:
- `scipopt-soplex`
- `scipopt-scip`
- `scipopt-zimpl`
- `scipopt-papilo`
- `scipopt-gcg`
- `scipopt-ug`

And I referenced myself as the maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- ~~For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))~~
  - ~~[ ] `sandbox = relaxed`~~
  - ~~[ ] `sandbox = true`~~
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - ~~and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)~~
  - ~~or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)~~
  - ~~made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages~~
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---
@david-r-cox maybe you have opinions? :)