### PR TITLE
etlegacy: 2.83.1 -> 2.83.2

### DIFF
--- a/pkgs/by-name/et/etlegacy-assets/package.nix
+++ b/pkgs/by-name/et/etlegacy-assets/package.nix
@@ -6,7 +6,7 @@
 
 stdenv.mkDerivation {
   pname = "etlegacy-assets";
-  version = "2.83.1";
+  version = "2.83.2";
 
   srcs =
     let

--- a/pkgs/by-name/et/etlegacy-unwrapped/package.nix
+++ b/pkgs/by-name/et/etlegacy-unwrapped/package.nix
@@ -3,7 +3,6 @@
   stdenv,
   writeShellApplication,
   fetchFromGitHub,
-  fetchpatch,
   cjson,
   cmake,
   git,
@@ -24,7 +23,7 @@
   zlib,
 }:
 let
-  version = "2.83.1";
+  version = "2.83.2";
   fakeGit = writeShellApplication {
     name = "git";
 
@@ -43,18 +42,8 @@ stdenv.mkDerivation {
     owner = "etlegacy";
     repo = "etlegacy";
     tag = "v${version}";
-    hash = "sha256-k1H3irA9UVOICY3keKGVJMtBczW/b5ObyNvB7fGAcFA=";
+    hash = "sha256-hZwLYaYV0j3YwFi8KRr4DZV73L2yIwFJ3XqCyq6L7hE=";
   };
-
-  patches = lib.optionals stdenv.hostPlatform.isDarwin [
-    # Fix compilation on Darwin archs
-    # Reported upstream at https://github.com/etlegacy/etlegacy/pull/3005
-    # Remove this patch when the PR is merged
-    (fetchpatch {
-      url = "https://github.com/etlegacy/etlegacy/commit/2767d15c67fe0680178d9cc85ed4cf2ad1d88ad0.patch?full_index=1";
-      hash = "sha256-rGfNIWb9zohk1QJLrYg9nqw6sMvXM0IbIl9kvYXRBuk=";
-    })
-  ];
 
   nativeBuildInputs = [
     cjson

--- a/pkgs/by-name/et/etlegacy/package.nix
+++ b/pkgs/by-name/et/etlegacy/package.nix
@@ -8,7 +8,7 @@
 
 symlinkJoin {
   name = "etlegacy";
-  version = "2.83.1";
+  version = "2.83.2";
   paths = [
     etlegacy-assets
     etlegacy-unwrapped


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
