### PR TITLE
nixos-rebuild-ng: fix repl behaving differently on git flakes than bu…

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_models.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+from pytest import MonkeyPatch
+
 import nixos_rebuild.models as m
 
 from .helpers import get_qualified_name
@@ -30,7 +32,7 @@ def test_build_attr_to_attr() -> None:
     )
 
 
-def test_flake_parse() -> None:
+def test_flake_parse(tmpdir: Path, monkeypatch: MonkeyPatch) -> None:
     assert m.Flake.parse("/path/to/flake#attr") == m.Flake(
         Path("/path/to/flake"), "nixosConfigurations.attr"
     )
@@ -40,14 +42,30 @@ def test_flake_parse() -> None:
     assert m.Flake.parse("/path/to/flake", lambda: "hostname") == m.Flake(
         Path("/path/to/flake"), "nixosConfigurations.hostname"
     )
-    assert m.Flake.parse(".#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
-    assert m.Flake.parse("#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
-    assert m.Flake.parse(".") == m.Flake(Path("."), "nixosConfigurations.default")
+    # change directory to tmpdir
+    with monkeypatch.context() as patch_context:
+        patch_context.chdir(tmpdir)
+        assert m.Flake.parse(".#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
+        assert m.Flake.parse("#attr") == m.Flake(Path("."), "nixosConfigurations.attr")
+        assert m.Flake.parse(".") == m.Flake(Path("."), "nixosConfigurations.default")
     assert m.Flake.parse("path:/to/flake#attr") == m.Flake(
         "path:/to/flake", "nixosConfigurations.attr"
     )
     assert m.Flake.parse("github:user/repo/branch") == m.Flake(
         "github:user/repo/branch", "nixosConfigurations.default"
+    )
+    git_root = tmpdir / "git_root"
+    git_root.mkdir()
+    (git_root / ".git").mkdir()
+    assert m.Flake.parse(str(git_root)) == m.Flake(
+        f"git+file://{git_root}", "nixosConfigurations.default"
+    )
+
+    work_tree = tmpdir / "work_tree"
+    work_tree.mkdir()
+    (work_tree / ".git").write_text("gitdir: /path/to/git", "utf-8")
+    assert m.Flake.parse(str(work_tree)) == m.Flake(
+        "git+file:///path/to/git", "nixosConfigurations.default"
     )
 
 
@@ -61,7 +79,7 @@ def test_flake_to_attr() -> None:
 
 
 @patch(get_qualified_name(platform.node), autospec=True)
-def test_flake_from_arg(mock_node: Any) -> None:
+def test_flake_from_arg(mock_node: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     mock_node.return_value = "hostname"
 
     # Flake string
@@ -73,9 +91,11 @@ def test_flake_from_arg(mock_node: Any) -> None:
     assert m.Flake.from_arg(False, None) is None
 
     # True
-    assert m.Flake.from_arg(True, None) == m.Flake(
-        Path("."), "nixosConfigurations.hostname"
-    )
+    with monkeypatch.context() as patch_context:
+        patch_context.chdir(tmpdir)
+        assert m.Flake.from_arg(True, None) == m.Flake(
+            Path("."), "nixosConfigurations.hostname"
+        )
 
     # None when we do not have /etc/nixos/flake.nix
     with patch(

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import ANY, call, patch
 
 import pytest
+from pytest import MonkeyPatch
 
 import nixos_rebuild.models as m
 import nixos_rebuild.nix as n
@@ -51,7 +52,8 @@ def test_build(mock_run: Any, monkeypatch: Any) -> None:
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_flake(mock_run: Any) -> None:
+def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
+    monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
 
     assert n.build_flake(
@@ -165,7 +167,10 @@ def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: Any) -> None:
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build_remote_flake(mock_run: Any, monkeypatch: Any) -> None:
+def test_build_remote_flake(
+    mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path
+) -> None:
+    monkeypatch.chdir(tmpdir)
     flake = m.Flake.parse(".#hostname")
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
@@ -287,7 +292,7 @@ def test_copy_closure(monkeypatch: Any) -> None:
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
     # Flake
-    flake = m.Flake.parse(".#attr")
+    flake = m.Flake.parse(f"{tmpdir}#attr")
     n.edit(flake, {"commit_lock_file": True})
     mock_run.assert_called_with(
         [
@@ -297,7 +302,7 @@ def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
             "edit",
             "--commit-lock-file",
             "--",
-            ".#nixosConfigurations.attr",
+            f"{tmpdir}#nixosConfigurations.attr",
         ],
         check=False,
     )


### PR DESCRIPTION
…ild commands

Since we use builtins.getFlake we have behavior differences between normal nix build and the nix repl because builtins.getFlake won't pick up local flakes as git+file but assumes path:// flakes instead. This can have surprising effects such as beeing able to access untracked files that would lead to build failures otherwise or copying large files to the nix store.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
