### PR TITLE
vigra: enable tests

### DIFF
--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -51,6 +51,8 @@ stdenv.mkDerivation rec {
       "-DCMAKE_C_FLAGS=-fPIC"
     ];
 
+  enableParallelBuilding = true;
+
   meta = with lib; {
     description = "Novel computer vision C++ library with customizable algorithms and data structures";
     mainProgram = "vigra-config";

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -41,6 +41,11 @@ stdenv.mkDerivation (finalAttrs: {
     python
   ];
 
+  postPatch = ''
+    chmod +x config/run_test.sh.in
+    patchShebangs --build config/run_test.sh.in
+  '';
+
   cmakeFlags =
     [
       "-DWITH_OPENEXR=1"
@@ -52,6 +57,14 @@ stdenv.mkDerivation (finalAttrs: {
     ];
 
   enableParallelBuilding = true;
+
+  passthru = {
+    tests = {
+      check = finalAttrs.finalPackage.overrideAttrs (previousAttrs: {
+        doCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+      });
+    };
+  };
 
   meta = with lib; {
     description = "Novel computer vision C++ library with customizable algorithms and data structures";

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -17,14 +17,14 @@
 let
   python = python3.withPackages (py: with py; [ numpy ]);
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "vigra";
   version = "1.12.1";
 
   src = fetchFromGitHub {
     owner = "ukoethe";
     repo = "vigra";
-    tag = "Version-${lib.replaceStrings [ "." ] [ "-" ] version}";
+    tag = "Version-${lib.replaceStrings [ "." ] [ "-" ] finalAttrs.version}";
     hash = "sha256-ZmHj1BSyoMBCuxI5hrRiBEb5pDUsGzis+T5FSX27UN8=";
   };
 
@@ -61,4 +61,4 @@ stdenv.mkDerivation rec {
     maintainers = [ ];
     platforms = platforms.unix;
   };
-}
+})

--- a/pkgs/development/libraries/vigra/default.nix
+++ b/pkgs/development/libraries/vigra/default.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "vigra-config";
     homepage = "https://hci.iwr.uni-heidelberg.de/vigra";
     license = licenses.mit;
-    maintainers = [ ];
+    maintainers = with maintainers; [ ShamrockLee ];
     platforms = platforms.unix;
   };
 })


### PR DESCRIPTION
This PR enables testing of upstream-provided test cases for the package `vigra`. and switch on the tests during the build.

The test cases took a significant amount of time to run (several minutes, while the build only took 15 seconds). Whether to enable the test during build or in a package test (under `passthru.tests`) is debatable.

Update: Now the test is available as `vigra.tests.check`.

Benchmark on a 8-core, 16 logical core laptop:

| | parallel | singlethreaded |
|-|-|-|
| doCheck = false | 10s | 36s |
| doCheck = true | 2m7s | 12m52s |
```console
nixpkgs_losslesscut on  vigra-test [$] 
❯ nix-store --gc
...

nixpkgs_losslesscut on  vigra-test [$] 
❯ nix build --no-link -f . vigra.inputDerivation

nixpkgs_losslesscut on  vigra-test [$] took 40s 
❯ time nix build --no-link --impure --expr "(import ./. { }).vigra.overrideAttrs { enableParallelBuilding = true; doCheck = false; }"

real	0m10.108s
user	0m0.560s
sys	0m0.190s

nixpkgs_losslesscut on  vigra-test [$] took 10s 
❯ time nix build --no-link --impure --expr "(import ./. { }).vigra.overrideAttrs { enableParallelBuilding = false; doCheck = false; }"

real	0m36.278s
user	0m0.601s
sys	0m0.171s

nixpkgs_losslesscut on  vigra-test [$] took 36s 
❯ time nix build --no-link --impure --expr "(import ./. { }).vigra.overrideAttrs { enableParallelBuilding = true; doCheck = true; }"

real	2m7.454s
user	0m0.724s
sys	0m0.253s

nixpkgs_losslesscut on  vigra-test [$] took 2m7s 
❯ time nix build --no-link --impure --expr "(import ./. { }).vigra.overrideAttrs { enableParallelBuilding = false; doCheck = true; }"

real	12m52.407s
user	0m1.290s
sys	0m0.486s

nixpkgs_losslesscut on  vigra-test [$] took 12m52s 
❯ 
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
