### PR TITLE
proxychains-ng: default to dyld hooking method

### DIFF
--- a/pkgs/by-name/pr/proxychains-ng/package.nix
+++ b/pkgs/by-name/pr/proxychains-ng/package.nix
@@ -2,6 +2,9 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
+  # "dlsym" for OSX version < 12
+  darwinHookMethod ? "dyld",
 }:
 
 stdenv.mkDerivation rec {
@@ -18,6 +21,16 @@ stdenv.mkDerivation rec {
   patches = [
     # https://github.com/NixOS/nixpkgs/issues/136093
     ./swap-priority-4-and-5-in-get_config_path.patch
+    # The fix is not present in v4.17; remove the patch next version update.
+    # https://github.com/rofl0r/proxychains-ng/issues/557
+    (fetchpatch {
+      url = "https://github.com/rofl0r/proxychains-ng/commit/fffd2532ad34bdf7bf430b128e4c68d1164833c6.patch";
+      hash = "sha256-l3qSFUDMUfVDW1Iw+R2aW/wRz4CxvpR4eOwx9KzuAAo=";
+    })
+  ];
+
+  configureFlags = lib.optionals stdenv.isDarwin [
+    "--hookmethod=${darwinHookMethod}"
   ];
 
   installFlags = [
@@ -29,7 +42,11 @@ stdenv.mkDerivation rec {
     description = "Preloader which hooks calls to sockets in dynamically linked programs and redirects it through one or more socks/http proxies";
     homepage = "https://github.com/rofl0r/proxychains-ng";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ zenithal ];
-    platforms = platforms.linux ++ [ "aarch64-darwin" ];
+    maintainers = with maintainers; [
+      zenithal
+      usertam
+    ];
+    platforms = platforms.unix;
+    mainProgram = "proxychains4";
   };
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Right now the build actually doesn't work in recent darwin versions because the new hooking method wasn't used. 
About new dyld hooking method: https://github.com/rofl0r/proxychains-ng/issues/409 and https://github.com/rofl0r/proxychains-ng/commit/e20c08fe47b743e250a220266f81b9de66a389d6

The default is `auto` and depends on a variable that probably doesn't exist in the nix sandbox, so it always falls back to the old hooking method.

If it is enabled, we should see something like this in the build log
```
checking checking whether we can use -lpthread ... yes
using Monterey style DYLD hooking
Done, now run make && make install
```
which I don't see in a recent hydra aarch64-darwin build: https://cache.nixos.org/log/n4rqgpqzqcwdd7vazjxi1gb7h36k3zqr-proxychains-ng-4.17.drv

Also bring in a hotfix because compile error: https://github.com/rofl0r/proxychains-ng/commit/fffd2532ad34bdf7bf430b128e4c68d1164833c6

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
