### PR TITLE
hyp2mat: fix cross build

### DIFF
--- a/pkgs/by-name/hy/hyp2mat/package.nix
+++ b/pkgs/by-name/hy/hyp2mat/package.nix
@@ -12,6 +12,7 @@
   pkg-config,
   libpng,
   zlib,
+  buildPackages,
 }:
 
 stdenv.mkDerivation rec {
@@ -25,8 +26,24 @@ stdenv.mkDerivation rec {
     sha256 = "03ibk51swxfl7pfrhcrfiffdi4mnf8kla0g1xj1lsrvrjwapfx03";
   };
 
+  postPatch = ''
+    substituteInPlace doc/Makefile.am --replace-fail \
+      '$(HELP2MAN) --output=$@ --no-info --include=$< $(PROGNAME)' \
+      '$(HELP2MAN) --output=$@ --no-info --include=$< ${
+        if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
+          (placeholder "out")
+        else
+          buildPackages.hyp2mat
+      }/bin/`basename $(PROGNAME)`'
+  '';
+
   nativeBuildInputs = [
     autoreconfHook
+    bison
+    flex
+    gengetopt
+    groff
+    help2man
     pkg-config
   ];
 
@@ -34,11 +51,6 @@ stdenv.mkDerivation rec {
     libharu
     libpng
     zlib
-    bison
-    flex
-    gengetopt
-    help2man
-    groff
   ];
 
   configureFlags = [ "--enable-library" ];


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).