### PR TITLE
[Backport release-24.11] awsume: install correct Zsh autocompletion

### DIFF
--- a/pkgs/tools/admin/awsume/default.nix
+++ b/pkgs/tools/admin/awsume/default.nix
@@ -44,7 +44,7 @@ buildPythonApplication rec {
   postInstall = ''
     installShellCompletion --cmd awsume \
       --bash <(PYTHONPATH=./awsume/configure ${python3}/bin/python3 -c"import autocomplete; print(autocomplete.SCRIPTS['bash'])") \
-      --zsh <(PYTHONPATH=./awsume/configure ${python3}/bin/python3 -c"import autocomplete; print(autocomplete.SCRIPTS['zsh'])") \
+      --zsh <(PYTHONPATH=./awsume/configure ${python3}/bin/python3 -c"import autocomplete; print(autocomplete.ZSH_AUTOCOMPLETE_FUNCTION)") \
       --fish <(PYTHONPATH=./awsume/configure ${python3}/bin/python3 -c"import autocomplete; print(autocomplete.SCRIPTS['fish'])") \
 
     rm -f $out/bin/awsume.bat

--- a/pkgs/tools/admin/awsume/default.nix
+++ b/pkgs/tools/admin/awsume/default.nix
@@ -39,6 +39,7 @@ buildPythonApplication rec {
   postPatch = ''
     patchShebangs shell_scripts
     substituteInPlace shell_scripts/{awsume,awsume.fish} --replace "awsumepy" "$out/bin/awsumepy"
+    substituteInPlace awsume/configure/autocomplete.py --replace-fail "awsume-autocomplete" "$out/bin/awsume-autocomplete"
   '';
 
   postInstall = ''


### PR DESCRIPTION
Manual backport of
- #373140

The label-based backport automation failed due to a conflict: https://github.com/NixOS/nixpkgs/pull/373140#issuecomment-2605766082