### PR TITLE
ci: Update pinned Nixpkgs

### DIFF
--- a/ci/pinned-nixpkgs.json
+++ b/ci/pinned-nixpkgs.json
@@ -1,4 +1,4 @@
 {
-  "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
-  "sha256": "1am61kcakn9j47435k4cgsarvypb8klv4avszxza0jn362hp3ck8"
+  "rev": "5757bbb8bd7c0630a0cc4bb19c47e588db30b97c",
+  "sha256": "0px0lr7ad2zrws400507c9w5nnaffz9mp9hqssm64icdm6f6h0fz"
 }


### PR DESCRIPTION
Same as https://github.com/NixOS/nixpkgs/pull/363585. This includes https://github.com/NixOS/nixpkgs/commit/170a250e10d47c77eb32ba3f5f8afb79977a272a and https://github.com/NixOS/nixpkgs/commit/dc208d29520965349de61f434cf67719772d80d2, which should allow nixpkgs-review to fetch eval results from GitHub.

Ran `ci/update-pinned-nixpkgs.sh`, which updated it to the version from this nixpkgs-unstable Hydra eval: https://hydra.nixos.org/eval/1811194#tabs-inputs

This should probably be automated using CI. See https://github.com/NixOS/nixpkgs/issues/346453#issuecomment-2608346811

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
