### PR TITLE
libsecret: enable TPM support

### DIFF
--- a/pkgs/by-name/li/libsecret/package.nix
+++ b/pkgs/by-name/li/libsecret/package.nix
@@ -24,8 +24,51 @@
   gjs,
   libintl,
   dbus,
+  withTpm2Tss ? false,
+  abrmdSupport ? false,
+  writeShellApplication,
+  tpm2-tss,
+  tpm2-abrmd,
+  libsecret,
 }:
 
+assert abrmdSupport -> withTpm2Tss;
+
+let
+  tpm-emu = writeShellApplication {
+    name = "tpm-emu";
+    runtimeInputs = [
+      dbus
+      tpm2-abrmd
+    ];
+
+    text = ''
+      coproc {
+        # Monitor session bus for name acquisition
+        dbus-monitor "type='signal',interface='org.freedesktop.DBus',member='NameAcquired',arg0='com.intel.tss2.Tabrmd'"
+      }
+
+      # Discard initial dbus-monitor output
+      while read -r -t 0.1 -u "''${COPROC[0]}"; do :; done
+
+      tpm2-abrmd \
+        --tcti=libtpms \
+        --allow-root \
+        --flush-all \
+        --session &
+
+      # Terminate tpm2-abrmd on exit
+      # shellcheck disable=SC2064 # immediate expansion intended
+      trap "kill '$!'" EXIT
+
+      # Wait for daemon to become available to avoid spurious test failures
+      read -r -t 60 -u "''${COPROC[0]}"
+      kill "$COPROC_PID"
+
+      TCTI="tabrmd:bus_type=session" "$@"
+    '';
+  };
+in
 stdenv.mkDerivation rec {
   pname = "libsecret";
   version = "0.21.6";
@@ -62,9 +105,12 @@ stdenv.mkDerivation rec {
       gobject-introspection
     ];
 
-  buildInputs = [
-    libgcrypt
-  ];
+  buildInputs =
+    [
+      libgcrypt
+    ]
+    ++ lib.optionals withTpm2Tss [ tpm2-tss ]
+    ++ lib.optionals abrmdSupport [ tpm2-abrmd ];
 
   propagatedBuildInputs = [
     glib
@@ -81,6 +127,7 @@ stdenv.mkDerivation rec {
   mesonFlags = [
     (lib.mesonBool "introspection" withIntrospection)
     (lib.mesonBool "gtk_doc" withIntrospection)
+    (lib.mesonBool "tpm2" withTpm2Tss)
     (lib.mesonOption "bashcompdir" "share/bash-completion/completions")
   ];
 
@@ -93,18 +140,38 @@ stdenv.mkDerivation rec {
     # dbus-run-session defaults to FHS path
     substituteInPlace meson.build --replace-fail \
       "exe_wrapper: dbus_run_session," \
-      "exe_wrapper: [dbus_run_session, '--config-file=${dbus}/share/dbus-1/session.conf'],"
+      "exe_wrapper: [dbus_run_session, '--config-file=${dbus}/share/dbus-1/session.conf'${lib.optionalString withTpm2Tss ", '${lib.getExe tpm-emu}'"}],"
   '';
 
-  preCheck = ''
-    # Our gobject-introspection patches make the shared library paths absolute
-    # in the GIR files. When running tests, the library is not yet installed,
-    # though, so we need to replace the absolute path with a local one during build.
-    # We are using a symlink that will be overwitten during installation.
-    mkdir -p $out/lib $out/lib
-    ln -s "$PWD/libsecret/libmock-service.so" "$out/lib/libmock-service.so"
-    ln -s "$PWD/libsecret/libsecret-1.so.0" "$out/lib/libsecret-1.so.0"
+  preConfigure = lib.optionalString abrmdSupport ''
+    # Add dependencies on TCTI modules required for user‐space TPM resource
+    # manager support so that they can be loaded at run time through dlopen().
+    mesonFlagsArray+=("-Dc_link_args=-Wl,--push-state,--no-as-needed -ltss2-tcti-tabrmd -ltss2-tcti-device -Wl,--pop-state")
   '';
+
+  preCheck =
+    ''
+      # Our gobject-introspection patches make the shared library paths absolute
+      # in the GIR files. When running tests, the library is not yet installed,
+      # though, so we need to replace the absolute path with a local one during build.
+      # We are using a symlink that will be overwitten during installation.
+      mkdir -p $out/lib $out/lib
+      ln -s "$PWD/libsecret/libmock-service.so" "$out/lib/libmock-service.so"
+      ln -s "$PWD/libsecret/libsecret-1.so.0" "$out/lib/libsecret-1.so.0"
+    ''
+    + lib.optionalString (withTpm2Tss && !abrmdSupport) ''
+      # If abrmdSupport is disabled, the user‐space resource manager TCTI
+      # module is not linked at compile time. It is however needed during
+      # testing because the TPM emulator lacks an integrated resource manager
+      # The module path is therefore injected temporarly using the
+      # LD_LIBRARY_PATH environment variable, so that it may be found by
+      # dlopen().
+      #
+      # If abrmdSupport is enabled, this is avoided to check that the
+      # module has been properly linked and can be located through the
+      # DT_RUNPATH and DT_NEEDED entries in libsecret-1.so.
+      export LD_LIBRARY_PATH+=":${lib.makeLibraryPath [ tpm2-abrmd ]}"
+    '';
 
   checkPhase = ''
     runHook preCheck
@@ -130,6 +197,18 @@ stdenv.mkDerivation rec {
       # Does not seem to use the odd-unstable policy: https://gitlab.gnome.org/GNOME/libsecret/issues/30
       versionPolicy = "none";
     };
+
+    tests = {
+      libsecret-tpm2 = libsecret.override {
+        withTpm2Tss = true;
+        abrmdSupport = false;
+      };
+
+      libsecret-tpm2-abrmd = libsecret.override {
+        withTpm2Tss = true;
+        abrmdSupport = true;
+      };
+    };
   };
 
   meta = {
@@ -137,6 +216,11 @@ stdenv.mkDerivation rec {
     homepage = "https://gitlab.gnome.org/GNOME/libsecret";
     license = lib.licenses.lgpl21Plus;
     mainProgram = "secret-tool";
-    inherit (glib.meta) platforms maintainers;
+    platforms =
+      if withTpm2Tss then
+        lib.intersectLists glib.meta.platforms tpm2-tss.meta.platforms
+      else
+        glib.meta.platforms;
+    inherit (glib.meta) maintainers;
   };
 }


### PR DESCRIPTION
libsecret supports binding the encryption key used for the file backend to a TPM, which offers security benefits over just deriving it from the user’s login password: https://gnome.pages.gitlab.gnome.org/libsecret/libsecret-tpm2.html

This change adds the option `withTpm2Tss` to enable building with TPM support. ~I suggest to enable it by default on x86-64 considering the almost universal prevalence of TPMs on x86-64 desktop systems.~

The option `abrmdSupport` is used to enable support for the user‐space TPM resource manager.  When enabled, `libtss2-tcti-tabrmd.so` and `libtss2-tcti-device.so` are added to the library’s dependencies to enable loading at run‐time through `dlopen()`.

libsecret requires a TPM resource manager, but works fine with the kernel‐space resource manager (`/dev/tpmrm0`). When using an emulated TPM (e.g. libtpms or swtpm), a user‐space resource manager (abrmd) has to be used.

## Things done

I tested this change on nixpkgs master.

The package tests run successfully and I manually tested `secret-tool` using the hardware TPM of my computer (NixOS x86-64) and the kernel‐space resource manager.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
