### PR TITLE
rav1d: init at 1.0.0

### DIFF
--- a/pkgs/by-name/ra/rav1d/package.nix
+++ b/pkgs/by-name/ra/rav1d/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  nasm,
+  meson,
+  ninja,
+  pkg-config,
+
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "rav1d";
+  version = "1.0.0";
+
+  src = fetchFromGitHub {
+    owner = "memorysafety";
+    repo = "rav1d";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-8Moj3v7cxPluzNPmOmGhYuz/Qh48BnBjN7Vt4f8aY2o=";
+  };
+
+  cargoHash = "sha256-M0j0zgDqElhG3Jgetjx2sL3rxLrShK0zTMmOXwNxBEI=";
+
+  nativeBuildInputs = [
+    nasm
+  ];
+
+  # Tests are using meson
+  # https://github.com/memorysafety/rav1d/tree/v1.0.0?tab=readme-ov-file#running-tests
+  nativeCheckInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  checkPhase =
+    let
+      cargoTarget = rustPlatform.cargoInstallHook.targetSubdirectory;
+    in
+    ''
+      runHook preCheck
+
+      patchShebangs .github/workflows/test.sh
+      .github/workflows/test.sh -r target/${cargoTarget}/release/dav1d
+
+      runHook postCheck
+    '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "AV1 cross-platform decoder, Rust port of dav1d";
+    homepage = "https://github.com/memorysafety/rav1d";
+    changelog = "https://github.com/memorysafety/rav1d/releases/tag/v${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ liberodark ];
+    mainProgram = "dav1d";
+  };
+})


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/348034

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
