### PR TITLE
racket: separate recipes, fix bugs

### DIFF
--- a/pkgs/development/interpreters/racket/configure-installation.rkt
+++ b/pkgs/development/interpreters/racket/configure-installation.rkt
@@ -1,0 +1,27 @@
+#lang racket/base
+(require
+ racket/function
+ racket/list
+ racket/pretty
+ racket/string
+ setup/dirs
+ )
+
+(define config-file (build-path (find-config-dir) "config.rktd"))
+
+(define lib-paths
+  ((compose remove-duplicates
+            (curry map (curryr string-trim "-L" #:right? #f))
+            (curry filter (curryr string-prefix? "-L"))
+            string-split)
+   (getenv "NIX_LDFLAGS")))
+
+(define config
+  (let* ([prev-config (read-installation-configuration-table)]
+         [prev-lib-search-dirs (hash-ref prev-config 'lib-search-dirs '(#f))]
+         [lib-search-dirs (remove-duplicates (append lib-paths prev-lib-search-dirs))])
+    (hash-set prev-config 'lib-search-dirs lib-search-dirs)))
+
+(call-with-output-file config-file
+  #:exists 'replace
+  (curry pretty-write config))

--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -60,6 +60,15 @@ minimal.overrideAttrs (
       wrapGAppsHook3
     ];
 
+    patches = prevAttrs.patches or [ ] ++ [
+      /*
+        Hardcode variant detection because nixpkgs wraps the Racket binary making it
+        fail to detect its variant at runtime.
+        https://github.com/NixOS/nixpkgs/issues/114993#issuecomment-812951247
+      */
+      ./patches/force-cs-variant.patch
+    ];
+
     preBuild =
       let
         libPaths = makeLibPaths finalAttrs.buildInputs;

--- a/pkgs/development/interpreters/racket/default.nix
+++ b/pkgs/development/interpreters/racket/default.nix
@@ -2,14 +2,9 @@
   lib,
   stdenv,
   fetchurl,
+  racket-minimal,
 
-  libiconvReal,
-  libz,
-  lz4,
-  ncurses,
   openssl,
-
-  isMinimal ? false,
 
   cairo,
   fontconfig,
@@ -29,10 +24,11 @@
   disableDocs ? false,
 
   callPackage,
-  writers,
 }:
 
 let
+  minimal = racket-minimal.override { inherit disableDocs; };
+
   makeLibPaths = lib.concatMapStringsSep " " (
     lib.flip lib.pipe [
       lib.getLib
@@ -41,9 +37,12 @@ let
   );
 
   manifest = lib.importJSON ./manifest.json;
-  inherit (stdenv.hostPlatform) isDarwin isStatic;
+  inherit (stdenv.hostPlatform) isDarwin;
 
-  runtimeDeps = [ openssl ];
+  runtimeDeps = [
+    openssl
+  ];
+
   mainDistDeps = [
     (if isDarwin then libiodbc else unixODBC)
     cairo
@@ -58,83 +57,22 @@ let
   ];
 in
 
-stdenv.mkDerivation (finalAttrs: {
-  pname = "racket";
-  inherit (manifest) version;
-
-  src =
-    let
-      info = manifest.${if isMinimal then "minimal" else "full"};
-    in
-    fetchurl {
-      url = "https://mirror.racket-lang.org/installers/${manifest.version}/${info.filename}";
-      inherit (info) sha256;
+minimal.overrideAttrs (
+  finalAttrs: prevAttrs: {
+    src = fetchurl {
+      url = "https://mirror.racket-lang.org/installers/${manifest.version}/${manifest.full.filename}";
+      inherit (manifest.full) sha256;
     };
 
-  nativeBuildInputs = lib.optionals (!isMinimal) [
-    wrapGAppsHook3
-  ];
-
-  buildInputs = [
-    libiconvReal
-    libz
-    lz4
-    ncurses
-  ];
-
-  patches = lib.optionals isDarwin [
-    /*
-      The entry point binary $out/bin/racket is codesigned at least once. The
-      following error is triggered as a result.
-      (error 'add-ad-hoc-signature "file already has a signature")
-      We always remove the existing signature then call add-ad-hoc-signature to
-      circumvent this error.
-    */
-    ./patches/force-remove-codesign-then-add.patch
-  ];
-
-  preConfigure =
-    /*
-      The configure script forces using `libtool -o` as AR on Darwin. But, the
-      `-o` option is only available from Apple libtool. GNU ar works here.
-    */
-    lib.optionalString isDarwin ''
-      substituteInPlace src/ChezScheme/zlib/configure \
-          --replace-fail 'ARFLAGS="-o"' 'AR=ar; ARFLAGS="rc"'
-    ''
-    + ''
-      mkdir src/build
-      cd src/build
-    '';
-
-  configureScript = "../configure";
-
-  configureFlags =
-    [
-      "--enable-check"
-      "--enable-csonly"
-      "--enable-liblz4"
-      "--enable-libz"
-    ]
-    ++ lib.optional disableDocs "--disable-docs"
-    ++ lib.optionals (!isStatic) [
-      # instead of `--disable-static` that `stdenv` assumes
-      "--disable-libs"
-      # "not currently supported" in `configure --help-cs` but still emphasized in README
-      "--enable-shared"
-    ]
-    ++ lib.optionals isDarwin [
-      "--disable-strip"
-      # "use Unix style (e.g., use Gtk) for Mac OS", which eliminates many problems
-      "--enable-xonx"
+    nativeBuildInputs = [
+      wrapGAppsHook3
     ];
 
-  preBuild =
-    let
-      libPaths = makeLibPaths mainDistDeps;
-      libPathsVar = if isDarwin then "DYLD_FALLBACK_LIBRARY_PATH" else "LD_LIBRARY_PATH";
-    in
-    lib.optionalString (!isMinimal) (
+    preBuild =
+      let
+        libPaths = makeLibPaths mainDistDeps;
+        libPathsVar = if isDarwin then "DYLD_FALLBACK_LIBRARY_PATH" else "LD_LIBRARY_PATH";
+      in
       /*
         Makes FFIs available for setting up `main-distribution` and its
         dependencies, which is integrated into the build process of Racket
@@ -148,81 +86,50 @@ stdenv.mkDerivation (finalAttrs: {
       + ''
         export FONTCONFIG_FILE=${makeFontsConf { fontDirectories = [ ]; }}
         export XDG_CACHE_HOME=$(mktemp -d)
-      ''
-    );
+      '';
 
-  dontStrip = isDarwin;
-
-  preFixup = lib.optionalString (!isMinimal && !isDarwin) ''
-    gappsWrapperArgs+=("--set" "LOCALE_ARCHIVE" "${glibcLocales}/lib/locale/locale-archive")
-  '';
-
-  postFixup =
-    let
-      libPaths = makeLibPaths (runtimeDeps ++ lib.optionals (!isMinimal) mainDistDeps);
-    in
-    ''
-      $out/bin/racket -f - <<EOF
-      (require setup/dirs)
-
-      (define config-path (build-path (find-config-dir) "config.rktd"))
-
-      (define prev-config (with-input-from-file config-path read))
-      (define prev-lib-search-dirs (hash-ref prev-config 'lib-search-dirs '(#f)))
-
-      (define lib-search-dirs (append '(${libPaths}) prev-lib-search-dirs))
-      (define config (hash-set prev-config 'lib-search-dirs lib-search-dirs))
-
-      (with-output-to-file config-path (thunk (pretty-write config))
-        #:exists 'replace)
-      EOF
+    preFixup = lib.optionalString (!isDarwin) ''
+      gappsWrapperArgs+=("--set" "LOCALE_ARCHIVE" "${glibcLocales}/lib/locale/locale-archive")
     '';
 
-  passthru = {
-    # Functionalities #
-    updateScript = {
-      command = ./update.py;
-      attrPath = "racket";
-      supportedFeatures = [ "commit" ];
-    };
-    writeScript =
-      nameOrPath:
-      {
-        libraries ? [ ],
-        ...
-      }@config:
-      assert lib.assertMsg (libraries == [ ]) "library integration for Racket has not been implemented";
-      writers.makeScriptWriter (
-        builtins.removeAttrs config [ "libraries" ]
-        // {
-          interpreter = "${lib.getExe finalAttrs.finalPackage}";
-        }
-      ) nameOrPath;
-    writeScriptBin = name: finalAttrs.passthru.writeScript "/bin/${name}";
-
-    # Tests #
-    tests = builtins.mapAttrs (name: path: callPackage path { racket = finalAttrs.finalPackage; }) (
-      {
-        ## Basic ##
-        write-greeting = ./tests/write-greeting.nix;
-        get-version-and-variant = ./tests/get-version-and-variant.nix;
-        load-openssl = ./tests/load-openssl.nix;
-
-        ## Nixpkgs supports ##
-        nix-write-script = ./tests/nix-write-script.nix;
-      }
-      // lib.optionalAttrs (!isMinimal) {
-        ## `main-distribution` ##
-        draw-crossing = ./tests/draw-crossing.nix;
-      }
-    );
-  };
-
-  meta = {
-    description =
-      "Programmable programming language" + lib.optionalString isMinimal " (minimal distribution)";
-    longDescription =
+    postFixup =
+      let
+        libPaths = makeLibPaths (runtimeDeps ++ mainDistDeps);
+      in
       ''
+        $out/bin/racket -f - <<EOF
+        (require setup/dirs)
+
+        (define config-path (build-path (find-config-dir) "config.rktd"))
+
+        (define prev-config (with-input-from-file config-path read))
+        (define prev-lib-search-dirs (hash-ref prev-config 'lib-search-dirs '(#f)))
+
+        (define lib-search-dirs (append '(${libPaths}) prev-lib-search-dirs))
+        (define config (hash-set prev-config 'lib-search-dirs lib-search-dirs))
+
+        (with-output-to-file config-path (thunk (pretty-write config))
+          #:exists 'replace)
+        EOF
+      '';
+
+    passthru =
+      let
+        notUpdated = x: !builtins.isAttrs x || lib.isDerivation x;
+        stopPred =
+          _: lhs: rhs:
+          notUpdated lhs || notUpdated rhs;
+      in
+      lib.recursiveUpdateUntil stopPred prevAttrs.passthru {
+        tests = builtins.mapAttrs (name: path: callPackage path { racket = finalAttrs.finalPackage; }) {
+          ## `main-distribution` ##
+          draw-crossing = ./tests/draw-crossing.nix;
+        };
+      };
+
+    meta = prevAttrs.meta // {
+      description = "Programmable programming language";
+      longDescription = ''
         Racket is a full-spectrum programming language. It goes beyond
         Lisp and Scheme with dialects that support objects, types,
         laziness, and more. Racket enables programmers to link
@@ -230,28 +137,9 @@ stdenv.mkDerivation (finalAttrs: {
         programmers to create new, project-specific dialects. Racket's
         libraries support applications from web servers and databases to
         GUIs and charts.
-      ''
-      + lib.optionalString isMinimal ''
-
-        This minimal distribution includes just enough of Racket that you can
-        use `raco pkg` to install more.
       '';
-    homepage = "https://racket-lang.org/";
-    changelog = "https://github.com/racket/racket/releases/tag/v${finalAttrs.version}";
-    /*
-      > Racket is distributed under the MIT license and the Apache version 2.0
-      > license, at your option.
-
-      > The Racket runtime system embeds Chez Scheme, which is distributed
-      > under the Apache version 2.0 license.
-    */
-    license = with lib.licenses; [
-      asl20
-      mit
-    ];
-    maintainers = with lib.maintainers; [ rc-zb ];
-    mainProgram = "racket";
-    platforms = lib.platforms.${if isMinimal then "all" else "unix"};
-    badPlatforms = lib.platforms.darwin;
-  };
-})
+      platforms = lib.platforms.unix;
+      badPlatforms = lib.platforms.darwin;
+    };
+  }
+)

--- a/pkgs/development/interpreters/racket/minimal.nix
+++ b/pkgs/development/interpreters/racket/minimal.nix
@@ -1,0 +1,172 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+
+  libiconvReal,
+  libz,
+  lz4,
+  ncurses,
+  openssl,
+
+  disableDocs ? false,
+
+  callPackage,
+  writers,
+}:
+
+let
+  manifest = lib.importJSON ./manifest.json;
+
+  inherit (stdenv.hostPlatform) isDarwin isStatic;
+in
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "racket";
+  inherit (manifest) version;
+
+  src = fetchurl {
+    url = "https://mirror.racket-lang.org/installers/${manifest.version}/${manifest.minimal.filename}";
+    inherit (manifest.minimal) sha256;
+  };
+
+  buildInputs = [
+    libiconvReal
+    libz
+    lz4
+    ncurses
+  ];
+
+  patches = lib.optionals isDarwin [
+    /*
+      The entry point binary $out/bin/racket is codesigned at least once. The
+      following error is triggered as a result.
+      (error 'add-ad-hoc-signature "file already has a signature")
+      We always remove the existing signature then call add-ad-hoc-signature to
+      circumvent this error.
+    */
+    ./patches/force-remove-codesign-then-add.patch
+  ];
+
+  preConfigure =
+    /*
+      The configure script forces using `libtool -o` as AR on Darwin. But, the
+      `-o` option is only available from Apple libtool. GNU ar works here.
+    */
+    lib.optionalString isDarwin ''
+      substituteInPlace src/ChezScheme/zlib/configure \
+          --replace-fail 'ARFLAGS="-o"' 'AR=ar; ARFLAGS="rc"'
+    ''
+    + ''
+      mkdir src/build
+      cd src/build
+    '';
+
+  configureScript = "../configure";
+
+  configureFlags =
+    [
+      "--enable-check"
+      "--enable-csonly"
+      "--enable-liblz4"
+      "--enable-libz"
+    ]
+    ++ lib.optional disableDocs "--disable-docs"
+    ++ lib.optionals (!isStatic) [
+      # instead of `--disable-static` that `stdenv` assumes
+      "--disable-libs"
+      # "not currently supported" in `configure --help-cs` but still emphasized in README
+      "--enable-shared"
+    ]
+    ++ lib.optionals isDarwin [
+      "--disable-strip"
+      # "use Unix style (e.g., use Gtk) for Mac OS", which eliminates many problems
+      "--enable-xonx"
+    ];
+
+  dontStrip = isDarwin;
+
+  postFixup = ''
+    $out/bin/racket -f - <<EOF
+    (require setup/dirs)
+
+    (define config-path (build-path (find-config-dir) "config.rktd"))
+
+    (define prev-config (with-input-from-file config-path read))
+    (define prev-lib-search-dirs (hash-ref prev-config 'lib-search-dirs '(#f)))
+
+    (define lib-search-dirs (append '("${lib.getLib openssl}/lib") prev-lib-search-dirs))
+    (define config (hash-set prev-config 'lib-search-dirs lib-search-dirs))
+
+    (with-output-to-file config-path (thunk (pretty-write config))
+      #:exists 'replace)
+    EOF
+  '';
+
+  passthru = {
+    # Functionalities #
+    updateScript = {
+      command = ./update.py;
+      attrPath = "racket";
+      supportedFeatures = [ "commit" ];
+    };
+    writeScript =
+      nameOrPath:
+      {
+        libraries ? [ ],
+        ...
+      }@config:
+      assert lib.assertMsg (libraries == [ ]) "library integration for Racket has not been implemented";
+      writers.makeScriptWriter (
+        builtins.removeAttrs config [ "libraries" ]
+        // {
+          interpreter = "${lib.getExe finalAttrs.finalPackage}";
+        }
+      ) nameOrPath;
+    writeScriptBin = name: finalAttrs.passthru.writeScript "/bin/${name}";
+
+    # Tests #
+    tests = builtins.mapAttrs (name: path: callPackage path { racket = finalAttrs.finalPackage; }) {
+      ## Basic ##
+      write-greeting = ./tests/write-greeting.nix;
+      get-version-and-variant = ./tests/get-version-and-variant.nix;
+      load-openssl = ./tests/load-openssl.nix;
+
+      ## Nixpkgs supports ##
+      nix-write-script = ./tests/nix-write-script.nix;
+    };
+  };
+
+  meta = {
+    description = "Programmable programming language (minimal distribution)";
+    longDescription = ''
+      Racket is a full-spectrum programming language. It goes beyond
+      Lisp and Scheme with dialects that support objects, types,
+      laziness, and more. Racket enables programmers to link
+      components written in different dialects, and it empowers
+      programmers to create new, project-specific dialects. Racket's
+      libraries support applications from web servers and databases to
+      GUIs and charts.
+
+      This minimal distribution includes just enough of Racket that you can
+      use `raco pkg` to install more.
+    '';
+    homepage = "https://racket-lang.org/";
+    changelog = "https://github.com/racket/racket/releases/tag/v${finalAttrs.version}";
+    /*
+      > Racket is distributed under the MIT license and the Apache version 2.0
+      > license, at your option.
+
+      > The Racket runtime system embeds Chez Scheme, which is distributed
+      > under the Apache version 2.0 license.
+    */
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ rc-zb ];
+    mainProgram = "racket";
+    platforms = lib.platforms.all;
+    badPlatforms = lib.platforms.darwin;
+  };
+})

--- a/pkgs/development/interpreters/racket/patches/force-cs-variant.patch
+++ b/pkgs/development/interpreters/racket/patches/force-cs-variant.patch
@@ -1,0 +1,12 @@
+--- old/collects/setup/variant.rkt
++++ new/collects/setup/variant.rkt
+@@ -7,7 +7,8 @@
+ (provide variant-suffix
+          script-variant?)
+
+-(define plain-variant
++(define plain-variant 'cs)
++#;(define plain-variant
+   (delay/sync
+    (cond
+      [(cross-installation?)

--- a/pkgs/development/interpreters/racket/tests/get-version-and-variant.nix
+++ b/pkgs/development/interpreters/racket/tests/get-version-and-variant.nix
@@ -1,27 +1,45 @@
-{ runCommandLocal, racket }:
+{
+  lib,
+  runCommandLocal,
+  racket,
+}:
 
 runCommandLocal "racket-test-get-version-and-variant"
   {
     nativeBuildInputs = [ racket ];
   }
-  ''
-    expectation="${racket.version}"
+  (
+    lib.concatLines (
+      builtins.map
+        (
+          { expectation, output }:
+          ''
+            expectation="${expectation}"
 
-    output="$(racket -e '(display (version))')"
+            output="${output}"
 
-    if test "$output" != "$expectation"; then
-        echo "output mismatch: expected ''${expectation}, but got ''${output}"
-        exit 1
-    fi
-
-    expectation="cs"
-
-    output="$(racket -e '(require launcher/launcher) (display (current-launcher-variant))')"
-
-    if test "$output" != "$expectation"; then
-        echo "output mismatch: expected ''${expectation}, but got ''${output}"
-        exit 1
-    fi
-
-    touch $out
-  ''
+            if test "$output" != "$expectation"; then
+                echo "output mismatch: expected ''${expectation}, but got ''${output}"
+                exit 1
+            fi
+          ''
+        )
+        [
+          {
+            expectation = racket.version;
+            output = "$(racket -e '(display (version))')";
+          }
+          {
+            expectation = "cs";
+            output = "$(racket -e '(require launcher/launcher) (display (current-launcher-variant))')";
+          }
+          {
+            expectation = "${lib.getExe racket}";
+            output = "$(racket -e '(require compiler/find-exe) (display (find-exe))')";
+          }
+        ]
+    )
+    + ''
+      touch $out
+    ''
+  )

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -7285,7 +7285,7 @@ with pkgs;
   wireplumber = callPackage ../development/libraries/pipewire/wireplumber.nix { };
 
   racket = callPackage ../development/interpreters/racket { };
-  racket-minimal = racket.override { isMinimal = true; };
+  racket-minimal = callPackage ../development/interpreters/racket/minimal.nix { };
 
   rakudo = callPackage ../development/interpreters/rakudo { };
   moarvm = darwin.apple_sdk_11_0.callPackage ../development/interpreters/rakudo/moarvm.nix {


### PR DESCRIPTION
This is originally part of #373716. However, the latter is currently stuck in abstruse build failures. So these commits are extracted out for review first.
1. Separate again the recipes for `racket` and `racket-minimal` for maintainability.
2. Add `sqlite.out` to the dependency list of `racket-minimal` to fix a documentation build failure.
3. Restore the patch added by #118490 to fix #377763.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
