### PR TITLE
python313Packages.pyannotate: disable lib2to3 test

### DIFF
--- a/pkgs/development/python-modules/pyannotate/default.nix
+++ b/pkgs/development/python-modules/pyannotate/default.nix
@@ -43,6 +43,7 @@ buildPythonPackage rec {
     ++ lib.optionals (pythonAtLeast "3.11") [
       # Tests are using lib2to3
       "pyannotate_tools/fixes/tests/test_annotate*.py"
+      "pyannotate_tools/annotations/tests/dundermain_test.py"
     ];
 
   meta = with lib; {


### PR DESCRIPTION
Previously this only generated a warning

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).