### PR TITLE
dioxus-cli: 0.6.0 -> 0.6.2

### DIFF
--- a/pkgs/by-name/di/dioxus-cli/fix-wasm-opt-target-dir.patch
+++ b/pkgs/by-name/di/dioxus-cli/fix-wasm-opt-target-dir.patch
@@ -1,0 +1,11 @@
+--- a/src/build/bundle.rs
++++ b/src/build/bundle.rs
+@@ -334,7 +334,7 @@ impl AppBundle {
+                 // Only run wasm-opt if the feature is enabled
+                 // Wasm-opt has an expensive build script that makes it annoying to keep enabled for iterative dev
+                 // We put it behind the "wasm-opt" feature flag so that it can be disabled when iterating on the cli
+-                self.run_wasm_opt(&self.build.exe_dir())?;
++                self.run_wasm_opt(&self.build.wasm_bindgen_out_dir())?;
+ 
+                 // Write the index.html file with the pre-configured contents we got from pre-rendering
+                 std::fs::write(

--- a/pkgs/by-name/di/dioxus-cli/package.nix
+++ b/pkgs/by-name/di/dioxus-cli/package.nix
@@ -14,16 +14,24 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "dioxus-cli";
-  version = "0.6.0";
+  version = "0.6.2";
 
   src = fetchCrate {
     inherit pname version;
-    hash = "sha256-0Kg2/+S8EuMYZQaK4Ao+mbS7K48VhVWjPL+LnoVJMSw=";
+    hash = "sha256-jUS/it2N5o5D7Jon0fKHWEt3f0wdtVgNIkqSNc7u830=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-uD3AHHY3edpqyQ8gnsTtxQsen8UzyVIbArSvpMa+B+8=";
-  buildFeatures = [ "optimizations" ];
+  cargoHash = "sha256-izvo092FGZmci1cXLo+qhGlBh8W3A1TeBHrYXcjE6HU=";
+  cargoPatches = [
+    # TODO: Remove once https://github.com/DioxusLabs/dioxus/issues/3659 is fixed upstream.
+    ./fix-wasm-opt-target-dir.patch
+  ];
+
+  buildFeatures = [
+    "no-downloads"
+    "optimizations"
+  ];
 
   nativeBuildInputs = [
     pkg-config
@@ -34,11 +42,18 @@ rustPlatform.buildRustPackage rec {
 
   OPENSSL_NO_VENDOR = 1;
 
+  # wasm-opt-sys build.rs tries to verify C++17 support, but the check appears to be faulty.
+  postPatch = ''
+    substituteInPlace $cargoDepsCopy/wasm-opt-sys-*/build.rs \
+      --replace-fail 'check_cxx17_support()?;' '// check_cxx17_support()?;'
+  '';
+
   nativeCheckInputs = [ rustfmt ];
 
   checkFlags = [
     # requires network access
     "--skip=serve::proxy::test"
+    "--skip=wasm_bindgen::test"
   ];
 
   passthru = {


### PR DESCRIPTION
- enabled 'no-downloads' feature
- patched wasm-opt-sys to fix build on Darwin (and possibly other?) hosts. See the check [here](https://github.com/brson/wasm-opt-rs/blob/master/components/wasm-opt-sys/build.rs#L354-L373) which was failing.
- patched dioxus-cli to fix wasm-opt target directory.
- skipped wasm-bindgen tests which try to download from GitHub

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
