### PR TITLE
wf-config: fix and enable strictDeps

### DIFF
--- a/pkgs/applications/window-managers/wayfire/wf-config.nix
+++ b/pkgs/applications/window-managers/wayfire/wf-config.nix
@@ -40,10 +40,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     cmake
+  ];
+  checkInputs = [
     doctest
   ];
   # CMake is just used for finding doctest.
   dontUseCmakeConfigure = true;
+
+  strictDeps = true;
 
   mesonFlags = [
     (lib.mesonEnable "tests" (stdenv.buildPlatform.canExecute stdenv.hostPlatform))


### PR DESCRIPTION
doctest is used to compile the tests, not to run the tests.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).