### PR TITLE
adriconf: fix cross build

### DIFF
--- a/pkgs/by-name/ad/adriconf/package.nix
+++ b/pkgs/by-name/ad/adriconf/package.nix
@@ -3,6 +3,8 @@
   lib,
   fetchFromGitLab,
   cmake,
+  gettext,
+  glib,
   pkg-config,
   libdrm,
   libGL,
@@ -28,6 +30,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     cmake
+    gettext # msgfmt
+    glib # glib-compile-resources
     pkg-config
   ];
   buildInputs = [
@@ -41,6 +45,7 @@ stdenv.mkDerivation rec {
     pciutils
   ];
 
+  # tries to download googletest
   cmakeFlags = [ "-DENABLE_UNIT_TESTS=off" ];
 
   postInstall = ''


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).