### PR TITLE
linuxKernel.kernels.linux_zen: 6.12.2-zen1 -> 6.12.10-zen1; linuxKernel.kernels.linux_lqx: 6.12.2-lqx1 -> 6.12.10-lqx1

### DIFF
--- a/pkgs/os-specific/linux/kernel/update-zen.py
+++ b/pkgs/os-specific/linux/kernel/update-zen.py
@@ -64,24 +64,24 @@ def update_file(relpath, variant, version, suffix, sha256):
         for line in f:
             result = line
             result = re.sub(
-                fr'^      version = ".+"; #{variant}',
-                f'      version = "{version}"; #{variant}',
+                fr'^      version = ".+"; # {variant}',
+                f'      version = "{version}"; # {variant}',
                 result)
             result = re.sub(
-                fr'^      suffix = ".+"; #{variant}',
-                f'      suffix = "{suffix}"; #{variant}',
+                fr'^      suffix = ".+"; # {variant}',
+                f'      suffix = "{suffix}"; # {variant}',
                 result)
             result = re.sub(
-                fr'^      sha256 = ".+"; #{variant}',
-                f'      sha256 = "{sha256}"; #{variant}',
+                fr'^      sha256 = ".+"; # {variant}',
+                f'      sha256 = "{sha256}"; # {variant}',
                 result)
             print(result, end='')
 
 
 def read_file(relpath, variant):
     file_path = os.path.join(DIR, relpath)
-    re_version = re.compile(fr'^\s*version = "(.+)"; #{variant}')
-    re_suffix = re.compile(fr'^\s*suffix = "(.+)"; #{variant}')
+    re_version = re.compile(fr'^\s*version = "(.+)"; # {variant}')
+    re_suffix = re.compile(fr'^\s*suffix = "(.+)"; # {variant}')
     version = None
     suffix = None
     with fileinput.FileInput(file_path, mode='r') as f:

--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -19,9 +19,9 @@ let
     };
     # ./update-zen.py lqx
     lqx = {
-      version = "6.12.2"; # lqx
-      suffix = "lqx3"; # lqx
-      sha256 = "18ibc0dz70vxb61mzdhbhbjg0kfxgcsrl3zdki0cqlhcvfxwk19h"; # lqx
+      version = "6.12.10"; # lqx
+      suffix = "lqx1"; # lqx
+      sha256 = "0sg905xdyy9wmjqv6d8p5jr307j767wgk27gzxhq8dnb2dz2yg5v"; # lqx
       isLqx = true;
     };
   };

--- a/pkgs/os-specific/linux/kernel/zen-kernels.nix
+++ b/pkgs/os-specific/linux/kernel/zen-kernels.nix
@@ -12,9 +12,9 @@ let
   variants = {
     # ./update-zen.py zen
     zen = {
-      version = "6.12.2"; # zen
+      version = "6.12.10"; # zen
       suffix = "zen1"; # zen
-      sha256 = "0a6anmfm6495j6lwlywr62ghpwdvbdn54bl5baya5jz7vfqc1ghj"; # zen
+      sha256 = "1kd3bcnhlarnrpl87mrdb5r9k2jdq7m8607ai847dkmncw7q2d1q"; # zen
       isLqx = false;
     };
     # ./update-zen.py lqx


### PR DESCRIPTION
I fixed the zen kernel update script since it did no longer work after the formatting slightly changed from the global nixfmt change. I also updated zen and lqx kernels to their latest version
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
