### PR TITLE
kio-extras, kio-extras-kf5: switch to openexr_3

### DIFF
--- a/pkgs/applications/kde/kio-extras.nix
+++ b/pkgs/applications/kde/kio-extras.nix
@@ -24,9 +24,8 @@
   syntax-highlighting,
   libmtp,
   libssh,
-  openexr,
+  openexr_3,
   libtirpc,
-  ilmbase,
   phonon,
   qtsvg,
   samba,
@@ -72,7 +71,7 @@ mkDerivation {
     syntax-highlighting
     libmtp
     libssh
-    openexr
+    openexr_3
     libtirpc
     phonon
     qtsvg
@@ -90,5 +89,4 @@ mkDerivation {
       --replace Exec=$out Exec=${kio}
   '';
 
-  CXXFLAGS = [ "-I${ilmbase.dev}/include/OpenEXR" ];
 }

--- a/pkgs/kde/gear/kio-extras/default.nix
+++ b/pkgs/kde/gear/kio-extras/default.nix
@@ -9,7 +9,7 @@
   libimobiledevice,
   gperf,
   libtirpc,
-  openexr,
+  openexr_3,
   taglib,
   shared-mime-info,
   libappimage,
@@ -34,7 +34,7 @@ mkKdeDerivation {
     libimobiledevice
     gperf
     libtirpc
-    openexr
+    openexr_3
     taglib
     libappimage
     xorg.libXcursor

--- a/pkgs/kde/misc/kio-extras-kf5/default.nix
+++ b/pkgs/kde/misc/kio-extras-kf5/default.nix
@@ -10,7 +10,7 @@
   libimobiledevice,
   gperf,
   libtirpc,
-  openexr,
+  openexr_3,
   taglib,
   libappimage,
 }:
@@ -58,7 +58,7 @@ stdenv.mkDerivation rec {
     libimobiledevice
     gperf
     libtirpc
-    openexr
+    openexr_3
     taglib
     libappimage
   ];


### PR DESCRIPTION
This makes kio-extras and kio-extras-kf5 use openxr v3. Rationale: https://github.com/NixOS/nixpkgs/pull/367406

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
