### PR TITLE
nixos/activation: improve preSwitchChecks

### DIFF
--- a/nixos/modules/system/activation/pre-switch-check.nix
+++ b/nixos/modules/system/activation/pre-switch-check.nix
@@ -10,8 +10,8 @@ let
       # pre-switch check ${name}
       if ! (
         ${text}
-      ); then
-        echo "Pre-switch check '${name}' failed"
+      ) >&2 ; then
+        echo "Pre-switch check '${name}' failed" >&2
         exit 1
       fi
     '') config.system.preSwitchChecks

--- a/nixos/modules/system/activation/pre-switch-check.nix
+++ b/nixos/modules/system/activation/pre-switch-check.nix
@@ -1,21 +1,35 @@
-{ lib, pkgs, ... }:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
 let
-  preSwitchCheckScript =
-    set:
-    lib.concatLines (
-      lib.mapAttrsToList (name: text: ''
-        # pre-switch check ${name}
-        (
-          ${text}
-        )
-        if [[ $? != 0 ]]; then
-          echo "Pre-switch check '${name}' failed"
-          exit 1
-        fi
-      '') set
-    );
+  preSwitchCheckScript = lib.concatLines (
+    lib.mapAttrsToList (name: text: ''
+      # pre-switch check ${name}
+      if ! (
+        ${text}
+      ); then
+        echo "Pre-switch check '${name}' failed"
+        exit 1
+      fi
+    '') config.system.preSwitchChecks
+  );
 in
 {
+  options.system.preSwitchChecksScript = lib.mkOption {
+    type = lib.types.pathInStore;
+    internal = true;
+    readOnly = true;
+    default = lib.getExe (
+      pkgs.writeShellApplication {
+        name = "pre-switch-checks";
+        text = preSwitchCheckScript;
+      }
+    );
+  };
+
   options.system.preSwitchChecks = lib.mkOption {
     default = { };
     example = lib.literalExpression ''
@@ -33,12 +47,5 @@ in
     '';
 
     type = lib.types.attrsOf lib.types.str;
-
-    apply =
-      set:
-      set
-      // {
-        script = pkgs.writeShellScript "pre-switch-checks" (preSwitchCheckScript set);
-      };
   };
 }

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -61,7 +61,7 @@ in
           --subst-var-by coreutils "${pkgs.coreutils}" \
           --subst-var-by distroId ${lib.escapeShellArg config.system.nixos.distroId} \
           --subst-var-by installBootLoader ${lib.escapeShellArg config.system.build.installBootLoader} \
-          --subst-var-by preSwitchCheck ${lib.escapeShellArg config.system.preSwitchChecks.script} \
+          --subst-var-by preSwitchCheck ${lib.escapeShellArg config.system.preSwitchChecksScript} \
           --subst-var-by localeArchive "${config.i18n.glibcLocales}/lib/locale/locale-archive" \
           --subst-var-by perl "${perlWrapped}" \
           --subst-var-by shell "${pkgs.bash}/bin/sh" \
@@ -94,7 +94,7 @@ in
             --set TOPLEVEL ''${!toplevelVar} \
             --set DISTRO_ID ${lib.escapeShellArg config.system.nixos.distroId} \
             --set INSTALL_BOOTLOADER ${lib.escapeShellArg config.system.build.installBootLoader} \
-            --set PRE_SWITCH_CHECK ${lib.escapeShellArg config.system.preSwitchChecks.script} \
+            --set PRE_SWITCH_CHECK ${lib.escapeShellArg config.system.preSwitchChecksScript} \
             --set LOCALE_ARCHIVE ${config.i18n.glibcLocales}/lib/locale/locale-archive \
             --set SYSTEMD ${config.systemd.package}
         )

--- a/nixos/modules/system/activation/top-level.nix
+++ b/nixos/modules/system/activation/top-level.nix
@@ -343,7 +343,7 @@ in
       perl = pkgs.perl.withPackages (p: with p; [ ConfigIniFiles FileSlurp ]);
       # End if legacy environment variables
 
-      preSwitchCheck = config.system.preSwitchChecks.script;
+      preSwitchCheck = config.system.preSwitchChecksScript;
 
       # Not actually used in the builder. `passedChecks` is just here to create
       # the build dependencies. Checks are similar to build dependencies in the

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -611,6 +611,10 @@ in {
     other = {
       system.switch.enable = true;
       users.mutableUsers = true;
+      system.preSwitchChecks.succeeds = ''
+        echo this will succeed
+        true
+      '';
       specialisation.failingCheck.configuration.system.preSwitchChecks.failEveryTime = ''
         echo this will fail
         false


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

A couple of improvements:

1. Avoid the generally discouraged apply argument to options, as it has quite weird semantics
2. Avoid issues when a user calls a preSwitchCheck `script`, which would've been silently overridden by the existing implementation.
   Reliance on a special attribute name like that is bound to lead to a very-hard-to-debug problem for someone at some point
3. Use writeShellApplication so that the preSwitchChecks are checked by shellcheck and and so that they run with basic bash guardrails
4. Fix shellcheck issue (testing the value of $?)
5. Add a positive preSwitchCheck to the nixos test, to make sure that that works as intended

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
