### PR TITLE
gqrx: add darwin support

### DIFF
--- a/pkgs/applications/radio/gqrx/default.nix
+++ b/pkgs/applications/radio/gqrx/default.nix
@@ -17,9 +17,10 @@
   # drivers (optional):
   rtl-sdr,
   hackrf,
-  pulseaudioSupport ? true,
+  stdenv,
+  pulseaudioSupport ? !stdenv.hostPlatform.isDarwin,
   libpulseaudio,
-  portaudioSupport ? false,
+  portaudioSupport ? stdenv.hostPlatform.isDarwin,
   portaudio,
 }:
 
@@ -50,15 +51,17 @@ gnuradioMinimal.pkgs.mkDerivation rec {
       gnuradioMinimal.unwrapped.logLib
       mpir
       fftwFloat
-      alsa-lib
       libjack2
       gnuradioMinimal.unwrapped.boost
       qtbase
       qtsvg
-      qtwayland
       gnuradioMinimal.pkgs.osmosdr
       rtl-sdr
       hackrf
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      alsa-lib
+      qtwayland
     ]
     ++ lib.optionals (gnuradioMinimal.hasFeature "gr-ctrlport") [
       thrift
@@ -78,7 +81,7 @@ gnuradioMinimal.pkgs.mkDerivation rec {
           "Gr-audio";
     in
     [
-      "-DLINUX_AUDIO_BACKEND=${audioBackend}"
+      "-D${if stdenv.hostPlatform.isDarwin then "OSX" else "LINUX"}_AUDIO_BACKEND=${audioBackend}"
     ];
 
   # Prevent double-wrapping, inject wrapper args manually instead.
@@ -100,7 +103,7 @@ gnuradioMinimal.pkgs.mkDerivation rec {
     # Some of the code comes from the Cutesdr project, with a BSD license, but
     # it's currently unknown which version of the BSD license that is.
     license = licenses.gpl3Plus;
-    platforms = platforms.linux; # should work on Darwin / macOS too
+    platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [
       bjornfor
       fpletz


### PR DESCRIPTION
![Gqrx running on macOS](https://github.com/user-attachments/assets/455ac9a6-511a-4b44-a0d4-cc5c9f833f35)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
