### PR TITLE
python312Packages.jaconv + python312Packages.macfsevents: fix data_files conflict

### DIFF
--- a/pkgs/development/python-modules/jaconv/default.nix
+++ b/pkgs/development/python-modules/jaconv/default.nix
@@ -21,7 +21,10 @@ buildPythonPackage rec {
     hash = "sha256-9ruhOLaYNESeKOwJs3IN6ct66fSq7My9DOyA7/cH3d0=";
   };
 
-  patches = [ ./use-pytest.patch ];
+  patches = [
+    ./fix-packaging.patch
+    ./use-pytest.patch
+  ];
 
   build-system = [ setuptools ];
 

--- a/pkgs/development/python-modules/jaconv/fix-packaging.patch
+++ b/pkgs/development/python-modules/jaconv/fix-packaging.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index 297357b..12b861f 100644
+--- a/setup.py
++++ b/setup.py
+@@ -39,7 +42,6 @@
+           'Programming Language :: Python :: 3.10',
+           'Programming Language :: Python :: 3.11', 'Topic :: Text Processing'
+       ],
+-      data_files=[('', ['README.rst', 'CHANGES.rst'])],
+       long_description='%s\n\n%s' %
+       (open('README.rst', encoding='utf8').read(),
+        open('CHANGES.rst', encoding='utf8').read()),

--- a/pkgs/development/python-modules/macfsevents/default.nix
+++ b/pkgs/development/python-modules/macfsevents/default.nix
@@ -16,6 +16,8 @@ buildPythonPackage rec {
     hash = "sha256-v3KD8dUXdkzNyBlbIWMdu6wcUGuSC/mo6ilWsxJ2Ucs=";
   };
 
+  patches = [ ./fix-packaging.patch ];
+
   buildInputs = [
     CoreFoundation
     CoreServices

--- a/pkgs/development/python-modules/macfsevents/default.nix
+++ b/pkgs/development/python-modules/macfsevents/default.nix
@@ -2,8 +2,6 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  CoreFoundation,
-  CoreServices,
 }:
 
 buildPythonPackage rec {
@@ -17,11 +15,6 @@ buildPythonPackage rec {
   };
 
   patches = [ ./fix-packaging.patch ];
-
-  buildInputs = [
-    CoreFoundation
-    CoreServices
-  ];
 
   # Some tests fail under nix build directory
   doCheck = false;

--- a/pkgs/development/python-modules/macfsevents/fix-packaging.patch
+++ b/pkgs/development/python-modules/macfsevents/fix-packaging.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index d7f9bb0..7707e38 100644
+--- a/setup.py
++++ b/setup.py
+@@ -21,11 +21,6 @@ def read(fname):
+       description = "Thread-based interface to file system observation primitives.",
+       long_description = "\n\n".join((read('README.rst'), read('CHANGES.rst'))),
+       license = "BSD",
+-      data_files = [("", [
+-          "compat.h",
+-          "LICENSE.txt",
+-          "CHANGES.rst"
+-      ])],
+       author = "Malthe Borch",
+       author_email = "mborch@gmail.com",
+       url = 'https://github.com/malthe/macfsevents',

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7860,9 +7860,7 @@ self: super: with self; {
 
   macaddress = callPackage ../development/python-modules/macaddress{ };
 
-  macfsevents = callPackage ../development/python-modules/macfsevents {
-    inherit (pkgs.darwin.apple_sdk.frameworks) CoreFoundation CoreServices;
-  };
+  macfsevents = callPackage ../development/python-modules/macfsevents { };
 
   macholib = callPackage ../development/python-modules/macholib { };
 


### PR DESCRIPTION
Both jaconv and macfsevents python modules use `data_files` in `setup.py` to install some generic files (e.g., `CHANGES.rst`). This installs those files into Python's installation prefix, causing a collision if both python modules are included.

It seems to me that the files installed via `data_files` should not really be part of the final packages, so I simply removed the corresponding lines. Alternatively, I assume one could pack those files into the corresponding module's directory (instead of the Python installation prefix).

The last commit in this PR also slightly simplifies the macfsevents derivation by removing Apple SDK related build inputs that are no longer needed thanks to the [new Apple SDK integration](https://nixos.org/manual/nixpkgs/stable/#sec-darwin).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
