### PR TITLE
nexusmods-app: 0.7.1 -> 0.7.2

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/deps.json
+++ b/pkgs/by-name/ne/nexusmods-app/deps.json
@@ -161,18 +161,18 @@
   },
   {
     "pname": "Bannerlord.LauncherManager",
-    "version": "1.0.138",
-    "hash": "sha256-U954PUK8oq1mFBqNjONMXi1DYSudT7gjpueWYBIXDdo="
+    "version": "1.0.140",
+    "hash": "sha256-zqfi52ATMfzBkYhsSS4I8xNIyy+SQc4fOOEfJIVEfoE="
   },
   {
     "pname": "Bannerlord.LauncherManager.Localization",
-    "version": "1.0.138",
-    "hash": "sha256-i7OhCR6pceJU7xyaY1pi67PLSnyDX5YDCIrbHw1Jcuc="
+    "version": "1.0.140",
+    "hash": "sha256-WMvQCbIykmF0V7yHf/yMsiov7cbwfujBUhYrWqmPbX8="
   },
   {
     "pname": "Bannerlord.LauncherManager.Models",
-    "version": "1.0.138",
-    "hash": "sha256-mo7Xmj7Ntxgy2/aMzywuyCJ9w/Y1FzbhKOf7fR6ebjw="
+    "version": "1.0.140",
+    "hash": "sha256-1E5s8PPehDmxQB1ln5oA2l3j3Q1PVqgj3HqMTE3uWA8="
   },
   {
     "pname": "Bannerlord.ModuleManager",
@@ -181,8 +181,8 @@
   },
   {
     "pname": "Bannerlord.ModuleManager",
-    "version": "6.0.242",
-    "hash": "sha256-nHBchr6mLQNOWEyfPGi4nzspaIviQY4j+fGJkUTN0Bs="
+    "version": "6.0.246",
+    "hash": "sha256-YXBoSra3bsLB86GLUfFcsVja6QKLqgZBFPQi71y2s1k="
   },
   {
     "pname": "Bannerlord.ModuleManager.Models",
@@ -191,8 +191,8 @@
   },
   {
     "pname": "Bannerlord.ModuleManager.Models",
-    "version": "6.0.242",
-    "hash": "sha256-iRTxQ7VhrYziaAy3jzD7qEXzq6bOM8eIrB6kyZMurkY="
+    "version": "6.0.246",
+    "hash": "sha256-i8sTl8pldn9VzluxtSZ0EctC9P4j5ymZ01s9oWnMFI4="
   },
   {
     "pname": "BenchmarkDotNet",
@@ -356,58 +356,58 @@
   },
   {
     "pname": "GameFinder",
-    "version": "4.3.3",
-    "hash": "sha256-uJzGa5CAa+6oHuG5gU0TN68biDb7ZQYGgqeW1nGLHQc="
+    "version": "4.4.0",
+    "hash": "sha256-MaVW4qgbZgsoyIq8cLQLNJnZe2M7wsKAIE+ICxRNyzg="
   },
   {
     "pname": "GameFinder.Common",
-    "version": "4.3.3",
-    "hash": "sha256-0mITSz+9TyknYO8zzvLNB70jWPe5v2Q3sKHPupvGGBk="
+    "version": "4.4.0",
+    "hash": "sha256-7tk84DGPBM2M8KvuTnDm4hLVmLUMd8GSLDFhsjl7Ra0="
   },
   {
     "pname": "GameFinder.Launcher.Heroic",
-    "version": "4.3.3",
-    "hash": "sha256-3DuhHRGbWeh4Smj0TXitzUsTPbCwHmtZsk3e+CVZHHA="
+    "version": "4.4.0",
+    "hash": "sha256-/fp62b11/TXEMsrZzafHbbZYmU9pGgr7qVE2iUCVJik="
   },
   {
     "pname": "GameFinder.RegistryUtils",
-    "version": "4.3.3",
-    "hash": "sha256-bd6qpOthn4ljNpwQi7pdVe5P1EN8DnXbyKyR4PnSxJk="
+    "version": "4.4.0",
+    "hash": "sha256-6Yk3A88xSWO7wr+1bJQtH6D2DRzQ0AOb8HkmSb34MPk="
   },
   {
     "pname": "GameFinder.StoreHandlers.EADesktop",
-    "version": "4.3.3",
-    "hash": "sha256-jvh672wPSH0T4W6dJHdvMGJi93LWDJBefcVFrkxT6hI="
+    "version": "4.4.0",
+    "hash": "sha256-k2tUCIxnKEdIZtaqATpJLoHh6p0mgLIB1UzBWoEcDec="
   },
   {
     "pname": "GameFinder.StoreHandlers.EGS",
-    "version": "4.3.3",
-    "hash": "sha256-IKDDTnCor3G7HdsVjo0wYNJQjBoQjQ+a+MgjnGVOaek="
+    "version": "4.4.0",
+    "hash": "sha256-7zxg064pFoHOYOa2kibtC1kpYgXRpbFh1Z9EatEcSNE="
   },
   {
     "pname": "GameFinder.StoreHandlers.GOG",
-    "version": "4.3.3",
-    "hash": "sha256-76+W+wi33ms0Xm5OCXQBmHCAilWRaA/OMd343vkkhc0="
+    "version": "4.4.0",
+    "hash": "sha256-8LWj1MaEKhukBXs0ZIt5pt5z1H1i3VuoJONqqH6gNvY="
   },
   {
     "pname": "GameFinder.StoreHandlers.Origin",
-    "version": "4.3.3",
-    "hash": "sha256-Ss48fc+19RqhjkEP0tld5Eui65XwECFeAMu+126JCo4="
+    "version": "4.4.0",
+    "hash": "sha256-TP9KYLDIZxFn3+N58zwjBPrL5COl2HxEpfr550OsUrM="
   },
   {
     "pname": "GameFinder.StoreHandlers.Steam",
-    "version": "4.3.3",
-    "hash": "sha256-EQxtM7k459MfHL0Z2Li45jWji6CgGvpJbJbJv8zXVc4="
+    "version": "4.4.0",
+    "hash": "sha256-D6ABxneqdc+467RvYMs8qULyYHNTs7I0GsmXBIpiZMM="
   },
   {
     "pname": "GameFinder.StoreHandlers.Xbox",
-    "version": "4.3.3",
-    "hash": "sha256-uzIPKS3O/uxqXZMysZfgRlQaDUSUhj1y9hCKAwwhK0g="
+    "version": "4.4.0",
+    "hash": "sha256-xLZJ4J79ptEjPduwdY8E288UJRQ92JnHSjkJc6Ubt+4="
   },
   {
     "pname": "GameFinder.Wine",
-    "version": "4.3.3",
-    "hash": "sha256-aEFkI7UVHsipCxdvHq3P+mrThgYdrFhpK6EbyFYqU6Y="
+    "version": "4.4.0",
+    "hash": "sha256-lmGF+gzipCBIu/c4wR2Qgqq6/5Dd4ZhqlxUuCRX7pmY="
   },
   {
     "pname": "Gee.External.Capstone",
@@ -1006,8 +1006,8 @@
   },
   {
     "pname": "Microsoft.CodeCoverage",
-    "version": "17.11.1",
-    "hash": "sha256-1dLlK3NGh88PuFYZiYpT+izA96etxhU3BSgixDgdtGA="
+    "version": "17.12.0",
+    "hash": "sha256-lGjifppD0OBMBp28pjUfPipaeXg739n8cPhtHWoo5RE="
   },
   {
     "pname": "Microsoft.Composition",
@@ -1436,8 +1436,8 @@
   },
   {
     "pname": "Microsoft.NET.Test.Sdk",
-    "version": "17.11.1",
-    "hash": "sha256-0JUEucQ2lzaPgkrjm/NFLBTbqU1dfhvhN3Tl3moE6mI="
+    "version": "17.12.0",
+    "hash": "sha256-DKFEbhh2wPzahNeHdEoFig8tZh/LEVrFc5+zpT43Btg="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
@@ -1481,13 +1481,13 @@
   },
   {
     "pname": "Microsoft.TestPlatform.ObjectModel",
-    "version": "17.11.1",
-    "hash": "sha256-5vX+vCzFY3S7xfMVIv8OlMMFtdedW9UIJzc0WEc+vm4="
+    "version": "17.12.0",
+    "hash": "sha256-3XBHBSuCxggAIlHXmKNQNlPqMqwFlM952Av6RrLw1/w="
   },
   {
     "pname": "Microsoft.TestPlatform.TestHost",
-    "version": "17.11.1",
-    "hash": "sha256-wSkY0H1fQAq0H3LcKT4u7Y5RzhAAPa6yueVN84g8HxU="
+    "version": "17.12.0",
+    "hash": "sha256-rf8Sh0fQq44Sneuvs64unkkIHg8kOjDGWE35j9iLx5I="
   },
   {
     "pname": "Microsoft.VisualStudio.Composition",
@@ -1800,9 +1800,24 @@
     "hash": "sha256-YfGVVfl/Yon9WgJCZscXZMbZoCNg+OvGFvdPSxe+Q1I="
   },
   {
+    "pname": "protobuf-net",
+    "version": "3.2.45",
+    "hash": "sha256-rWitxe3uP3SOyoG1fwM5n00RpR5IL1V6u1zXMI0p0JA="
+  },
+  {
+    "pname": "protobuf-net.Core",
+    "version": "3.2.45",
+    "hash": "sha256-bsMGUmd0yno8g0H0637jJboKJwyyHLHoHg45+bt9pLQ="
+  },
+  {
     "pname": "QoiSharp",
     "version": "1.0.0",
     "hash": "sha256-iN/yCXVN0M5+T/Ye9KJ+EGoLsaBxFU/uCIXvX17EhkM="
+  },
+  {
+    "pname": "QRCoder",
+    "version": "1.6.0",
+    "hash": "sha256-2Ev/6d7PH6K4dVYQQHlZ+ZggkCnDtrlaGygs65mDo28="
   },
   {
     "pname": "R3",
@@ -2183,6 +2198,11 @@
     "pname": "Splat.Microsoft.Extensions.Logging",
     "version": "15.2.22",
     "hash": "sha256-4QO7NAcOqTDxwsheB2wyXRdH626JylEbahQaKWKZpIc="
+  },
+  {
+    "pname": "SteamKit2",
+    "version": "3.0.0",
+    "hash": "sha256-bRRdX8WFo9k+QCZWh0KHb3TULpJxpR4Hg9FDXKBW6d4="
   },
   {
     "pname": "StrawberryShake.Core",

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -135,6 +135,9 @@ buildDotnetModule (finalAttrs: {
       "NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_RemoteImage"
       "NexusMods.UI.Tests.ImageCacheTests.Test_LoadAndCache_ImageStoredFile"
 
+      # Fails in ofborg with VerifyException tests/Games/NexusMods.Games.StardewValley.Tests
+      "NexusMods.Games.StardewValley.Tests.StardewValleyInstallersTests.CanInstallMod"
+
       # Fails with: Expected a <System.ArgumentException> to be thrown, but no exception was thrown.
       "NexusMods.Networking.ModUpdates.Tests.PerFeedCacheUpdaterTests.Constructor_WithItemsFromDifferentGames_ShouldThrowArgumentException_InDebug"
     ]

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -97,7 +97,7 @@ buildDotnetModule (finalAttrs: {
       size=''${i}x''${i}
       dir=$out/share/icons/hicolor/$size/apps
       mkdir -p $dir
-      convert -background none -resize $size $icon $dir/com.nexusmods.app.png
+      magick -background none $icon -resize $size $dir/com.nexusmods.app.png
     done
   '';
 

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -25,12 +25,12 @@ let
 in
 buildDotnetModule (finalAttrs: {
   inherit pname;
-  version = "0.7.1";
+  version = "0.7.2";
 
   src = fetchgit {
     url = "https://github.com/Nexus-Mods/NexusMods.App.git";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-TcT+siZMJlOYRtiQV+RAPPfM47wewfsz7WiPFaxCUkc=";
+    hash = "sha256-Kss1K1ZqXLZ/WbbyY3ZQRe8Kvmjdu3tRGfcagE7Q42Q=";
     fetchSubmodules = true;
     fetchLFS = true;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Bump version: 0.7.1 -> 0.7.2
- [Upstream's changelog](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.7.2)
- [Previous update PR](https://github.com/NixOS/nixpkgs/pull/365942)

Also:
- Still need .NET 8 runtime available while building, for the StrawberryShake dependency 😦
- Replaced usage of `convert` with `magick` to resolve deprecation warnings in the build log.
- The package's tests still seem flaky, they failed when building locally
  - Actually building/running the app works fine though

## Notes for end-users

> [!TIP]
> When upgrading from version 0.7.0 or newer, it _should_ be safe to upgrade **without** resetting/uninstalling.

> [!CAUTION]
> When upgrading from a **version older than 0.7.0**, you will need a fresh start.
> If you have configuration leftover from an old version, the updated app will crash.
>
> See upstream's guide on [how to uninstall the app](https://nexus-mods.github.io/NexusMods.App/users/Uninstall/).

<details><summary>Resetting tips</summary>
<p>

You can reset all modded games and wipe your nexusmods-app config using:
```
NexusMods.App uninstall-app
```
- This should be done **before** updating the app.
- **Be careful**: There's no way to recover a wiped config!

If you've run the appimage version from upstream, or a pre-0.6 nixpkgs version, you may also need to remove old desktop entries to avoid other issues:
```
rm ~/.local/share/applications/com.nexusmods.app.desktop
```


</p>
</details>

> [!CAUTION]
> Known issues are listed on the [changelog](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.7.2), but include:
> - Stardew Valley (Native Linux version) is not detected when installed via Heroic Launcher on Linux. The Windows version of the game can be used instead until this issue is fixed.
> - Bundled mods included with collections do not appear in the UI but are still applied to your game.
> - The success rating for collections is not showing the correct value.
> - The game version is not checked when adding a collection meaning you can install outdated mods without being warned.
> - The Collections (WIP) page is not filtered by game.
> - The "Switch View" option does not persist in the Library/Installed Mods view.
> - The "Load Order" heading toggle does not persist in the Load Order view.



## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
