### PR TITLE
nixos/nats: fix config validation to avoid check at build time

### DIFF
--- a/nixos/modules/services/networking/nats.nix
+++ b/nixos/modules/services/networking/nats.nix
@@ -14,17 +14,6 @@ let
   format = pkgs.formats.json { };
 
   configFile = format.generate "nats.conf" cfg.settings;
-
-  validateConfig =
-    file:
-    pkgs.runCommand "validate-nats-conf"
-      {
-        nativeBuildInputs = [ pkgs.nats-server ];
-      }
-      ''
-        nats-server --config "${configFile}" -t
-        ln -s "${configFile}" "$out"
-      '';
 in
 {
 
@@ -120,7 +109,9 @@ in
         })
         {
           Type = "simple";
-          ExecStart = "${pkgs.nats-server}/bin/nats-server -c ${validateConfig configFile}";
+
+          ExecStartPre = "${pkgs.nats-server}/bin/nats-server -c ${configFile} -t";
+          ExecStart = "${pkgs.nats-server}/bin/nats-server -c ${configFile}";
           ExecReload = "${pkgs.coreutils}/bin/kill -HUP $MAINPID";
           ExecStop = "${pkgs.coreutils}/bin/kill -SIGINT $MAINPID";
           Restart = "on-failure";


### PR DESCRIPTION
The nixos nats module is performing validation of the nats configuration during build time.
This result in failure when building nixos top level derivation because, for instance, tls certificates mentionned in the configuration does not exist.

Example:

```nix
{
  services.nats.settings.tls = let 
    certDir = config.security.acme.certs."nats.example.tld".directory;
  in {
    cert_file = "${certDir}/cert.pem";
    key_file = "${certDir}/key.pem";
  };
}
```

```
$> nix build --print-build-logs .#'nixosConfigurations.host42.config.system.build.toplevel'
validate-nats-conf> nats-server: /nix/store/waryqcg992bjz746xbb0wirr5niq2myg-nats.conf:62:6: error parsing X509 certificate/key pair: open /var/lib/acme/nats.example.tld/cert.pem: no such file or directory
validate-nats-conf> /nix/store/waryqcg992bjz746xbb0wirr5niq2myg-nats.conf:78:4: error parsing X509 certificate/key pair: open /var/lib/acme/nats.example.tld/cert.pem: no such file or directory
error: build of '/nix/store/bc1mdh5ky4fpvl5iyzgg6jqd7yk3dbxs-validate-nats-conf.drv' on 'ssh-ng://builder@linux-builder' failed: builder for '/nix/store/bc1mdh5ky4fpvl5iyzgg6jqd7yk3dbxs-validate-nats-conf.drv' failed with exit code 1;
       last 3 log lines:
       > nats-server: /nix/store/waryqcg992bjz746xbb0wirr5niq2myg-nats.conf:62:6: error parsing X509 certificate/key pair: open /var/lib/acme/nats.example.tld/cert.pem: no such file or directory
       > /nix/store/waryqcg992bjz746xbb0wirr5niq2myg-nats.conf:78:4: error parsing X509 certificate/key pair: open /var/lib/acme/nats.example.tld/cert.pem: no such file or directory
       >
       For full logs, run 'nix-store -l /nix/store/bc1mdh5ky4fpvl5iyzgg6jqd7yk3dbxs-validate-nats-conf.drv'.
perl> created 183 symlinks in user environment
error: builder for '/nix/store/bc1mdh5ky4fpvl5iyzgg6jqd7yk3dbxs-validate-nats-conf.drv' failed with exit code 1
error: 1 dependencies of derivation '/nix/store/ra79qwbppcmp1pygyjhzjnx9yqsilwmi-unit-nats.service.drv' failed to build
error: 1 dependencies of derivation '/nix/store/40zir33qc33h5ypgb0rrfvvvi5h2n73i-system-units.drv' failed to build
error: 1 dependencies of derivation '/nix/store/gazyxg7mi9h3xb7b8yr6s1n2kfdx7czx-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/21fa0j8lhxnzkyw8vx33svwd232z8fk2-nixos-system-host42-24.11.20250120.ae584d9.drv' failed to build
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

I'm not sure this validation check make sens to perform right before nats starts, because I'm guessing nats will be also checking the configuration when started, but the intend of this PR is to fix the validation performed at build time, not challenging whenever this check is useful or not at runtime.

See https://github.com/NixOS/nixpkgs/pull/322035#issuecomment-2271503711, https://github.com/NixOS/nixpkgs/pull/322035#issuecomment-2607665883, https://github.com/NixOS/nixpkgs/pull/322035.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
