### PR TITLE
Update aeron and aeron-cpp to latest

### DIFF
--- a/pkgs/by-name/ae/aeron-cpp/package.nix
+++ b/pkgs/by-name/ae/aeron-cpp/package.nix
@@ -36,7 +36,6 @@ let
   sbeAll = sbeAll_1_34_1;
 
 in
-
 stdenv.mkDerivation {
   pname = "aeron-cpp";
   inherit version;
@@ -117,7 +116,7 @@ stdenv.mkDerivation {
 
     mkdir --parents "$out"
     cp --archive --verbose --target-directory="$out" install/*
-    
+
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ae/aeron-cpp/package.nix
+++ b/pkgs/by-name/ae/aeron-cpp/package.nix
@@ -19,6 +19,13 @@
 let
   version = aeron.version;
 
+  sbeAll_1_31_1 = fetchMavenArtifact {
+    groupId = "uk.co.real-logic";
+    version = "1.31.1";
+    artifactId = "sbe-all";
+    hash = "sha512-Ypsk8PbShFOxm49u1L+TTuApaW6ECTSee+hHEhmY/jNi5AymHXBWwDMBMkzC25aowiHLJS5EnzLk6hu9Lea93Q==";
+  };
+
   sbeAll_1_34_1 = fetchMavenArtifact {
     groupId = "uk.co.real-logic";
     version = "1.34.1";

--- a/pkgs/by-name/ae/aeron-cpp/package.nix
+++ b/pkgs/by-name/ae/aeron-cpp/package.nix
@@ -4,7 +4,8 @@
   cmake,
   fetchFromGitHub,
   fetchMavenArtifact,
-  jdk11,
+  jdk ? jdk17,
+  jdk17,
   lib,
   libbsd,
   libuuid,
@@ -12,19 +13,20 @@
   patchelf,
   stdenv,
   zlib,
+  ninja,
 }:
 
 let
   version = aeron.version;
 
-  sbeAll_1_31_1 = fetchMavenArtifact {
+  sbeAll_1_34_1 = fetchMavenArtifact {
     groupId = "uk.co.real-logic";
-    version = "1.31.1";
+    version = "1.34.1";
     artifactId = "sbe-all";
-    hash = "sha512-Ypsk8PbShFOxm49u1L+TTuApaW6ECTSee+hHEhmY/jNi5AymHXBWwDMBMkzC25aowiHLJS5EnzLk6hu9Lea93Q==";
+    hash = "sha512-Z0zBQrrqJSjfkUADhIANskIUb+FgOto5kr1+Y3Lw9RhSAxslaP+NdB705RdITC/kq7qTMlUstc2xM797dE/6BA==";
   };
 
-  sbeAll = sbeAll_1_31_1;
+  sbeAll = sbeAll_1_34_1;
 
 in
 
@@ -56,8 +58,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     autoPatchelfHook
     cmake
-    jdk11
+    jdk
     makeWrapper
+    ninja
     patchelf
   ];
 
@@ -68,7 +71,7 @@ stdenv.mkDerivation {
     (
       cd cppbuild/Release
       cmake \
-        -G "CodeBlocks - Unix Makefiles" \
+        -G Ninja \
         -DCMAKE_BUILD_TYPE=Release \
         -DAERON_TESTS=OFF \
         -DAERON_SYSTEM_TESTS=OFF \
@@ -88,8 +91,7 @@ stdenv.mkDerivation {
     mkdir --parents aeron-all/build/libs
     (
       cd cppbuild/Release
-
-      make -j $NIX_BUILD_CORES \
+      ninja -j $NIX_BUILD_CORES \
         aeron \
         aeron_archive_client \
         aeron_client_shared \
@@ -97,8 +99,7 @@ stdenv.mkDerivation {
         aeron_client \
         aeron_driver_static \
         aeronmd
-
-      make install
+      ninja install
     )
 
     runHook postBuild
@@ -109,7 +110,7 @@ stdenv.mkDerivation {
 
     mkdir --parents "$out"
     cp --archive --verbose --target-directory="$out" install/*
-
+    
     runHook postInstall
   '';
 

--- a/pkgs/by-name/ae/aeron/package.nix
+++ b/pkgs/by-name/ae/aeron/package.nix
@@ -1,4 +1,5 @@
 {
+
   lib,
   stdenv,
   fetchMavenArtifact,
@@ -95,9 +96,7 @@ stdenv.mkDerivation {
     aeronSamples
   ];
 
-  nativeBuildInputs = [
-    makeWrapper
-  ];
+  nativeBuildInputs = [ makeWrapper ];
 
   dontUnpack = true;
   dontConfigure = true;
@@ -140,8 +139,6 @@ stdenv.mkDerivation {
     license = licenses.asl20;
     mainProgram = "${pname}-media-driver";
     maintainers = [ maintainers.vaci ];
-    sourceProvenance = [
-      sourceTypes.binaryBytecode
-    ];
+    sourceProvenance = [ sourceTypes.binaryBytecode ];
   };
 }

--- a/pkgs/by-name/ae/aeron/package.nix
+++ b/pkgs/by-name/ae/aeron/package.nix
@@ -2,13 +2,14 @@
   lib,
   stdenv,
   fetchMavenArtifact,
-  jdk11,
+  jdk17,
+  jdk ? jdk17,
   makeWrapper,
 }:
 
 let
   pname = "aeron";
-  version = "1.44.1";
+  version = "1.47.0";
   groupId = "io.aeron";
 
   aeronAll_1_40_0 = fetchMavenArtifact {
@@ -67,8 +68,22 @@ let
     hash = "sha256-ZSuTed45BRzr4JJuGeXghUgEifv/FpnCzTNJWa+nwjo=";
   };
 
-  aeronAll = aeronAll_1_44_1;
-  aeronSamples = aeronSamples_1_44_1;
+  aeronAll_1_47_0 = fetchMavenArtifact {
+    inherit groupId;
+    artifactId = "aeron-all";
+    version = "1.47.0";
+    hash = "sha256-CfWsJBpk637o+CKkvpAMS+muEY/8tCh4SkEML8kYY1k=";
+  };
+
+  aeronSamples_1_47_0 = fetchMavenArtifact {
+    inherit groupId;
+    version = "1.47.0";
+    artifactId = "aeron-samples";
+    hash = "sha256-QVlBif/EmzFTB3XPLWXRdZME46Ipky+O300AH+kd9+M=";
+  };
+
+  aeronAll = aeronAll_1_47_0;
+  aeronSamples = aeronSamples_1_47_0;
 
 in
 stdenv.mkDerivation {
@@ -100,7 +115,7 @@ stdenv.mkDerivation {
 
   postFixup = ''
     function wrap {
-      makeWrapper "${jdk11}/bin/java" "$out/bin/$1" \
+      makeWrapper "${jdk}/bin/java" "$out/bin/$1" \
         --add-flags "--add-opens java.base/sun.nio.ch=ALL-UNNAMED" \
         --add-flags "--class-path ${aeronAll.jar}" \
         --add-flags "$2"


### PR DESCRIPTION
Update aeron to 1.47.0 and aeron-cpp with build system improvements
- Upgrade aeron from 1.44.1 to 1.47.0
- Switch aeron-cpp build system from Make to Ninja for better build performance
- Update SBE dependency from 1.31.1 to 1.34.1
- Make JDK configurable (default to JDK17) for both packages
Changelog: https://github.com/real-logic/aeron/releases

## Things done
- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - No NixOS tests available for these packages
  - Basic package tests pass
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
  - Verified aeron media driver starts correctly
  - Verified aeron sample applications run
  - Verified aeron-cpp builds and links correctly
- [x] 25.05 Release Notes
  - [x] (Package updates) No release notes entry needed as changes are not breaking
  - [x] (Module updates) N/A
  - [x] (Module addition) N/A
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

The JDK change is backward compatible as it maintains the same major version features, just makes it configurable with a sensible default. The switch to Ninja build system for aeron-cpp should provide faster builds without affecting the end result.