### PR TITLE
liquidsoap: 2.2.5 → 2.3.0

### DIFF
--- a/pkgs/development/ocaml-modules/ffmpeg/base.nix
+++ b/pkgs/development/ocaml-modules/ffmpeg/base.nix
@@ -1,13 +1,13 @@
 { lib, fetchFromGitHub }:
 
 rec {
-  version = "1.1.11";
+  version = "1.2.1";
 
   src = fetchFromGitHub {
     owner = "savonet";
     repo = "ocaml-ffmpeg";
     rev = "refs/tags/v${version}";
-    sha256 = "sha256-Tr0YhoaaUSOlA7vlhAjPyFJI/iL7Z54oO27RnG7d+nA=";
+    sha256 = "sha256-Df+dU7Cd1rgsC/TelPzQ7wYlwsX9MGd8qcYsVN6dyMg=";
   };
 
   meta = with lib; {

--- a/pkgs/development/ocaml-modules/mem_usage/default.nix
+++ b/pkgs/development/ocaml-modules/mem_usage/default.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildDunePackage,
+}:
+
+buildDunePackage rec {
+  pname = "mem_usage";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "savonet";
+    repo = "ocaml-mem_usage";
+    rev = "v${version}";
+    hash = "sha256-5tQNsqbiU9oJvKHUjeTo/ST4A0Axc95gdJISLaa9VRM=";
+  };
+
+  minimalOCamlVersion = "4.07";
+
+  doCheck = true;
+
+  meta = {
+    license = lib.licenses.mit;
+    homepage = "https://www.liquidsoap.info/ocaml-mem_usage/";
+    description = "Cross-platform memory usage information";
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/tools/audio/liquidsoap/full.nix
+++ b/pkgs/tools/audio/liquidsoap/full.nix
@@ -3,6 +3,7 @@
   stdenv,
   makeWrapper,
   fetchFromGitHub,
+  fetchpatch,
   which,
   pkg-config,
   libjpeg,
@@ -23,7 +24,7 @@
 
 let
   pname = "liquidsoap";
-  version = "2.2.5";
+  version = "2.3.0";
 in
 stdenv.mkDerivation {
   inherit pname version;
@@ -32,8 +33,17 @@ stdenv.mkDerivation {
     owner = "savonet";
     repo = "liquidsoap";
     rev = "refs/tags/v${version}";
-    hash = "sha256-o3P7oTizO2l2WkB4LormZ/Ses5jZOpgQ1r1zB1Y3Bjs=";
+    hash = "sha256-wNOENkIQw8LWfceI24aa8Ja3ZkePgTIGdIpGgqs/3Ss=";
   };
+
+  patches = [
+    # Compatibility with saturn_lockfree 0.5.0
+    (fetchpatch {
+      url = "https://github.com/savonet/liquidsoap/commit/3d6d2d9cd1c7750f2e97449516235a692b28bf56.patch";
+      includes = [ "src/*" ];
+      hash = "sha256-pmC3gwmkv+Hat61aulNkTKS4xMz+4D94OCMtzhzNfT4=";
+    })
+  ];
 
   postPatch = ''
     substituteInPlace src/lang/dune \
@@ -88,7 +98,7 @@ stdenv.mkDerivation {
     ocamlPackages.duppy
     ocamlPackages.mm
     ocamlPackages.ocurl
-    ocamlPackages.ocaml_pcre
+    ocamlPackages.re
     ocamlPackages.cry
     ocamlPackages.camomile
     ocamlPackages.uri
@@ -96,10 +106,13 @@ stdenv.mkDerivation {
     ocamlPackages.magic-mime
     ocamlPackages.menhir # liquidsoap-lang
     ocamlPackages.menhirLib
+    ocamlPackages.mem_usage
     ocamlPackages.metadata
     ocamlPackages.dune-build-info
     ocamlPackages.re
+    ocamlPackages.saturn_lockfree # liquidsoap-lang
     ocamlPackages.sedlex # liquidsoap-lang
+    ocamlPackages.ppx_hash # liquidsoap-lang
     ocamlPackages.ppx_string
 
     # Recommended dependencies

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1085,6 +1085,8 @@ let
 
     memtrace = callPackage ../development/ocaml-modules/memtrace { };
 
+    mem_usage = callPackage ../development/ocaml-modules/mem_usage { };
+
     menhir = callPackage ../development/ocaml-modules/menhir { };
 
     menhirLib = callPackage ../development/ocaml-modules/menhir/lib.nix { };


### PR DESCRIPTION
This subsumes #374563 and incorporates a commit from Mutsuha Asada (@momeemt).

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
