### PR TITLE
postgresql: fix build

### DIFF
--- a/pkgs/by-name/tz/tzdata/package.nix
+++ b/pkgs/by-name/tz/tzdata/package.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchurl,
   buildPackages,
+  postgresql,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -81,6 +82,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   setupHook = ./tzdata-setup-hook.sh;
+
+  # PostgreSQL is sensitive to tzdata updates, because the test-suite often breaks.
+  # Upstream provides patches very quickly, we just need to apply them until the next
+  # minor releases.
+  passthru.tests = postgresql;
 
   meta = with lib; {
     homepage = "http://www.iana.org/time-zones";

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -299,6 +299,11 @@ let
           ./patches/paths-for-split-outputs.patch
           ./patches/paths-with-postgresql-suffix.patch
 
+          (fetchpatch {
+            url = "https://github.com/postgres/postgres/commit/8108674f0e5639baebcf03b54b7ccf9e9a8662a2.patch";
+            hash = "sha256-EQJkDR0eb7QWCjyMzXMn+Vbcwx3MMdC83oN7XSVJP0U=";
+          })
+
           (substituteAll {
             src = ./patches/locale-binary-path.patch;
             locale = "${


### PR DESCRIPTION
PostgreSQL broke after the recent tzdata update to 2025a in #374725. The same happened on the last update as well (#342026).

Fix this by applying upstream's patch and add postgresql as passthru test for tzdata to prevent it in the future.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
