### PR TITLE
epsonscan2: 6.7.70.0 -> 6.7.70.0-01-2025, pin boost, minor refactor

### DIFF
--- a/pkgs/by-name/ep/epsonscan2/package.nix
+++ b/pkgs/by-name/ep/epsonscan2/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation {
 
   postPatch = ''
     substituteInPlace src/Controller/Src/Scanner/Engine.cpp \
-      --replace-fail '@KILLALL@' ${killall}/bin/killall
+      --replace-fail '@KILLALL@' ${lib.getExe killall}
 
     substituteInPlace src/Controller/Src/Filter/GetOrientation.cpp \
       --replace-fail '@OCR_ENGINE_GETROTATE@' $out/libexec/epsonscan2-ocr/ocr-engine-getrotate
@@ -137,7 +137,7 @@ stdenv.mkDerivation {
 
   desktopItems = lib.optionals withGui [
     (makeDesktopItem {
-      name = pname;
+      name = "epsonscan2";
       exec = "epsonscan2";
       icon = "epsonscan2";
       desktopName = "Epson Scan 2";
@@ -154,22 +154,27 @@ stdenv.mkDerivation {
     inherit description;
     mainProgram = "epsonscan2";
     longDescription = ''
-      Epson Scan 2 scanner driver including optional non-free plugins such as OCR and network
-      scanning.
+      The Epson Scan 2 scanner driver, including optional non-free plugins such
+      as OCR and network scanning.
 
       To use the SANE backend:
-      <literal>
-      hardware.sane.extraBackends = [ pkgs.epsonscan2 ];
-      </literal>
+      ```nix
+      {
+        hardware.sane.extraBackends = [ pkgs.epsonscan2 ];
+      }
+      ```
 
-      Overrides can be used to customise this package. For example, to enable non-free plugins and
-      disable the Epson GUI:
-      <literal>
-      pkgs.epsonscan2.override { withNonFreePlugins = true; withGui = false; }
-      </literal>
+      Overrides can be used to customise this package. For example, to enable
+      non-free plugins and disable the Epson GUI:
+      ```nix
+      pkgs.epsonscan2.override {
+        withNonFreePlugins = true;
+        withGui = false;
+      }
+      ```
     '';
     homepage = "https://support.epson.net/linux/en/epsonscan2.php";
-    platforms = [ "x86_64-linux" ];
+    platforms = lib.systems.inspect.patternLogicalAnd lib.systems.inspect.patterns.isLinux lib.systems.inspect.patterns.isx86_64;
     sourceProvenance =
       with lib.sourceTypes;
       [ fromSource ] ++ lib.optionals withNonFreePlugins [ binaryNativeCode ];

--- a/pkgs/by-name/ep/epsonscan2/package.nix
+++ b/pkgs/by-name/ep/epsonscan2/package.nix
@@ -25,13 +25,17 @@
 let
   pname = "epsonscan2";
   description = "Epson Scan 2 scanner driver for many modern Epson scanners and multifunction printers";
-  version = "6.7.70.0";
+  # Epson updates projects without changing their version numbers.
+  # There can be multiple different packages identified by the same
+  #version, so we also tag them with the month and year shown in
+  # the Epson download page.
+  version = "6.7.70.0-01-2025";
 
   system = stdenv.hostPlatform.system;
 
   src = fetchzip {
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/16/14/37/7577ee65efdad48ee2d2f38d9eda75418e490552/epsonscan2-6.7.70.0-1.src.tar.gz";
-    hash = "sha256-y7XGxrOpVou/ZSfUffV3qv+SsFFpTiU7pWvtfsiLZWc=";
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/16/60/70/c7fc14e41ec84255008c6125b63bcac40f55e11c/epsonscan2-6.7.70.0-1.src.tar.gz";
+    hash = "sha256-WvNBy5hAxNJfwgjBR5VGaXuyTCK2YEiD3i7SMDl3U/U=";
   };
   bundle =
     {
@@ -65,8 +69,6 @@ stdenv.mkDerivation {
   ];
 
   postPatch = ''
-    rm CMakeCache.txt
-
     substituteInPlace src/Controller/Src/Scanner/Engine.cpp \
       --replace-fail '@KILLALL@' ${killall}/bin/killall
 

--- a/pkgs/by-name/ep/epsonscan2/package.nix
+++ b/pkgs/by-name/ep/epsonscan2/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   autoPatchelfHook,
-  boost,
+  boost186,
   cmake,
   copyDesktopItems,
   imagemagick,
@@ -90,7 +90,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [
-      boost
+      boost186 # uses Boost.Optional but epsonscan2 is pre-C++11.
       libjpeg
       libpng
       libtiff


### PR DESCRIPTION
Fixes #376449

- Updates the package to the latest release from Epson. Please see the comment in the file for an explanation as to why the version is the way it is.

- Pins Boost 1.86 because Epson is too good for C++11.

- Fixes up some minor things in the package.

I should also note that this package is currently failing on `master`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
