### PR TITLE
nixos/authentik: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -57,6 +57,8 @@
 
 - [AmneziaVPN](https://amnezia.org/en), an open-source VPN client, with a key feature that enables you to deploy your own VPN server on your server. Available as [programs.amnezia-vpn](#opt-programs.amnezia-vpn.enable).
 
+- [authentik](https://goauthentik.io/), an IdP (Identity Provider) and SSO (single sign on) that is built with security at the forefront of every piece of code, every feature, with an emphasis on flexibility and versatility. Available as [services.authentik](#opt-services.authentik.enable).
+
 - [Bazecor](https://github.com/Dygmalab/Bazecor), the graphical configurator for Dygma Products.
 
 - [Bonsai](https://git.sr.ht/~stacyharper/bonsai), a general-purpose event mapper/state machine primarily used to create complex key shortcuts, and as part of the [SXMO](https://sxmo.org/) desktop environment. Available as [services.bonsaid](#opt-services.bonsaid.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1453,6 +1453,7 @@
   ./services/web-apps/anuko-time-tracker.nix
   ./services/web-apps/artalk.nix
   ./services/web-apps/audiobookshelf.nix
+  ./services/web-apps/authentik.nix
   ./services/web-apps/bluemap.nix
   ./services/web-apps/bookstack.nix
   ./services/web-apps/c2fmzq-server.nix

--- a/nixos/modules/services/web-apps/authentik.nix
+++ b/nixos/modules/services/web-apps/authentik.nix
@@ -1,0 +1,586 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  service = "authentik";
+
+  cfg = config.services.authentik;
+
+  environment =
+    { }
+    # General settings
+    // lib.optionalAttrs (cfg.secretKey != null) {
+      AUTHENTIK_SECRET_KEY = cfg.secretKey;
+    }
+    # Postgresql settings:
+    // (
+      if cfg.postgresql.createLocally && cfg.postgresql.port == 0 then
+        {
+          AUTHENTIK_POSTGRESQL__HOST = "/run/postgresql";
+          AUTHENTIK_POSTGRESQL__NAME = cfg.postgresql.name;
+          AUTHENTIK_POSTGRESQL__USER = cfg.postgresql.username;
+        }
+      else
+        { }
+        // lib.optionalAttrs (cfg.postgresql.host != null) {
+          AUTHENTIK_POSTGRESQL__HOST = cfg.postgresql.host;
+        }
+        // lib.optionalAttrs (cfg.postgresql.port != null) {
+          AUTHENTIK_POSTGRESQL__PORT = toString cfg.postgresql.port;
+        }
+        // lib.optionalAttrs (cfg.postgresql.name != null) {
+          AUTHENTIK_POSTGRESQL__NAME = cfg.postgresql.name;
+        }
+        // lib.optionalAttrs (cfg.postgresql.username != null) {
+          AUTHENTIK_POSTGRESQL__USER = cfg.postgresql.username;
+        }
+        // lib.optionalAttrs (cfg.postgresql.password != null) {
+          AUTHENTIK_POSTGRESQL__PASSWORD = cfg.postgresql.password;
+        }
+    )
+    # Redis settings:
+    // (
+      if cfg.redis.createLocally && cfg.redis.port == 0 then
+        {
+          AUTHENTIK_CACHE__URL = "unix://${config.services.redis.servers."${cfg.redis.name}".unixSocket}";
+          AUTHENTIK_CHANNEL__URL = "unix://${config.services.redis.servers."${cfg.redis.name}".unixSocket}";
+          AUTHENTIK_BROKER__URL = "redis+socket://${
+            config.services.redis.servers."${cfg.redis.name}".unixSocket
+          }";
+          AUTHENTIK_RESULT_BACKEND__URL = "redis+socket://${
+            config.services.redis.servers."${cfg.redis.name}".unixSocket
+          }";
+        }
+      else
+        { }
+        // lib.optionalAttrs (cfg.redis.host != null) {
+          AUTHENTIK_REDIS__HOST = cfg.redis.host;
+        }
+        // lib.optionalAttrs (cfg.redis.port != null) {
+          AUTHENTIK_REDIS__PORT = toString cfg.redis.port;
+        }
+        // lib.optionalAttrs (cfg.redis.name != null) {
+          AUTHENTIK_REDIS__DB = cfg.redis.name;
+        }
+        // lib.optionalAttrs (cfg.redis.username != null) {
+          AUTHENTIK_REDIS__USERNAME = cfg.redis.username;
+        }
+        // lib.optionalAttrs (cfg.redis.password != null) {
+          AUTHENTIK_REDIS__PASSWORD = cfg.redis.password;
+        }
+    )
+    # Listen settings
+    // lib.optionalAttrs (cfg.listen.http.address != null && cfg.listen.http.port != null) {
+      AUTHENTIK_LISTEN__HTTP = "${cfg.listen.http.address}:${toString cfg.listen.http.port}";
+    }
+    // lib.optionalAttrs (cfg.listen.https.address != null && cfg.listen.https.port != null) {
+      AUTHENTIK_LISTEN__HTTPS = "${cfg.listen.https.address}:${toString cfg.listen.https.port}";
+    }
+    // lib.optionalAttrs (cfg.listen.trustedProxyCidrs != null) {
+      AUTHENTIK_LISTEN__TRUSTED_PROXY_CIDRS = lib.concatStringsSep "," cfg.listen.trustedProxyCidrs;
+    }
+    # Email settings:
+    // lib.optionalAttrs (cfg.email.host != null) {
+      AUTHENTIK_EMAIL__HOST = cfg.email.host;
+    }
+    // lib.optionalAttrs (cfg.email.port != null) {
+      AUTHENTIK_EMAIL__PORT = toString cfg.email.port;
+    }
+    // lib.optionalAttrs (cfg.email.username != null) {
+      AUTHENTIK_EMAIL__USERNAME = cfg.email.username;
+    }
+    // lib.optionalAttrs (cfg.email.password != null) {
+      AUTHENTIK_EMAIL__PASSWORD = cfg.email.password;
+    }
+    // lib.optionalAttrs (cfg.email.useTls != null) {
+      AUTHENTIK_EMAIL__USE_TLS = lib.boolToString cfg.email.useTls;
+    }
+    // lib.optionalAttrs (cfg.email.useSsl != null) {
+      AUTHENTIK_EMAIL__USE_SSL = lib.boolToString cfg.email.useSsl;
+    }
+    // lib.optionalAttrs (cfg.email.timeout != null) {
+      AUTHENTIK_EMAIL__TIMEOUT = toString cfg.email.timeout;
+    }
+    // lib.optionalAttrs (cfg.email.from != null) {
+      AUTHENTIK_EMAIL__FROM = cfg.email.from;
+    }
+    # Boostrap settings:
+    // lib.optionalAttrs (cfg.bootstrap.password != null) {
+      AUTHENTIK_BOOTSTRAP_PASSWORD = cfg.bootstrap.password;
+    }
+    // lib.optionalAttrs (cfg.bootstrap.token != null) {
+      AUTHENTIK_BOOTSTRAP_TOKEN = cfg.bootstrap.token;
+    }
+    // lib.optionalAttrs (cfg.bootstrap.email != null) {
+      AUTHENTIK_BOOTSTRAP_EMAIL = cfg.bootstrap.email;
+    }
+    # Extra environment variables:
+    // cfg.extraEnv;
+
+  defaultServiceConfig = {
+    User = cfg.user;
+    Group = cfg.group;
+    Restart = "on-failure";
+
+    # Hardening
+    NoNewPrivileges = true;
+    PrivateTmp = true;
+    PrivateDevices = true;
+    ProtectSystem = true;
+    ProtectHome = true;
+    ProtectControlGroups = true;
+    ProtectKernelModules = true;
+    ProtectKernelTunables = true;
+    ProtectProc = "invisible";
+    RestrictAddressFamilies = [
+      "AF_UNIX"
+      "AF_INET"
+      "AF_INET6"
+      "AF_NETLINK"
+    ];
+    RestrictRealtime = true;
+    RestrictSUIDSGID = true;
+    MemoryDenyWriteExecute = true;
+    LockPersonality = true;
+  };
+
+  defaultDescriptionForSecrets = ''
+    Like for almost all other authentik settings, you can also use a
+    URI-like format to read values from other sources. Especially for
+    secrets it is recommended to read the values from a secrets file.
+
+    env://<name> Loads the value from the environment variable <name>.
+    Fallback can be optionally set like env://<name>?<default>
+
+    file://<name> Loads the value from the file <name>.
+    Fallback can be optionally set like file://<name>?<default>
+  '';
+in
+
+{
+  options = {
+    services.authentik = {
+      enable = lib.mkEnableOption "authentik";
+
+      package = lib.mkPackageOption pkgs "authentik" { };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = service;
+        description = ''
+          User account under which authentik runs.
+        '';
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = service;
+        description = ''
+          User account under which authentik runs.
+        '';
+      };
+
+      secretKey = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Secret key used for cookie signing. Changing this will invalidate active sessions.
+
+          ${defaultDescriptionForSecrets}
+        '';
+      };
+
+      postgresql = {
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to create the Postgresql database locally.
+          '';
+        };
+
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = service;
+          description = ''
+            Name of the PostgreSQL database.
+          '';
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1";
+          description = ''
+            Host of the PostgreSQL database server.
+          '';
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 0;
+          description = ''
+            Port of the PostgreSQL database server.
+          '';
+        };
+
+        username = lib.mkOption {
+          type = lib.types.str;
+          default = service;
+          description = ''
+            Username of the PostgreSQL database.
+          '';
+        };
+
+        password = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Password of the PostgreSQL database.
+
+            ${defaultDescriptionForSecrets}
+          '';
+        };
+      };
+
+      redis = {
+        createLocally = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to create the Redis database locally.
+          '';
+        };
+
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = service;
+          description = ''
+            Name of the Redis database.
+          '';
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "127.0.0.1";
+          description = ''
+            Host of the Redis database server.
+          '';
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 0;
+          description = ''
+            Port of the Redis database server. Can be set to 0 to use a Unix socket instead.
+          '';
+        };
+
+        username = lib.mkOption {
+          type = lib.types.str;
+          default = service;
+          description = ''
+            Username of the Redis database.
+          '';
+        };
+
+        password = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Password of the Redis database.
+
+            ${defaultDescriptionForSecrets}
+          '';
+        };
+      };
+
+      listen = {
+        http = {
+          address = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1";
+            description = ''
+              IP address on which authentik will listen for HTTP connections.
+
+              Set to the empty string to listen on all interfaces.
+            '';
+          };
+
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 9000;
+            description = ''
+              Port on which authentik will listen for HTTP connections.
+            '';
+          };
+
+          openFirewall = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Open port needed for HTTP connections.
+            '';
+          };
+        };
+
+        https = {
+          address = lib.mkOption {
+            type = lib.types.str;
+            default = "127.0.0.1";
+            description = ''
+              IP address on which authentik will listen for HTTPS connections.
+
+              Set to the empty string to listen on all interfaces.
+            '';
+          };
+
+          port = lib.mkOption {
+            type = lib.types.port;
+            default = 9443;
+            description = ''
+              Port on which authentik will listen for HTTPS connections.
+            '';
+          };
+
+          openFirewall = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Open port needed for HTTPS connections.
+            '';
+          };
+        };
+
+        trustedProxyCidrs = lib.mkOption {
+          type = lib.types.nullOr (lib.types.listOf lib.types.str);
+          default = null;
+          description = ''
+            List of CIDR's that proxy headers should be accepted from.
+
+            If unset, all CIDR's of private IP's are considered as trusted by authentik.
+          '';
+        };
+      };
+
+      email = {
+        host = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Host of the email (SMTP) server.
+          '';
+        };
+
+        port = lib.mkOption {
+          type = lib.types.nullOr lib.types.port;
+          default = null;
+          description = ''
+            Port of the email (SMTP) server.
+          '';
+        };
+
+        username = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Username of the email (SMTP) server.
+          '';
+        };
+
+        password = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Password of the email (SMTP) server.
+
+            ${defaultDescriptionForSecrets}
+          '';
+        };
+
+        useTls = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to use TLS when communicating with the email (SMTP) server.
+          '';
+        };
+
+        useSsl = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to use SSL when communicating with the email (SMTP) server.
+          '';
+        };
+
+        timeout = lib.mkOption {
+          type = lib.types.int;
+          default = 10;
+          description = ''
+            Timeout in seconds when communicating with the email (SMTP) server.
+          '';
+        };
+
+        from = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            From email address to use when sending emails.
+          '';
+        };
+      };
+
+      bootstrap = {
+        email = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Email address for the default akadmin user.
+          '';
+        };
+
+        password = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "changeme";
+          description = ''
+            Password for the default akadmin user.
+
+            Only read on the first startup. Can be used for any flow executor.
+
+            Careful: This option does not support reading values from other sources,
+            such as other environment variables or files. So it is recommended to
+            change this value directly after the first startup.
+          '';
+        };
+
+        token = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Token for the default akadmin user.
+
+            Only read on the first startup. The string you specify for this variable
+            is the token key you can use to authenticate yourself to the API.
+
+            Careful: This option does not support reading values from other sources,
+            such as other environment variables or files. So it is recommended to
+            change this value directly after the first startup.
+          '';
+        };
+      };
+
+      extraEnv = lib.mkOption {
+        type = with lib.types; attrsOf str;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            AUTHENTIK_LOG_LEVEL = "info";
+          }
+        '';
+        description = ''
+          Extra environment variables for authentik.
+
+          The available configuration options can be found in
+          [the configuration documentation](https://docs.goauthentik.io/docs/install-config/configuration/).
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.secretKey != "" && cfg.secretKey != null;
+        message = "service.authentik.secretKey must be set";
+      }
+      {
+        assertion = cfg.listen.http.address != null && cfg.listen.http.port != null;
+        message = "listen.http.address and listen.http.port must be set together";
+      }
+      {
+        assertion = cfg.listen.https.address != null && cfg.listen.https.port != null;
+        message = "listen.https.address and listen.https.port must be set together";
+      }
+    ];
+
+    services.postgresql = lib.mkIf cfg.postgresql.createLocally {
+      enable = true;
+      ensureDatabases = [ cfg.postgresql.name ];
+      ensureUsers = [
+        {
+          name = cfg.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    services.redis.servers."${cfg.redis.name}" = lib.mkIf cfg.redis.createLocally {
+      enable = true;
+      port = cfg.redis.port;
+      user = cfg.user;
+    };
+
+    users.groups.authentik = {
+      name = cfg.group;
+    };
+
+    users.users.authentik = {
+      name = cfg.user;
+      description = "Authentik user";
+      group = cfg.group;
+      isSystemUser = true;
+    };
+
+    systemd.services.authentik = {
+      after =
+        [ "network.target" ]
+        ++ lib.optionals cfg.postgresql.createLocally [ "postgresql.service" ]
+        ++ lib.optionals cfg.redis.createLocally [ "redis-${cfg.redis.name}.service" ];
+
+      requires =
+        lib.optionals cfg.postgresql.createLocally [ "postgresql.service" ]
+        ++ lib.optionals cfg.redis.createLocally [ "redis-${cfg.redis.name}.service" ];
+
+      inherit environment;
+
+      serviceConfig = defaultServiceConfig // {
+        ExecStart = "${cfg.package}/bin/ak server";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    systemd.services.authentik-worker = {
+      after =
+        [ "network.target" ]
+        ++ lib.optionals cfg.postgresql.createLocally [ "postgresql.service" ]
+        ++ lib.optionals cfg.redis.createLocally [ "redis-${cfg.redis.name}.service" ];
+
+      requires =
+        lib.optionals cfg.postgresql.createLocally [ "postgresql.service" ]
+        ++ lib.optionals cfg.redis.createLocally [ "redis-${cfg.redis.name}.service" ];
+
+      inherit environment;
+
+      serviceConfig = defaultServiceConfig // {
+        ExecStart = "${cfg.package}/bin/ak worker";
+      };
+
+      wantedBy = [ "multi-user.target" ];
+    };
+
+    networking.firewall = lib.mkMerge [
+      (lib.mkIf cfg.listen.http.openFirewall {
+        allowedTCPPorts = [ cfg.listen.http.port ];
+      })
+      (lib.mkIf cfg.listen.https.openFirewall {
+        allowedTCPPorts = [ cfg.listen.https.port ];
+      })
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -143,6 +143,7 @@ in {
   audiobookshelf = handleTest ./audiobookshelf.nix {};
   auth-mysql = handleTest ./auth-mysql.nix {};
   authelia = handleTest ./authelia.nix {};
+  authentik = runTest ./authentik.nix;
   auto-cpufreq = handleTest ./auto-cpufreq.nix {};
   autobrr = handleTest ./autobrr.nix {};
   avahi = handleTest ./avahi.nix {};

--- a/nixos/tests/authentik.nix
+++ b/nixos/tests/authentik.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  ...
+}:
+
+let
+  port = 9000;
+in
+
+{
+  name = "authentik";
+  meta.maintainers = with lib.maintainers; [ pathob ];
+
+  nodes.machine =
+    {
+      pkgs,
+      ...
+    }:
+
+    {
+      services.authentik = {
+        enable = true;
+        secretKey = "verysecretkey";
+        postgresql.createLocally = true;
+        redis.createLocally = true;
+        listen.http.port = port;
+      };
+    };
+
+  testScript = ''
+    def authentik_is_up(_) -> bool:
+        status, _ = machine.execute("curl --fail http://localhost:${toString port}")
+        return status == 0
+
+    machine.start()
+    machine.wait_for_unit("authentik.service")
+    machine.wait_for_unit("authentik-worker.service")
+    machine.wait_for_open_port(${toString port})
+
+    with machine.nested("Waiting for UI to work"):
+        retry(authentik_is_up)
+  '';
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hi,

I've been working quite a while on this authentik service module and now want to share it with the NixOS community. I'm aware of https://github.com/nix-community/authentik-nix/ but I've done a couple of things a bit different.

Things that imho are solved better compared to authentik-nix:

1. This module provides high-level config options for the most important settings while still allowing to set config based on environment variables, so that starting a simple authentik instance is literally possible within seconds (authentik-nix requires providing an environment file for all settings).
2. This module per default uses Unix sockets for Redis which helps to prevent collisions with other services using Redis (authentik-nix uses a port).
3. This module does NOT include Nginx to provide a reverse proxy with TLS certs (authentik-nix does)
4. This module configures the service solely based on environment variables (authentik-nix additionally generates a config file based on the passed environment variables).

Things that are missing compared to authentik-nix:

1. authentik-nix allows configuring authentik outposts also, which could be added to this module later.
2. authentik-nix provides a pre-configured CLI wrapper, which would be nice to have for this module also, but which is not so easy to implement in a clean way. So I think it's okay that it's missing.
3. authentik-nix has a dedicated oneshot service to run migrations. This module oriented more on the official [docker-compose](https://github.com/goauthentik/authentik/blob/main/docker-compose.yml) file which just runs migrations with either the authentik-core or authentik-worker service.

In general I would say this module is more implemented the NixOS-way. But I also know that the 8 contributors of authentik-nix have invested a lot of brainpower and might have more experience with authentik and Linux / NixOS in general. And I may also have oversimplified things.

That being said, I'm looking forward for your reviews! Thanks!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
