### PR TITLE
treewide: standardize JDKs on darwin

### DIFF
--- a/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
@@ -68,9 +68,9 @@ let
 
     # FIXME: use multiple outputs or return actual JRE package
     passthru = {
-      jre = result;
-      home = result;
-      bundle = "${result}/Library/Java/JavaVirtualMachines/${name-prefix}-${lib.versions.major finalAttrs.version}.jdk";
+      jre = finalAttrs.finalPackage;
+      home = finalAttrs.finalPackage;
+      bundle = "${finalAttrs.finalPackage}/Library/Java/JavaVirtualMachines/${name-prefix}-${lib.versions.major finalAttrs.version}.jdk";
     };
 
     meta = with lib; {

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
@@ -67,6 +67,7 @@ let
     passthru = {
       jre = result;
       home = result;
+      bundle = result;
     };
 
     meta = with lib; {

--- a/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
+++ b/pkgs/development/compilers/temurin-bin/jdk-darwin-base.nix
@@ -19,7 +19,7 @@ let
   providedCpuTypes = builtins.filter (arch: builtins.elem arch validCpuTypes) (
     builtins.attrNames sourcePerArch
   );
-  result = stdenv.mkDerivation {
+  result = stdenv.mkDerivation (finalAttrs: {
     pname =
       if sourcePerArch.packageType == "jdk" then
         "${name-prefix}-bin"
@@ -40,16 +40,19 @@ let
     installPhase = ''
       cd ..
 
-      mv $sourceRoot $out
+      mkdir -p $out/Library/Java/JavaVirtualMachines
+
+      bundle=$out/Library/Java/JavaVirtualMachines/${name-prefix}-${lib.versions.major finalAttrs.version}.jdk
+      mv $sourceRoot $bundle
 
       # jni.h expects jni_md.h to be in the header search path.
-      ln -s $out/Contents/Home/include/darwin/*_md.h $out/Contents/Home/include/
+      ln -s $bundle/Contents/Home/include/darwin/*_md.h $bundle/Contents/Home/include/
 
       # Remove some broken manpages.
       # Only for 11 and earlier.
-      [ -e "$out/Contents/Home/man/ja" ] && rm -r $out/Contents/Home/man/ja
+      [ -e "$bundle/Contents/Home/man/ja" ] && rm -r $bundle/Contents/Home/man/ja
 
-      ln -s $out/Contents/Home/* $out/
+      ln -s $bundle/Contents/Home/* $out/
 
       # Propagate the setJavaClassPath setup hook from the JDK so that
       # any package that depends on the JDK has $CLASSPATH set up
@@ -67,7 +70,7 @@ let
     passthru = {
       jre = result;
       home = result;
-      bundle = result;
+      bundle = "${result}/Library/Java/JavaVirtualMachines/${name-prefix}-${lib.versions.major finalAttrs.version}.jdk";
     };
 
     meta = with lib; {
@@ -82,6 +85,6 @@ let
       inherit knownVulnerabilities;
       mainProgram = "java";
     };
-  };
+  });
 in
 result

--- a/pkgs/development/compilers/zulu/common.nix
+++ b/pkgs/development/compilers/zulu/common.nix
@@ -174,6 +174,7 @@ let
       })
       // {
         home = jdk;
+        bundle = "${jdk}/zulu-${lib.versions.major version}.jdk";
       };
 
     meta = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The proper way to install a JDK on macOS is to copy or link a "JDK bundle" into `/Library/Java/JavaVirtualMachines` (or `~/Library/Java/JavaVirtualMachines`). Most of the JDKs in nixpkgs already produce these JDKs, but they are not produced at a consistent path relative to the root of the derivation, so it's hard to install them. For example:
- the Zulu JDKs produce bundles at `$out/zulu-$MAJOR_VERSION.jdk`
- the Temurin (and thus Semeru) JDKs produce bundles at `$out`

This PR standardizes the bundle path at `$out/Library/Java/JavaVirtualMachines/$NAME-$MAJOR_VERSION.jdk` (chosen because it feels like adding the JDK to `environment.systemPackages` with the appropriate `pathsToLink`). It also sets a `passthru.bundle` attribute that is the path to this produced bundle.

This PR should have no effect on non-Darwin platforms. It is technically a breaking change for anything that expects to find JDK bundles at the previous locations, but I couldn't find any use of this in-tree and this PR should make it easier to find JDK bundles in any case.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
