### PR TITLE
vimPlugins.rocks-nvim: add initLua for a working out of the box exper…

### DIFF
--- a/pkgs/applications/editors/neovim/tests/default.nix
+++ b/pkgs/applications/editors/neovim/tests/default.nix
@@ -103,6 +103,13 @@ let
       ${pkgs.perl}/bin/perl -pe "s|\Q$NIX_STORE\E/[a-z0-9]{32}-|$NIX_STORE/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-|g" < "$luarc" > "$luarcGeneric"
     '' + buildCommand);
 
+  nvim_with_rocks_nvim = (
+    wrapNeovimUnstable neovim-unwrapped {
+      extraName = "with-rocks-nvim";
+      wrapperArgs = "--set NVIM_APPNAME test-rocks-nvim";
+      plugins = [ vimPlugins.rocks-nvim ];
+    }
+  );
 in
   pkgs.recurseIntoAttrs (rec {
 
@@ -365,6 +372,11 @@ in
   can_require_transitive_deps =
     runTest nvim-with-luasnip ''
     ${nvim-with-luasnip}/bin/nvim -i NONE --cmd "lua require'jsregexp'" -e +quitall!
+  '';
+
+  inherit nvim_with_rocks_nvim;
+  rocks_install_plenary = runTest nvim_with_rocks_nvim ''
+    ${nvim_with_rocks_nvim}/bin/nvim -V3log.txt -i NONE +'Rocks install plenary.nvim' +quit! -e
   '';
 
   inherit (vimPlugins) corePlugins;

--- a/pkgs/applications/editors/vim/plugins/overrides.nix
+++ b/pkgs/applications/editors/vim/plugins/overrides.nix
@@ -4045,7 +4045,6 @@ in
       "papis-nvim"
       "rest-nvim"
       "rocks-config-nvim"
-      "rocks-nvim"
       "rtp-nvim"
       "telescope-manix"
       "telescope-nvim"
@@ -4058,3 +4057,20 @@ in
   in
   lib.genAttrs luarocksPackageNames toVimPackage
 )
+// {
+
+  rocks-nvim =
+    (neovimUtils.buildNeovimPlugin {
+      luaAttr = luaPackages.rocks-nvim;
+    }).overrideAttrs
+      (oa: {
+        passthru = oa.passthru // {
+          initLua = ''
+            vim.g.rocks_nvim = {
+              luarocks_binary = "${neovim-unwrapped.lua.pkgs.luarocks_bootstrap}/bin/luarocks"
+              }
+          '';
+        };
+
+      });
+}


### PR DESCRIPTION
…ience

currently triggers
```
Error executing vim.schedule lua callback: ...-luajit2.1-nvim-nio-1.10.0-1/share/lua/5.1/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message:                                                                         
...uajit2.1-nvim-nio-1.10.0-1/share/lua/5.1/nio/control.lua:145: /usr/bin/env: ‘lua’: No such file or directory                                                                                                                                                 
                                                                                                                                                                                                                                                                
stack traceback:                                                                                                                                                                                                                                                
        [C]: in function 'error'                                                                                                                                                                                                                                
        ...uajit2.1-nvim-nio-1.10.0-1/share/lua/5.1/nio/control.lua:145: in function 'wait'                                                                                                                                                                     
        /home/teto/rocks.nvim/lua/rocks/state.lua:43: in function 'installed_rocks'           
```

which might be why I had thios in my config (not sure). 
```
vim.g.rocks_nvim.luarocks_config = {
  ["rocks_trees"] = {
    {
      ["name"] = "rocks.nvim",
      ["root"] = "/home/teto/.local/share/nvim/rocks"
    },
    {
      ["name"] = "rocks-generated.nvim",
      ["root"] = "/nix/store/1k2nlfxwhzf4nn4ldqszqd3dlxrbcm3w-luajit2.1-luarocks-3.11.1-1"
    },
}

```
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
