### PR TITLE
emulationstation-de: fix cross build

### DIFF
--- a/pkgs/by-name/em/emulationstation-de/package.nix
+++ b/pkgs/by-name/em/emulationstation-de/package.nix
@@ -10,6 +10,7 @@
   ffmpeg,
   freeimage,
   freetype,
+  gettext,
   harfbuzz,
   icu,
   libgit2,
@@ -31,8 +32,15 @@ stdenv.mkDerivation (finalAttrs: {
     ./001-add-nixpkgs-retroarch-cores.patch
   ];
 
+  postPatch = ''
+    # ldd-based detection fails for cross builds
+    substituteInPlace CMake/Packages/FindPoppler.cmake \
+      --replace-fail 'GET_PREREQUISITES("''${POPPLER_LIBRARY}" POPPLER_PREREQS 1 0 "" "")' ""
+  '';
+
   nativeBuildInputs = [
     cmake
+    gettext # msgfmt
     pkg-config
   ];
 


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).