### PR TITLE
vikunja: fix frontend build after nodejs update to 22.12

### DIFF
--- a/pkgs/by-name/vi/vikunja/nodejs-22.12-tailwindcss-update.patch
+++ b/pkgs/by-name/vi/vikunja/nodejs-22.12-tailwindcss-update.patch
@@ -1,0 +1,3060 @@
+From 09e77d8c4e58d0e61a8d0b820ce2ad8db705f27f Mon Sep 17 00:00:00 2001
+From: Leona Maroni <dev@leona.is>
+Date: Tue, 21 Jan 2025 23:29:01 +0100
+Subject: [PATCH] update(frontend): tailwindcss 3.4.13 -> 3.4.17
+
+In 3.4.17 a workaround for a change in NodeJS 22.12.0 was implemented.
+This version enables `require(esm)` by default.
+
+generated with `pnpm up tailwindcss@3.4.17`
+---
+ package.json   |    2 +-
+ pnpm-lock.yaml | 1511 +++++++++++++++++++++++++++++++++++++--
+ 2 files changed, 1456 insertions(+), 57 deletions(-)
+
+diff --git a/package.json b/package.json
+index 1caa9145a..9fab2e98e 100644
+--- a/package.json
++++ b/package.json
+@@ -113,7 +113,7 @@
+     "pinia": "2.2.2",
+     "register-service-worker": "1.7.2",
+     "sortablejs": "1.15.3",
+-    "tailwindcss": "3.4.13",
++    "tailwindcss": "3.4.17",
+     "tippy.js": "6.3.7",
+     "ufo": "1.5.4",
+     "vue": "3.5.10",
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index e66f9117f..5bfbd4a98 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -206,8 +206,8 @@ importers:
+         specifier: 1.15.3
+         version: 1.15.3
+       tailwindcss:
+-        specifier: 3.4.13
+-        version: 3.4.13
++        specifier: 3.4.17
++        version: 3.4.17
+       tippy.js:
+         specifier: 6.3.7
+         version: 6.3.7
+@@ -419,22 +419,42 @@ packages:
+     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/code-frame@7.26.2':
++    resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/compat-data@7.25.4':
+     resolution: {integrity: sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/compat-data@7.26.5':
++    resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/core@7.25.2':
+     resolution: {integrity: sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/core@7.26.0':
++    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/generator@7.25.5':
+     resolution: {integrity: sha512-abd43wyLfbWoxC6ahM8xTkqLpGB2iWBVyuKC9/srhFunCd1SDNrV1s72bBpK4hLj8KLzHBBcOblvLQZBNw9r3w==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/generator@7.26.5':
++    resolution: {integrity: sha512-2caSP6fN9I7HOe6nqhtft7V4g7/V/gfDsC3Ag4W7kEzzvRGKqiv0pu0HogPiZ3KaVSoNDhUws6IJjDjpfmYIXw==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-annotate-as-pure@7.24.7':
+     resolution: {integrity: sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-annotate-as-pure@7.25.9':
++    resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
+     resolution: {integrity: sha512-xZeCVVdwb4MsDBkkyZ64tReWYrLRHlMN72vP7Bdm3OUOuyFZExhsHUUnuWnm2/XOlAJzR0LfPpB56WXZn0X/lA==}
+     engines: {node: '>=6.9.0'}
+@@ -443,57 +463,112 @@ packages:
+     resolution: {integrity: sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-compilation-targets@7.26.5':
++    resolution: {integrity: sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-create-class-features-plugin@7.25.4':
+     resolution: {integrity: sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/helper-create-class-features-plugin@7.25.9':
++    resolution: {integrity: sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/helper-create-regexp-features-plugin@7.25.2':
+     resolution: {integrity: sha512-+wqVGP+DFmqwFD3EH6TMTfUNeqDehV3E/dl+Sd54eaXqm17tEUNbEIn4sVivVowbvUpOtIGxdo3GoXyDH9N/9g==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/helper-create-regexp-features-plugin@7.26.3':
++    resolution: {integrity: sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/helper-define-polyfill-provider@0.6.2':
+     resolution: {integrity: sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==}
+     peerDependencies:
+       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+ 
++  '@babel/helper-define-polyfill-provider@0.6.3':
++    resolution: {integrity: sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==}
++    peerDependencies:
++      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
++
+   '@babel/helper-member-expression-to-functions@7.24.8':
+     resolution: {integrity: sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-member-expression-to-functions@7.25.9':
++    resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-module-imports@7.24.7':
+     resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-module-imports@7.25.9':
++    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-module-transforms@7.25.2':
+     resolution: {integrity: sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/helper-module-transforms@7.26.0':
++    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/helper-optimise-call-expression@7.24.7':
+     resolution: {integrity: sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-optimise-call-expression@7.25.9':
++    resolution: {integrity: sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-plugin-utils@7.24.8':
+     resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-plugin-utils@7.26.5':
++    resolution: {integrity: sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-remap-async-to-generator@7.25.0':
+     resolution: {integrity: sha512-NhavI2eWEIz/H9dbrG0TuOicDhNexze43i5z7lEqwYm0WEZVTwnPpA0EafUTP7+6/W79HWIP2cTe3Z5NiSTVpw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/helper-remap-async-to-generator@7.25.9':
++    resolution: {integrity: sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/helper-replace-supers@7.25.0':
+     resolution: {integrity: sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/helper-replace-supers@7.26.5':
++    resolution: {integrity: sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/helper-simple-access@7.24.7':
+     resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
+     engines: {node: '>=6.9.0'}
+@@ -502,26 +577,50 @@ packages:
+     resolution: {integrity: sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
++    resolution: {integrity: sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-string-parser@7.24.8':
+     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-string-parser@7.25.9':
++    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-validator-identifier@7.24.7':
+     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-validator-identifier@7.25.9':
++    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-validator-option@7.24.8':
+     resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-validator-option@7.25.9':
++    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helper-wrap-function@7.25.0':
+     resolution: {integrity: sha512-s6Q1ebqutSiZnEjaofc/UKDyC4SbzV5n5SrA2Gq8UawLycr3i04f1dX4OzoQVnexm6aOCh37SQNYlJ/8Ku+PMQ==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helper-wrap-function@7.25.9':
++    resolution: {integrity: sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/helpers@7.25.0':
+     resolution: {integrity: sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/helpers@7.26.0':
++    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/highlight@7.24.7':
+     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
+     engines: {node: '>=6.9.0'}
+@@ -531,36 +630,71 @@ packages:
+     engines: {node: '>=6.0.0'}
+     hasBin: true
+ 
++  '@babel/parser@7.26.5':
++    resolution: {integrity: sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==}
++    engines: {node: '>=6.0.0'}
++    hasBin: true
++
+   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.3':
+     resolution: {integrity: sha512-wUrcsxZg6rqBXG05HG1FPYgsP6EvwF4WpBbxIpWIIYnH8wG0gzx3yZY3dtEHas4sTAOGkbTsc9EGPxwff8lRoA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9':
++    resolution: {integrity: sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.0':
+     resolution: {integrity: sha512-Bm4bH2qsX880b/3ziJ8KD711LT7z4u8CFudmjqle65AZj/HNUFhEf90dqYv6O86buWvSBmeQDjv0Tn2aF/bIBA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9':
++    resolution: {integrity: sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0':
+     resolution: {integrity: sha512-lXwdNZtTmeVOOFtwM/WDe7yg1PL8sYhRk/XH0FzbR2HDQ0xC+EnQ/JHeoMYSavtU115tnUk0q9CDyq8si+LMAA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.9':
++    resolution: {integrity: sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7':
+     resolution: {integrity: sha512-+izXIbke1T33mY4MSNnrqhPXDz01WYhEf3yF5NbnUtkiNnm+XBZJl3kNfoK6NKmYlz/D07+l2GWVK/QfDkNCuQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.13.0
+ 
++  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.9':
++    resolution: {integrity: sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.13.0
++
+   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.0':
+     resolution: {integrity: sha512-tggFrk1AIShG/RUQbEwt2Tr/E+ObkfwrPjR6BjbRvsx24+PSjK8zrq0GWPNCjo8qpRx4DuJzlcvWJqlm+0h3kw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.9':
++    resolution: {integrity: sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2':
+     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
+     engines: {node: '>=6.9.0'}
+@@ -599,12 +733,24 @@ packages:
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-syntax-import-assertions@7.26.0':
++    resolution: {integrity: sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-syntax-import-attributes@7.24.7':
+     resolution: {integrity: sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-syntax-import-attributes@7.26.0':
++    resolution: {integrity: sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-syntax-import-meta@7.10.4':
+     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+     peerDependencies:
+@@ -669,300 +815,606 @@ packages:
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-arrow-functions@7.25.9':
++    resolution: {integrity: sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-async-generator-functions@7.25.4':
+     resolution: {integrity: sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-async-generator-functions@7.25.9':
++    resolution: {integrity: sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-async-to-generator@7.24.7':
+     resolution: {integrity: sha512-SQY01PcJfmQ+4Ash7NE+rpbLFbmqA2GPIgqzxfFTL4t1FKRq4zTms/7htKpoCUI9OcFYgzqfmCdH53s6/jn5fA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-async-to-generator@7.25.9':
++    resolution: {integrity: sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-block-scoped-functions@7.24.7':
+     resolution: {integrity: sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-block-scoped-functions@7.26.5':
++    resolution: {integrity: sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-block-scoping@7.25.0':
+     resolution: {integrity: sha512-yBQjYoOjXlFv9nlXb3f1casSHOZkWr29NX+zChVanLg5Nc157CrbEX9D7hxxtTpuFy7Q0YzmmWfJxzvps4kXrQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-block-scoping@7.25.9':
++    resolution: {integrity: sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-class-properties@7.25.4':
+     resolution: {integrity: sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-class-properties@7.25.9':
++    resolution: {integrity: sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-class-static-block@7.24.7':
+     resolution: {integrity: sha512-HMXK3WbBPpZQufbMG4B46A90PkuuhN9vBCb5T8+VAHqvAqvcLi+2cKoukcpmUYkszLhScU3l1iudhrks3DggRQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.12.0
+ 
++  '@babel/plugin-transform-class-static-block@7.26.0':
++    resolution: {integrity: sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.12.0
++
+   '@babel/plugin-transform-classes@7.25.4':
+     resolution: {integrity: sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-classes@7.25.9':
++    resolution: {integrity: sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-computed-properties@7.24.7':
+     resolution: {integrity: sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-computed-properties@7.25.9':
++    resolution: {integrity: sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-destructuring@7.24.8':
+     resolution: {integrity: sha512-36e87mfY8TnRxc7yc6M9g9gOB7rKgSahqkIKwLpz4Ppk2+zC2Cy1is0uwtuSG6AE4zlTOUa+7JGz9jCJGLqQFQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-destructuring@7.25.9':
++    resolution: {integrity: sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-dotall-regex@7.24.7':
+     resolution: {integrity: sha512-ZOA3W+1RRTSWvyqcMJDLqbchh7U4NRGqwRfFSVbOLS/ePIP4vHB5e8T8eXcuqyN1QkgKyj5wuW0lcS85v4CrSw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-dotall-regex@7.25.9':
++    resolution: {integrity: sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-duplicate-keys@7.24.7':
+     resolution: {integrity: sha512-JdYfXyCRihAe46jUIliuL2/s0x0wObgwwiGxw/UbgJBr20gQBThrokO4nYKgWkD7uBaqM7+9x5TU7NkExZJyzw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-duplicate-keys@7.25.9':
++    resolution: {integrity: sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.0':
+     resolution: {integrity: sha512-YLpb4LlYSc3sCUa35un84poXoraOiQucUTTu8X1j18JV+gNa8E0nyUf/CjZ171IRGr4jEguF+vzJU66QZhn29g==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.9':
++    resolution: {integrity: sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/plugin-transform-dynamic-import@7.24.7':
+     resolution: {integrity: sha512-sc3X26PhZQDb3JhORmakcbvkeInvxz+A8oda99lj7J60QRuPZvNAk9wQlTBS1ZynelDrDmTU4pw1tyc5d5ZMUg==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-dynamic-import@7.25.9':
++    resolution: {integrity: sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-exponentiation-operator@7.24.7':
+     resolution: {integrity: sha512-Rqe/vSc9OYgDajNIK35u7ot+KeCoetqQYFXM4Epf7M7ez3lWlOjrDjrwMei6caCVhfdw+mIKD4cgdGNy5JQotQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-exponentiation-operator@7.26.3':
++    resolution: {integrity: sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-export-namespace-from@7.24.7':
+     resolution: {integrity: sha512-v0K9uNYsPL3oXZ/7F9NNIbAj2jv1whUEtyA6aujhekLs56R++JDQuzRcP2/z4WX5Vg/c5lE9uWZA0/iUoFhLTA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-export-namespace-from@7.25.9':
++    resolution: {integrity: sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-for-of@7.24.7':
+     resolution: {integrity: sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-for-of@7.25.9':
++    resolution: {integrity: sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-function-name@7.25.1':
+     resolution: {integrity: sha512-TVVJVdW9RKMNgJJlLtHsKDTydjZAbwIsn6ySBPQaEAUU5+gVvlJt/9nRmqVbsV/IBanRjzWoaAQKLoamWVOUuA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-function-name@7.25.9':
++    resolution: {integrity: sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-json-strings@7.24.7':
+     resolution: {integrity: sha512-2yFnBGDvRuxAaE/f0vfBKvtnvvqU8tGpMHqMNpTN2oWMKIR3NqFkjaAgGwawhqK/pIN2T3XdjGPdaG0vDhOBGw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-json-strings@7.25.9':
++    resolution: {integrity: sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-literals@7.25.2':
+     resolution: {integrity: sha512-HQI+HcTbm9ur3Z2DkO+jgESMAMcYLuN/A7NRw9juzxAezN9AvqvUTnpKP/9kkYANz6u7dFlAyOu44ejuGySlfw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-literals@7.25.9':
++    resolution: {integrity: sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-logical-assignment-operators@7.24.7':
+     resolution: {integrity: sha512-4D2tpwlQ1odXmTEIFWy9ELJcZHqrStlzK/dAOWYyxX3zT0iXQB6banjgeOJQXzEc4S0E0a5A+hahxPaEFYftsw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-logical-assignment-operators@7.25.9':
++    resolution: {integrity: sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-member-expression-literals@7.24.7':
+     resolution: {integrity: sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-member-expression-literals@7.25.9':
++    resolution: {integrity: sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-modules-amd@7.24.7':
+     resolution: {integrity: sha512-9+pB1qxV3vs/8Hdmz/CulFB8w2tuu6EB94JZFsjdqxQokwGa9Unap7Bo2gGBGIvPmDIVvQrom7r5m/TCDMURhg==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-modules-amd@7.25.9':
++    resolution: {integrity: sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-modules-commonjs@7.24.8':
+     resolution: {integrity: sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-modules-commonjs@7.26.3':
++    resolution: {integrity: sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-modules-systemjs@7.25.0':
+     resolution: {integrity: sha512-YPJfjQPDXxyQWg/0+jHKj1llnY5f/R6a0p/vP4lPymxLu7Lvl4k2WMitqi08yxwQcCVUUdG9LCUj4TNEgAp3Jw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-modules-systemjs@7.25.9':
++    resolution: {integrity: sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-modules-umd@7.24.7':
+     resolution: {integrity: sha512-3aytQvqJ/h9z4g8AsKPLvD4Zqi2qT+L3j7XoFFu1XBlZWEl2/1kWnhmAbxpLgPrHSY0M6UA02jyTiwUVtiKR6A==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-modules-umd@7.25.9':
++    resolution: {integrity: sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-named-capturing-groups-regex@7.24.7':
+     resolution: {integrity: sha512-/jr7h/EWeJtk1U/uz2jlsCioHkZk1JJZVcc8oQsJ1dUlaJD83f4/6Zeh2aHt9BIFokHIsSeDfhUmju0+1GPd6g==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/plugin-transform-named-capturing-groups-regex@7.25.9':
++    resolution: {integrity: sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/plugin-transform-new-target@7.24.7':
+     resolution: {integrity: sha512-RNKwfRIXg4Ls/8mMTza5oPF5RkOW8Wy/WgMAp1/F1yZ8mMbtwXW+HDoJiOsagWrAhI5f57Vncrmr9XeT4CVapA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-new-target@7.25.9':
++    resolution: {integrity: sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-nullish-coalescing-operator@7.24.7':
+     resolution: {integrity: sha512-Ts7xQVk1OEocqzm8rHMXHlxvsfZ0cEF2yomUqpKENHWMF4zKk175Y4q8H5knJes6PgYad50uuRmt3UJuhBw8pQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-nullish-coalescing-operator@7.26.6':
++    resolution: {integrity: sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-numeric-separator@7.24.7':
+     resolution: {integrity: sha512-e6q1TiVUzvH9KRvicuxdBTUj4AdKSRwzIyFFnfnezpCfP2/7Qmbb8qbU2j7GODbl4JMkblitCQjKYUaX/qkkwA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-numeric-separator@7.25.9':
++    resolution: {integrity: sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-object-rest-spread@7.24.7':
+     resolution: {integrity: sha512-4QrHAr0aXQCEFni2q4DqKLD31n2DL+RxcwnNjDFkSG0eNQ/xCavnRkfCUjsyqGC2OviNJvZOF/mQqZBw7i2C5Q==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-object-rest-spread@7.25.9':
++    resolution: {integrity: sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-object-super@7.24.7':
+     resolution: {integrity: sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-object-super@7.25.9':
++    resolution: {integrity: sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-optional-catch-binding@7.24.7':
+     resolution: {integrity: sha512-uLEndKqP5BfBbC/5jTwPxLh9kqPWWgzN/f8w6UwAIirAEqiIVJWWY312X72Eub09g5KF9+Zn7+hT7sDxmhRuKA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-optional-catch-binding@7.25.9':
++    resolution: {integrity: sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-optional-chaining@7.24.8':
+     resolution: {integrity: sha512-5cTOLSMs9eypEy8JUVvIKOu6NgvbJMnpG62VpIHrTmROdQ+L5mDAaI40g25k5vXti55JWNX5jCkq3HZxXBQANw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-optional-chaining@7.25.9':
++    resolution: {integrity: sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-parameters@7.24.7':
+     resolution: {integrity: sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-parameters@7.25.9':
++    resolution: {integrity: sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-private-methods@7.25.4':
+     resolution: {integrity: sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-private-methods@7.25.9':
++    resolution: {integrity: sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-private-property-in-object@7.24.7':
+     resolution: {integrity: sha512-9z76mxwnwFxMyxZWEgdgECQglF2Q7cFLm0kMf8pGwt+GSJsY0cONKj/UuO4bOH0w/uAel3ekS4ra5CEAyJRmDA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-private-property-in-object@7.25.9':
++    resolution: {integrity: sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-property-literals@7.24.7':
+     resolution: {integrity: sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-property-literals@7.25.9':
++    resolution: {integrity: sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-regenerator@7.24.7':
+     resolution: {integrity: sha512-lq3fvXPdimDrlg6LWBoqj+r/DEWgONuwjuOuQCSYgRroXDH/IdM1C0IZf59fL5cHLpjEH/O6opIRBbqv7ELnuA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-regenerator@7.25.9':
++    resolution: {integrity: sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
++  '@babel/plugin-transform-regexp-modifiers@7.26.0':
++    resolution: {integrity: sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/plugin-transform-reserved-words@7.24.7':
+     resolution: {integrity: sha512-0DUq0pHcPKbjFZCfTss/pGkYMfy3vFWydkUBd9r0GHpIyfs2eCDENvqadMycRS9wZCXR41wucAfJHJmwA0UmoQ==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-reserved-words@7.25.9':
++    resolution: {integrity: sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-shorthand-properties@7.24.7':
+     resolution: {integrity: sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-shorthand-properties@7.25.9':
++    resolution: {integrity: sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-spread@7.24.7':
+     resolution: {integrity: sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-spread@7.25.9':
++    resolution: {integrity: sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-sticky-regex@7.24.7':
+     resolution: {integrity: sha512-kHPSIJc9v24zEml5geKg9Mjx5ULpfncj0wRpYtxbvKyTtHCYDkVE3aHQ03FrpEo4gEe2vrJJS1Y9CJTaThA52g==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-sticky-regex@7.25.9':
++    resolution: {integrity: sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-template-literals@7.24.7':
+     resolution: {integrity: sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-template-literals@7.25.9':
++    resolution: {integrity: sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-typeof-symbol@7.24.8':
+     resolution: {integrity: sha512-adNTUpDCVnmAE58VEqKlAA6ZBlNkMnWD0ZcW76lyNFN3MJniyGFZfNwERVk8Ap56MCnXztmDr19T4mPTztcuaw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-typeof-symbol@7.25.9':
++    resolution: {integrity: sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-unicode-escapes@7.24.7':
+     resolution: {integrity: sha512-U3ap1gm5+4edc2Q/P+9VrBNhGkfnf+8ZqppY71Bo/pzZmXhhLdqgaUl6cuB07O1+AQJtCLfaOmswiNbSQ9ivhw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-unicode-escapes@7.25.9':
++    resolution: {integrity: sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-unicode-property-regex@7.24.7':
+     resolution: {integrity: sha512-uH2O4OV5M9FZYQrwc7NdVmMxQJOCCzFeYudlZSzUAHRFeOujQefa92E74TQDVskNHCzOXoigEuoyzHDhaEaK5w==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-unicode-property-regex@7.25.9':
++    resolution: {integrity: sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-unicode-regex@7.24.7':
+     resolution: {integrity: sha512-hlQ96MBZSAXUq7ltkjtu3FJCCSMx/j629ns3hA3pXnBXjanNP0LHi+JpPeA81zaWgVK1VGH95Xuy7u0RyQ8kMg==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/plugin-transform-unicode-regex@7.25.9':
++    resolution: {integrity: sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/plugin-transform-unicode-sets-regex@7.25.4':
+     resolution: {integrity: sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0
+ 
++  '@babel/plugin-transform-unicode-sets-regex@7.25.9':
++    resolution: {integrity: sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0
++
+   '@babel/preset-env@7.25.4':
+     resolution: {integrity: sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==}
+     engines: {node: '>=6.9.0'}
+     peerDependencies:
+       '@babel/core': ^7.0.0-0
+ 
++  '@babel/preset-env@7.26.0':
++    resolution: {integrity: sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==}
++    engines: {node: '>=6.9.0'}
++    peerDependencies:
++      '@babel/core': ^7.0.0-0
++
+   '@babel/preset-modules@0.1.6-no-external-plugins':
+     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
+     peerDependencies:
+@@ -975,18 +1427,34 @@ packages:
+     resolution: {integrity: sha512-DSgLeL/FNcpXuzav5wfYvHCGvynXkJbn3Zvc3823AEe9nPwW9IK4UoCSS5yGymmQzN0pCPvivtgS6/8U2kkm1w==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/runtime@7.26.0':
++    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/template@7.25.0':
+     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/template@7.25.9':
++    resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/traverse@7.25.4':
+     resolution: {integrity: sha512-VJ4XsrD+nOvlXyLzmLzUs/0qjFS4sK30te5yEFlvbbUNEgKaVb2BHZUpAL+ttLPQAHNrsI3zZisbfha5Cvr8vg==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/traverse@7.26.5':
++    resolution: {integrity: sha512-rkOSPOw+AXbgtwUga3U4u8RpoK9FEFWBNAlTpcnkLFjL5CT+oyHNuUUC/xx6XefEJ16r38r8Bc/lfp6rYuHeJQ==}
++    engines: {node: '>=6.9.0'}
++
+   '@babel/types@7.25.4':
+     resolution: {integrity: sha512-zQ1ijeeCXVEh+aNL0RlmkPkG8HUiDcU2pzQQFjtbntgAczRASFzj4H+6+bV+dy1ntKR14I/DypeuRG1uma98iQ==}
+     engines: {node: '>=6.9.0'}
+ 
++  '@babel/types@7.26.5':
++    resolution: {integrity: sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==}
++    engines: {node: '>=6.9.0'}
++
+   '@cliqz/adblocker-content@1.33.0':
+     resolution: {integrity: sha512-p8nYftY77VQNZ4JVvWbK/JWKWR0zeMWovt2FUgyb+ffqtlTtnUPwYF1PMEfG3invaq7dgDAeW5qAjEOxfm23Sg==}
+ 
+@@ -1691,22 +2159,22 @@ packages:
+     resolution: {integrity: sha512-ysJnTGDtuXPa6R2Ii4JIvfMVvDahUUny3aY8+P4r6/0TYHkblgzIMjV6cAn60em67AB0M7OWNAdcAVfWWeN8Qg==}
+     engines: {node: '>= 16'}
+ 
+-  '@intlify/message-compiler@10.0.0':
+-    resolution: {integrity: sha512-OcaWc63NC/9p1cMdgoNKBj4d61BH8sUW1Hfs6YijTd9656ZR4rNqXAlRnBrfS5ABq0vjQjpa8VnyvH9hK49yBw==}
+-    engines: {node: '>= 16'}
+-
+   '@intlify/message-compiler@10.0.3':
+     resolution: {integrity: sha512-KC2fG8nCzSYmXjHptEt6i/xM3k6S2szsPaHDCRgWKEYAbeHe6JFm6X4KRw3Csy112A8CxpavMi1dh3h7khwV5w==}
+     engines: {node: '>= 16'}
+ 
+-  '@intlify/shared@10.0.0':
+-    resolution: {integrity: sha512-6ngLfI7DOTew2dcF9WMJx+NnMWghMBhIiHbGg+wRvngpzD5KZJZiJVuzMsUQE1a5YebEmtpTEfUrDp/NqVGdiw==}
++  '@intlify/message-compiler@11.0.0-rc.1':
++    resolution: {integrity: sha512-TGw2uBfuTFTegZf/BHtUQBEKxl7Q/dVGLoqRIdw8lFsp9g/53sYn5iD+0HxIzdYjbWL6BTJMXCPUHp9PxDTRPw==}
+     engines: {node: '>= 16'}
+ 
+   '@intlify/shared@10.0.3':
+     resolution: {integrity: sha512-PWxrCb6fDlnoGLnXLlWu6d7o/HdWACB9TjRnpLro+9uyfqgWA9hvqg5vekcPRyraTieV5srCbTk/ldYw9V3LHw==}
+     engines: {node: '>= 16'}
+ 
++  '@intlify/shared@11.0.0-rc.1':
++    resolution: {integrity: sha512-8tR1xe7ZEbkabTuE/tNhzpolygUn9OaYp9yuYAF4MgDNZg06C3Qny80bes2/e9/Wm3aVkPUlCw6WgU7mQd0yEg==}
++    engines: {node: '>= 16'}
++
+   '@intlify/unplugin-vue-i18n@5.2.0':
+     resolution: {integrity: sha512-pmRiPY2Nj9mmSrixT69aO45XxGUr5fDBy/IIw4ajLlDTJm5TSmQKA5YNdsH0uxVDCPWy5tlQrF18hkDwI7UJvg==}
+     engines: {node: '>= 18'}
+@@ -1750,6 +2218,10 @@ packages:
+     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
+     engines: {node: '>=6.0.0'}
+ 
++  '@jridgewell/gen-mapping@0.3.8':
++    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
++    engines: {node: '>=6.0.0'}
++
+   '@jridgewell/resolve-uri@3.1.2':
+     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+     engines: {node: '>=6.0.0'}
+@@ -1850,6 +2322,15 @@ packages:
+       rollup:
+         optional: true
+ 
++  '@rollup/plugin-node-resolve@15.3.1':
++    resolution: {integrity: sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==}
++    engines: {node: '>=14.0.0'}
++    peerDependencies:
++      rollup: ^2.78.0||^3.0.0||^4.0.0
++    peerDependenciesMeta:
++      rollup:
++        optional: true
++
+   '@rollup/plugin-replace@2.4.2':
+     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
+     peerDependencies:
+@@ -1879,6 +2360,15 @@ packages:
+       rollup:
+         optional: true
+ 
++  '@rollup/pluginutils@5.1.4':
++    resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
++    engines: {node: '>=14.0.0'}
++    peerDependencies:
++      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
++    peerDependenciesMeta:
++      rollup:
++        optional: true
++
+   '@rollup/rollup-android-arm-eabi@4.22.5':
+     resolution: {integrity: sha512-SU5cvamg0Eyu/F+kLeMXS7GoahL+OoizlclVFX3l5Ql6yNlywJJ0OuqTzUx0v+aHhPHEB/56CT06GQrRrGNYww==}
+     cpu: [arm]
+@@ -2750,6 +3240,11 @@ packages:
+     peerDependencies:
+       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+ 
++  babel-plugin-polyfill-corejs2@0.4.12:
++    resolution: {integrity: sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==}
++    peerDependencies:
++      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
++
+   babel-plugin-polyfill-corejs3@0.10.6:
+     resolution: {integrity: sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==}
+     peerDependencies:
+@@ -2760,6 +3255,11 @@ packages:
+     peerDependencies:
+       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+ 
++  babel-plugin-polyfill-regenerator@0.6.3:
++    resolution: {integrity: sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==}
++    peerDependencies:
++      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
++
+   balanced-match@1.0.2:
+     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+ 
+@@ -2817,6 +3317,11 @@ packages:
+     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+     hasBin: true
+ 
++  browserslist@4.24.4:
++    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
++    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
++    hasBin: true
++
+   buffer-crc32@0.2.13:
+     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+ 
+@@ -2872,6 +3377,9 @@ packages:
+   caniuse-lite@1.0.30001664:
+     resolution: {integrity: sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==}
+ 
++  caniuse-lite@1.0.30001695:
++    resolution: {integrity: sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==}
++
+   capital-case@1.0.4:
+     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
+ 
+@@ -3049,6 +3557,9 @@ packages:
+   core-js-compat@3.38.1:
+     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+ 
++  core-js-compat@3.40.0:
++    resolution: {integrity: sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==}
++
+   core-js@3.38.1:
+     resolution: {integrity: sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==}
+ 
+@@ -3214,6 +3725,15 @@ packages:
+       supports-color:
+         optional: true
+ 
++  debug@4.4.0:
++    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
++    engines: {node: '>=6.0'}
++    peerDependencies:
++      supports-color: '*'
++    peerDependenciesMeta:
++      supports-color:
++        optional: true
++
+   decamelize-keys@1.1.1:
+     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
+     engines: {node: '>=0.10.0'}
+@@ -3365,6 +3885,9 @@ packages:
+   electron-to-chromium@1.5.28:
+     resolution: {integrity: sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw==}
+ 
++  electron-to-chromium@1.5.84:
++    resolution: {integrity: sha512-I+DQ8xgafao9Ha6y0qjHHvpZ9OfyA1qKlkHkjywxzniORU2awxyz7f/iVJcULmrF2yrM3nHQf+iDjJtbbexd/g==}
++
+   emoji-picker-element@1.22.7:
+     resolution: {integrity: sha512-lX0a8f8yeDw2YuMDRqC1YXjMFRhTxezSGcSYnvgkEvtbtUnzYuNadxFrl4VBOeiwZMtwSe81nMk1Of6muNhCtQ==}
+ 
+@@ -3436,6 +3959,10 @@ packages:
+     resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+     engines: {node: '>=6'}
+ 
++  escalade@3.2.0:
++    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
++    engines: {node: '>=6'}
++
+   escape-goat@2.1.1:
+     resolution: {integrity: sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==}
+     engines: {node: '>=8'}
+@@ -3558,6 +4085,10 @@ packages:
+     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
+     engines: {node: '>=8.6.0'}
+ 
++  fast-glob@3.3.3:
++    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
++    engines: {node: '>=8.6.0'}
++
+   fast-json-stable-stringify@2.1.0:
+     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+ 
+@@ -4012,6 +4543,10 @@ packages:
+     resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
+     engines: {node: '>= 0.4'}
+ 
++  is-core-module@2.16.1:
++    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
++    engines: {node: '>= 0.4'}
++
+   is-data-view@1.0.1:
+     resolution: {integrity: sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==}
+     engines: {node: '>= 0.4'}
+@@ -4164,6 +4699,10 @@ packages:
+     resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
+     hasBin: true
+ 
++  jiti@1.21.7:
++    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
++    hasBin: true
++
+   joi@17.13.3:
+     resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+ 
+@@ -4211,6 +4750,16 @@ packages:
+     engines: {node: '>=4'}
+     hasBin: true
+ 
++  jsesc@3.0.2:
++    resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
++    engines: {node: '>=6'}
++    hasBin: true
++
++  jsesc@3.1.0:
++    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
++    engines: {node: '>=6'}
++    hasBin: true
++
+   json-buffer@3.0.0:
+     resolution: {integrity: sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==}
+ 
+@@ -4288,12 +4837,8 @@ packages:
+     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+     engines: {node: '>= 0.8.0'}
+ 
+-  lilconfig@2.1.0:
+-    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+-    engines: {node: '>=10'}
+-
+-  lilconfig@3.1.2:
+-    resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
++  lilconfig@3.1.3:
++    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+     engines: {node: '>=14'}
+ 
+   lines-and-columns@1.2.4:
+@@ -4583,6 +5128,9 @@ packages:
+   node-releases@2.0.18:
+     resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
+ 
++  node-releases@2.0.19:
++    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
++
+   nopt@7.2.1:
+     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+@@ -4803,6 +5351,9 @@ packages:
+   picocolors@1.1.0:
+     resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+ 
++  picocolors@1.1.1:
++    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
++
+   picomatch@2.3.1:
+     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+     engines: {node: '>=8.6'}
+@@ -5231,6 +5782,10 @@ packages:
+     resolution: {integrity: sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==}
+     engines: {node: '>=4'}
+ 
++  regenerate-unicode-properties@10.2.0:
++    resolution: {integrity: sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==}
++    engines: {node: '>=4'}
++
+   regenerate@1.4.2:
+     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
+ 
+@@ -5248,6 +5803,10 @@ packages:
+     resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
+     engines: {node: '>=4'}
+ 
++  regexpu-core@6.2.0:
++    resolution: {integrity: sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==}
++    engines: {node: '>=4'}
++
+   register-service-worker@1.7.2:
+     resolution: {integrity: sha512-CiD3ZSanZqcMPRhtfct5K9f7i3OLCcBBWsJjLh1gW9RO/nS94sVzY59iS+fgYBOBqaBpf4EzfqUF3j9IG+xo8A==}
+ 
+@@ -5259,6 +5818,13 @@ packages:
+     resolution: {integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==}
+     engines: {node: '>=8'}
+ 
++  regjsgen@0.8.0:
++    resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
++
++  regjsparser@0.12.0:
++    resolution: {integrity: sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==}
++    hasBin: true
++
+   regjsparser@0.9.1:
+     resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
+     hasBin: true
+@@ -5281,6 +5847,11 @@ packages:
+     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+     engines: {node: '>=4'}
+ 
++  resolve@1.22.10:
++    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
++    engines: {node: '>= 0.4'}
++    hasBin: true
++
+   resolve@1.22.8:
+     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
+     hasBin: true
+@@ -5319,6 +5890,11 @@ packages:
+     engines: {node: '>=10.0.0'}
+     hasBin: true
+ 
++  rollup@2.79.2:
++    resolution: {integrity: sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==}
++    engines: {node: '>=10.0.0'}
++    hasBin: true
++
+   rollup@4.22.5:
+     resolution: {integrity: sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==}
+     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+@@ -5632,8 +6208,8 @@ packages:
+   systemjs@6.15.1:
+     resolution: {integrity: sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==}
+ 
+-  tailwindcss@3.4.13:
+-    resolution: {integrity: sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==}
++  tailwindcss@3.4.17:
++    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
+     engines: {node: '>=14.0.0'}
+     hasBin: true
+ 
+@@ -5850,6 +6426,10 @@ packages:
+     resolution: {integrity: sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==}
+     engines: {node: '>=4'}
+ 
++  unicode-match-property-value-ecmascript@2.2.0:
++    resolution: {integrity: sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==}
++    engines: {node: '>=4'}
++
+   unicode-property-aliases-ecmascript@2.1.0:
+     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
+     engines: {node: '>=4'}
+@@ -5897,6 +6477,12 @@ packages:
+     peerDependencies:
+       browserslist: '>= 4.21.0'
+ 
++  update-browserslist-db@1.1.2:
++    resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
++    hasBin: true
++    peerDependencies:
++      browserslist: '>= 4.21.0'
++
+   update-notifier@4.1.3:
+     resolution: {integrity: sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==}
+     engines: {node: '>=8'}
+@@ -6304,8 +6890,8 @@ packages:
+     resolution: {integrity: sha512-4wZWvE398hCP7O8n3nXKu/vdq1HcH01ixYlCREaJL5NUMwQ0g3MaGFUBNSlmBtKmhbtVG/Cm6lyYmSVTEVil8A==}
+     engines: {node: ^14.17.0 || >=16.0.0}
+ 
+-  yaml@2.5.0:
+-    resolution: {integrity: sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==}
++  yaml@2.7.0:
++    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
+     engines: {node: '>= 14'}
+     hasBin: true
+ 
+@@ -6364,8 +6950,16 @@ snapshots:
+       '@babel/highlight': 7.24.7
+       picocolors: 1.1.0
+ 
++  '@babel/code-frame@7.26.2':
++    dependencies:
++      '@babel/helper-validator-identifier': 7.25.9
++      js-tokens: 4.0.0
++      picocolors: 1.1.1
++
+   '@babel/compat-data@7.25.4': {}
+ 
++  '@babel/compat-data@7.26.5': {}
++
+   '@babel/core@7.25.2':
+     dependencies:
+       '@ampproject/remapping': 2.3.0
+@@ -6386,6 +6980,26 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/core@7.26.0':
++    dependencies:
++      '@ampproject/remapping': 2.3.0
++      '@babel/code-frame': 7.26.2
++      '@babel/generator': 7.26.5
++      '@babel/helper-compilation-targets': 7.26.5
++      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
++      '@babel/helpers': 7.26.0
++      '@babel/parser': 7.26.5
++      '@babel/template': 7.25.9
++      '@babel/traverse': 7.26.5
++      '@babel/types': 7.26.5
++      convert-source-map: 2.0.0
++      debug: 4.4.0
++      gensync: 1.0.0-beta.2
++      json5: 2.2.3
++      semver: 6.3.1
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/generator@7.25.5':
+     dependencies:
+       '@babel/types': 7.25.4
+@@ -6393,10 +7007,22 @@ snapshots:
+       '@jridgewell/trace-mapping': 0.3.25
+       jsesc: 2.5.2
+ 
++  '@babel/generator@7.26.5':
++    dependencies:
++      '@babel/parser': 7.26.5
++      '@babel/types': 7.26.5
++      '@jridgewell/gen-mapping': 0.3.8
++      '@jridgewell/trace-mapping': 0.3.25
++      jsesc: 3.1.0
++
+   '@babel/helper-annotate-as-pure@7.24.7':
+     dependencies:
+       '@babel/types': 7.25.4
+ 
++  '@babel/helper-annotate-as-pure@7.25.9':
++    dependencies:
++      '@babel/types': 7.26.5
++
+   '@babel/helper-builder-binary-assignment-operator-visitor@7.24.7':
+     dependencies:
+       '@babel/traverse': 7.25.4
+@@ -6412,6 +7038,14 @@ snapshots:
+       lru-cache: 5.1.1
+       semver: 6.3.1
+ 
++  '@babel/helper-compilation-targets@7.26.5':
++    dependencies:
++      '@babel/compat-data': 7.26.5
++      '@babel/helper-validator-option': 7.25.9
++      browserslist: 4.24.0
++      lru-cache: 5.1.1
++      semver: 6.3.1
++
+   '@babel/helper-create-class-features-plugin@7.25.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6425,6 +7059,19 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-create-class-features-plugin@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-annotate-as-pure': 7.25.9
++      '@babel/helper-member-expression-to-functions': 7.25.9
++      '@babel/helper-optimise-call-expression': 7.25.9
++      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.0)
++      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
++      '@babel/traverse': 7.26.5
++      semver: 6.3.1
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-create-regexp-features-plugin@7.25.2(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6432,6 +7079,20 @@ snapshots:
+       regexpu-core: 5.3.2
+       semver: 6.3.1
+ 
++  '@babel/helper-create-regexp-features-plugin@7.25.2(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-annotate-as-pure': 7.24.7
++      regexpu-core: 5.3.2
++      semver: 6.3.1
++
++  '@babel/helper-create-regexp-features-plugin@7.26.3(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-annotate-as-pure': 7.25.9
++      regexpu-core: 6.2.0
++      semver: 6.3.1
++
+   '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6443,6 +7104,28 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-compilation-targets': 7.25.2
++      '@babel/helper-plugin-utils': 7.24.8
++      debug: 4.3.7(supports-color@8.1.1)
++      lodash.debounce: 4.0.8
++      resolve: 1.22.8
++    transitivePeerDependencies:
++      - supports-color
++
++  '@babel/helper-define-polyfill-provider@0.6.3(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-compilation-targets': 7.26.5
++      '@babel/helper-plugin-utils': 7.26.5
++      debug: 4.4.0
++      lodash.debounce: 4.0.8
++      resolve: 1.22.10
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-member-expression-to-functions@7.24.8':
+     dependencies:
+       '@babel/traverse': 7.25.4
+@@ -6450,6 +7133,13 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-member-expression-to-functions@7.25.9':
++    dependencies:
++      '@babel/traverse': 7.26.5
++      '@babel/types': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-module-imports@7.24.7':
+     dependencies:
+       '@babel/traverse': 7.25.4
+@@ -6457,6 +7147,13 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-module-imports@7.25.9':
++    dependencies:
++      '@babel/traverse': 7.26.5
++      '@babel/types': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-module-transforms@7.25.2(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6467,12 +7164,27 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-module-imports': 7.25.9
++      '@babel/helper-validator-identifier': 7.25.9
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-optimise-call-expression@7.24.7':
+     dependencies:
+       '@babel/types': 7.25.4
+ 
++  '@babel/helper-optimise-call-expression@7.25.9':
++    dependencies:
++      '@babel/types': 7.26.5
++
+   '@babel/helper-plugin-utils@7.24.8': {}
+ 
++  '@babel/helper-plugin-utils@7.26.5': {}
++
+   '@babel/helper-remap-async-to-generator@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6482,6 +7194,15 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-remap-async-to-generator@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-annotate-as-pure': 7.25.9
++      '@babel/helper-wrap-function': 7.25.9
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-replace-supers@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6491,6 +7212,15 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-replace-supers@7.26.5(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-member-expression-to-functions': 7.25.9
++      '@babel/helper-optimise-call-expression': 7.25.9
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-simple-access@7.24.7':
+     dependencies:
+       '@babel/traverse': 7.25.4
+@@ -6505,12 +7235,25 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
++    dependencies:
++      '@babel/traverse': 7.26.5
++      '@babel/types': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helper-string-parser@7.24.8': {}
+ 
++  '@babel/helper-string-parser@7.25.9': {}
++
+   '@babel/helper-validator-identifier@7.24.7': {}
+ 
++  '@babel/helper-validator-identifier@7.25.9': {}
++
+   '@babel/helper-validator-option@7.24.8': {}
+ 
++  '@babel/helper-validator-option@7.25.9': {}
++
+   '@babel/helper-wrap-function@7.25.0':
+     dependencies:
+       '@babel/template': 7.25.0
+@@ -6519,11 +7262,24 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/helper-wrap-function@7.25.9':
++    dependencies:
++      '@babel/template': 7.25.9
++      '@babel/traverse': 7.26.5
++      '@babel/types': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/helpers@7.25.0':
+     dependencies:
+       '@babel/template': 7.25.0
+       '@babel/types': 7.25.4
+ 
++  '@babel/helpers@7.26.0':
++    dependencies:
++      '@babel/template': 7.25.9
++      '@babel/types': 7.26.5
++
+   '@babel/highlight@7.24.7':
+     dependencies:
+       '@babel/helper-validator-identifier': 7.24.7
+@@ -6535,6 +7291,10 @@ snapshots:
+     dependencies:
+       '@babel/types': 7.25.4
+ 
++  '@babel/parser@7.26.5':
++    dependencies:
++      '@babel/types': 7.26.5
++
+   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.3(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6543,16 +7303,34 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6562,6 +7340,15 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
++      '@babel/plugin-transform-optional-chaining': 7.25.9(@babel/core@7.26.0)
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6570,10 +7357,22 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+ 
++  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++
+   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6604,11 +7403,21 @@ snapshots:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6665,11 +7474,22 @@ snapshots:
+       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.24.8
++
+   '@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-async-generator-functions@7.25.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6680,6 +7500,15 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-async-generator-functions@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6689,21 +7518,48 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-async-to-generator@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-module-imports': 7.25.9
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-remap-async-to-generator': 7.25.9(@babel/core@7.26.0)
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-block-scoped-functions@7.26.5(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-block-scoping@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-class-properties@7.25.4(@babel/core@7.25.2)':
+     dependencies:
+-      '@babel/core': 7.25.2
+-      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.25.2)
+-      '@babel/helper-plugin-utils': 7.24.8
++      '@babel/core': 7.25.2
++      '@babel/helper-create-class-features-plugin': 7.25.4(@babel/core@7.25.2)
++      '@babel/helper-plugin-utils': 7.24.8
++    transitivePeerDependencies:
++      - supports-color
++
++  '@babel/plugin-transform-class-properties@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
+     transitivePeerDependencies:
+       - supports-color
+ 
+@@ -6716,6 +7572,14 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-class-static-block@7.26.0(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-classes@7.25.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6728,40 +7592,85 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-classes@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-annotate-as-pure': 7.25.9
++      '@babel/helper-compilation-targets': 7.26.5
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.0)
++      '@babel/traverse': 7.26.5
++      globals: 11.12.0
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/template': 7.25.0
+ 
++  '@babel/plugin-transform-computed-properties@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/template': 7.25.9
++
+   '@babel/plugin-transform-destructuring@7.24.8(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-dotall-regex@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-duplicate-keys@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-dynamic-import@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6770,12 +7679,22 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-exponentiation-operator@7.26.3(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-export-namespace-from@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-export-namespace-from@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6784,6 +7703,14 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-for-of@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-function-name@7.25.1(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6793,28 +7720,57 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-function-name@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-compilation-targets': 7.26.5
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-json-strings@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-json-strings@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-literals@7.25.2(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-literals@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-logical-assignment-operators@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-member-expression-literals@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6823,6 +7779,14 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-modules-amd@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-modules-commonjs@7.24.8(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6832,6 +7796,14 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-modules-commonjs@7.26.3(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-modules-systemjs@7.25.0(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6842,6 +7814,16 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-modules-systemjs@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-validator-identifier': 7.25.9
++      '@babel/traverse': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6850,29 +7832,58 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-modules-umd@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-named-capturing-groups-regex@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-new-target@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-nullish-coalescing-operator@7.26.6(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-numeric-separator@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6881,6 +7892,13 @@ snapshots:
+       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
+       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-object-rest-spread@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-compilation-targets': 7.26.5
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.0)
++
+   '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6889,12 +7907,25 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.0)
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-optional-catch-binding@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
+ 
++  '@babel/plugin-transform-optional-catch-binding@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-optional-chaining@7.24.8(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6904,11 +7935,24 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-optional-chaining@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-parameters@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-private-methods@7.25.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6917,6 +7961,14 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-private-methods@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6927,27 +7979,63 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-private-property-in-object@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-annotate-as-pure': 7.25.9
++      '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-property-literals@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+       regenerator-transform: 0.15.2
+ 
++  '@babel/plugin-transform-regenerator@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      regenerator-transform: 0.15.2
++
++  '@babel/plugin-transform-regexp-modifiers@7.26.0(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-reserved-words@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-shorthand-properties@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-spread@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -6956,44 +8044,90 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/plugin-transform-spread@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-sticky-regex@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-template-literals@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-typeof-symbol@7.24.8(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-typeof-symbol@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-unicode-escapes@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-unicode-property-regex@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-unicode-regex@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/plugin-transform-unicode-sets-regex@7.25.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+       '@babel/helper-create-regexp-features-plugin': 7.25.2(@babel/core@7.25.2)
+       '@babel/helper-plugin-utils': 7.24.8
+ 
++  '@babel/plugin-transform-unicode-sets-regex@7.25.9(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-create-regexp-features-plugin': 7.26.3(@babel/core@7.26.0)
++      '@babel/helper-plugin-utils': 7.26.5
++
+   '@babel/preset-env@7.25.4(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/compat-data': 7.25.4
+@@ -7083,6 +8217,81 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/preset-env@7.26.0(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/compat-data': 7.26.5
++      '@babel/core': 7.26.0
++      '@babel/helper-compilation-targets': 7.26.5
++      '@babel/helper-plugin-utils': 7.26.5
++      '@babel/helper-validator-option': 7.25.9
++      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.0)
++      '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.26.0)
++      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
++      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.0)
++      '@babel/plugin-transform-arrow-functions': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-block-scoped-functions': 7.26.5(@babel/core@7.26.0)
++      '@babel/plugin-transform-block-scoping': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-class-properties': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-class-static-block': 7.26.0(@babel/core@7.26.0)
++      '@babel/plugin-transform-classes': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-computed-properties': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-destructuring': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-dotall-regex': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-duplicate-keys': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-dynamic-import': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-exponentiation-operator': 7.26.3(@babel/core@7.26.0)
++      '@babel/plugin-transform-export-namespace-from': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-for-of': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-function-name': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-json-strings': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-literals': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-logical-assignment-operators': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-member-expression-literals': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-modules-amd': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-modules-commonjs': 7.26.3(@babel/core@7.26.0)
++      '@babel/plugin-transform-modules-systemjs': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-modules-umd': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-named-capturing-groups-regex': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-new-target': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-nullish-coalescing-operator': 7.26.6(@babel/core@7.26.0)
++      '@babel/plugin-transform-numeric-separator': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-object-rest-spread': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-object-super': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-optional-catch-binding': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-optional-chaining': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-private-methods': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-private-property-in-object': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-property-literals': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-regenerator': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-regexp-modifiers': 7.26.0(@babel/core@7.26.0)
++      '@babel/plugin-transform-reserved-words': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-shorthand-properties': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-spread': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-sticky-regex': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-template-literals': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-typeof-symbol': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-unicode-escapes': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-unicode-property-regex': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-unicode-regex': 7.25.9(@babel/core@7.26.0)
++      '@babel/plugin-transform-unicode-sets-regex': 7.25.9(@babel/core@7.26.0)
++      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.0)
++      babel-plugin-polyfill-corejs2: 0.4.12(@babel/core@7.26.0)
++      babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.26.0)
++      babel-plugin-polyfill-regenerator: 0.6.3(@babel/core@7.26.0)
++      core-js-compat: 3.40.0
++      semver: 6.3.1
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.25.2)':
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -7090,18 +8299,35 @@ snapshots:
+       '@babel/types': 7.25.4
+       esutils: 2.0.3
+ 
++  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.0)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-plugin-utils': 7.24.8
++      '@babel/types': 7.25.4
++      esutils: 2.0.3
++
+   '@babel/regjsgen@0.8.0': {}
+ 
+   '@babel/runtime@7.25.4':
+     dependencies:
+       regenerator-runtime: 0.14.1
+ 
++  '@babel/runtime@7.26.0':
++    dependencies:
++      regenerator-runtime: 0.14.1
++
+   '@babel/template@7.25.0':
+     dependencies:
+       '@babel/code-frame': 7.24.7
+       '@babel/parser': 7.25.4
+       '@babel/types': 7.25.4
+ 
++  '@babel/template@7.25.9':
++    dependencies:
++      '@babel/code-frame': 7.26.2
++      '@babel/parser': 7.26.5
++      '@babel/types': 7.26.5
++
+   '@babel/traverse@7.25.4':
+     dependencies:
+       '@babel/code-frame': 7.24.7
+@@ -7114,12 +8340,29 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@babel/traverse@7.26.5':
++    dependencies:
++      '@babel/code-frame': 7.26.2
++      '@babel/generator': 7.26.5
++      '@babel/parser': 7.26.5
++      '@babel/template': 7.25.9
++      '@babel/types': 7.26.5
++      debug: 4.4.0
++      globals: 11.12.0
++    transitivePeerDependencies:
++      - supports-color
++
+   '@babel/types@7.25.4':
+     dependencies:
+       '@babel/helper-string-parser': 7.24.8
+       '@babel/helper-validator-identifier': 7.24.7
+       to-fast-properties: 2.0.0
+ 
++  '@babel/types@7.26.5':
++    dependencies:
++      '@babel/helper-string-parser': 7.25.9
++      '@babel/helper-validator-identifier': 7.25.9
++
+   '@cliqz/adblocker-content@1.33.0':
+     dependencies:
+       '@cliqz/adblocker-extended-selectors': 1.33.0
+@@ -7758,8 +9001,8 @@ snapshots:
+ 
+   '@intlify/bundle-utils@9.0.0-beta.0(vue-i18n@10.0.3(vue@3.5.10(typescript@5.6.2)))':
+     dependencies:
+-      '@intlify/message-compiler': 10.0.0
+-      '@intlify/shared': 10.0.0
++      '@intlify/message-compiler': 11.0.0-rc.1
++      '@intlify/shared': 11.0.0-rc.1
+       acorn: 8.12.1
+       escodegen: 2.1.0
+       estree-walker: 2.0.2
+@@ -7775,26 +9018,26 @@ snapshots:
+       '@intlify/message-compiler': 10.0.3
+       '@intlify/shared': 10.0.3
+ 
+-  '@intlify/message-compiler@10.0.0':
+-    dependencies:
+-      '@intlify/shared': 10.0.0
+-      source-map-js: 1.2.1
+-
+   '@intlify/message-compiler@10.0.3':
+     dependencies:
+       '@intlify/shared': 10.0.3
+       source-map-js: 1.2.1
+ 
+-  '@intlify/shared@10.0.0': {}
++  '@intlify/message-compiler@11.0.0-rc.1':
++    dependencies:
++      '@intlify/shared': 11.0.0-rc.1
++      source-map-js: 1.2.1
+ 
+   '@intlify/shared@10.0.3': {}
+ 
++  '@intlify/shared@11.0.0-rc.1': {}
++
+   '@intlify/unplugin-vue-i18n@5.2.0(@vue/compiler-dom@3.5.10)(eslint@8.57.1)(rollup@4.22.5)(typescript@5.6.2)(vue-i18n@10.0.3(vue@3.5.10(typescript@5.6.2)))(vue@3.5.10(typescript@5.6.2))':
+     dependencies:
+       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
+       '@intlify/bundle-utils': 9.0.0-beta.0(vue-i18n@10.0.3(vue@3.5.10(typescript@5.6.2)))
+-      '@intlify/shared': 10.0.0
+-      '@intlify/vue-i18n-extensions': 7.0.0(@intlify/shared@10.0.0)(@vue/compiler-dom@3.5.10)(vue-i18n@10.0.3(vue@3.5.10(typescript@5.6.2)))(vue@3.5.10(typescript@5.6.2))
++      '@intlify/shared': 11.0.0-rc.1
++      '@intlify/vue-i18n-extensions': 7.0.0(@intlify/shared@11.0.0-rc.1)(@vue/compiler-dom@3.5.10)(vue-i18n@10.0.3(vue@3.5.10(typescript@5.6.2)))(vue@3.5.10(typescript@5.6.2))
+       '@rollup/pluginutils': 5.1.0(rollup@4.22.5)
+       '@typescript-eslint/scope-manager': 7.18.0
+       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.2)
+@@ -7816,11 +9059,11 @@ snapshots:
+       - supports-color
+       - typescript
+ 
+-  '@intlify/vue-i18n-extensions@7.0.0(@intlify/shared@10.0.0)(@vue/compiler-dom@3.5.10)(vue-i18n@10.0.3(vue@3.5.10(typescript@5.6.2)))(vue@3.5.10(typescript@5.6.2))':
++  '@intlify/vue-i18n-extensions@7.0.0(@intlify/shared@11.0.0-rc.1)(@vue/compiler-dom@3.5.10)(vue-i18n@10.0.3(vue@3.5.10(typescript@5.6.2)))(vue@3.5.10(typescript@5.6.2))':
+     dependencies:
+       '@babel/parser': 7.25.4
+     optionalDependencies:
+-      '@intlify/shared': 10.0.0
++      '@intlify/shared': 11.0.0-rc.1
+       '@vue/compiler-dom': 3.5.10
+       vue: 3.5.10(typescript@5.6.2)
+       vue-i18n: 10.0.3(vue@3.5.10(typescript@5.6.2))
+@@ -7844,6 +9087,12 @@ snapshots:
+       '@jridgewell/sourcemap-codec': 1.5.0
+       '@jridgewell/trace-mapping': 0.3.25
+ 
++  '@jridgewell/gen-mapping@0.3.8':
++    dependencies:
++      '@jridgewell/set-array': 1.2.1
++      '@jridgewell/sourcemap-codec': 1.5.0
++      '@jridgewell/trace-mapping': 0.3.25
++
+   '@jridgewell/resolve-uri@3.1.2': {}
+ 
+   '@jridgewell/set-array@1.2.1': {}
+@@ -7929,6 +9178,15 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  '@rollup/plugin-babel@5.3.1(@babel/core@7.26.0)(rollup@2.79.2)':
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-module-imports': 7.24.7
++      '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
++      rollup: 2.79.2
++    transitivePeerDependencies:
++      - supports-color
++
+   '@rollup/plugin-node-resolve@15.2.3(rollup@2.79.1)':
+     dependencies:
+       '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+@@ -7940,12 +9198,28 @@ snapshots:
+     optionalDependencies:
+       rollup: 2.79.1
+ 
++  '@rollup/plugin-node-resolve@15.3.1(rollup@2.79.2)':
++    dependencies:
++      '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
++      '@types/resolve': 1.20.2
++      deepmerge: 4.3.1
++      is-module: 1.0.0
++      resolve: 1.22.10
++    optionalDependencies:
++      rollup: 2.79.2
++
+   '@rollup/plugin-replace@2.4.2(rollup@2.79.1)':
+     dependencies:
+       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
+       magic-string: 0.25.9
+       rollup: 2.79.1
+ 
++  '@rollup/plugin-replace@2.4.2(rollup@2.79.2)':
++    dependencies:
++      '@rollup/pluginutils': 3.1.0(rollup@2.79.2)
++      magic-string: 0.25.9
++      rollup: 2.79.2
++
+   '@rollup/plugin-terser@0.4.4(rollup@2.79.1)':
+     dependencies:
+       serialize-javascript: 6.0.2
+@@ -7954,6 +9228,14 @@ snapshots:
+     optionalDependencies:
+       rollup: 2.79.1
+ 
++  '@rollup/plugin-terser@0.4.4(rollup@2.79.2)':
++    dependencies:
++      serialize-javascript: 6.0.2
++      smob: 1.5.0
++      terser: 5.31.6
++    optionalDependencies:
++      rollup: 2.79.2
++
+   '@rollup/pluginutils@3.1.0(rollup@2.79.1)':
+     dependencies:
+       '@types/estree': 0.0.39
+@@ -7961,6 +9243,13 @@ snapshots:
+       picomatch: 2.3.1
+       rollup: 2.79.1
+ 
++  '@rollup/pluginutils@3.1.0(rollup@2.79.2)':
++    dependencies:
++      '@types/estree': 0.0.39
++      estree-walker: 1.0.1
++      picomatch: 2.3.1
++      rollup: 2.79.2
++
+   '@rollup/pluginutils@5.1.0(rollup@2.79.1)':
+     dependencies:
+       '@types/estree': 1.0.5
+@@ -7977,6 +9266,14 @@ snapshots:
+     optionalDependencies:
+       rollup: 4.22.5
+ 
++  '@rollup/pluginutils@5.1.4(rollup@2.79.2)':
++    dependencies:
++      '@types/estree': 1.0.6
++      estree-walker: 2.0.2
++      picomatch: 4.0.2
++    optionalDependencies:
++      rollup: 2.79.2
++
+   '@rollup/rollup-android-arm-eabi@4.22.5':
+     optional: true
+ 
+@@ -8912,6 +10209,15 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  babel-plugin-polyfill-corejs2@0.4.12(@babel/core@7.26.0):
++    dependencies:
++      '@babel/compat-data': 7.26.5
++      '@babel/core': 7.26.0
++      '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.26.0)
++      semver: 6.3.1
++    transitivePeerDependencies:
++      - supports-color
++
+   babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.25.2):
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -8920,6 +10226,14 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.26.0):
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-define-polyfill-provider': 0.6.2(@babel/core@7.26.0)
++      core-js-compat: 3.38.1
++    transitivePeerDependencies:
++      - supports-color
++
+   babel-plugin-polyfill-regenerator@0.6.2(@babel/core@7.25.2):
+     dependencies:
+       '@babel/core': 7.25.2
+@@ -8927,6 +10241,13 @@ snapshots:
+     transitivePeerDependencies:
+       - supports-color
+ 
++  babel-plugin-polyfill-regenerator@0.6.3(@babel/core@7.26.0):
++    dependencies:
++      '@babel/core': 7.26.0
++      '@babel/helper-define-polyfill-provider': 0.6.3(@babel/core@7.26.0)
++    transitivePeerDependencies:
++      - supports-color
++
+   balanced-match@1.0.2: {}
+ 
+   base64-js@1.5.1: {}
+@@ -8989,6 +10310,13 @@ snapshots:
+       node-releases: 2.0.18
+       update-browserslist-db: 1.1.0(browserslist@4.24.0)
+ 
++  browserslist@4.24.4:
++    dependencies:
++      caniuse-lite: 1.0.30001695
++      electron-to-chromium: 1.5.84
++      node-releases: 2.0.19
++      update-browserslist-db: 1.1.2(browserslist@4.24.4)
++
+   buffer-crc32@0.2.13: {}
+ 
+   buffer-from@1.1.2: {}
+@@ -9043,6 +10371,8 @@ snapshots:
+ 
+   caniuse-lite@1.0.30001664: {}
+ 
++  caniuse-lite@1.0.30001695: {}
++
+   capital-case@1.0.4:
+     dependencies:
+       no-case: 3.0.4
+@@ -9247,6 +10577,10 @@ snapshots:
+     dependencies:
+       browserslist: 4.24.0
+ 
++  core-js-compat@3.40.0:
++    dependencies:
++      browserslist: 4.24.4
++
+   core-js@3.38.1: {}
+ 
+   core-util-is@1.0.2: {}
+@@ -9436,6 +10770,10 @@ snapshots:
+     optionalDependencies:
+       supports-color: 8.1.1
+ 
++  debug@4.4.0:
++    dependencies:
++      ms: 2.1.3
++
+   decamelize-keys@1.1.1:
+     dependencies:
+       decamelize: 1.2.0
+@@ -9580,6 +10918,8 @@ snapshots:
+ 
+   electron-to-chromium@1.5.28: {}
+ 
++  electron-to-chromium@1.5.84: {}
++
+   emoji-picker-element@1.22.7: {}
+ 
+   emoji-regex@8.0.0: {}
+@@ -9733,6 +11073,8 @@ snapshots:
+ 
+   escalade@3.1.2: {}
+ 
++  escalade@3.2.0: {}
++
+   escape-goat@2.1.1: {}
+ 
+   escape-html@1.0.3: {}
+@@ -9927,6 +11269,14 @@ snapshots:
+       merge2: 1.4.1
+       micromatch: 4.0.8
+ 
++  fast-glob@3.3.3:
++    dependencies:
++      '@nodelib/fs.stat': 2.0.5
++      '@nodelib/fs.walk': 1.2.8
++      glob-parent: 5.1.2
++      merge2: 1.4.1
++      micromatch: 4.0.8
++
+   fast-json-stable-stringify@2.1.0: {}
+ 
+   fast-levenshtein@2.0.6: {}
+@@ -10440,6 +11790,10 @@ snapshots:
+     dependencies:
+       hasown: 2.0.2
+ 
++  is-core-module@2.16.1:
++    dependencies:
++      hasown: 2.0.2
++
+   is-data-view@1.0.1:
+     dependencies:
+       is-typed-array: 1.1.13
+@@ -10558,6 +11912,8 @@ snapshots:
+ 
+   jiti@1.21.6: {}
+ 
++  jiti@1.21.7: {}
++
+   joi@17.13.3:
+     dependencies:
+       '@hapi/hoek': 9.3.0
+@@ -10628,6 +11984,10 @@ snapshots:
+ 
+   jsesc@2.5.2: {}
+ 
++  jsesc@3.0.2: {}
++
++  jsesc@3.1.0: {}
++
+   json-buffer@3.0.0: {}
+ 
+   json-buffer@3.0.1: {}
+@@ -10698,9 +12058,7 @@ snapshots:
+       prelude-ls: 1.2.1
+       type-check: 0.4.0
+ 
+-  lilconfig@2.1.0: {}
+-
+-  lilconfig@3.1.2: {}
++  lilconfig@3.1.3: {}
+ 
+   lines-and-columns@1.2.4: {}
+ 
+@@ -10972,6 +12330,8 @@ snapshots:
+ 
+   node-releases@2.0.18: {}
+ 
++  node-releases@2.0.19: {}
++
+   nopt@7.2.1:
+     dependencies:
+       abbrev: 2.0.0
+@@ -11183,6 +12543,8 @@ snapshots:
+ 
+   picocolors@1.1.0: {}
+ 
++  picocolors@1.1.1: {}
++
+   picomatch@2.3.1: {}
+ 
+   picomatch@4.0.2: {}
+@@ -11320,7 +12682,7 @@ snapshots:
+       postcss: 8.4.47
+       postcss-value-parser: 4.2.0
+       read-cache: 1.0.0
+-      resolve: 1.22.8
++      resolve: 1.22.10
+ 
+   postcss-js@4.0.1(postcss@8.4.47):
+     dependencies:
+@@ -11338,8 +12700,8 @@ snapshots:
+ 
+   postcss-load-config@4.0.2(postcss@8.4.47):
+     dependencies:
+-      lilconfig: 3.1.2
+-      yaml: 2.5.0
++      lilconfig: 3.1.3
++      yaml: 2.7.0
+     optionalDependencies:
+       postcss: 8.4.47
+ 
+@@ -11703,6 +13065,10 @@ snapshots:
+     dependencies:
+       regenerate: 1.4.2
+ 
++  regenerate-unicode-properties@10.2.0:
++    dependencies:
++      regenerate: 1.4.2
++
+   regenerate@1.4.2: {}
+ 
+   regenerator-runtime@0.14.1: {}
+@@ -11727,6 +13093,15 @@ snapshots:
+       unicode-match-property-ecmascript: 2.0.0
+       unicode-match-property-value-ecmascript: 2.1.0
+ 
++  regexpu-core@6.2.0:
++    dependencies:
++      regenerate: 1.4.2
++      regenerate-unicode-properties: 10.2.0
++      regjsgen: 0.8.0
++      regjsparser: 0.12.0
++      unicode-match-property-ecmascript: 2.0.0
++      unicode-match-property-value-ecmascript: 2.2.0
++
+   register-service-worker@1.7.2: {}
+ 
+   registry-auth-token@4.2.2:
+@@ -11737,6 +13112,12 @@ snapshots:
+     dependencies:
+       rc: 1.2.8
+ 
++  regjsgen@0.8.0: {}
++
++  regjsparser@0.12.0:
++    dependencies:
++      jsesc: 3.0.2
++
+   regjsparser@0.9.1:
+     dependencies:
+       jsesc: 0.5.0
+@@ -11753,6 +13134,12 @@ snapshots:
+ 
+   resolve-from@4.0.0: {}
+ 
++  resolve@1.22.10:
++    dependencies:
++      is-core-module: 2.16.1
++      path-parse: 1.0.7
++      supports-preserve-symlinks-flag: 1.0.0
++
+   resolve@1.22.8:
+     dependencies:
+       is-core-module: 2.15.1
+@@ -11789,6 +13176,10 @@ snapshots:
+     optionalDependencies:
+       fsevents: 2.3.3
+ 
++  rollup@2.79.2:
++    optionalDependencies:
++      fsevents: 2.3.3
++
+   rollup@4.22.5:
+     dependencies:
+       '@types/estree': 1.0.6
+@@ -12115,7 +13506,7 @@ snapshots:
+ 
+   sucrase@3.35.0:
+     dependencies:
+-      '@jridgewell/gen-mapping': 0.3.5
++      '@jridgewell/gen-mapping': 0.3.8
+       commander: 4.1.1
+       glob: 10.4.5
+       lines-and-columns: 1.2.4
+@@ -12151,29 +13542,29 @@ snapshots:
+ 
+   systemjs@6.15.1: {}
+ 
+-  tailwindcss@3.4.13:
++  tailwindcss@3.4.17:
+     dependencies:
+       '@alloc/quick-lru': 5.2.0
+       arg: 5.0.2
+       chokidar: 3.6.0
+       didyoumean: 1.2.2
+       dlv: 1.1.3
+-      fast-glob: 3.3.2
++      fast-glob: 3.3.3
+       glob-parent: 6.0.2
+       is-glob: 4.0.3
+-      jiti: 1.21.6
+-      lilconfig: 2.1.0
++      jiti: 1.21.7
++      lilconfig: 3.1.3
+       micromatch: 4.0.8
+       normalize-path: 3.0.0
+       object-hash: 3.0.0
+-      picocolors: 1.1.0
++      picocolors: 1.1.1
+       postcss: 8.4.47
+       postcss-import: 15.1.0(postcss@8.4.47)
+       postcss-js: 4.0.1(postcss@8.4.47)
+       postcss-load-config: 4.0.2(postcss@8.4.47)
+       postcss-nested: 6.2.0(postcss@8.4.47)
+       postcss-selector-parser: 6.1.2
+-      resolve: 1.22.8
++      resolve: 1.22.10
+       sucrase: 3.35.0
+     transitivePeerDependencies:
+       - ts-node
+@@ -12382,6 +13773,8 @@ snapshots:
+ 
+   unicode-match-property-value-ecmascript@2.1.0: {}
+ 
++  unicode-match-property-value-ecmascript@2.2.0: {}
++
+   unicode-property-aliases-ecmascript@2.1.0: {}
+ 
+   unique-string@2.0.0:
+@@ -12417,6 +13810,12 @@ snapshots:
+       escalade: 3.1.2
+       picocolors: 1.1.0
+ 
++  update-browserslist-db@1.1.2(browserslist@4.24.4):
++    dependencies:
++      browserslist: 4.24.4
++      escalade: 3.2.0
++      picocolors: 1.1.1
++
+   update-notifier@4.1.3:
+     dependencies:
+       boxen: 4.2.0
+@@ -12801,13 +14200,13 @@ snapshots:
+   workbox-build@7.1.1:
+     dependencies:
+       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
+-      '@babel/core': 7.25.2
+-      '@babel/preset-env': 7.25.4(@babel/core@7.25.2)
+-      '@babel/runtime': 7.25.4
+-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.25.2)(rollup@2.79.1)
+-      '@rollup/plugin-node-resolve': 15.2.3(rollup@2.79.1)
+-      '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)
+-      '@rollup/plugin-terser': 0.4.4(rollup@2.79.1)
++      '@babel/core': 7.26.0
++      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
++      '@babel/runtime': 7.26.0
++      '@rollup/plugin-babel': 5.3.1(@babel/core@7.26.0)(rollup@2.79.2)
++      '@rollup/plugin-node-resolve': 15.3.1(rollup@2.79.2)
++      '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)
++      '@rollup/plugin-terser': 0.4.4(rollup@2.79.2)
+       '@surma/rollup-plugin-off-main-thread': 2.2.3
+       ajv: 8.17.1
+       common-tags: 1.8.2
+@@ -12816,7 +14215,7 @@ snapshots:
+       glob: 7.2.3
+       lodash: 4.17.21
+       pretty-bytes: 5.6.0
+-      rollup: 2.79.1
++      rollup: 2.79.2
+       source-map: 0.8.0-beta.0
+       stringify-object: 3.3.0
+       strip-comments: 2.0.1
+@@ -12966,9 +14365,9 @@ snapshots:
+     dependencies:
+       eslint-visitor-keys: 3.4.3
+       lodash: 4.17.21
+-      yaml: 2.5.0
++      yaml: 2.7.0
+ 
+-  yaml@2.5.0: {}
++  yaml@2.7.0: {}
+ 
+   yargs-parser@18.1.3:
+     dependencies:
+-- 
+2.47.0
+

--- a/pkgs/by-name/vi/vikunja/package.nix
+++ b/pkgs/by-name/vi/vikunja/package.nix
@@ -23,16 +23,20 @@ let
     pname = "vikunja-frontend";
     inherit version src;
 
+    patches = [
+      ./nodejs-22.12-tailwindcss-update.patch
+    ];
     sourceRoot = "${finalAttrs.src.name}/frontend";
 
     pnpmDeps = pnpm.fetchDeps {
       inherit (finalAttrs)
         pname
         version
+        patches
         src
         sourceRoot
         ;
-      hash = "sha256-D2dOyYsdsNV1ZSQdjpy6rfoix7yBACEHj/2XyHb7HWE=";
+      hash = "sha256-94ZlywOZYmW/NsvE0dtEA81MeBWGUrJsBXTUauuOmZM=";
     };
 
     nativeBuildInputs = [


### PR DESCRIPTION
fixes #375520

In NodeJS 22.12.0 `require(esm)` [was introduced unconditionally](https://nodejs.org/en/blog/release/v22.12.0) which broke tailwindcss < [3.4.17](https://github.com/tailwindlabs/tailwindcss/releases/tag/v3.4.17)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
