### PR TITLE
audiobookshelf: 2.17.7 -> 2.18.1

### DIFF
--- a/pkgs/by-name/au/audiobookshelf/source.json
+++ b/pkgs/by-name/au/audiobookshelf/source.json
@@ -1,9 +1,9 @@
 {
   "owner": "advplyr",
   "repo": "audiobookshelf",
-  "rev": "de8b0abc3af740148bddde462fe809f03159d678",
-  "hash": "sha256-lLCG6xw1qWbIOxHbD8ONH7iYzayJ8OhMy+WgaXExcFQ=",
-  "version": "2.17.7",
-  "depsHash": "sha256-1uDCbgZNmx8e+LrsOHTfM29SZhS1TLDHmTg48XMbwkg=",
-  "clientDepsHash": "sha256-cDT45OtLbFDF0TXO4zVVj9+UOJhkb9TjCajtSWq4H8U="
+  "rev": "66b90e0841f2b08a4a401fad202605c8fbaf3c48",
+  "hash": "sha256-SAce3URkZxPa5URyaO7G9xty4JCG0/tJym5fXLnwv74=",
+  "version": "2.18.1",
+  "depsHash": "sha256-1d3V8MzIaJdYpY5BdoAX96HTGfjBBNz/JLkG7jl0TRY=",
+  "clientDepsHash": "sha256-hClfu993JpHWOqPMgmKdMIneAFDYAi6pCPlf8GmXzow="
 }


### PR DESCRIPTION
https://github.com/advplyr/audiobookshelf/releases/tag/v2.18.0
https://github.com/advplyr/audiobookshelf/releases/tag/v2.18.1

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
