### PR TITLE
netbird: 0.35.2 -> 0.36.3

### DIFF
--- a/pkgs/tools/networking/netbird/default.nix
+++ b/pkgs/tools/networking/netbird/default.nix
@@ -1,33 +1,37 @@
-{ stdenv
-, lib
-, nixosTests
-, nix-update-script
-, buildGoModule
-, fetchFromGitHub
-, installShellFiles
-, pkg-config
-, gtk3
-, libayatana-appindicator
-, libX11
-, libXcursor
-, libXxf86vm
-, Cocoa
-, IOKit
-, Kernel
-, UserNotifications
-, WebKit
-, ui ? false
-, netbird-ui
+{
+  stdenv,
+  lib,
+  nixosTests,
+  nix-update-script,
+  buildGoModule,
+  fetchFromGitHub,
+  installShellFiles,
+  pkg-config,
+  gtk3,
+  libayatana-appindicator,
+  libX11,
+  libXcursor,
+  libXxf86vm,
+  Cocoa,
+  IOKit,
+  Kernel,
+  UserNotifications,
+  WebKit,
+  ui ? false,
+  netbird-ui,
 }:
 let
   modules =
-    if ui then {
-      "client/ui" = "netbird-ui";
-    } else {
-      client = "netbird";
-      management = "netbird-mgmt";
-      signal = "netbird-signal";
-    };
+    if ui then
+      {
+        "client/ui" = "netbird-ui";
+      }
+    else
+      {
+        client = "netbird";
+        management = "netbird-mgmt";
+        signal = "netbird-signal";
+      };
 in
 buildGoModule rec {
   pname = "netbird";
@@ -40,23 +44,25 @@ buildGoModule rec {
     hash = "sha256-ZAKVjBjffinOyHhzln/ny7tooZwtKHfMEDb/Uy0k6Gw=";
   };
 
-  vendorHash = "sha256-CgfZZOiFDLf6vCbzovpwzt7FlO9BnzNSdR8e5U+xCDQ=";
+  vendorHash = "sha256-xZz2JkD3yD7tuXVFlMm2g1hRBItkGmO9OvnLdUfqai0=";
 
   nativeBuildInputs = [ installShellFiles ] ++ lib.optional ui pkg-config;
 
-  buildInputs = lib.optionals (stdenv.hostPlatform.isLinux && ui) [
-    gtk3
-    libayatana-appindicator
-    libX11
-    libXcursor
-    libXxf86vm
-  ] ++ lib.optionals (stdenv.hostPlatform.isDarwin && ui) [
-    Cocoa
-    IOKit
-    Kernel
-    UserNotifications
-    WebKit
-  ];
+  buildInputs =
+    lib.optionals (stdenv.hostPlatform.isLinux && ui) [
+      gtk3
+      libayatana-appindicator
+      libX11
+      libXcursor
+      libXxf86vm
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && ui) [
+      Cocoa
+      IOKit
+      Kernel
+      UserNotifications
+      WebKit
+    ];
 
   subPackages = lib.attrNames modules;
 
@@ -78,26 +84,31 @@ buildGoModule rec {
       --replace-fail 'unix:///var/run/netbird.sock' 'unix:///var/run/netbird/sock'
   '';
 
-  postInstall = lib.concatStringsSep "\n"
-    (lib.mapAttrsToList
-      (module: binary: ''
-        mv $out/bin/${lib.last (lib.splitString "/" module)} $out/bin/${binary}
-      '' + lib.optionalString (!ui) ''
-        installShellCompletion --cmd ${binary} \
-          --bash <($out/bin/${binary} completion bash) \
-          --fish <($out/bin/${binary} completion fish) \
-          --zsh <($out/bin/${binary} completion zsh)
-      '')
-      modules) + lib.optionalString (stdenv.hostPlatform.isLinux && ui) ''
-    mkdir -p $out/share/pixmaps
-    cp $src/client/ui/netbird-systemtray-connected.png $out/share/pixmaps/netbird.png
+  postInstall =
+    lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (
+        module: binary:
+        ''
+          mv $out/bin/${lib.last (lib.splitString "/" module)} $out/bin/${binary}
+        ''
+        + lib.optionalString (!ui) ''
+          installShellCompletion --cmd ${binary} \
+            --bash <($out/bin/${binary} completion bash) \
+            --fish <($out/bin/${binary} completion fish) \
+            --zsh <($out/bin/${binary} completion zsh)
+        ''
+      ) modules
+    )
+    + lib.optionalString (stdenv.hostPlatform.isLinux && ui) ''
+      mkdir -p $out/share/pixmaps
+      cp $src/client/ui/netbird-systemtray-connected.png $out/share/pixmaps/netbird.png
 
-    mkdir -p $out/share/applications
-    cp $src/client/ui/netbird.desktop $out/share/applications/netbird.desktop
+      mkdir -p $out/share/applications
+      cp $src/client/ui/netbird.desktop $out/share/applications/netbird.desktop
 
-    substituteInPlace $out/share/applications/netbird.desktop \
-      --replace-fail "Exec=/usr/bin/netbird-ui" "Exec=$out/bin/netbird-ui"
-  '';
+      substituteInPlace $out/share/applications/netbird.desktop \
+        --replace-fail "Exec=/usr/bin/netbird-ui" "Exec=$out/bin/netbird-ui"
+    '';
 
   passthru = {
     tests.netbird = nixosTests.netbird;
@@ -110,7 +121,10 @@ buildGoModule rec {
     changelog = "https://github.com/netbirdio/netbird/releases/tag/v${version}";
     description = "Connect your devices into a single secure private WireGuard®-based mesh network with SSO/MFA and simple access controls";
     license = licenses.bsd3;
-    maintainers = with maintainers; [ vrifox saturn745 ];
+    maintainers = with maintainers; [
+      vrifox
+      saturn745
+    ];
     mainProgram = "netbird";
   };
 }

--- a/pkgs/tools/networking/netbird/default.nix
+++ b/pkgs/tools/networking/netbird/default.nix
@@ -31,13 +31,13 @@ let
 in
 buildGoModule rec {
   pname = "netbird";
-  version = "0.35.2";
+  version = "0.36.3";
 
   src = fetchFromGitHub {
     owner = "netbirdio";
     repo = "netbird";
     rev = "v${version}";
-    hash = "sha256-CvKJiv3CyCRp0wyH+OZejOChcumnMOrA7o9wL4ElJio=";
+    hash = "sha256-ZAKVjBjffinOyHhzln/ny7tooZwtKHfMEDb/Uy0k6Gw=";
   };
 
   vendorHash = "sha256-CgfZZOiFDLf6vCbzovpwzt7FlO9BnzNSdR8e5U+xCDQ=";


### PR DESCRIPTION
## Package Information

- Package name: netbird
- Latest released version: 0.36.3
- Current version on the unstable channel: 0.35.2
- Current version on the stable/release channel: 0.35.2

### Maintainer Ping:
@vrifox @saturn745


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
