### PR TITLE
quirc: fix cross build

### DIFF
--- a/pkgs/by-name/qu/quirc/package.nix
+++ b/pkgs/by-name/qu/quirc/package.nix
@@ -23,8 +23,12 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
+    # use correct pkg-config / ar / ranlib for cross
     # don't try to change ownership
     substituteInPlace Makefile \
+      --replace-fail "pkg-config " "${stdenv.cc.targetPrefix}pkg-config " \
+      --replace-fail "ar " "${stdenv.cc.targetPrefix}ar " \
+      --replace-fail "ranlib " "${stdenv.cc.targetPrefix}ranlib " \
       --replace-fail "-o root" "" \
       --replace-fail "-g root" ""
   '';


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).