### PR TITLE
lpac: init at 2.2.1

### DIFF
--- a/pkgs/by-name/lp/lpac/lpac-version.patch
+++ b/pkgs/by-name/lp/lpac/lpac-version.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/git-version.cmake b/cmake/git-version.cmake
+index be226fd..1451ff6 100644
+--- a/cmake/git-version.cmake
++++ b/cmake/git-version.cmake
+@@ -15,6 +15,8 @@ if(GIT_EXECUTABLE)
+   endif()
+ endif()
+ 
++set(LPAC_VERSION "$ENV{LPAC_VERSION}")
++
+ # Final fallback: Just use a bogus version string that is semantically older
+ # than anything else and spit out a warning to the developer.
+ if(NOT DEFINED LPAC_VERSION)

--- a/pkgs/by-name/lp/lpac/package.nix
+++ b/pkgs/by-name/lp/lpac/package.nix
@@ -1,0 +1,59 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  pkg-config,
+  pcsclite,
+  curl,
+  withDrivers ? true,
+  withLibeuicc ? true,
+  nix-update-script,
+}:
+
+let
+  inherit (lib) optional;
+in
+stdenv.mkDerivation (finalAttrs: {
+
+  pname = "lpac";
+  version = "2.2.1";
+
+  src = fetchFromGitHub {
+    owner = "estkme-group";
+    repo = "lpac";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-dxoYuX3dNj4piXQBqU4w1ICeyOGid35c+6ZITQiN6wA=";
+  };
+
+  env.LPAC_VERSION = finalAttrs.version;
+
+  patches = [ ./lpac-version.patch ];
+
+  cmakeFlags =
+    optional withDrivers "-DLPAC_DYNAMIC_DRIVERS=on"
+    ++ optional withLibeuicc "-DLPAC_DYNAMIC_LIBEUICC=on";
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    pcsclite
+  ];
+
+  passthru = {
+    updateScript = nix-update-script { attrPath = finalAttrs.pname; };
+  };
+
+  meta = {
+    description = "C-based eUICC LPA";
+    homepage = "https://github.com/estkme-group/lpac";
+    mainProgram = "lpac";
+    license = [ lib.licenses.agpl3Plus ] ++ optional withLibeuicc lib.licenses.lgpl21Plus;
+    maintainers = with lib.maintainers; [ sarcasticadmin ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

`lpac` is a cross-platform local profile agent program, compatible with [SGP.22 version 2.2.2](https://www.gsma.com/solutions-and-impact/technologies/esim/wp-content/uploads/2020/06/SGP.22-v2.2.2.pdf) (esim)

Features:

    Support Activation Code and Confirmation Code
    Support Custom IMEI sent to server
    Support Profile Discovery (SM-DS)
    Profile management: list, enable, disable, delete and nickname
    Notification management: list, send and delete
    Lookup eUICC chip info
    etc

Originally packaged in NUR https://github.com/nix-community/nur-combined/tree/b7fe29a117aca44ef8ac15d0458cd87d81a56d78/repos/linyinfeng/pkgs/lpac by @linyinfeng

This would be much more helpful to have in core nixpkgs.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
