### PR TITLE
vwifi: init at 6.3-unstable-2025-02-04

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2019,6 +2019,12 @@
     githubId = 21687187;
     name = "Mirza Arnaut";
   };
+  asappia = {
+    email = "asappia@gmail.com";
+    github = "asappia";
+    githubId = 891399;
+    name = "Alessandro Sappia";
+  };
   asbachb = {
     email = "asbachb-nixpkgs-5c2a@impl.it";
     matrix = "@asbachb:matrix.org";

--- a/pkgs/by-name/vw/vwifi/makefile.patch
+++ b/pkgs/by-name/vw/vwifi/makefile.patch
@@ -1,0 +1,41 @@
+diff --git a/Makefile b/Makefile
+index 9430d7e..e46efd3 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,8 +2,10 @@
+ #
+ NAME	:=	vwifi
+ VERSION	:=	6.3
+-BINDIR	:=	$(DESTDIR)/usr/local/bin
+-MANDIR	:=	$(DESTDIR)/usr/local/man/man1
++PREFIX	?=	$(out)
++DESTDIR	?=	$(PREFIX)
++BINDIR	?=	$(PREFIX)/bin
++MANDIR	?=	$(PREFIX)/share/man/man1
+ 
+ EXEC	:=	vwifi-server vwifi-client vwifi-ctrl vwifi-add-interfaces
+ #EXEC	:=	vwifi-server vwifi-client vwifi-ctrl vwifi-add-interfaces vwifi-inet-monitor
+@@ -23,10 +25,8 @@ MODE+= -O3 -s -Wall -Wextra -pedantic # //////////      RELEASE
+ 
+ EDITOR	?=	geany
+ 
+-NETLINK_FLAGS_PATH := /usr/include/libnl3
+-NETLINK_FLAGS := -I $(NETLINK_FLAGS_PATH)
+-NETLINK_LIBS_PATH := .
+-NETLINK_LIBS := -L $(NETLINK_LIBS_PATH) -lnl-genl-3 -lnl-3
++NETLINK_FLAGS := $(shell pkg-config --cflags libnl-3.0 libnl-genl-3.0)
++NETLINK_LIBS := $(shell pkg-config --libs libnl-3.0 libnl-genl-3.0)
+ 
+ THREAD_LIBS := -lpthread
+ 
+@@ -101,10 +101,6 @@ gitversion: .git
+ 	@sed -i "s/^\(VERSION.[^\-]*\)\(-.*\)\?/\1-$(shell git log --pretty=format:"%h" -n 1)/g" Makefile
+ 
+ install : build
+-ifneq ($(EUID),0)
+-	@echo "Please run 'make install' as root user"
+-	@exit 1
+-endif
+ 	chmod +x $(EXEC)
+ 	# Install binaire :
+ 	mkdir -p $(BINDIR) && cp -p $(EXEC) $(BINDIR)

--- a/pkgs/by-name/vw/vwifi/package.nix
+++ b/pkgs/by-name/vw/vwifi/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  libnl,
+  pkg-config,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "vwifi";
+  version = "6.3-unstable-2025-02-04";
+  src = fetchFromGitHub {
+    owner = "Raizo62";
+    repo = "vwifi";
+    rev = "18c320b1b92bea241ad801d05e0f2b4748478fd9";
+    hash = "sha256-rlwBO5/xyr8KjvacxYt7dBrV1noXhwBJaElGhmM/eWU=";
+  };
+
+  patches = [ ./makefile.patch ];
+
+  buildInputs = [
+    libnl
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  doInstallCheck = true;
+
+  installCheckPhase = ''
+    checksRan=0
+    for bin in $out/bin/vwifi-*; do
+      echo -n "$(basename -- "$bin"): "
+      $bin --version 2>&1 | grep -F "${lib.versions.majorMinor finalAttrs.version}"
+      checksRan=$((checksRan+1))
+    done
+    [ $checksRan -gt 0 ] || exit 1
+  '';
+
+  meta = {
+    description = "Simulate Wi-Fi (802.11) between Linux Virtual Machines";
+    homepage = "https://github.com/Raizo62/vwifi";
+    license = lib.licenses.lgpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ asappia ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [X] aarch64-linux
  - [X] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
