### PR TITLE
nixos/rundeck: init

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -128,6 +128,8 @@
 
 - [porxie](https://codeberg.org/Blooym/porxie), a correct and efficient ATProto blob proxy for secure content delivery. Available as [services.porxie](#opt-services.porxie.enable).
 
+- [Rundeck](https://www.rundeck.com), Self-Service Operations [services.rundeck](#opt-services.rundeck.enable).
+
 ## Backward Incompatibilities {#sec-release-26.05-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2611.section.md
+++ b/nixos/doc/manual/release-notes/rl-2611.section.md
@@ -108,6 +108,8 @@
 
 - [Umbriel](https://docs.noctalia.dev/umbriel/), a Wayland compositor built on wlroots and SceneFX. Available as [programs.umbriel](#opt-programs.umbriel.enable).
 
+- [Rundeck](https://www.rundeck.com), Self-Service Operations [services.rundeck](#opt-services.rundeck.enable).
+
 ## Backward Incompatibilities {#sec-release-26.11-incompatibilities}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1761,6 +1761,7 @@
   ./services/web-apps/rimgo.nix
   ./services/web-apps/rss-bridge.nix
   ./services/web-apps/rsshub.nix
+  ./services/web-apps/rundeck.nix
   ./services/web-apps/rutorrent.nix
   ./services/web-apps/screego.nix
   ./services/web-apps/selfoss.nix

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1824,6 +1824,7 @@
   ./services/web-apps/romm.nix
   ./services/web-apps/rss-bridge.nix
   ./services/web-apps/rsshub.nix
+  ./services/web-apps/rundeck.nix
   ./services/web-apps/rustical.nix
   ./services/web-apps/rutorrent.nix
   ./services/web-apps/screego.nix

--- a/nixos/modules/services/web-apps/rundeck.nix
+++ b/nixos/modules/services/web-apps/rundeck.nix
@@ -1,0 +1,653 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.rundeck;
+  formatConfig = lib.mapAttrsToList (name: value: "${name}=${toString value}");
+  effectivePort = if cfg.ssl.enable then cfg.ssl.port else cfg.serverPort;
+  scheme = if cfg.ssl.enable then "https" else "http";
+  defaultServerURL = "${scheme}://${cfg.serverHostname}:${toString effectivePort}";
+  effectiveServerURL = if cfg.serverURL != "" then cfg.serverURL else defaultServerURL;
+
+  rundeckStartScript = pkgs.writeShellScript "start-rundeck" ''
+    ${lib.optionalString (cfg.serverUUID == "") ''
+      # Generate UUID
+      UUID_FILE="${cfg.dataDir}/.uuid"
+      if [ ! -f "$UUID_FILE" ]; then
+        umask 0137
+        touch "$UUID_FILE"
+        chown ${cfg.user}:${cfg.group} "$UUID_FILE"
+        ${lib.getExe' pkgs.util-linux "uuidgen"} > "$UUID_FILE"
+      fi
+    ''}
+
+    # Generate SSH
+    if [ ! -f ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType} ]; then
+      umask 0077
+      ${lib.getExe' pkgs.openssh "ssh-keygen"} -t ${cfg.sshKeyType} ${
+        lib.optionalString (cfg.sshKeyType == "rsa") "-b 4096"
+      } -N "" -f ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}
+      chmod 644 ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}.pub
+      chown ${cfg.user}:${cfg.group} ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType} ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}.pub
+    fi
+
+    ${lib.getExe cfg.package} \
+      --skipinstall \
+      -b ${cfg.dataDir} \
+      -c ${cfg.configDir} \
+      -p ${cfg.dataDir}/projects
+  '';
+in
+{
+  options = {
+    services.rundeck = {
+      enable = lib.mkEnableOption "Rundeck service";
+
+      package = lib.mkPackageOption pkgs "rundeck" { };
+
+      adminUser = lib.mkOption {
+        type = lib.types.str;
+        default = "admin";
+        description = "Username for the Rundeck admin user";
+        example = "rundeck-admin";
+      };
+
+      adminPassword = lib.mkOption {
+        type = lib.types.str;
+        default = "admin";
+        description = "Password for the Rundeck admin user";
+        example = "securePassword123";
+      };
+
+      adminPasswordFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = "Path to a file containing the admin password (more secure than adminPassword)";
+        example = "/run/secrets/rundeck-admin-password";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "rundeck";
+        description = "User account under which Rundeck runs";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "rundeck";
+        description = "Group account under which Rundeck runs";
+      };
+
+      serverAddress = lib.mkOption {
+        type = lib.types.str;
+        default = "0.0.0.0";
+        description = "Address on which Rundeck will listen";
+      };
+
+      serverHostname = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost";
+        description = "Hostname for the Rundeck server";
+      };
+
+      serverURL = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "Complete Grails server URL (if set, overrides automatic URL generation)";
+        example = "https://myhost:4443/rundeck";
+      };
+
+      serverPort = lib.mkOption {
+        type = lib.types.port;
+        default = 4440;
+        description = "Port on which Rundeck will listen";
+      };
+
+      serverUUID = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "UUID for the Rundeck server (automatically generated if not specified)";
+      };
+
+      dataDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/rundeck";
+        description = "Directory for Rundeck runtime data (RDECK_BASE)";
+      };
+
+      configDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/etc/rundeck";
+        description = "Directory for Rundeck configuration files";
+      };
+
+      sshTimeout = lib.mkOption {
+        type = lib.types.int;
+        default = 60;
+        description = "SSH connection timeout in seconds";
+      };
+
+      javaOpts = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "-Xmx1024m"
+          "-Xms256m"
+          "-XX:MaxMetaspaceSize=256m"
+          "-server"
+        ];
+        description = "Additional Java options for Rundeck";
+      };
+
+      aclPolicies = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = "ACL policies for Rundeck, where the attribute name is the filename and the value is the policy content";
+        example = lib.literalExpression ''
+          {
+            "admin.aclpolicy" = '''
+              description: Admin access for administrators
+              context:
+                project: '.*'
+              for:
+                resource:
+                  - allow: '*'
+                job:
+                  - allow: '*'
+                node:
+                  - allow: '*'
+              by:
+                group: admin
+              ---
+              description: Admin access in application scope
+              context:
+                application: 'rundeck'
+              for:
+                resource:
+                  - allow: '*'
+                project:
+                  - allow: '*'
+              by:
+                group: admin
+            ''';
+          }
+        '';
+      };
+
+      extraConfig = lib.mkOption {
+        type = lib.types.attrs;
+        default = { };
+        description = "Additional configuration options for rundeck-config.properties";
+        example = lib.literalExpression ''
+          {
+            "rundeck.gui.title" = "My Rundeck Server";
+            "rundeck.feature.repository.enabled" = "true";
+            "rundeck.projectsStorageType" = "db";
+          }
+        '';
+      };
+
+      sshKeyType = lib.mkOption {
+        type = lib.types.enum [
+          "rsa"
+          "ed25519"
+        ];
+        default = "rsa";
+        description = "Type of SSH key to generate (rsa for compatibility, ed25519 for better security)";
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to open the Rundeck port in the firewall";
+      };
+
+      startTimeout = lib.mkOption {
+        type = lib.types.int;
+        default = 180;
+        description = "Timeout in seconds before systemd considers the service startup as failed";
+        example = 120;
+      };
+
+      database = {
+        type = lib.mkOption {
+          type = lib.types.enum [
+            "h2"
+            "postgresql"
+            "mysql"
+          ];
+          default = "h2";
+          description = "Database type to use (h2, postgresql, or mysql)";
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "localhost";
+          description = "Database host";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 0;
+          description = "Database port (defaults: PostgreSQL: 5432, MySQL: 3306)";
+        };
+
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = "rundeck";
+          description = "Database name";
+        };
+
+        username = lib.mkOption {
+          type = lib.types.str;
+          default = "rundeck";
+          description = "Database username";
+        };
+
+        password = lib.mkOption {
+          type = lib.types.str;
+          default = "rundeck";
+          description = "Database password (not recommended, use passwordFile instead)";
+        };
+
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Path to a file containing the database password";
+          example = "/run/secrets/rundeck-db-password";
+        };
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.attrsOf (
+          lib.types.oneOf [
+            lib.types.bool
+            lib.types.int
+            lib.types.str
+          ]
+        );
+        default = { };
+        description = ''
+          Rundeck configuration options.
+          See https://docs.rundeck.com/docs/administration/configuration/config-file-reference.html
+          for all available options.
+
+          Note: Top-level options like serverAddress, serverPort, etc. will override
+          any corresponding keys defined here.
+        '';
+        example = lib.literalExpression ''
+          {
+            # These are different from the top-level options:
+            "rundeck.feature.repository.enabled" = "true";
+            "rundeck.projectsStorageType" = "db";
+            "rundeck.gui.title" = "My Rundeck Instance";
+            "rdeck.security.useHMacRequestTokens" = "true";
+            "rundeck.web.jetty.servlet.MaxFormKeys" = "2000";
+          }
+        '';
+      };
+
+      ssl = {
+        enable = lib.mkEnableOption "SSL support";
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 4443;
+          description = "Port on which Rundeck will listen for HTTPS when ssl.enable is true";
+        };
+
+        keyStore = lib.mkOption {
+          type = lib.types.path;
+          example = "/etc/rundeck/ssl/keystore";
+          description = "Path to the keystore containing the SSL certificate";
+        };
+
+        keyStorePassword = lib.mkOption {
+          type = lib.types.str;
+          description = "Password for the SSL keystore (not recommended for production, use keyStorePasswordFile instead)";
+        };
+
+        keyStorePasswordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Path to a file containing the SSL keystore password";
+          example = "/run/secrets/rundeck-keystore-password";
+        };
+
+        keyPassword = lib.mkOption {
+          type = lib.types.str;
+          description = "Password for the SSL key (not recommended for production, use keyPasswordFile instead)";
+        };
+
+        keyPasswordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Path to a file containing the SSL key password";
+          example = "/run/secrets/rundeck-key-password";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    services.rundeck.database.port = lib.mkDefault (
+      if cfg.database.type == "postgresql" then
+        5432
+      else if cfg.database.type == "mysql" then
+        3306
+      else
+        null
+    );
+
+    assertions = [
+      {
+        assertion =
+          cfg.database.type == "h2"
+          || (
+            cfg.database.host != ""
+            && cfg.database.username != ""
+            && (cfg.database.password != "" || cfg.database.passwordFile != null)
+          );
+        message = "When using external database (PostgreSQL/MySQL), host, username, and password/passwordFile must be provided";
+      }
+      {
+        assertion = cfg.database.type == "h2" || cfg.database.port > 0;
+        message = "Database port must be set when using an external database";
+      }
+    ];
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+      createHome = true;
+    };
+
+    users.groups.${cfg.group} = { };
+
+    systemd.tmpfiles.settings."10-rundeck" = {
+      "${cfg.dataDir}" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/etc" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/data" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/projects" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/libext" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/var" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/var/logs" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/var/tmp" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/.ssh" = {
+        d = {
+          mode = "0700";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.configDir}" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.configDir}/ssl" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "/var/log/rundeck" = {
+        L = {
+          argument = "${cfg.dataDir}/var/logs";
+        };
+      };
+    };
+
+    environment.etc."rundeck/jaas-loginmodule.conf" = {
+      mode = "0640";
+      user = cfg.user;
+      group = cfg.group;
+      text = ''
+        RDpropertyfilelogin {
+          org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required
+          debug="true"
+          file="/etc/rundeck/realm.properties";
+        };
+      '';
+    };
+
+    environment.etc."rundeck/log4j2.properties" = {
+      mode = "0640";
+      user = cfg.user;
+      group = cfg.group;
+      text = ''
+        status = info
+        name = RundeckPro
+
+        appender.console.type = Console
+        appender.console.name = STDOUT
+        appender.console.layout.type = PatternLayout
+        appender.console.layout.pattern = %d{DEFAULT} %-5p %c{1} - %m%n
+
+        appender.file.type = RollingFile
+        appender.file.name = FILE
+        appender.file.fileName = ${cfg.dataDir}/var/logs/rundeck.log
+        appender.file.filePattern = ${cfg.dataDir}/var/logs/rundeck.%d{yyyy-MM-dd}.log
+        appender.file.layout.type = PatternLayout
+        appender.file.layout.pattern = %d{DEFAULT} [%t] %-5p %c{1} - %m%n
+        appender.file.policies.type = Policies
+        appender.file.policies.time.type = TimeBasedTriggeringPolicy
+        appender.file.policies.time.interval = 1
+        appender.file.policies.time.modulate = true
+
+        rootLogger.level = info
+        rootLogger.appenderRef.stdout.ref = STDOUT
+        rootLogger.appenderRef.file.ref = FILE
+
+        logger.hibernate.name = org.hibernate
+        logger.hibernate.level = ERROR
+      '';
+    };
+
+    systemd.services.rundeck = {
+      description = "Rundeck Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network.target" ];
+      wants =
+        lib.optional (cfg.database.type == "mysql") "mysql.service"
+        ++ lib.optional (cfg.database.type == "postgresql") "postgresql.service";
+
+      environment = {
+        RDECK_BASE = cfg.dataDir;
+        RUNDECK_CONFIG_DIR = cfg.configDir;
+        JAVA_OPTS = lib.concatStringsSep " " cfg.javaOpts;
+      };
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = rundeckStartScript;
+        WorkingDirectory = cfg.dataDir;
+        RuntimeDirectory = "rundeck";
+        RuntimeDirectoryMode = "0750";
+        UMask = "0027";
+
+        LimitNOFILE = 65536;
+        ReadWritePaths = [
+          cfg.dataDir
+          cfg.configDir
+        ];
+        RestartSec = "10s";
+        Restart = "always";
+        TimeoutStartSec = "${toString cfg.startTimeout}s";
+      };
+
+      preStart = ''
+        cat > ${cfg.configDir}/rundeck-config.properties <<EOF
+        ${lib.concatStringsSep "\n" (
+          formatConfig (
+            cfg.settings
+            // {
+              "server.address" = toString cfg.serverAddress;
+              "server.port" = toString cfg.serverPort;
+              "grails.serverURL" = effectiveServerURL;
+              "logging.config" = "${cfg.configDir}/log4j2.properties";
+              "dataSource.url" =
+                if cfg.database.type == "h2" then
+                  "jdbc:h2:file:${cfg.dataDir}/data/rundeckdb;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=MONTH,HOUR,MINUTE,YEAR,SECONDS"
+                else if cfg.database.type == "postgresql" then
+                  "jdbc:postgresql://${cfg.database.host}:${toString cfg.database.port}/${cfg.database.name}"
+                else
+                  "jdbc:mysql://${cfg.database.host}:${toString cfg.database.port}/${cfg.database.name}?autoReconnect=true&useSSL=false";
+              "dataSource.driverClassName" =
+                if cfg.database.type == "h2" then
+                  "org.h2.Driver"
+                else if cfg.database.type == "postgresql" then
+                  "org.postgresql.Driver"
+                else
+                  "org.mariadb.jdbc.Driver";
+              "dataSource.username" = cfg.database.username;
+              "dataSource.password" =
+                if cfg.database.passwordFile != null then
+                  "$(cat ${cfg.database.passwordFile})"
+                else
+                  cfg.database.password;
+            }
+            // cfg.extraConfig
+            // lib.optionalAttrs (cfg.database.type == "h2") {
+              "dataSource.dialect" = "org.hibernate.dialect.H2Dialect";
+            }
+            // lib.optionalAttrs (cfg.database.type == "mysql") {
+              "dataSource.dialect" = "org.hibernate.dialect.MariaDB103Dialect";
+            }
+            // lib.optionalAttrs cfg.ssl.enable {
+              "server.https.port" = toString cfg.ssl.port;
+              "server.ssl.keyStore" = toString cfg.ssl.keyStore;
+              "server.ssl.keyStorePassword" =
+                if cfg.ssl.keyStorePasswordFile != null then
+                  "$(cat ${cfg.ssl.keyStorePasswordFile})"
+                else
+                  cfg.ssl.keyStorePassword;
+              "server.ssl.keyPassword" =
+                if cfg.ssl.keyPasswordFile != null then
+                  "$(cat ${cfg.ssl.keyPasswordFile})"
+                else
+                  cfg.ssl.keyPassword;
+            }
+          )
+        )}
+        EOF
+
+        cat > ${cfg.configDir}/framework.properties <<EOF
+        framework.server.name = ${cfg.serverHostname}
+        framework.server.hostname = ${cfg.serverHostname}
+        framework.server.port = ${toString effectivePort}
+        framework.server.url = ${effectiveServerURL}
+        rdeck.base = ${cfg.dataDir}
+        framework.projects.dir = ${cfg.dataDir}/projects
+        framework.etc.dir = ${cfg.configDir}
+        framework.var.dir = ${cfg.dataDir}/var
+        framework.tmp.dir = ${cfg.dataDir}/var/tmp
+        framework.logs.dir = ${cfg.dataDir}/var/logs
+        framework.libext.dir = ${cfg.dataDir}/libext
+        framework.ssh.keypath = ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}
+        framework.ssh.user = ${cfg.user}
+        framework.ssh.timeout = ${toString cfg.sshTimeout}
+        rundeck.server.uuid = ${
+          if toString cfg.serverUUID == "" then "$(cat ${cfg.dataDir}/.uuid)" else toString cfg.serverUUID
+        }
+        EOF
+
+        if [ -f ${cfg.dataDir}/etc/framework.properties ]; then
+          cp -a "${cfg.configDir}/framework.properties" "${cfg.dataDir}/etc/framework.properties"
+        fi
+
+        ${lib.optionalString (cfg.adminPasswordFile != null) ''
+          cat > ${cfg.configDir}/realm.properties <<EOF
+          ${cfg.adminUser}:$(cat ${cfg.adminPasswordFile}),user,admin
+          EOF
+        ''}
+
+        ${lib.optionalString (cfg.adminPasswordFile == null) ''
+          cat > ${cfg.configDir}/realm.properties <<EOF
+          ${cfg.adminUser}:${cfg.adminPassword},user,admin
+          EOF
+        ''}
+
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (name: content: ''
+            cat > ${cfg.dataDir}/etc/${name} <<EOF
+            ${content}
+            EOF
+          '') cfg.aclPolicies
+        )}
+      '';
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      (if cfg.ssl.enable then cfg.ssl.port else cfg.serverPort)
+    ];
+  };
+}

--- a/nixos/modules/services/web-apps/rundeck.nix
+++ b/nixos/modules/services/web-apps/rundeck.nix
@@ -1,0 +1,651 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.rundeck;
+  settingsFormat = pkgs.formats.javaProperties { };
+  effectivePort = if cfg.ssl.enable then cfg.ssl.port else cfg.serverPort;
+  scheme = if cfg.ssl.enable then "https" else "http";
+
+  configFile = settingsFormat.generate "rundeck-config.properties" cfg.settings;
+  frameworkFile = settingsFormat.generate "framework.properties" cfg.frameworkSettings;
+
+  realmFile = pkgs.writeText "realm.properties" ''
+    ${cfg.adminUser}:@ADMIN_PASSWORD@,user,admin
+  '';
+
+  replaceSecret =
+    placeholder: file: target:
+    "replace-secret ${
+      lib.escapeShellArgs [
+        placeholder
+        file
+        target
+      ]
+    }";
+
+  rundeckStartScript = pkgs.writeShellScript "start-rundeck" ''
+    # Generate SSH
+    if [ ! -f ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType} ]; then
+      umask 0077
+      ${lib.getExe' pkgs.openssh "ssh-keygen"} -t ${cfg.sshKeyType} ${
+        lib.optionalString (cfg.sshKeyType == "rsa") "-b 4096"
+      } -N "" -f ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}
+      chmod 644 ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}.pub
+      chown ${cfg.user}:${cfg.group} ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType} ${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}.pub
+    fi
+
+    ${lib.getExe cfg.package} \
+      --skipinstall \
+      -b ${cfg.dataDir} \
+      -c ${cfg.configDir} \
+      -p ${cfg.dataDir}/projects
+  '';
+in
+{
+  options = {
+    services.rundeck = {
+      enable = lib.mkEnableOption "Rundeck service";
+
+      package = lib.mkPackageOption pkgs "rundeck" { };
+
+      adminUser = lib.mkOption {
+        type = lib.types.str;
+        default = "admin";
+        description = "Username for the Rundeck admin user";
+        example = "rundeck-admin";
+      };
+
+      adminPasswordFile = lib.mkOption {
+        type = lib.types.path;
+        description = "Path to a file containing the admin password";
+        example = "/run/secrets/rundeck-admin-password";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "rundeck";
+        description = "User account under which Rundeck runs";
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "rundeck";
+        description = "Group account under which Rundeck runs";
+      };
+
+      serverHostname = lib.mkOption {
+        type = lib.types.str;
+        default = "localhost";
+        description = "Hostname for the Rundeck server";
+      };
+
+      serverURL = lib.mkOption {
+        type = lib.types.str;
+        default = "${scheme}://${cfg.serverHostname}:${toString effectivePort}";
+        defaultText = lib.literalMD ''
+          `<scheme>://<serverHostname>:<port>`, where scheme is `https` when
+          `ssl.enable` else `http`, and port is `ssl.port` when `ssl.enable`
+          else `serverPort`.
+        '';
+        description = "Complete Grails server URL";
+        example = "https://myhost:4443/rundeck";
+      };
+
+      serverPort = lib.mkOption {
+        type = lib.types.port;
+        default = 4440;
+        description = "Port on which Rundeck will listen";
+      };
+
+      serverUUID = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "UUID for the Rundeck server (automatically generated if not specified)";
+      };
+
+      dataDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/rundeck";
+        description = "Directory for Rundeck runtime data (RDECK_BASE)";
+      };
+
+      configDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/etc/rundeck";
+        description = "Directory for Rundeck configuration files";
+      };
+
+      javaOpts = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "-Xmx1024m"
+          "-Xms256m"
+          "-XX:MaxMetaspaceSize=256m"
+          "-server"
+        ];
+        description = "Additional Java options for Rundeck";
+      };
+
+      aclPolicies = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        description = "ACL policies for Rundeck, where the attribute name is the filename and the value is the policy content";
+        example = lib.literalExpression ''
+          {
+            "admin.aclpolicy" = '''
+              description: Admin access for administrators
+              context:
+                project: '.*'
+              for:
+                resource:
+                  - allow: '*'
+                job:
+                  - allow: '*'
+                node:
+                  - allow: '*'
+              by:
+                group: admin
+              ---
+              description: Admin access in application scope
+              context:
+                application: 'rundeck'
+              for:
+                resource:
+                  - allow: '*'
+                project:
+                  - allow: '*'
+              by:
+                group: admin
+            ''';
+          }
+        '';
+      };
+
+      sshKeyType = lib.mkOption {
+        type = lib.types.enum [
+          "rsa"
+          "ed25519"
+        ];
+        default = "rsa";
+        description = "Type of SSH key to generate (rsa for compatibility, ed25519 for better security)";
+      };
+
+      openFirewall = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to open the Rundeck port in the firewall";
+      };
+
+      startTimeout = lib.mkOption {
+        type = lib.types.int;
+        default = 180;
+        description = "Timeout in seconds before systemd considers the service startup as failed";
+        example = 120;
+      };
+
+      database = {
+        type = lib.mkOption {
+          type = lib.types.enum [
+            "h2"
+            "postgresql"
+            "mysql"
+          ];
+          default = "h2";
+          description = "Database type to use (h2, postgresql, or mysql)";
+        };
+
+        host = lib.mkOption {
+          type = lib.types.str;
+          default = "localhost";
+          description = "Database host";
+        };
+
+        port = lib.mkOption {
+          type = lib.types.nullOr lib.types.port;
+          default =
+            if cfg.database.type == "postgresql" then
+              5432
+            else if cfg.database.type == "mysql" then
+              3306
+            else
+              null;
+          defaultText = lib.literalExpression ''
+            if config.services.rundeck.database.type == "postgresql" then
+              5432
+            else if config.services.rundeck.database.type == "mysql" then
+              3306
+            else
+              null
+          '';
+          description = "Database port (defaults: PostgreSQL: 5432, MySQL: 3306)";
+        };
+
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = "rundeck";
+          description = "Database name";
+        };
+
+        username = lib.mkOption {
+          type = lib.types.str;
+          default = "rundeck";
+          description = "Database username";
+        };
+
+        passwordFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Path to a file containing the database password";
+          example = "/run/secrets/rundeck-db-password";
+        };
+      };
+
+      settings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+        };
+        default = { };
+        description = ''
+          Configuration written to `rundeck-config.properties`.
+          See <https://docs.rundeck.com/docs/administration/configuration/config-file-reference.html>
+          for available options.
+
+          Secrets must not be set here, as this ends up world-readable in the Nix
+          store. Use the dedicated `*File` options instead.
+        '';
+        example = lib.literalExpression ''
+          {
+            "rundeck.feature.repository.enabled" = "true";
+            "rundeck.projectsStorageType" = "db";
+            "rundeck.gui.title" = "My Rundeck Instance";
+            "rdeck.security.useHMacRequestTokens" = "true";
+            "rundeck.web.jetty.servlet.MaxFormKeys" = "2000";
+          }
+        '';
+      };
+
+      frameworkSettings = lib.mkOption {
+        type = lib.types.submodule {
+          freeformType = settingsFormat.type;
+        };
+        default = { };
+        description = ''
+          Configuration written to `framework.properties`.
+          See <https://docs.rundeck.com/docs/administration/configuration/config-file-reference.html>
+          for available options.
+        '';
+        example = lib.literalExpression ''
+          {
+            "framework.ssh.timeout" = "120";
+            "framework.ssh.user" = "deploy";
+          }
+        '';
+      };
+
+      ssl = {
+        enable = lib.mkEnableOption "SSL support";
+
+        port = lib.mkOption {
+          type = lib.types.port;
+          default = 4443;
+          description = "Port on which Rundeck will listen for HTTPS when ssl.enable is true";
+        };
+
+        keyStore = lib.mkOption {
+          type = lib.types.path;
+          example = "/etc/rundeck/ssl/keystore";
+          description = "Path to the keystore containing the SSL certificate";
+        };
+
+        keyStorePasswordFile = lib.mkOption {
+          type = lib.types.path;
+          description = "Path to a file containing the SSL keystore password";
+          example = "/run/secrets/rundeck-keystore-password";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    assertions = [
+      {
+        assertion =
+          cfg.database.type == "h2"
+          || (cfg.database.host != "" && cfg.database.username != "" && cfg.database.passwordFile != null);
+        message = "When using external database (PostgreSQL/MySQL), host, username, and passwordFile must be provided";
+      }
+      {
+        assertion = cfg.database.type == "h2" || cfg.database.port != null;
+        message = "Database port must be set when using an external database";
+      }
+    ];
+
+    services.rundeck.settings = {
+      "server.address" = lib.mkDefault "0.0.0.0";
+      "server.port" = lib.mkDefault (toString cfg.serverPort);
+      "grails.serverURL" = lib.mkDefault cfg.serverURL;
+      "logging.config" = lib.mkDefault "${cfg.configDir}/log4j2.properties";
+      "dataSource.url" = lib.mkDefault (
+        if cfg.database.type == "h2" then
+          "jdbc:h2:file:${cfg.dataDir}/data/rundeckdb;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=MONTH,HOUR,MINUTE,YEAR,SECONDS"
+        else if cfg.database.type == "postgresql" then
+          "jdbc:postgresql://${cfg.database.host}:${toString cfg.database.port}/${cfg.database.name}"
+        else
+          "jdbc:mysql://${cfg.database.host}:${toString cfg.database.port}/${cfg.database.name}?autoReconnect=true&useSSL=false"
+      );
+      "dataSource.driverClassName" = lib.mkDefault (
+        if cfg.database.type == "h2" then
+          "org.h2.Driver"
+        else if cfg.database.type == "postgresql" then
+          "org.postgresql.Driver"
+        else
+          "org.mariadb.jdbc.Driver"
+      );
+      "dataSource.username" = lib.mkDefault cfg.database.username;
+    }
+    // lib.optionalAttrs (cfg.database.passwordFile != null) {
+      "dataSource.password" = lib.mkDefault "@DB_PASSWORD@";
+    }
+    // lib.optionalAttrs (cfg.database.type == "h2") {
+      "dataSource.dialect" = lib.mkDefault "org.hibernate.dialect.H2Dialect";
+    }
+    // lib.optionalAttrs (cfg.database.type == "mysql") {
+      "dataSource.dialect" = lib.mkDefault "org.hibernate.dialect.MariaDB103Dialect";
+    }
+    // lib.optionalAttrs cfg.ssl.enable {
+      "server.https.port" = lib.mkDefault (toString cfg.ssl.port);
+      "server.ssl.keyStore" = lib.mkDefault (toString cfg.ssl.keyStore);
+      "server.ssl.keyStorePassword" = lib.mkDefault "@KEYSTORE_PASSWORD@";
+    };
+
+    services.rundeck.frameworkSettings = {
+      "framework.server.name" = lib.mkDefault cfg.serverHostname;
+      "framework.server.hostname" = lib.mkDefault cfg.serverHostname;
+      "framework.server.port" = lib.mkDefault (toString effectivePort);
+      "framework.server.url" = lib.mkDefault cfg.serverURL;
+      "framework.ssh.keypath" = lib.mkDefault "${cfg.dataDir}/.ssh/id_${cfg.sshKeyType}";
+      "framework.ssh.user" = lib.mkDefault cfg.user;
+      "framework.ssh.timeout" = lib.mkDefault "60";
+      "rdeck.base" = cfg.dataDir;
+      "framework.projects.dir" = "${cfg.dataDir}/projects";
+      "framework.etc.dir" = toString cfg.configDir;
+      "framework.var.dir" = "${cfg.dataDir}/var";
+      "framework.tmp.dir" = "${cfg.dataDir}/var/tmp";
+      "framework.logs.dir" = "${cfg.dataDir}/var/logs";
+      "framework.libext.dir" = "${cfg.dataDir}/libext";
+      "rundeck.server.uuid" = if cfg.serverUUID != "" then cfg.serverUUID else "@SERVER_UUID@";
+    };
+
+    users.users.${cfg.user} = {
+      isSystemUser = true;
+      group = cfg.group;
+      home = cfg.dataDir;
+      createHome = true;
+    };
+
+    users.groups.${cfg.group} = { };
+
+    systemd.tmpfiles.settings."10-rundeck" = {
+      "${cfg.dataDir}" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/etc" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/data" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/projects" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/libext" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/var" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/var/logs" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/var/tmp" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.dataDir}/.ssh" = {
+        d = {
+          mode = "0700";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.configDir}" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "${cfg.configDir}/ssl" = {
+        d = {
+          mode = "0750";
+          user = cfg.user;
+          group = cfg.group;
+        };
+      };
+
+      "/var/log/rundeck" = {
+        L = {
+          argument = "${cfg.dataDir}/var/logs";
+        };
+      };
+    };
+
+    environment.etc."rundeck/jaas-loginmodule.conf" = {
+      mode = "0640";
+      user = cfg.user;
+      group = cfg.group;
+      text = ''
+        RDpropertyfilelogin {
+          org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required
+          debug="true"
+          file="/etc/rundeck/realm.properties";
+        };
+      '';
+    };
+
+    environment.etc."rundeck/log4j2.properties" = {
+      mode = "0640";
+      user = cfg.user;
+      group = cfg.group;
+      text = ''
+        status = info
+        name = RundeckPro
+
+        appender.console.type = Console
+        appender.console.name = STDOUT
+        appender.console.layout.type = PatternLayout
+        appender.console.layout.pattern = %d{DEFAULT} %-5p %c{1} - %m%n
+
+        appender.file.type = RollingFile
+        appender.file.name = FILE
+        appender.file.fileName = ${cfg.dataDir}/var/logs/rundeck.log
+        appender.file.filePattern = ${cfg.dataDir}/var/logs/rundeck.%d{yyyy-MM-dd}.log
+        appender.file.layout.type = PatternLayout
+        appender.file.layout.pattern = %d{DEFAULT} [%t] %-5p %c{1} - %m%n
+        appender.file.policies.type = Policies
+        appender.file.policies.time.type = TimeBasedTriggeringPolicy
+        appender.file.policies.time.interval = 1
+        appender.file.policies.time.modulate = true
+
+        rootLogger.level = info
+        rootLogger.appenderRef.stdout.ref = STDOUT
+        rootLogger.appenderRef.file.ref = FILE
+
+        logger.hibernate.name = org.hibernate
+        logger.hibernate.level = ERROR
+      '';
+    };
+
+    systemd.services.rundeck = {
+      description = "Rundeck Service";
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network.target"
+      ]
+      ++ lib.optional (cfg.database.type == "mysql") "mysql.service"
+      ++ lib.optional (cfg.database.type == "postgresql") "postgresql.service";
+      wants =
+        lib.optional (cfg.database.type == "mysql") "mysql.service"
+        ++ lib.optional (cfg.database.type == "postgresql") "postgresql.service";
+
+      environment = {
+        RDECK_BASE = cfg.dataDir;
+        RUNDECK_CONFIG_DIR = cfg.configDir;
+        JAVA_OPTS = lib.concatStringsSep " " cfg.javaOpts;
+      };
+
+      path = [ pkgs.replace-secret ];
+
+      serviceConfig = {
+        User = cfg.user;
+        Group = cfg.group;
+        ExecStart = rundeckStartScript;
+        WorkingDirectory = cfg.dataDir;
+        RuntimeDirectory = "rundeck";
+        RuntimeDirectoryMode = "0750";
+        UMask = "0027";
+
+        LimitNOFILE = 65536;
+        ReadWritePaths = [
+          cfg.dataDir
+          cfg.configDir
+        ];
+        RestartSec = "10s";
+        Restart = "always";
+        TimeoutStartSec = "${toString cfg.startTimeout}s";
+
+        CapabilityBoundingSet = [ "CAP_SYS_ADMIN" ];
+        AmbientCapabilities = [ "CAP_SYS_ADMIN" ];
+
+        LimitCORE = 0;
+        LockPersonality = true;
+        MemorySwapMax = 0;
+        MemoryZSwapMax = 0;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+          "AF_NETLINK"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+      };
+
+      preStart = ''
+        ${lib.optionalString (cfg.serverUUID == "") ''
+          # Generate UUID
+          UUID_FILE="${cfg.dataDir}/.uuid"
+          if [ ! -f "$UUID_FILE" ]; then
+            umask 0137
+            ${lib.getExe' pkgs.util-linux "uuidgen"} > "$UUID_FILE"
+          fi
+        ''}
+
+
+        install -m 0640 ${configFile} ${cfg.configDir}/rundeck-config.properties
+        install -m 0640 ${frameworkFile} ${cfg.configDir}/framework.properties
+        install -m 0600 ${realmFile} ${cfg.configDir}/realm.properties
+
+        ${replaceSecret "@ADMIN_PASSWORD@" cfg.adminPasswordFile "${cfg.configDir}/realm.properties"}
+
+        ${lib.optionalString (cfg.database.passwordFile != null) (
+          replaceSecret "@DB_PASSWORD@" cfg.database.passwordFile "${cfg.configDir}/rundeck-config.properties"
+        )}
+
+        ${lib.optionalString cfg.ssl.enable (
+          replaceSecret "@KEYSTORE_PASSWORD@" cfg.ssl.keyStorePasswordFile
+            "${cfg.configDir}/rundeck-config.properties"
+        )}
+
+        ${lib.optionalString (cfg.serverUUID == "") (
+          replaceSecret "@SERVER_UUID@" "${cfg.dataDir}/.uuid" "${cfg.configDir}/framework.properties"
+        )}
+
+        if [ -f ${cfg.dataDir}/etc/framework.properties ]; then
+          install -m 0640 ${cfg.configDir}/framework.properties ${cfg.dataDir}/etc/framework.properties
+        fi
+
+        ${lib.concatStringsSep "\n" (
+          lib.mapAttrsToList (
+            name: content:
+            "install -m 0640 ${pkgs.writeText "rundeck-${name}" content} ${cfg.dataDir}/etc/${name}"
+          ) cfg.aclPolicies
+        )}
+      '';
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall [
+      (if cfg.ssl.enable then cfg.ssl.port else cfg.serverPort)
+    ];
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1440,6 +1440,7 @@ in
   rsyslogd = handleTest ./rsyslogd.nix { };
   rtkit = runTest ./rtkit.nix;
   rtorrent = runTest ./rtorrent.nix;
+  rundeck = runTest ./rundeck.nix;
   rush = runTest ./rush.nix;
   rustls-libssl = runTest ./rustls-libssl.nix;
   rxe = runTest ./rxe.nix;

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1553,6 +1553,7 @@ in
   rsyslogd = handleTest ./rsyslogd.nix { };
   rtkit = runTest ./rtkit.nix;
   rtorrent = runTest ./rtorrent.nix;
+  rundeck = runTest ./rundeck.nix;
   rush = runTest ./rush.nix;
   rustfs = runTest ./rustfs.nix;
   rustical = runTest ./web-apps/rustical.nix;

--- a/nixos/tests/rundeck.nix
+++ b/nixos/tests/rundeck.nix
@@ -1,0 +1,75 @@
+{
+  name = "rundeck";
+
+  nodes = {
+    rundeck =
+      { pkgs, ... }:
+      {
+        services.rundeck = {
+          enable = true;
+          serverHostname = "rundeck";
+          adminUser = "testadmin";
+          adminPassword = "testpassword";
+          serverPort = 4441;
+          database.type = "h2";
+          openFirewall = true;
+        };
+        environment.systemPackages = with pkgs; [
+          curl
+          jq
+        ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    def login_and_verify_api(machine, host, port, user, password, timeout=300):
+        """Authenticate via Rundeck form login and verify API access."""
+        machine.wait_until_succeeds(
+            f"curl -s -c /tmp/cookies -L"
+            f" -d 'j_username={user}&j_password={password}'"
+            f" http://{host}:{port}/j_security_check -o /dev/null"
+            f" && curl -s -b /tmp/cookies -H 'Accept: application/json'"
+            f" http://{host}:{port}/api/26/system/info"
+            f" | jq -e '.system.rundeck.version'",
+            timeout=timeout,
+        )
+
+    with subtest("Rundeck starts and serves homepage"):
+        rundeck.wait_for_unit("rundeck.service")
+        rundeck.wait_for_open_port(4441)
+        rundeck.wait_until_succeeds(
+            "curl -s http://rundeck:4441 | grep -q Rundeck"
+        )
+
+    with subtest("Regression - port is included in generated URLs"):
+        rundeck.succeed(
+            "grep -qE '^grails\\.serverURL=http://rundeck:4441$'"
+            " /etc/rundeck/rundeck-config.properties"
+        )
+
+        rundeck.succeed(
+            "grep -qE '^framework\\.server\\.url = http://rundeck:4441$'"
+            " /etc/rundeck/framework.properties"
+        )
+
+    with subtest("API authentication via form login"):
+        login_and_verify_api(rundeck, "rundeck", 4441, "testadmin", "testpassword")
+
+        rundeck.succeed(
+            "curl -s -b /tmp/cookies -X POST"
+            " -H 'Accept: application/json'"
+            " -H 'Content-Type: application/json'"
+            " -d '{\"name\":\"test-project\",\"config\":{}}'"
+            " http://rundeck:4441/api/26/projects"
+            " | jq -e '.name == \"test-project\"'"
+        )
+
+        rundeck.succeed(
+            "curl -s -b /tmp/cookies -H 'Accept: application/json'"
+            " http://rundeck:4441/api/26/projects"
+            " | jq -e 'any(.[]; .name == \"test-project\")'"
+        )
+  '';
+}

--- a/nixos/tests/rundeck.nix
+++ b/nixos/tests/rundeck.nix
@@ -1,0 +1,111 @@
+{
+  name = "rundeck";
+
+  nodes = {
+    rundeck =
+      { pkgs, ... }:
+      {
+        environment.etc."rundeck-admin-password" = {
+          text = "testpassword";
+          mode = "0400";
+          user = "rundeck";
+          group = "rundeck";
+        };
+
+        services.rundeck = {
+          enable = true;
+          serverHostname = "rundeck";
+          adminUser = "testadmin";
+          adminPasswordFile = "/etc/rundeck-admin-password";
+          serverPort = 4441;
+          database.type = "h2";
+          openFirewall = true;
+        };
+
+        environment.systemPackages = with pkgs; [
+          curl
+          jq
+        ];
+      };
+  };
+
+  testScript = ''
+    start_all()
+
+    def login_and_verify_api(machine, host, port, user, password, timeout=300):
+        """Authenticate via Rundeck form login and verify API access."""
+        machine.wait_until_succeeds(
+            f"curl -s -c /tmp/cookies -L"
+            f" -d 'j_username={user}&j_password={password}'"
+            f" http://{host}:{port}/j_security_check -o /dev/null"
+            f" && curl -s -b /tmp/cookies -H 'Accept: application/json'"
+            f" http://{host}:{port}/api/26/system/info"
+            f" | jq -e '.system.rundeck.version'",
+            timeout=timeout,
+        )
+
+    def properties(machine, path):
+        return machine.succeed(f"cat {path}").replace("\\", "").replace(" = ", "=")
+
+    with subtest("Rundeck starts and serves homepage"):
+        rundeck.wait_for_unit("rundeck.service")
+        rundeck.wait_for_open_port(4441)
+        rundeck.wait_until_succeeds(
+            "curl -sL http://rundeck:4441 | grep -qi Rundeck"
+        )
+
+    with subtest("Regression - port is included in generated URLs"):
+        config = properties(rundeck, "/etc/rundeck/rundeck-config.properties")
+        framework = properties(rundeck, "/etc/rundeck/framework.properties")
+
+        assert "grails.serverURL=http://rundeck:4441" in config, config
+        assert "server.port=4441" in config, config
+        assert "framework.server.url=http://rundeck:4441" in framework, framework
+
+    with subtest("Structural settings end up in the generated config"):
+        config = properties(rundeck, "/etc/rundeck/rundeck-config.properties")
+
+        assert "dataSource.driverClassName=org.h2.Driver" in config, config
+        assert "dataSource.dialect=org.hibernate.dialect.H2Dialect" in config, config
+
+    with subtest("Server UUID is generated and substituted"):
+        framework = properties(rundeck, "/etc/rundeck/framework.properties")
+
+        assert "@SERVER_UUID@" not in framework, framework
+        rundeck.succeed(
+            "grep -qE '^rundeck\\.server\\.uuid = [0-9a-f-]{36}$'"
+            " /etc/rundeck/framework.properties"
+        )
+
+    with subtest("Secrets are substituted and not world-readable"):
+        rundeck.succeed(
+            "grep -qxF 'testadmin:testpassword,user,admin'"
+            " /etc/rundeck/realm.properties"
+        )
+        rundeck.fail("grep -q '@ADMIN_PASSWORD@' /etc/rundeck/realm.properties")
+        rundeck.succeed(
+            "[ \"$(stat -c %a /etc/rundeck/realm.properties)\" = 600 ]"
+        )
+        rundeck.succeed(
+            "[ \"$(stat -c %U /etc/rundeck/realm.properties)\" = rundeck ]"
+        )
+
+    with subtest("API authentication via form login"):
+        login_and_verify_api(rundeck, "rundeck", 4441, "testadmin", "testpassword")
+
+        rundeck.succeed(
+            "curl -s -b /tmp/cookies -X POST"
+            " -H 'Accept: application/json'"
+            " -H 'Content-Type: application/json'"
+            " -d '{\"name\":\"test-project\",\"config\":{}}'"
+            " http://rundeck:4441/api/26/projects"
+            " | jq -e '.name == \"test-project\"'"
+        )
+
+        rundeck.succeed(
+            "curl -s -b /tmp/cookies -H 'Accept: application/json'"
+            " http://rundeck:4441/api/26/projects"
+            " | jq -e 'any(.[]; .name == \"test-project\")'"
+        )
+  '';
+}


### PR DESCRIPTION
This is a module for Run & Manage Rundeck.

- Auto Installation
- Manage system users and permissions required by Rundeck
- Create directory structure for Rundeck data, config, and logs
- Configure DB (H2, PostgreSQL, or MySQL)
- Sets up authentication including admin user creation and external auth systems
- Enables SSL/TLS
- Manages ACL policies for authorization and access control
- Configure Java runtime options for performance tuning
- Open Firewall Port

PS: It's not perfect but there is already a good basis for personal/enterprise use.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
