### PR TITLE
sysstat: fix homepage url

### DIFF
--- a/pkgs/by-name/sy/sysstat/package.nix
+++ b/pkgs/by-name/sy/sysstat/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
 
   meta = {
     mainProgram = "iostat";
-    homepage = "http://sebastien.godard.pagesperso-orange.fr/";
+    homepage = "https://sysstat.github.io/";
     description = "Collection of performance monitoring tools for Linux (such as sar, iostat and pidstat)";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Old URL seems broken

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
