### PR TITLE
fstar: remove pnmadelaine as maintainer

### DIFF
--- a/pkgs/development/compilers/fstar/default.nix
+++ b/pkgs/development/compilers/fstar/default.nix
@@ -86,7 +86,6 @@ stdenv.mkDerivation {
     license = licenses.asl20;
     maintainers = with maintainers; [
       gebner
-      pnmadelaine
     ];
     mainProgram = "fstar.exe";
     platforms = with platforms; darwin ++ linux;


### PR DESCRIPTION
I've not been working in the fstar ecosystem for a few months now and I've not even been following the project lately. It does not make a lot of sense for me to be labeled as a maintainer anymore.