### PR TITLE
nixos/lib/test-driver: try more OCR options

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine.py
+++ b/nixos/lib/test-driver/src/test_driver/machine.py
@@ -90,35 +90,79 @@ def make_command(args: list) -> str:
     return " ".join(map(shlex.quote, (map(str, args))))
 
 
+def _preprocess_screenshot(screenshot_path: str, negate: bool = False) -> str:
+    magick_args = [
+        "-filter",
+        "Catrom",
+        "-density",
+        "72",
+        "-resample",
+        "300",
+        "-contrast",
+        "-normalize",
+        "-despeckle",
+        "-type",
+        "grayscale",
+        "-sharpen",
+        "1",
+        "-posterize",
+        "3",
+        "-gamma",
+        "100",
+        "-blur",
+        "1x65535",
+    ]
+
+    out_file = screenshot_path
+
+    if negate:
+        magick_args.append("-negate")
+        out_file += ".negative"
+
+    out_file += ".png"
+
+    ret = subprocess.run(
+        ["magick", "convert"] + magick_args + [screenshot_path, out_file],
+        capture_output=True,
+    )
+
+    if ret.returncode != 0:
+        raise Exception(
+            f"Image processing failed with exit code {ret.returncode}, stdout: {ret.stdout.decode()}, stderr: {ret.stderr.decode()}"
+        )
+
+    return out_file
+
+
 def _perform_ocr_on_screenshot(
     screenshot_path: str, model_ids: Iterable[int]
 ) -> list[str]:
     if shutil.which("tesseract") is None:
         raise Exception("OCR requested but enableOCR is false")
 
-    magick_args = (
-        "-filter Catrom -density 72 -resample 300 "
-        + "-contrast -normalize -despeckle -type grayscale "
-        + "-sharpen 1 -posterize 3 -negate -gamma 100 "
-        + "-blur 1x65535"
-    )
-
-    tess_args = "-c debug_file=/dev/null --psm 11"
-
-    cmd = f"magick convert {magick_args} '{screenshot_path}' '{screenshot_path}.png'"
-    ret = subprocess.run(cmd, shell=True, capture_output=True)
-    if ret.returncode != 0:
-        raise Exception(
-            f"Image processing failed with exit code {ret.returncode}, stdout: {ret.stdout.decode()}, stderr: {ret.stderr.decode()}"
-        )
+    processed_image = _preprocess_screenshot(screenshot_path, negate=False)
+    processed_negative = _preprocess_screenshot(screenshot_path, negate=True)
 
     model_results = []
-    for model_id in model_ids:
-        cmd = f"tesseract '{screenshot_path}.png' - {tess_args} --oem '{model_id}'"
-        ret = subprocess.run(cmd, shell=True, capture_output=True)
-        if ret.returncode != 0:
-            raise Exception(f"OCR failed with exit code {ret.returncode}")
-        model_results.append(ret.stdout.decode("utf-8"))
+    for image in [screenshot_path, processed_image, processed_negative]:
+        for model_id in model_ids:
+            ret = subprocess.run(
+                [
+                    "tesseract",
+                    image,
+                    "-",
+                    "--oem",
+                    str(model_id),
+                    "-c",
+                    "debug_file=/dev/null",
+                    "--psm",
+                    "11",
+                ],
+                capture_output=True,
+            )
+            if ret.returncode != 0:
+                raise Exception(f"OCR failed with exit code {ret.returncode}")
+            model_results.append(ret.stdout.decode("utf-8"))
 
     return model_results
 


### PR DESCRIPTION
The current setup is really weird and definitely wrong for many cases because it inverts the colors of the image, which is never a good idea for GUIs. So, try to OCR three different times: once on the source image, once with processing, and once with processing but no negation.

This should hopefully make things work at least somewhat better for GUIs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
