### PR TITLE
llvmPackages.openmp: fix cross build

### DIFF
--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -14,6 +14,7 @@
 , clang-unwrapped
 , perl
 , pkg-config
+, python3
 , version
 , devExtraCmakeFlags ? []
 }:
@@ -45,6 +46,7 @@ stdenv.mkDerivation (rec {
 
   nativeBuildInputs = [
     cmake
+    python3.pythonOnBuildForHost
   ] ++ lib.optionals (lib.versionAtLeast release_version "15") [
     ninja
   ] ++ [ perl ] ++ lib.optionals (lib.versionAtLeast release_version "14") [
@@ -53,6 +55,7 @@ stdenv.mkDerivation (rec {
 
   buildInputs = [
     (if stdenv.buildPlatform == stdenv.hostPlatform then llvm else targetLlvm)
+    python3
   ];
 
   cmakeFlags = lib.optionals (lib.versions.major release_version == "13") [


### PR DESCRIPTION
Python is required for one of the plugins. Previously only a native Python was picked up, which failed to link.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).