### PR TITLE
umu-launcher: fix overriding umu-launcher-unwrapped arg

### DIFF
--- a/pkgs/by-name/um/umu-launcher/package.nix
+++ b/pkgs/by-name/um/umu-launcher/package.nix
@@ -7,7 +7,8 @@ buildFHSEnv {
   pname = "umu-launcher";
   inherit (umu-launcher-unwrapped) version meta;
 
-  targetPkgs = pkgs: [ pkgs.umu-launcher-unwrapped ];
+  # Use umu-launcher-unwrapped from the package args, to simplify overriding
+  targetPkgs = _: [ umu-launcher-unwrapped ];
 
   executableName = umu-launcher-unwrapped.meta.mainProgram;
   runScript = lib.getExe umu-launcher-unwrapped;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Normally, fhs-env target packages come from the supplied package set, however in this case the umu-launcher-unwrapped package from the _package args_ is being used throughout the rest of the package.

This means the following example will end up using both the overridden and non-overridden unwrapped package:

```nix
pkgs.umu-launcher.override {
  umu-launcher-unwrapped = pkgs.umu-launcher-unwrapped.overrideAttrs {
    # example override
    foobar = true;
  };
}
```

In the above example, the overridden package is used for `version`, `meta`, `runScript` and the `extraInstallCommands`, while a different (non-overridden) package is used for `targetPkgs`.

To properly override, you would need to do something like:

```nix
let
  umu-launcher-unwrapped = pkgs.umu-launcher-unwrapped.overrideAttrs {
    # example override
    foobar = true;
  };
in
(pkgs.umu-launcher.override { inherit umu-launcher-unwrapped; }).overrideAttrs {
  targetPkgs = _: [ umu-launcher-unwrapped ];
}
```

However, the above doesn't actually work because `targetPkgs` isn't a derivation attr. It is just an argument to [`buildFHSEnv`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/build-fhsenv-bubblewrap/default.nix) and therefore isn't overridable.


With this PR, the same unwrapped package is used throughout the umu-launcher package.

---

cc @LovingMelody @diniamo 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
