### PR TITLE
[Backport release-24.11] nodejs_22: 22.12.0 -> 22.13.1

### DIFF
--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -8,8 +8,8 @@ let
 in
 buildNodejs {
   inherit enableNpm;
-  version = "22.12.0";
-  sha256 = "fe1bc4be004dc12721ea2cb671b08a21de01c6976960ef8a1248798589679e16";
+  version = "22.13.1";
+  sha256 = "cfce282119390f7e0c2220410924428e90dadcb2df1744c0c4a0e7baae387cc2";
   patches = [
     ./configure-emulator.patch
     ./configure-armv6-vfpv2.patch
@@ -47,16 +47,21 @@ buildNodejs {
       hash = "sha256-gmIyiSyNzC3pClL1SM2YicckWM+/2tsbV1xv2S3d5G0=";
       revert = true;
     })
-    # Fix for https://github.com/NixOS/nixpkgs/issues/355919
     # FIXME: remove after a minor point release
     (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/f270462c09ddfd770291a7c8a2cd204b2c63d730.patch?full_index=1";
-      hash = "sha256-Err0i5g7WtXcnhykKgrS3ocX7/3oV9UrT0SNeRtMZNU=";
+      url = "https://github.com/nodejs/node/commit/49acdc8748fe9fe83bc1b444e24c456dff00ecc5.patch?full_index=1";
+      hash = "sha256-iK7bj4KswTeQ9I3jJ22ZPTsvCU8xeGGXEOo43dxg3Mk=";
     })
-    # fixes test failure, remove when included in release
     (fetchpatch2 {
-      url = "https://github.com/nodejs/node/commit/b6fe731c55eb4cb9d14042a23e5002ed39b7c8b7.patch?full_index=1";
-      hash = "sha256-KoKsQBFKUji0GeEPTR8ixBflCiHBhPqd2cPVPuKyua8=";
+      url = "https://github.com/nodejs/node/commit/d0ff34f4b690ad49c86b6df8fd424f39d183e1a6.patch?full_index=1";
+      hash = "sha256-ezcCrg7UwK091pqYxXJn4ay9smQwsrYeMO/NBE7VaM8=";
+    })
+    # test-icu-env is failing on ICU 74.2
+    # FIXME: remove once https://github.com/nodejs/node/pull/56661 is included in a next release
+    (fetchpatch2 {
+      url = "https://github.com/nodejs/node/commit/a364ec1d1cbbd5a6d20ee54d4f8648dd7592ebcd.patch?full_index=1";
+      hash = "sha256-EL1NgCBzz5O1spwHgocLm5mkORAiqGFst0N6pc3JvFg=";
+      revert = true;
     })
   ];
 }


### PR DESCRIPTION
(cherry picked from commit a9eac74572da24c4c1d670e1d69055c5603870d1 / PR https://github.com/NixOS/nixpkgs/pull/371908)

N.B.: this is not targeting `staging` because https://github.com/NixOS/nixpkgs/commit/1e99bcac6f2b2bb2caee862c34976474280ea924 has not landed on 24.11, so it shouldn't cause any mass rebuild