### PR TITLE
chromium: unbreak build on aarch64-linux

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -750,6 +750,10 @@ let
         # Use nixpkgs Rust compiler instead of the one shipped by Chromium.
         rust_sysroot_absolute = "${buildPackages.rustc}";
       }
+      // lib.optionalAttrs (chromiumVersionAtLeast "132" && stdenv.hostPlatform.isAarch64) {
+        # Hotfix for "ld.lld: error: undefined symbol: __arm_tpidr2_save" on aarch64-linux
+        libyuv_use_sme = false;
+      }
       // lib.optionalAttrs (chromiumVersionAtLeast "127") {
         rust_bindgen_root = "${buildPackages.rust-bindgen}";
       }


### PR DESCRIPTION
Unbreaks a channel blocker, see https://github.com/NixOS/nixpkgs/pull/374107#issuecomment-2598727360

---

This hotfixes the following error happening only on aarch64-linux:

~~~
FAILED: v8_context_snapshot_generator

ld.lld: error: undefined symbol: __arm_tpidr2_save
>>> referenced by rotate_sme.cc
>>>               obj/third_party/libyuv/v8_context_snapshot_generator.lto.libyuv_sme.a(rotate_sme.o at 94).o:(TransposeWxH_SME)
>>> referenced by rotate_sme.cc
>>>               obj/third_party/libyuv/v8_context_snapshot_generator.lto.libyuv_sme.a(rotate_sme.o at 94).o:(TransposeUVWxH_SME)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
~~~

It's unclear to me what underlying change is causing this, but given this is a channel blocker, a hotfix should be good enough for now and buys us enough time to fix this properly.

Note that libyuv SME is only a thing on aarch64-linux and was recently also recently temporarily disabled by upstream due to LLVM regressions.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (`chromium`, `chromedriver`)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
