### PR TITLE
restinio: fix build

### DIFF
--- a/pkgs/by-name/re/restinio/package.nix
+++ b/pkgs/by-name/re/restinio/package.nix
@@ -82,6 +82,28 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = true;
   enableParallelChecking = false;
+  __darwinAllowLocalNetworking = true;
+  preCheck =
+    let
+      disabledTests =
+        [ ]
+        ++ lib.optionals stdenv.hostPlatform.isDarwin [
+          # Tests that fail with error: 'unable to write: Operation not permitted'
+          "HTTP echo server"
+          "single_thread_connection_limiter"
+          "simple sendfile"
+          "simple sendfile with std::filesystem::path"
+          "sendfile the same file several times"
+          "sendfile 2 files"
+          "sendfile offsets_and_size"
+          "sendfile chunks"
+          "sendfile with partially-read response"
+        ];
+      excludeRegex = "^(${builtins.concatStringsSep "|" disabledTests})";
+    in
+    lib.optionalString (builtins.length disabledTests != 0) ''
+      checkFlagsArray+=(ARGS="--exclude-regex '${excludeRegex}'")
+    '';
 
   meta = with lib; {
     description = "Cross-platform, efficient, customizable, and robust asynchronous HTTP(S)/WebSocket server C++ library";

--- a/pkgs/by-name/re/restinio/package.nix
+++ b/pkgs/by-name/re/restinio/package.nix
@@ -30,6 +30,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-heVdo0MtsWi/r9yse+/FZ55lhiunyEdwB3UkOOY5Vj0=";
   };
 
+  # https://www.github.com/Stiffstream/restinio/issues/230
+  # > string sub-command JSON failed parsing json string: * Line 1, Column 1
+  # > Syntax error: value, object or array expected.
+  postPatch = ''
+    substituteInPlace dev/test/CMakeLists.txt \
+      --replace-fail "add_subdirectory(metaprogramming)" ""
+  '';
+
   strictDeps = true;
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
Test builds fail with cmake configuration error:
> string sub-command JSON failed parsing json string: * Line 1, Column 1

This is a silly regression from catch2_3 3.7.1 -> 3.8.0 bump [1].
Looks like the upstream doesn't hold catch2 correctly and overrides `main`
for this test so catch2 test discovery machinery can't work.

Upstream issue [2].

[1]: https://www.github.com/NixOS/nixpkgs/pull/371311
[2]: https://www.github.com/Stiffstream/restinio/issues/230

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
