### PR TITLE
chatterino{2,7}: pin boost to 1.86

### DIFF
--- a/pkgs/by-name/ch/chatterino2/package.nix
+++ b/pkgs/by-name/ch/chatterino2/package.nix
@@ -3,42 +3,48 @@
   callPackage,
   fetchFromGitHub,
   nix-update-script,
+  boost186,
 }:
 
-(callPackage ./common.nix { }).overrideAttrs (finalAttrs: _: {
-  pname = "chatterino2";
-  version = "2.5.2";
+(callPackage ./common.nix {
+  boost = boost186;
+}).overrideAttrs
+  (
+    finalAttrs: _: {
+      pname = "chatterino2";
+      version = "2.5.2";
 
-  src = fetchFromGitHub {
-    owner = "Chatterino";
-    repo = "chatterino2";
-    tag = "v${finalAttrs.version}";
-    hash = "sha256-nrw4dQ7QjPPMbZXMC+p3VgUQKwc1ih6qS13D9+9oNuw=";
-    fetchSubmodules = true;
-  };
+      src = fetchFromGitHub {
+        owner = "Chatterino";
+        repo = "chatterino2";
+        tag = "v${finalAttrs.version}";
+        hash = "sha256-nrw4dQ7QjPPMbZXMC+p3VgUQKwc1ih6qS13D9+9oNuw=";
+        fetchSubmodules = true;
+      };
 
-  passthru = {
-    buildChatterino = args: callPackage ./common.nix args;
-    updateScript = nix-update-script { };
-  };
+      passthru = {
+        buildChatterino = args: callPackage ./common.nix args;
+        updateScript = nix-update-script { };
+      };
 
-  meta = {
-    description = "Chat client for Twitch chat";
-    mainProgram = "chatterino";
-    longDescription = ''
-      Chatterino is a chat client for Twitch chat. It aims to be an
-      improved/extended version of the Twitch web chat. Chatterino 2 is
-      the second installment of the Twitch chat client series
-      "Chatterino".
-    '';
-    homepage = "https://github.com/Chatterino/chatterino2";
-    changelog = "https://github.com/Chatterino/chatterino2/blob/${finalAttrs.src.rev}/CHANGELOG.md";
-    license = lib.licenses.mit;
-    platforms = lib.platforms.unix;
-    maintainers = with lib.maintainers; [
-      rexim
-      supa
-      marie
-    ];
-  };
-})
+      meta = {
+        description = "Chat client for Twitch chat";
+        mainProgram = "chatterino";
+        longDescription = ''
+          Chatterino is a chat client for Twitch chat. It aims to be an
+          improved/extended version of the Twitch web chat. Chatterino 2 is
+          the second installment of the Twitch chat client series
+          "Chatterino".
+        '';
+        homepage = "https://github.com/Chatterino/chatterino2";
+        changelog = "https://github.com/Chatterino/chatterino2/blob/${finalAttrs.src.rev}/CHANGELOG.md";
+        license = lib.licenses.mit;
+        platforms = lib.platforms.unix;
+        maintainers = with lib.maintainers; [
+          rexim
+          supa
+          marie
+        ];
+      };
+    }
+  )

--- a/pkgs/by-name/ch/chatterino7/package.nix
+++ b/pkgs/by-name/ch/chatterino7/package.nix
@@ -3,10 +3,12 @@
   chatterino2,
   fetchFromGitHub,
   nix-update-script,
+  boost186,
 }:
 
 (chatterino2.buildChatterino {
   enableAvifSupport = true;
+  boost = boost186;
 }).overrideAttrs
   (
     finalAttrs: _: {


### PR DESCRIPTION
Upstream already released a patch[^1], but it's not yet released. It modifies submodules so it's difficult to apply, so we just use boost 1.86 until a new release is made.

[^1]: https://github.com/Chatterino/chatterino2/pull/5832/commits/ec728f3ca70f9b201e3108c91f44817f3e38d668

Closes #375913

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
