### PR TITLE
ocamlPackages.ocsigen_server: fix for conduit 7.1.0

### DIFF
--- a/pkgs/development/ocaml-modules/ocsigen-server/conduit.patch
+++ b/pkgs/development/ocaml-modules/ocsigen-server/conduit.patch
@@ -1,0 +1,14 @@
+diff --git a/src/server/ocsigen_cohttp.ml b/src/server/ocsigen_cohttp.ml
+index 66895339..edbfcbf2 100644
+--- a/src/server/ocsigen_cohttp.ml
++++ b/src/server/ocsigen_cohttp.ml
+@@ -105,7 +105,8 @@ let handler ~ssl ~address ~port ~connector (flow, conn) request body =
+   let rec getsockname = function
+     | `TCP (ip, port) -> Unix.ADDR_INET (Ipaddr_unix.to_inet_addr ip, port)
+     | `Unix_domain_socket path -> Unix.ADDR_UNIX path
+-    | `TLS (_, edn) -> getsockname edn
++    | `TLS (_, edn) -> getsockname (edn :> Conduit_lwt_unix.endp)
++    | `TLS_tunnel _ -> raise (Failure "TLS tunnel not supported")
+     | `Unknown err -> raise (Failure ("resolution failed: " ^ err))
+     | `Vchan_direct _ -> raise (Failure "VChan not supported")
+     | `Vchan_domain_socket _ -> raise (Failure "VChan not supported")

--- a/pkgs/development/ocaml-modules/ocsigen-server/default.nix
+++ b/pkgs/development/ocaml-modules/ocsigen-server/default.nix
@@ -64,6 +64,8 @@ buildDunePackage rec {
     hash = "sha256-T3bgPZpDO6plgebLJDBtBuR2eR/bN3o24UAUv1VwgtI=";
   };
 
+  patches = [ ./conduit.patch ];
+
   nativeBuildInputs = [
     makeWrapper
     which


### PR DESCRIPTION
Fix build, broken by @alexfmpe in #366374.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
