### PR TITLE
gcr_4: Switch to new version policy

### DIFF
--- a/pkgs/desktops/gnome/find-latest-version.py
+++ b/pkgs/desktops/gnome/find-latest-version.py
@@ -48,6 +48,16 @@ class Stability(Enum):
             case Stability.UNSTABLE:
                 return True
 
+    def __repr__(self) -> str:
+        """
+        Useful for tests.
+        """
+        match self:
+            case Stability.STABLE:
+                return "Stability.STABLE"
+            case Stability.UNSTABLE:
+                return "Stability.UNSTABLE"
+
 
 VersionPolicy = Callable[[Version], bool]
 VersionClassifier = Callable[[Version], Stability]
@@ -61,7 +71,39 @@ def version_to_list(version: str) -> List[int]:
     return list(map(int, version.split(".")))
 
 
-def odd_unstable(version: Version, selected: Stability) -> bool:
+def odd_unstable(version: Version) -> Stability:
+    """
+    Traditional GNOME version policy
+
+    >>> odd_unstable(Version("32"))
+    Stability.STABLE
+    >>> odd_unstable(Version("3.2.1"))
+    Stability.STABLE
+    >>> odd_unstable(Version("3.2.1.alpha"))
+    Stability.UNSTABLE
+    >>> odd_unstable(Version("3.2.1beta"))
+    Stability.UNSTABLE
+    >>> odd_unstable(Version("4.2.89"))
+    Stability.STABLE
+    >>> odd_unstable(Version("4.2.90"))
+    Stability.STABLE
+    >>> odd_unstable(Version("4.88.2"))
+    Stability.STABLE
+    >>> odd_unstable(Version("4.90.2"))
+    Stability.UNSTABLE
+    >>> odd_unstable(Version("4.3.0"))
+    Stability.UNSTABLE
+    >>> odd_unstable(Version("4.3.89"))
+    Stability.UNSTABLE
+    >>> odd_unstable(Version("4.2.899"))
+    Stability.STABLE
+    >>> odd_unstable(Version("4.2.900"))
+    Stability.STABLE
+    >>> odd_unstable(Version("4.898.2"))
+    Stability.STABLE
+    >>> odd_unstable(Version("4.900.2"))
+    Stability.UNSTABLE
+    """
     try:
         version_parts = version_to_list(version.value)
     except:
@@ -81,6 +123,22 @@ def odd_unstable(version: Version, selected: Stability) -> bool:
 
 
 def tagged(version: Version) -> Stability:
+    """
+    Considers only versions with explicit `alpha`, `beta` or `rc` tags unstable.
+
+    >>> tagged(Version("32"))
+    Stability.STABLE
+    >>> tagged(Version("3.2.1"))
+    Stability.STABLE
+    >>> tagged(Version("4.3.0"))
+    Stability.STABLE
+    >>> tagged(Version("3.2.1.alpha"))
+    Stability.UNSTABLE
+    >>> tagged(Version("3.2.1beta"))
+    Stability.UNSTABLE
+    >>> tagged(Version("3.2.1rc.3"))
+    Stability.UNSTABLE
+    """
     prerelease = "alpha" in version.value or "beta" in version.value or "rc" in version.value
     if prerelease:
         return Stability.UNSTABLE
@@ -89,6 +147,18 @@ def tagged(version: Version) -> Stability:
 
 
 def no_policy(version: Version) -> Stability:
+    """
+    Considers any version stable.
+
+    >>> no_policy(Version("32"))
+    Stability.STABLE
+    >>> no_policy(Version("3.2.1"))
+    Stability.STABLE
+    >>> no_policy(Version("3.2.1.alpha"))
+    Stability.STABLE
+    >>> no_policy(Version("3.2.1beta"))
+    Stability.STABLE
+    """
     return Stability.STABLE
 
 

--- a/pkgs/desktops/gnome/find-latest-version.py
+++ b/pkgs/desktops/gnome/find-latest-version.py
@@ -122,6 +122,47 @@ def odd_unstable(version: Version) -> Stability:
         return Stability.UNSTABLE
 
 
+def ninety_micro_unstable(version: Version) -> Stability:
+    """
+    <https://gitlab.gnome.org/GNOME/gcr/-/tree/4.3.90.3#versions>:
+    > To denote unstable versions, the micro version number will correspond to 90 or
+    > higher, e.g. 4.$MINOR.90.
+
+    >>> ninety_micro_unstable(Version("3.2.1"))
+    Stability.STABLE
+    >>> ninety_micro_unstable(Version("3.2.1.alpha"))
+    Stability.UNSTABLE
+    >>> ninety_micro_unstable(Version("3.2.1beta"))
+    Stability.UNSTABLE
+    >>> ninety_micro_unstable(Version("4.2.89"))
+    Stability.STABLE
+    >>> ninety_micro_unstable(Version("4.3.89"))
+    Stability.STABLE
+    >>> ninety_micro_unstable(Version("4.2.90"))
+    Stability.UNSTABLE
+    >>> ninety_micro_unstable(Version("4.2.89.3"))
+    Stability.STABLE
+    >>> ninety_micro_unstable(Version("4.2.90.3"))
+    Stability.UNSTABLE
+    >>> ninety_micro_unstable(Version("4.90.1"))
+    Stability.STABLE
+    """
+    try:
+        version_parts = version_to_list(version.value)
+    except:
+        # Failing to parse as a list of numbers likely means the version contains a string tag like “beta”, therefore it is not a stable release.
+        return Stability.UNSTABLE
+
+    if len(version_parts) < 3:
+        return Stability.STABLE
+
+    prerelease = version_parts[2] >= 90
+    if prerelease:
+        return Stability.UNSTABLE
+    else:
+        return Stability.STABLE
+
+
 def tagged(version: Version) -> Stability:
     """
     Considers only versions with explicit `alpha`, `beta` or `rc` tags unstable.
@@ -166,6 +207,7 @@ class VersionPolicyKind(Enum):
     # HACK: Using function as values directly would make Enum
     # think they are methods and skip them.
     ODD_UNSTABLE = VersionClassifierHolder(odd_unstable)
+    NINETY_MICRO_UNSTABLE = VersionClassifierHolder(ninety_micro_unstable)
     TAGGED = VersionClassifierHolder(tagged)
     NONE = VersionClassifierHolder(no_policy)
 

--- a/pkgs/development/libraries/gcr/4.nix
+++ b/pkgs/development/libraries/gcr/4.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
+    url = "mirror://gnome/sources/gcr/${lib.versions.majorMinor version}/gcr-${version}.tar.xz";
     hash = "sha256-w+6HKOQ2SwOX9DX6IPkvkBqxOdKyZPTgWdZ7PA9DzTY=";
   };
 
@@ -103,7 +103,8 @@ stdenv.mkDerivation rec {
   passthru = {
     updateScript = gnome.updateScript {
       attrPath = "gcr_4";
-      packageName = pname;
+      packageName = "gcr";
+      versionPolicy = "ninety-micro-unstable";
     };
   };
 


### PR DESCRIPTION
It uses SemVer with `micro >= 90` being considered unstable.

https://gitlab.gnome.org/GNOME/gcr/-/tree/4.3.90.3#versions


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
