### PR TITLE
open-webui: 0.5.4 -> 0.5.5

### DIFF
--- a/pkgs/by-name/op/open-webui/package.nix
+++ b/pkgs/by-name/op/open-webui/package.nix
@@ -7,19 +7,19 @@
 }:
 let
   pname = "open-webui";
-  version = "0.5.4";
+  version = "0.5.5";
 
   src = fetchFromGitHub {
     owner = "open-webui";
     repo = "open-webui";
     tag = "v${version}";
-    hash = "sha256-vlaJv4CbhjbJbiNZHKsedS2vBXp44oE/7ZALgkPASHI=";
+    hash = "sha256-4g+dt1dbN/ulERW3WLjTJ0++JD5NLREXjGu6ngPdxAI=";
   };
 
   frontend = buildNpmPackage {
     inherit pname version src;
 
-    npmDepsHash = "sha256-g47tK6BC6CE0hqdZbToQMB5QeNdufhO12xPrAjbfMTk=";
+    npmDepsHash = "sha256-cIocYy91JfcZM35ZiT6onEsz89qAZ+7jCjpjg6lV4pc=";
 
     # Disabling `pyodide:fetch` as it downloads packages during `buildPhase`
     # Until this is solved, running python packages from the browser will not work.
@@ -89,19 +89,21 @@ python312.pkgs.buildPythonApplication rec {
     flask-cors
     fpdf2
     ftfy
+    gcp-storage-emulator
     google-api-python-client
     google-auth-httplib2
     google-auth-oauthlib
+    google-cloud-storage
     google-generativeai
     googleapis-common-protos
     iso-639
     langchain
-    langchain-chroma
     langchain-community
     langdetect
     langfuse
     ldap3
     markdown
+    moto
     nltk
     openai
     opencv-python-headless
@@ -137,6 +139,7 @@ python312.pkgs.buildPythonApplication rec {
     sentence-transformers
     soundfile
     tiktoken
+    transformers
     unstructured
     uvicorn
     validators

--- a/pkgs/development/python-modules/gcp-storage-emulator/default.nix
+++ b/pkgs/development/python-modules/gcp-storage-emulator/default.nix
@@ -1,0 +1,55 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  wheel,
+  flake8,
+  fs,
+  google-cloud-storage,
+  google-crc32c,
+  pytest,
+  pytestCheckHook,
+  pytest-cov,
+  requests,
+}:
+
+buildPythonPackage rec {
+  pname = "gcp-storage-emulator";
+  version = "2024.08.03";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "oittaa";
+    repo = "gcp-storage-emulator";
+    rev = "v${version}";
+    hash = "sha256-Lp9Wvod0wSE2+cnvLXguhagT30ax9TivyR8gC/kB7w0=";
+  };
+
+  build-system = [
+    setuptools
+    wheel
+  ];
+
+  nativeCheckInputs = [
+    flake8
+    fs
+    google-cloud-storage
+    google-crc32c
+    pytest
+    pytestCheckHook
+    pytest-cov
+    requests
+  ];
+
+  pythonImportsCheck = [
+    "gcp_storage_emulator"
+  ];
+
+  meta = {
+    description = "Local emulator for Google Cloud Storage";
+    homepage = "https://github.com/oittaa/gcp-storage-emulator";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ drupol ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5083,6 +5083,8 @@ self: super: with self; {
 
   gcovr = callPackage ../development/python-modules/gcovr { };
 
+  gcp-storage-emulator = callPackage ../development/python-modules/gcp-storage-emulator { };
+
   gcsa = callPackage ../development/python-modules/gcsa { };
 
   gcsfs = callPackage ../development/python-modules/gcsfs { };


### PR DESCRIPTION
changelog: https://github.com/open-webui/open-webui/releases/tag/v0.5.5
diff: https://github.com/open-webui/open-webui/compare/v0.5.4..v0.5.5

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
