### PR TITLE
nixos/wordpress: Use https by default for caddy

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -445,6 +445,10 @@
   For those unable to upgrade yet, there is a [v0 compatibility mode](https://www.openpolicyagent.org/docs/v1.0.1/v0-compatibility/)
   available too.
 
+- Wordpress with the Caddy webserver (`services.wordpress.webserver = "caddy"`) now sets up sites with Caddy's automatic HTTPS instead of HTTP-only.
+  Given a site example.com, http://example.com now 301 redirects to https://example.com.
+  To keep the old behavior for a site `example.com`, set `services.caddy.virtualHosts."example.com".hostName = "http://example.com"`.
+
 - `vscode-utils.buildVscodeExtension` now requires pname as an argument
 
 - The behavior of `services.hostapd.radios.<name>.networks.<name>.authentication.enableRecommendedPairwiseCiphers` was changed to not include `CCMP-256` anymore.

--- a/nixos/modules/services/web-apps/wordpress.nix
+++ b/nixos/modules/services/web-apps/wordpress.nix
@@ -545,7 +545,7 @@ in
     services.caddy = {
       enable = true;
       virtualHosts = mapAttrs' (hostName: cfg: (
-        nameValuePair "http://${hostName}" {
+        nameValuePair hostName {
           extraConfig = ''
             root    * /${pkg hostName cfg}/share/wordpress
             file_server

--- a/nixos/tests/wordpress.nix
+++ b/nixos/tests/wordpress.nix
@@ -75,7 +75,7 @@ rec {
               };
             };
 
-            networking.firewall.allowedTCPPorts = [ 80 ];
+            networking.firewall.allowedTCPPorts = [ 80 443 ];
             networking.hosts."127.0.0.1" = [
               "site1.local"
               "site2.local"
@@ -106,7 +106,7 @@ rec {
             machine.wait_for_unit(f"phpfpm-wordpress-{site_name}")
 
             with subtest("website returns welcome screen"):
-                assert "Welcome to the famous" in machine.succeed(f"curl -L {site_name}")
+                assert "Welcome to the famous" in machine.succeed(f"curl -k -L {site_name}")
 
             with subtest("wordpress-init went through"):
                 info = machine.get_unit_info(f"wordpress-init-{site_name}")


### PR DESCRIPTION
Previously, `http://` scheme was hard coded into the caddy config if `webserver = "caddy"` was chosen. This is fine for local testing, but is problematic if you want your nixos host to be public facing.

In the public facing case, you generally want to be using TLS. But since the wordpress module generates the caddyfile rule, the user's nixos config cannot easily change it to also allow https.

An alternative would be to reverse proxy an https rule to the generated http rule, but that's somewhat questionable as there's not an internal http endpoint to proxy to. It might be possible but I couldn't figure it out.

So simplify by omitting the scheme. This causes caddy to use https by default and 301 redirect any http requests to the https endpoint. Caddy will just do the right thing if it's being hosted on a local/internal hostname (self sign certificates).

This should be backwards compatible with previous default if users are using reasonable browsers/tools.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
