### PR TITLE
ckdl: init at 1.0

### DIFF
--- a/pkgs/by-name/ck/ckdl/package.nix
+++ b/pkgs/by-name/ck/ckdl/package.nix
@@ -1,0 +1,53 @@
+{ pkgs, lib, cmake, ninja, sphinx, python3Packages, ... }:
+
+pkgs.stdenv.mkDerivation {
+  pname = "ckdl";
+  version = "1.0";
+
+  src = pkgs.fetchFromGitHub {
+    owner = "tjol";
+    repo = "ckdl";
+    tag = "1.0";
+    hash = "sha256-qEfRZzoUQZ8umdWgx+N4msjPBbuwDtkN1kNDfZicRjY=";
+  };
+
+  outputs = [ "bin" "dev" "lib" "doc" "out" ];
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    sphinx
+    python3Packages.furo
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "BUILD_TESTS" true)
+  ];
+
+  postPatch = ''
+    cd doc
+    make singlehtml
+    mkdir -p $doc/share/doc
+    mv _build/singlehtml $doc/share/doc/ckdl
+
+    cd ..
+  '';
+
+  postInstall = ''
+    mkdir -p $bin/bin
+
+    # some tools that are important for debugging.
+    # idk why they are not copied to bin by cmake, but I’m too tired to figure it out
+    install src/utils/ckdl-tokenize $bin/bin
+    install src/utils/ckdl-parse-events $bin/bin
+    install src/utils/ckdl-cat $bin/bin
+    touch $out
+  '';
+
+
+  meta = {
+    description = "ckdl is a C (C11) library that implements reading and writing the KDL Document Language.";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
ckdl KDL C parser library

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
