### PR TITLE
hatch: skip more hatch test failures on darwin

### DIFF
--- a/pkgs/by-name/ha/hatch/package.nix
+++ b/pkgs/by-name/ha/hatch/package.nix
@@ -74,18 +74,33 @@ python3Packages.buildPythonApplication rec {
     export HOME=$(mktemp -d);
   '';
 
-  pytestFlagsArray = [
-    # AssertionError on the version metadata
-    # https://github.com/pypa/hatch/issues/1877
-    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_all"
-    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_license_expression"
-    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_all"
-    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_license_expression"
-    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_all"
-    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_expression"
-    "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_files"
-    "--deselect=tests/backend/metadata/test_spec.py::TestProjectMetadataFromCoreMetadata::test_license_files"
-  ];
+  pytestFlagsArray =
+    [
+      # AssertionError on the version metadata
+      # https://github.com/pypa/hatch/issues/1877
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_all"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV21::test_license_expression"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_all"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV22::test_license_expression"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_all"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_expression"
+      "--deselect=tests/backend/metadata/test_spec.py::TestCoreMetadataV23::test_license_files"
+      "--deselect=tests/backend/metadata/test_spec.py::TestProjectMetadataFromCoreMetadata::test_license_files"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # Dependency/versioning errors in the CLI tests, only seem to show up on Darwin
+      # https://github.com/pypa/hatch/issues/1893
+      "--deselect=tests/cli/env/test_create.py::test_sync_dependencies_pip"
+      "--deselect=tests/cli/env/test_create.py::test_sync_dependencies_uv"
+      "--deselect=tests/cli/project/test_metadata.py::TestBuildDependenciesMissing::test_no_compatibility_check_if_exists"
+      "--deselect=tests/cli/run/test_run.py::TestScriptRunner::test_dependencies"
+      "--deselect=tests/cli/run/test_run.py::TestScriptRunner::test_dependencies_from_tool_config"
+      "--deselect=tests/cli/run/test_run.py::test_dependency_hash_checking"
+      "--deselect=tests/cli/run/test_run.py::test_sync_dependencies"
+      "--deselect=tests/cli/run/test_run.py::test_sync_project_dependencies"
+      "--deselect=tests/cli/run/test_run.py::test_sync_project_features"
+      "--deselect=tests/cli/version/test_version.py::test_no_compatibility_check_if_exists"
+    ];
 
   disabledTests =
     [


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/371743 skipped tests to get `hatch` building again.

I've reported additional test issues on Darwin upstream:
- https://github.com/pypa/hatch/issues/1893

Tested locally on darwin, this fixes https://github.com/NixOS/nixpkgs/issues/366359 by skipping the offending tests.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
