### PR TITLE
lldap-cli: 0-unstable-2024-02-24 -> 0-unstable-2024-11-11

### DIFF
--- a/pkgs/by-name/ll/lldap-cli/package.nix
+++ b/pkgs/by-name/ll/lldap-cli/package.nix
@@ -7,18 +7,21 @@
   gnugrep,
   gnused,
   jq,
+  lldap,
+  unixtools,
   curl,
   makeWrapper,
+  unstableGitUpdater,
 }:
 stdenv.mkDerivation {
   pname = "lldap-cli";
-  version = "0-unstable-2024-02-24";
+  version = "0-unstable-2024-11-11";
 
   src = fetchFromGitHub {
     owner = "Zepmann";
     repo = "lldap-cli";
-    rev = "d1fe50006c4a3a1796d4fb2d73d8c8dcfc875fd5";
-    hash = "sha256-ZKRTYdgtOfV7TgpaVKLhYrCttYvB/bUexMshmmF8NyY=";
+    rev = "2a80dc47c334c88faf3000b45c631bc2cea09906";
+    hash = "sha256-uk7SOiQmUYtoJnihSnPsu/7Er4wXX4xvPboJaNSMjkM=";
   };
 
   nativeBuildInputs = [ makeWrapper ];
@@ -42,14 +45,18 @@ stdenv.mkDerivation {
       --prefix PATH : ${
         lib.makeBinPath [
           bash
+          unixtools.column
           coreutils
           gnugrep
           gnused
           jq
+          lldap # Needed for lldap_set_password
           curl
         ]
       }
   '';
+
+  passthru.updateScript = unstableGitUpdater { };
 
   meta = {
     description = "Command line tool for managing LLDAP";


### PR DESCRIPTION
Quick smoke check:

```bash
$ nix-build -A pkgs.lldap-cli
this derivation will be built:
  /nix/store/zy0ixjrflb94kvsbrkl97817pj9y3d46-lldap-cli-0-unstable-2024-11-11.drv
building '/nix/store/zy0ixjrflb94kvsbrkl97817pj9y3d46-lldap-cli-0-unstable-2024-11-11.drv'...
Running phase: unpackPhase
unpacking source archive /nix/store/lq9y7rmkp0x1g51jr1hs10wbhc78i0qw-source
source root is source
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: installPhase
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/m69yq15chb53pcajbvdz1z4j5jjnagql-lldap-cli-0-unstable-2024-11-11
checking for references to /build/ in /nix/store/m69yq15chb53pcajbvdz1z4j5jjnagql-lldap-cli-0-unstable-2024-11-11...
patching script interpreter paths in /nix/store/m69yq15chb53pcajbvdz1z4j5jjnagql-lldap-cli-0-unstable-2024-11-11
/nix/store/m69yq15chb53pcajbvdz1z4j5jjnagql-lldap-cli-0-unstable-2024-11-11/bin/.lldap-cli-wrapped: interpreter directive changed from "#!/usr/bin/env bash" to "/nix/store/5mh7kaj2fyv8mk4sfq1brwxgc02884wi-bash-5.2p37/bin/bash"
stripping (with command strip and flags -S -p) in  /nix/store/m69yq15chb53pcajbvdz1z4j5jjnagql-lldap-cli-0-unstable-2024-11-11/bin
/nix/store/m69yq15chb53pcajbvdz1z4j5jjnagql-lldap-cli-0-unstable-2024-11-11

$ ./result/bin/lldap-cli --help
LLDAP-CLI(1)

NAME
  lldap-cli - 'lldap' Administration & Configuration CLI

...
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
