### PR TITLE
mistral-rs: 0.3.2 -> 0.4.0

### DIFF
--- a/pkgs/by-name/mi/mistral-rs/package.nix
+++ b/pkgs/by-name/mi/mistral-rs/package.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  stdenv,
   rustPlatform,
   fetchFromGitHub,
 
@@ -11,8 +12,6 @@
   oniguruma,
   openssl,
   mkl,
-  stdenv,
-  darwin,
 
   # env
   fetchurl,
@@ -68,32 +67,26 @@ let
     (acceleration == "metal")
     || (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64 && (acceleration == null));
 
-  darwinBuildInputs =
-    with darwin.apple_sdk.frameworks;
-    [
-      Accelerate
-      CoreVideo
-      CoreGraphics
-    ]
-    ++ lib.optionals metalSupport [
-      MetalKit
-      MetalPerformanceShaders
-    ];
 in
-
 rustPlatform.buildRustPackage rec {
   pname = "mistral-rs";
-  version = "0.3.2";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "EricLBuehler";
     repo = "mistral.rs";
     tag = "v${version}";
-    hash = "sha256-aflzpJZ48AFBqNTssZl2KxkspQb662nGkEU6COIluxk=";
+    hash = "sha256-dsqW0XpZN2FGZlmNKgAEYGcdY5iGvRwNUko2OuU87Gw=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-USp8siEXVjtkPoCHfQjDYPtgLfNHcy02LSUNdwDbxgs=";
+  cargoHash = "sha256-Fp/5xQ1ib2TTBSayxR5EDKkk7G+5c1QdnVW+kzcE5Jo=";
+
+  # Otherwise, fails with
+  # failed to get `anyhow` as a dependency of package
+  postPatch = ''
+    rm "$cargoDepsCopy"/llguidance-*/build.rs
+  '';
 
   nativeBuildInputs = [
     pkg-config
@@ -111,19 +104,12 @@ rustPlatform.buildRustPackage rec {
       cudaPackages.libcublas
       cudaPackages.libcurand
     ]
-    ++ lib.optionals mklSupport [ mkl ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin darwinBuildInputs;
+    ++ lib.optionals mklSupport [ mkl ];
 
-  cargoBuildFlags =
-    [
-      # This disables the plotly crate which fails to build because of the kaleido feature requiring
-      # network access at build-time.
-      # See https://github.com/NixOS/nixpkgs/pull/323788#issuecomment-2206085825
-      "--no-default-features"
-    ]
-    ++ lib.optionals cudaSupport [ "--features=cuda" ]
-    ++ lib.optionals mklSupport [ "--features=mkl" ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && metalSupport) [ "--features=metal" ];
+  buildFeatures =
+    lib.optionals cudaSupport [ "cuda" ]
+    ++ lib.optionals mklSupport [ "mkl" ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && metalSupport) [ "metal" ];
 
   env =
     {
@@ -163,16 +149,15 @@ rustPlatform.buildRustPackage rec {
     rm -rf target/${stdenv.hostPlatform.config}/release/build/
   '';
 
+  # Prevent checkFeatures from inheriting buildFeatures because
+  # - `cargo check ... --features=cuda` requires access to a real GPU
+  # - `cargo check ... --features=metal` (on darwin) requires the sandbox to be completely disabled
+  checkFeatures = [ ];
+
   # Try to access internet
   checkFlags = [
-    "--skip=gguf::gguf_tokenizer::tests::test_decode_gpt2"
-    "--skip=gguf::gguf_tokenizer::tests::test_decode_llama"
     "--skip=gguf::gguf_tokenizer::tests::test_encode_decode_gpt2"
     "--skip=gguf::gguf_tokenizer::tests::test_encode_decode_llama"
-    "--skip=gguf::gguf_tokenizer::tests::test_encode_gpt2"
-    "--skip=gguf::gguf_tokenizer::tests::test_encode_llama"
-    "--skip=sampler::tests::test_argmax"
-    "--skip=sampler::tests::test_gumbel_speculative"
     "--skip=util::tests::test_parse_image_url"
   ];
 
@@ -187,7 +172,6 @@ rustPlatform.buildRustPackage rec {
     tests = {
       version = testers.testVersion { package = mistral-rs; };
 
-      # TODO: uncomment when mkl support will be fixed
       withMkl = lib.optionalAttrs (stdenv.hostPlatform == "x86_64-linux") (
         mistral-rs.override { acceleration = "mkl"; }
       );


### PR DESCRIPTION
## Things done

Changelog: https://github.com/EricLBuehler/mistral.rs/releases/tag/v0.4.0

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
