### PR TITLE
[Backport release-24.11] python3Packages.netbox-floorplan-plugin: init at 0.6.0

### DIFF
--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9168,8 +9168,6 @@ self: super: with self; {
 
   netbox-floorplan-plugin = callPackage ../development/python-modules/netbox-floorplan-plugin { };
 
-  netbox-interface-synchronization = callPackage ../development/python-modules/netbox-interface-synchronization { };
-
   netbox-napalm-plugin = callPackage ../development/python-modules/netbox-napalm-plugin { };
 
   netbox-plugin-prometheus-sd = callPackage ../development/python-modules/netbox-plugin-prometheus-sd { };


### PR DESCRIPTION
Backport to release-24.11, triggered by a label in https://github.com/NixOS/nixpkgs/pull/374618 didn't work, due to merge conflict, so I did it manually.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
      - Even as a non-commiter, if you find that it is not acceptable, leave a comment.