### PR TITLE
nixos.services.actkbd.brightness: init module

### DIFF
--- a/nixos/modules/services/hardware/actkbd-brightness.nix
+++ b/nixos/modules/services/hardware/actkbd-brightness.nix
@@ -1,0 +1,114 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.actkbd.brightness;
+
+  inherit (lib)
+    concatStringsSep
+    getExe
+    mkEnableOption
+    mkOption
+    singleton
+    types
+    ;
+
+  actkbdConfig = pkgs.writeText "actkbd-brightness.conf" ''
+    224:key,rep:exec:${cfg.upCommand}
+    225:key,rep:exec:${cfg.downCommand}
+  '';
+in
+{
+  options.services.actkbd.brightness = {
+    enable = mkEnableOption ''
+      a hardened systemd unit to for global brightness control hotkeys with actkbd.
+      This hardening is specifically tailored to only allow the controlling of brightness, to minimize the attack surface, since actkbd is a service that runs run arbitrary (configured) commands.
+      So far it has only been tested on one system, so if it doesn't work for you, please open an issue.
+    '';
+    upCommand = mkOption {
+      type = types.str;
+      description = ''
+        Command to increase the brightness.
+        Use the full path, to the binary in the store since the unit won't have access to PATH.
+      '';
+      default = "${getExe pkgs.brightnessctl} set +5%";
+    };
+    downCommand = lib.mkOption {
+      type = types.str;
+      description = ''
+        Command to increase the brightness.
+        Use the full path, to the binary in the store since the unit won't have access to PATH.
+      '';
+      default = "${getExe pkgs.brightnessctl} set 5%-";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.udev.packages = singleton (
+      pkgs.writeTextFile {
+        name = "actkbd-brightness-udev-rules";
+        destination = "/etc/udev/rules.d/61-actkbd-brightness.rules";
+        text = concatStringsSep ", " [
+          ''ACTION=="add"''
+          ''KERNEL=="event[0-9]*"''
+          ''SUBSYSTEM=="input"''
+          ''ENV{ID_INPUT_KEY}=="1"''
+          ''ENV{ID_PATH}=="acpi-LNXVIDEO:[0-9]*"''
+          ''TAG+="systemd"''
+          ''ENV{SYSTEMD_WANTS}+="actkbd-brightness@$env{DEVNAME}.service"''
+        ];
+      }
+    );
+
+    systemd.services."actkbd-brightness@" = {
+      restartIfChanged = true;
+      unitConfig = {
+        Description = "actkbd on %I for brightness control";
+        ConditionPathExists = "%I";
+      };
+
+      serviceConfig = {
+        Type = "forking";
+        ExecStart = "${lib.getExe pkgs.actkbd} -D -c ${actkbdConfig} -d %I";
+
+        # hardening
+
+        # allow access to event device
+        DeviceAllow = [ "%I" ];
+        DevicePolicy = "closed";
+
+        CapabilityBoundingSet = "";
+        IPAddressDeny = "any";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateUsers = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        ProtectSystem = "strict";
+        RestrictAddressFamilies = "none";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SocketBindDeny = "any";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "~@aio:EPERM @chown:EPERM @clock:EPERM @cpu-emulation:EPERM @debug:EPERM @io-event:EPERM @keyring:EPERM @memlock:EPERM @module:EPERM @mount:EPERM @network-io:EPERM @obsolete:EPERM @pkey:EPERM @privileged:EPERM @raw-io:EPERM @reboot:EPERM @resources:EPERM @sandbox:EPERM @setuid:EPERM @swap:EPERM @sync:EPERM @timer:EPERM";
+        UMask = "0077";
+
+        # -> 1.2 OK
+      };
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ quantenzitrone ];
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
