### PR TITLE
[Backport 374320 to release 24.11] raycast: 1.88.3 -> 1.89.0

### DIFF
--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -12,19 +12,19 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raycast";
-  version = "1.88.4";
+  version = "1.89.0";
 
   src =
     {
       aarch64-darwin = fetchurl {
         name = "Raycast.dmg";
         url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=arm";
-        hash = "sha256-q3pX/mOl/u9KMcAfvXm4giYKjnTB903N1ibubvaO9Uw=";
+        hash = "sha256-v/0Sg7f/pf7wt7r0+ewSXGKgBqMFnOwldKQUwKQ8Fz0=";
       };
       x86_64-darwin = fetchurl {
         name = "Raycast.dmg";
         url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=x86_64";
-        hash = "sha256-l61AVKx+aYmgnVK8d+by2pKiu1cIAueLipRjOzCvib4=";
+        hash = "sha256-UIdoFcnXeCpf1CSBTmdxkP5uKz+WoJt5u5u6MXCqnG4=";
       };
     }
     .${stdenvNoCC.system} or (throw "raycast: ${stdenvNoCC.system} is unsupported.");

--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -12,19 +12,19 @@
 
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raycast";
-  version = "1.88.3";
+  version = "1.88.4";
 
   src =
     {
       aarch64-darwin = fetchurl {
         name = "Raycast.dmg";
         url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=arm";
-        hash = "sha256-EeD9EcP4q85CjjZ7MrG9/ASlKl1x0/9q/S3ySNMv3XY=";
+        hash = "sha256-q3pX/mOl/u9KMcAfvXm4giYKjnTB903N1ibubvaO9Uw=";
       };
       x86_64-darwin = fetchurl {
         name = "Raycast.dmg";
         url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=x86_64";
-        hash = "sha256-Uxe3YNVmT41VB3ehxy/pKntIafWbzo6d1HuLJc12nkg=";
+        hash = "sha256-l61AVKx+aYmgnVK8d+by2pKiu1cIAueLipRjOzCvib4=";
       };
     }
     .${stdenvNoCC.system} or (throw "raycast: ${stdenvNoCC.system} is unsupported.");

--- a/pkgs/by-name/ra/raycast/package.nix
+++ b/pkgs/by-name/ra/raycast/package.nix
@@ -3,9 +3,10 @@
   stdenvNoCC,
   fetchurl,
   writeShellApplication,
+  cacert,
   curl,
   jq,
-  common-updater-scripts,
+  openssl,
   undmg,
 }:
 
@@ -13,11 +14,20 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "raycast";
   version = "1.88.3";
 
-  src = fetchurl {
-    name = "Raycast.dmg";
-    url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=universal";
-    hash = "sha256-MOJlEUQHLDw8YeQC9sG5QLSO8qhgcWG8HtyRZCPHb+M=";
-  };
+  src =
+    {
+      aarch64-darwin = fetchurl {
+        name = "Raycast.dmg";
+        url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=arm";
+        hash = "sha256-EeD9EcP4q85CjjZ7MrG9/ASlKl1x0/9q/S3ySNMv3XY=";
+      };
+      x86_64-darwin = fetchurl {
+        name = "Raycast.dmg";
+        url = "https://releases.raycast.com/releases/${finalAttrs.version}/download?build=x86_64";
+        hash = "sha256-Uxe3YNVmT41VB3ehxy/pKntIafWbzo6d1HuLJc12nkg=";
+      };
+    }
+    .${stdenvNoCC.system} or (throw "raycast: ${stdenvNoCC.system} is unsupported.");
 
   dontPatch = true;
   dontConfigure = true;
@@ -40,14 +50,26 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   passthru.updateScript = lib.getExe (writeShellApplication {
     name = "raycast-update-script";
     runtimeInputs = [
+      cacert
       curl
       jq
-      common-updater-scripts
+      openssl
     ];
     text = ''
       url=$(curl --silent "https://releases.raycast.com/releases/latest?build=universal")
       version=$(echo "$url" | jq -r '.version')
-      update-source-version raycast "$version" --file=./pkgs/by-name/ra/raycast/package.nix
+
+      arm_url="https://releases.raycast.com/releases/$version/download?build=arm"
+      x86_url="https://releases.raycast.com/releases/$version/download?build=x86_64"
+
+      arm_hash="sha256-$(curl -sL "$arm_url" | openssl dgst -sha256 -binary | openssl base64)"
+      x86_hash="sha256-$(curl -sL "$x86_url" | openssl dgst -sha256 -binary | openssl base64)"
+
+      sed -i -E \
+        -e 's|(version = )"[0-9]+\.[0-9]+\.[0-9]+";|\1"'"$version"'";|' \
+        -e '/aarch64-darwin = fetchurl/,/};/ s|(hash = )"sha256-[A-Za-z0-9+/]+=";|\1"'"$arm_hash"'";|' \
+        -e '/x86_64-darwin = fetchurl/,/};/ s|(hash = )"sha256-[A-Za-z0-9+/]+=";|\1"'"$x86_hash"'";|' \
+        ./pkgs/by-name/ra/raycast/package.nix
     '';
   });
 


### PR DESCRIPTION
Backport of:
https://github.com/NixOS/nixpkgs/pull/368171
https://github.com/NixOS/nixpkgs/pull/374320

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
