### PR TITLE
nixos/kernel: Module inclusion improvements

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -1456,6 +1456,12 @@ let
           nestedTypes.finalType = finalType;
         };
 
+      # A list of attrnames is coerced into an attrset of bools by
+      # setting the values to true.
+      attrNamesToTrue = coercedTo (types.listOf types.str) (
+        enabledList: lib.genAttrs enabledList (_attrName: true)
+      ) (types.attrsOf types.bool);
+
       # Augment the given type with an additional type check function.
       addCheck = elemType: check: elemType // { check = x: elemType.check x && check x; };
 

--- a/nixos/doc/manual/development/option-types.section.md
+++ b/nixos/doc/manual/development/option-types.section.md
@@ -135,6 +135,29 @@ merging is handled.
     problems.
     :::
 
+`types.attrNamesToTrue`
+
+:   Either a list of attribute names, or an attribute set of
+    booleans. A list will be coerced into an attribute set with those
+    names, whose values are set to `true`. This is useful when it is
+    convenient to be able to write definitions as a simple list, but
+    still need to be able to override and disable individual values.
+
+    ::: {#ex-types-attrNamesToTrue .example}
+    ### `types.attrNamesToTrue`
+    ```
+    {
+      foo = [ "bar" ];
+    }
+    ```
+
+    ```
+    {
+      foo.bar = true;
+    }
+    ```
+    :::
+
 `types.pkgs`
 
 :   A type for the top level Nixpkgs package set.

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -258,6 +258,24 @@ in
       '';
     };
 
+    boot.initrd.allowMissingModules = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Whether the initrd can be built even though modules listed in
+        {option}`boot.initrd.kernelModules` or
+        {option}`boot.initrd.availableKernelModules` are missing from
+        the kernel. This is useful when combining configurations that
+        include a lot of modules, such as
+        {option}`hardware.enableAllHardware`, with kernels that don't
+        provide as many modules as typical NixOS kernels.
+
+        Note that enabling this is discouraged. Instead, try disabling
+        individual modules by setting e.g.
+        `boot.initrd.availableKernelModules.foo = lib.mkForce false;`
+      '';
+    };
+
     system.modulesTree = mkOption {
       type = types.listOf types.path;
       internal = true;

--- a/nixos/modules/system/boot/kernel.nix
+++ b/nixos/modules/system/boot/kernel.nix
@@ -13,6 +13,14 @@ let
   inherit (config.boot.kernel) features randstructSeed;
   inherit (config.boot.kernelPackages) kernel;
 
+  modulesTypeDesc = ''
+    This can either be a list of modules, or an attrset. In an
+    attrset, names that are set to `true` represent modules that will
+    be included. Note that setting these names to `false` does not
+    prevent the module from being loaded. For that, use
+    {option}`boot.blacklistedKernelModules`.
+  '';
+
   kernelModulesConf = pkgs.writeText "nixos.conf" ''
     ${concatStringsSep "\n" config.boot.kernelModules}
   '';
@@ -188,20 +196,23 @@ in
     };
 
     boot.kernelModules = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
+      type = types.attrNamesToTrue;
+      default = { };
       description = ''
         The set of kernel modules to be loaded in the second stage of
         the boot process.  Note that modules that are needed to
         mount the root file system should be added to
         {option}`boot.initrd.availableKernelModules` or
         {option}`boot.initrd.kernelModules`.
+
+        ${modulesTypeDesc}
       '';
+      apply = mods: lib.attrNames (lib.filterAttrs (_: v: v) mods);
     };
 
     boot.initrd.availableKernelModules = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
+      type = types.attrNamesToTrue;
+      default = { };
       example = [
         "sata_nv"
         "ext3"
@@ -220,13 +231,21 @@ in
         modules for PCI devices are loaded when they match the PCI ID
         of a device in your system).  To force a module to be loaded,
         include it in {option}`boot.initrd.kernelModules`.
+
+        ${modulesTypeDesc}
       '';
+      apply = mods: lib.attrNames (lib.filterAttrs (_: v: v) mods);
     };
 
     boot.initrd.kernelModules = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      description = "List of modules that are always loaded by the initrd.";
+      type = types.attrNamesToTrue;
+      default = { };
+      description = ''
+        Set of modules that are always loaded by the initrd.
+
+        ${modulesTypeDesc}
+      '';
+      apply = mods: lib.attrNames (lib.filterAttrs (_: v: v) mods);
     };
 
     boot.initrd.includeDefaultModules = mkOption {

--- a/nixos/modules/system/boot/modprobe.nix
+++ b/nixos/modules/system/boot/modprobe.nix
@@ -25,16 +25,19 @@ with lib;
       };
 
     boot.blacklistedKernelModules = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
+      type = types.attrNamesToTrue;
+      default = { };
       example = [
         "cirrusfb"
         "i2c_piix4"
       ];
       description = ''
-        List of names of kernel modules that should not be loaded
-        automatically by the hardware probing code.
+        Set of names of kernel modules that should not be loaded
+        automatically by the hardware probing code. This can either be
+        a list of modules or an attrset. In an attrset, names that are
+        set to `true` represent modules that will be blacklisted.
       '';
+      apply = mods: lib.attrNames (lib.filterAttrs (_: v: v) mods);
     };
 
     boot.extraModprobeConfig = mkOption {

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -783,7 +783,14 @@ in
     ];
 
     system.build = mkMerge [
-      { inherit bootStage1 initialRamdiskSecretAppender extraUtils; }
+      {
+        inherit
+          bootStage1
+          initialRamdiskSecretAppender
+          extraUtils
+          modulesClosure
+          ;
+      }
 
       # generated in nixos/modules/system/boot/systemd/initrd.nix
       (mkIf (!config.boot.initrd.systemd.enable) { inherit initialRamdisk; })

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -25,7 +25,7 @@ let
     rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernelModules;
     kernel = config.system.modulesTree;
     firmware = config.hardware.firmware;
-    allowMissing = false;
+    allowMissing = config.boot.initrd.allowMissingModules;
     inherit (config.boot.initrd) extraFirmwarePaths;
   };
 

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -99,14 +99,6 @@ let
   };
 
   kernel-name = config.boot.kernelPackages.kernel.name or "kernel";
-  # Determine the set of modules that we need to mount the root FS.
-  modulesClosure = pkgs.makeModulesClosure {
-    rootModules = config.boot.initrd.availableKernelModules ++ config.boot.initrd.kernelModules;
-    kernel = config.system.modulesTree;
-    firmware = config.hardware.firmware;
-    allowMissing = false;
-    inherit (config.boot.initrd) extraFirmwarePaths;
-  };
 
   initrdBinEnv = pkgs.buildEnv {
     name = "initrd-bin-env";
@@ -477,7 +469,7 @@ in
             }
           '';
 
-          "/lib".source = "${modulesClosure}/lib";
+          "/lib".source = "${config.system.build.modulesClosure}/lib";
 
           "/etc/modules-load.d/nixos.conf".text = concatStringsSep "\n" config.boot.initrd.kernelModules;
 

--- a/nixos/modules/tasks/filesystems.nix
+++ b/nixos/modules/tasks/filesystems.nix
@@ -326,9 +326,7 @@ in
           zfs = lib.mkForce false;
         }
       '';
-      type = types.coercedTo (types.listOf types.str) (
-        enabled: lib.listToAttrs (map (fs: lib.nameValuePair fs true) enabled)
-      ) (types.attrsOf types.bool);
+      type = types.attrNamesToTrue;
       description = ''
         Names of supported filesystem types, or an attribute set of file system types
         and their state. The set form may be used together with `lib.mkForce` to


### PR DESCRIPTION
`boot.initrd.allowMissingModules = true` to allow a system to build even when the kernel doesn't have all the requested modules. Or `boot.availableKernelModules.foo = true;` to enable / disable a module.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
