### PR TITLE
crc-reveng: init at 3.0.6

### DIFF
--- a/pkgs/by-name/cr/crc-reveng/configure_for_64_bit_system.patch
+++ b/pkgs/by-name/cr/crc-reveng/configure_for_64_bit_system.patch
@@ -1,0 +1,20 @@
+diff --git a/config.h b/config.h
+index 112c9ac..f592b29 100644
+--- a/config.h
++++ b/config.h
+@@ -73,13 +73,13 @@
+ 
+ /* Size in bits of a bmp_t.  Not necessarily a power of two. */
+ 
+-#define BMP_BIT   32
++#define BMP_BIT   64
+ 
+ /* The highest power of two that is strictly less than BMP_BIT.
+  * Initialises the index of a binary search for set bits in a bmp_t.
+  */
+ 
+-#define BMP_SUB   16
++#define BMP_SUB   32
+ 
+ /*****************************************
+  *					 *

--- a/pkgs/by-name/cr/crc-reveng/do_not_hardcode_gcc_in_makefile.patch
+++ b/pkgs/by-name/cr/crc-reveng/do_not_hardcode_gcc_in_makefile.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile b/Makefile
+index b70c562..b50808d 100755
+--- a/Makefile
++++ b/Makefile
+@@ -24,7 +24,6 @@
+ # The bmptst and pretst invocations are Bourne shell command lines.
+ SHELL = /bin/sh
+ # C compiler and flags.  Adjust to taste.
+-CC = gcc
+ CFLAGS = -O3 -Wall -ansi -fomit-frame-pointer
+ # Binary optimiser
+ STRIP = strip

--- a/pkgs/by-name/cr/crc-reveng/no_exe_extension_for_unix.patch
+++ b/pkgs/by-name/cr/crc-reveng/no_exe_extension_for_unix.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index b70c562..34ed3c0 100755
+--- a/Makefile
++++ b/Makefile
+@@ -34,7 +34,7 @@ RM = rm
+ TOUCH = touch
+ FALSE = false
+ # Executable extension
+-EXT = .exe
++EXT =
+ 
+ # Target executable
+ EXE = reveng

--- a/pkgs/by-name/cr/crc-reveng/package.nix
+++ b/pkgs/by-name/cr/crc-reveng/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  fetchzip,
+  lib,
+  versionCheckHook,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "crc-reveng";
+  version = "3.0.6";
+
+  src = fetchzip {
+    url = "mirror://sourceforge/reveng/${finalAttrs.version}/reveng-${finalAttrs.version}.tar.gz";
+    hash = "sha256-j/+snFczF0GP492ABvyn/ZIc1JNerD9KJqnfnGA1lak=";
+  };
+
+  # Upstream has modified versioned releases to replace prebuilt binaries
+  # in the past. As we don’t care about the upstream builds, delete the `bin`
+  # directory so that changes there won’t affect the source hash.
+  # See: <https://github.com/NixOS/nixpkgs/pull/375220#issuecomment-3961416281>
+  postFetch = ''
+    rm bin
+  '';
+
+  patches = [
+    ./no_exe_extension_for_unix.patch
+    ./do_not_hardcode_gcc_in_makefile.patch
+  ]
+  ++ (if stdenv.hostPlatform.is64bit then [ ./configure_for_64_bit_system.patch ] else [ ]);
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D reveng -t $out/bin
+
+    runHook postInstall
+  '';
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-h";
+  doInstallCheck = true;
+
+  meta = {
+    description = "Arbitrary-precision CRC calculator and algorithm finder";
+    longDescription = ''
+      CRC RevEng is a portable, arbitrary-precision CRC calculator and algorithm finder.
+      It calculates CRCs using any of the 113 preset algorithms, or a user-specified algorithm to any width.
+      It calculates reversed CRCs to give the bit pattern that produces a desired forward CRC.
+      CRC RevEng also reverse-engineers any CRC algorithm from sufficient correctly formatted message-CRC pairs and optional known parameters.
+      It comprises powerful input interpretation options. Compliant with Ross Williams' Rocksoft(tm) model of parametrised CRC algorithms.
+    '';
+    homepage = "https://reveng.sourceforge.io/";
+    downloadPage = "https://sourceforge.net/projects/reveng/files/";
+    license = lib.licenses.gpl3Plus;
+    changelog = "https://reveng.sourceforge.io/changes.htm";
+    maintainers = with lib.maintainers; [
+      acuteaangle
+    ];
+    mainProgram = "reveng";
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds [CRC RevEng](https://reveng.sourceforge.io/), an arbitrary-precision CRC calculator and algorithm finder.

Homepage: https://reveng.sourceforge.io/
Source URL: https://sourceforge.net/projects/reveng/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
