### PR TITLE
.github/labeler.yml: automatically add backport label for PRs touching `ci/`

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -1,0 +1,21 @@
+# This file is used by .github/workflows/labels.yml
+# This version uses `sync-labels: false`, meaning that a non-match will NOT remove the label
+
+"6.topic: policy discussion":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/**/*
+        - CONTRIBUTING.md
+        - pkgs/README.md
+        - nixos/README.md
+        - maintainers/README.md
+        - lib/README.md
+        - doc/README.md
+
+"8.has: documentation":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - doc/**/*
+        - nixos/doc/**/*

--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -1,6 +1,14 @@
 # This file is used by .github/workflows/labels.yml
 # This version uses `sync-labels: false`, meaning that a non-match will NOT remove the label
 
+"backport: release-24.11":
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - .github/workflows/*
+        - ci/**/*
+        - "!ci/OWNERS"
+
 "6.topic: policy discussion":
   - any:
     - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,6 @@
+# This file is used by .github/workflows/labels.yml
+# This version uses `sync-labels: true`, meaning that a non-match will remove the label
+
 # NOTE: bsd, darwin and cross-compilation labels are handled by ofborg
 "6.topic: agda":
   - any:
@@ -387,18 +390,6 @@
         - pkgs/test/php/default.nix
         - pkgs/top-level/php-packages.nix
 
-"6.topic: policy discussion":
-  - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - .github/**/*
-        - CONTRIBUTING.md
-        - pkgs/README.md
-        - nixos/README.md
-        - maintainers/README.md
-        - lib/README.md
-        - doc/README.md
-
 "6.topic: printing":
   - any:
     - changed-files:
@@ -571,13 +562,6 @@
     - changed-files:
       - any-glob-to-any-file:
         - nixos/doc/manual/release-notes/**/*
-
-"8.has: documentation":
-  - any:
-    - changed-files:
-      - any-glob-to-any-file:
-        - doc/**/*
-        - nixos/doc/**/*
 
 "8.has: module (update)":
   - any:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -22,4 +22,10 @@ jobs:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml # default
           sync-labels: true
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler-no-sync.yml
+          sync-labels: false


### PR DESCRIPTION
I assume it makes sense to keep master and stable in sync since these folders are also used in downstream tools such as nixpkgs-review


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
