### PR TITLE
octave: fix cross build

### DIFF
--- a/pkgs/development/interpreters/octave/default.nix
+++ b/pkgs/development/interpreters/octave/default.nix
@@ -106,11 +106,14 @@ stdenv.mkDerivation (finalAttrs: {
     sha256 = "sha256-gJ+jmnrMhIFb9NxNLX5rIoznWgfzskE/MxOqjgqqMoc=";
   };
 
+  postPatch = ''
+    patchShebangs --build build-aux/*.pl
+  '';
+
   buildInputs =
     [
       readline
       ncurses
-      perl
       flex
       qhull
       graphicsmagick
@@ -157,6 +160,7 @@ stdenv.mkDerivation (finalAttrs: {
     ];
   nativeBuildInputs =
     [
+      perl
       pkg-config
       gfortran
       texinfo


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).