### PR TITLE
nixos/lib/test-driver: Revert magick args order

### DIFF
--- a/nixos/lib/test-driver/src/test_driver/machine.py
+++ b/nixos/lib/test-driver/src/test_driver/machine.py
@@ -107,18 +107,19 @@ def _preprocess_screenshot(screenshot_path: str, negate: bool = False) -> str:
         "1",
         "-posterize",
         "3",
-        "-gamma",
-        "100",
-        "-blur",
-        "1x65535",
     ]
-
     out_file = screenshot_path
 
     if negate:
         magick_args.append("-negate")
         out_file += ".negative"
 
+    magick_args += [
+        "-gamma",
+        "100",
+        "-blur",
+        "1x65535",
+    ]
     out_file += ".png"
 
     ret = subprocess.run(


### PR DESCRIPTION
...as it apparently matters when we do the -negate

#375504 changed where the `-negate` in the list of `magick` commands for OCR pre-processing happens. This gets most OCR commands in `nixosTests.lomiri*` tests stuck (i.e. the user name on the lightdm lomiri greeter in `nixosTests.lomiri.greeter`, "Rotation Lock" in the lomiri settings app in `nixosTests.lomiri.{desktop-basics,desktop-appinteractions}`).

```
machine: waiting for (AM|PM) to appear on screen
machine # [   43.596169] systemd[1]: systemd-timedated.service: Deactivated successfully.
machine # [   47.628680] systemd[1]: systemd-hostnamed.service: Deactivated successfully.
(finished: waiting for (AM|PM) to appear on screen, in 20.34 seconds)
machine: making screenshot /nix/store/b30ywc00v4bvhxn8jqazi8029vrxyyan-vm-test-run-lomiri-greeter/lomiri_greeter_launched.png
(finished: making screenshot /nix/store/b30ywc00v4bvhxn8jqazi8029vrxyyan-vm-test-run-lomiri-greeter/lomiri_greeter_launched.png, in 0.29 seconds)
machine: sending key 'ret'
(finished: sending key 'ret', in 0.01 seconds)
machine: must succeed: sleep 10
(finished: must succeed: sleep 10, in 10.05 seconds)
machine: waiting for Alice Foobar to appear on screen
machine # [  907.191483] systemd[1]: Starting Cleanup of Temporary Directories...
machine # [  907.341173] systemd[1]: systemd-tmpfiles-clean.service: Deactivated successfully.
machine # [  907.343061] systemd[1]: Finished Cleanup of Temporary Directories.
timeout reached; test terminating...
```

With the assumption that this was done for convenience instead of fixing any OCR issue in another setup, restore the original order of `magick` args.

With #375365 applied to fix all required test dependencies, all of `nixosTests.lomiri` passes again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
