### PR TITLE
eb-garamond: add TTF and WOFF

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2792,6 +2792,12 @@
     githubId = 29384538;
     keys = [ { fingerprint = "D35E C9CE E631 638F F1D8  B401 6F0E 410D C3EE D02"; } ];
   };
+  bengsparks = {
+    email = "benjamin.sparks@protonmail.com";
+    github = "bengsparks";
+    githubId = 4313548;
+    name = "Ben Sparks";
+  };
   benhiemer = {
     name = "Benedikt Hiemer";
     email = "ben.email@posteo.de";

--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -46,6 +46,7 @@ stdenvNoCC.mkDerivation rec {
     homepage = "http://www.georgduffner.at/ebgaramond/";
     description = "Digitization of the Garamond shown on the Egenolff-Berner specimen";
     maintainers = with maintainers; [
+      bengsparks
       relrod
       rycee
     ];

--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -1,16 +1,17 @@
 {
   lib,
   stdenvNoCC,
-  fetchzip,
+  fetchFromGitHub,
 }:
-
 stdenvNoCC.mkDerivation rec {
   pname = "eb-garamond";
   version = "0.016";
 
-  src = fetchzip {
-    url = "https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-${version}.zip";
-    hash = "sha256-P2VCLcqcMBBoTDJyRLP9vlHI+jE0EqPjPziN2MJbgEg=";
+  src = fetchFromGitHub {
+    owner = "georgd";
+    repo = "EB-Garamond";
+    tag = "v${version}";
+    hash = "sha256-ajieKhTeH6yv2qiE2xqnHFoMS65//4ZKiccAlC2PXGQ=";
   };
 
   installPhase = ''

--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -35,7 +35,10 @@ stdenvNoCC.mkDerivation rec {
   installPhase = ''
     runHook preInstall
 
-    install -Dm644 otf/*.otf                                 -t $out/share/fonts/opentype
+    install -Dm644 build/*.ttf  -t $out/share/fonts/truetype
+    install -Dm644 build/*.otf  -t $out/share/fonts/opentype
+    install -Dm644 build/*.woff -t $out/share/fonts/woff
+
     install -Dm644 Changes README.markdown README.xelualatex -t $out/share/doc/${pname}-${version}
 
     runHook postInstall

--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -2,6 +2,8 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  python3,
+  ttfautohint,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "eb-garamond";
@@ -13,6 +15,22 @@ stdenvNoCC.mkDerivation rec {
     tag = "v${version}";
     hash = "sha256-ajieKhTeH6yv2qiE2xqnHFoMS65//4ZKiccAlC2PXGQ=";
   };
+
+  nativeBuildInputs = [
+    (python3.withPackages (p: [ p.fontforge ]))
+    ttfautohint
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace-fail "@\$(SFNTTOOL) -w \$< \$@"   "@fontforge -lang=ff -c 'Open(\$\$1); Generate(\$\$2)' \$< \$@"
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+    make WEB=build EOT="" all
+    runHook postBuild
+  '';
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/by-name/eb/eb-garamond/package.nix
+++ b/pkgs/by-name/eb/eb-garamond/package.nix
@@ -39,8 +39,6 @@ stdenvNoCC.mkDerivation rec {
     install -Dm644 build/*.otf  -t $out/share/fonts/opentype
     install -Dm644 build/*.woff -t $out/share/fonts/woff
 
-    install -Dm644 Changes README.markdown README.xelualatex -t $out/share/doc/${pname}-${version}
-
     runHook postInstall
   '';
 


### PR DESCRIPTION
EB Garamond is currently made available by installing OTF files to the correct location.
By building the font from source using the GitHub repository instead of the bitbucket archive, the TTF and WOFF files also become available for installation.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
