### PR TITLE
scalpel: fix cross build

### DIFF
--- a/pkgs/by-name/sc/scalpel/package.nix
+++ b/pkgs/by-name/sc/scalpel/package.nix
@@ -23,6 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
     autoconf
     automake
     libtool
+  ];
+
+  buildInputs = [
     tre
   ];
 


### PR DESCRIPTION
`tre` is a runtime dependency.

Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).