### PR TITLE
nixos/mediamtx: restart service on failure

### DIFF
--- a/nixos/modules/services/video/mediamtx.nix
+++ b/nixos/modules/services/video/mediamtx.nix
@@ -66,6 +66,7 @@ in
         Group = "mediamtx";
         SupplementaryGroups = lib.mkIf cfg.allowVideoAccess "video";
         ExecStart = "${cfg.package}/bin/mediamtx /etc/mediamtx.yaml";
+        Restart = "always";
       };
     };
   };

--- a/nixos/modules/services/video/mediamtx.nix
+++ b/nixos/modules/services/video/mediamtx.nix
@@ -66,7 +66,7 @@ in
         Group = "mediamtx";
         SupplementaryGroups = lib.mkIf cfg.allowVideoAccess "video";
         ExecStart = "${cfg.package}/bin/mediamtx /etc/mediamtx.yaml";
-        Restart = "always";
+        Restart = "on-failure";
       };
     };
   };


### PR DESCRIPTION
I had mediamtx crash and fail to restart, this will make sure it actually restarts.