### PR TITLE
llvmPackages.bolt: add experimental bolt hook

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -104,6 +104,8 @@ let
           # Derived meta-data
           useLLVM = final.isFreeBSD || final.isOpenBSD;
 
+          useBolt = false;
+
           libc =
             if final.isDarwin then
               "libSystem"

--- a/pkgs/build-support/cc-wrapper/default.nix
+++ b/pkgs/build-support/cc-wrapper/default.nix
@@ -845,6 +845,14 @@ stdenvNoCC.mkDerivation {
       substituteAll ${./add-clang-cc-cflags-before.sh} $out/nix-support/add-local-cc-cflags-before.sh
     ''
 
+    ###
+    ### Bolt support
+    ### Binaries need to be linked with relocations.
+    ###
+    + optionalString targetPlatform.useBolt ''
+      echo " --emit-relocs" >> $out/nix-support/cc-ldflags
+    ''
+
     ##
     ## Extra custom steps
     ##

--- a/pkgs/development/compilers/llvm/common/bolt/default.nix
+++ b/pkgs/development/compilers/llvm/common/bolt/default.nix
@@ -16,6 +16,7 @@
   patches ? [ ],
   devExtraCmakeFlags ? [ ],
   fetchpatch,
+  replaceVars,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -83,12 +84,19 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     mkdir -p $dev/lib
     mv $out/lib/libLLVMBOLT*.a $dev/lib
+
+    mkdir -p $out/nix-support
+    cp $setupHook $out/nix-support/setup-hook
   '';
 
   outputs = [
     "out"
     "dev"
   ];
+
+  setupHook = replaceVars ./setup-hook.sh.in {
+    readelf = lib.getExe' libllvm "llvm-readelf";
+  };
 
   meta = llvm_meta // {
     homepage = "https://github.com/llvm/llvm-project/tree/main/bolt";

--- a/pkgs/development/compilers/llvm/common/bolt/setup-hook.sh.in
+++ b/pkgs/development/compilers/llvm/common/bolt/setup-hook.sh.in
@@ -1,0 +1,16 @@
+# shellcheck shell=bash
+
+boltFixupPhase() {
+  local i
+  while IFS= read -r -d $'\0' i; do
+    if ! isELF "$i"; then continue; fi
+    if ! @readelf@ --program-headers "$i" | grep -q LOAD; then continue; fi
+
+    llvm-bolt "$i" -o $(dirname "$i")/.bolt-$(basename "$i") "${boltFlags[@]-}"
+    mv $(dirname "$i")/.bolt-$(basename "$i") "$i"
+  done < <(find "$prefix" -type f -print0)
+}
+
+if [ -z "${dontUseBolt-}" ]; then
+    appendToVar preFixupPhases boltFixupPhase
+fi

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -64,6 +64,9 @@ stdenv.mkDerivation (
 
     enableParallelBuilding = true;
 
+    # Bolt works best with clang
+    dontUseBolt = stdenv.cc.isGNU;
+
     patches =
       [
         /*

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -69,6 +69,9 @@ lib.init bootStages
           extraNativeBuildInputs =
             old.extraNativeBuildInputs
             ++ lib.optionals (hostPlatform.isLinux && !buildPlatform.isLinux) [ buildPackages.patchelf ]
+            ++ lib.optionals hostPlatform.useBolt [
+              buildPackages.llvmPackages.bolt
+            ]
             ++ lib.optional (
               let
                 f =

--- a/pkgs/top-level/release-attrpaths-superset.nix
+++ b/pkgs/top-level/release-attrpaths-superset.nix
@@ -50,6 +50,7 @@ let
 
     # cross packagesets
     pkgsLLVM = true;
+    pkgsBolt = true;
     pkgsMusl = true;
     pkgsStatic = true;
     pkgsCross = true;

--- a/pkgs/top-level/release.nix
+++ b/pkgs/top-level/release.nix
@@ -379,6 +379,10 @@ let
           "x86_64-linux"
           "aarch64-linux"
         ];
+        pkgsBolt.stdenv = [
+          "x86_64-linux"
+          "aarch64-linux"
+        ];
         pkgsArocc.stdenv = [
           "x86_64-linux"
           "aarch64-linux"

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -237,6 +237,20 @@ let
       };
     };
 
+    pkgsBolt = nixpkgsFun {
+      overlays = [
+        (self': super': {
+          pkgsBolt = super';
+        })
+      ] ++ overlays;
+      # Bootstrap a cross stdenv and apply the Bolt post-link optimizer.
+      # This is currently not possible when compiling natively,
+      # so we don't need to check hostPlatform != buildPlatform.
+      crossSystem = stdenv.hostPlatform // {
+        useBolt = true;
+      };
+    };
+
     pkgsArocc = nixpkgsFun {
       overlays = [
         (self': super': {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Experimental concept, this adds a hook which calls bolt on the installed binaries. The idea is this will optimize the installed binaries. We'll test with just `hello` however all packages can be tried by enabling `useBolt` when specifying the cross platform.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
