### PR TITLE
usbip-ssh: init at 0-unstable-2024-10-09

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -12019,6 +12019,12 @@
     github = "kaeeraa";
     githubId = 99148867;
   };
+  kagehisa = {
+    name = "Sven Woelfel";
+    email = "woelfel.pub@gmail.com";
+    github = "kagehisa";
+    githubId = 37015428;
+  };
   kaiha = {
     email = "kai.harries@gmail.com";
     github = "KaiHa";

--- a/pkgs/by-name/us/usbip-ssh/package.nix
+++ b/pkgs/by-name/us/usbip-ssh/package.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  perl,
+  openssh,
+  kmod,
+  makeWrapper,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "usbip-ssh";
+  version = "0-unstable-2024-10-09";
+
+  src = fetchFromGitHub {
+    owner = "turistu";
+    repo = "usbip-ssh";
+    rev = "1b38f2d7854048bf6129ffe992f3c9caa630e377";
+    hash = "sha256-3kGGMlIMTXnBVLgsZijc0yLbyaZZSDf7lr46mg0viWw=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    perl
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -Dm755 usbip-ssh -t $out/bin
+    runHook postInstall
+  '';
+
+  postInstall = ''
+    wrapProgram $out/bin/usbip-ssh --prefix PATH : ${
+      lib.makeBinPath [
+        perl
+        openssh
+        kmod
+      ]
+    }
+  '';
+
+  meta = {
+    homepage = "https://github.com/turistu/usbip-ssh";
+    description = "Import usb devices from another linux machine with ssh's connection forwarding mechanism";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ kagehisa ];
+    mainProgram = "usbip-ssh";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
Added the [usbip-ssh](https://github.com/turistu/usbip-ssh) package at version 0-unstable-2024-10-09 to nixpkgs.

This script is using the kernel's USB/IP modules and the ssh's connection forwarding mechanism to import usb devices from another linux machine. It does not depend on the USB/IP's project userland components and does not require any extra software on either the local or the remote machine besides an openssh client/server and a base perl installation.
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
