### PR TITLE
gcc-xtensa-lx106-embedded-8: init

### DIFF
--- a/pkgs/by-name/gc/gcc-xtensa-lx106-embedded-8/package.nix
+++ b/pkgs/by-name/gc/gcc-xtensa-lx106-embedded-8/package.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, fetchurl, }:
+
+stdenv.mkDerivation rec {
+  pname = "gcc-xtensa-lx106";
+  version = "2020r3";
+
+  suffix = {
+    x86_64-linux = "linux-amd64";
+    x86_64-darwin = "mac";
+    i686-linux = "linux-i686";
+  }.${stdenv.hostPlatform.system} or (throw
+    "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  src = fetchurl {
+    url =
+      "https://dl.espressif.com/dl/xtensa-lx106-elf-gcc8_4_0-esp-${version}-${suffix}.tar.gz";
+    hash = {
+      x86_64-linux = "sha256-ChgEteIjHG24tyr2vCoPmltplM+6KZVtQSZREJ8T/n4=";
+      x86_64-darwin = "sha256-eCPF/fPOorWIzwxb2WJ3SrYKMLjZwZrgBWoO82l1N9s=";
+      i686-linux = "sha256-yNzn6OtYwf304DunTrgJToA6C1uK1qnVcSFvYOtyyzY=";
+    }.${stdenv.hostPlatform.system} or (throw
+      "Unsupported system: ${stdenv.hostPlatform.system}");
+  };
+
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    cp -r . $out
+    find $out -type f | while read f; do
+      patchelf "$f" > /dev/null 2>&1 || continue
+      patchelf --set-interpreter $(cat ${stdenv.cc}/nix-support/dynamic-linker) "$f" || true
+      patchelf --set-rpath ${
+        lib.makeLibraryPath [ "$out" stdenv.cc.cc ]
+      } "$f" || true
+    done
+  '';
+
+  meta = with lib; {
+    description = "Pre-built GNU toolchain for ESP8266 processors";
+    homepage =
+      "https://docs.espressif.com/projects/esp8266-rtos-sdk/en/latest/get-started/linux-setup.html";
+    license = with licenses; [ bsd2 gpl2 gpl3 lgpl21 lgpl3 mit ];
+    platforms = [ "x86_64-linux" "x86_64-darwin" "i686-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
I've added the GCC compiler chain for developing on ESP8266 boards / the gcc-xtensa-lx106 compiler chain.

The compiler chain is provided as a binary package for x86_64-linux, x86_64-darwin and i686-linux by [espressif.com](https://espressif.com/), but I have only been able to test x86_64-linux.

I have tested building and running the `gcc` binary on (x86_64-linux):
- NixOS VM using nix flakes
- Fedora using nix flakes

If anything is out of order or not up to standard then please comment it.

Last thing; I'm not sure what to do with the maintainers key in the package.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
