### PR TITLE
python312Packages.astropy: Use 'ci' hypothesis-profile & reenable flaky tests

### DIFF
--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -6,6 +6,7 @@
   pythonOlder,
 
   # build time
+  stdenv,
   cython,
   extension-helpers,
   setuptools,
@@ -43,7 +44,6 @@
 
   # testing
   pytestCheckHook,
-  stdenv,
   pytest-xdist,
   pytest-astropy-header,
   pytest-astropy,

--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -56,7 +56,7 @@ buildPythonPackage rec {
   version = "7.0.0";
   pyproject = true;
 
-  disabled = pythonOlder "3.10";
+  disabled = pythonOlder "3.11";
 
   src = fetchPypi {
     inherit pname version;

--- a/pkgs/development/python-modules/astropy/default.nix
+++ b/pkgs/development/python-modules/astropy/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchPypi,
+  fetchpatch,
   buildPythonPackage,
   pythonOlder,
 
@@ -61,6 +62,12 @@ buildPythonPackage rec {
     inherit pname version;
     hash = "sha256-6S18n+6G6z34cU5d1Bu/nxY9ND4aGD2Vv2vQnkMTyUA=";
   };
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/astropy/astropy/commit/13b89edc9acd6d5f12eea75983084c57cb458130.patch";
+      hash = "sha256-2MgmW4kKBrZnTE1cjYYLOH5hStv5Q6tv4gN4sPSLBpM=";
+    })
+  ];
 
   env = lib.optionalAttrs stdenv.cc.isClang {
     NIX_CFLAGS_COMPILE = "-Wno-error=unused-command-line-argument";
@@ -132,35 +139,21 @@ buildPythonPackage rec {
 
   __darwinAllowLocalNetworking = true;
 
-  # Not running it inside the build directory. See:
-  # https://github.com/astropy/astropy/issues/15316#issuecomment-1722190547
   preCheck = ''
-    cd "$out"
     export HOME="$(mktemp -d)"
     export OMP_NUM_THREADS=$(( $NIX_BUILD_CORES / 4 ))
+    # See https://github.com/astropy/astropy/issues/17649 and see
+    # --hypothesis-profile=ci pytest flag below.
+    cp conftest.py $out/
+    # https://github.com/NixOS/nixpkgs/issues/255262
+    cd "$out"
   '';
-
-  disabledTests = [
-    # tests for all availability of all optional deps
-    "test_basic_testing_completeness"
-    "test_all_included"
-
-    # May fail due to parallelism, see:
-    # https://github.com/astropy/astropy/issues/15441
-    "TestUnifiedOutputRegistry"
-
-    # flaky
-    "test_timedelta_conversion"
-    # More flaky tests, see: https://github.com/NixOS/nixpkgs/issues/294392
-    "test_sidereal_lon_independent"
-    "test_timedelta_full_precision_arithmetic"
-    "test_datetime_to_timedelta"
-
-    "test_datetime_difference_agrees_with_timedelta_no_hypothesis"
-
-    # SAMPProxyError 1: 'Timeout expired!'
-    "TestStandardProfile.test_main"
-  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ "test_sidereal_lat_independent" ];
+  pytestFlagsArray = [
+    "--hypothesis-profile=ci"
+  ];
+  postCheck = ''
+    rm conftest.py
+  '';
 
   meta = {
     description = "Astronomy/Astrophysics library for Python";


### PR DESCRIPTION
## Description of changes

Alternative to:

- https://github.com/NixOS/nixpkgs/pull/375032

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
