### PR TITLE
thrift: 0.18.1 -> 0.21.0

### DIFF
--- a/pkgs/by-name/th/thrift/package.nix
+++ b/pkgs/by-name/th/thrift/package.nix
@@ -1,8 +1,8 @@
 {
   lib,
   stdenv,
-  fetchurl,
   fetchpatch,
+  fetchFromGitHub,
   boost,
   zlib,
   libevent,
@@ -17,11 +17,13 @@
 
 stdenv.mkDerivation rec {
   pname = "thrift";
-  version = "0.18.1";
+  version = "0.21.0";
 
-  src = fetchurl {
-    url = "https://archive.apache.org/dist/thrift/${version}/${pname}-${version}.tar.gz";
-    hash = "sha256-BMbxDl14jKeOE+4u8NIVLHsHDAr1VIPWuULinP8pZyY=";
+  src = fetchFromGitHub {
+    owner = "apache";
+    repo = "thrift";
+    tag = "v0.21.0";
+    hash = "sha256-OF/pFG8OXROsyYGf6jgfVTYTrTc8UB5QJh4gbostFfU=";
   };
 
   # Workaround to make the Python wrapper not drop this package:
@@ -53,45 +55,9 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
-  postPatch = ''
-    # Python 3.10 related failures:
-    # SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
-    # AttributeError: module 'collections' has no attribute 'Hashable'
-    substituteInPlace test/py/RunClientServer.py \
-      --replace "'FastbinaryTest.py'," "" \
-      --replace "'TestEof.py'," "" \
-      --replace "'TestFrozen.py'," ""
-
-    # these functions are removed in Python3.12
-    substituteInPlace test/py/SerializationTest.py \
-      --replace-fail "assertEquals" "assertEqual" \
-      --replace-fail "assertNotEquals" "assertNotEqual"
-  '';
-
   preConfigure = ''
     export PY_PREFIX=$out
   '';
-
-  patches = [
-    # ToStringTest.cpp is failing from some reason due to locale issue, this
-    # doesn't disable all UnitTests as in Darwin.
-    ./disable-failing-test.patch
-    (fetchpatch {
-      name = "setuptools-gte-62.1.0.patch"; # https://github.com/apache/thrift/pull/2635
-      url = "https://github.com/apache/thrift/commit/c41ad9d5119e9bdae1746167e77e224f390f2c42.diff";
-      hash = "sha256-FkErrg/6vXTomS4AsCsld7t+Iccc55ZiDaNjJ3W1km0=";
-    })
-    (fetchpatch {
-      name = "thrift-install-FindLibevent.patch"; # https://github.com/apache/thrift/pull/2726
-      url = "https://github.com/apache/thrift/commit/2ab850824f75d448f2ba14a468fb77d2594998df.diff";
-      hash = "sha256-ejMKFG/cJgoPlAFzVDPI4vIIL7URqaG06/IWdQ2NkhY=";
-    })
-    (fetchpatch {
-      name = "thrift-fix-tests-OpenSSL3.patch"; # https://github.com/apache/thrift/pull/2760
-      url = "https://github.com/apache/thrift/commit/eae3ac418f36c73833746bcd53e69ed8a12f0e1a.diff";
-      hash = "sha256-0jlN4fo94cfGFUKcLFQgVMI/x7uxn5OiLiFk6txVPzs=";
-    })
-  ];
 
   cmakeFlags =
     [
@@ -105,32 +71,6 @@ stdenv.mkDerivation rec {
     ++ lib.optionals static [
       "-DWITH_STATIC_LIB:BOOL=ON"
       "-DOPENSSL_USE_STATIC_LIBS=ON"
-    ];
-
-  disabledTests =
-    [
-      "PythonTestSSLSocket"
-      "PythonThriftTNonblockingServer"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Tests that hang up in the Darwin sandbox
-      "SecurityTest"
-      "SecurityFromBufferTest"
-      "python_test"
-
-      # fails on hydra, passes locally
-      "concurrency_test"
-
-      # Tests that fail in the Darwin sandbox when trying to use network
-      "UnitTests"
-      "TInterruptTest"
-      "TServerIntegrationTest"
-      "processor"
-      "TNonblockingServerTest"
-      "TNonblockingSSLServerTest"
-      "StressTest"
-      "StressTestConcurrent"
-      "StressTestNonBlocking"
     ];
 
   doCheck = !static;


### PR DESCRIPTION
I'm fetching from Github instead of the apache server since the release from apache.org appears to be missing the file
"lib/cpp/test/Thrift5272.thrift". As such, it will not build. For reasons that are unclear, the mirror on github appears to have that file and will build.

I remove all the patches since it appears to build on aarch64-darwin without the patches.

I removed the disabled tests since it appears to build on aarch64-darwin (sandbox = true) without those tests being disabled.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
