### PR TITLE
cemu: pin Boost 1.86

### DIFF
--- a/pkgs/by-name/ce/cemu/package.nix
+++ b/pkgs/by-name/ce/cemu/package.nix
@@ -2,7 +2,8 @@
   lib,
   SDL2,
   addDriverRunpath,
-  boost,
+  # pin Boost 1.86 due to use of boost::asio::io_service
+  boost186,
   cmake,
   cubeb,
   curl,
@@ -81,7 +82,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   buildInputs = [
     SDL2
-    boost
+    boost186
     cubeb
     curl
     fmt_9


### PR DESCRIPTION
ref. #369118

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).