### PR TITLE
nixos/clamav: add ClamAV on-access scanner support

### DIFF
--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -223,11 +223,24 @@ in
       description = "ClamAV Antivirus Slice";
     };
 
+    systemd.sockets.clamav-daemon = lib.mkIf cfg.daemon.enable {
+      description = "Socket for ClamAV daemon (clamd)";
+      wantedBy = [ "sockets.target" ];
+      listenStreams = [
+        cfg.daemon.settings.LocalSocket
+      ];
+      socketConfig = {
+        SocketUser = clamavUser;
+        SocketGroup = clamavGroup;
+      };
+    };
+
     systemd.services.clamav-daemon = lib.mkIf cfg.daemon.enable {
       description = "ClamAV daemon (clamd)";
       documentation = [ "man:clamd(8)" ];
       after = lib.optionals cfg.updater.enable [ "clamav-freshclam.service" ];
       wants = lib.optionals cfg.updater.enable [ "clamav-freshclam.service" ];
+      requires = [ "clamav-daemon.socket" ];
       wantedBy = [ "multi-user.target" ];
       restartTriggers = [ clamdConfigFile ];
 

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -172,6 +172,13 @@ in
   };
 
   config = lib.mkIf (cfg.updater.enable || cfg.daemon.enable) {
+    assertions = [
+      {
+        assertion = cfg.scanner.enable -> cfg.daemon.enable;
+        message = "ClamAV scanner requires ClamAV daemon to operate";
+      }
+    ];
+
     environment.systemPackages = [ cfg.package ];
 
     users.users.${clamavUser} = {
@@ -189,7 +196,7 @@ in
       DatabaseDirectory = stateDir;
       LocalSocket = "/run/clamav/clamd.ctl";
       PidFile = "/run/clamav/clamd.pid";
-      User = "clamav";
+      User = clamavUser;
       Foreground = true;
     };
 

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -65,6 +65,34 @@ in
           '';
         };
       };
+
+      clamonacc = {
+        enable = lib.mkOption {
+          default = false;
+          example = true;
+          description = ''
+            Whether to enable ClamAV on-access scanner.
+
+            The settings for ClamAV's on-access scanner is configured in `clamd.conf` via `services.clamav.daemon.settings`.
+            Refer to <https://docs.clamav.net/manual/OnAccess.html> on how to configure it.
+
+            Example to scan `/home/foo/Downloads` (and block access until scanning is completed) would be:
+            ```
+            services.clamav = {
+              daemon.enable = true;
+              clamonacc.enable = true;
+
+              daemon.settings = {
+                OnAccessPrevention = true;
+                OnAccessIncludePath = "/home/foo/Downloads";
+              };
+            };
+            ```
+          '';
+          type = lib.types.bool;
+        };
+      };
+
       updater = {
         enable = lib.mkEnableOption "ClamAV freshclam updater";
 
@@ -177,6 +205,10 @@ in
         assertion = cfg.scanner.enable -> cfg.daemon.enable;
         message = "ClamAV scanner requires ClamAV daemon to operate";
       }
+      {
+        assertion = cfg.clamonacc.enable -> cfg.daemon.enable;
+        message = "ClamAV on-access scanner requires ClamAV daemon to operate";
+      }
     ];
 
     environment.systemPackages = [ cfg.package ];
@@ -198,6 +230,8 @@ in
       PidFile = "/run/clamav/clamd.pid";
       User = clamavUser;
       Foreground = true;
+      # Prevent infinite recursion in scanning
+      OnAccessExcludeUname = clamavUser;
     };
 
     services.clamav.updater.settings = {
@@ -254,6 +288,20 @@ in
         PrivateTmp = "yes";
         PrivateDevices = "yes";
         PrivateNetwork = "yes";
+        Slice = "system-clamav.slice";
+      };
+    };
+
+    systemd.services.clamav-clamonacc = lib.mkIf cfg.clamonacc.enable {
+      description = "ClamAV on-access scanner (clamonacc)";
+      after = [ "clamav-daemon.socket" ];
+      requires = [ "clamav-daemon.socket" ];
+      wantedBy = [ "multi-user.target" ];
+      restartTriggers = [ clamdConfigFile ];
+
+      # This unit must start as root to be able to use fanotify.
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/clamonacc -F --fdpass";
         Slice = "system-clamav.slice";
       };
     };

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -266,6 +266,8 @@ in
       socketConfig = {
         SocketUser = clamavUser;
         SocketGroup = clamavGroup;
+        # LocalSocketMode setting in clamd.conf is not prefixed with octal 0, add it here.
+        SocketMode = "0${cfg.daemon.settings.LocalSocketMode or "666"}";
       };
     };
 

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -345,6 +345,7 @@ in
   cinnamon = runTest ./cinnamon.nix;
   cinnamon-wayland = runTest ./cinnamon-wayland.nix;
   cjdns = runTest ./cjdns.nix;
+  clamav = runTest ./clamav.nix;
   clatd = runTest ./clatd.nix;
   clickhouse = import ./clickhouse {
     inherit runTest;

--- a/nixos/tests/clamav.nix
+++ b/nixos/tests/clamav.nix
@@ -1,0 +1,45 @@
+# Test ClamAV.
+
+{ lib, pkgs, ... }:
+{
+  name = "clamav";
+  nodes = {
+    machine = {
+      services.clamav = {
+        daemon.enable = true;
+        clamonacc.enable = true;
+
+        daemon.settings = {
+          OnAccessPrevention = true;
+          OnAccessIncludePath = "/opt";
+        };
+      };
+
+      # Add the definition for our test file.
+      # We cannot download definitions from Internet using freshclam in sandboxed test.
+      systemd.tmpfiles.settings."10-eicar"."/var/lib/clamav/test.hdb".L.argument = "${pkgs.runCommand
+        "test.hdb"
+        { }
+        ''
+          echo CLAMAVTEST > testfile
+          ${lib.getExe' pkgs.clamav "sigtool"} --sha256 testfile > $out
+        ''
+      }";
+
+      # Test using /opt as the ClamAV on-access scanner-protected directory.
+      systemd.tmpfiles.settings."10-testdir"."/opt".d = { };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    machine.wait_for_unit("default.target")
+
+    # Write test file into the test directory.
+    # This won't trigger ClamAV as it scans on file open.
+    machine.succeed("echo CLAMAVTEST > /opt/testfile")
+
+    machine.fail("cat /opt/testfile")
+  '';
+}


### PR DESCRIPTION
Please review by commits.

This adds the `services.clamav.clamonacc.enable` option to enable the ClamAV on-access scanner (clamonacc). There's no separate configuration options as the options are in `clamd.conf` (so configured through `services.clamav.daemon.settings`).

Example:
```nix
services.clamav = {
  daemon.enable = true;
  updater.enable = true;
  clamonacc.enable = true;

  daemon.settings = {
      OnAccessPrevention = true;
      OnAccessIncludePath = "/home/gary/Downloads";
  };
};
```

Fix #350437

## Things done

I tested this by enabling the above example config and then download a EICAR test file, and then trying to access it. I got a `Operation not permitted` and and both clamd and clamonacc services loged to journal with `Win.Test.EICAR_HDB-1 FOUND`.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
