### PR TITLE
[24.11] linux_latest: pin to 6.12, out of tree modules are broken

### DIFF
--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -715,7 +715,7 @@ in {
   packageAliases = {
     linux_default = packages.linux_6_6;
     # Update this when adding the newest kernel major version!
-    linux_latest = packages.linux_6_13;
+    linux_latest = packages.linux_6_12;
     linux_mptcp = throw "'linux_mptcp' has been moved to https://github.com/teto/mptcp-flake";
     linux_rt_default = packages.linux_rt_5_15;
     linux_rt_latest = packages.linux_rt_6_6;


### PR DESCRIPTION
This shouldn't have been backported to 24.11 without proper testing in #375263.

/cc #375605 @K900 