### PR TITLE
ghidra: fix build on gradle 8.12

### DIFF
--- a/pkgs/tools/security/ghidra/0004-Fix-build-on-Gradle-8.12.patch
+++ b/pkgs/tools/security/ghidra/0004-Fix-build-on-Gradle-8.12.patch
@@ -1,0 +1,13 @@
+diff --git a/gradle/hasPythonPackage.gradle b/gradle/hasPythonPackage.gradle
+index 2d83cf0cd3..8f3205f9ff 100644
+--- a/gradle/hasPythonPackage.gradle
++++ b/gradle/hasPythonPackage.gradle
+@@ -44,7 +44,7 @@ task buildPyPackage {
+ 	doLast {
+ 		File setuptools = project(":Debugger-rmi-trace").findPyDep(".")
+ 		exec {
+-			workingDir { "build/pypkg" }
++			workingDir { file("build/pypkg") }
+ 			commandLine	rootProject.PYTHON3, "-m", "pip"
+ 			args "wheel", "-w", "dist/", "--no-index", "--no-deps"
+ 			args "-f", setuptools

--- a/pkgs/tools/security/ghidra/build.nix
+++ b/pkgs/tools/security/ghidra/build.nix
@@ -52,6 +52,10 @@ let
 
     # Remove build dates from output filenames for easier reference
     ./0003-Remove-build-datestamp.patch
+
+    # Fix build on Gradle 8.12
+    # Upstream: https://github.com/NationalSecurityAgency/ghidra/commit/20285e267d110cfa585676dfd40804a59031598b
+    ./0004-Fix-build-on-Gradle-8.12.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Fixes #374703. The build is still broken on macOS.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
