### PR TITLE
lix_2_92: init at 2.92.0

### DIFF
--- a/nixos/tests/installer.nix
+++ b/nixos/tests/installer.nix
@@ -638,6 +638,7 @@ let
       clevisTest ? false,
       clevisFallbackTest ? false,
       disableFileSystems ? false,
+      selectNixPackage ? pkgs: pkgs.nixStable,
     }:
     let
       isEfi = bootLoader == "systemd-boot" || (bootLoader == "grub" && grubUseEfi);
@@ -701,6 +702,7 @@ let
             virtualisation.rootDevice = "/dev/vdb";
 
             hardware.enableAllFirmware = mkForce false;
+            nix.package = selectNixPackage pkgs;
 
             # The test cannot access the network, so any packages we
             # need must be included in the VM.
@@ -1101,6 +1103,9 @@ in
   # The (almost) simplest partitioning scheme: a swap partition and
   # one big filesystem partition.
   simple = makeInstallerTest "simple" simple-test-config;
+  lix-simple = makeInstallerTest "simple" simple-test-config // {
+    selectNixPackage = pkgs: pkgs.lix;
+  };
 
   switchToFlake = makeInstallerTest "switch-to-flake" simple-test-config-flake;
 

--- a/pkgs/by-name/ca/capnproto/package.nix
+++ b/pkgs/by-name/ca/capnproto/package.nix
@@ -2,11 +2,25 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  binutils,
   cmake,
   openssl,
   zlib,
 }:
-
+let
+  # HACK: work around https://github.com/NixOS/nixpkgs/issues/177129
+  # Though this is an issue between Clang and GCC,
+  # so it may not get fixed anytime soon...
+  empty-libgcc_eh = stdenv.mkDerivation {
+    pname = "empty-libgcc_eh";
+    version = "0";
+    dontUnpack = true;
+    installPhase = ''
+      mkdir -p "$out"/lib
+      "${binutils}"/bin/ar r "$out"/lib/libgcc_eh.a
+    '';
+  };
+in
 stdenv.mkDerivation rec {
   pname = "capnproto";
   version = "1.0.2";
@@ -23,7 +37,20 @@ stdenv.mkDerivation rec {
   propagatedBuildInputs = [
     openssl
     zlib
+  ] ++ lib.optional (stdenv.cc.isClang && stdenv.targetPlatform.isStatic) empty-libgcc_eh;
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    # Take optimization flags from CXXFLAGS rather than cmake injecting them
+    (lib.cmakeFeature "CMAKE_BUILD_TYPE" "None")
   ];
+
+  env = {
+    # Required to build the coroutine library
+    CXXFLAGS = "-std=c++20";
+  };
+
+  separateDebugInfo = true;
 
   meta = with lib; {
     homepage = "https://capnproto.org/";
@@ -35,6 +62,6 @@ stdenv.mkDerivation rec {
     '';
     license = licenses.mit;
     platforms = platforms.all;
-    maintainers = [ ];
+    maintainers = lib.teams.lix.members;
   };
 }

--- a/pkgs/by-name/ed/editline/package.nix
+++ b/pkgs/by-name/ed/editline/package.nix
@@ -31,6 +31,14 @@ stdenv.mkDerivation rec {
       url = "https://github.com/troglobit/editline/commit/f444a316f5178b8e20fe31e7b2d979e651da077e.patch";
       hash = "sha256-m3jExTkPvE+ZBwHzf/A+ugzzfbLmeWYn726l7Po7f10=";
     })
+
+    # Pending editline new release:
+    #   https://github.com/troglobit/editline/pull/70
+    (fetchpatch {
+      name = "alt-left-and-alt-right.patch";
+      url = "https://github.com/troglobit/editline/commit/fb4d7268de024ed31ad2417f533cc0cbc2cd9b29.patch";
+      hash = "sha256-MDFe24lRDXKxEchACQXvC+Sw4sG0wpzBYdfe6UHa+iY=";
+    })
   ];
 
   configureFlags = [ (lib.enableFeature true "sigstop") ];

--- a/pkgs/by-name/ed/editline/package.nix
+++ b/pkgs/by-name/ed/editline/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   autoreconfHook,
+  ncurses,
   nix-update-script,
   fetchpatch,
 }:
@@ -41,9 +42,18 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  configureFlags = [ (lib.enableFeature true "sigstop") ];
+  configureFlags = [
+    # Enable SIGSTOP (Ctrl-Z) behavior.
+    (lib.enableFeature true "sigstop")
+    # Enable ANSI arrow keys.
+    (lib.enableFeature true "arrow-keys")
+    # Use termcap library to query terminal size.
+    (lib.enableFeature true "termcap")
+  ];
 
   nativeBuildInputs = [ autoreconfHook ];
+
+  propagatedBuildInputs = [ ncurses ];
 
   outputs = [
     "out"
@@ -56,7 +66,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     homepage = "https://troglobit.com/projects/editline/";
-    description = "Readline() replacement for UNIX without termcap (ncurses)";
+    description = "Readline() replacement for UNIX";
     license = licenses.bsdOriginal;
     maintainers = with maintainers; [ oxalica ];
     platforms = platforms.all;

--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -341,6 +341,7 @@ stdenv.mkDerivation (finalAttrs: {
     inherit aws-sdk-cpp boehmgc;
     tests = {
       misc = nixosTests.nix-misc.lix;
+      installer = nixosTests.installer.lix-simple;
     };
   };
 


### PR DESCRIPTION
This brings the required stuff to package Lix 2.92 in Nixpkgs.

https://lix.systems/blog/2025-01-18-lix-2.92-release/

If you want to review this PR, to make it easier on authors, please get involved in Lix release management and do not mindlessly nixpkgs-review or comment on things you do not necessarily understand.

## Lix release management QA list

- [x] Build on 4 platforms
- [x] Build with debuginfo
- [x] Verify that manual is present
- [x] Verify that lix-doc is working as intended
- [x] Cross from x86_64 → aarch64
- [x] Cross from x86_64 → riscv64
- [x] Cross from x86_64 → armv7l
- [x] Cross from aarch64 → x86_64 (not mandatory)
- [ ] Static builds on x86_64-linux, aarch64-linux, aarch64-darwin: :red_circle: — broken!
- [x] Perform closure checks and verify that no unnecessary dependencies are included: Lix 2.92 got to 17MB (+2MB increase, mostly due to the Nix binary itself growing of 400 KB).
- [x] Ensure that previous versions did not explode in size neither in functionality:  all good (15MB).
- [x] Run various NixOS VM smoke tests: nixosTests.misc, etc. with Lix:
   - [x] Misc test (aarch64 & x86_64)
   - [x] Installer test