### PR TITLE
ci/eval: restore `501+` label

### DIFF
--- a/ci/eval/compare/utils.nix
+++ b/ci/eval/compare/utils.nix
@@ -212,13 +212,25 @@ rec {
             else if rebuildCount <= 500 then
               [ "101-500" ]
             else if rebuildCount <= 1000 then
-              [ "501-1000" ]
+              [
+                "501-1000"
+                "501+"
+              ]
             else if rebuildCount <= 2500 then
-              [ "1001-2500" ]
+              [
+                "1001-2500"
+                "501+"
+              ]
             else if rebuildCount <= 5000 then
-              [ "2501-5000" ]
+              [
+                "2501-5000"
+                "501+"
+              ]
             else
-              [ "5001+" ];
+              [
+                "5001+"
+                "501+"
+              ];
         in
         lib.forEach numbers (number: "10.rebuild-${kernel}: ${number}")
       ) rebuildCountByKernel


### PR DESCRIPTION
The update bot sends PRs with rebuilds >=501 to staging, this label was useful for reviewing those PRs. Can use various OR combinations of the current labels and base:master / base:staging to get roughly the same search but the 501+ label is much simpler.

```
nix-repl> (import ./ci/eval/compare/utils.nix { inherit lib; }).getLabels { linux = 500; darwin = 500; }
[
  "10.rebuild-darwin: 101-500"
  "10.rebuild-linux: 101-500"
]

nix-repl> (import ./ci/eval/compare/utils.nix { inherit lib; }).getLabels { linux = 501; darwin = 501; }
[
  "10.rebuild-darwin: 501-1000"
  "10.rebuild-darwin: 501+"
  "10.rebuild-linux: 501-1000"
  "10.rebuild-linux: 501+"
]

nix-repl> (import ./ci/eval/compare/utils.nix { inherit lib; }).getLabels { linux = 5000; darwin = 5000; }
[
  "10.rebuild-darwin: 2501-5000"
  "10.rebuild-darwin: 501+"
  "10.rebuild-linux: 2501-5000"
  "10.rebuild-linux: 501+"
]
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
