### PR TITLE
Bump/jetbrains 2024.3.2

### DIFF
--- a/pkgs/applications/editors/jetbrains/bin/versions.json
+++ b/pkgs/applications/editors/jetbrains/bin/versions.json
@@ -11,10 +11,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "054eff2dcdb7779b97d940b5425ae7c56bfafd657367e3a749275ef6a0a40368",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1.tar.gz",
-      "build_number": "243.22562.225"
+      "version": "2024.3.2",
+      "sha256": "f21d72269bc0f3ce618f925ded44b5da440bcf1ec4ef3d83335acd90d020b6fa",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.2.tar.gz",
+      "build_number": "243.23654.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -43,26 +43,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "028cb0c004c1f0d6e46ce897784ea37291900a85ea49df47678c86aaea1ea681",
-      "url": "https://download.jetbrains.com/go/goland-2024.3.1.tar.gz",
-      "build_number": "243.22562.186"
+      "version": "2024.3.2",
+      "sha256": "6700ec71240cbde6002e9b28680b02f3a4b9ee0a7bd7a4d3bf5a13f67b8d53af",
+      "url": "https://download.jetbrains.com/go/goland-2024.3.2.tar.gz",
+      "build_number": "243.23654.119"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "b183b126de2cd457475eea184874b5da2fa33ba5ae2ff874bdc8c1d534156428",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1.tar.gz",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "ad9d587b704806d9a21dfebe5c51415df94699bba958d7133763cfd56934ced8",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.2.tar.gz",
+      "build_number": "243.23654.117"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "d80684aa73fe9dee14ea405058d54a34340266cf675bfbaf4c760da6eb2d3fe9",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1.tar.gz",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "05f30fff53c1b73f9c261e812c236134e203bf7d847424a27d9409fd6b0b6fcb",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.2.tar.gz",
+      "build_number": "243.23654.117"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -75,10 +75,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "8bb909b6322f296d4e44265223cffca2649e4344d1233b670f751c5b2d7ae698",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1.tar.gz",
-      "build_number": "243.22562.233",
+      "version": "2024.3.2",
+      "sha256": "922f11f877b66d1815d5440b4891421269d2d235112e2fa6270b61096db36c2f",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.2.tar.gz",
+      "build_number": "243.23654.115",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -108,26 +108,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "fe849fd90725f12c6dabb20973f1d5eb6fc9baddd692961197527326639d7def",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1.tar.gz",
-      "build_number": "243.22562.213"
+      "version": "2024.3.2",
+      "sha256": "8c064b6119062ae568df795c45054cbdf608951e9c59957d95879fed7c30714e",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.2.tar.gz",
+      "build_number": "243.23654.112"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.tar.gz",
-      "version": "2024.3.2",
-      "sha256": "c6549572baa913c9842b0227257f7477531269393d5989622a3d0b802b999bf8",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2.tar.gz",
-      "build_number": "243.22562.230"
+      "version": "2024.3.3",
+      "sha256": "abb5738327c0530c05be26b65abaead342e6aedb409b481dd537274d3dfd33f0",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.3.tar.gz",
+      "build_number": "243.23654.116"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "275999ca069658257d6f06875f283abf9c0b102bdf812cf7eefe86a1dda90c1b",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1.tar.gz",
-      "build_number": "243.22562.222"
+      "version": "2024.3.2",
+      "sha256": "2e9054ae506e578cf89e4cea017d953c416281470a4a5728b157e43ac4888d4e",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.2.tar.gz",
+      "build_number": "243.23654.120"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -150,10 +150,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "dacd54a45145ed65b2c40520706432449e4bc3ff2bb23be6cb1fb4c73d9db223",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1-aarch64.tar.gz",
-      "build_number": "243.22562.225"
+      "version": "2024.3.2",
+      "sha256": "95c19bbc97ebac6e61db214548a547dd3892e0e3520682a443006b4a682451df",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.23654.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -182,26 +182,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.tar.gz",
-      "version": "2024.3.1",
-      "sha256": "9292d1502e3fada094469c590a59465d105fb6c81988f5414dac792ef3ae9dc5",
-      "url": "https://download.jetbrains.com/go/goland-2024.3.1-aarch64.tar.gz",
-      "build_number": "243.22562.186"
+      "version": "2024.3.2",
+      "sha256": "46a83f45cbc7193483d19cacd79ab310adb7b88af859903c2dc7713835d53f6c",
+      "url": "https://download.jetbrains.com/go/goland-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.23654.119"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "8e82e9c1ff8bc561df88d9c6ef3b83498aecdac6f980b9df0cb183bc6dca0c90",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1-aarch64.tar.gz",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "0135027b97fcabd8f9e31d34cd2444323c63c894ef3f8c6eaf734fbecb8694ef",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.23654.117"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "b3487662edf0904de4bfcd069231068350f7d8e964c0718b88ecbc18a83e5f47",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1-aarch64.tar.gz",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "d41082d25ec1639d399a5cbbabf29afa8082d6eddff8b24e56107f159dbe85b4",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.23654.117"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -214,10 +214,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "d6f0cb476f3a83636b14e7b678d2e0a7f47e060c63bf31a5d645ee7e18adb0fa",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1-aarch64.tar.gz",
-      "build_number": "243.22562.233",
+      "version": "2024.3.2",
+      "sha256": "b01643f20e9db333baa5204f8e0cf7da2eb952ca9e5a526290daf8cb4b14b74f",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.23654.115",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -247,26 +247,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "af3cf7b5e8ac4306a4f5f03bcfc3425aa7ed3aa71f61213d85fd4f5a3d425b75",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1-aarch64.tar.gz",
-      "build_number": "243.22562.213"
+      "version": "2024.3.2",
+      "sha256": "8d6981e056bfded160b2a14d81aaa3ca45d1b102a9f58c11578389988c8c6441",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.23654.112"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.tar.gz",
-      "version": "2024.3.2",
-      "sha256": "d5187d7d449d1b1ec6ff2699c0ccdb3c3280841360d3f43c0318a41b865064c8",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2-aarch64.tar.gz",
-      "build_number": "243.22562.230"
+      "version": "2024.3.3",
+      "sha256": "7e002489c7167f39744d746127dc7a3f06d5cfbf9d63aa6a2835b0a80a261155",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.3-aarch64.tar.gz",
+      "build_number": "243.23654.116"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.tar.gz",
-      "version": "2024.3.1.1",
-      "sha256": "b136ec6696a47511a7396eb5416ff055964a040d72ed29eb6c362e1b37ce0ab5",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1-aarch64.tar.gz",
-      "build_number": "243.22562.222"
+      "version": "2024.3.2",
+      "sha256": "9914fe6e6b5f0a7e87c9628fdf70b5083b68ec14b8873ad6847e4ea8e8c80a96",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.2-aarch64.tar.gz",
+      "build_number": "243.23654.120"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -289,10 +289,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "276ae335421b6eddd1d7fbdc27fc826bf7ffa68e32a23f9335ff8be88d89b747",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1.dmg",
-      "build_number": "243.22562.225"
+      "version": "2024.3.2",
+      "sha256": "ecfb07f2ed3985a82faa940df4bbf195c421ba9a32c2c85dd56f057f40b9af38",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.2.dmg",
+      "build_number": "243.23654.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -321,26 +321,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}.dmg",
-      "version": "2024.3.1",
-      "sha256": "ec442f7a42cd95a7956d0ff4eb039f856e99451685a537dda9d67fbcd5b729e6",
-      "url": "https://download.jetbrains.com/go/goland-2024.3.1.dmg",
-      "build_number": "243.22562.186"
+      "version": "2024.3.2",
+      "sha256": "a8a0567d571f5bb94fe48cba6035db054f07db87c353765c823c90cb2f9783a1",
+      "url": "https://download.jetbrains.com/go/goland-2024.3.2.dmg",
+      "build_number": "243.23654.119"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "505d978a27d0691a7ad8070c005e74bb13862fbb880b75ae924aa4f4558047a0",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1.dmg",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "d60b7148d6d0da8d3bf1d43282d282d41ea8d7b3443d8173d4dd1e692c44ce9a",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.2.dmg",
+      "build_number": "243.23654.117"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "eca0be9cd1d35df6453075dd447c8945d97134b90d1de4313e9b98069d3a39a3",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1.dmg",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "eaa4fc6f6aecdf023965d76f391fa5d438193d1f2fe42d6a8c2cffab7599c22b",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.2.dmg",
+      "build_number": "243.23654.117"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -353,10 +353,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "30a6f0cffa15034578bd026a80d3faf4469c2123d319a805cc31bfc59f2097a8",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1.dmg",
-      "build_number": "243.22562.233",
+      "version": "2024.3.2",
+      "sha256": "df4b63e60d22a63d75f1780dc1354b570982eca6d4462ced232c2492a158d520",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.2.dmg",
+      "build_number": "243.23654.115",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -386,26 +386,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "6762f4987be03eb4d6adccc8b9e093598a86c77d341695792c985d9a35b84703",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1.dmg",
-      "build_number": "243.22562.213"
+      "version": "2024.3.2",
+      "sha256": "a70feb35207706d25d5da7357f4e3ac0d8af63c43e6bbe0d350681745586dd2e",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.2.dmg",
+      "build_number": "243.23654.112"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}.dmg",
-      "version": "2024.3.2",
-      "sha256": "85ba87fc294d957c3e8efe51633589fd252bc9e6608eb2dbe4b8e5492ef75788",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2.dmg",
-      "build_number": "243.22562.230"
+      "version": "2024.3.3",
+      "sha256": "b33400542422d7b3a0206014347de2e7a299c76b49ebf8aa8c8728f2a995309c",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.3.dmg",
+      "build_number": "243.23654.116"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "cff8b644670fc36aea9f37cd26dbfc1418177b835dd455beb99b8fa483d68063",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1.dmg",
-      "build_number": "243.22562.222"
+      "version": "2024.3.2",
+      "sha256": "c95225ad78b1109feccf539c9005aa3ddf1388459a3af0fa49571f5643591dbd",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.2.dmg",
+      "build_number": "243.23654.120"
     },
     "writerside": {
       "update-channel": "Writerside EAP",
@@ -428,10 +428,10 @@
     "clion": {
       "update-channel": "CLion RELEASE",
       "url-template": "https://download.jetbrains.com/cpp/CLion-{version}-aarch64.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "57d7040f197dc1859ab16636bbb7006acc542eb15d1892692e78dc205bae2502",
-      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.1.1-aarch64.dmg",
-      "build_number": "243.22562.225"
+      "version": "2024.3.2",
+      "sha256": "fd9fdca6467ddc6baf24f85afb1b5f07b907521102523a8379ea35acd58492ee",
+      "url": "https://download.jetbrains.com/cpp/CLion-2024.3.2-aarch64.dmg",
+      "build_number": "243.23654.114"
     },
     "datagrip": {
       "update-channel": "DataGrip RELEASE",
@@ -460,26 +460,26 @@
     "goland": {
       "update-channel": "GoLand RELEASE",
       "url-template": "https://download.jetbrains.com/go/goland-{version}-aarch64.dmg",
-      "version": "2024.3.1",
-      "sha256": "4805e527a7d0cb66c278fcdba70468e14854defc3619edad439763d355303eba",
-      "url": "https://download.jetbrains.com/go/goland-2024.3.1-aarch64.dmg",
-      "build_number": "243.22562.186"
+      "version": "2024.3.2",
+      "sha256": "75579b5b6815d3f365c72b18d0455eb8402ae0a53d714e2776a75716383d402e",
+      "url": "https://download.jetbrains.com/go/goland-2024.3.2-aarch64.dmg",
+      "build_number": "243.23654.119"
     },
     "idea-community": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIC-{version}-aarch64.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "ea8c050308c46e276055193d882daa6d965f33256a447c05d5ad9f22b54e5d14",
-      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.1.1-aarch64.dmg",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "1cc440d163460d345aa31ccb9ca9309218f4f887ceddcd8eddf96d09b0218250",
+      "url": "https://download.jetbrains.com/idea/ideaIC-2024.3.2-aarch64.dmg",
+      "build_number": "243.23654.117"
     },
     "idea-ultimate": {
       "update-channel": "IntelliJ IDEA RELEASE",
       "url-template": "https://download.jetbrains.com/idea/ideaIU-{version}-aarch64.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "308773c0f5d15754fbdf1bbaf2155e34b8808880afdee55e5ac8bad8d477162d",
-      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1-aarch64.dmg",
-      "build_number": "243.22562.218"
+      "version": "2024.3.2",
+      "sha256": "60c96ca67507f811d66ac1fa42a2a93d3310c4457f32689a6e10d0a04e6bc34a",
+      "url": "https://download.jetbrains.com/idea/ideaIU-2024.3.2-aarch64.dmg",
+      "build_number": "243.23654.117"
     },
     "mps": {
       "update-channel": "MPS RELEASE",
@@ -492,10 +492,10 @@
     "phpstorm": {
       "update-channel": "PhpStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webide/PhpStorm-{version}-aarch64.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "8d9a3251fea4611c8b90d010571965993836ff1738bc55c2c3692f37f6169eed",
-      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1-aarch64.dmg",
-      "build_number": "243.22562.233",
+      "version": "2024.3.2",
+      "sha256": "0fcec802f70143b926db9ce7700331dadf85063ea310cbb0360bc7428ec385bf",
+      "url": "https://download.jetbrains.com/webide/PhpStorm-2024.3.2-aarch64.dmg",
+      "build_number": "243.23654.115",
       "version-major-minor": "2022.3"
     },
     "pycharm-community": {
@@ -525,26 +525,26 @@
     "ruby-mine": {
       "update-channel": "RubyMine RELEASE",
       "url-template": "https://download.jetbrains.com/ruby/RubyMine-{version}-aarch64.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "1e96dcbaf0b6d6821de44f394a671780b21e88fbb05a3cf67d90fcfb9dcbc559",
-      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1-aarch64.dmg",
-      "build_number": "243.22562.213"
+      "version": "2024.3.2",
+      "sha256": "c2285b17539f77667897dc2534182f0d9f1e8f8cd48c970f1ea9fa37b38704ce",
+      "url": "https://download.jetbrains.com/ruby/RubyMine-2024.3.2-aarch64.dmg",
+      "build_number": "243.23654.112"
     },
     "rust-rover": {
       "update-channel": "RustRover RELEASE",
       "url-template": "https://download.jetbrains.com/rustrover/RustRover-{version}-aarch64.dmg",
-      "version": "2024.3.2",
-      "sha256": "2d715c9a4137815a45abcd208121ef5d66f2b89d3f041d5e905e45c487834985",
-      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.2-aarch64.dmg",
-      "build_number": "243.22562.230"
+      "version": "2024.3.3",
+      "sha256": "0777399d545ff01a4c65fde3eaa7917556b60d1cc474a29dc68bb20fcf717575",
+      "url": "https://download.jetbrains.com/rustrover/RustRover-2024.3.3-aarch64.dmg",
+      "build_number": "243.23654.116"
     },
     "webstorm": {
       "update-channel": "WebStorm RELEASE",
       "url-template": "https://download.jetbrains.com/webstorm/WebStorm-{version}-aarch64.dmg",
-      "version": "2024.3.1.1",
-      "sha256": "afa44c3603ecdf093ab701b19e6bfc5379a45f27c0df54a507d48c20b7941bb8",
-      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1-aarch64.dmg",
-      "build_number": "243.22562.222"
+      "version": "2024.3.2",
+      "sha256": "de4ac18cf6002b7540a9fe3ec5c774cd4cf4021bf57893164e38971ec1efc2b4",
+      "url": "https://download.jetbrains.com/webstorm/WebStorm-2024.3.2-aarch64.dmg",
+      "build_number": "243.23654.120"
     },
     "writerside": {
       "update-channel": "Writerside EAP",

--- a/pkgs/applications/editors/jetbrains/plugins/plugins.json
+++ b/pkgs/applications/editors/jetbrains/plugins/plugins.json
@@ -18,16 +18,17 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.22562.250": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip",
-        "243.23654.19": "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip"
       },
       "name": "ideavim"
     },
@@ -36,7 +37,7 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/631/654554/python-243.22562.218.zip"
+        "243.23654.117": "https://plugins.jetbrains.com/files/631/666772/python-243.23654.117.zip"
       },
       "name": "python"
     },
@@ -46,7 +47,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/1347/652338/scala-intellij-bin-2024.3.23.zip"
+        "243.22562.218": "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip"
       },
       "name": "scala"
     },
@@ -68,15 +70,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip"
       },
       "name": "string-manipulation"
@@ -99,15 +102,16 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": null,
-        "243.22562.213": null,
         "243.22562.218": null,
         "243.22562.220": null,
-        "243.22562.222": null,
-        "243.22562.225": null,
-        "243.22562.230": null,
-        "243.22562.233": null,
         "243.22562.250": null,
+        "243.23654.112": null,
+        "243.23654.114": null,
+        "243.23654.115": null,
+        "243.23654.116": null,
+        "243.23654.117": null,
+        "243.23654.119": null,
+        "243.23654.120": null,
         "243.23654.19": null
       },
       "name": "kotlin"
@@ -130,16 +134,17 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip",
-        "243.23654.19": "https://plugins.jetbrains.com/files/6981/654857/ini-243.23654.19.zip"
+        "243.23654.112": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip"
       },
       "name": "ini"
     },
@@ -161,15 +166,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip"
       },
       "name": "acejump"
@@ -180,8 +186,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
+        "243.23654.115": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip"
       },
       "name": "symfony-support"
     },
@@ -191,8 +197,8 @@
         "phpstorm"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
+        "243.23654.115": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip"
       },
       "name": "php-annotations"
     },
@@ -209,14 +215,15 @@
         "webstorm"
       ],
       "builds": {
-        "243.22562.186": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip",
-        "243.23654.19": "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip"
+        "243.23654.114": "https://plugins.jetbrains.com/files/7322/666773/python-ce-243.23654.117.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/7322/666773/python-ce-243.23654.117.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/7322/666773/python-ce-243.23654.117.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/7322/666773/python-ce-243.23654.117.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/7322/666773/python-ce-243.23654.117.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/7322/666773/python-ce-243.23654.117.zip"
       },
       "name": "python-community-edition"
     },
@@ -238,15 +245,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/7391/561441/asciidoctor-intellij-plugin-0.42.2.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip"
       },
       "name": "asciidoc"
@@ -268,14 +276,15 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": null,
-        "243.22562.213": null,
         "243.22562.218": null,
         "243.22562.220": null,
-        "243.22562.222": null,
-        "243.22562.225": null,
-        "243.22562.233": null,
         "243.22562.250": null,
+        "243.23654.112": null,
+        "243.23654.114": null,
+        "243.23654.115": null,
+        "243.23654.117": null,
+        "243.23654.119": null,
+        "243.23654.120": null,
         "243.23654.19": null
       },
       "name": "-deprecated-rust"
@@ -297,14 +306,15 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": null,
-        "243.22562.213": null,
         "243.22562.218": null,
         "243.22562.220": null,
-        "243.22562.222": null,
-        "243.22562.225": null,
-        "243.22562.233": null,
         "243.22562.250": null,
+        "243.23654.112": null,
+        "243.23654.114": null,
+        "243.23654.115": null,
+        "243.23654.117": null,
+        "243.23654.119": null,
+        "243.23654.120": null,
         "243.23654.19": null
       },
       "name": "-deprecated-rust-beta"
@@ -327,16 +337,17 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip",
-        "243.23654.19": "https://plugins.jetbrains.com/files/8554/654851/featuresTrainer-243.23654.19.zip"
+        "243.23654.112": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip"
       },
       "name": "ide-features-trainer"
     },
@@ -358,15 +369,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip"
       },
       "name": "nixidea"
@@ -377,8 +389,8 @@
         "idea-ultimate"
       ],
       "builds": {
-        "243.22562.186": "https://plugins.jetbrains.com/files/9568/654587/go-plugin-243.22562.218.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/9568/654587/go-plugin-243.22562.218.zip"
+        "243.23654.117": "https://plugins.jetbrains.com/files/9568/666746/go-plugin-243.23654.117.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/9568/666746/go-plugin-243.23654.117.zip"
       },
       "name": "go"
     },
@@ -400,15 +412,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/10037/585243/CSVEditor-3.4.0-241.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip"
       },
       "name": "csv-editor"
@@ -430,17 +443,18 @@
         "webstorm"
       ],
       "builds": {
-        "241.19072.1155": "https://plugins.jetbrains.com/files/11349/653392/aws-toolkit-jetbrains-standalone-3.46-241.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.218": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.220": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.22562.250": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip",
-        "243.23654.19": "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip"
+        "241.19072.1155": "https://plugins.jetbrains.com/files/11349/666864/aws-toolkit-jetbrains-standalone-3.48-241.zip",
+        "243.22562.218": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.22562.220": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.22562.250": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip",
+        "243.23654.19": "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip"
       },
       "name": "aws-toolkit"
     },
@@ -462,15 +476,16 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip"
       },
       "name": "vscode-keymap"
@@ -492,16 +507,17 @@
         "webstorm"
       ],
       "builds": {
-        "241.19072.1155": "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "241.19072.1155": null,
         "243.22562.218": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip"
       },
       "name": "eclipse-keymap"
@@ -524,15 +540,16 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip"
       },
       "name": "visual-studio-keymap"
@@ -555,15 +572,16 @@
       ],
       "builds": {
         "241.19072.1155": null,
-        "243.22562.186": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip"
       },
       "name": "protocol-buffers"
@@ -586,15 +604,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.186": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.213": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.22562.218": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.22562.220": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.222": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.225": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.230": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
-        "243.22562.233": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.22562.250": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.112": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.114": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.115": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.116": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.117": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.119": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
+        "243.23654.120": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar",
         "243.23654.19": "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar"
       },
       "name": "darcula-pitch-black"
@@ -617,15 +636,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/17718/654596/github-copilot-intellij-1.5.30-231.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip"
       },
       "name": "github-copilot"
@@ -648,15 +668,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip"
       },
       "name": "netbeans-6-5-keymap"
@@ -679,15 +700,16 @@
       ],
       "builds": {
         "241.19072.1155": "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip",
-        "243.22562.186": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.213": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.22562.218": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.22562.220": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.222": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
-        "243.22562.233": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.22562.250": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.112": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.114": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.115": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.119": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
+        "243.23654.120": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip",
         "243.23654.19": "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip"
       },
       "name": "mermaid"
@@ -699,9 +721,9 @@
         "rust-rover"
       ],
       "builds": {
-        "243.22562.218": "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip",
-        "243.22562.225": "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip",
-        "243.22562.230": "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip"
+        "243.23654.114": "https://plugins.jetbrains.com/files/22407/666537/intellij-rust-243.23654.116.zip",
+        "243.23654.116": "https://plugins.jetbrains.com/files/22407/666537/intellij-rust-243.23654.116.zip",
+        "243.23654.117": "https://plugins.jetbrains.com/files/22407/666537/intellij-rust-243.23654.116.zip"
       },
       "name": "rust"
     }
@@ -709,37 +731,37 @@
   "files": {
     "https://plugins.jetbrains.com/files/10037/585243/CSVEditor-3.4.0-241.zip": "sha256-QwguD4ENrL7GxmX+CGEyCPowbAPNpYgntVGAbHxOlyQ=",
     "https://plugins.jetbrains.com/files/10037/658496/intellij-csv-validator-4.0.2.zip": "sha256-frvQ+Dm1ueID6+vNlja0HtecGyn+ppq9GTgmU3kQ+58=",
-    "https://plugins.jetbrains.com/files/11349/653392/aws-toolkit-jetbrains-standalone-3.46-241.zip": "sha256-oaD/caqrSYNPy579UeswUNKCr6R7Nzj/1ZXLjVY3Q6w=",
-    "https://plugins.jetbrains.com/files/11349/653394/aws-toolkit-jetbrains-standalone-3.46-243.zip": "sha256-5dTE4THfqFutMNbGe11CvQkPaXWwB/EuxBzlDzbRJ1s=",
+    "https://plugins.jetbrains.com/files/11349/666864/aws-toolkit-jetbrains-standalone-3.48-241.zip": "sha256-2bz6CZQr+pQ5Sl+zhBnfKBQMyTF5wBk+Xk3Y+wh5c48=",
+    "https://plugins.jetbrains.com/files/11349/666866/aws-toolkit-jetbrains-standalone-3.48-243.zip": "sha256-jKcanbs0qobJebe4onrSY43xp6V7ViAOVZNEMyaSvkY=",
     "https://plugins.jetbrains.com/files/12062/630060/keymap-vscode-243.21565.122.zip": "sha256-phv8MTGKNGzRviKzX+nIVTbkX4WkU82QVO5zXUQLtAo=",
-    "https://plugins.jetbrains.com/files/12559/508216/keymap-eclipse-241.14494.150.zip": "sha256-/hEx0gIFvUXD799tRmMHAt9Z5ziFgaQs1RX0zQwTJIA=",
     "https://plugins.jetbrains.com/files/12559/629985/keymap-eclipse-243.21565.122.zip": "sha256-/g1ucT18ywVJnCePH7WyMWKgM9umowBz5wFObmO7cws=",
     "https://plugins.jetbrains.com/files/13017/630016/keymap-visualStudio-243.21565.122.zip": "sha256-VQqK0Cm9ddXN63KYIqimuGOh7EB9VvdlErp/VrWx8SA=",
-    "https://plugins.jetbrains.com/files/1347/652338/scala-intellij-bin-2024.3.23.zip": "sha256-K7MiFc5mcECDKI2P2Kh3/w9sPdze6LuEhAItUxgpdKM=",
+    "https://plugins.jetbrains.com/files/1347/667258/scala-intellij-bin-2024.3.35.zip": "sha256-4I75KqXyFl73S63O+00usrg8QBcuBRBgfjRmCQMpNks=",
     "https://plugins.jetbrains.com/files/14004/636643/protoeditor-243.22562.13.zip": "sha256-Tgu8CfDhO6KugfuLNhmxe89dMm+Qo3fmAg/8hwjUaoc=",
     "https://plugins.jetbrains.com/files/14059/82616/darcula-pitch-black.jar": "sha256-eXInfAqY3yEZRXCAuv3KGldM1pNKEioNwPB0rIGgJFw=",
     "https://plugins.jetbrains.com/files/164/590339/IdeaVIM-2.16.0.zip": "sha256-uMIrYoZE16X/K96HuDJx8QMh6wUbi4+qSw+HJAq7ukI=",
-    "https://plugins.jetbrains.com/files/164/635855/IdeaVIM-2.17.0.zip": "sha256-ESbvyp66+X2Ko+bol3mk8aLIf8xjG7Qa0vz8k/zYl4A=",
+    "https://plugins.jetbrains.com/files/164/666347/IdeaVIM-2.18.1.zip": "sha256-wkh88imoNLt9Q7M6chu28+e0EhudpVGN4ZhvfSdj/l4=",
     "https://plugins.jetbrains.com/files/17718/654596/github-copilot-intellij-1.5.30-231.zip": "sha256-xrZJBCGPT1s5+fyWsMSEC69vILM+BkKef2wKxzbTCM4=",
     "https://plugins.jetbrains.com/files/17718/654597/github-copilot-intellij-1.5.30-242.zip": "sha256-bWrtG3cE6qAqXiQ4mtgRLutt8XaTqts+kyClDWVcMO4=",
     "https://plugins.jetbrains.com/files/18444/165585/NetBeans6.5Keymap.zip": "sha256-KrzZTKZMQqoEMw+vDUv2jjs0EX0leaPBkU8H/ecq/oI=",
     "https://plugins.jetbrains.com/files/20146/537545/Mermaid-0.0.22_IJ.232.zip": "sha256-DUiIQYIzYoXmgtBakSLtMB+xxJMaR70Jgg9erySa3wQ=",
     "https://plugins.jetbrains.com/files/20146/633971/Mermaid-0.0.24_IJ.243.zip": "sha256-jGWRU0g120qYvvFiUFI10zvprTsemuIq3XmIjYxZGts=",
     "https://plugins.jetbrains.com/files/2162/640476/StringManipulation-9.15.0.zip": "sha256-TZPup3EJ0cBv4i2eVAQwVmmzy0rmt4KptEsk3C7baEM=",
-    "https://plugins.jetbrains.com/files/22407/654680/intellij-rust-243.22562.230.zip": "sha256-80iFSJoUMunKj7iiXxOC2OuoUxYNeTt/E/MMLM5FsDU=",
-    "https://plugins.jetbrains.com/files/631/654554/python-243.22562.218.zip": "sha256-hI+f5TXP6B7LDBmvrRYrDJ/XKYIl7Tjv9gEda3EsU0c=",
-    "https://plugins.jetbrains.com/files/6981/654857/ini-243.23654.19.zip": "sha256-w/uvHVEOuP9a2tvvH8XUxiahqMMbTIZuDu3TS/kg920=",
+    "https://plugins.jetbrains.com/files/22407/666537/intellij-rust-243.23654.116.zip": "sha256-abOkEYViOYFht9hk4KhqANfk63q4rp3ywenXeKj2ovQ=",
+    "https://plugins.jetbrains.com/files/631/666772/python-243.23654.117.zip": "sha256-UGGhKZGlnq+MrTWfpb3eiIGkLkJE77V4sLKZi16oATU=",
     "https://plugins.jetbrains.com/files/6981/654905/ini-243.22562.236.zip": "sha256-kL/A2R8j2JKMU61T/xJahPwKPYmwFCFy55NPSoBh/Xc=",
+    "https://plugins.jetbrains.com/files/6981/667161/ini-243.23654.119.zip": "sha256-MhN7iARzX/xB3H1sC5T2A3psMNDmws0QGhQOUqhGlIc=",
     "https://plugins.jetbrains.com/files/7086/518678/AceJump.zip": "sha256-kVUEgfEKUupV/qlB4Dpzi5pFHjhVvX74XIPetKtjysM=",
     "https://plugins.jetbrains.com/files/7086/610924/AceJump.zip": "sha256-Qp24juITBXEF5izdzayWq28Ioy4/kgT0qz6snZ0dND0=",
     "https://plugins.jetbrains.com/files/7219/605730/Symfony_Plugin-2024.1.276.zip": "sha256-drNmhJMe+kuY2fcHjY+SQmkACvFk0rVI4vAhyZ/bgLc=",
     "https://plugins.jetbrains.com/files/7320/630497/PHP_Annotations-11.1.1.zip": "sha256-05aBYbqNIuwe/JTwntFdIqML8NHbTOwVusl1P9FzuYY=",
     "https://plugins.jetbrains.com/files/7322/646590/python-ce-243.22562.145.zip": "sha256-45UtQRZMtKF6addrrB3A+goeyICMfcZ2FKcJvJSqgg4=",
+    "https://plugins.jetbrains.com/files/7322/666773/python-ce-243.23654.117.zip": "sha256-l6ePJtwdj6+k7Qvpus9zGqIs141eT0/qTeZL0Ud4rM0=",
     "https://plugins.jetbrains.com/files/7391/561441/asciidoctor-intellij-plugin-0.42.2.zip": "sha256-oKczkLHAk2bJRNRgToVe0ySEJGF8+P4oWqQ33olwzWw=",
     "https://plugins.jetbrains.com/files/7391/658997/asciidoctor-intellij-plugin-0.43.6.zip": "sha256-3RJ7YVFtynyqeLIzdrirCMbWNZmUkJ+DT/9my71H0Dk=",
     "https://plugins.jetbrains.com/files/8554/654690/featuresTrainer-243.22562.233.zip": "sha256-JugbJM8Lr2kbhP9hdLE3kUStl2vOMUB5wGTwNLxAZd0=",
-    "https://plugins.jetbrains.com/files/8554/654851/featuresTrainer-243.23654.19.zip": "sha256-2z9QMebAjCuddPawPUaFdT2U3CN0YYyDqiP0zDoK7Ig=",
+    "https://plugins.jetbrains.com/files/8554/666817/featuresTrainer-243.23654.115.zip": "sha256-3HiNFTBJ1b/6IvMMkMCmNVo/4VMtTTKeiC6XqR6LIUs=",
     "https://plugins.jetbrains.com/files/8607/606922/NixIDEA-0.4.0.16.zip": "sha256-9GMqs/hSavcw1E4ZJTLDH1lx3HEeQ5NR8BT+Q9pN3io=",
-    "https://plugins.jetbrains.com/files/9568/654587/go-plugin-243.22562.218.zip": "sha256-dEPywEl/uboDTTv9k8G8sACOrC5HBcMqkxf0CsDmZfg="
+    "https://plugins.jetbrains.com/files/9568/666746/go-plugin-243.23654.117.zip": "sha256-8Y7JyjX8ytias4ix1azWkhPEVYXDomWRiMQlrKco9zM="
   }
 }


### PR DESCRIPTION
```
    jetbrains: 2024.3.1 -> 2024.3.3
    
    jetbrains.clion: 2024.3.1.1 -> 2024.3.2
    jetbrains.goland: 2024.3.1 -> 2024.3.2
    jetbrains.idea-community: 2024.3.1.1 -> 2024.3.2
    jetbrains.idea-ultimate: 2024.3.1.1 -> 2024.3.2
    jetbrains.phpstorm: 2024.3.1.1 -> 2024.3.2
    jetbrains.ruby-mine: 2024.3.1.1 -> 2024.3.2
    jetbrains.rust-rover: 2024.3.2 -> 2024.3.3
    jetbrains.webstorm: 2024.3.1.1 -> 2024.3.2
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
