### PR TITLE
nixos/wireless: remove patch warning from allowAuxiliaryImperativeNetworks option

### DIFF
--- a/nixos/modules/services/networking/wpa_supplicant.nix
+++ b/nixos/modules/services/networking/wpa_supplicant.nix
@@ -220,8 +220,6 @@ in
             Whether to allow configuring networks "imperatively" (e.g. via
             `wpa_supplicant_gui`) and declaratively via
             [](#opt-networking.wireless.networks).
-
-            Please note that this adds a custom patch to `wpa_supplicant`.
           '';
         };
 


### PR DESCRIPTION
The patch was removed in #330386.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
