### PR TITLE
[Backport release-24.11] python3Packages.netbox-floorplan-plugin: init at 0.6.0

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4245,6 +4245,12 @@
     github = "CnTeng";
     githubId = 56501688;
   };
+  cobalt = {
+    email = "cobalt@cobalt.rocks";
+    github = "Chaostheorie";
+    githubId = 42151227;
+    name = "Cobalt";
+  };
   CobaltCause = {
     name = "Charles Hall";
     email = "charles@computer.surgery";

--- a/pkgs/development/python-modules/netbox-floorplan-plugin/default.nix
+++ b/pkgs/development/python-modules/netbox-floorplan-plugin/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  pythonAtLeast,
+}:
+buildPythonPackage rec {
+  pname = "netbox-floorplan-plugin";
+  version = "0.6.0";
+  pyproject = true;
+
+  disabled = pythonAtLeast "3.13";
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-floorplan-plugin";
+    tag = version;
+    hash = "sha256-cJrqSXRCBedZh/pIozz/bHyhQosTy8cFYyji3KJva9Q=";
+  };
+
+  build-system = [ setuptools ];
+
+  nativeCheckInputs = [ netbox ];
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  pythonImportsCheck = [ "netbox_floorplan" ];
+
+  meta = with lib; {
+    description = "Netbox plugin providing floorplan mapping capability for locations and sites";
+    homepage = "https://github.com/netbox-community/netbox-floorplan-plugin";
+    changelog = "https://github.com/netbox-community/netbox-floorplan-plugin/releases/tag/${src.tag}";
+    license = licenses.lgpl3;
+    maintainers = with maintainers; [ cobalt ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9033,6 +9033,8 @@ self: super: with self; {
 
   netbox-documents = callPackage ../development/python-modules/netbox-documents { };
 
+  netbox-floorplan-plugin = callPackage ../development/python-modules/netbox-floorplan-plugin { };
+
   netbox-interface-synchronization = callPackage ../development/python-modules/netbox-interface-synchronization { };
 
   netbox-napalm-plugin = callPackage ../development/python-modules/netbox-napalm-plugin { };


### PR DESCRIPTION
Backport to release-24.11, triggered by a label in https://github.com/NixOS/nixpkgs/pull/374618 didn't work, due to merge conflict, so I did it manually.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
      - Even as a non-commiter, if you find that it is not acceptable, leave a comment.