### PR TITLE
sockstat: init at 1.1.0

### DIFF
--- a/pkgs/by-name/so/sockstat/package.nix
+++ b/pkgs/by-name/so/sockstat/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  installShellFiles,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sockstat";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "mezantrop";
+    repo = "sockstat";
+    tag = finalAttrs.version;
+    hash = "sha256-7VfideKNWlWb9nnAL2TK7HiD0T5EJsQiagT2kPMwrdA=";
+  };
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  installPhase = ''
+    runHook preInstall
+
+    installBin sockstat
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-v";
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "FreeBSD-like sockstat for macOS using libproc";
+    homepage = "https://github.com/mezantrop/sockstat";
+    changelog = "https://github.com/mezantrop/sockstat/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.bsd2;
+    maintainers = with lib.maintainers; [ DimitarNestorov ];
+    platforms = lib.platforms.darwin;
+    mainProgram = "sockstat";
+  };
+})


### PR DESCRIPTION
## Things done

Added [sockstat](https://github.com/mezantrop/sockstat)

Tested manually:
```sh
$ nix-build -A sockstat
/nix/store/i26ffqdzq125w70ixfpdc0qvdra9sz6b-sockstat-1.1.0
$ ./result/bin/sockstat
USER                    PID     COMMAND                         FD      PROTO   LOCAL ADDRESS           REMOTE ADDRESS
dimitar                 76344   ThemeWidgetControlViewService   3       unix    0xfac9ee47990de00f      /private//var/run/syslog
dimitar                 75849   Google Chrome Helper            12      unix    0xfac9ee47990de00f      /private//var/run/syslog
dimitar                 74844   Calendar                        4       unix    0xfac9ee47990de00f      /private//var/run/syslog
dimitar                 74795   DocumentPopoverViewService      5       unix    0xfac9ee47990de00f      /private//var/run/syslog
dimitar                 74788   QuickLookUIService              3       unix    0xfac9ee47990de00f      /private//var/run/syslog
```

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
