### PR TITLE
shadps4: 0.5.0-unstable-2025-01-02 -> 0.5.0-unstable-2025-01-20

### DIFF
--- a/pkgs/by-name/sh/shadps4/package.nix
+++ b/pkgs/by-name/sh/shadps4/package.nix
@@ -37,13 +37,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shadps4";
-  version = "0.5.0-unstable-2025-01-02";
+  version = "0.5.0-unstable-2025-01-20";
 
   src = fetchFromGitHub {
     owner = "shadps4-emu";
     repo = "shadPS4";
-    rev = "596f4cdf0e66a97c9d2d4272091d8c0167a5b8e1";
-    hash = "sha256-apwAl8TCzSKchqYGHV0UsMSGErF4GgiwhlwmOPWpeLs=";
+    rev = "95a30b2b3e1aa4e20c3db632955cc67bbded0fb1";
+    hash = "sha256-52BhGKSUv+9asACNkppxiNm3Gja7r3LcXOIwhQR5ALs=";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Required for Boost 1.87. (ref #369118)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).