### PR TITLE
[24.11] cpupower: add `which` to nativeBuildInputs

### DIFF
--- a/pkgs/os-specific/linux/cpupower/default.nix
+++ b/pkgs/os-specific/linux/cpupower/default.nix
@@ -5,13 +5,17 @@
   kernel,
   pciutils,
   gettext,
+  which,
 }:
 
 stdenv.mkDerivation {
   pname = "cpupower";
   inherit (kernel) version src patches;
 
-  nativeBuildInputs = [ gettext ];
+  nativeBuildInputs = [
+    gettext
+    which
+  ];
   buildInputs = [ pciutils ];
 
   postPatch = ''


### PR DESCRIPTION
Manual backport of #362044.
