### PR TITLE
testers.testBuildFailure: fix

### DIFF
--- a/pkgs/build-support/testers/default.nix
+++ b/pkgs/build-support/testers/default.nix
@@ -31,7 +31,7 @@
         };
       })
       orig.realBuilder or stdenv.shell
-    ] ++ orig.args or ["-e" (orig.builder or ../../stdenv/generic/default-builder.sh)];
+    ] ++ orig.args or ["-e" ../../stdenv/generic/source-stdenv.sh (orig.builder or ../../stdenv/generic/default-builder.sh)];
   });
 
   # See https://nixos.org/manual/nixpkgs/unstable/#tester-testEqualDerivation

--- a/pkgs/build-support/testers/expect-failure.sh
+++ b/pkgs/build-support/testers/expect-failure.sh
@@ -35,7 +35,7 @@ echo "testBuildFailure: Original builder produced exit code: $r"
 # -----------------------------------------
 # Write the build log to the default output
 
-# Source structured attrs as per nixpkgs/pkgs/stdenv/generic/default-builder.sh
+# Source structured attrs as per nixpkgs/pkgs/stdenv/generic/source-stdenv.sh
 #
 # We need this so that we can read $outputs when `__structuredAttrs` is enabled
 #


### PR DESCRIPTION
Introduced by cf127c9dc389231b03bae610fec546e2017969ea, which changed default-builder.sh, but forgot to tell testBuildFailure about it.

As reported in https://github.com/NixOS/nixpkgs/pull/357053#issuecomment-2605142607.

## Things done

Both `tests.testers.testBuildFailure` and `tests.stdenv.outputs-no-out` pass now. Also grepped for `default-builder.sh` - nobody else uses it, so this PR should fix the issue for good.

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
