### PR TITLE
nixos/mongodb: add support for mongodb-ce package

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -220,6 +220,8 @@
 
 - `racket_7_9` has been removed, as it is insecure. It is recommended to use Racket 8 instead.
 
+- `services.mongodb.initialRootPassword` has been replaced with the more secure option [`services.mongodb.initialRootPasswordFile`](#opt-services.mongodb.initialRootPasswordFile)
+
 - `rofi` has been updated from 1.7.5 to 1.7.6 which introduces some breaking changes to binary plugins, and also contains a lot of new features and bug fixes. This is highlighted because the patch version bump does not indicate the volume of changes by itself. See the [upstream release notes](https://github.com/davatorium/rofi/releases/tag/1.7.6) for the full list of changes.
 
 - `ente-auth` now uses the name `enteauth` for its binary. The previous name was `ente_auth`.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -380,6 +380,8 @@
 
 - GOverlay has been updated to 1.2, please check the [upstream changelog](https://github.com/benjamimgois/goverlay/releases) for more details.
 
+- [`services.mongodb`](#opt-services.mongodb.enable) is now compatible with the `mongodb-ce` binary package. To make use of it, set [`services.mongodb.package`](#opt-services.mongodb.package) to `pkgs.mongodb-ce`.
+
 - [`services.jupyter`](#opt-services.jupyter.enable) is now compatible with `Jupyter Notebook 7`. See [the migration guide](https://jupyter-notebook.readthedocs.io/en/latest/migrate_to_notebook7.html) for details.
 
 - `networking.wireguard` now has an optional networkd backend. It is enabled by default when `networking.useNetworkd` is enabled, and it can be enabled alongside scripted networking with `networking.wireguard.useNetworkd`. Some `networking.wireguard` options have slightly different behavior with the networkd and script-based backends, documented in each option.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -390,6 +390,8 @@
 
 - `bind.cacheNetworks` now only controls access for recursive queries, where it previously controlled access for all queries.
 
+- [`services.mongodb.enableAuth`](#opt-services.mongodb.enableAuth) now uses the newer [mongosh](https://github.com/mongodb-js/mongosh) shell instead of the legacy shell to configure the initial superuser. You can configure the mongosh package to use through the [`services.mongodb.mongoshPackage`](#opt-services.mongodb.mongoshPackage) option.
+
 - The paperless module now has an option for regular automatic export of
   documents data using the integrated document exporter.
 

--- a/nixos/modules/services/databases/mongodb.nix
+++ b/nixos/modules/services/databases/mongodb.nix
@@ -43,7 +43,9 @@ in
 
       enable = lib.mkEnableOption "the MongoDB server";
 
-      package = lib.mkPackageOption pkgs "mongodb" { };
+      package = lib.mkPackageOption pkgs "mongodb" {
+        example = "pkgs.mongodb-ce";
+      };
 
       mongoshPackage = lib.mkPackageOption pkgs "mongosh" { };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -622,7 +622,7 @@ in {
   monado = handleTest ./monado.nix {};
   monetdb = handleTest ./monetdb.nix {};
   monica = handleTest ./web-apps/monica.nix {};
-  mongodb = handleTest ./mongodb.nix {};
+  mongodb = runTest ./mongodb.nix;
   moodle = handleTest ./moodle.nix {};
   moonraker = handleTest ./moonraker.nix {};
   mopidy = handleTest ./mopidy.nix {};

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -623,6 +623,10 @@ in {
   monetdb = handleTest ./monetdb.nix {};
   monica = handleTest ./web-apps/monica.nix {};
   mongodb = runTest ./mongodb.nix;
+  mongodb-ce = runTest ({ config, ... }: {
+    imports = [ ./mongodb.nix ];
+    defaults.services.mongodb.package = config.node.pkgs.mongodb-ce;
+  });
   moodle = handleTest ./moodle.nix {};
   moonraker = handleTest ./moonraker.nix {};
   mopidy = handleTest ./mopidy.nix {};

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -1,56 +1,37 @@
-# This test start mongodb, runs a query using mongo shell
-{ pkgs, ... }:
+# This test starts mongodb and runs a query using mongo shell
+{ config, lib, ... }:
 let
+  # required for test execution on darwin
+  pkgs = config.node.pkgs;
   testQuery = pkgs.writeScript "nixtest.js" ''
-    db.greetings.insert({ "greeting": "hello" });
+    db.greetings.insertOne({ "greeting": "hello" });
     print(db.greetings.findOne().greeting);
   '';
-
-  runMongoDBTest = pkg: ''
-    node.execute("(rm -rf data || true) && mkdir data")
-    node.execute(
-        "${pkg}/bin/mongod --fork --logpath logs --dbpath data"
-    )
-    node.wait_for_open_port(27017)
-
-    assert "hello" in node.succeed(
-        "${pkg}/bin/mongo ${testQuery}"
-    )
-
-    node.execute(
-        "${pkg}/bin/mongod --shutdown --dbpath data"
-    )
-    node.wait_for_closed_port(27017)
-  '';
-
+  mongoshExe = lib.getExe pkgs.mongosh;
 in
 {
   name = "mongodb";
-  meta = with pkgs.lib.maintainers; {
-    maintainers = [
-      bluescreen303
-      offline
-      phile314
-    ];
+  meta.maintainers = with pkgs.lib.maintainers; [
+    bluescreen303
+    offline
+    phile314
+    niklaskorz
+  ];
+
+  nodes.mongodb = {
+    services.mongodb.enable = true;
   };
 
-  nodes = {
-    node =
-      { ... }:
-      {
-        environment.systemPackages = with pkgs; [
-          # remember to update mongodb.passthru.tests if you change this
-          mongodb-7_0
-        ];
-      };
-  };
+  testScript = ''
+    start_all()
 
-  testScript =
-    ''
-      node.start()
-    ''
-    + runMongoDBTest pkgs.mongodb-7_0
-    + ''
-      node.shutdown()
-    '';
+    with subtest("start mongodb"):
+        mongodb.wait_for_unit("mongodb.service")
+        mongodb.wait_for_open_port(27017)
+
+    with subtest("insert and find a document"):
+        result = mongodb.succeed("${mongoshExe} ${testQuery}")
+        print("Test output:", result)
+        assert result.strip() == "hello"
+  '';
 }

--- a/nixos/tests/mongodb.nix
+++ b/nixos/tests/mongodb.nix
@@ -1,59 +1,56 @@
 # This test start mongodb, runs a query using mongo shell
+{ pkgs, ... }:
+let
+  testQuery = pkgs.writeScript "nixtest.js" ''
+    db.greetings.insert({ "greeting": "hello" });
+    print(db.greetings.findOne().greeting);
+  '';
 
-import ./make-test-python.nix (
-  { pkgs, ... }:
-  let
-    testQuery = pkgs.writeScript "nixtest.js" ''
-      db.greetings.insert({ "greeting": "hello" });
-      print(db.greetings.findOne().greeting);
+  runMongoDBTest = pkg: ''
+    node.execute("(rm -rf data || true) && mkdir data")
+    node.execute(
+        "${pkg}/bin/mongod --fork --logpath logs --dbpath data"
+    )
+    node.wait_for_open_port(27017)
+
+    assert "hello" in node.succeed(
+        "${pkg}/bin/mongo ${testQuery}"
+    )
+
+    node.execute(
+        "${pkg}/bin/mongod --shutdown --dbpath data"
+    )
+    node.wait_for_closed_port(27017)
+  '';
+
+in
+{
+  name = "mongodb";
+  meta = with pkgs.lib.maintainers; {
+    maintainers = [
+      bluescreen303
+      offline
+      phile314
+    ];
+  };
+
+  nodes = {
+    node =
+      { ... }:
+      {
+        environment.systemPackages = with pkgs; [
+          # remember to update mongodb.passthru.tests if you change this
+          mongodb-7_0
+        ];
+      };
+  };
+
+  testScript =
+    ''
+      node.start()
+    ''
+    + runMongoDBTest pkgs.mongodb-7_0
+    + ''
+      node.shutdown()
     '';
-
-    runMongoDBTest = pkg: ''
-      node.execute("(rm -rf data || true) && mkdir data")
-      node.execute(
-          "${pkg}/bin/mongod --fork --logpath logs --dbpath data"
-      )
-      node.wait_for_open_port(27017)
-
-      assert "hello" in node.succeed(
-          "${pkg}/bin/mongo ${testQuery}"
-      )
-
-      node.execute(
-          "${pkg}/bin/mongod --shutdown --dbpath data"
-      )
-      node.wait_for_closed_port(27017)
-    '';
-
-  in
-  {
-    name = "mongodb";
-    meta = with pkgs.lib.maintainers; {
-      maintainers = [
-        bluescreen303
-        offline
-        phile314
-      ];
-    };
-
-    nodes = {
-      node =
-        { ... }:
-        {
-          environment.systemPackages = with pkgs; [
-            # remember to update mongodb.passthru.tests if you change this
-            mongodb-7_0
-          ];
-        };
-    };
-
-    testScript =
-      ''
-        node.start()
-      ''
-      + runMongoDBTest pkgs.mongodb-7_0
-      + ''
-        node.shutdown()
-      '';
-  }
-)
+}

--- a/pkgs/by-name/mo/mongodb-ce/package.nix
+++ b/pkgs/by-name/mo/mongodb-ce/package.nix
@@ -12,6 +12,7 @@
   nix-update,
   gitMinimal,
   pup,
+  nixosTests,
 }:
 
 let
@@ -102,9 +103,12 @@ stdenv.mkDerivation (finalAttrs: {
         command = lib.getExe script;
       };
 
-    tests.version = testers.testVersion {
-      package = mongodb-ce;
-      command = "mongod --version";
+    tests = {
+      inherit (nixosTests) mongodb-ce;
+      version = testers.testVersion {
+        package = mongodb-ce;
+        command = "mongod --version";
+      };
     };
   };
 

--- a/pkgs/by-name/mo/mongodb-ce/package.nix
+++ b/pkgs/by-name/mo/mongodb-ce/package.nix
@@ -5,8 +5,7 @@
   autoPatchelfHook,
   curl,
   openssl,
-  testers,
-  mongodb-ce,
+  versionCheckHook,
   writeShellApplication,
   jq,
   nix-update,
@@ -64,6 +63,11 @@ stdenv.mkDerivation (finalAttrs: {
     runHook postInstall
   '';
 
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/mongod";
+  versionCheckProgramArg = [ "--version" ];
+  doInstallCheck = true;
+
   passthru = {
 
     updateScript =
@@ -105,10 +109,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     tests = {
       inherit (nixosTests) mongodb-ce;
-      version = testers.testVersion {
-        package = mongodb-ce;
-        command = "mongod --version";
-      };
     };
   };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR fixes issues inside `services.mongodb` currently making it incompatible with the `mongodb-ce` package. Namely, it now uses the mongosh package to configure the initial superuser instead of the legacy shell bundled in the other mongodb packages.

I also refactored the mongodb tests to:

1. actually use `services.mongodb` instead of trying to start the `mongod` binary inside the test
2. make it compatible with the mongodb-ce package

Note that test execution requires unfree packages to be allowed, e.g. `NIXPKGS_ALLOW_UNFREE=1 nix-build -A nixosTests.mongodb-ce`, until https://github.com/NixOS/rfcs/pull/185 is accepted.

CC @drupol as maintainer of mongodb-ce

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
