### PR TITLE
switcheroo-control: fix gobject introspection error

### DIFF
--- a/pkgs/by-name/sw/switcheroo-control/package.nix
+++ b/pkgs/by-name/sw/switcheroo-control/package.nix
@@ -8,6 +8,7 @@
   pkg-config,
   glib,
   python3Packages,
+  wrapGAppsNoGuiHook,
 }:
 
 python3Packages.buildPythonApplication rec {
@@ -28,6 +29,7 @@ python3Packages.buildPythonApplication rec {
     ninja
     meson
     pkg-config
+    wrapGAppsNoGuiHook
   ];
 
   buildInputs = [


### PR DESCRIPTION
Fixes #321590

The `switcherooctl` command was failing to execute, due to [a common GObject introspection issue](https://github.com/NixOS/nixpkgs/blob/6a3dd6351fb32a8a4e607a942f79787d19fb3f4e/doc/languages-frameworks/gnome.section.md#gobject-introspection-typelibs-ssec-gnome-typelibs).  Fix it automatically using Gnome hooks.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable: No tests seem to exist for this package
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) 
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking: Not a major change
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I am unfortunately not able to commit to maintaining this package at this point, as I'm just trying out Nix.