### PR TITLE
vulkan-loader: remove outdated patch

### DIFF
--- a/pkgs/by-name/vu/vulkan-loader/package.nix
+++ b/pkgs/by-name/vu/vulkan-loader/package.nix
@@ -27,16 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-6GHZUiYL3gDWN61SaLiD/3xXSoQb1rx6U5eu1cl8ZwM=";
   };
 
-  patches =
-    [ ./fix-pkgconfig.patch ]
-    ++ lib.optionals stdenv.hostPlatform.is32bit [
-      # Backport patch to support 64-bit inodes on 32-bit systems
-      # FIXME: remove in next update
-      (fetchpatch {
-        url = "https://github.com/KhronosGroup/Vulkan-Loader/commit/ecd88b5c6b1e4c072c55c8652d76513d74c5ad4e.patch";
-        hash = "sha256-Ea+v+RfmVl8fRbkr2ETM3/7R4vp+jw7hvTq2hnw4V/0=";
-      })
-    ];
+  patches = [ ./fix-pkgconfig.patch ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: pkgsi686Linux, for wine
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).