### PR TITLE
monitorcontrol: 4.2.0 -> 4.3.3

### DIFF
--- a/pkgs/by-name/mo/monitorcontrol/package.nix
+++ b/pkgs/by-name/mo/monitorcontrol/package.nix
@@ -2,7 +2,7 @@
   lib,
   fetchurl,
   stdenv,
-  _7zz,
+  undmg,
 }:
 
 # This cannot be built from source due to the problematic nature of XCode - so
@@ -10,17 +10,22 @@
 
 stdenv.mkDerivation rec {
   pname = "MonitorControl";
-  version = "4.2.0";
+  version = "4.3.3";
 
   src = fetchurl {
     url = "https://github.com/MonitorControl/${pname}/releases/download/v${version}/MonitorControl.${version}.dmg";
-    sha256 = "Q96uK6wVe1D2uLvWL+pFR6LcmrU7cgmr2Y5tPvvTDgI=";
+    hash = "sha256-myx3adoU3FYYrs6LFRSiXtwSsoaujjQ/PYgAF/Xuk2g=";
   };
 
-  # MonitorControl.${version}.dmg is APFS formatted, unpack with 7zz
-  nativeBuildInputs = [ _7zz ];
+  nativeBuildInputs = [ undmg ];
 
   sourceRoot = "MonitorControl.app";
+
+  unpackCmd = ''
+    runHook preUnpack
+    undmg $src
+    runHook postUnpack
+  '';
 
   installPhase = ''
     mkdir -p "$out/Applications/MonitorControl.app"


### PR DESCRIPTION
Includes upstream's fixes for Sequoia. I also 

- switched to using `undmg` as 7zz struggled to unpack this new version, apparently due to a symlink to `/Applications` (removing the symling from the original archive did cause app signature validation to fail).
- ran `nixfmt`

Closes https://github.com/NixOS/nixpkgs/issues/373268

Closes https://github.com/NixOS/nixpkgs/pull/373444

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
