### PR TITLE
llvmPackages.libc: fix infinite recursion

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -136,6 +136,8 @@ let
             "uclibc"
           else if final.isAndroid then
             "bionic"
+          else if final.isLLVMLibc then
+            "llvm"
           else if
             final.isLinux # default
           then
@@ -261,7 +263,7 @@ let
         # don't support dynamic linking, but don't get the `staticMarker`.
         # `pkgsStatic` sets `isStatic=true`, so `pkgsStatic.hostPlatform` always
         # has the `staticMarker`.
-        isStatic = final.isWasi || final.isRedox;
+        isStatic = final.isWasi || final.isRedox || final.isLLVMLibc;
 
         # Just a guess, based on `system`
         inherit

--- a/lib/systems/inspect.nix
+++ b/lib/systems/inspect.nix
@@ -395,6 +395,7 @@ rec {
         uclibceabi
         uclibceabihf
       ];
+    isLLVMLibc = [ { abi = abis.llvm; } ];
 
     isEfi = [
       {

--- a/lib/systems/parse.nix
+++ b/lib/systems/parse.nix
@@ -740,6 +740,9 @@ rec {
     };
     uclibc = { };
 
+    # LLVM libc
+    llvm = { };
+
     unknown = { };
   };
 

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -144,6 +144,9 @@ let
     && libcxx == null
     && !targetPlatform.isDarwin
     && !(targetPlatform.useLLVM or false)
+    # Should be using LLVM libc with the LLVM libc
+    # Also, prevent infinite recursion with this:
+    && !(targetPlatform.libc == "llvm")
     && !(targetPlatform.useAndroidPrebuilt or false)
     && !(targetPlatform.isiOS or false)
     && gccForLibs != null;
@@ -650,6 +653,7 @@ stdenvNoCC.mkDerivation {
           && targetPlatform.isLinux
           && !(targetPlatform.useAndroidPrebuilt or false)
           && !(targetPlatform.useLLVM or false)
+          && !(targetPlatform.libc == "llvm")
           && gccForLibs != null
         )
         (

--- a/pkgs/development/compilers/llvm/common/libc/default.nix
+++ b/pkgs/development/compilers/llvm/common/libc/default.nix
@@ -7,11 +7,9 @@
   version,
   release_version,
   runCommand,
-  python3,
-  python3Packages,
   patches ? [ ],
-  cmake,
-  ninja,
+  pkgsBuildBuild,
+  buildPackages,
   isFullBuild ? true,
   linuxHeaders,
 }:
@@ -40,11 +38,11 @@ stdenv.mkDerivation (finalAttrs: {
   sourceRoot = "${finalAttrs.src.name}/runtimes";
 
   nativeBuildInputs = [
-    cmake
-    python3
-    ninja
+    buildPackages.cmakeMinimal
+    pkgsBuildBuild.python3
   ]
-  ++ (lib.optional isFullBuild python3Packages.pyyaml);
+  ++ (lib.optional (lib.versionAtLeast release_version "15") pkgsBuildBuild.ninja)
+  ++ (lib.optional isFullBuild pkgsBuildBuild.python3.pkgs.pyyaml);
 
   buildInputs = lib.optional isFullBuild linuxHeaders;
 

--- a/pkgs/development/compilers/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/default.nix
@@ -2,6 +2,7 @@
   lib,
   callPackage,
   stdenvAdapters,
+  pkgsBuildBuild,
   buildPackages,
   targetPackages,
   stdenv,

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -380,6 +380,10 @@ let
           "x86_64-linux"
           "aarch64-linux"
         ];
+        pkgsLLVMLibc.stdenv = [
+          "x86_64-linux"
+          "aarch64-linux"
+        ];
         pkgsArocc.stdenv = [
           "x86_64-linux"
           "aarch64-linux"

--- a/pkgs/top-level/variants.nix
+++ b/pkgs/top-level/variants.nix
@@ -39,6 +39,22 @@ self: super: {
     };
   };
 
+  pkgsLLVMLibc = nixpkgsFun {
+    overlays = [
+      (self': super': {
+        pkgsLLVMLibc = super';
+      })
+    ]
+    ++ overlays;
+    # Bootstrap a cross stdenv using LLVM libc.
+    # This is currently not possible when compiling natively,
+    # so we don't need to check hostPlatform != buildPlatform.
+    crossSystem = stdenv.hostPlatform // {
+      config = lib.systems.parse.tripleFromSystem (makeLLVMParsedPlatform stdenv.hostPlatform.parsed);
+      libc = "llvm";
+    };
+  };
+
   pkgsArocc = nixpkgsFun {
     overlays = [
       (self': super': {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fix https://github.com/nix-community/infra/issues/1676, still need to fix which comes from curl which comes from cmake:
```
       … in the right operand of the AND (&&) operator
         at /nix/store/85v74j29midz064radxs2kcr1xzzgbq9-source/pkgs/development/libraries/openssl/default.nix:101:82:
          100|       separateDebugInfo =
          101|         !stdenv.hostPlatform.isDarwin && !(stdenv.hostPlatform.useLLVM or false) && stdenv.cc.isGNU;
             |                                                                                  ^
          102|

       … while evaluating the attribute 'cc.isGNU'
         at /nix/store/85v74j29midz064radxs2kcr1xzzgbq9-source/pkgs/stdenv/generic/default.nix:208:15:
          207|
          208|       inherit cc hasCC;
             |               ^
          209|

       error: infinite recursion encountered
       at /nix/store/85v74j29midz064radxs2kcr1xzzgbq9-source/pkgs/development/libraries/openssl/default.nix:101:85:
          100|       separateDebugInfo =
          101|         !stdenv.hostPlatform.isDarwin && !(stdenv.hostPlatform.useLLVM or false) && stdenv.cc.isGNU;
             |                                                                                     ^
          102
```

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
