### PR TITLE
python3Packages.jax: add missing cuda libraries

### DIFF
--- a/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-pjrt/default.nix
@@ -18,10 +18,16 @@ let
   cudaLibPath = lib.makeLibraryPath (
     with cudaPackages;
     [
+      (lib.getLib libcublas) # libcublas.so
+      (lib.getLib cuda_cupti) # libcupti.so
       (lib.getLib cuda_cudart) # libcudart.so
       (lib.getLib cudnn) # libcudnn.so
-      (lib.getLib libcublas) # libcublas.so
-      addDriverRunpath.driverLink # libcuda.so
+      (lib.getLib libcufft) # libcufft.so
+      (lib.getLib libcusolver) # libcusolver.so
+      (lib.getLib libcusparse) # libcusparse.so
+      (lib.getLib nccl) # libnccl.so
+      (lib.getLib libnvjitlink) # libnvJitLink.so
+      (lib.getLib addDriverRunpath.driverLink) # libcuda.so
     ]
   );
 
@@ -82,6 +88,8 @@ buildPythonPackage {
   doCheck = true;
 
   pythonImportsCheck = [ "jax_plugins" ];
+
+  inherit cudaLibPath;
 
   meta = {
     description = "JAX XLA PJRT Plugin for NVIDIA GPUs";

--- a/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
+++ b/pkgs/development/python-modules/jax-cuda12-plugin/default.nix
@@ -95,7 +95,7 @@ buildPythonPackage {
     wheelUnpackHook
   ];
 
-  # jax-cuda12-plugin looks for ptxas at runtime, e.g. with a xla custom call.
+  # jax-cuda12-plugin looks for ptxas at runtime, e.g. with a triton kernel.
   # Linking into $out is the least bad solution. See
   # * https://github.com/NixOS/nixpkgs/pull/164176#discussion_r828801621
   # * https://github.com/NixOS/nixpkgs/pull/288829#discussion_r1493852211

--- a/pkgs/development/python-modules/jax/default.nix
+++ b/pkgs/development/python-modules/jax/default.nix
@@ -194,10 +194,6 @@ buildPythonPackage rec {
 
   meta = {
     description = "Source-built JAX frontend: differentiate, compile, and transform Numpy code";
-    longDescription = ''
-      This is the JAX frontend package, it's meant to be used together with one of the jaxlib implementations,
-      e.g. `python3Packages.jaxlib`, `python3Packages.jaxlib-bin`, or `python3Packages.jaxlibWithCuda`.
-    '';
     homepage = "https://github.com/google/jax";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ samuela ];

--- a/pkgs/development/python-modules/jax/test-cuda.nix
+++ b/pkgs/development/python-modules/jax/test-cuda.nix
@@ -11,13 +11,18 @@ pkgs.writers.writePython3Bin "jax-test-cuda"
   }
   ''
     import jax
+    import jax.numpy as jnp
     from jax import random
+    from jax.experimental import sparse
 
-    assert jax.devices()[0].platform == "gpu"
+    assert jax.devices()[0].platform == "gpu"  # libcuda.so
 
-    rng = random.PRNGKey(0)
+    rng = random.key(0)  # libcudart.so, libcudnn.so
     x = random.normal(rng, (100, 100))
-    x @ x
+    x @ x  # libcublas.so
+    jnp.fft.fft(x)  # libcufft.so
+    jnp.linalg.inv(x)  # libcusolver.so
+    sparse.CSR.fromdense(x) @ x  # libcusparse.so
 
     print("success!")
   ''


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

It seems https://github.com/NixOS/nixpkgs/pull/369920 accidentally deleted a number of cuda libraries (this breaks `jax.numpy.fft.ftt`, for example), so I added the ones from [upstream](https://github.com/jax-ml/jax/blob/d415c80b86b23d449e985037d89e551d41cffa61/jax_plugins/cuda/plugin_setup.py#L54-L74). Minimum working example is below.

```python
import jax.numpy as jnp
from jax import random

if __name__ == "__main__":
    rng = random.key(0)
    rng, subkey = random.split(rng)

    n = 1 << 10
    x = random.normal(subkey, (n, n))
    print(jnp.fft.fft(x))  # libcufft
    print(jnp.linalg.inv(x))  # libcusolver
```

In addition, I think I'm running into https://github.com/NixOS/nixpkgs/pull/164176#discussion_r828801621 as jax wants `ptxas` for a xla custom call. Apologies for the lack of a minimum working example as the ffi interface is [relatively involved](https://jax.readthedocs.io/en/latest/ffi.html). I'm testing on the example in [jax-triton](https://jax-ml.github.io/jax-triton/#quickstart) using [this derivation](https://github.com/stephen-huan/maipkgs/blob/master/pkgs/jax-triton/default.nix) for jax-triton (which doesn't involve any c++ because it can leverage code from jaxlib). The full error is

```text
jaxlib.xla_extension.XlaRuntimeError: INTERNAL: CustomCall failed: Couldn't find a suitable version of ptxas. The following locations were considered: bin/ptxas, /nix/store/r1dw8c14c4mvw6b44y0hmvxajap7s6aq-python3-3.12.8-env/bin/ptxas, /nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/ptxas, /nix/store/0sgkksgr178brspwfgin207yidgpfw93-python3.12-wheel-0.45.1/bin/ptxas, /nix/store/n6ncnjqqxzhscvjw96jvg0z7r1qwxw4c-python3.12-cmake-3.30.5/bin/ptxas, /nix/store/l22xmzagzf4xbb4jb25sn3aa3wm49x42-python3.12-ninja-1.12.1/bin/ptxas, /nix/store/ll40w9mfpybkn17vs148wz47226i7bbh-python3.12-lit-18.1.8/bin/ptxas, /nix/store/gdp64ps5j34q5n7c0ajb7dbjinnsyv8m-triton-llvm-19.1.0-rc1/bin/ptxas, /nix/store/3lbb9lx1gmis6qm8clq9g9k37i5l8l52-ncurses-6.4.20221231-dev/bin/ptxas, /nix/store/wm1qn5jqrxpcjkc640gq8a90ns5gw3cn-ncurses-6.4.20221231/bin/ptxas, /nix/store/srfxqk119fijwnprgsqvn68ys9kiw0bn-patchelf-0.15.0/bin/ptxas, /nix/store/xcn9p4xxfbvlkpah7pwchpav4ab9d135-gcc-wrapper-14-20241116/bin/ptxas, /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/bin/ptxas, /nix/store/1c6bmxrrhm8bd26ai2rjqld2yyjrxhds-glibc-2.40-36-bin/bin/ptxas, /nix/store/4s9rah4cwaxflicsk5cndnknqlk9n4p3-coreutils-9.5/bin/ptxas, /nix/store/srcmmqi8kxjfygd0hyy42c8hv6cws83b-binutils-wrapper-2.43.1/bin/ptxas, /nix/store/j7p46r8v9gcpbxx89pbqlh61zhd33gzv-binutils-2.43.1/bin/ptxas, /nix/store/4s9rah4cwaxflicsk5cndnknqlk9n4p3-coreutils-9.5/bin/ptxas, /nix/store/jqrz1vq5nz4lnv9pqzydj0ir58wbjfy1-findutils-4.10.0/bin/ptxas, /nix/store/00g69vw7c9lycy63h45ximy0wmzqx5y6-diffutils-3.10/bin/ptxas, /nix/store/abm77lnrkrkb58z6xp1qwjcr1xgkcfwm-gnused-4.9/bin/ptxas, /nix/store/aap6cq56amx4mzbyxp2wpgsf1kqjcr1f-gnugrep-3.11/bin/ptxas, /nix/store/a3c47r5z1q2c4rz0kvq8hlilkhx2s718-gawk-5.3.1/bin/ptxas, /nix/store/9cwwj1c9csmc85l2cqzs3h9hbf1vwl6c-gnutar-1.35/bin/ptxas, /nix/store/nvvj6sk0k6px48436drlblf4gafgbvzr-gzip-1.13/bin/ptxas, /nix/store/mglixp03lsp0w986svwdvm7vcy17rdax-bzip2-1.0.8-bin/bin/ptxas, /nix/store/fp6cjl1zcmm6mawsnrb5yak1wkz2ma8l-gnumake-4.4.1/bin/ptxas, /nix/store/5mh7kaj2fyv8mk4sfq1brwxgc02884wi-bash-5.2p37/bin/ptxas, /nix/store/5yja5dpk2qw1v5mbfbl2d7klcdfrh90w-patch-2.7.6/bin/ptxas, /nix/store/h18s640fnhhj2qdh5vivcfbxvz377srg-xz-5.6.3-bin/bin/ptxas, /nix/store/c4rj90r2m89rxs64hmm857mipwjhig5d-file-5.46/bin/ptxas, /keep/home/slhuan/programs/nix/pinpkgs/.direnv/bin/ptxas, /home/slhuan/bin/ptxas, /nix/store/c9m6yd8fg1flz2j5r4bif1ib5j20a0cy-python3-3.12.8/bin/ptxas, /nix/store/1drw3gx2q4chryrh6qy62ikhdh0p9392-ranger-1.9.4/bin/ptxas, /nix/store/3cp5gn414sb3v9nzznpi0jq33pj1nr3k-less-668/bin/ptxas, /nix/store/ks6xg51nxksqy772bj3y5682m0xqa689-file-5.46/bin/ptxas, /nix/store/s77ik3wgzf99lzam0m9fgkjjvss420ly-imagemagick-7.1.1-43-dev/bin/ptxas, /nix/store/g26bs63hz87c9s3sg0v42d6d8gjk36qw-curl-8.11.0-dev/bin/ptxas, /nix/store/kcd3nbf8iklwi5djyjyqg4k55cgf0xbp-brotli-1.1.0/bin/ptxas, /nix/store/xdmmmg9cpbp207fgyviwdixc6pwgrm4c-krb5-1.21.3-dev/bin/ptxas, /nix/store/zqkizm9zn19bf9n58xcfxl4ks7yfs8my-krb5-1.21.3-lib/bin/ptxas, /nix/store/l0gvngj52vp9g2fc131rl6289kc3hwnl-krb5-1.21.3/bin/ptxas, /nix/store/3813yqzj1adyilq0g5qdffrj8s506xmq-nghttp2-1.64.0/bin/ptxas, /nix/store/chm94r4s4i1nn6v20idna7h03i4k49i3-libidn2-2.3.7-bin/bin/ptxas, /nix/store/lygl27c44xv73kx1spskcgvzwq7z337c-openssl-3.3.2-bin/bin/ptxas, /nix/store/aqr1xjmsi8xn0kwhjzmc18s251kh7xib-libpsl-0.21.5-bin/bin/ptxas, /nix/store/gxn6if7mzv1fqq2hlsl9nfqvx5ahszg7-zstd-1.5.6-bin/bin/ptxas, /nix/store/s0zynhz13rhg0gg8cy0ga4c0lnv3yqdn-zstd-1.5.6/bin/ptxas, /nix/store/yckhqngmx90bakzhcyrsk7dww1fm352s-curl-8.11.0-bin/bin/ptxas, /nix/store/mglixp03lsp0w986svwdvm7vcy17rdax-bzip2-1.0.8-bin/bin/ptxas, /nix/store/wc97xp20zf23vx6rj65ah6knqpqwn9bn-freetype-2.13.3-dev/bin/ptxas, /nix/store/j0cx534qlwqdinajjm4f7l3c2460785l-libpng-apng-1.6.43-dev/bin/ptxas, /nix/store/v4kqr0bx2d6acb2bxmj4ck71mxjy9i10-libjpeg-turbo-3.0.4-bin/bin/ptxas, /nix/store/03vb8v0mmr98b2rh11klsyd5xhmk0wd2-libdeflate-1.22/bin/ptxas, /nix/store/mmah8dm69x4rj9zhpf0nawrlr6wwnmpp-libwebp-1.4.0/bin/ptxas, /nix/store/h18s640fnhhj2qdh5vivcfbxvz377srg-xz-5.6.3-bin/bin/ptxas, /nix/store/sf8b71w6f9r0fb3ya6ymnn7gpxdrjfzw-libtiff-4.7.0-bin/bin/ptxas, /nix/store/br6d30xcg13w6jjsj5rlp51779skipjc-lcms2-2.16-bin/bin/ptxas, /nix/store/75v06fahb45kf0rcq37957n93jxka2cf-libwebp-1.4.0/bin/ptxas, /nix/store/rjjzv280allyyi10z049fkpsjpmwfj42-fftw-double-3.3.10-dev/bin/ptxas, /nix/store/wj4gp2b1mks14ry6m25rfwkpbj0qwvc0-imagemagick-7.1.1-43/bin/ptxas, /nix/store/6hlrwk6ia8p127a8vzhg9vsmx3fs5kfm-python3.12-chardet-5.2.0/bin/ptxas, /run/wrappers/bin/ptxas, /home/slhuan/.nix-profile/bin/ptxas, /nix/profile/bin/ptxas, /home/slhuan/.local/state/nix/profile/bin/ptxas, /etc/profiles/per-user/slhuan/bin/ptxas, /nix/var/nix/profiles/default/bin/ptxas, /run/current-system/sw/bin/ptxas, add.py.runfiles/cuda_nvcc/bin/ptxas, add.py/cuda_nvcc/bin/ptxas, bin/ptxas, /usr/local/cuda/bin/ptxas, /nix/store/r1dw8c14c4mvw6b44y0hmvxajap7s6aq-python3-3.12.8-env/lib/python3.12/site-packages/jax_cuda12_plugin/../nvidia/cuda_nvcc/bin/ptxas, /nix/store/r1dw8c14c4mvw6b44y0hmvxajap7s6aq-python3-3.12.8-env/lib/python3.12/site-packages/jax_cuda12_plugin/../../nvidia/cuda_nvcc/bin/ptxas, /nix/store/r1dw8c14c4mvw6b44y0hmvxajap7s6aq-python3-3.12.8-env/lib/python3.12/site-packages/jax_cuda12_plugin/cuda/bin/ptxas
```

As far as I can tell, the paths we can control are

- `jax_cuda12_plugin/../nvidia/cuda_nvcc/bin/ptxas`
- `jax_cuda12_plugin/../../nvidia/cuda_nvcc/bin/ptxas`
- `jax_cuda12_plugin/cuda/bin/ptxas`

The first two paths match the structure of `jax-cuda12-pjrt`'s `jax_plugins` but are frustratingly outside of the `jax_cuda12_plugin` folder so I was forced to use the last path, hence the awkward copy. Not sure why we need to do this for custom call specifically; things like `jax.jit` work without it.

Lastly, the reason this PR is draft is I haven't gotten operations using cusolver like `jax.numpy.inv`, `jax.numpy.slogdet`, etc. to work. Running the above example gives the error

```python
E0119 18:00:52.316803  330063 pjrt_stream_executor_client.cc:3086] Execution of replica 0 failed: INTERNAL: jaxlib/gpu/solver_handle_pool.cc:37: operation gpusolverDnCreate(&handle) failed: cuSolver internal error
Traceback (most recent call last):
  File "...", line 12, in <module>
    print(jnp.linalg.inv(x))  # libcusolver
          ^^^^^^^^^^^^^^^^^
jaxlib.xla_extension.XlaRuntimeError: INTERNAL: jaxlib/gpu/solver_handle_pool.cc:37: operation gpusolverDnCreate(&handle) failed: cuSolver internal error
```

Supposedly [`CUSOLVER_STATUS_INTERNAL_ERROR`](https://docs.nvidia.com/cuda/cusolver/index.html) "is usually caused by a `cudaMemcpyAsync()` failure"? I tried running with `XLA_PYTHON_CLIENT_PREALLOCATE=false` to no avail, cf. https://github.com/jax-ml/jax/issues/8916, https://github.com/jax-ml/jax/issues/12846, https://github.com/jax-ml/jax/issues/21950. Maybe the memory is a red herring since I get the same error even when libcusolver is not provided, i.e. the current state of jax before this PR, so might be some version incompatibility?  GPU is a NVIDIA GeForce RTX 4070 and I am using NixOS with

```nix
{
  hardware.nvidia.open = true;
  services.xserver.videoDrivers = [ "nvidia" ];
}
```

with driver version 550.142 and cuda version 12.4. I checked that the cuda libraries match upstream's minimums.

(the last two commits are some small cleanup commits.)

cc @natsukium  @GaetanLepage @samuela

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
