### PR TITLE
woodpecker-{agent,cli,server}: 2.8.3 -> 3.0.1, invert deprecation wrapper for woodpecker-cli

### DIFF
--- a/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/cli.nix
@@ -18,6 +18,6 @@ buildGoModule {
 
   meta = common.meta // {
     description = "Command line client for the Woodpecker Continuous Integration server";
-    mainProgram = "woodpecker";
+    mainProgram = "woodpecker-cli";
   };
 }

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 let
-  version = "2.8.3";
-  srcHash = "sha256-/Ozzibz2BhVSxQeH9tg3cC5uVl0gEA/Hw2AMOELW/I8=";
+  version = "3.0.0";
+  srcHash = "sha256-AM+qMTbvlLOLtuADJGWKRmeqwK+ssV7YxydOsx+L8Nc=";
   # The tarball contains vendored dependencies
   vendorHash = null;
 in
@@ -37,7 +37,7 @@ in
   ldflags = [
     "-s"
     "-w"
-    "-X go.woodpecker-ci.org/woodpecker/v2/version.Version=${version}"
+    "-X go.woodpecker-ci.org/woodpecker/v3/version.Version=${version}"
   ];
 
   meta = with lib; {

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -18,18 +18,16 @@ in
     cd $out/bin
     for f in *; do
       if [ "$f" = cli ]; then
-        mv -- "$f" "woodpecker"
         # Issue a warning to the user if they call the deprecated executable
-        cat >woodpecker-cli << EOF
+        cat >woodpecker << EOF
     #!/bin/sh
-    echo 'WARNING: calling \`woodpecker-cli\` is deprecated, use \`woodpecker\` instead.' >&2
-    $out/bin/woodpecker "\$@"
+    echo 'WARNING: calling \`woodpecker\` is deprecated, use \`woodpecker-cli\` instead.' >&2
+    $out/bin/woodpecker-cli "\$@"
     EOF
-        chmod +x woodpecker-cli
-        patchShebangs woodpecker-cli
-      else
-        mv -- "$f" "woodpecker-$f"
+        chmod +x woodpecker
+        patchShebangs woodpecker
       fi
+        mv -- "$f" "woodpecker-$f"
     done
     cd -
   '';

--- a/pkgs/development/tools/continuous-integration/woodpecker/common.nix
+++ b/pkgs/development/tools/continuous-integration/woodpecker/common.nix
@@ -1,7 +1,7 @@
 { lib, fetchzip }:
 let
-  version = "3.0.0";
-  srcHash = "sha256-AM+qMTbvlLOLtuADJGWKRmeqwK+ssV7YxydOsx+L8Nc=";
+  version = "3.0.1";
+  srcHash = "sha256-BJHvZhi/jjVH/NZKqGwL2ZiYGxM72EtJ0KTO21IigAY=";
   # The tarball contains vendored dependencies
   vendorHash = null;
 in


### PR DESCRIPTION
Please refer to the commits messages for details.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).