### PR TITLE
WIP sparkle: init at 2.6.4

### DIFF
--- a/pkgs/by-name/sp/sparkle/package.nix
+++ b/pkgs/by-name/sp/sparkle/package.nix
@@ -1,0 +1,46 @@
+{
+  stdenvNoCC,
+  fetchurl,
+  lib,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "sparkle";
+  version = "2.6.4";
+
+  src = fetchurl {
+    url = "https://github.com/sparkle-project/Sparkle/releases/download/${finalAttrs.version}/Sparkle-${finalAttrs.version}.tar.xz";
+    hash = "sha256-UGEqBgOKvJMfFgEdeQO4Mmo2LBB02rzLcYQEzo5YXws=";
+  };
+
+  sourceRoot = ".";
+
+  buildPhase = ''
+    mkdir -p "$out"/Applications
+
+    # Link sparkle-cli binary from sparkle.app
+    ln -s ../Applications/sparkle.app/Contents/MacOS/sparkle bin/sparkle
+
+    # Move "bin/old_dsa_scripts/sign_update" to "bin/sign_update_dsa"
+    mv bin/old_dsa_scripts/sign_update bin/sign_update_dsa
+    rm -rf bin/old_dsa_scripts
+
+    mv sparkle.app "Sparkle Test App.app" "$out"/Applications
+    mv Sparkle.framework bin "$out"
+  '';
+
+  meta = {
+    description = "Software update framework for macOS";
+    homepage = "https://sparkle-project.org/";
+    changelog = "https://github.com/sparkle-project/Sparkle/blob/${finalAttrs.version}/CHANGELOG";
+    platforms = lib.platforms.darwin;
+    license = with lib.licenses; [
+      mit # Sparkle itself
+      bsd2 # bsdiff and SUSignatureVerifier.m
+      zlib # ed25519
+    ];
+    mainProgram = "sparkle";
+    maintainers = with lib.maintainers; [ andre4ik3 ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+  };
+})


### PR DESCRIPTION
Adds [Sparkle](https://sparkle-project.org), a software update framework for macOS.

It contains tools used when developing apps that update with Sparkle, such as `BinaryDelta` (to generate delta updates), `generate_appcast` (to generate manifest of available app versions), and `sign_update` (to sign updates with cryptographic keys). The main `sparkle` CLI can also be used to check and install available updates for an app bundle that uses Sparkle.

In the package, there was two `sign_update` binaries: one for newer Ed25519 keys, and one for older DSA keys. To avoid collisions I renamed the latter to `sign_update_dsa`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
