### PR TITLE
Updating software versions yandex-browser...

### DIFF
--- a/pkgs/by-name/ya/yandex-browser/package.nix
+++ b/pkgs/by-name/ya/yandex-browser/package.nix
@@ -54,9 +54,9 @@
 
 let
   version = {
-    corporate = "24.7.1.1195-1";
-    beta = "24.7.1.1124-1";
-    stable = "24.7.1.1120-1";
+    corporate = "24.10.4.817-1";
+    beta = "24.12.1.704-1";
+    stable = "24.12.1.712-1";
   }.${edition};
 
   hash = {


### PR DESCRIPTION
The version has changed in the official repository of the manufacturer of the Yandex Browser program (https://repo.yandex.ru/yandex-browser/deb/pool/main/y/yandex-browser-stable/yandex-browser-stable_24.12.1.712-1_amd64.deb).

In this regard, the installation in NixOS ends with an error.