### PR TITLE
lomiri.trust-store: Fix compatibility with glog 0.7.x, pin Boost to 1.86

### DIFF
--- a/pkgs/desktops/lomiri/development/trust-store/1001-treewide-Switch-to-glog-CMake-module.patch
+++ b/pkgs/desktops/lomiri/development/trust-store/1001-treewide-Switch-to-glog-CMake-module.patch
@@ -1,0 +1,57 @@
+From dbd44fbdc580a83ce7fb67fe8d2c87acee087cb0 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Mon, 20 Jan 2025 19:25:00 +0100
+Subject: [PATCH] treewide: Switch to glog CMake module
+
+---
+ CMakeLists.txt     | 5 ++---
+ src/CMakeLists.txt | 2 +-
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6f03c1c..b58d8ab 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,8 +38,9 @@ IF(CMAKE_BUILD_TYPE MATCHES [cC][oO][vV][eE][rR][aA][gG][eE])
+   SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -ftest-coverage -fprofile-arcs" )
+ ENDIF(CMAKE_BUILD_TYPE MATCHES [cC][oO][vV][eE][rR][aA][gG][eE])
+ 
+-find_package(PkgConfig)
++find_package(PkgConfig REQUIRED)
+ find_package(Boost COMPONENTS filesystem program_options system REQUIRED)
++find_package(glog REQUIRED)
+ 
+ add_subdirectory(3rd_party/xdg)
+ 
+@@ -56,7 +57,6 @@ if (TRUST_STORE_MIR_AGENT_ENABLED)
+   )
+ endif()
+ 
+-pkg_check_modules(GLOG libglog REQUIRED)
+ pkg_check_modules(PROCESS_CPP process-cpp REQUIRED)
+ 
+ include(CTest)
+@@ -66,7 +66,6 @@ include_directories(
+   3rd_party/xdg
+ 
+   ${GFLAGS_INCLUDE_DIRS}
+-  ${GLOG_INCLUDE_DIRS}
+   ${PROCESS_CPP_INCLUDE_DIRS}
+ )
+ 
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index ac87e7f..416549c 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -211,7 +211,7 @@ target_link_libraries(
+   ${Boost_LIBRARIES}
+   ${DBUS_LIBRARIES}
+   ${GFLAGS_LDFLAGS}
+-  ${GLOG_LDFLAGS}
++  glog::glog
+   ${GLIB_LDFLAGS}
+   ${GOBJECT_LDFLAGS}
+   ${LIBAPPARMOR_LDFLAGS}
+-- 
+2.47.1
+

--- a/pkgs/desktops/lomiri/development/trust-store/default.nix
+++ b/pkgs/desktops/lomiri/development/trust-store/default.nix
@@ -5,7 +5,9 @@
   fetchpatch,
   gitUpdater,
   testers,
-  boost,
+  # dbus-cpp not compatible with Boost 1.87
+  # https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/issues/8
+  boost186,
   cmake,
   cmake-extras,
   dbus,
@@ -50,6 +52,10 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://gitlab.com/ubports/development/core/trust-store/-/commit/569f6b35d8bcdb2ae5ff84549cd92cfc0899675b.patch";
       hash = "sha256-3lrdVIzscXGiLKwftC5oECICVv3sBoS4UedfRHx7uOs=";
     })
+
+    # Fix compatibility with glog 0.7.x
+    # Remove when https://gitlab.com/ubports/development/core/trust-store/-/merge_requests/18 merged & in release
+    ./1001-treewide-Switch-to-glog-CMake-module.patch
   ];
 
   postPatch =
@@ -79,7 +85,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost
+    boost186
     cmake-extras
     dbus-cpp
     glog


### PR DESCRIPTION
Glog issue was mentioned in https://github.com/NixOS/nixpkgs/pull/371915#issuecomment-2592669676.

Additionally, Boost 1.87 dropped some legacy code which dbus-cpp's headers depend on, so pin to `boost186`: https://gitlab.com/ubports/development/core/lib-cpp/dbus-cpp/-/issues/8

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
