### PR TITLE
slacky: init at 0.0.5

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -2397,6 +2397,12 @@
     githubId = 206242;
     name = "Andreas Wiese";
   };
+  awwpotato = {
+    email = "awwpotato@voidq.com";
+    github = "awwpotato";
+    githubId = 153149335;
+    name = "awwpotato";
+  };
   axertheaxe = {
     email = "axertheaxe@proton.me";
     github = "AxerTheAxe";

--- a/pkgs/by-name/sl/slacky/package.nix
+++ b/pkgs/by-name/sl/slacky/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  electron,
+  copyDesktopItems,
+  makeDesktopItem,
+  nix-update-script,
+}:
+buildNpmPackage rec {
+  pname = "slacky";
+  version = "0.0.5";
+
+  src = fetchFromGitHub {
+    owner = "andirsun";
+    repo = "Slacky";
+    tag = "v${version}";
+    hash = "sha256-nDxmzZqi7xEe4hnY6iXJg+613lSKElWxvF3w8bRDW90=";
+  };
+
+  npmDepsHash = "sha256-9+4cxeQw2Elug+xIgzNvpaSMgDVlBFz/+TW1jJwDm40=";
+
+  npmPackFlags = [ "--ignore-scripts" ];
+
+  nativeBuildInputs = [
+    electron
+    copyDesktopItems
+  ];
+
+  env.ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
+
+  postInstall = ''
+    mkdir -p $out/share/icons
+    ln -s $out/lib/node_modules/slacky/build/icons/icon.png $out/share/icons/slacky.png
+    makeWrapper ${electron}/bin/electron $out/bin/slacky \
+      --add-flags $out/lib/node_modules/slacky/
+  '';
+
+  desktopItems = lib.singleton (makeDesktopItem {
+    name = "slacky";
+    exec = "slacky %u";
+    icon = "slacky";
+    desktopName = "Slacky";
+    comment = "An unofficial Slack desktop client for arm64 Linux";
+    startupWMClass = "com.andersonlaverde.slacky";
+    type = "Application";
+    categories = [
+      "Network"
+      "InstantMessaging"
+    ];
+    mimeTypes = [
+      "x-scheme-handler/slack"
+    ];
+  });
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Unofficial Slack desktop client for arm64 Linux";
+    homepage = "https://github.com/andirsun/Slacky";
+    changelog = "https://github.com/andirsun/Slacky/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ awwpotato ];
+    platforms = [ "aarch64-linux" ];
+    mainProgram = "slacky";
+  };
+}


### PR DESCRIPTION
unofficial Slack desktop client for arm64 Linux distributions https://github.com/andirsun/Slacky
resolves #375621

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
