### PR TITLE
zap-chip: fix apack.json

### DIFF
--- a/pkgs/by-name/za/zap-chip/package.nix
+++ b/pkgs/by-name/za/zap-chip/package.nix
@@ -3,6 +3,7 @@
   buildNpmPackage,
   electron_31,
   fetchFromGitHub,
+  jq,
   writers,
   makeWrapper,
   withGui ? false,
@@ -50,6 +51,9 @@ buildNpmPackage rec {
     ''
       cp ${writers.writeJSON "zapversion.json" versionJson} .version.json
       cat .version.json
+      # this file is required to use zap-cli with scl
+      < apack.json jq '.path = [ "'"$out"'/bin" ]' > apack.json.new
+      mv -f apack.json.new apack.json
     '';
 
   postBuild = lib.optionalString withGui ''
@@ -59,26 +63,22 @@ buildNpmPackage rec {
       -c.electronVersion=${electron.version}
   '';
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    jq
+  ];
 
   postInstall =
     ''
       # this file is also used at runtime
       install -m644 .version.json $out/lib/node_modules/zap/
-    ''
-    + lib.optionalString (!withGui) ''
+
       # home-assistant chip-* python packages need the executable under the name zap-cli
       mv $out/bin/zap $out/bin/zap-cli
     ''
     + lib.optionalString withGui ''
-      pushd dist/linux-*unpacked
-      mkdir -p $out/opt/zap-chip
-      cp -r locales resources{,.pak} $out/opt/zap-chip
-      popd
-
-      rm $out/bin/zap
       makeWrapper '${lib.getExe electron}' "$out/bin/zap" \
-        --add-flags $out/opt/zap-chip/resources/app.asar \
+        --add-flags $out/lib/node_modules/zap/dist/linux-unpacked/resources/app.asar \
         --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}" \
         --set-default ELECTRON_IS_DEV 0 \
         --inherit-argv0


### PR DESCRIPTION
also notice that the electron package was already installed in node modules

since the apack reference both the gui and cli, leave the cli installed in gui mode

Related: https://github.com/NixOS/nixpkgs/issues/374582#issuecomment-2600812789


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
