### PR TITLE
libtomcrypt: fix cross build

### DIFF
--- a/pkgs/by-name/li/libtomcrypt/package.nix
+++ b/pkgs/by-name/li/libtomcrypt/package.nix
@@ -24,13 +24,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = [
-    libtool
+  buildInputs = [
     libtommath
   ];
 
   postPatch = ''
-    substituteInPlace makefile.shared --replace "LIBTOOL:=glibtool" "LIBTOOL:=libtool"
+    substituteInPlace makefile.shared \
+      --replace-fail "LIBTOOL:=glibtool" "LIBTOOL:=libtool" \
+      --replace-fail libtool "${lib.getExe libtool}"
   '';
 
   preBuild = ''


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).