### PR TITLE
mir,mir_2_15: Fix builds, modernise & fix VM tests

### DIFF
--- a/nixos/tests/miracle-wm.nix
+++ b/nixos/tests/miracle-wm.nix
@@ -22,6 +22,8 @@
         user = "alice";
       };
 
+      programs.ydotool.enable = true;
+
       services.xserver.enable = true;
       services.displayManager.defaultSession = lib.mkForce "miracle-wm";
 
@@ -114,7 +116,17 @@
           machine.wait_for_file("/tmp/test-wayland-exit-ok")
           machine.copy_from_vm("/tmp/test-wayland.out")
           machine.screenshot("foot_wayland_info")
+
+          # please actually register that we want to close the window
+          machine.succeed("ydotool mousemove -- 10 10")
+          machine.sleep(3)
+
           machine.send_chars("exit\n")
+
+          # please actually register that we want to close the window
+          machine.succeed("ydotool mousemove -- 10 10")
+          machine.sleep(3)
+
           machine.wait_until_fails("pgrep foot")
 
       # Test XWayland
@@ -125,7 +137,17 @@
           machine.wait_for_file("/tmp/test-x11-exit-ok")
           machine.copy_from_vm("/tmp/test-x11.out")
           machine.screenshot("alacritty_glinfo")
+
+          # please actually register that we want to close the window
+          machine.succeed("ydotool mousemove -- 10 10")
+          machine.sleep(3)
+
           machine.send_chars("exit\n")
+
+          # please actually register that we want to close the window
+          machine.succeed("ydotool mousemove -- 10 10")
+          machine.sleep(3)
+
           machine.wait_until_fails("pgrep alacritty")
     '';
 }

--- a/nixos/tests/miracle-wm.nix
+++ b/nixos/tests/miracle-wm.nix
@@ -59,7 +59,7 @@
         ];
 
         # To help with OCR
-        etc."xdg/foot/foot.ini".text = lib.generators.toINI { } {
+        etc."xdg/foot/foot.ini".source = (pkgs.formats.ini { }).generate "foot.ini" {
           main = {
             font = "inconsolata:size=16";
           };
@@ -69,7 +69,7 @@
             regular2 = foreground;
           };
         };
-        etc."xdg/alacritty/alacritty.yml".text = lib.generators.toYAML { } {
+        etc."xdg/alacritty/alacritty.toml".source = (pkgs.formats.toml { }).generate "alacritty.toml" {
           font = rec {
             normal.family = "Inconsolata";
             bold.family = normal.family;

--- a/nixos/tests/miriway.nix
+++ b/nixos/tests/miriway.nix
@@ -55,7 +55,7 @@ import ./make-test-python.nix (
           ];
 
           # To help with OCR
-          etc."xdg/foot/foot.ini".text = lib.generators.toINI { } {
+          etc."xdg/foot/foot.ini".source = (pkgs.formats.ini { }).generate "foot.ini" {
             main = {
               font = "inconsolata:size=16";
             };
@@ -65,7 +65,7 @@ import ./make-test-python.nix (
               regular2 = foreground;
             };
           };
-          etc."xdg/alacritty/alacritty.yml".text = lib.generators.toYAML { } {
+          etc."xdg/alacritty/alacritty.toml".source = (pkgs.formats.toml { }).generate "alacritty.toml" {
             font = rec {
               normal.family = "Inconsolata";
               bold.family = normal.family;

--- a/nixos/tests/miriway.nix
+++ b/nixos/tests/miriway.nix
@@ -109,10 +109,8 @@ import ./make-test-python.nix (
         machine.wait_for_file("/tmp/test-wayland-exit-ok")
         machine.copy_from_vm("/tmp/test-wayland.out")
         machine.screenshot("foot_wayland_info")
-        # Only succeeds when a mouse is moved inside an interactive session?
-        # machine.send_chars("exit\n")
-        # machine.wait_until_fails("pgrep foot")
-        machine.succeed("pkill foot")
+        machine.send_chars("exit\n")
+        machine.wait_until_fails("pgrep foot")
 
         # Test XWayland
         machine.send_key("ctrl-alt-a")
@@ -121,10 +119,8 @@ import ./make-test-python.nix (
         machine.wait_for_file("/tmp/test-x11-exit-ok")
         machine.copy_from_vm("/tmp/test-x11.out")
         machine.screenshot("alacritty_glinfo")
-        # Only succeeds when a mouse is moved inside an interactive session?
-        # machine.send_chars("exit\n")
-        # machine.wait_until_fails("pgrep alacritty")
-        machine.succeed("pkill alacritty")
+        machine.send_chars("exit\n")
+        machine.wait_until_fails("pgrep alacritty")
       '';
   }
 )

--- a/nixos/tests/miriway.nix
+++ b/nixos/tests/miriway.nix
@@ -23,6 +23,8 @@ import ./make-test-python.nix (
           user = "alice";
         };
 
+        programs.ydotool.enable = true;
+
         services.xserver.enable = true;
         services.displayManager.defaultSession = lib.mkForce "miriway";
 
@@ -109,7 +111,17 @@ import ./make-test-python.nix (
         machine.wait_for_file("/tmp/test-wayland-exit-ok")
         machine.copy_from_vm("/tmp/test-wayland.out")
         machine.screenshot("foot_wayland_info")
+
+        # please actually register that we want to close the window
+        machine.succeed("ydotool mousemove -- 10 10")
+        machine.sleep(3)
+
         machine.send_chars("exit\n")
+
+        # please actually register that we want to close the window
+        machine.succeed("ydotool mousemove -- 10 10")
+        machine.sleep(3)
+
         machine.wait_until_fails("pgrep foot")
 
         # Test XWayland
@@ -119,7 +131,17 @@ import ./make-test-python.nix (
         machine.wait_for_file("/tmp/test-x11-exit-ok")
         machine.copy_from_vm("/tmp/test-x11.out")
         machine.screenshot("alacritty_glinfo")
+
+        # please actually register that we want to close the window
+        machine.succeed("ydotool mousemove -- 10 10")
+        machine.sleep(3)
+
         machine.send_chars("exit\n")
+
+        # please actually register that we want to close the window
+        machine.succeed("ydotool mousemove -- 10 10")
+        machine.sleep(3)
+
         machine.wait_until_fails("pgrep alacritty")
       '';
   }

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -12,7 +12,6 @@
   freetype,
   glib,
   glm,
-  glog,
   libapparmor,
   libdrm,
   libepoxy,
@@ -112,7 +111,6 @@ stdenv.mkDerivation (finalAttrs: {
     freetype
     glib
     glm
-    glog
     libdrm
     libepoxy
     libevdev

--- a/pkgs/servers/mir/common.nix
+++ b/pkgs/servers/mir/common.nix
@@ -159,7 +159,12 @@ stdenv.mkDerivation (finalAttrs: {
     # BadBufferTest.test_truncated_shm_file *doesn't* throw an error as the test expected, mark as such
     # https://github.com/canonical/mir/pull/1947#issuecomment-811810872
     (lib.cmakeBool "MIR_SIGBUS_HANDLER_ENVIRONMENT_BROKEN" true)
-    (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (lib.strings.concatStringsSep ";" [ ]))
+    (lib.cmakeFeature "MIR_EXCLUDE_TESTS" (
+      lib.strings.concatStringsSep ";" [
+        # https://github.com/canonical/mir/issues/3716#issuecomment-2580698552
+        "UdevWrapperTest.UdevMonitorDoesNotTriggerBeforeEnabling"
+      ]
+    ))
     # These get built but don't get executed by default, yet they get installed when tests are enabled
     (lib.cmakeBool "MIR_BUILD_PERFORMANCE_TESTS" false)
     (lib.cmakeBool "MIR_BUILD_PLATFORM_TEST_HARNESS" false)

--- a/pkgs/servers/mir/default.nix
+++ b/pkgs/servers/mir/default.nix
@@ -29,6 +29,14 @@ in
         hash = "sha256-k+51piPQandbHdm+ioqpBrb+C7Aqi2kugchAehZ1aiU=";
       })
 
+      # Always depend on epoxy
+      # Remove when version > 2.15.0
+      (fetchpatch {
+        name = "0003-mir-cmake-always-require-epoxy.patch";
+        url = "https://github.com/canonical/mir/commit/171c42ac3929f946a70505ee42be0ce8220f245a.patch";
+        hash = "sha256-QuVZBcHSn/DK+xbjM36Y89+w22vk7NRV4MkbjgvS28A=";
+      })
+
       # Fix ignored return value of std::lock_guard
       # Remove when version > 2.15.0
       # Was changed as part of the big platform API change, no individual upstream commit with this fix
@@ -44,6 +52,33 @@ in
       # Partially done in https://github.com/canonical/mir/pull/3192, though one of the calloc was fixed earlier
       # when some code was moved into that file
       ./1003-mir-2_15-calloc-args-in-right-order.patch
+
+      # Drop gflags & glog dependencies
+      # Remove when version > 2.16.4
+      (fetchpatch {
+        name = "0101-Drop-unused-dependency-on-gflags.patch";
+        url = "https://github.com/canonical/mir/commit/15a40638e5e9c4b6a11b7fa446ad31e190f485e7.patch";
+        includes = [
+          "CMakeLists.txt"
+          "examples/mir_demo_server/CMakeLists.txt"
+          "examples/mir_demo_server/glog_logger.cpp"
+        ];
+        hash = "sha256-qIsWCOs6Ap0jJ2cpgdO+xJHmSqC6zP+J3ALAfmlA6Vc=";
+      })
+      (fetchpatch {
+        name = "0102-Drop-the-glog-example.patch";
+        url = "https://github.com/canonical/mir/commit/8407da28ddb9a535df2775f224bf5143e8770d52.patch";
+        includes = [
+          "CMakeLists.txt"
+          "examples/mir_demo_server/CMakeLists.txt"
+          "examples/mir_demo_server/glog_logger.cpp"
+          "examples/mir_demo_server/glog_logger.h"
+          "examples/mir_demo_server/server_example.cpp"
+          "examples/mir_demo_server/server_example_log_options.cpp"
+          "examples/mir_demo_server/server_example_log_options.h"
+        ];
+        hash = "sha256-jVhVR7wZZZGRS40z+HPNoGBLHulvE1nHRKgYhQ6/g9M=";
+      })
     ];
   };
 }


### PR DESCRIPTION
#### 1st:

`mir` and `mir_2_15` currently fail on master, for different reasons.

- `mir`: Borked test
- `mir_2_15`: Borked test + glog dropped pkg-config generation + new glog version errors out when used: https://github.com/NixOS/nixpkgs/pull/371915#issuecomment-2592669676

Fix these builds, to unblock Mir-based compositors (Miriway & miracle-wm) and the Lomiri DE.

#### 2nd:

Additionally, Alacritty, when launched in the VM tests, complains about the YAML config format:
```
machine # [   24.987840] miriway[1098]: [0.004055543s] [WARN ] [alacritty] YAML config "/etc/xdg/alacritty/alacritty.yml" is deprecated, please migrate to TOML using `alacritty migrate`
```

A `lib.generators.toTOML` was rejected in the past, so switch to `pkgs.formats.yaml`. For consistency, switch the INI file generation to `pkgs.formats.ini` as well.

#### 3rd:

OfBorg fails to run the VM tests. Try some things to hopefully resolve this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
