### PR TITLE
screen: 4.9.1 -> 5.0.0

### DIFF
--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -11,11 +11,11 @@
 
 stdenv.mkDerivation rec {
   pname = "screen";
-  version = "4.9.1";
+  version = "5.0.0";
 
   src = fetchurl {
     url = "mirror://gnu/screen/screen-${version}.tar.gz";
-    hash = "sha256-Js7z48QlccDUhK1vrxEMXBUJH7+HKwb6eqR2bHQFrGk=";
+    hash = "sha256-8Eo50AoOXHyGpVM4gIkDCCrV301z3xov00JZdq7ZSXE=";
   };
 
   configureFlags = [
@@ -25,6 +25,9 @@ stdenv.mkDerivation rec {
     "--enable-colors256"
     "--enable-rxvt_osc"
   ];
+
+  # We need _GNU_SOURCE so that mallocmock_reset() is defined: https://savannah.gnu.org/bugs/?66416
+  NIX_CFLAGS_COMPILE = lib.optionalString (stdenv.cc.isGNU) "-D_GNU_SOURCE=1 -Wno-int-conversion -Wno-incompatible-pointer-types";
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -21,9 +21,6 @@ stdenv.mkDerivation rec {
   configureFlags = [
     "--enable-telnet"
     "--enable-pam"
-    "--with-sys-screenrc=/etc/screenrc"
-    "--enable-colors256"
-    "--enable-rxvt_osc"
   ];
 
   # We need _GNU_SOURCE so that mallocmock_reset() is defined: https://savannah.gnu.org/bugs/?66416

--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -71,5 +71,7 @@ stdenv.mkDerivation rec {
 
     platforms = platforms.unix;
     maintainers = [ ];
+    # checking for PAM support... configure: error: no
+    broken = stdenv.hostPlatform.isDarwin;
   };
 }

--- a/pkgs/tools/misc/screen/default.nix
+++ b/pkgs/tools/misc/screen/default.nix
@@ -32,15 +32,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     autoreconfHook
   ];
-  buildInputs =
-    [
-      ncurses
-      libxcrypt
-    ]
-    ++ lib.optional stdenv.hostPlatform.isLinux pam
-    ++ lib.optional stdenv.hostPlatform.isDarwin utmp;
+  buildInputs = [
+    ncurses
+    libxcrypt
+    pam
+  ] ++ lib.optional stdenv.hostPlatform.isDarwin utmp;
 
-  doCheck = true;
+  # The test suite seems to have some glibc malloc hooks that don't exist/link on macOS
+  doCheck = !stdenv.hostPlatform.isDarwin;
 
   meta = with lib; {
     homepage = "https://www.gnu.org/software/screen/";
@@ -71,7 +70,5 @@ stdenv.mkDerivation rec {
 
     platforms = platforms.unix;
     maintainers = [ ];
-    # checking for PAM support... configure: error: no
-    broken = stdenv.hostPlatform.isDarwin;
   };
 }


### PR DESCRIPTION
GNU Screen project has a bug open about broken tests (https://savannah.gnu.org/bugs/?66416). Screen v5.0.0. test does not compile with GCC 14/15. Rational of swithing to version v5.0.0. was v4.9.1. broken cross-compilation with GCC 14.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
