### PR TITLE
libfakekey: fix cross build

### DIFF
--- a/pkgs/by-name/li/libfakekey/package.nix
+++ b/pkgs/by-name/li/libfakekey/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-QNJlxZ9uNwNgFWm9qRJdPfusx7dXHZajjFH7wDhpgcs=";
   };
 
-  preConfigure = "./autogen.sh";
+  configureScript = "./autogen.sh";
 
   nativeBuildInputs = [
     automake


### PR DESCRIPTION
Otherwise the configure flags aren't made available to autogen.sh

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).