### PR TITLE
python312Packages.pendulum: fix cross build

### DIFF
--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -9,6 +9,7 @@
 
   # build-system
   poetry-core,
+  python,
   rustPlatform,
 
   # native dependencies
@@ -70,6 +71,8 @@ buildPythonPackage rec {
   ];
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ iconv ];
+
+  maturinBuildFlags = [ "--interpreter ${python.executable}" ];
 
   propagatedBuildInputs =
     [


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).