### PR TITLE
systemd: Fix locale archive path

### DIFF
--- a/nixos/modules/config/i18n.nix
+++ b/nixos/modules/config/i18n.nix
@@ -95,9 +95,15 @@
         LOCALE_ARCHIVE = "/run/current-system/sw/lib/locale/locale-archive";
       } // config.i18n.extraLocaleSettings;
 
-    systemd.globalEnvironment = lib.mkIf (config.i18n.supportedLocales != []) {
-      LOCALE_ARCHIVE = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
+    systemd = {
+      globalEnvironment = lib.mkIf (config.i18n.supportedLocales != []) {
+        LOCALE_ARCHIVE = "${config.i18n.glibcLocales}/lib/locale/locale-archive";
+      };
+      tmpfiles.rules = [
+        "L /usr/lib/locale/locale-archive - - - - /run/current-system/sw/lib/locale/locale-archive"
+      ];
     };
+
 
     # ‘/etc/locale.conf’ is used by systemd.
     environment.etc."locale.conf".source = pkgs.writeText "locale.conf"

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -460,6 +460,7 @@ in {
   hound = handleTest ./hound.nix {};
   hub = handleTest ./git/hub.nix {};
   hydra = handleTest ./hydra {};
+  i18n = handleTest ./i18n.nix {};
   i3wm = handleTest ./i3wm.nix {};
   icingaweb2 = handleTest ./icingaweb2.nix {};
   ifm = handleTest ./ifm.nix {};

--- a/nixos/tests/i18n.nix
+++ b/nixos/tests/i18n.nix
@@ -1,0 +1,34 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  let
+    nodeName = "machine";
+  in
+  {
+    name = "localectl-locale-list";
+
+    nodes.${nodeName} =
+      {
+        config,
+        pkgs,
+        options,
+        ...
+      }:
+      {
+        i18n.supportedLocales = options.i18n.supportedLocales.default ++ [ "nb_NO.UTF-8/UTF-8" ];
+      };
+
+    testScript = ''
+      start_all()
+
+      expected_locale_list = """C.UTF-8
+      en_US.UTF-8
+      nb_NO.UTF-8
+      """
+      actual_locale_list = ${nodeName}.succeed("localectl list-locales")
+
+      assert (
+          expected_locale_list == actual_locale_list
+      ), f"Expected locale list\n{expected_locale_list}\n, but got\n{actual_locale_list}"
+    '';
+  }
+)


### PR DESCRIPTION
Closes #267101.

[Original fix by @csarn.](https://github.com/NixOS/nixpkgs/issues/267101#issuecomment-2284844496)

I also considered patching the [relevant single line of systemd](https://github.com/systemd/systemd/blob/ed8a737e087424fa34b8df34e5888c8a85fabc27/src/basic/locale-util.c#L104), but that would change the functionality for non-NixOS users. 

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
