### PR TITLE
nixos/modules: drop findutils locate support

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -168,6 +168,9 @@
   to review the new defaults and description of
   [](#opt-services.nextcloud.poolSettings).
 
+- The `services.locate` module does no longer support findutil's `locate` due to its inferior performance compared to `mlocate` and `plocate`. The new default is `plocate`.
+  As the `service.locate.localuser` option only applied when using findutil's `locate`, it has also been removed.
+
 - `kmonad` is now hardened by default using common `systemd` settings.
   If KMonad is used to execute shell commands, hardening may make some of them fail.  In that case, you can disable hardening using {option}`services.kmonad.keyboards.<name>.enableHardening` option.
 

--- a/nixos/modules/misc/locate.nix
+++ b/nixos/modules/misc/locate.nix
@@ -9,14 +9,15 @@ let
   cfg = config.services.locate;
   isMLocate = lib.hasPrefix "mlocate" cfg.package.name;
   isPLocate = lib.hasPrefix "plocate" cfg.package.name;
-  isMorPLocate = isMLocate || isPLocate;
-  isFindutils = lib.hasPrefix "findutils" cfg.package.name;
 in
 {
   imports = [
     (lib.mkRenamedOptionModule [ "services" "locate" "period" ] [ "services" "locate" "interval" ])
     (lib.mkRenamedOptionModule [ "services" "locate" "locate" ] [ "services" "locate" "package" ])
     (lib.mkRemovedOptionModule [ "services" "locate" "includeStore" ] "Use services.locate.prunePaths")
+    (lib.mkRemovedOptionModule [ "services" "locate" "localuser" ]
+      "The services.locate.localuser option has been removed because support for findutils locate has been removed."
+    )
   ];
 
   options.services.locate = {
@@ -29,7 +30,7 @@ in
       '';
     };
 
-    package = lib.mkPackageOption pkgs [ "findutils" "locate" ] {
+    package = lib.mkPackageOption pkgs [ "plocate" ] {
       example = "mlocate";
     };
 
@@ -62,15 +63,6 @@ in
       default = "/var/cache/locatedb";
       description = ''
         The database file to build.
-      '';
-    };
-
-    localuser = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = "nobody";
-      description = ''
-        The user to search non-network directories as, using
-        {command}`su`.
       '';
     };
 
@@ -180,7 +172,7 @@ in
 
     pruneNames = lib.mkOption {
       type = lib.types.listOf lib.types.str;
-      default = lib.optionals (!isFindutils) [
+      default = [
         ".bzr"
         ".cache"
         ".git"
@@ -229,7 +221,7 @@ in
           source = "${cfg.package}/bin/plocate";
         };
       in
-      lib.mkIf isMorPLocate {
+      {
         locate = lib.mkMerge [
           common
           mlocate
@@ -253,59 +245,31 @@ in
       '';
 
       systemPackages = [ cfg.package ];
-
-      variables = lib.mkIf isFindutils {
-        LOCATE_PATH = cfg.output;
-      };
     };
-
-    warnings =
-      lib.optional (isMorPLocate && cfg.localuser != null)
-        "mlocate and plocate do not support the services.locate.localuser option. updatedb will run as root. Silence this warning by setting services.locate.localuser = null."
-      ++ lib.optional (
-        isFindutils && cfg.pruneNames != [ ]
-      ) "findutils locate does not support pruning by directory component"
-      ++ lib.optional (
-        isFindutils && cfg.pruneBindMounts
-      ) "findutils locate does not support skipping bind mounts";
 
     systemd.services.update-locatedb = {
       description = "Update Locate Database";
-      path = lib.mkIf (!isMorPLocate) [ pkgs.su ];
 
       # mlocate's updatedb takes flags via a configuration file or
       # on the command line, but not by environment variable.
       script =
-        if isMorPLocate then
-          let
-            toFlags =
-              x: lib.optional (cfg.${x} != [ ]) "--${lib.toLower x} '${lib.concatStringsSep " " cfg.${x}}'";
-            args = lib.concatLists (
-              map toFlags [
-                "pruneFS"
-                "pruneNames"
-                "prunePaths"
-              ]
-            );
-          in
-          ''
-            exec ${cfg.package}/bin/updatedb \
-              --output ${toString cfg.output} ${lib.concatStringsSep " " args} \
-              --prune-bind-mounts ${if cfg.pruneBindMounts then "yes" else "no"} \
-              ${lib.concatStringsSep " " cfg.extraFlags}
-          ''
-        else
-          ''
-            exec ${cfg.package}/bin/updatedb \
-              ${lib.optionalString (cfg.localuser != null && !isMorPLocate) "--localuser=${cfg.localuser}"} \
-              --output=${toString cfg.output} ${lib.concatStringsSep " " cfg.extraFlags}
-          '';
-      environment = lib.optionalAttrs (!isMorPLocate) {
-        PRUNEFS = lib.concatStringsSep " " cfg.pruneFS;
-        PRUNEPATHS = lib.concatStringsSep " " cfg.prunePaths;
-        PRUNENAMES = lib.concatStringsSep " " cfg.pruneNames;
-        PRUNE_BIND_MOUNTS = if cfg.pruneBindMounts then "yes" else "no";
-      };
+        let
+          toFlags =
+            x: lib.optional (cfg.${x} != [ ]) "--${lib.toLower x} '${lib.concatStringsSep " " cfg.${x}}'";
+          args = lib.concatLists (
+            map toFlags [
+              "pruneFS"
+              "pruneNames"
+              "prunePaths"
+            ]
+          );
+        in
+        ''
+          exec ${cfg.package}/bin/updatedb \
+            --output ${toString cfg.output} ${lib.concatStringsSep " " args} \
+            --prune-bind-mounts ${if cfg.pruneBindMounts then "yes" else "no"} \
+            ${lib.concatStringsSep " " cfg.extraFlags}
+        '';
       serviceConfig = {
         CapabilityBoundingSet = "CAP_DAC_READ_SEARCH CAP_CHOWN";
         Nice = 19;


### PR DESCRIPTION
Closes #375343

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
