### PR TITLE
buildPython*: restructure in preparation for fixed-point argument support and `overridePythonAttrs` deprecation

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -208,248 +208,248 @@ in
 let
   # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
   self = stdenv.mkDerivation (
-      finalAttrs:
-      let
-  format' =
-    assert (pyproject != null) -> (format == null);
-    if pyproject != null then
-      if pyproject then "pyproject" else "other"
-    else if format != null then
-      format
-    else
-      "setuptools";
-
-  withDistOutput = withDistOutput' format';
-
-  validatePythonMatches =
+    finalAttrs:
     let
-      throwMismatch =
-        attrName: drv:
+      format' =
+        assert (pyproject != null) -> (format == null);
+        if pyproject != null then
+          if pyproject then "pyproject" else "other"
+        else if format != null then
+          format
+        else
+          "setuptools";
+
+      withDistOutput = withDistOutput' format';
+
+      validatePythonMatches =
         let
-          myName = "'${namePrefix}${name}'";
-          theirName = "'${drv.name}'";
-          optionalLocation =
+          throwMismatch =
+            attrName: drv:
             let
-              pos = unsafeGetAttrPos (if attrs ? "pname" then "pname" else "name") attrs;
+              myName = "'${namePrefix}${name}'";
+              theirName = "'${drv.name}'";
+              optionalLocation =
+                let
+                  pos = unsafeGetAttrPos (if attrs ? "pname" then "pname" else "name") attrs;
+                in
+                optionalString (pos != null) " at ${pos.file}:${toString pos.line}:${toString pos.column}";
             in
-            optionalString (pos != null) " at ${pos.file}:${toString pos.line}:${toString pos.column}";
+            throw ''
+              Python version mismatch in ${myName}:
+
+              The Python derivation ${myName} depends on a Python derivation
+              named ${theirName}, but the two derivations use different versions
+              of Python:
+
+                  ${leftPadName myName theirName} uses ${python}
+                  ${leftPadName theirName myName} uses ${toString drv.pythonModule}
+
+              Possible solutions:
+
+                * If ${theirName} is a Python library, change the reference to ${theirName}
+                  in the ${attrName} of ${myName} to use a ${theirName} built from the same
+                  version of Python
+
+                * If ${theirName} is used as a tool during the build, move the reference to
+                  ${theirName} in ${myName} from ${attrName} to nativeBuildInputs
+
+                * If ${theirName} provides executables that are called at run time, pass its
+                  bin path to makeWrapperArgs:
+
+                      makeWrapperArgs = [ "--prefix PATH : ''${lib.makeBinPath [ ${getName drv} ] }" ];
+
+              ${optionalLocation}
+            '';
+
+          checkDrv =
+            attrName: drv:
+            if (isPythonModule drv) && (isMismatchedPython drv) then throwMismatch attrName drv else drv;
+
         in
-        throw ''
-          Python version mismatch in ${myName}:
+        attrName: inputs: map (checkDrv attrName) inputs;
 
-          The Python derivation ${myName} depends on a Python derivation
-          named ${theirName}, but the two derivations use different versions
-          of Python:
+      isBootstrapInstallPackage = isBootstrapInstallPackage' (attrs.pname or null);
 
-              ${leftPadName myName theirName} uses ${python}
-              ${leftPadName theirName myName} uses ${toString drv.pythonModule}
+      isBootstrapPackage = isBootstrapInstallPackage || isBootstrapPackage' (attrs.pname or null);
 
-          Possible solutions:
-
-            * If ${theirName} is a Python library, change the reference to ${theirName}
-              in the ${attrName} of ${myName} to use a ${theirName} built from the same
-              version of Python
-
-            * If ${theirName} is used as a tool during the build, move the reference to
-              ${theirName} in ${myName} from ${attrName} to nativeBuildInputs
-
-            * If ${theirName} provides executables that are called at run time, pass its
-              bin path to makeWrapperArgs:
-
-                  makeWrapperArgs = [ "--prefix PATH : ''${lib.makeBinPath [ ${getName drv} ] }" ];
-
-          ${optionalLocation}
-        '';
-
-      checkDrv =
-        attrName: drv:
-        if (isPythonModule drv) && (isMismatchedPython drv) then throwMismatch attrName drv else drv;
+      isSetuptoolsDependency = isSetuptoolsDependency' (attrs.pname or null);
 
     in
-    attrName: inputs: map (checkDrv attrName) inputs;
+    (cleanAttrs attrs)
+    // {
 
-  isBootstrapInstallPackage = isBootstrapInstallPackage' (attrs.pname or null);
+      name = namePrefix + name;
 
-  isBootstrapPackage = isBootstrapInstallPackage || isBootstrapPackage' (attrs.pname or null);
+      nativeBuildInputs =
+        [
+          python
+          wrapPython
+          ensureNewerSourcesForZipFilesHook # move to wheel installer (pip) or builder (setuptools, flit, ...)?
+          pythonRemoveTestsDirHook
+        ]
+        ++ optionals (catchConflicts && !isBootstrapPackage && !isSetuptoolsDependency) [
+          #
+          # 1. When building a package that is also part of the bootstrap chain, we
+          #    must ignore conflicts after installation, because there will be one with
+          #    the package in the bootstrap.
+          #
+          # 2. When a package is a dependency of setuptools, we must ignore conflicts
+          #    because the hook that checks for conflicts uses setuptools.
+          #
+          pythonCatchConflictsHook
+        ]
+        ++ optionals (attrs ? pythonRelaxDeps || attrs ? pythonRemoveDeps) [
+          pythonRelaxDepsHook
+        ]
+        ++ optionals removeBinBytecode [
+          pythonRemoveBinBytecodeHook
+        ]
+        ++ optionals (hasSuffix "zip" (attrs.src.name or "")) [
+          unzip
+        ]
+        ++ optionals (format' == "setuptools") [
+          setuptoolsBuildHook
+        ]
+        ++ optionals (format' == "pyproject") [
+          (
+            if isBootstrapPackage then
+              pypaBuildHook.override {
+                inherit (python.pythonOnBuildForHost.pkgs.bootstrap) build;
+                wheel = null;
+              }
+            else
+              pypaBuildHook
+          )
+          (
+            if isBootstrapPackage then
+              pythonRuntimeDepsCheckHook.override {
+                inherit (python.pythonOnBuildForHost.pkgs.bootstrap) packaging;
+              }
+            else
+              pythonRuntimeDepsCheckHook
+          )
+        ]
+        ++ optionals (format' == "wheel") [
+          wheelUnpackHook
+        ]
+        ++ optionals (format' == "egg") [
+          eggUnpackHook
+          eggBuildHook
+          eggInstallHook
+        ]
+        ++ optionals (format' != "other") [
+          (
+            if isBootstrapInstallPackage then
+              pypaInstallHook.override {
+                inherit (python.pythonOnBuildForHost.pkgs.bootstrap) installer;
+              }
+            else
+              pypaInstallHook
+          )
+        ]
+        ++ optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+          # This is a test, however, it should be ran independent of the checkPhase and checkInputs
+          pythonImportsCheckHook
+        ]
+        ++ optionals (python.pythonAtLeast "3.3") [
+          # Optionally enforce PEP420 for python3
+          pythonNamespacesHook
+        ]
+        ++ optionals withDistOutput [
+          pythonOutputDistHook
+        ]
+        ++ nativeBuildInputs
+        ++ build-system;
 
-  isSetuptoolsDependency = isSetuptoolsDependency' (attrs.pname or null);
+      buildInputs = validatePythonMatches "buildInputs" (buildInputs ++ pythonPath);
 
-      in
-      (cleanAttrs attrs)
-      // {
+      propagatedBuildInputs = validatePythonMatches "propagatedBuildInputs" (
+        propagatedBuildInputs
+        ++ dependencies
+        ++ [
+          # we propagate python even for packages transformed with 'toPythonApplication'
+          # this pollutes the PATH but avoids rebuilds
+          # see https://github.com/NixOS/nixpkgs/issues/170887 for more context
+          python
+        ]
+      );
 
-        name = namePrefix + name;
+      inherit strictDeps;
 
-        nativeBuildInputs =
-          [
-            python
-            wrapPython
-            ensureNewerSourcesForZipFilesHook # move to wheel installer (pip) or builder (setuptools, flit, ...)?
-            pythonRemoveTestsDirHook
-          ]
-          ++ optionals (catchConflicts && !isBootstrapPackage && !isSetuptoolsDependency) [
-            #
-            # 1. When building a package that is also part of the bootstrap chain, we
-            #    must ignore conflicts after installation, because there will be one with
-            #    the package in the bootstrap.
-            #
-            # 2. When a package is a dependency of setuptools, we must ignore conflicts
-            #    because the hook that checks for conflicts uses setuptools.
-            #
-            pythonCatchConflictsHook
-          ]
-          ++ optionals (attrs ? pythonRelaxDeps || attrs ? pythonRemoveDeps) [
-            pythonRelaxDepsHook
-          ]
-          ++ optionals removeBinBytecode [
-            pythonRemoveBinBytecodeHook
-          ]
-          ++ optionals (hasSuffix "zip" (attrs.src.name or "")) [
-            unzip
-          ]
-          ++ optionals (format' == "setuptools") [
-            setuptoolsBuildHook
-          ]
-          ++ optionals (format' == "pyproject") [
-            (
-              if isBootstrapPackage then
-                pypaBuildHook.override {
-                  inherit (python.pythonOnBuildForHost.pkgs.bootstrap) build;
-                  wheel = null;
-                }
-              else
-                pypaBuildHook
-            )
-            (
-              if isBootstrapPackage then
-                pythonRuntimeDepsCheckHook.override {
-                  inherit (python.pythonOnBuildForHost.pkgs.bootstrap) packaging;
-                }
-              else
-                pythonRuntimeDepsCheckHook
-            )
-          ]
-          ++ optionals (format' == "wheel") [
-            wheelUnpackHook
-          ]
-          ++ optionals (format' == "egg") [
-            eggUnpackHook
-            eggBuildHook
-            eggInstallHook
-          ]
-          ++ optionals (format' != "other") [
-            (
-              if isBootstrapInstallPackage then
-                pypaInstallHook.override {
-                  inherit (python.pythonOnBuildForHost.pkgs.bootstrap) installer;
-                }
-              else
-                pypaInstallHook
-            )
-          ]
-          ++ optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
-            # This is a test, however, it should be ran independent of the checkPhase and checkInputs
-            pythonImportsCheckHook
-          ]
-          ++ optionals (python.pythonAtLeast "3.3") [
-            # Optionally enforce PEP420 for python3
-            pythonNamespacesHook
-          ]
-          ++ optionals withDistOutput [
-            pythonOutputDistHook
-          ]
-          ++ nativeBuildInputs
-          ++ build-system;
+      LANG = "${if python.stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8";
 
-        buildInputs = validatePythonMatches "buildInputs" (buildInputs ++ pythonPath);
+      # Python packages don't have a checkPhase, only an installCheckPhase
+      doCheck = false;
+      doInstallCheck = attrs.doCheck or true;
+      nativeInstallCheckInputs = nativeCheckInputs;
+      installCheckInputs = checkInputs;
 
-        propagatedBuildInputs = validatePythonMatches "propagatedBuildInputs" (
-          propagatedBuildInputs
-          ++ dependencies
-          ++ [
-            # we propagate python even for packages transformed with 'toPythonApplication'
-            # this pollutes the PATH but avoids rebuilds
-            # see https://github.com/NixOS/nixpkgs/issues/170887 for more context
-            python
-          ]
-        );
+      postFixup =
+        optionalString (!dontWrapPythonPrograms) ''
+          wrapPythonPrograms
+        ''
+        + attrs.postFixup or "";
 
-        inherit strictDeps;
+      # Python packages built through cross-compilation are always for the host platform.
+      disallowedReferences = optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
+        python.pythonOnBuildForHost
+      ];
 
-        LANG = "${if python.stdenv.hostPlatform.isDarwin then "en_US" else "C"}.UTF-8";
+      outputs = outputs ++ optional withDistOutput "dist";
 
-        # Python packages don't have a checkPhase, only an installCheckPhase
-        doCheck = false;
-        doInstallCheck = attrs.doCheck or true;
-        nativeInstallCheckInputs = nativeCheckInputs;
-        installCheckInputs = checkInputs;
+      passthru =
+        {
+          inherit disabled;
+        }
+        // {
+          updateScript =
+            let
+              filename = head (splitString ":" finalAttrs.finalPackage.meta.position);
+            in
+            [
+              update-python-libraries
+              filename
+            ];
+        }
+        // optionalAttrs (dependencies != [ ]) {
+          inherit dependencies;
+        }
+        // optionalAttrs (optional-dependencies != { }) {
+          inherit optional-dependencies;
+        }
+        // optionalAttrs (build-system != [ ]) {
+          inherit build-system;
+        }
+        // attrs.passthru or { };
 
-        postFixup =
-          optionalString (!dontWrapPythonPrograms) ''
-            wrapPythonPrograms
-          ''
-          + attrs.postFixup or "";
-
-        # Python packages built through cross-compilation are always for the host platform.
-        disallowedReferences = optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
-          python.pythonOnBuildForHost
-        ];
-
-        outputs = outputs ++ optional withDistOutput "dist";
-
-        passthru =
-          {
-            inherit disabled;
-          }
-          // {
-            updateScript =
-              let
-                filename = head (splitString ":" finalAttrs.finalPackage.meta.position);
-              in
-              [
-                update-python-libraries
-                filename
-              ];
-          }
-          // optionalAttrs (dependencies != [ ]) {
-            inherit dependencies;
-          }
-          // optionalAttrs (optional-dependencies != { }) {
-            inherit optional-dependencies;
-          }
-          // optionalAttrs (build-system != [ ]) {
-            inherit build-system;
-          }
-          // attrs.passthru or { };
-
-        meta = {
-          # default to python's platforms
-          platforms = python.meta.platforms;
-          isBuildPythonPackage = python.meta.platforms;
-        } // meta;
+      meta = {
+        # default to python's platforms
+        platforms = python.meta.platforms;
+        isBuildPythonPackage = python.meta.platforms;
+      } // meta;
+    }
+    // optionalAttrs (attrs ? checkPhase) {
+      # If given use the specified checkPhase, otherwise use the setup hook.
+      # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
+      installCheckPhase = attrs.checkPhase;
+    }
+    // optionalAttrs (attrs.doCheck or true) (
+      optionalAttrs (disabledTestPaths != [ ]) {
+        disabledTestPaths = escapeShellArgs disabledTestPaths;
       }
-      // optionalAttrs (attrs ? checkPhase) {
-        # If given use the specified checkPhase, otherwise use the setup hook.
-        # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-        installCheckPhase = attrs.checkPhase;
+      // optionalAttrs (attrs ? disabledTests) {
+        # `escapeShellArgs` should be used as well as `disabledTestPaths`,
+        # but some packages rely on existing raw strings.
+        disabledTests = attrs.disabledTests;
       }
-      // optionalAttrs (attrs.doCheck or true) (
-        optionalAttrs (disabledTestPaths != [ ]) {
-          disabledTestPaths = escapeShellArgs disabledTestPaths;
-        }
-        // optionalAttrs (attrs ? disabledTests) {
-          # `escapeShellArgs` should be used as well as `disabledTestPaths`,
-          # but some packages rely on existing raw strings.
-          disabledTests = attrs.disabledTests;
-        }
-        // optionalAttrs (attrs ? pytestFlagsArray) {
-          pytestFlagsArray = attrs.pytestFlagsArray;
-        }
-        // optionalAttrs (attrs ? unittestFlagsArray) {
-          unittestFlagsArray = attrs.unittestFlagsArray;
-        }
-      )
-    );
+      // optionalAttrs (attrs ? pytestFlagsArray) {
+        pytestFlagsArray = attrs.pytestFlagsArray;
+      }
+      // optionalAttrs (attrs ? unittestFlagsArray) {
+        unittestFlagsArray = attrs.unittestFlagsArray;
+      }
+    )
+  );
 
   # This derivation transformation function must be independent to `attrs`
   # for fixed-point arguments support in the future.

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -207,8 +207,7 @@ in
 
 let
   # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-  self = (
-    stdenv.mkDerivation (
+  self = stdenv.mkDerivation (
       finalAttrs:
       let
   format' =
@@ -450,8 +449,7 @@ let
           unittestFlagsArray = attrs.unittestFlagsArray;
         }
       )
-    )
-  );
+    );
 
   # This derivation transformation function must be independent to `attrs`
   # for fixed-point arguments support in the future.

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -271,7 +271,7 @@ let
   isSetuptoolsDependency = isSetuptoolsDependency' (attrs.pname or null);
 
   # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-  self = toPythonModule (
+  self = (
     stdenv.mkDerivation (
       finalAttrs:
       (cleanAttrs attrs)
@@ -451,7 +451,14 @@ let
     )
   );
 
+  # This derivation transformation function must be independent to `attrs`
+  # for fixed-point arguments support in the future.
+  transformDrv =
+    drv:
+    extendDerivation (
+      drv.disabled
+      -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
+    ) { } (toPythonModule drv);
+
 in
-extendDerivation (
-  disabled -> throw "${name} not supported for interpreter ${python.executable}"
-) { } self
+transformDrv self

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -206,6 +206,11 @@ in
 }@attrs:
 
 let
+  # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
+  self = (
+    stdenv.mkDerivation (
+      finalAttrs:
+      let
   format' =
     assert (pyproject != null) -> (format == null);
     if pyproject != null then
@@ -270,10 +275,7 @@ let
 
   isSetuptoolsDependency = isSetuptoolsDependency' (attrs.pname or null);
 
-  # Keep extra attributes from `attrs`, e.g., `patchPhase', etc.
-  self = (
-    stdenv.mkDerivation (
-      finalAttrs:
+      in
       (cleanAttrs attrs)
       // {
 


### PR DESCRIPTION
This PR restructures the expression layout to prepare for implementing the fixed-point attribute support (#271387) and the transition from `overridePythonAttrs` to `overrideAttrs` (#376372). #271387 depends on #271762, which might need additional discussion and consensus. This PR makes it easier to proceed with #376372 simultaneously.

The only part of this PR that touches the programming logic is to use `drv.disabled` (from `<pkg>.passthru`) instead of `attrs.disabled` (from the `buildPython*` arguments) to determine whether to throw the interpreter-unsupported error. This is necessary for transferring to `lib.extendMkDerivation`, as `transformDrv` must be independent of the build-helper arguments.

Please consider reviewing this PR commit-by-commit, as the total diff might not be intuitive to read after formatting. 

#### How the layout changes

Before:

```nix
# buildPython*.override set pattern
{
  lib,
  python,
  hooks,
}:

let
  argument-independent-utils = "..."; # <---

  cleanAttrs = lib.flip removeAttrs [
    "..."
  ];
in

# buildPython* arguments
{
  name,
  pyproject,
  ...
}@attrs:

let
  argument-dependent-utils = "...";

  # The result Python package
  self = toPythonModule (
    stdenv.mkDerivation (
      cleanAttrs attrs
      // {
        # Phases
      }
    )
  );
in
extendDerivation (
  disabled -> throw "${name} not supported for interpreter ${python.executable}"
) { } self
```

After this PR:

```nix
# buildPython*.override set pattern
{
  lib,
  python,
  hooks,
}:

let
  argument-independent-utils = "...";

  cleanAttrs = lib.flip removeAttrs [
    "..."
  ];
in

# buildPython* arguments
{
  name,
  pyproject,
  ...
}@attrs:

let
  # The result Python package
  self = stdenv.mkDerivation (
    finalAttrs:
    let
      argument-dependent-utils = "..."; # <---
    in
    cleanAttrs attrs
    // {
      # Phases
    }
  )
);

  # This derivation transformation function must be independent to `attrs`
  # for fixed-point arguments support in the future.
  transformDrv =
    drv:
    extendDerivation (
      drv.disabled
      -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
    ) { } (toPythonModule drv);
in
transformDrv self
```

After adopting `lib.extendMkDerivation` (#271387)
```nix
# buildPython*.override set pattern
{
  lib,
  python,
  stdenv,
  hooks,
}:

let
  argument-independent-utils = "...";
in

lib.extendMkDerivation {
  constructDrv = stdenv.mkDerivation;

  excludeDrvArgNames = [
    "..."
  ];

  extendDrvArgs =
    finalAttrs:
    # buildPython* arguments
    {
      name,
      pyproject,
      ...
    }@attrs:

    let
      argument-dependent-utils = "..."; # <---
    in
    {
      # Phases
    };

  transformDrv =
    drv:
    extendDerivation (
      drv.disabled
      -> throw "${lib.removePrefix namePrefix drv.name} not supported for interpreter ${python.executable}"
    ) { } (toPythonModule drv);
}
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
