### PR TITLE
plex-desktop: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/pl/plex-desktop/package.nix
+++ b/pkgs/by-name/pl/plex-desktop/package.nix
@@ -69,25 +69,25 @@ let
       hash = "sha512-3ofO4a8HDWeUfjsv+4A5bC0jlQwxIew1CnL39Oa0bjnqShwRQjMW1vSHOjsJ1AHMkbp3h5W/2tFRxPL2C/Heqg==";
     };
 
-    nativeBuildInputs = [ squashfsTools ];
+    nativeBuildInputs = [
+      autoPatchelfHook
+      makeShellWrapper
+      squashfsTools
+    ];
 
     buildInputs = [
       alsa-lib
-      autoPatchelfHook
       dbus
       elfutils
       expat
       glib
-      glibc
       libGL
       libapparmor
       libbsd
       libedit
       libffi_3_3
       libgcrypt
-      makeShellWrapper
       sqlite
-      squashfsTools
       stdenv.cc.cc
       tcp_wrappers
       udev
@@ -96,6 +96,8 @@ let
       xz
       zstd
     ];
+
+    strictDeps = true;
 
     unpackPhase = ''
       runHook preUnpack


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).