### PR TITLE
tinycc: 0.9.27-unstable-2022-07-15 -> 0.9.27-unstable-2025-01-06

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -18,6 +18,9 @@
   - [`lib.types.enum`](https://nixos.org/manual/nixos/unstable/#sec-option-types-basic): Previously the `functor.payload` was the list of enum values directly. Now it is an attribute set containing the values in the `values` attribute.
   - [`lib.types.separatedString`](https://nixos.org/manual/nixos/unstable/#sec-option-types-string): Previously the `functor.payload` was the seperator directly. Now it is an attribute set containing the seperator in the `sep` attribute.
 
+- The `tinycc` package now has the `dev`, `doc` and `lib` outputs, thus,
+`tinycc.out` may now only provide the tcc and cross compilers binaries.
+
 - The `virtualisation.hypervGuest.videoMode` option has been removed. Standard tooling can now be used to configure display modes for Hyper-V VMs.
 
 ### Deprecations {#sec-nixpkgs-release-25.05-lib-deprecations}

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -133,6 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
     maintainers = with lib.maintainers; [
       joachifm
       AndersonTorres
+      onemoresuza
     ];
     platforms = lib.platforms.unix;
     # https://www.mail-archive.com/tinycc-devel@nongnu.org/msg10199.html

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -8,22 +8,24 @@
   texinfo,
   which,
 }:
-
 stdenv.mkDerivation (finalAttrs: {
   pname = "tcc";
-  version = "0.9.27-unstable-2022-07-15";
+  version = "0.9.27-unstable-2025-01-06";
+
+  outputs = [
+    "dev"
+    "doc"
+    "info"
+    "lib"
+    "man"
+    "out"
+  ];
 
   src = fetchFromRepoOrCz {
     repo = "tinycc";
-    rev = "af1abf1f45d45b34f0b02437f559f4dfdba7d23c";
-    hash = "sha256-jY0P2GErmo//YBaz6u4/jj/voOE3C2JaIDRmo0orXN8=";
+    rev = "f6385c05308f715bdd2c06336801193a21d69b50";
+    hash = "sha256-tO3N+NplYy8QUOC2N3x0CO5Ui75j9bQzLSZQF1HQyhY=";
   };
-
-  outputs = [
-    "out"
-    "info"
-    "man"
-  ];
 
   nativeBuildInputs = [
     copyPkgconfigItems
@@ -57,23 +59,36 @@ stdenv.mkDerivation (finalAttrs: {
       (makePkgconfigItem libtcc-pcitem)
     ];
 
-  postPatch = ''
-    patchShebangs texi2pod.pl
-  '';
-
   configureFlags =
     [
       "--cc=$CC"
       "--ar=$AR"
       "--crtprefix=${lib.getLib stdenv.cc.libc}/lib"
       "--sysincludepaths=${lib.getDev stdenv.cc.libc}/include:{B}/include"
-      "--libpaths=${lib.getLib stdenv.cc.libc}/lib"
+      # The first libpath will be the one in which tcc will look for libtcc1.a,
+      # which is need for its tests.
+      "--libpaths=$lib/lib/tcc:$lib/lib:${lib.getLib stdenv.cc.libc}/lib"
       # build cross compilers
       "--enable-cross"
     ]
     ++ lib.optionals stdenv.hostPlatform.isMusl [
       "--config-musl"
     ];
+
+  enableParallelBuilding = true;
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=implicit-int"
+    "-Wno-error=int-conversion"
+  ];
+
+  # Test segfault for static build
+  doInstallCheck =
+    !stdenv.hostPlatform.isStatic && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  postPatch = ''
+    patchShebangs texi2pod.pl
+  '';
 
   preConfigure =
     let
@@ -90,19 +105,14 @@ stdenv.mkDerivation (finalAttrs: {
       configureFlagsArray+=("--elfinterp=$(< $NIX_CC/nix-support/dynamic-linker)")
     '';
 
-  env.NIX_CFLAGS_COMPILE = toString [
-    "-Wno-error=implicit-int"
-    "-Wno-error=int-conversion"
-  ];
+  installCheckTarget = "test";
 
-  # Test segfault for static build
-  doCheck = !stdenv.hostPlatform.isStatic;
-
-  checkTarget = "test";
   # https://www.mail-archive.com/tinycc-devel@nongnu.org/msg10142.html
-  preCheck = lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64) ''
-    rm tests/tests2/{108,114}*
-  '';
+  preInstallCheck =
+    lib.optionalString (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isx86_64)
+      ''
+        rm tests/tests2/{108,114}*
+      '';
 
   meta = {
     homepage = "https://repo.or.cz/tinycc.git";
@@ -139,5 +149,4 @@ stdenv.mkDerivation (finalAttrs: {
     broken = stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64;
   };
 })
-# TODO: more multiple outputs
 # TODO: self-compilation

--- a/pkgs/development/compilers/tinycc/default.nix
+++ b/pkgs/development/compilers/tinycc/default.nix
@@ -132,7 +132,6 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "tcc";
     maintainers = with lib.maintainers; [
       joachifm
-      AndersonTorres
       onemoresuza
     ];
     platforms = lib.platforms.unix;


### PR DESCRIPTION
Fix checkPhase by making it instalCheckPhase, since tcc depends on
libtcc1.a, which is build together with it, for its tests.

Create dev, doc and lib outpus. Now the binaries, i. e., tcc and the
cross compilers are what the user gets with tinycc.out.

Make the recipe compliant with nixpkgs-hammer.

Enable parallel building.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 8 packages built:</summary>
  <ul>
    <li>kak-tree-sitter</li>
    <li>nrpl</li>
    <li>tinycc</li>
    <li>tinycc.dev</li>
    <li>tinycc.doc</li>
    <li>tinycc.info</li>
    <li>tinycc.lib</li>
    <li>tinycc.man</li>
  </ul>
</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [X] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
