### PR TITLE
yek: init at 0.16.0

### DIFF
--- a/pkgs/by-name/ye/yek/package.nix
+++ b/pkgs/by-name/ye/yek/package.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  nix-update-script,
+  versionCheckHook,
+}:
+let
+  version = "0.16.0";
+in
+rustPlatform.buildRustPackage {
+  pname = "yek";
+  version = version;
+
+  src = fetchFromGitHub {
+    owner = "bodo-run";
+    repo = "yek";
+    tag = "v${version}";
+    hash = "sha256-dboKZuY6mlFZu/xCoLXFJ4ARXyYs5/yOYeGkAnUKRX4=";
+  };
+  cargoHash = "sha256-3+jTzYwu9eHji8o4abLiiJGXtZYPfXtXeiZEZajxrVo=";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ openssl ];
+
+  env.OPENSSL_NO_VENDOR = 1;
+
+  checkFlags = [
+    # Tests with git fail
+    "--skip=e2e_tests::test_git_boost_config"
+    "--skip=e2e_tests::test_git_integration"
+    "--skip=lib_tests::test_serialize_repo_with_git"
+    "--skip=priority_tests::test_get_recent_commit_times_empty_repo"
+    "--skip=priority_tests::test_get_recent_commit_times_with_git"
+    "--skip=priority_tests::test_get_recent_commit_times_git_failure"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Serialize text files for LLM consumption";
+    longDescription = ''
+      Tool to read text-based files, chunk them, and serialize them for LLM consumption.
+    '';
+    homepage = "https://github.com/bodo-run/yek";
+    changelog = "https://github.com/bodo-run/yek/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    mainProgram = "yek";
+    maintainers = with lib.maintainers; [ louis-thevenet ];
+  };
+}


### PR DESCRIPTION
Yek is a rust based tool to read text-based files in a repository or directory, chunk them, and serialize them for LLM consumption.
Homepage: https://github.com/bodo-run/yek
Changelog: https://github.com/bodo-run/yek/releases/tag/v0.16.0
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
