### PR TITLE
python312Packages.jaxopt: disable more failing tests, add patch

### DIFF
--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -79,6 +79,9 @@ buildPythonPackage rec {
       # AssertionError: Not equal to tolerance rtol=1e-06, atol=1e-06
       # https://github.com/google/jaxopt/issues/618
       "test_binary_logit_log_likelihood"
+
+      # AssertionError (flaky numerical tests)
+      "test_logreg_with_intercept_manual_loop3"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
       # https://github.com/google/jaxopt/issues/577

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -1,6 +1,5 @@
 {
   lib,
-  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
@@ -76,29 +75,18 @@ buildPythonPackage rec {
       # https://github.com/google/jaxopt/issues/592
       "test_solve_sparse"
 
+      # https://github.com/google/jaxopt/issues/593
+      # Makes the test suite crash
+      "test_dtype_consistency"
+
       # AssertionError: Not equal to tolerance rtol=1e-06, atol=1e-06
       # https://github.com/google/jaxopt/issues/618
       "test_binary_logit_log_likelihood"
 
       # AssertionError (flaky numerical tests)
       "test_logreg_with_intercept_manual_loop3"
-    ]
-    ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-      # Flaky (AssertionError)
       "test_inv_hessian_product_pytree3"
-
-      # https://github.com/google/jaxopt/issues/593
-      # Makes the test suite crash
-      "test_dtype_consistency"
-      # AssertionError: Array(0.01411963, dtype=float32) not less than or equal to 0.01
       "test_multiclass_logreg6"
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      # Fatal Python error: Aborted
-      "test_dtype_consistency"
-
-      # AssertionError (flaky numerical tests)
-      "test_inv_hessian_product_pytree3"
     ];
 
   meta = {

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -84,11 +84,6 @@ buildPythonPackage rec {
       "test_logreg_with_intercept_manual_loop3"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-      # https://github.com/google/jaxopt/issues/577
-      "test_binary_logit_log_likelihood"
-      "test_solve_sparse"
-      "test_logreg_with_intercept_manual_loop3"
-
       # Flaky (AssertionError)
       "test_inv_hessian_product_pytree3"
 
@@ -103,8 +98,6 @@ buildPythonPackage rec {
       "test_dtype_consistency"
 
       # AssertionError (flaky numerical tests)
-      "test_logreg_with_intercept_manual_loop3"
-      "test_binary_logit_log_likelihood"
       "test_inv_hessian_product_pytree3"
     ];
 

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -87,6 +87,8 @@ buildPythonPackage rec {
       "test_logreg_with_intercept_manual_loop3"
       "test_inv_hessian_product_pytree3"
       "test_multiclass_logreg6"
+      "test_Rosenbrock2"
+      "test_Rosenbrock5"
     ];
 
   meta = {

--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -42,6 +42,12 @@ buildPythonPackage rec {
       url = "https://github.com/google/jaxopt/commit/48b09dc4cc93b6bc7e6764ed5d333f9b57f3493b.patch";
       hash = "sha256-v+617W7AhxA1Dzz+DBtljA4HHl89bRTuGi1QfatobNY=";
     })
+    # fix invalid string escape sequences
+    (fetchpatch {
+      name = "fix-escape-sequences.patch";
+      url = "https://github.com/google/jaxopt/commit/f5bb530f5f000d0739c9b26eee2d32211eb99f40.patch";
+      hash = "sha256-E0ZXIfzWxKHuiBn4lAWf7AjNtll7OJU/NGZm6PTmhzo=";
+    })
   ];
 
   build-system = [ setuptools ];
@@ -70,26 +76,25 @@ buildPythonPackage rec {
     "jaxopt.tree_util"
   ];
 
-  disabledTests =
-    [
-      # https://github.com/google/jaxopt/issues/592
-      "test_solve_sparse"
+  disabledTests = [
+    # https://github.com/google/jaxopt/issues/592
+    "test_solve_sparse"
 
-      # https://github.com/google/jaxopt/issues/593
-      # Makes the test suite crash
-      "test_dtype_consistency"
+    # https://github.com/google/jaxopt/issues/593
+    # Makes the test suite crash
+    "test_dtype_consistency"
 
-      # AssertionError: Not equal to tolerance rtol=1e-06, atol=1e-06
-      # https://github.com/google/jaxopt/issues/618
-      "test_binary_logit_log_likelihood"
+    # AssertionError: Not equal to tolerance rtol=1e-06, atol=1e-06
+    # https://github.com/google/jaxopt/issues/618
+    "test_binary_logit_log_likelihood"
 
-      # AssertionError (flaky numerical tests)
-      "test_logreg_with_intercept_manual_loop3"
-      "test_inv_hessian_product_pytree3"
-      "test_multiclass_logreg6"
-      "test_Rosenbrock2"
-      "test_Rosenbrock5"
-    ];
+    # AssertionError (flaky numerical tests)
+    "test_logreg_with_intercept_manual_loop3"
+    "test_inv_hessian_product_pytree3"
+    "test_multiclass_logreg6"
+    "test_Rosenbrock2"
+    "test_Rosenbrock5"
+  ];
 
   meta = {
     homepage = "https://jaxopt.github.io";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Currently jaxopt fails to build ([hydra](https://hydra.nixos.org/build/285055648)) due to a failing test. This PR adds more disables like https://github.com/NixOS/nixpkgs/pull/371423. Also, add https://github.com/google/jaxopt/pull/591 which fixes some invalid string escape sequences, which trigger a `SyntaxWarning` in python 3.12+.

```python
>>> "\hi"
<stdin>:1: SyntaxWarning: invalid escape sequence '\h'
'\\hi'
```

This can cause other packages' tests to fail when using beartype, e.g. [gpjax](https://github.com/JaxGaussianProcesses/GPJax).

The diff is bigger than it looks. Going through the commits one-by-one,

- first commit disables the failing test on x86_64-linux (`test_logreg_with_intercept_manual_loop3`).
- second commit removes tests that are redundant between all three (no-op).
- after the second commit, all the disabled tests in darwin are also in aarch64. Since failing tests seem to have a tendency to show up on all platforms (e.g. first commit), unify them all. This also simplifies maintenance.
- hydra has some [additional failures](https://hydra.nixos.org/build/285055648/log/tail) that I can't replicate locally. Add them to be safe as they are [failing consistently](https://hydra.nixos.org/job/nixos/trunk-combined/nixpkgs.python312Packages.jaxopt.x86_64-linux).

  ```text
  FAILED tests/lbfgsb_test.py::LbfgsbTest::test_Rosenbrock2 - AssertionError: Array(0.00122692, dtype=float32) not less than or equal to ...
  FAILED tests/lbfgsb_test.py::LbfgsbTest::test_Rosenbrock5 - AssertionError: Array(0.00122692, dtype=float32) not less than or equal to ...
  FAILED tests/polyak_sgd_test.py::PolyakSgdTest::test_logreg_with_intercept_manual_loop3 - AssertionError: Array(0.02134909, dtype=float32) not less than or equal to ...
  ```
- add the patch from https://github.com/google/jaxopt/pull/591.

cc @bcdarwin @GaetanLepage

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
