### PR TITLE
mkPackageOption: add defaultText option

### DIFF
--- a/lib/options.nix
+++ b/lib/options.nix
@@ -311,29 +311,30 @@ rec {
       {
         nullable ? false,
         default ? name,
+        defaultText ? null,
         example ? null,
         extraDescription ? "",
         pkgsText ? "pkgs"
       }:
       let
-        name' = if isList name then last name else name;
-        default' = if isList default then default else [ default ];
-        defaultText = concatStringsSep "." default';
-        defaultValue = attrByPath default'
-          (throw "${defaultText} cannot be found in ${pkgsText}") pkgs;
+        name' = if lib.isList name then lib.last name else name;
+        default' = if lib.isList default then default else [ default ];
+        defaultText' = lib.showAttrPath default';
+        defaultValue = lib.attrByPath default'
+          (throw "${defaultText'} cannot be found in ${pkgsText}") pkgs;
         defaults = if default != null then {
           default = defaultValue;
-          defaultText = literalExpression ("${pkgsText}." + defaultText);
-        } else optionalAttrs nullable {
+          defaultText = if defaultText != null then defaultText else lib.literalExpression ("${pkgsText}." + defaultText');
+        } else lib.optionalAttrs nullable {
           default = null;
         };
       in mkOption (defaults // {
         description = "The ${name'} package to use."
           + (if extraDescription == "" then "" else " ") + extraDescription;
-        type = with lib.types; (if nullable then nullOr else lib.id) package;
-      } // optionalAttrs (example != null) {
-        example = literalExpression
-          (if isList example then "${pkgsText}." + concatStringsSep "." example else example);
+        type = (if nullable then lib.types.nullOr else lib.id) lib.types.package;
+      } // lib.optionalAttrs (example != null) {
+        example = lib.literalExpression
+          (if lib.isList example then "${pkgsText}." + concatStringsSep "." example else example);
       });
 
   /**

--- a/lib/tests/modules.sh
+++ b/lib/tests/modules.sh
@@ -322,6 +322,7 @@ checkConfigError 'The option .undefinedPackage. was accessed but has no value de
 checkConfigOutput '^null$' config.nullablePackage ./declare-mkPackageOption.nix
 checkConfigOutput '^"null or package"$' options.nullablePackageWithDefault.type.description ./declare-mkPackageOption.nix
 checkConfigOutput '^"myPkgs\.hello"$' options.packageWithPkgsText.defaultText.text ./declare-mkPackageOption.nix
+checkConfigOutput 'if config.useGo then pkgs.hello-go else pkgs.hello' options.packageWithDefaultText.defaultText.text ./declare-mkPackageOption.nix
 checkConfigOutput '^"hello-other"$' options.packageFromOtherSet.default.pname ./declare-mkPackageOption.nix
 
 # submoduleWith

--- a/lib/tests/modules/declare-mkPackageOption.nix
+++ b/lib/tests/modules/declare-mkPackageOption.nix
@@ -48,6 +48,10 @@ in
       pkgsText = "myPkgs";
     };
 
+    packageWithDefaultText = lib.mkPackageOption pkgs "hello" {
+      defaultText = lib.literalExpression "if config.useGo then pkgs.hello-go else pkgs.hello";
+    };
+
     packageFromOtherSet =
       let
         myPkgs = {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Separated from https://github.com/NixOS/nixpkgs/pull/374656

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
