### PR TITLE
rke2: passthru images archives

### DIFF
--- a/nixos/tests/rke2/single-node.nix
+++ b/nixos/tests/rke2/single-node.nix
@@ -6,69 +6,78 @@ import ../make-test-python.nix (
     ...
   }:
   let
-    pauseImage = pkgs.dockerTools.streamLayeredImage {
-      name = "test.local/pause";
+    throwSystem = throw "RKE2: Unsupported system: ${pkgs.stdenv.hostPlatform.system}";
+    coreImages =
+      {
+        aarch64-linux = rke2.images-core-linux-arm64-tar-zst;
+        x86_64-linux = rke2.images-core-linux-amd64-tar-zst;
+      }
+      .${pkgs.stdenv.hostPlatform.system} or throwSystem;
+    canalImages =
+      {
+        aarch64-linux = rke2.images-canal-linux-arm64-tar-zst;
+        x86_64-linux = rke2.images-canal-linux-amd64-tar-zst;
+      }
+      .${pkgs.stdenv.hostPlatform.system} or throwSystem;
+    helloImage = pkgs.dockerTools.buildImage {
+      name = "test.local/hello";
       tag = "local";
-      contents = pkgs.buildEnv {
-        name = "rke2-pause-image-env";
-        paths = with pkgs; [
-          tini
-          (hiPrio coreutils)
-          busybox
-        ];
-      };
-      config.Entrypoint = [
-        "/bin/tini"
-        "--"
-        "/bin/sleep"
-        "inf"
-      ];
+      compressor = "zstd";
+      copyToRoot = pkgs.hello;
+      config.Entrypoint = [ "${pkgs.hello}/bin/hello" ];
     };
-    testPodYaml = pkgs.writeText "test.yaml" ''
-      apiVersion: v1
-      kind: Pod
+    testJobYaml = pkgs.writeText "test.yaml" ''
+      apiVersion: batch/v1
+      kind: Job
       metadata:
         name: test
       spec:
-        containers:
-        - name: test
-          image: test.local/pause:local
-          imagePullPolicy: Never
-          command: ["sh", "-c", "sleep inf"]
+        template:
+          spec:
+            containers:
+            - name: test
+              image: "test.local/hello:local"
+            restartPolicy: Never
     '';
   in
   {
     name = "${rke2.name}-single-node";
     meta.maintainers = rke2.meta.maintainers;
-
     nodes.machine =
-      { pkgs, ... }:
+      { nodes, pkgs, ... }:
       {
-        networking.firewall.enable = false;
-        networking.useDHCP = false;
-        networking.defaultGateway = "192.168.1.1";
-        networking.interfaces.eth1.ipv4.addresses = pkgs.lib.mkForce [
-          {
-            address = "192.168.1.1";
-            prefixLength = 24;
-          }
-        ];
+        # Setup image archives to be imported by rke2
+        systemd.tmpfiles.settings."10-rke2" = {
+          "/var/lib/rancher/rke2/agent/images/rke2-images-core.tar.zst" = {
+            "L+".argument = "${coreImages}";
+          };
+          "/var/lib/rancher/rke2/agent/images/rke2-images-canal.tar.zst" = {
+            "L+".argument = "${canalImages}";
+          };
+          "/var/lib/rancher/rke2/agent/images/hello.tar.zst" = {
+            "L+".argument = "${helloImage}";
+          };
+        };
 
-        virtualisation.memorySize = 1536;
-        virtualisation.diskSize = 4096;
+        # RKE2 needs more resources than the default
+        virtualisation.cores = 4;
+        virtualisation.memorySize = 4096;
+        virtualisation.diskSize = 8092;
 
         services.rke2 = {
           enable = true;
           role = "server";
           package = rke2;
-          nodeIP = "192.168.1.1";
+          # Without nodeIP the apiserver starts with the wrong service IP family
+          nodeIP = nodes.machine.networking.primaryIPAddress;
+          # Slightly reduce resource consumption
           disable = [
             "rke2-coredns"
             "rke2-metrics-server"
             "rke2-ingress-nginx"
-          ];
-          extraFlags = [
-            "--cluster-reset"
+            "rke2-snapshot-controller"
+            "rke2-snapshot-controller-crd"
+            "rke2-snapshot-validation-webhook"
           ];
         };
       };
@@ -76,23 +85,19 @@ import ../make-test-python.nix (
     testScript =
       let
         kubectl = "${pkgs.kubectl}/bin/kubectl --kubeconfig=/etc/rancher/rke2/rke2.yaml";
-        ctr = "${pkgs.containerd}/bin/ctr -a /run/k3s/containerd/containerd.sock";
       in
+      # python
       ''
         start_all()
 
-        machine.wait_for_unit("rke2")
+        machine.wait_for_unit("rke2-server")
         machine.succeed("${kubectl} cluster-info")
-        machine.wait_until_succeeds(
-          "${pauseImage} | ${ctr} -n k8s.io image import -"
-        )
 
         machine.wait_until_succeeds("${kubectl} get serviceaccount default")
-        machine.succeed("${kubectl} apply -f ${testPodYaml}")
-        machine.succeed("${kubectl} wait --for 'condition=Ready' pod/test")
-        machine.succeed("${kubectl} delete -f ${testPodYaml}")
-
-        machine.shutdown()
+        machine.succeed("${kubectl} apply -f ${testJobYaml}")
+        machine.wait_until_succeeds("${kubectl} wait --for 'condition=complete' job/test")
+        output = machine.succeed("${kubectl} logs -l batch.kubernetes.io/job-name=test")
+        assert output.rstrip() == "Hello, world!", f"unexpected output of test job: {output}"
       '';
   }
 )

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -1,5 +1,6 @@
 lib:
 {
+  releaseName,
   rke2Version,
   rke2Commit,
   rke2TarballHash,
@@ -131,9 +132,9 @@ buildGoModule rec {
           version = "v${version}";
         };
       }
-      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-        inherit (nixosTests) rke2;
-      };
+      // (lib.optionalAttrs stdenv.isLinux (
+        lib.mapAttrs (name: value: nixosTests.rke2.${name}.${releaseName}) nixosTests.rke2
+      ));
   } // (lib.mapAttrs (_: value: fetchurl value) imagesVersions);
 
   meta = with lib; {

--- a/pkgs/applications/networking/cluster/rke2/builder.nix
+++ b/pkgs/applications/networking/cluster/rke2/builder.nix
@@ -10,6 +10,7 @@ lib:
   pauseVersion,
   ccmVersion,
   dockerizedVersion,
+  imagesVersions,
   ...
 }:
 
@@ -21,6 +22,7 @@ lib:
   go,
   makeWrapper,
   fetchzip,
+  fetchurl,
 
   # Runtime dependencies
   procps,
@@ -120,18 +122,19 @@ buildGoModule rec {
 
   doCheck = false;
 
-  passthru.updateScript = updateScript;
-
-  passthru.tests =
-    {
-      version = testers.testVersion {
-        package = rke2;
-        version = "v${version}";
+  passthru = {
+    inherit updateScript;
+    tests =
+      {
+        version = testers.testVersion {
+          package = rke2;
+          version = "v${version}";
+        };
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        inherit (nixosTests) rke2;
       };
-    }
-    // lib.optionalAttrs stdenv.hostPlatform.isLinux {
-      inherit (nixosTests) rke2;
-    };
+  } // (lib.mapAttrs (_: value: fetchurl value) imagesVersions);
 
   meta = with lib; {
     homepage = "https://github.com/rancher/rke2";

--- a/pkgs/applications/networking/cluster/rke2/latest/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/latest/images-versions.json
@@ -1,0 +1,138 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "6cc665aca7623e916ce55a30df0c74e7cce961a9bb0b6d502cbe84dcfa7ba070"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "69c6084054c667aa9c4efa2b566bfd3c7c540abe890be389a5bfab78dee2402a"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "ed6bfde7e89680bf7dd3fec393f670d24e5941c1298a565d1abb3dcadb2d0c0f"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "13eea977f79bce3f9730e6b1dbbe3b0a2373c5712659dc1e4da6f2b4f16877eb"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "2e080252178d5160866a46d16fceb68bf92ab6d9d9ecbe150344c5fbc7c2656b"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "ddca94606ae1787c00b93b74002190274ab543c50049382c17a8d6427a7177d9"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "cacb07923f70f9b76a1b4ac984cecd9aaabfea353e9cd1e64b61010376a4f233"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "c0c8e1d18c3d3ea04c012c6b8940c5a3dd6f6212300de0283c002d8af4251282"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "a7f0a8a014a879486592e26ec1ba4fa0aa2dd46b86b1a76d50a6454f69bc911f"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "7ccb9eef9c241e5f371d631844d8f6bb01aff72424e19e5a5942e2d6c580fee2"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "4e63f3e158b07d3b86413aaa2ad12be34979871ec1f467affe5be6dfc9c974c3"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "fd45ce71ab5872df28cae7a0ae91796f3643b1520096c56e25e3d7daf3f206e0"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "cb8a60fc7f3207f6f24f72edb1944f7934cc3bc73863395782c5c68ce2bc4c77"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "0ae02e40aaf6b40ec30306076e9eb1160fa0add377f1614f92184bb5c31d54ea"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "61a50112796b1316d8739a860e4c4afa0048d5cc46bc59b4161d611d47a7187c"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "55741d17b1f222e146a77aa0caf19c4e339b55f684e88f8d8626ced86d17b80a"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "986a5ce33db40a623002bd9cf946a8d93c36fc839a6c2df3aacaadff83692c81"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "de9495eeedc94e11cee6d770120e1a0be0fb4ec82b8586b204c586dc6dd22076"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "5653935c5be8bb27978fca1c0bc691c0eea524be0ddf0d120c9607defcfa5d35"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "c82601dd9acf6cfff61497f19a48bc755057ac298c9097acf8c19da577b1b8b9"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "cdd283583729deddad7c8254ac1950f7d16fccf995302a14703c661872c72b8d"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "e992301be2c4ccfb6ff9a977007699d3490001ff0be0f70b892b5b9f9fb73002"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "cc3990348fe841f8a04b4528ba97f2e6083bb58b77b7d9370529be29d6bacafa"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "54873b93d3eb2e5771103547045f7b2fcc349bc836e8c61c1c47ee978a5cfd7e"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "b75a6e22b8c2e3595aa95193c3ff5cf185745c12ec2b87ebe6fdffd9bcd1c764"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "49fa0dacf5148fd75686f7394c30d2aadb35b6512342b7fd31cda8f91e89c122"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "0afb4a61c10f666655a5418231c4c24fa9908d7bfb94497c3eabb0ea61da44d4"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "4a71e99b830f63c71f380e1073fdc570672d77322110d74cff5322ffb21ffd46"
+  },
+  "images-traefik-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "4fe4edc04eb2c0da64e58be2eda387195a2febf354dd36121bd876ce3c321d47"
+  },
+  "images-traefik-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "36f41a5bb6175d291675e8fed3f228b7d1ef5b239a59d7daeae50d343f736e87"
+  },
+  "images-traefik-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "6320304b6f3d3a6f4634baff1d5fc9a46486fb6773dc68c9fa6b406003fbdaa5"
+  },
+  "images-traefik-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "f905546a81dea41fe34afe9e04a40f565bd9c51afa27a1e3c338495c097b38b9"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "e537002e722f83d0eca3128afc611e330ffbd767b4fde95239eb15b132ecbb57"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.32.0%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "c7472777c4aed1930edf572a390c17920a5d4e7587ae4ec0a0c599f4389697f8"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/latest/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/latest/versions.nix
@@ -11,4 +11,5 @@
   dockerizedVersion = "v1.32.1-rke2r1";
   golangVersion = "go1.23.4";
   eol = "2026-02-28";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/latest/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/latest/versions.nix
@@ -1,10 +1,11 @@
 {
-  rke2Version = "1.32.1+rke2r1";
-  rke2Commit = "c0f7be4407cf2c437cacfe735e5c943e827f2ff8";
-  rke2TarballHash = "sha256-clZpTnMnj2PRDDYz7+r11RlyX2ExwsE1Tmdt3/kUmtE=";
-  rke2VendorHash = "sha256-aIB2fRkccx5fXMnFxZ+tirXp5gg8o/h/a6Lgc+EG4L4=";
-  k8sVersion = "v1.32.1";
-  k8sImageTag = "v1.32.1-rke2r1-build20250115";
+  releaseName = "rke2_latest";
+  rke2Version = "1.32.0+rke2r1";
+  rke2Commit = "1182e7eb91b27b1686e69306eb2e227928a27a38";
+  rke2TarballHash = "sha256-mmHQxiNcfgZTTdYPJPO7WTIlaCRM4CWsWwfRUcAR8ho=";
+  rke2VendorHash = "sha256-6Y3paEQJ8yHzONqalzoe15TjWhF3zGsM92LS1AcJ2GM=";
+  k8sVersion = "v1.32.0";
+  k8sImageTag = "v1.32.0-rke2r1-build20241212";
   etcdVersion = "v3.5.16-k3s1-build20241106";
   pauseVersion = "3.6";
   ccmVersion = "v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101";

--- a/pkgs/applications/networking/cluster/rke2/stable/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/stable/images-versions.json
@@ -1,0 +1,138 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "e8db8dbeb4a4d423cdb6bbd473ad9be6eaeac51fe124d1941ddaef65a030e235"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "51afda2f03617c22e8df17f3a3b67460f2fe8bbb6afd761489038dbf56209c5c"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "5b25820169187a92d461f98a4c880181673d588c144dae9d926ff0ae6dd53b20"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "65d68813b6c40f22275ebaa139b0dcae2c8700b3cb7d0b3f958c883996c46057"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "b8b0029b4f59617283b4a5e5c75cc232760795740c2580a1e8e6f32356a3bd8e"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "80e49a26dd7c1c504bef21e9f719c3ea0a936bc778a925c03268508c894d30f0"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "72a17aec7f5e8b98f1611a43c9cce53bd78dbcfc267b6c1cdf0b730018c768cd"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "aac8f6978dd9f8bf97277cddef7187c51bee5ead9bf07961e7f9da8cc6cd95c5"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "ca48cca1e993eefbdb32eab0efaff7251218292e3a8e84b537812cd297e6fe93"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "5edb544a141d8aed2089a3844af59e3a976c61ccbada18b8831d3ffdebe7761f"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "79b336b82f49367b0beaeecabf118cdebcf8f3ccd2b1860b5022578c3d6531f2"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "dbdd6cd35a5201457b4755c1ed7739f97344bccd888d8706dd73a3d45884bbfc"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "d7719b7d643691957767b6bf3d355098982edb77aadcc06ad081ac057917a3fd"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "644aa9636d384dcf4a60749e6fe83e7330350713661b4a734e24f18d90b63df4"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "e5a3f5f48158c2538d2ef995f7f3e13f00fa244bec623888595d79c6b5ec36ee"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "cea8d5d06193748a1d98aef42bc6177db875e941ee370f6379d986cda157cd1a"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "380a1ccca33af74f9a3919c374c888dcd677a09aeb86e9e5781fa9a60e25c63f"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "df76c6c0362a0eff95add065d13c7f5566b4c13b81c1d0404c29864ca0d42c52"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "1ade532ca1397ec19603728d13b7e811d32abe3b2c763e8014f54047b400906f"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "0e80c679cb154005f1ae23c57924b4c421568733906568a35f4948daa6097eb8"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "c7d2b024e385ee963d2b8fa7b7fc5412731497ae545fc8ff3b5b503a572e7882"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "ae0540c64384befc3c7c6dca283ee414fa19ef8ec11c61a27d9ff5059f604b37"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "93a04bce4afe74899cfeb95f9a330e01bd88a8cee216783de4d5fd41f9948687"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "e75e02514b77a8e606f4fe9e3fe348449e1ebb7df16acd120d8da3313a5c68fa"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "6844e462ee0118467511605cdb666a3843f4e3947c08b14ccf71bbb9f03a67e0"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "1dd82ebe29fc84a4db9f2c6fcd3b356199a8b6b7d6220f13b5fcc47f0df940c2"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "de60e1414d236a1fdee31b52d1f7fa95a19f45eadb3cf4f6bed41f170f3cf635"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "9ed84c190aeac5447e3d580650bcb9f8dd3d396fb7eeb5727ae7ed545c20b76a"
+  },
+  "images-traefik-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "4c9207325dc5dc47cc9eed706b980dc46db744b9ce81a1f072a8c45f86b22d8b"
+  },
+  "images-traefik-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "be35435aac4276b6f9844a4d9d15026255c669a94656ded7c9f300b43d5ccfad"
+  },
+  "images-traefik-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "58a6ecd53eb3d3fb7b9d468732618236461b7c7bfd0259c27ebd532405cb5b2f"
+  },
+  "images-traefik-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "06bd22a65230651f8195e1a831cc788654e8211f3966da8fc92f7623995388e5"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "efe1a09e5d6cbc7d7c9ac860c97e5aae6623297f4367d8ab4ad663a2f6993724"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "882a45622801a7d101806a064244305ef5fdf9bd636307afeb4cf19fdce66dd3"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/stable/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/stable/versions.nix
@@ -11,4 +11,5 @@
   dockerizedVersion = "v1.31.5-rke2r1";
   golangVersion = "go1.22.10";
   eol = "2025-10-28";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/stable/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/stable/versions.nix
@@ -1,10 +1,11 @@
 {
-  rke2Version = "1.31.5+rke2r1";
-  rke2Commit = "08e198bbe3f0b8d4c9b0af4d92085c06bb94aa89";
-  rke2TarballHash = "sha256-GG1GOs/kLWDCvc/+l0ymRpJzEthIyGpampCjvfnEPB8=";
-  rke2VendorHash = "sha256-xWqMidOWiLgJXp6AEITkyOieLw4yi1JMmi80YS4RNy0=";
-  k8sVersion = "v1.31.5";
-  k8sImageTag = "v1.31.5-rke2r1-build20250115";
+  releaseName = "rke2_stable";
+  rke2Version = "1.31.4+rke2r1";
+  rke2Commit = "5142beec71f7a61804840df5b434c2fd7137ce82";
+  rke2TarballHash = "sha256-Lebi3a7kNA9IQCVVkYfUoGEeEiLScqpOx1aTCFElDvw=";
+  rke2VendorHash = "sha256-DGmu1vFNcu1O2wuEwRZRBTL/TP2lJ9ggQ2M/Ix+jknM=";
+  k8sVersion = "v1.31.4";
+  k8sImageTag = "v1.31.4-rke2r1-build20241212";
   etcdVersion = "v3.5.16-k3s1-build20241106";
   pauseVersion = "3.6";
   ccmVersion = "v1.31.2-0.20241016053446-0955fa330f90-build20241016";

--- a/pkgs/applications/networking/cluster/rke2/testing/images-versions.json
+++ b/pkgs/applications/networking/cluster/rke2/testing/images-versions.json
@@ -1,0 +1,138 @@
+{
+  "images-calico-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-calico.linux-amd64.tar.gz",
+    "sha256": "f5a306330084e27d82b3e9dd498c9817796aa2ae971f334a912f4e945f64c92b"
+  },
+  "images-calico-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-calico.linux-amd64.tar.zst",
+    "sha256": "56b23be0fbe393b31e422ea5048a9f94df1f0e5d06939b1f0c53ca4e6eb21466"
+  },
+  "images-calico-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-calico.linux-arm64.tar.gz",
+    "sha256": "b29ca038358daa84b66f306fccebd3d5c7d2b9ca1a11ca3d333a1c80dc411c0e"
+  },
+  "images-calico-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-calico.linux-arm64.tar.zst",
+    "sha256": "6aeffa4f519561dfdb5e2a8a410a91fda61e24bb37f255fb9adc7264132dc846"
+  },
+  "images-canal-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-canal.linux-amd64.tar.gz",
+    "sha256": "bcbfb7012af6e7d93b794548562a60eac7fbe02fc431ec8dcc56de329cbc34da"
+  },
+  "images-canal-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-canal.linux-amd64.tar.zst",
+    "sha256": "1a6edd91b8841c6c3effd830816746968807e06173241d050287f553f57d28b2"
+  },
+  "images-canal-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-canal.linux-arm64.tar.gz",
+    "sha256": "39c67d4d388976e394d328ecd0a6f758d9656ec3758d58d75ff226899996f776"
+  },
+  "images-canal-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-canal.linux-arm64.tar.zst",
+    "sha256": "74c12b1f4f9918bca35928713a494c81652df6730c86ded1559059761953606c"
+  },
+  "images-cilium-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.gz",
+    "sha256": "8cb101d6f897c707e43d3f21b96925ee5ee2aa684bb190825f6a570fb9dcec99"
+  },
+  "images-cilium-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-cilium.linux-amd64.tar.zst",
+    "sha256": "72af9aa7257598663b6a62c7e333b88e6b6cc55f43b5a7d21c3d2edcbe1c4e59"
+  },
+  "images-cilium-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-cilium.linux-arm64.tar.gz",
+    "sha256": "5c9aa48c96b3797932d09910f36996b0ce4a12ddce533af4f0534f23495892ac"
+  },
+  "images-cilium-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-cilium.linux-arm64.tar.zst",
+    "sha256": "2879ccd50acd437dd0c41fb80329040728919fc6fed43fb97ddb855dfeb4f172"
+  },
+  "images-core-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-core.linux-amd64.tar.gz",
+    "sha256": "b550e3673e7951c6be79e48de8513f3f24a76589da4abc5362ef532916d05a74"
+  },
+  "images-core-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-core.linux-amd64.tar.zst",
+    "sha256": "da5175df689ef6d820a974b53a26cbff7d041feefd60be2776f745126b5a0df7"
+  },
+  "images-core-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-core.linux-arm64.tar.gz",
+    "sha256": "299a5216e8464e2e808b31ef9b2aff90786180c595cbd7f35da4878d2c59d4fd"
+  },
+  "images-core-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-core.linux-arm64.tar.zst",
+    "sha256": "13cbae98b8031463150d785550dbab3c317aa3b307f44aef5202ae276cf33d32"
+  },
+  "images-flannel-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-flannel.linux-amd64.tar.gz",
+    "sha256": "391b1a777fbc681f11fc4112da84e312d298e9f954522280ac9e8e025d586007"
+  },
+  "images-flannel-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-flannel.linux-amd64.tar.zst",
+    "sha256": "ae6423c7ba2cb0bacfd4e499256a6b9aa7d64061a60396132d6ad959b41f9519"
+  },
+  "images-flannel-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-flannel.linux-arm64.tar.gz",
+    "sha256": "fb33738a1e91a11378e4c92d39fd5ca353b0d97d50da05ae77dbe0d32626b465"
+  },
+  "images-flannel-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-flannel.linux-arm64.tar.zst",
+    "sha256": "ec281888e63377eacf02bd87cd2dcd99a272d6c776fc3e161c9af0a29ae3213d"
+  },
+  "images-harvester-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-harvester.linux-amd64.tar.gz",
+    "sha256": "7a06631b5570e511039b3a46f8e626e1840583289d814b788254d9af23714ca4"
+  },
+  "images-harvester-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-harvester.linux-amd64.tar.zst",
+    "sha256": "b42d407ab3ed90c7c3f01dfb18311096b3d4d4d42a218574285b0b3fc11b1ab7"
+  },
+  "images-harvester-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-harvester.linux-arm64.tar.gz",
+    "sha256": "bc5f780cc668e05e93ef2d5414fdfa9452095d56a2dc7ca7d077d51a92bae31f"
+  },
+  "images-harvester-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-harvester.linux-arm64.tar.zst",
+    "sha256": "3df9fdfc8fb101ccd9e49453f4618cf9c5fe390c1d15120d99218b66854b5630"
+  },
+  "images-multus-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-multus.linux-amd64.tar.gz",
+    "sha256": "3cf1361e76bf7c1dfa31390a6caa174efb95275c79b1069a2eb4af50879339fd"
+  },
+  "images-multus-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-multus.linux-amd64.tar.zst",
+    "sha256": "81522db5a58844d01bba351ebf057c7f95725e4e66cf3822941783228e5c8968"
+  },
+  "images-multus-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-multus.linux-arm64.tar.gz",
+    "sha256": "e7ef321669bfb7a800187fa3f4c6b34df68c8d53d7785a0384a30d16f2d34314"
+  },
+  "images-multus-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-multus.linux-arm64.tar.zst",
+    "sha256": "a5c1597bc025b7fba9849835b544378f505d82156161de72dca0aee71b16f3b7"
+  },
+  "images-traefik-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-traefik.linux-amd64.tar.gz",
+    "sha256": "2c68fa2b0dc92cce6c831ab058ee4a96c700abcdb269d16a2c68dc3e1c18294e"
+  },
+  "images-traefik-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-traefik.linux-amd64.tar.zst",
+    "sha256": "9bc8934990b54060628bd680c4d07e7a0c9bb301b7af019e9a9176b856f3e8eb"
+  },
+  "images-traefik-linux-arm64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-traefik.linux-arm64.tar.gz",
+    "sha256": "848d515ae815a15c52b4ddeb6092da232f975bd563f9b3ec1057023ac8f0e197"
+  },
+  "images-traefik-linux-arm64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-traefik.linux-arm64.tar.zst",
+    "sha256": "b309fa8e5699b84e091164dc998a8e8dd0d8707641286fb7f801cc2c7faedad8"
+  },
+  "images-vsphere-linux-amd64-tar-gz": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.gz",
+    "sha256": "c00b6eb63c81b23ef6ad0422cf3a6caa73b5a91ba70fd8fb169b8cd2ff5fc0a8"
+  },
+  "images-vsphere-linux-amd64-tar-zst": {
+    "url": "https://github.com/rancher/rke2/releases/download/v1.31.4-rc3%2Brke2r1/rke2-images-vsphere.linux-amd64.tar.zst",
+    "sha256": "e709d9081069bf009a35c34ceefe6993083529777b1777fd0432ddff17e07e50"
+  }
+}

--- a/pkgs/applications/networking/cluster/rke2/testing/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/testing/versions.nix
@@ -1,4 +1,5 @@
 {
+  releaseName = "rke2_testing";
   rke2Version = "1.31.4-rc3+rke2r1";
   rke2Commit = "b2d8003d79075e7331ab8f2d1e1a3c494ed944b9";
   rke2TarballHash = "sha256-eTA+/fF6HuXDT4EUnvPIaJtLfbNGk9BXG+z3zCRPh9s=";

--- a/pkgs/applications/networking/cluster/rke2/testing/versions.nix
+++ b/pkgs/applications/networking/cluster/rke2/testing/versions.nix
@@ -11,4 +11,5 @@
   dockerizedVersion = "v1.31.4-rc3-rke2r1";
   golangVersion = "go1.22.9";
   eol = "2025-10-28";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }

--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -36,6 +36,29 @@ KUBERNETES_EOL=$(curl -sS --fail https://endoflife.date/api/kubernetes/${KUBERNE
 
 FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
+# Get sha256sums for amd64 and arm64
+SHA256_AMD64=$(curl -L "https://github.com/rancher/rke2/releases/download/v${RKE2_VERSION}/sha256sum-amd64.txt")
+SHA256_ARM64=$(curl -L "https://github.com/rancher/rke2/releases/download/v${RKE2_VERSION}/sha256sum-arm64.txt")
+# Merge both sha256sums in a single variable, one entry per line
+SHA256_HASHES="$SHA256_AMD64\n$SHA256_ARM64"
+# Get a list of images archives that are assets of this release, one entry (name and download_url) per line
+IMAGES_ARCHIVES=$(curl "https://api.github.com/repos/rancher/rke2/releases/tags/v${RKE2_VERSION}" | \
+    # Filter the assets by name, we discard .txt files and legacy archives (e.g. rke2-images.linux-arm64.tar.gz) on purpose
+    # It would be nice to also filter on "content_type", however, for now it's "application/octet-stream" for all assets
+    jq -r '.assets[] | select(.name | test("^rke2-images-.*\\.tar\\.")) | "\(.name) \(.browser_download_url)"')
+
+# Iterate over all lines of $IMAGES_ARCHIVES, pick the appropriate sha256, and create a JSON file
+# that can be used by builder.nix
+while read -r name url; do
+  sha256=$(grep "$name" <<< "$SHA256_HASHES" | cut -d ' ' -f 1)
+  # Remove the rke2 prefix and replace all dots in $name with hyphens
+  clean_name=$(sed -e "s/^rke2-//" -e "s/\./-/g" <<< "$name")
+  jq --null-input --arg name "$clean_name" \
+    --arg url "$url" \
+    --arg sha256 "$sha256" \
+    '{$name: {"url": $url, "sha256": $sha256}}'
+done <<<"${IMAGES_ARCHIVES}" | jq --slurp 'reduce .[] as $item ({}; . * $item)' > "${WORKDIR}/${CHANNEL_NAME}/images-versions.json"
+
 cat << EOF > "${WORKDIR}/${CHANNEL_NAME}/versions.nix"
 {
   rke2Version = "${RKE2_VERSION}";
@@ -50,6 +73,7 @@ cat << EOF > "${WORKDIR}/${CHANNEL_NAME}/versions.nix"
   dockerizedVersion = "${DOCKERIZED_VERSION}";
   golangVersion = "${VERSION_GOLANG}";
   eol = "${KUBERNETES_EOL}";
+  imagesVersions = with builtins; fromJSON (readFile ./images-versions.json);
 }
 EOF
 

--- a/pkgs/applications/networking/cluster/rke2/update-script.sh
+++ b/pkgs/applications/networking/cluster/rke2/update-script.sh
@@ -61,6 +61,7 @@ done <<<"${IMAGES_ARCHIVES}" | jq --slurp 'reduce .[] as $item ({}; . * $item)' 
 
 cat << EOF > "${WORKDIR}/${CHANNEL_NAME}/versions.nix"
 {
+  releaseName = "rke2_${CHANNEL_NAME}";
   rke2Version = "${RKE2_VERSION}";
   rke2Commit = "${RKE2_COMMIT}";
   rke2TarballHash = "${STORE_HASH}";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

The `rke2-images-...` archives, which are available as assets of rke2 releases, are now passthrued to the RKE2 derivation, similar to what is done in k3s. This allows to provision RKE2 nodes with the required container images already in place, e.g. for tests or air-gapped environments. Since RKE2 provides the sha256 hashes for every asset, this requires no pre-fetching.

Additionally, the image archives are used directly in the RKE2 nixos tests, since the container images cannot be downloaded in tests. I also fixed other things in the tests and changed them to not consume too much resources, RKE2 nodes require a lot of CPU during initialization.

Closes https://github.com/NixOS/nixpkgs/issues/330638

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@mogeko @zimbatm @stefan-bordei 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
