### PR TITLE
llvmPackages.lldb: use debugserver on Darwin

### DIFF
--- a/pkgs/by-name/de/debugserver/package.nix
+++ b/pkgs/by-name/de/debugserver/package.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  fetchurl,
+  stdenvNoCC,
+  unzip,
+}:
+
+let
+  platforms = {
+    aarch64-darwin = {
+      arch = "arm64";
+      hash = "sha256-M4VYOmd72I8GAkRbeBztqbugrb4eHSotTUyrkmPmreA=";
+    };
+    x86_64-darwin = {
+      arch = "x64";
+      hash = "sha256-JHjIT84dDK7jCULe4YE3CAUNE+XFoFmwzsLJk4ktF44=";
+    };
+  };
+
+  inherit (platforms.${stdenvNoCC.hostPlatform.system}) arch hash;
+in
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "debugserver";
+  version = "1.11.1";
+
+  src = fetchurl {
+    url = "https://github.com/vadimcn/codelldb/releases/download/v${finalAttrs.version}/codelldb-darwin-${arch}.vsix";
+    inherit hash;
+  };
+
+  nativeBuildInputs = [ unzip ];
+
+  buildCommand = ''
+    unzip "$src"
+
+    mkdir -p "$out/bin"
+    cp extension/lldb/bin/debugserver "$out/bin"
+  '';
+
+  dontFixup = true;
+
+  meta = {
+    description = "debugserver binary for use with LLDB";
+    homepage = "https://github.com/vadimcn/codelldb";
+    license = lib.licenses.asl20;
+    mainProgram = "debugserver";
+    maintainers = [ lib.maintainers.reckenrode ];
+    platforms = lib.platforms.darwin; # Other platforms are supported, but this is really only needed on Darwin.
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+})

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -3,6 +3,7 @@
 , llvm_meta
 , release_version
 , cmake
+, debugserver
 , zlib
 , ncurses
 , swig

--- a/pkgs/development/compilers/llvm/common/lldb.nix
+++ b/pkgs/development/compilers/llvm/common/lldb.nix
@@ -141,7 +141,8 @@ stdenv.mkDerivation (rec {
   '';
 
   postInstall = ''
-    wrapProgram $out/bin/lldb --prefix PYTHONPATH : $lib/${python3.sitePackages}/
+    wrapProgram $out/bin/lldb --prefix PYTHONPATH : $lib/${python3.sitePackages}/ \
+      ${lib.optionalString stdenv.hostPlatform.isDarwin "--set-default LLDB_DEBUGSERVER_PATH '${lib.getExe debugserver}'"}
 
     # Editor support
     # vscode:


### PR DESCRIPTION
Darwin requires a `debugserver` binary that is signed and has the correct entitlements for debugging. Fortunately, the CodeLLDB package has one that can be extracted and used without requiring Xcode for debugging.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
