### PR TITLE
pyquaternion: Patch for numpy2 support

### DIFF
--- a/pkgs/development/python-modules/pyquaternion/default.nix
+++ b/pkgs/development/python-modules/pyquaternion/default.nix
@@ -19,6 +19,10 @@ buildPythonPackage rec {
     hash = "sha256-L0wT9DFUDRcmmN7OpmIDNvtQWQrM7iFnZt6R2xrJ+3A=";
   };
 
+  patches = [
+    ./numpy2-repr.patch
+  ];
+
   # The VERSION.txt file is required for setup.py
   # See: https://github.com/KieranWynn/pyquaternion/blob/master/setup.py#L14-L15
   postPatch = ''

--- a/pkgs/development/python-modules/pyquaternion/numpy2-repr.patch
+++ b/pkgs/development/python-modules/pyquaternion/numpy2-repr.patch
@@ -1,0 +1,68 @@
+diff --git a/pyquaternion/test/test_quaternion.py b/pyquaternion/test/test_quaternion.py
+index f56afff..7178b52 100644
+--- a/pyquaternion/test/test_quaternion.py
++++ b/pyquaternion/test/test_quaternion.py
+@@ -50,6 +50,16 @@ ALMOST_EQUAL_TOLERANCE = 13
+ def randomElements():
+     return tuple(np.random.uniform(-1, 1, 4))
+
++# In numpy 2, repr(np.float64(0.123)) becomes "np.float64(0.123)"
++# which means it's not directly a parseable float. In numpy 1 that
++# used to be the case. This hack papers over that
++def repr_np(x):
++    has_item = hasattr(x, 'item')
++    if isinstance(x, np.generic) and has_item:
++        return repr(x.item())
++    else:
++        return repr(x)
++
+ class TestQuaternionInitialisation(unittest.TestCase):
+
+     def test_init_default(self):
+@@ -77,7 +87,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
+     def test_init_from_scalar(self):
+         s = random()
+         q1 = Quaternion(s)
+-        q2 = Quaternion(repr(s))
++        q2 = Quaternion(repr_np(s))
+         self.assertIsInstance(q1, Quaternion)
+         self.assertIsInstance(q2, Quaternion)
+         self.assertEqual(q1, Quaternion(s, 0.0, 0.0, 0.0))
+@@ -90,8 +100,8 @@ class TestQuaternionInitialisation(unittest.TestCase):
+     def test_init_from_elements(self):
+         a, b, c, d = randomElements()
+         q1 = Quaternion(a, b, c, d)
+-        q2 = Quaternion(repr(a), repr(b), repr(c), repr(d))
+-        q3 = Quaternion(a, repr(b), c, d)
++        q2 = Quaternion(repr_np(a), repr_np(b), repr_np(c), repr_np(d))
++        q3 = Quaternion(a, repr_np(b), c, d)
+         self.assertIsInstance(q1, Quaternion)
+         self.assertIsInstance(q2, Quaternion)
+         self.assertIsInstance(q3, Quaternion)
+@@ -154,7 +164,7 @@ class TestQuaternionInitialisation(unittest.TestCase):
+     def test_init_from_explicit_elements(self):
+         e1, e2, e3, e4 = randomElements()
+         q1 = Quaternion(w=e1, x=e2, y=e3, z=e4)
+-        q2 = Quaternion(a=e1, b=repr(e2), c=e3, d=e4)
++        q2 = Quaternion(a=e1, b=repr_np(e2), c=e3, d=e4)
+         q3 = Quaternion(a=e1, i=e2, j=e3, k=e4)
+         q4 = Quaternion(a=e1)
+         self.assertIsInstance(q1, Quaternion)
+@@ -525,7 +535,7 @@ class TestQuaternionArithmetic(unittest.TestCase):
+             q3 = q1
+             self.assertEqual(q1 * s, q2) # post-multiply by scalar
+             self.assertEqual(s * q1, q2) # pre-multiply by scalar
+-            q3 *= repr(s)
++            q3 *= repr_np(s)
+             self.assertEqual(q3, q2)
+
+     def test_multiply_incorrect_type(self):
+@@ -595,7 +605,7 @@ class TestQuaternionArithmetic(unittest.TestCase):
+                 with self.assertRaises(ZeroDivisionError):
+                     s / q1
+
+-            q3 /= repr(s)
++            q3 /= repr_np(s)
+             self.assertEqual(q3, q2)
+
+         with self.assertRaises(ZeroDivisionError):


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

pyquaternion is basically unmaintained and not accepting updates. But now we have moved to numpy 2 which meant test were failing. This patch fixes the tests. There are still a ton of warnings but I have left them. 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
