### PR TITLE
stage-2-init: fix false positives for RO Nix store mounts

### DIFF
--- a/nixos/modules/system/boot/stage-2-init.sh
+++ b/nixos/modules/system/boot/stage-2-init.sh
@@ -69,7 +69,8 @@ fi
 chown -f 0:30000 /nix/store
 chmod -f 1775 /nix/store
 if [ -n "@readOnlyNixStore@" ]; then
-    if ! [[ "$(findmnt --noheadings --output OPTIONS /nix/store)" =~ ro(,|$) ]]; then
+    # #375257: Ensure that we pick the "top" (i.e. last) mount so we don't get a false positive for a lower mount.
+    if ! [[ "$(findmnt --direction backward --first-only --noheadings --output OPTIONS /nix/store)" =~ (^|,)ro(,|$) ]]; then
         if [ -z "$container" ]; then
             mount --bind /nix/store /nix/store
         else

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -165,6 +165,7 @@ in {
   boot = handleTestOn ["x86_64-linux" "aarch64-linux"] ./boot.nix {};
   bootspec = handleTestOn ["x86_64-linux"] ./bootspec.nix {};
   boot-stage1 = handleTest ./boot-stage1.nix {};
+  boot-stage2 = handleTest ./boot-stage2.nix {};
   borgbackup = handleTest ./borgbackup.nix {};
   borgmatic = handleTest ./borgmatic.nix {};
   botamusique = handleTest ./botamusique.nix {};

--- a/nixos/tests/boot-stage2.nix
+++ b/nixos/tests/boot-stage2.nix
@@ -1,0 +1,73 @@
+import ./make-test-python.nix (
+  { pkgs, ... }:
+  {
+    name = "boot-stage2";
+
+    nodes.machine =
+      {
+        config,
+        pkgs,
+        lib,
+        ...
+      }:
+      {
+        virtualisation = {
+          emptyDiskImages = [ 256 ];
+
+          # Mount an ext4 as the upper layer of the Nix store.
+          fileSystems = {
+            "/nix/store" = lib.mkForce {
+              device = "/dev/vdb"; # the above disk image
+              fsType = "ext4";
+
+              # data=journal always displays after errors=remount-ro; this is only needed because of the overlay
+              # and #375257 will trigger with `errors=remount-ro` on a non-overlaid store:
+              # see ordering in https://github.com/torvalds/linux/blob/v6.12/fs/ext4/super.c#L2974
+              options = [
+                "defaults"
+                "errors=remount-ro"
+                "data=journal"
+              ];
+            };
+          };
+        };
+
+        boot = {
+          initrd = {
+            # Format the upper Nix store.
+            postDeviceCommands = ''
+              ${pkgs.e2fsprogs}/bin/mkfs.ext4 /dev/vdb
+            '';
+
+            # Overlay the RO store onto it.
+            # Note that bug #375257 can be triggered without an overlay,
+            # using the errors=remount-ro option (or similar) or with an overlay where any of the
+            # paths ends in 'ro'. The offending mountpoint also has to be the last (top) one
+            # if an option ending in 'ro' is the last in the list, so test both cases here.
+            postMountCommands = ''
+              mkdir -p /mnt-root/nix/store/ro /mnt-root/nix/store/rw /mnt-root/nix/store/work
+              mount --bind /mnt-root/nix/.ro-store /mnt-root/nix/store/ro
+              mount -t overlay overlay \
+                -o lowerdir=/mnt-root/nix/store/ro,upperdir=/mnt-root/nix/store/rw,workdir=/mnt-root/nix/store/work \
+                /mnt-root/nix/store
+            '';
+
+            kernelModules = [ "overlay" ];
+          };
+
+          postBootCommands = ''
+            touch /etc/post-boot-ran
+            mount
+          '';
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed("test /etc/post-boot-ran")
+      machine.fail("touch /nix/store/should-not-work");
+    '';
+
+    meta.maintainers = with pkgs.lib.maintainers; [ numinit ];
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Mounting an ext4 Nix store with the option `errors=remount-ro` results in the store not being remounted as RO after stage2 runs. In fact, many mount options involving "ro" at the end of the option are susceptible to this.

We need to take the "top" mount instead of any mount, which is the last line printed by findmnt. Additionally, make the regex more strict, so we don't select mount options ending in ro (like `errors=remount-ro` from
ext4, or overlay paths ending in 'ro') and accidentally leave the Nix store RW after boot.

The tests for this look a little tortured, because of how the tests overlay mount the Nix store. It is much easier to hit this on real hardware, with a single mountpoint (though, incidentally, I first hit this with an overlay).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
