### PR TITLE
mmseqs2: 16-747c6 -> 17-b804f

### DIFF
--- a/pkgs/by-name/mm/mmseqs2/package.nix
+++ b/pkgs/by-name/mm/mmseqs2/package.nix
@@ -26,13 +26,13 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mmseqs2";
-  version = "16-747c6";
+  version = "17-b804f";
 
   src = fetchFromGitHub {
     owner = "soedinglab";
     repo = "mmseqs2";
     tag = finalAttrs.version;
-    hash = "sha256-O7tx+gdVAmZLihPnWSo9RWNVzfPjI61LGY/XeaGHrI0=";
+    hash = "sha256-nmvFoW+Ey18NcM2w14Ak/3D/Kic52Vka/RxvBd0YoKI=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/mm/mmseqs2/package.nix
+++ b/pkgs/by-name/mm/mmseqs2/package.nix
@@ -89,6 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Ultra fast and sensitive sequence search and clustering suite";
     mainProgram = "mmseqs";
     homepage = "https://mmseqs.com/";
+    changelog = "https://github.com/soedinglab/MMseqs2/releases/tag/${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ natsukium ];
     platforms = platforms.unix;


### PR DESCRIPTION
Diff: https://github.com/soedinglab/MMseqs2/compare/refs/tags/16-747c6...17-b804f

Changelog: https://github.com/soedinglab/MMseqs2/releases/tag/17-b804f
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
