### PR TITLE
mysql80: fix darwin and LLVM 19 build

### DIFF
--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   bison,
   cmake,
   pkg-config,
@@ -47,12 +48,20 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     ./no-force-outline-atomics.patch # Do not force compilers to turn on -moutline-atomics switch
+    # Fix compilation with LLVM 19, adapted from https://github.com/mysql/mysql-server/commit/3a51d7fca76e02257f5c42b6a4fc0c5426bf0421
+    # in https://github.com/NixOS/nixpkgs/pull/374591#issuecomment-2615855076
+    ./libcpp-fixes.patch
+    (fetchpatch {
+      url = "https://github.com/mysql/mysql-server/commit/4a5c00d26f95faa986ffed7a15ee15e868e9dcf2.patch";
+      hash = "sha256-MEl1lQlDYtFjHk0+S02RQFnxMr+YeFxAyNjpDtVHyeE=";
+    })
   ];
 
   ## NOTE: MySQL upstream frequently twiddles the invocations of libtool. When updating, you might proactively grep for libtool references.
-  postPatch = ''
-    substituteInPlace cmake/libutils.cmake --replace /usr/bin/libtool libtool
-    substituteInPlace cmake/os/Darwin.cmake --replace /usr/bin/libtool libtool
+  postPatch = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    substituteInPlace cmake/libutils.cmake --replace-fail /usr/bin/libtool ${cctools}/bin/libtool
+    substituteInPlace cmake/os/Darwin.cmake --replace-fail /usr/bin/libtool ${cctools}/bin/libtool
+    substituteInPlace cmake/package_name.cmake --replace-fail "COMMAND sw_vers" "COMMAND ${DarwinTools}/bin/sw_vers"
   '';
 
   buildInputs =
@@ -77,10 +86,8 @@ stdenv.mkDerivation (finalAttrs: {
       libtirpc
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      cctools
       CoreServices
       developer_cmds
-      DarwinTools
     ];
 
   strictDeps = true;

--- a/pkgs/servers/sql/mysql/libcpp-fixes.patch
+++ b/pkgs/servers/sql/mysql/libcpp-fixes.patch
@@ -1,0 +1,183 @@
+diff --git a/include/my_char_traits.h b/include/my_char_traits.h
+new file mode 100644
+index 00000000..6336bc03
+--- /dev/null
++++ b/include/my_char_traits.h
+@@ -0,0 +1,65 @@
++/* Copyright (c) 2024, Oracle and/or its affiliates.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU General Public License, version 2.0,
++   as published by the Free Software Foundation.
++
++   This program is designed to work with certain software (including
++   but not limited to OpenSSL) that is licensed under separate terms,
++   as designated in a particular file or component or in included license
++   documentation.  The authors of MySQL hereby grant you an additional
++   permission to link the program and your derivative works with the
++   separately licensed software that they have either included with
++   the program or referenced in the documentation.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU General Public License, version 2.0, for more details.
++
++   You should have received a copy of the GNU General Public License
++   along with this program; if not, write to the Free Software
++   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
++
++#ifndef MY_CHAR_TRAITS_INCLUDED
++#define MY_CHAR_TRAITS_INCLUDED
++
++#include <cstring>
++
++template <class CharT>
++struct my_char_traits;
++
++/*
++  This is a standards-compliant, drop-in replacement for
++    std::char_traits<unsigned char>
++  We need this because clang libc++ is removing support for it in clang 19.
++  It is not a complete implementation. Rather we implement just enough to
++  compile any usage of char_traits<uchar> we have in our codebase.
++ */
++template <>
++struct my_char_traits<unsigned char> {
++  using char_type = unsigned char;
++  using int_type = unsigned int;
++
++  static void assign(char_type &c1, const char_type &c2) { c1 = c2; }
++
++  static char_type *assign(char_type *s, std::size_t n, char_type a) {
++    return static_cast<char_type *>(memset(s, a, n));
++  }
++
++  static int compare(const char_type *s1, const char_type *s2, std::size_t n) {
++    return memcmp(s1, s2, n);
++  }
++
++  static char_type *move(char_type *s1, const char_type *s2, std::size_t n) {
++    if (n == 0) return s1;
++    return static_cast<char_type *>(memmove(s1, s2, n));
++  }
++
++  static char_type *copy(char_type *s1, const char_type *s2, std::size_t n) {
++    if (n == 0) return s1;
++    return static_cast<char_type *>(memcpy(s1, s2, n));
++  }
++};
++
++#endif  // MY_CHAR_TRAITS_INCLUDED
+diff --git a/sql/mdl_context_backup.h b/sql/mdl_context_backup.h
+index 89e7e23d..cf9c307e 100644
+--- a/sql/mdl_context_backup.h
++++ b/sql/mdl_context_backup.h
+@@ -28,6 +28,7 @@
+ #include <map>
+ #include <memory>
+ 
++#include "my_char_traits.h"
+ #include "sql/malloc_allocator.h"
+ #include "sql/mdl.h"
+ 
+@@ -47,7 +48,8 @@ class MDL_context_backup_manager {
+   /**
+     Key for uniquely identifying MDL_context in the MDL_context_backup map.
+   */
+-  typedef std::basic_string<uchar> MDL_context_backup_key;
++  using MDL_context_backup_key =
++      std::basic_string<uchar, my_char_traits<uchar>>;
+ 
+   class MDL_context_backup;
+ 
+diff --git a/sql/stream_cipher.h b/sql/stream_cipher.h
+index 606d4064..358fbb41 100644
+--- a/sql/stream_cipher.h
++++ b/sql/stream_cipher.h
+@@ -28,6 +28,8 @@
+ #include <memory>
+ #include <string>
+ 
++#include "my_char_traits.h"
++
+ /**
+   @file stream_cipher.h
+ 
+@@ -35,7 +37,8 @@
+          binary log files.
+ */
+ 
+-typedef std::basic_string<unsigned char> Key_string;
++using Key_string =
++    std::basic_string<unsigned char, my_char_traits<unsigned char>>;
+ 
+ /**
+   @class Stream_cipher
+diff --git a/unittest/gunit/binlogevents/transaction_compression-t.cc b/unittest/gunit/binlogevents/transaction_compression-t.cc
+index ba13f979..01af0e3a 100644
+--- a/unittest/gunit/binlogevents/transaction_compression-t.cc
++++ b/unittest/gunit/binlogevents/transaction_compression-t.cc
+@@ -23,6 +23,7 @@
+ */
+ 
+ #include <array>
++#include <string>
+ 
+ #include <gtest/gtest.h>
+ #include "libbinlogevents/include/binary_log.h"
+@@ -51,14 +52,13 @@ class TransactionPayloadCompressionTest : public ::testing::Test {
+   using Managed_buffer_t = Decompressor_t::Managed_buffer_t;
+   using Size_t = Decompressor_t::Size_t;
+   using Char_t = Decompressor_t::Char_t;
+-  using String_t = std::basic_string<Char_t>;
+   using Decompress_status_t =
+       binary_log::transaction::compression::Decompress_status;
+   using Compress_status_t =
+       binary_log::transaction::compression::Compress_status;
+ 
+-  static String_t constant_data(Size_t size) {
+-    return String_t(size, (Char_t)'a');
++  static std::string constant_data(Size_t size) {
++    return std::string(size, (Char_t)'a');
+   }
+ 
+  protected:
+@@ -69,7 +69,7 @@ class TransactionPayloadCompressionTest : public ::testing::Test {
+   void TearDown() override {}
+ 
+   static void compression_idempotency_test(Compressor_t &c, Decompressor_t &d,
+-                                           String_t data) {
++                                           const std::string &data) {
+     auto debug_string = concat(
+         binary_log::transaction::compression::type_to_string(c.get_type_code()),
+         " ", data.size());
+@@ -104,8 +104,8 @@ class TransactionPayloadCompressionTest : public ::testing::Test {
+ 
+     // Check decompressed data
+     ASSERT_EQ(managed_buffer.read_part().size(), data.size()) << debug_string;
+-    ASSERT_EQ(data, String_t(managed_buffer.read_part().begin(),
+-                             managed_buffer.read_part().end()))
++    ASSERT_EQ(data, std::string(managed_buffer.read_part().begin(),
++                                managed_buffer.read_part().end()))
+         << debug_string;
+ 
+     // Check that we reached EOF
+@@ -118,7 +118,7 @@ TEST_F(TransactionPayloadCompressionTest, CompressDecompressZstdTest) {
+   for (auto size : buffer_sizes) {
+     binary_log::transaction::compression::Zstd_dec d;
+     binary_log::transaction::compression::Zstd_comp c;
+-    String_t data{TransactionPayloadCompressionTest::constant_data(size)};
++    std::string data{TransactionPayloadCompressionTest::constant_data(size)};
+     TransactionPayloadCompressionTest::compression_idempotency_test(c, d, data);
+     c.set_compression_level(22);
+     TransactionPayloadCompressionTest::compression_idempotency_test(c, d, data);
+@@ -129,7 +129,7 @@ TEST_F(TransactionPayloadCompressionTest, CompressDecompressNoneTest) {
+   for (auto size : buffer_sizes) {
+     binary_log::transaction::compression::None_dec d;
+     binary_log::transaction::compression::None_comp c;
+-    String_t data{TransactionPayloadCompressionTest::constant_data(size)};
++    std::string data{TransactionPayloadCompressionTest::constant_data(size)};
+     TransactionPayloadCompressionTest::compression_idempotency_test(c, d, data);
+   }
+ }


### PR DESCRIPTION
- Hardcoded path in `postPatch`, because it fails to pick up either tools used there (`libtool` and `sw_vers`)
- Fixes current build failure https://hydra.nixos.org/build/283867178/log
- Similar fix as in #373514
- partly fixes https://github.com/NixOS/nixpkgs/issues/371921 (mysql84 is fixed by the above PR)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
