### PR TITLE
[Backport release-24.11] python3Packages.netbox-napalm-plugin: init at 0.3.1

### DIFF
--- a/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
+++ b/pkgs/development/python-modules/netbox-napalm-plugin/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  netbox,
+  pythonAtLeast,
+  napalm,
+}:
+buildPythonPackage rec {
+  pname = "netbox-napalm-plugin";
+  version = "0.3.1";
+  pyproject = true;
+
+  disabled = pythonAtLeast "3.13";
+
+  src = fetchFromGitHub {
+    owner = "netbox-community";
+    repo = "netbox-napalm-plugin";
+    rev = "v${version}";
+    hash = "sha256-nog6DymnnD0ABzG21jy00yNWhSTHfd7vJ4vo1DjsfKs=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [ napalm ];
+
+  nativeCheckInputs = [ netbox ];
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'napalm<5.0' 'napalm'
+  '';
+
+  preFixup = ''
+    export PYTHONPATH=${netbox}/opt/netbox/netbox:$PYTHONPATH
+  '';
+
+  pythonImportsCheck = [ "netbox_napalm_plugin" ];
+
+  meta = {
+    description = "Netbox plugin for Napalm integration";
+    homepage = "https://github.com/netbox-community/netbox-napalm-plugin";
+    changelog = "https://github.com/netbox-community/netbox-napalm-plugin/releases/tag/${src.rev}";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ felbinger ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9035,6 +9035,8 @@ self: super: with self; {
 
   netbox-interface-synchronization = callPackage ../development/python-modules/netbox-interface-synchronization { };
 
+  netbox-napalm-plugin = callPackage ../development/python-modules/netbox-napalm-plugin { };
+
   netbox-plugin-prometheus-sd = callPackage ../development/python-modules/netbox-plugin-prometheus-sd { };
 
   netbox-qrcode = callPackage ../development/python-modules/netbox-qrcode { };


### PR DESCRIPTION
Backport to release-24.11, triggered by a label in https://github.com/NixOS/nixpkgs/pull/374534 didn't work, due to merge conflict, so I did it manually.

- [ ] Before merging, ensure that this backport is [acceptable for the release](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#changes-acceptable-for-releases).
      - Even as a non-commiter, if you find that it is not acceptable, leave a comment.