### PR TITLE
python312Packages.astropy: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -160,6 +160,9 @@ buildPythonPackage rec {
 
     # SAMPProxyError 1: 'Timeout expired!'
     "TestStandardProfile.test_main"
+
+    # fails with timeout on slow builders
+    "test_group_stable_sort"
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ "test_sidereal_lat_independent" ];
 
   meta = {


### PR DESCRIPTION
Previously failed: https://paste.fliegendewurst.eu/jOoXaa.log
`Unreliable test timings! On an initial run, this test took 250.35ms, which exceeded the deadline of 200.00ms, but on a subsequent run it took 6.60 ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.`

I don't see where to set `deadline=None`. I tried `--disable-deadlines` which did not work.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).