### PR TITLE
cargo-make: 0.37.23 -> 0.37.24

### DIFF
--- a/pkgs/by-name/ca/cargo-make/package.nix
+++ b/pkgs/by-name/ca/cargo-make/package.nix
@@ -8,6 +8,7 @@
   openssl,
   stdenv,
   darwin,
+  versionCheckHook,
   nix-update-script,
 }:
 
@@ -47,6 +48,13 @@ rustPlatform.buildRustPackage rec {
   # See also:
   #   https://travis-ci.org/sagiegurari/cargo-make
   doCheck = false;
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  doInstallCheck = true;
+  versionCheckProgram = "${placeholder "out"}/bin/makers";
+  versionCheckProgramArg = [ "--version" ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/ca/cargo-make/package.nix
+++ b/pkgs/by-name/ca/cargo-make/package.nix
@@ -8,6 +8,7 @@
   openssl,
   stdenv,
   darwin,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -46,6 +47,8 @@ rustPlatform.buildRustPackage rec {
   # See also:
   #   https://travis-ci.org/sagiegurari/cargo-make
   doCheck = false;
+
+  passthru.updateScript = nix-update-script { };
 
   meta = with lib; {
     description = "Rust task runner and build tool";

--- a/pkgs/by-name/ca/cargo-make/package.nix
+++ b/pkgs/by-name/ca/cargo-make/package.nix
@@ -13,16 +13,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-make";
-  version = "0.37.23";
+  version = "0.37.24";
 
   src = fetchFromGitHub {
     owner = "sagiegurari";
     repo = "cargo-make";
     rev = version;
-    hash = "sha256-yYZasrnfxpLf0z6GndLYhkIFfVNjTkx4zdfHYX6WyXk=";
+    hash = "sha256-hrUd4J15cDyd78BVVzi8jiDqJI1dE35WUdOo6Tq8gH8=";
   };
 
-  cargoHash = "sha256-X4FhUqhf58wbl3A8nlXAqnYkkaXajxxqRyJn5K7BVqM=";
+  cargoHash = "sha256-kSoEqiaKeS0VYk7MTir6twY/gXJWjEbS+nFlC3CH8HU=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Diff: https://github.com/sagiegurari/cargo-make/compare/0.37.23...0.37.24

Changelog: https://github.com/sagiegurari/cargo-make/blob/0.37.24/CHANGELOG.md?plain=1#L3-L9

<details>
<summary>

[Omitted](https://github.com/NixOS/nixpkgs/pull/374845#discussion_r1921127408) to add [new zsh task completions](https://github.com/sagiegurari/cargo-make/pull/1182) in this PR.

</summary>

~The generated script including awk.
Don't we need to add awk in runtime dependency for these case? https://github.com/NixOS/nixpkgs/blob/f52cc903969954c3c683711a2df89491f6c1a8c6/doc/stdenv/stdenv.chapter.md?plain=1#L175~

</details>

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


