### PR TITLE
ci/request-reviews: Don't fail when there's too many reviewers

### DIFF
--- a/ci/request-reviews/request-reviewers.sh
+++ b/ci/request-reviews/request-reviewers.sh
@@ -69,8 +69,8 @@ for user in "${!users[@]}"; do
 done
 
 if [[ "${#users[@]}" -gt 10 ]]; then
-    log "Too many reviewers (${!users[@]}), skipping review requests"
-    exit 1
+    log "Too many reviewers (${!users[*]}), skipping review requests"
+    exit 0
 fi
 
 for user in "${!users[@]}"; do


### PR DESCRIPTION
It's better than getting failed CI and emails: https://github.com/NixOS/nixpkgs/pull/371528#issuecomment-2573926369

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
