### PR TITLE
svox: 2018-02-14 -> 2021-05-06 + darwin fix

### DIFF
--- a/pkgs/by-name/sv/svox/fix-compilation-darwin.patch
+++ b/pkgs/by-name/sv/svox/fix-compilation-darwin.patch
@@ -1,0 +1,15 @@
+diff --git a/pico/lib/picopltf.h b/pico/lib/picopltf.h
+index 9b7cffd..f0f129b 100644
+--- a/pico/lib/picopltf.h
++++ b/pico/lib/picopltf.h
+@@ -70,6 +70,10 @@
+ #define __BYTE_ORDER _BYTE_ORDER
+ #define __BIG_ENDIAN _BIG_ENDIAN
+ #include <sys/endian.h>
++#elif (PICO_PLATFORM == PICO_MacOSX)
++#define __BYTE_ORDER BYTE_ORDER
++#define __BIG_ENDIAN BIG_ENDIAN
++#include <machine/endian.h>
+ #else
+ #include <endian.h>
+ #endif

--- a/pkgs/by-name/sv/svox/package.nix
+++ b/pkgs/by-name/sv/svox/package.nix
@@ -8,15 +8,20 @@
 
 stdenv.mkDerivation {
   pname = "svox";
-  version = "2018-02-14";
+  version = "0-unstable-2021-05-06";
 
   # basically took the source code from android and borrowed autotool patches from debian
   src = fetchFromGitHub {
     owner = "naggety";
     repo = "picotts";
-    rev = "e3ba46009ee868911fa0b53db672a55f9cc13b1c";
-    sha256 = "0k3m7vh1ak9gmxd83x29cvhzfkybgz5hnlhd9xj19l1bjyx84s8v";
+    rev = "21089d223e177ba3cb7e385db8613a093dff74b5";
+    hash = "sha256-NmmYa3mVUSMsLC1blFAET3zLY66anGY2ff6ZQ424h1s=";
   };
+
+  patches = [
+    # upstream PR: https://github.com/ihuguet/picotts/pull/14
+    ./fix-compilation-darwin.patch
+  ];
 
   postPatch = ''
     cd pico
@@ -29,7 +34,7 @@ stdenv.mkDerivation {
   meta = {
     description = "Text-to-speech engine";
     homepage = "https://android.googlesource.com/platform/external/svox";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.unix;
     license = lib.licenses.asl20;
     maintainers = [ ];
     mainProgram = "pico2wave";


### PR DESCRIPTION
This updates `svox` to the latest commit (fixing compilation on FreeBSD) and applies a PR (fixing compilation on Darwin).

The specific changes of the new versions are:
* naggety/picotts@269a02a: minor fix ("Replaced wildcard unsupported by autotools")
* naggety/picotts@8e73e30: FreeBSD support
* naggety/picotts@21089d2: minor cleanup

The change of the PR to svox  (by myself) that is applied:
* naggety/picotts#14: Darwin support (very similar to how the second commit above added FreeBSD support)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
