### PR TITLE
breakpointHook: several improvements

### DIFF
--- a/pkgs/by-name/br/breakpointHook/attach.sh
+++ b/pkgs/by-name/br/breakpointHook/attach.sh
@@ -2,16 +2,36 @@
 
 set -eu -o pipefail
 
-id="$1"
-pids="$(pgrep -f "sleep $id" || :)"
-if [ -z "$pids" ]; then
-  echo "Error: No process found for 'sleep $id'. The build must still be running in order to attach. Also make sure it's not on a remote builder." >&2
-  exit 1
-elif [ "$(echo "$pids" | wc -l)" -ne 1 ]; then
-  echo "Error: Multiple processes found matching 'sleep $id'" >&2
-  exit 1
-fi
-pid="$(echo "$pids" | head -n1)"
+# A shell implementation for pgrep as we don't want to depend on procps
+pgrep(){
+  PATTERN="$1"
+  for pid_dir in /proc/[0-9]*; do
+    pid="${pid_dir##*/}"
+
+    # Attempt to open /proc/<PID>/cmdline for reading on a new file descriptor
+    # If we can't read it (no permission or doesn't exist), skip
+    exec {fd}< "$pid_dir/cmdline" 2>/dev/null || continue
+
+    cmdline=""
+    # Read each null-delimited token from /proc/<PID>/cmdline
+    # and join them with a space for easier pattern matching
+    while IFS= read -r -d $'\0' arg <&$fd; do
+        if [[ -z "$cmdline" ]]; then
+            cmdline="$arg"
+        else
+            cmdline="$cmdline $arg"
+        fi
+    done
+
+    # Close the file descriptor
+    exec {fd}>&-
+
+    # If cmdline is non-empty and matches the pattern, print the PID
+    if [[ -n "$cmdline" && "$cmdline" =~ $PATTERN ]]; then
+        echo "$pid"
+    fi
+  done
+}
 
 # helper to extract variables from the build env
 getVar(){
@@ -25,6 +45,17 @@ getVar(){
   | cut -d "=" -f 2
 }
 
+id="$1"
+pids="$(pgrep "sleep $id" || :)"
+if [ -z "$pids" ]; then
+  echo "Error: No process found for 'sleep $id'. The build must still be running in order to attach. Also make sure it's not on a remote builder." >&2
+  exit 1s
+elif [ "$(echo "$pids" | wc -l)" -ne 1 ]; then
+  echo "Error: Multiple processes found matching 'sleep $id'" >&2
+  exit 1
+fi
+pid="$(echo "$pids" | head -n1)"
+
 # bash is needed to load the env vars, as we do not know the syntax of the debug shell.
 # bashInteractive is used instead of bash, as we depend on it anyways, due to it being
 #   the default debug shell
@@ -35,12 +66,16 @@ debugShell="$(getVar debugShell)"
 pwd="$(readlink /proc/$pid/cwd)"
 
 # enter the namespace of the failed build
-exec nsenter --mount --net --target "$pid" "$bashInteractive" -c "
+# bash needs to be executed with --init-file /build/env-vars to include the bash native
+#   variables like ones declared via `declare -a`.
+# If another shell is chosen via `debugShell`, it will only have simple env vars avaialable.
+exec nsenter --mount --ipc --uts --pid  --net --target "$pid" "$bashInteractive" -c "
   set -eu -o pipefail
-  while IFS= read -r -d \$'\0' line; do
-    export \"\$line\"
-  done <&3
-  exec 3>&-
+  source /build/env-vars
   cd \"$pwd\"
-  exec \"$debugShell\"
-" 3< /proc/$pid/environ
+  if [ -n \"$debugShell\" ]; then
+    exec \"$debugShell\"
+  else
+    exec \"$bashInteractive\" --init-file /build/env-vars
+  fi
+"

--- a/pkgs/by-name/br/breakpointHook/breakpoint-hook.sh
+++ b/pkgs/by-name/br/breakpointHook/breakpoint-hook.sh
@@ -6,9 +6,7 @@ breakpointHook() {
 
     # provide the user with an interactive shell for better experience
     export bashInteractive="@bashInteractive@"
-    if [ -z "$debugShell" ]; then
-        export debugShell="@bashInteractive@"
-    fi
+    dumpVars
 
     local id
     id="$(shuf -i 999999-9999999 -n1)"

--- a/pkgs/by-name/br/breakpointHook/package.nix
+++ b/pkgs/by-name/br/breakpointHook/package.nix
@@ -1,24 +1,19 @@
 {
   lib,
   stdenv,
+  buildPackages,
 
-  bash,
   bashInteractive,
-  coreutils,
   makeSetupHook,
-  procps,
-  util-linux,
-  writeShellScriptBin,
 }:
 
 let
-  attach = writeShellScriptBin "attach" ''
+  attach = buildPackages.writeShellScriptBin "attach" ''
     export PATH="${
       lib.makeBinPath [
-        bash
-        coreutils
-        procps # needed for pgrep
-        util-linux # needed for nsenter
+        buildPackages.bash
+        buildPackages.coreutils
+        buildPackages.util-linuxMinimal # needed for nsenter
       ]
     }"
     exec bash ${./attach.sh} "$@"


### PR DESCRIPTION
done:
1. Implement pgrep in bash to get rid of procps dependency
2. dump env vars one more time to make sure /build/env-vars includes everything at the point of failure
3. Load env vars via `--init-file /build/env-vars` when executing the interacitve bash session to include bash native variables
4. Use buildPackages for tools used in attach script, to allow usage in cross compiling screnarios
5. use util-linuxMinimal instead of util-linux to get rid of systemd dependency

@mic92

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
