### PR TITLE
k3s: use available sha256sum instead of prefetching in update script

### DIFF
--- a/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_29/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.12%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "0p3d0k4ckzrbd3xd4v9vb8rhw9jcl4ilx9ch94yhf8kxnnblgzyb"
+    "sha256": "cbff4797b57d22073d4990a54e23a14c260e335a3b6dd2fa682bffc9c8046d5c"
   },
   "airgap-images-arm": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.12%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0j9ajjz201w319gfryx2q7jnmyi8gg805v7jsdmy4xkyl8ki80jw"
+    "sha256": "5c021427a27e76e26bd3f2ec02d07b28fa6ae5c1a2fbec5e0a830720be942a49"
   },
   "airgap-images-arm64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.12%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "1yc1yafr16mli1jk9xc4vgp6q36zk9z5p4rjmdng42dp0j6kvj0w"
+    "sha256": "1cc83d8d04b709f26cab32935b7e9adf0c6ceedb84f5346588b49a909df281f9"
   },
   "images-list": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.29.12%2Bk3s1/k3s-images.txt",
-    "sha256": "1gqiaszfw49hsbn7xkkadykaf028vys13ykqvpkqar0f7hwwbja6"
+    "sha256": "46c9c5393c0e6485e7dd78fa11b4df4800a7a66f6ace7eecd23011eebe5611bf"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_30/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.8%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "12vvc79jy1nyvcpsr2bi6w1zf28rqx99vh7anjm13snzsk7kzqc2"
+    "sha256": "82e13fcfd4dfea11aab4eac09d52c71909f703377189ac2fdbde062fd3617b8b"
   },
   "airgap-images-arm": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.8%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0mhn1ilh830m403yg1y3nqzjcakhs3i6hgdq2s8w2spyz2kdrgv1"
+    "sha256": "61bfdca6f8fe6ac19116b83d68e2d0702a263fb6c387e70720150c04690c1656"
   },
   "airgap-images-arm64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.8%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "0jdxf36dksypjvgil23wn8ins5rp0achmlavmv12vhijfllkqnn5"
+    "sha256": "c55a3c297532c22dc2ae5bd10a990237176d23b27c081adf96d7ebd9cc70bd49"
   },
   "images-list": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.30.8%2Bk3s1/k3s-images.txt",
-    "sha256": "1gqiaszfw49hsbn7xkkadykaf028vys13ykqvpkqar0f7hwwbja6"
+    "sha256": "46c9c5393c0e6485e7dd78fa11b4df4800a7a66f6ace7eecd23011eebe5611bf"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_31/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "1dykfk58sp4phf125jfrzx031pp1mj0g8q0kliis139sig14vagp"
+    "sha256": "f7a94dc28b3a8da063a41360f480ace1de3040ffd9c9228283975c8dca74d3b7"
   },
   "airgap-images-arm": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "0z4h9yd8843q58hhm8jw072k1ixxnmprp9c30pwb796iy1mpirbm"
+    "sha256": "75e5786bf0d1a4b3f80583a59b6fb5bdc730c5015ca20a212a7810849a4f907c"
   },
   "airgap-images-arm64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "0xsq095dkf89c6jjd126rrdl7k0zy7cxb38rimzpacb8zfj4ss82"
+    "sha256": "02694da4fb6831757f8d198dd5d9f11fcc435bce468426a56109b9d94a025877"
   },
   "images-list": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.31.4%2Bk3s1/k3s-images.txt",
-    "sha256": "1gqiaszfw49hsbn7xkkadykaf028vys13ykqvpkqar0f7hwwbja6"
+    "sha256": "46c9c5393c0e6485e7dd78fa11b4df4800a7a66f6ace7eecd23011eebe5611bf"
   }
 }

--- a/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
+++ b/pkgs/applications/networking/cluster/k3s/1_32/images-versions.json
@@ -1,18 +1,18 @@
 {
   "airgap-images-amd64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.1%2Bk3s1/k3s-airgap-images-amd64.tar.zst",
-    "sha256": "0sn4m1djj8npdx90mny7cwc843ri9q4s0w906rgabjw2v1h56qz0"
+    "sha256": "e0635360d882cba55e362071a0094e310f821867c7db0a526fd722295ba8c46a"
   },
   "airgap-images-arm": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.1%2Bk3s1/k3s-airgap-images-arm.tar.zst",
-    "sha256": "1mk8xjc4zj3a6jm53drwicqsipy58faxmq990s14lqvrhh3qjnh4"
+    "sha256": "045a89078479634a820629e1da9543c5dfa8318b3cb751aa346ac84f98ec68d6"
   },
   "airgap-images-arm64": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.1%2Bk3s1/k3s-airgap-images-arm64.tar.zst",
-    "sha256": "0s1h6lksn83r71ia61h9cjwiqigz9nw9n9jm92749782c8zi918x"
+    "sha256": "1d85143f62029d448e4855269bb84dff451cb9640906a362387920ab27353068"
   },
   "images-list": {
     "url": "https://github.com/k3s-io/k3s/releases/download/v1.32.1%2Bk3s1/k3s-images.txt",
-    "sha256": "08qxykq9aylfgm24g8ybki62r2sdzvnmv72pan4i2nn0js93nnk9"
+    "sha256": "695a3b9296c05a118955579c5dedfe4d8b2c4c9ccba347447d8e7a95f0f41d23"
   }
 }


### PR DESCRIPTION
K3s already provides sha256 hashes of all release assets. This uses those hashes, instead of prefetching airgap images archives during update. This saves around 450MB of download for each k3s release. I guess the hashes in the `images-versions.nix` files changed because of a different encoding, however, Nix works with both hashes equally.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

@NixOS/k3s 

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
