### PR TITLE
Cross fixes

### DIFF
--- a/pkgs/by-name/ab/abuild/package.nix
+++ b/pkgs/by-name/ab/abuild/package.nix
@@ -53,7 +53,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   patchPhase = ''
     substituteInPlace ./Makefile \
-      --replace 'chmod 4555' '#chmod 4555'
+      --replace 'chmod 4555' '#chmod 4555' \
+      --replace 'pkg-config' "$PKG_CONFIG"
   '';
 
   makeFlags = [

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -8,6 +8,7 @@
   openssl,
   pcre,
   zlib,
+  buildPackages,
   odbcSupport ? true,
   unixODBC,
   snmpSupport ? stdenv.buildPlatform == stdenv.hostPlatform,
@@ -29,6 +30,23 @@ assert sqliteSupport -> !mysqlSupport && !postgresqlSupport;
 
 let
   inherit (lib) optional optionalString;
+
+  fake_pg_config = buildPackages.writeShellScript "pg_config" ''
+    if [[ "$1" == "--version" ]]; then
+      $PKG_CONFIG libpq --modversion
+    else
+      $PKG_CONFIG libpq --variable="''${1//--/}"
+    fi
+  '';
+
+  fake_mysql_config = buildPackages.writeShellScript "mysql_config" ''
+    if [[ "$1" == "--version" ]]; then
+      $PKG_CONFIG mysqlclient --modversion
+    else
+      $PKG_CONFIG mysqlclient $@
+    fi
+  '';
+
 in
 import ./versions.nix (
   { version, hash, ... }:
@@ -71,8 +89,8 @@ import ./versions.nix (
       ++ optional snmpSupport "--with-net-snmp"
       ++ optional sqliteSupport "--with-sqlite3=${sqlite.dev}"
       ++ optional sshSupport "--with-ssh2=${libssh2.dev}"
-      ++ optional mysqlSupport "--with-mysql"
-      ++ optional postgresqlSupport "--with-postgresql";
+      ++ optional mysqlSupport "--with-mysql=${fake_mysql_config}"
+      ++ optional postgresqlSupport "--with-postgresql=${fake_pg_config}";
 
     prePatch = ''
       find database -name data.sql -exec sed -i 's|/usr/bin/||g' {} +


### PR DESCRIPTION
A few from https://github.com/NickCao/nixpkgs/commits/riscv/

@NickCao I didn't include https://github.com/NickCao/nixpkgs/commit/6bc8a753fde82b00172c69b1ad8c502b6a92b01f because it didn't fix the build if `snmpSupport = true`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
