### PR TITLE
python3Packages.pycapnp: 1.1.0 -> 2.0.0

### DIFF
--- a/pkgs/development/python-modules/pycapnp/default.nix
+++ b/pkgs/development/python-modules/pycapnp/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   capnproto,
-  cython,
+  cython_0,
   fetchFromGitHub,
   isPy27,
   isPyPy,
@@ -11,19 +11,19 @@
 
 buildPythonPackage rec {
   pname = "pycapnp";
-  version = "1.1.0";
+  version = "2.0.0";
   format = "setuptools";
   disabled = isPyPy || isPy27;
 
   src = fetchFromGitHub {
     owner = "capnproto";
     repo = pname;
-    rev = "v${version}";
-    sha256 = "1xi6df93ggkpmwckwbi356v7m32zv5qry8s45hvsps66dz438kmi";
+    tag = "v${version}";
+    sha256 = "sha256-SVeBRJMMR1Z8+S+QoiUKGRFGUPS/MlmWLi1qRcGcPoE=";
   };
 
   nativeBuildInputs = [
-    cython
+    cython_0
     pkgconfig
   ];
 
@@ -38,8 +38,5 @@ buildPythonPackage rec {
     homepage = "https://capnproto.github.io/pycapnp/";
     maintainers = [ ];
     license = licenses.bsd2;
-    # No support for capnproto 1.0 yet
-    # https://github.com/capnproto/pycapnp/issues/323
-    broken = lib.versionAtLeast capnproto.version "1.0";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This should fix the broken pycapnp with modern versions of capnproto.
This updated version fixes the underlying issues by removing the `allowCancellation` method as that was removed upstream in capnproto. Note this might be a breaking change for dependents previously using capnproto < 1.0, but seeing as this package was essentially broken for two years and using that oid capnproto required overrides anyways, this should be fine.
Fixing the issue in a backwards-compatible way is being tracked in https://github.com/capnproto/pycapnp/issues/323, but as nixpkgs ships modern capnproto it should be fine to ignore that.

As documented in https://github.com/capnproto/pycapnp/pull/320, pycapnp has some issues with cython3+. Upstream claims these issues are fixed in 2.0 releases of pycapnp, but that seems to not be the case judging by build errors. Pinning to cython 0.29 like upstream does for their pip package seems to work.

Sorry, no nixpkgs-review: my merge base seems to be a bit broken, will rebase in a few days and try again. But pycapnp does build and test fine, and seems to not have dependents in nixpkgs either.

closes https://github.com/NixOS/nixpkgs/issues/268340

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
