### PR TITLE
crusader: init at 0.3.2

### DIFF
--- a/pkgs/by-name/cr/crusader/package.nix
+++ b/pkgs/by-name/cr/crusader/package.nix
@@ -1,0 +1,90 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # nativeBuildInputs
+  makeWrapper,
+  pkg-config,
+  autoPatchelfHook,
+
+  # buildInputs
+  fontconfig,
+  libgcc,
+  libxkbcommon,
+  xorg,
+
+  libGL,
+  wayland,
+  versionCheckHook,
+  nix-update-script,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "crusader";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "Zoxc";
+    repo = "crusader";
+    tag = "v${version}";
+    hash = "sha256-M5zMOOYDS91p0EuDSlQ3K6eiVQpbX6953q+cXBMix2s=";
+  };
+
+  sourceRoot = "${src.name}/src";
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-f0TWiRX203/gNsa9UEr/1Bv+kUxLAK/Zlw+S693xZlE=";
+
+  # autoPatchelfHook required on linux for crusader-gui
+  nativeBuildInputs =
+    [
+      makeWrapper
+      pkg-config
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      autoPatchelfHook
+    ];
+
+  buildInputs =
+    [
+      fontconfig
+      libgcc
+      libxkbcommon
+    ]
+    ++ lib.optionals stdenv.isLinux [
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXi
+    ];
+
+  # required for crusader-gui
+  runtimeDependencies = [
+    libGL
+    libxkbcommon
+  ];
+
+  postFixup = ''
+    # the program looks for libwayland-client.so at runtime
+    wrapProgram $out/bin/crusader-gui \
+      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ wayland ]}
+  '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Network throughput and latency tester";
+    homepage = "https://github.com/Zoxc/crusader";
+    changelog = "https://github.com/Zoxc/crusader/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ x123 ];
+    platforms = lib.platforms.all;
+    mainProgram = "crusader";
+  };
+}


### PR DESCRIPTION
Add rust-based crusader network throughput and latency testing tool.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
