### PR TITLE
pahole: 1.27 -> 1.29

### DIFF
--- a/pkgs/by-name/pa/pahole/package.nix
+++ b/pkgs/by-name/pa/pahole/package.nix
@@ -10,15 +10,14 @@
   argp-standalone,
   musl-obstack,
   nixosTests,
-  fetchpatch,
 }:
 
 stdenv.mkDerivation rec {
   pname = "pahole";
-  version = "1.27";
+  version = "1.29";
   src = fetchzip {
     url = "https://git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-${version}.tar.gz";
-    hash = "sha256-BwA17lc2yegmOzLfoIu8OmG/PVdc+4sOGzB8Jc4ZjGM=";
+    hash = "sha256-ke7WIIz0ZURw3Pgmt7WNL9WPbcv5B998Rflw/8/JQ8U=";
   };
 
   nativeBuildInputs = [
@@ -39,22 +38,11 @@ stdenv.mkDerivation rec {
   patches = [
     # https://github.com/acmel/dwarves/pull/51 / https://lkml.kernel.org/r/20240626032253.3406460-1-asmadeus@codewreck.org
     ./threading-reproducibility.patch
-    # https://github.com/acmel/dwarves/issues/53
-    (fetchpatch {
-      name = "fix-clang-btf-generation-bug.patch";
-      url = "https://github.com/acmel/dwarves/commit/6a2b27c0f512619b0e7a769a18a0fb05bb3789a5.patch";
-      hash = "sha256-Le1BAew/a/QKkYNLgSQxEvZ9mEEglUw8URwz1kiheeE=";
-    })
-    (fetchpatch {
-      name = "fix-clang-btf-generation-bug-2.patch";
-      url = "https://github.com/acmel/dwarves/commit/94a01bde592c555b3eb526aeb4c2ad695c5660d8.patch";
-      hash = "sha256-SMIxLEBjBkprAqVNX1h7nXxAsgbwvCD/Bz7c1ekwg5w=";
-    })
   ];
 
   # Put libraries in "lib" subdirectory, not top level of $out
   cmakeFlags = [
-    "-D__LIB=lib"
+    "-DCMAKE_INSTALL_LIBDIR=lib"
     "-DLIBBPF_EMBEDDED=OFF"
   ];
 

--- a/pkgs/by-name/pa/pahole/threading-reproducibility.patch
+++ b/pkgs/by-name/pa/pahole/threading-reproducibility.patch
@@ -1,5 +1,3 @@
-diff --git a/pahole.c b/pahole.c
-index 954498d2ad4f..2b010658330c 100644
 --- a/pahole.c
 +++ b/pahole.c
 @@ -3705,6 +3705,10 @@ int main(int argc, char *argv[])
@@ -10,6 +8,6 @@ index 954498d2ad4f..2b010658330c 100644
 +	if (getenv("SOURCE_DATE_EPOCH"))
 +		conf_load.reproducible_build = true;
 +
- 	if (languages.str && parse_languages())
- 		return rc;
+ 	if (show_running_kernel_vmlinux) {
+ 		const char *vmlinux = vmlinux_path__find_running_kernel();
  


### PR DESCRIPTION
Changes:
- https://lore.kernel.org/bpf/Z1RcnB8WD8wZphcr@x1/T/
- https://lore.kernel.org/bpf/Z4-TDt42dTKZvCo6@x1/T/

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
