### PR TITLE
Add Hetzner Cloud image builder

### DIFF
--- a/nixos/maintainers/scripts/hcloud/create-image.sh
+++ b/nixos/maintainers/scripts/hcloud/create-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env nix-shell
+#! nix-shell -i bash -p hcloud-upload-image
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo >&2 "Usage: $0 <x86|arm>"
+    exit 64
+fi
+
+hetzner_arch="$1"
+case "$hetzner_arch" in
+    x86)
+        nix_arch="x86_64"
+        ;;
+    arm)
+        nix_arch="aarch64"
+        ;;
+    *)
+        echo >&2 "Unknown Hetzner architecture: ${hetzner_arch}"
+        exit 64
+        ;;
+esac
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+nix-build '../../../lib/eval-config.nix' \
+   -A config.system.build.image \
+   --arg modules "[ ../../../modules/virtualisation/hcloud-image.nix ]" \
+   --argstr system "${nix_arch}-linux" \
+   -o hcloud
+
+image="$(echo hcloud/nixos-image-hcloud-*.img)"
+hcloud-upload-image upload \
+    --architecture "${hetzner_arch}" \
+    --description "$(basename "${image}")" \
+    --image-path "${image}"

--- a/nixos/modules/virtualisation/hcloud-config.nix
+++ b/nixos/modules/virtualisation/hcloud-config.nix
@@ -1,0 +1,125 @@
+# Configuration for Hetzner Cloud virtual servers.
+
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.hcloud;
+  dynamicHostname = config.networking.hostName == "";
+in
+
+{
+  imports = [
+    ../profiles/qemu-guest.nix
+  ];
+
+  options = {
+    hcloud = {
+      efi = lib.mkOption {
+        default = pkgs.stdenv.hostPlatform.isAarch64;
+        defaultText = lib.literalExpression "pkgs.stdenv.hostPlatform.isAarch64";
+        internal = true;
+        description = ''
+          Whether the server is using EFI to boot.
+        '';
+      };
+
+      networkGeneratorPackage = lib.mkPackageOption pkgs "systemd-network-generator-hcloud" { };
+
+      fetchMetadata = lib.mkOption {
+        default = false;
+        description = ''
+          Whether to make server metadata available as
+          {file}`/run/hcloud-metadata` and {file}`/run/hcloud-userdata`.
+        '';
+      };
+    };
+  };
+
+  config = {
+
+    boot.growPartition = true;
+
+    fileSystems."/" = {
+      device = "/dev/disk/by-label/nixos";
+      fsType = "ext4";
+      autoResize = true;
+    };
+
+    fileSystems."/boot" = lib.mkIf cfg.efi {
+      device = "/dev/disk/by-label/ESP";
+      fsType = "vfat";
+      options = [ "umask=0077" ];
+    };
+
+    boot.loader = {
+      grub.enable = !cfg.efi;
+      grub.device = "/dev/sda";
+      systemd-boot.enable = cfg.efi;
+      efi.canTouchEfiVariables = true;
+    };
+
+    # Set the hostname from server metadata by default.
+    networking.hostName = lib.mkDefault "";
+
+    # Allow root logins only using the SSH key that the user specified
+    # at server creation time.
+    services.openssh = {
+      enable = true;
+      settings.PermitRootLogin = "prohibit-password";
+    };
+
+    # Per: https://community.hetzner.com/tutorials/install-and-configure-ntp
+    networking.timeServers = [
+      "ntp1.hetzner.de"
+      "ntp2.hetzner.com"
+      "ntp3.hetzner.net"
+    ];
+
+    # Generate network configuration for systemd-networkd.
+    #
+    # This is primarily useful to configure IPv6 on the primary interfaces.
+    # Private networks do not appear to be listed in metadata, nor do they
+    # support IPv6, but the regular `useDHCP = true` fallback works fine.
+    networking.useNetworkd = lib.mkDefault true;
+    systemd.packages = [ cfg.networkGeneratorPackage ];
+    systemd.targets.sysinit.wants = [ "systemd-network-generator-hcloud.service" ];
+    systemd.services.systemd-network-generator-hcloud = {
+      # Replace the command to set additional arguments.
+      serviceConfig.ExecStart = [
+        ""
+        (
+          "${cfg.networkGeneratorPackage}/bin/systemd-network-generator-hcloud"
+          # For the below postStart script.
+          + lib.optionalString dynamicHostname " --write-hostname /run/hcloud-hostname"
+          + " --write-public-keys /run/hcloud-public-keys"
+          # For general use.
+          + lib.optionalString cfg.fetchMetadata " --write-metadata /run/hcloud-metadata --write-userdata /run/hcloud-userdata"
+        )
+      ];
+      # Amend the service with a script that applies other metadata properties.
+      postStart =
+        lib.optionalString dynamicHostname ''
+          if [[ -s /run/hcloud-hostname ]]; then
+            echo "setting hostname..."
+            ${pkgs.nettools}/bin/hostname $(</run/hcloud-hostname)
+            rm /run/hcloud-hostname
+          fi
+        ''
+        + ''
+          if [[ -e /run/hcloud-public-keys ]]; then
+            echo "configuring root ssh authorized keys..."
+            install -o root -g root -m 0700 -d /root/.ssh/
+            mv /run/hcloud-public-keys /root/.ssh/authorized_keys
+          fi
+        '';
+    };
+
+  };
+
+  meta.maintainers = with lib.maintainers; [ stephank ];
+}

--- a/nixos/modules/virtualisation/hcloud-image.nix
+++ b/nixos/modules/virtualisation/hcloud-image.nix
@@ -1,0 +1,32 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.hcloud;
+in
+
+{
+  imports = [
+    ./hcloud-config.nix
+    ../image/file-options.nix
+  ];
+
+  config.system.nixos.tags = [ "hcloud" ];
+  config.image.extension = "raw";
+  config.system.build.image = import ../../lib/make-disk-image.nix {
+    inherit lib config pkgs;
+    inherit (config.image) baseName;
+    partitionTableType = if cfg.efi then "efi" else "legacy";
+    configFile = pkgs.writeText "configuration.nix" ''
+      { modulesPath, ... }: {
+        imports = [ "''${modulesPath}/virtualisation/hcloud-config.nix" ];
+      }
+    '';
+  };
+
+  meta.maintainers = with lib.maintainers; [ stephank ];
+}

--- a/pkgs/by-name/hc/hcloud-upload-image/package.nix
+++ b/pkgs/by-name/hc/hcloud-upload-image/package.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+let
+  version = "1.3.0";
+in
+
+buildGoModule {
+  pname = "hcloud-upload-image";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "apricote";
+    repo = "hcloud-upload-image";
+    tag = "v${version}";
+    hash = "sha256-1u9tpzciYjB/EgBI81pg9w0kez7hHZON7+AHvfKW7k0=";
+  };
+
+  proxyVendor = true;
+  vendorHash = "sha256-Xz2oOM/mhcA3OgbMaE9N6Bx3Gz1QlNVBTfGEox8Yc7A=";
+  subPackages = [ "." ];
+
+  meta = {
+    description = "Quickly upload any raw disk images into your Hetzner Cloud projects";
+    homepage = "https://github.com/apricote/hcloud-upload-image";
+    changelog = "https://github.com/apricote/hcloud-upload-image/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ stephank ];
+    mainProgram = "hcloud-upload-image";
+  };
+}

--- a/pkgs/by-name/sy/systemd-network-generator-hcloud/package.nix
+++ b/pkgs/by-name/sy/systemd-network-generator-hcloud/package.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildGoModule,
+}:
+
+let
+  version = "1.0";
+in
+
+buildGoModule {
+  pname = "systemd-network-generator-hcloud";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "stephank";
+    repo = "systemd-network-generator-hcloud";
+    rev = "v${version}";
+    sha256 = "sha256-yzaEc0N7bXuZxqs4/D0pP6VNtVoMe2LwPGBjw5hzbXo=";
+  };
+
+  vendorHash = "sha256-l3uOzNt6e9gQvjXa/+rxfaLER2AOsWVXwgZgBqHzquU=";
+
+  postInstall = ''
+    mkdir -p $out/lib/systemd/system
+    substitute \
+      systemd-network-generator-hcloud.service.in \
+      $out/lib/systemd/system/systemd-network-generator-hcloud.service \
+      --replace-fail '{{LIBEXECDIR}}' "$out/bin"
+  '';
+
+  meta = with lib; {
+    description = "Generate network units from Hetzner Cloud server metadata";
+    homepage = "https://github.com/stephank/systemd-network-generator-hcloud";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ stephank ];
+    platforms = lib.platforms.linux;
+    mainProgram = "systemd-network-generator-hcloud";
+  };
+}


### PR DESCRIPTION
This adds a config and some scripts to build images for Hetzner Cloud. (NOTE: Not the dedicated server products.)

Hetzner currently doesn't really have a public image repository, but this is helpful in building snapshots you can use in your own project. I needed a base for this myself, and thought it be useful to bring it back into NixOS.

(I do wonder if we can work with Hetzner to get listed among the official images. I believe those also have faster startup. Starting from a snapshot takes a minute or two.)

To get there, this packages [hcloud-upload-image](https://github.com/apricote/hcloud-upload-image), which basically boots a machine in rescue mode, writes the image to disk, then creates the snapshot.

It also packages [systemd-network-generator-hcloud](https://github.com/stephank/systemd-network-generator-hcloud), which is a tool I wrote to configure the network based on metadata provided to the server. Notably, Hetzner does DHCPv4 just fine, but has no autoconfiguration for IPv6, which is what this provides. I also added some flags to the tool to dump metadata and userdata to files, so it can be available very early in the boot process for general use.

Some points that I'm unsure about:
- This uses systemd-boot on aarch64. I'm not sure if we'd rather have grub as a default, even for EFI.
- This uses systemd-networkd, to accomplish autoconfiguration. I think systemd-networkd is the future? But currently not the NixOS default.
- No handling of userdata currently. I believe EC2 images interpret it as a NixOS config, but also extract SSH host keys from it, and that makes the format feel hacky. (I generally disable this module myself, because I use userdata for other stuff.)
- No handling of cloud-init stuff. Some if it is Hetzner-specified, but there's also an input for it in the Hetzner Cloud console. I think this is mostly a concern if we want to get listed among the official images, to not confuse users.
- No support for root passwords provisioned by Hetzner, only SSH keys.

Tested both x86_64 and aarch64 images.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
