### PR TITLE
urbackup-server: init at 2.5.33; nixos/urbackup: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -185,6 +185,8 @@
 
 - [`g3proxy`](https://github.com/bytedance/g3), an open source enterprise forward proxy from ByteDance, similar to Squid or tinyproxy. Available as [services.g3proxy](#opt-services.g3proxy.enable).
 
+- [Urbackup Server](https://www.urbackup.org/index.html), an easy to setup Open Source client/server backup system. Available as [services.urbackup](#opt-services.urbackup.enable).
+
 - [echoip](https://github.com/mpolden/echoip), a simple service for looking up your IP address. Available as [services.echoip](#opt-services.echoip.enable).
 
 - [whoami](https://github.com/traefik/whoami), a tiny Go server that prints OS information and HTTP request to output. Available as [services.whoami](#opt-services.whoami.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -446,6 +446,7 @@
   ./services/backup/syncoid.nix
   ./services/backup/tarsnap.nix
   ./services/backup/tsm.nix
+  ./services/backup/urbackup.nix
   ./services/backup/zfs-replication.nix
   ./services/backup/znapzend.nix
   ./services/backup/zrepl.nix

--- a/nixos/modules/services/backup/urbackup.nix
+++ b/nixos/modules/services/backup/urbackup.nix
@@ -1,0 +1,286 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.urbackup;
+
+  urbackup = cfg.package.override {
+    withMountVhd = cfg.mountVhd.enable;
+  };
+
+  urbackupsrvWrapper = pkgs.writeShellScriptBin "urbackupsrv" ''
+    exec systemd-run \
+      --quiet \
+      --pipe \
+      --pty \
+      --wait \
+      --collect \
+      --property=User=${cfg.user} \
+      --property=StateDirectory=urbackup \
+      --property=DynamicUser=yes \
+      --property=SystemCallFilter=~@setuid \
+      --service-type=exec \
+      ${urbackup}/bin/urbackupsrv "$@"
+  '';
+in
+{
+  options = {
+    services.urbackup = {
+      enable = lib.mkEnableOption "UrBackup, an easy to setup Open Source client/server backup system";
+
+      mountVhd.enable = lib.mkEnableOption "Enable mounting of VHD files via fuse";
+
+      package = lib.mkPackageOption pkgs "urbackup-server" { };
+
+      fastcgiPort = lib.mkOption {
+        type = lib.types.port;
+        default = 55413;
+        description = "Port for FastCGI requests";
+      };
+
+      enableHttpServer = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Enable internal HTTP server.
+          Required for serving web interface without FastCGI
+          and for websocket connections from client.
+        '';
+      };
+
+      httpPort = lib.mkOption {
+        type = lib.types.port;
+        default = 55414;
+        description = "Port for the web interface (if internal HTTP server is enabled)";
+      };
+
+      httpLocalhostOnly = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Bind HTTP server to localhost only";
+      };
+
+      internetLocalhostOnly = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Bind Internet port to localhost only";
+      };
+
+      logFile = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/log/urbackup/urbackup.log";
+        description = "Path to the log file";
+      };
+
+      logLevel = lib.mkOption {
+        type = lib.types.enum [
+          "debug"
+          "warn"
+          "info"
+          "error"
+        ];
+        default = "warn";
+        description = "Logging level (either debug, warn, info or error)";
+      };
+
+      daemonTmpDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/tmp";
+        description = ''
+          Temporary file directory.
+          This may get very large depending on the advanced settings.
+        '';
+      };
+
+      sqliteTmpDir = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Tmp file directory for sqlite temporary tables.
+          You might want to put the databases on another filesystem than the other temporary files.
+          Defaults to the same as daemonTmpDir if not specified.
+        '';
+      };
+
+      broadcastInterfaces = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = ''
+          Interfaces from which to send broadcasts.
+          Empty list means all interfaces.
+          Example: ["eth0" "eth1"]
+        '';
+      };
+
+      allowUserEnumeration = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Enable better error messages if a user cannot be found during login";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "urbackup";
+        description = "User the urbackupsrv process runs as";
+      };
+
+      backupStoragePath = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Absolute path to backup storage location. This path must exist.
+          Note: By default, the service will be restricted to access this path only.
+        '';
+      };
+
+      dataset = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Create a separate ZFS dataset for storing images.";
+      };
+
+      datasetFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Sets the dataset where the copy-on-write file backups are to be stored.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.etc."urbackup/backupfolder" = lib.mkIf (cfg.backupStoragePath != null) {
+      text = cfg.backupStoragePath;
+    };
+
+    environment.etc."urbackup/dataset" = lib.mkIf (cfg.dataset != null) {
+      text = cfg.dataset;
+    };
+
+    environment.etc."urbackup/dataset_file" = lib.mkIf (cfg.datasetFile != null) {
+      text = cfg.datasetFile;
+    };
+
+    environment.etc."urbackup/urbackupsrv".text = ''
+      #Port for FastCGI requests
+      FASTCGI_PORT=${toString cfg.fastcgiPort}
+
+      #Enable internal HTTP server
+      #Required for serving web interface without FastCGI
+      #and for websocket connections from client
+      HTTP_SERVER="${if cfg.enableHttpServer then "true" else "false"}"
+
+      #Port for the web interface
+      #(if internal HTTP server is enabled)
+      HTTP_PORT=${toString cfg.httpPort}
+
+      #Bind HTTP server to localhost only
+      HTTP_LOCALHOST_ONLY=${if cfg.httpLocalhostOnly then "true" else "false"}
+
+      #Bind Internet port to localhost only
+      INTERNET_LOCALHOST_ONLY=${if cfg.internetLocalhostOnly then "true" else "false"}
+
+      #log file name
+      LOGFILE="${cfg.logFile}"
+
+      #Either debug,warn,info or error
+      LOGLEVEL="${cfg.logLevel}"
+
+      #Temporary file directory
+      DAEMON_TMPDIR="${cfg.daemonTmpDir}"
+
+      #Tmp file directory for sqlite temporary tables.
+      #You might want to put the databases on another filesystem than the other temporary files.
+      #Default is the same as DAEMON_TMPDIR
+      SQLITE_TMPDIR="${if cfg.sqliteTmpDir == null then "" else cfg.sqliteTmpDir}"
+
+      #Interfaces from which to send broadcasts. (Default: all).
+      #Comma separated -- e.g. "eth0,eth1"
+      BROADCAST_INTERFACES="${lib.concatStringsSep "," cfg.broadcastInterfaces}"
+
+      # Enable better error messages if a user cannot be found during login
+      ALLOW_USER_ENUMERATION="${if cfg.allowUserEnumeration then "true" else "false"}"
+
+      #User the urbackupsrv process runs as
+      USER="${cfg.user}"
+    '';
+
+    users = {
+      users = lib.mkIf (cfg.user == "urbackup") {
+        urbackup = {
+          group = "urbackup";
+          isSystemUser = true;
+        };
+      };
+      groups = {
+        urbackup = { };
+      };
+    };
+
+    security.wrappers.urbackup_mount_helper = {
+      setuid = true;
+      owner = cfg.user;
+      group = "urbackup";
+      source = "${urbackup}/bin/urbackup_mount_helper";
+    };
+
+    security.wrappers.urbackup_snapshot_helper = {
+      setuid = true;
+      owner = cfg.user;
+      group = "urbackup";
+      source = "${urbackup}/bin/urbackup_snapshot_helper";
+    };
+
+    environment.systemPackages = [
+      urbackupsrvWrapper
+    ] ++ lib.optionals (cfg.mountVhd.enable) [ pkgs.libguestfs ];
+
+    systemd.services.urbackup-server = {
+      description = "UrBackup Client/Server Network Backup System";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      serviceConfig = {
+        StateDirectory = "urbackup";
+        LogsDirectory = "urbackup";
+        ReadWritePaths =
+          [
+            cfg.backupStoragePath
+          ]
+          ++ lib.optionals (cfg.sqliteTmpDir != null) [ cfg.sqliteTmpDir ]
+          ++ lib.optionals (cfg.daemonTmpDir != "/tmp") [ cfg.daemonTmpDir ]
+          ++ lib.optionals (cfg.logFile != "/var/log/urbackup/urbackup.log") [ cfg.logFile ];
+        ExecStart = "${urbackup}/bin/urbackupsrv run --config /etc/urbackup/urbackupsrv --no-consoletime";
+        User = cfg.user;
+        DynamicUser = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateMounts = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        RemoveIPC = true;
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "~@setuid"
+        ];
+      };
+    };
+  };
+}

--- a/pkgs/by-name/ur/urbackup-server/package.nix
+++ b/pkgs/by-name/ur/urbackup-server/package.nix
@@ -1,0 +1,59 @@
+{
+  cryptopp,
+  curl,
+  fetchzip,
+  fuse,
+  lib,
+  pkg-config,
+  sqlite,
+  stdenv,
+  withMountVhd ? false,
+  zlib,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "urbackup-server";
+  version = "2.5.33";
+
+  src = fetchzip {
+    url = "https://hndl.urbackup.org/Server/${version}/urbackup-server-${version}.tar.gz";
+    hash = "sha256-XfVQaeenNvQwf0WsWSnUKR5SrdsSGho7UhhXmoHWoYU=";
+  };
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    cryptopp
+    curl
+    sqlite
+    zlib
+  ] ++ lib.optionals (withMountVhd) [ fuse ];
+
+  configureFlags = [
+    "--with-crypto-prefix=${cryptopp.dev}"
+    "--enable-packaging"
+  ] ++ lib.optionals (withMountVhd) [ "--with-mountvhd" ];
+
+  enableParallelBuilding = true;
+
+  postPatch = ''
+    # prevent chmod failure. setuid is set in the service.
+    substituteInPlace Makefile.in \
+    --replace-fail "chmod +s" "# chmod +s"
+
+    # Adjust statedir at compile time for systemd service.
+    substituteInPlace Makefile.in \
+    --replace-fail "-DVARDIR='\"\$(localstatedir)\"'"  "-DVARDIR='\"/var/lib\"'"
+  '';
+
+  meta = {
+    description = "Easy to setup Open Source client/server backup system";
+    longDescription = "An easy to setup Open Source client/server backup system, that through a combination of image and file backups accomplishes both data safety and a fast restoration time";
+    homepage = "https://www.urbackup.org/index.html";
+    license = lib.licenses.agpl3Plus;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ quincepie ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds in urbackup-server package and NixOS module.

the urbackup-server package applies a workaround for allowing the generation of keys & using state directory (since it's set at compile time).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
