### PR TITLE
deepsearch-glm: init at 1.0.0

### DIFF
--- a/pkgs/development/python-modules/deepsearch-glm/default.nix
+++ b/pkgs/development/python-modules/deepsearch-glm/default.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cmake,
+  cxxopts,
+  deepsearch-toolkit,
+  docling-core,
+  fasttext,
+  fmt,
+  loguru,
+  matplotlib,
+  nlohmann_json,
+  pandas,
+  pcre2,
+  pkg-config,
+  poetry-core,
+  pybind11,
+  python-dotenv,
+  requests,
+  rich,
+  sentencepiece,
+  tabulate,
+  tqdm,
+  utf8cpp,
+  zlib,
+}:
+
+buildPythonPackage rec {
+  pname = "deepsearch-glm";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "DS4SD";
+    repo = "deepsearch-glm";
+    tag = "v${version}";
+    hash = "sha256-3sJNkrx0tTm6RMYAwV8Aha7x8dZjf4tGdds8OScRff8=";
+  };
+
+  dontUseCmakeConfigure = true;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  build-system = [
+    poetry-core
+    pybind11
+  ];
+
+  env = {
+    NIX_CFLAGS_COMPILE = "-I${lib.getDev utf8cpp}/include/utf8cpp";
+    USE_SYSTEM_DEPS = true;
+  };
+
+  optional-dependencies = {
+    docling = [
+      docling-core
+      pandas
+    ];
+    pyplot = [
+      matplotlib
+    ];
+    toolkit = [
+      deepsearch-toolkit
+      python-dotenv
+    ];
+    utils = [
+      pandas
+      python-dotenv
+      requests
+      rich
+      tabulate
+      tqdm
+    ];
+  };
+
+  buildInputs = [
+    cxxopts
+    fasttext
+    fmt
+    loguru
+    nlohmann_json
+    pcre2
+    sentencepiece
+    utf8cpp
+    zlib
+  ];
+
+  # Test suite insists on downloading models, data etc. from s3 bucket
+  doCheck = false;
+
+  pythonImportsCheck = [
+    "deepsearch_glm"
+  ];
+
+  meta = {
+    changelog = "https://github.com/DS4SD/deepsearch-glm/releases/tag/v${version}";
+    description = "Create fast graph language models from converted PDF documents for knowledge extraction and Q&A";
+    homepage = "https://github.com/DS4SD/deepsearch-glm";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ booxter ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3121,6 +3121,10 @@ self: super: with self; {
 
   deepmerge = callPackage ../development/python-modules/deepmerge { };
 
+  deepsearch-glm = callPackage ../development/python-modules/deepsearch-glm {
+    inherit (pkgs) loguru sentencepiece fasttext;
+  };
+
   deepsearch-toolkit = callPackage ../development/python-modules/deepsearch-toolkit { };
 
   deeptoolsintervals = callPackage ../development/python-modules/deeptoolsintervals { };


### PR DESCRIPTION
This is yet another dependency that should unblock docling packaging for nixpkgs. The module imports, haven't done more validation than that. (pytest tests run successfully if enabled; but since they pull models etc. from the internet - and there are lots of files from s3 bucket, not a handful of files..., I have to disable the tests in the package.)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

@drupol 