### PR TITLE
dcap: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/dc/dcap/package.nix
+++ b/pkgs/by-name/dc/dcap/package.nix
@@ -30,14 +30,16 @@ stdenv.mkDerivation rec {
     libxcrypt
   ];
 
+  strictDeps = true;
+
   preConfigure = ''
-    patchShebangs bootstrap.sh
+    patchShebangs --build bootstrap.sh
     ./bootstrap.sh
   '';
 
   doCheck = true;
 
-  nativeCheckInputs = [ cunit ];
+  checkInputs = [ cunit ];
 
   outputs = [
     "bin"


### PR DESCRIPTION
cunit is required to compile the tests, not as executable.

Fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).