### PR TITLE
speechd: 0.11.5 -> 0.12.1

### DIFF
--- a/nixos/modules/services/accessibility/speechd.nix
+++ b/nixos/modules/services/accessibility/speechd.nix
@@ -7,7 +7,6 @@
 let
   cfg = config.services.speechd;
   inherit (lib)
-    getExe
     mkEnableOption
     mkIf
     mkPackageOption
@@ -21,12 +20,12 @@ in
     package = mkPackageOption pkgs "speechd" { };
   };
 
-  # FIXME: speechd 0.12 (or whatever the next version is)
-  # will support socket activation, so switch to that once it's out.
   config = mkIf cfg.enable {
     environment = {
       systemPackages = [ cfg.package ];
-      sessionVariables.SPEECHD_CMD = getExe cfg.package;
     };
+    systemd.packages = [ cfg.package ];
+    # have to set `wantedBy` since `systemd.packages` ignores `[Install]`
+    systemd.user.sockets.speech-dispatcher.wantedBy = [ "sockets.target" ];
   };
 }

--- a/pkgs/by-name/sp/speechd/fix-paths.patch
+++ b/pkgs/by-name/sp/speechd/fix-paths.patch
@@ -1,3 +1,13 @@
+diff --git a/speech-dispatcher.service.in b/speech-dispatcher.service.in
+index 6280f2d9..edf6024c 100644
+--- a/speech-dispatcher.service.in
++++ b/speech-dispatcher.service.in
+@@ -20,4 +20,4 @@ Requires=speech-dispatcher.socket
+ [Service]
+ Type=simple
+ ExecStart=@bindir@/speech-dispatcher -s -t 0
+-ExecReload=/bin/kill -HUP $MAINPID
++ExecReload=@utillinux@/bin/kill -HUP $MAINPID
 diff --git a/speech-dispatcherd.service.in b/speech-dispatcherd.service.in
 index ab14b99d..12521b1b 100644
 --- a/speech-dispatcherd.service.in

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -36,13 +36,13 @@
 let
   inherit (python3Packages) python pyxdg wrapPython;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "speech-dispatcher";
-  version = "0.11.5";
+  version = "0.12.1";
 
   src = fetchurl {
-    url = "https://github.com/brailcom/speechd/releases/download/${version}/${pname}-${version}.tar.gz";
-    sha256 = "sha256-HOR1n/q7rxrrQzpewHOb4Gdum9+66URKezvhsq8+wSs=";
+    url = "https://github.com/brailcom/speechd/releases/download/${finalAttrs.version}/speech-dispatcher-${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-sUpSONKH0tzOTdQrvWbKZfoijn5oNwgmf3s0A297pLQ=";
   };
 
   patches =
@@ -77,8 +77,10 @@ stdenv.mkDerivation rec {
       libsndfile
       libao
       libpulseaudio
-      alsa-lib
       python
+    ]
+    ++ lib.optionals withAlsa [
+      alsa-lib
     ]
     ++ lib.optionals withEspeak [
       espeak
@@ -121,7 +123,7 @@ stdenv.mkDerivation rec {
       "--with-pico"
     ];
 
-  postPatch = ''
+  postPatch = lib.optionalString withPico ''
     substituteInPlace src/modules/pico.c --replace "/usr/share/pico/lang" "${svox}/share/pico/lang"
   '';
 
@@ -146,7 +148,8 @@ stdenv.mkDerivation rec {
       berce
       jtojnar
     ];
-    platforms = platforms.linux;
+    # TODO: remove checks for `withPico` once PR #375450 is merged
+    platforms = if withAlsa || withPico then platforms.linux else platforms.unix;
     mainProgram = "speech-dispatcher";
   };
-}
+})

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -9,6 +9,7 @@
   itstool,
   libtool,
   texinfo,
+  systemdMinimal,
   util-linux,
   autoreconfHook,
   glib,
@@ -79,6 +80,9 @@ stdenv.mkDerivation (finalAttrs: {
       libpulseaudio
       python
     ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      systemdMinimal # libsystemd
+    ]
     ++ lib.optionals withAlsa [
       alsa-lib
     ]
@@ -103,6 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
       # Audio method falls back from left to right.
       "--with-default-audio-method=\"libao,pulse,alsa,oss\""
       "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
+      "--with-systemduserunitdir=${placeholder "out"}/lib/systemd/user"
     ]
     ++ lib.optionals withPulse [
       "--with-pulse"


### PR DESCRIPTION
The upgrade to `0.12.0-rc4` enables building `speechd-minimal` on Darwin (see the [upstream changelog](https://github.com/brailcom/speechd/releases/tag/0.12.0-rc4)).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
