### PR TITLE
motif: fix and enable strictDeps, fix cross build

### DIFF
--- a/pkgs/by-name/li/libdaemon/package.nix
+++ b/pkgs/by-name/li/libdaemon/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     [ "--disable-lynx" ]
     ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       # Can't run this test while cross-compiling
-      "ac_cv_func_setpgrp_void=yes"
+      "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
     ];
 
   meta = {

--- a/pkgs/by-name/mo/motif/package.nix
+++ b/pkgs/by-name/mo/motif/package.nix
@@ -90,6 +90,11 @@ stdenv.mkDerivation rec {
     })
   ];
 
+  # provide correct configure answers for cross builds
+  configureFlags = [
+    "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
+  ];
+
   env = lib.optionalAttrs stdenv.cc.isClang {
     NIX_CFLAGS_COMPILE = toString [
       "-Wno-error=implicit-function-declaration"

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -56,10 +56,9 @@ stdenv.mkDerivation rec {
     sed 's/^\(s[ug]idperms\) = [0-9]755/\1 = 0755/' -i src/Makefile.am
   '';
 
-  # Assume System V `setpgrp (void)', which is the default on GNU variants
-  # (`AC_FUNC_SETPGRP' is not cross-compilation capable.)
+  # `AC_FUNC_SETPGRP' is not cross-compilation capable.
   preConfigure = ''
-    export ac_cv_func_setpgrp_void=yes
+    export ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}
     export shadow_cv_logdir=/var/log
   '';
 

--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
       "--with-gc=${boehmgc.dev}"
     ]
     ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
-      "ac_cv_func_setpgrp_void=yes"
+      "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
     ]
     ++ lib.optional graphicsSupport "--enable-image=${lib.optionalString x11Support "x11,"}fb"
     ++ lib.optional (graphicsSupport && !x11Support) "--without-x";

--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -38,8 +38,9 @@ stdenv.mkDerivation rec {
     lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       # For cross builds, provide answers to the configure time tests.
       # These answers are valid on x86_64-linux and aarch64-linux.
+      # TODO: provide all valid answers for BSD.
       "ac_cv_file__dev_zero=yes"
-      "ac_cv_func_setpgrp_void=yes"
+      "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
       "apr_cv_tcp_nodelay_with_cork=yes"
       "ac_cv_define_PTHREAD_PROCESS_SHARED=yes"
       "apr_cv_process_shared_works=yes"

--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -56,7 +56,9 @@ stdenv.mkDerivation rec {
       "--with-working-dir=/var/lib/bacula"
       "--mandir=\${out}/share/man"
     ]
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "ac_cv_func_setpgrp_void=yes"
+    ++
+      lib.optional (stdenv.buildPlatform != stdenv.hostPlatform)
+        "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # bacula’s `configure` script fails to detect CoreFoundation correctly,
       # but these symbols are available in the nixpkgs CoreFoundation framework.


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).