### PR TITLE
waypipe: add missing runtime dependencies

### DIFF
--- a/pkgs/by-name/wa/waypipe/package.nix
+++ b/pkgs/by-name/wa/waypipe/package.nix
@@ -6,7 +6,7 @@
   ninja,
   pkg-config,
   scdoc,
-  mesa,
+  libgbm,
   lz4,
   zstd,
   ffmpeg,
@@ -55,15 +55,22 @@ llvmPackages.stdenv.mkDerivation rec {
     rustc
     wayland-scanner
     rustPlatform.cargoSetupHook
+    autoPatchelfHook
     rust-bindgen
   ];
 
   buildInputs = [
-    mesa
+    libgbm
     lz4
     zstd
     ffmpeg
     vulkan-headers
+    vulkan-loader
+  ];
+
+  runtimeDependencies = [
+    libgbm
+    ffmpeg.lib
     vulkan-loader
   ];
 

--- a/pkgs/by-name/wa/waypipe/package.nix
+++ b/pkgs/by-name/wa/waypipe/package.nix
@@ -10,20 +10,15 @@
   lz4,
   zstd,
   ffmpeg,
-  libva,
   cargo,
   rustc,
-  git,
   vulkan-headers,
   vulkan-loader,
   shaderc,
-  vulkan-tools,
   llvmPackages,
   autoPatchelfHook,
-  wayland,
   wayland-scanner,
   rust-bindgen,
-  egl-wayland,
 }:
 llvmPackages.stdenv.mkDerivation rec {
   pname = "waypipe";

--- a/pkgs/development/python-modules/cyclopts/default.nix
+++ b/pkgs/development/python-modules/cyclopts/default.nix
@@ -19,7 +19,7 @@
 
 buildPythonPackage rec {
   pname = "cyclopts";
-  version = "3.2.0";
+  version = "3.2.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
@@ -28,7 +28,7 @@ buildPythonPackage rec {
     owner = "BrianPugh";
     repo = "cyclopts";
     tag = "v${version}";
-    hash = "sha256-U2H/SyVqoNlKAiim6FieEQw0SKK/b9diP9AjXb8PZjg=";
+    hash = "sha256-dHmoO9agZBhDviowtvuAox8hJsHcxgQTRxpaYmy50Dk=";
   };
 
   build-system = [


### PR DESCRIPTION
Waypipe dynamically loads ffmpeg[^1] and libgbm[^2] at runtime, therefore their library paths need to be included in the binary's RUNPATH. libvulkan.so.1 also needs to be in the RUNPATH, because the ash Rust crate used by Waypipe loads it dynamically at runtime[^3].

https://github.com/NixOS/nixpkgs/pull/374615 removed all runtimeDependencies and the autoPatchelfHook that adds them to the RUNPATH.

This commit readds the autoPatchelfHook and adds the three dynamically loaded libraries to the runtimeDependencies.
In addition, it replaces the mesa buildInput with libgbm (which was used before https://github.com/NixOS/nixpkgs/pull/373212) because Waypipe depends only on libgbm.

Resolves https://github.com/NixOS/nixpkgs/issues/374595

[^1]: https://gitlab.freedesktop.org/mstoeckl/waypipe/-/blob/cb53f342af8a3009561e0566ed81962acbde6fc0/wrap-ffmpeg/build.rs#L110-111
[^2]: https://gitlab.freedesktop.org/mstoeckl/waypipe/-/blob/cb53f342af8a3009561e0566ed81962acbde6fc0/wrap-gbm/build.rs#L76-77l
[^3]: https://github.com/ash-rs/ash?tab=readme-ov-file#optional-linking


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
