### PR TITLE
xdg-user-dirs-gtk: 0.11 → 0.14

### DIFF
--- a/pkgs/by-name/xd/xdg-user-dirs-gtk/package.nix
+++ b/pkgs/by-name/xd/xdg-user-dirs-gtk/package.nix
@@ -2,9 +2,8 @@
   stdenv,
   lib,
   fetchurl,
-  fetchpatch,
-  autoreconfHook,
-  intltool,
+  meson,
+  ninja,
   pkg-config,
   xdg-user-dirs,
   wrapGAppsHook3,
@@ -14,36 +13,30 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "xdg-user-dirs-gtk";
-  version = "0.11";
+  version = "0.14";
 
   src = fetchurl {
     url = "mirror://gnome/sources/xdg-user-dirs-gtk/${lib.versions.majorMinor finalAttrs.version}/xdg-user-dirs-gtk-${finalAttrs.version}.tar.xz";
-    hash = "sha256-U0vVY9PA4/jcvzV4y4qw5J07pByWbUd8ivlDg2QSHn0=";
+    hash = "sha256-U3++FCskc27XiU5KAfaf11jLbHpnejgoeVKdIX9KKHM=";
   };
 
-  patches = [
-    # Fix cross: ./configure: line 7633: no: command not found
-    (fetchpatch {
-      url = "https://salsa.debian.org/gnome-team/xdg-user-dirs-gtk/-/raw/b047b613d5f18aebe8e9bca4e0a82b75b2d1f8c4/debian/patches/fix-pkg-config-cross-compilation.patch";
-      hash = "sha256-QHq8hlX0SS+T6jtagMs9qApJCWFG1PHxftzoID2Nag4=";
-    })
-  ];
-
   nativeBuildInputs = [
-    autoreconfHook
-    intltool
+    meson
+    ninja
     pkg-config
-    xdg-user-dirs # for AC_PATH_PROG
+    xdg-user-dirs
     wrapGAppsHook3
   ];
 
   buildInputs = [ gtk3 ];
 
   postPatch = ''
-    # Fetch translations from correct localedir.
+    # Fetch “xdg-user-dirs” translations from correct localedir.
     substituteInPlace update.c --replace-fail \
       'bindtextdomain ("xdg-user-dirs", GLIBLOCALEDIR);' \
       'bindtextdomain ("xdg-user-dirs", "${xdg-user-dirs}/share/locale");'
+
+    patchShebangs meson_custom_install_desktop_file.sh
   '';
 
   preFixup = ''
@@ -57,7 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     homepage = "https://gitlab.gnome.org/GNOME/xdg-user-dirs-gtk";
     description = "Companion to xdg-user-dirs that integrates it into the GNOME desktop and GTK applications";
-    license = lib.licenses.gpl2Only;
+    license = lib.licenses.gpl2Plus;
     maintainers = lib.teams.gnome.members;
     platforms = lib.platforms.unix;
     mainProgram = "xdg-user-dirs-gtk-update";


### PR DESCRIPTION
Depends on https://gitlab.gnome.org/GNOME/xdg-user-dirs-gtk/-/merge_requests/18 and https://gitlab.gnome.org/GNOME/xdg-user-dirs-gtk/-/merge_requests/16

- Port to Meson.
- Correct license according to `meson.build` file.
- Clarify the comment that the `bindtextdomain` replacement is to find translations for `dgettext("xdg-user-dirs", …)`.

https://gitlab.gnome.org/GNOME/xdg-user-dirs-gtk/-/compare/0.11...0.13


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
