### PR TITLE
python312Packages.simple-parsing: 0.1.6 -> 0.1.7

### DIFF
--- a/pkgs/development/python-modules/simple-parsing/default.nix
+++ b/pkgs/development/python-modules/simple-parsing/default.nix
@@ -27,14 +27,14 @@
 
 buildPythonPackage rec {
   pname = "simple-parsing";
-  version = "0.1.6";
+  version = "0.1.7";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "lebrice";
     repo = "SimpleParsing";
     tag = "v${version}";
-    hash = "sha256-RDS1sWzaQqXp/0a7dXlUHnd6z+GTIpUN1MnUCTI9LGw=";
+    hash = "sha256-wHk3osr5CNmA/g9ipLy1dgvJoMy1zE/BAGD9ZATE+tc=";
   };
 
   build-system = [
@@ -67,10 +67,18 @@ buildPythonPackage rec {
   ];
 
   disabledTests = [
-    # Expected: OrderedDict([('a', 1), ('b', 2), ('c', 5), ('d', 6), ('e', 7)])
-    # Got: OrderedDict({'a': 1, 'b': 2, 'c': 5, 'd': 6, 'e': 7})
-    # https://github.com/lebrice/SimpleParsing/issues/326
-    "simple_parsing.utils.dict_union"
+    # AssertionError
+    # https://github.com/lebrice/SimpleParsing/issues/338
+    "test_bool_args_in_help"
+    "test_desc_from_cls_docstring"
+    "test_docstring_builds_upon_bases"
+    "test_help_string"
+    "test_help_string_displays_default_factory_arguments"
+    "test_help_takes_value_from_docstring"
+    "test_issue_48"
+    "test_running_example_outputs_expected_without_arg"
+    "test_subgroup_partial_with_nested_field"
+    "test_weird_docstring_with_field_like"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done

Changelog: https://github.com/lebrice/SimpleParsing/releases/tag/v0.1.7

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
