### PR TITLE
docker-slim: 1.40.11 -> 1.41.7

### DIFF
--- a/pkgs/by-name/do/docker-slim/package.nix
+++ b/pkgs/by-name/do/docker-slim/package.nix
@@ -3,27 +3,31 @@
   buildGoModule,
   fetchFromGitHub,
   makeBinaryWrapper,
+  nix-update-script,
+  versionCheckHook,
 }:
 
 buildGoModule rec {
   pname = "docker-slim";
-  version = "1.40.11";
+  version = "1.41.7";
 
   src = fetchFromGitHub {
-    owner = "slimtoolkit";
-    repo = "slim";
-    rev = version;
-    hash = "sha256-X+1euWp4W53axbiBpL82bUPfod/JNhGVGWgOqKyhz6A=";
+    owner = "mintoolkit";
+    repo = "mint";
+    tag = version;
+    hash = "sha256-gPssqt3/irMeKQXxwSA2UZ0j1zLumdc1NLO9kogvjOI=";
   };
 
-  vendorHash = null;
+#  vendorHash = null;
 
   env.CGO_ENABLED = 0;
 
   subPackages = [
-    "cmd/slim"
-    "cmd/slim-sensor"
+    "cmd/mint"
+    "cmd/mint-sensor"
   ];
+
+  tags = [ "containers_image_openpgp" ];
 
   nativeBuildInputs = [ makeBinaryWrapper ];
 
@@ -34,21 +38,30 @@ buildGoModule rec {
   ldflags = [
     "-s"
     "-w"
-    "-X github.com/slimtoolkit/slim/pkg/version.appVersionTag=${version}"
-    "-X github.com/slimtoolkit/slim/pkg/version.appVersionRev=${src.rev}"
+    "-X github.com/mintoolkit/mint/pkg/version.appVersionTag=${version}"
+    "-X github.com/mintoolkit/mint/pkg/version.appVersionRev=${src.rev}"
   ];
 
   # docker-slim tries to create its state dir next to the binary (inside the nix
   # store), so we set it to use the working directory at the time of invocation
   postInstall = ''
-    wrapProgram "$out/bin/slim" --add-flags '--state-path "$(pwd)"'
+    wrapProgram "$out/bin/mint" --add-flags '--state-path "$(pwd)"'
   '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Minify and secure Docker containers";
-    homepage = "https://slimtoolkit.org/";
-    changelog = "https://github.com/slimtoolkit/slim/raw/${version}/CHANGELOG.md";
+    homepage = "https://github.com/mintoolkit/mint"; # no domain registered yet
+    changelog = "https://github.com/mintoolkit/mint/raw/${version}/CHANGELOG.md";
     license = lib.licenses.asl20;
+    mainProgram = "mint";
     maintainers = with lib.maintainers; [
       Br1ght0ne
       mbrgm


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.

-->

docker-slim has renamed (again) to https://github.com/mintoolkit/mint, taking part in CNCF. They do not have webpage yet and the whole situation is very chaotic, so I would hold off with renaming the package.

In the meantime, I updated the repo, bumped version and added a version test.

I found the `containers_image_openpgp` the only relevant out of all the combinations they use to build [upstream](https://github.com/mintoolkit/mint/blob/master/scripts/src.build.sh) (stubs for Docker etc).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
