### PR TITLE
wireshark: enable building stratoshark

### DIFF
--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -48,6 +48,7 @@
   zlib-ng,
   zstd,
 
+  withStratoshark ? true,
   withQt ? true,
   qt6 ? null,
 }:
@@ -55,10 +56,11 @@ let
   isAppBundle = withQt && stdenv.hostPlatform.isDarwin;
 in
 assert withQt -> qt6 != null;
+assert withStratoshark -> withQt;
 
 stdenv.mkDerivation rec {
   pname = "wireshark-${if withQt then "qt" else "cli"}";
-  version = "4.4.3";
+  version = "ssv0.9.0";
 
   outputs = [
     "out"
@@ -68,8 +70,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitLab {
     repo = "wireshark";
     owner = "wireshark";
-    rev = "v${version}";
-    hash = "sha256-QTDOwJXo9+A2J/uXdyTtK5D5DVYLUAaUKT8desQGvd4=";
+    tag = "${version}";
+    hash = "sha256-P2Bx/GoV2l7iPLlh0WzKRPAUxSiWfG7pkMRGfSdDXBU=";
   };
 
   patches = [
@@ -158,6 +160,10 @@ stdenv.mkDerivation rec {
   cmakeFlags =
     [
       "-DBUILD_wireshark=${if withQt then "ON" else "OFF"}"
+      "-DBUILD_stratoshark=${if withStratoshark then "ON" else "OFF"}"
+      "-DBUILD_falcodump=${if withStratoshark then "ON" else "OFF"}"
+      "-DBUILD_sshdig=${if withStratoshark then "ON" else "OFF"}"
+      "-DENABLE_WERROR=OFF" # FIXME: Required on ssv0.9.0, please check if we can remove this later
       # Fix `extcap` and `plugins` paths. See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=16444
       "-DCMAKE_INSTALL_LIBDIR=lib"
       "-DENABLE_APPLICATION_BUNDLE=${if isAppBundle then "ON" else "OFF"}"


### PR DESCRIPTION
This enables building the new [stratoshark](https://stratoshark.org/) interface in wireshark. Since this shares a lot of code with wireshark, I've added it to the existing package instead of creating a new one.

This also currently changes the version of the wireshark sources to `ssv0.9.0`, so this should not be merged until this is properly released in the next wireshark release.

If anyone reading this uses darwin, I'd appreciate if you could test whether this needs adjustments on darwin to work.
An example capture file can be obtained using `nix run nixpkgs#sysdig -- -w test.pcap`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
