### PR TITLE
treewide: migrate to fetchCargoVendor, batch 2

### DIFF
--- a/pkgs/applications/audio/listenbrainz-mpd/default.nix
+++ b/pkgs/applications/audio/listenbrainz-mpd/default.nix
@@ -26,7 +26,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-QBc0avci232UIxzTKlS0pjL7cCuvwAFgw6dSwdtYAtU=";
   };
 
-  cargoHash = "sha256-jnDS9tIJ387A2P9oUSYB3tXrXjwwVmQ26erIIlHBkao=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NQXXR6b1XZDihVoRNFJLXtMNjlzOIzkc4rthwx0A7AE=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/audio/minidsp/default.nix
+++ b/pkgs/applications/audio/minidsp/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-8bKP9/byVRKj1P1MP3ZVg8yw0WaNB0BcqarCti7B8CA=";
   };
 
-  cargoHash = "sha256-GUrYEFpTo83lKuDyENaVN3VhnZ2Y/igtsbEY7kNa1os=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-JIm0XcgqXGPXlkQ1rhG5D38bQkQT9K44F71ZaCT2g8o=";
 
   cargoBuildFlags = [ "-p minidsp -p minidsp-daemon" ];
 

--- a/pkgs/applications/audio/muso/default.nix
+++ b/pkgs/applications/audio/muso/default.nix
@@ -35,7 +35,8 @@ rustPlatform.buildRustPackage rec {
     cp share/* $out/share/muso/
   '';
 
-  cargoHash = "sha256-+UVUejKCfjC6zdW315wmu7f3A5GmnoQ3rIk8SK6LIRI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-L0ZQoz9J5Hxg98puk1RbKuybLboIoOsy5qqGnvEPi1U=";
 
   meta = with lib; {
     broken = stdenv.hostPlatform.isDarwin;

--- a/pkgs/applications/audio/parrot/default.nix
+++ b/pkgs/applications/audio/parrot/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-3YTXIKj1iqCB+tN7/0v1DAaMM6aJiSxBYHO98uK8KFo=";
   };
 
-  cargoHash = "sha256-3G7NwSZaiocjgfdtmJVWfMZOHCNhC08NgolPa9AvPfE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-be/gGKCd8/VgcjzhyMKDl5TzAuavm1rPNYBm8RLTP90=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/blockchains/electrs/default.nix
+++ b/pkgs/applications/blockchains/electrs/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-L26jzAn8vwnw9kFd6ciyYS/OLEFTbN8doNKy3P8qKRE=";
   };
 
-  cargoHash = "sha256-/0XS4xF5gzEBWXS39f0FsIK1dFwmGT4McaExR/srB5Y=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-dqVnIiaGXnoKLvwQm/aiwSptKksikNGgAOu704rhDPA=";
 
   # needed for librocksdb-sys
   nativeBuildInputs = [ rustPlatform.bindgenHook ];

--- a/pkgs/applications/blockchains/snarkos/default.nix
+++ b/pkgs/applications/blockchains/snarkos/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-+z9dgg5HdR+Gomug03gI1zdCU6t4SBHkl1Pxoq69wrc=";
   };
 
-  cargoHash = "sha256-qW/ZV4JqpNqqh8BYc+/d5g8junwhdZ38NhHclx+k/0M=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-riUOxmuXDP5+BPSPu5+cLBP43bZxAqvVG/k5kvThSAs=";
 
   # buildAndTestSubdir = "cli";
 

--- a/pkgs/applications/blockchains/teos/default.nix
+++ b/pkgs/applications/blockchains/teos/default.nix
@@ -32,7 +32,8 @@ in
     pname = "teos";
     inherit version src;
 
-    cargoHash = "sha256-U0imKEPszlBOaS6xEd3kfzy/w2SYe3EY/E1e0L+ViDk=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-lod5I94T4wGwXEDtvh2AyaDYM0byCfaSBP8emKV7+3M=";
 
     buildAndTestSubdir = "teos";
 
@@ -58,7 +59,8 @@ in
     pname = "teos-watchtower-plugin";
     inherit version src;
 
-    cargoHash = "sha256-3ke1qTFw/4I5dPLuPjIGp1n2C/eRfPB7A6ErMFfwUzE=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-lod5I94T4wGwXEDtvh2AyaDYM0byCfaSBP8emKV7+3M=";
 
     buildAndTestSubdir = "watchtower-plugin";
 

--- a/pkgs/applications/blockchains/zcash/default.nix
+++ b/pkgs/applications/blockchains/zcash/default.nix
@@ -42,7 +42,8 @@ rustPlatform.buildRustPackage.override { inherit stdenv; } rec {
       --replace "linker = \"aarch64-linux-gnu-gcc\"" ""
   '';
 
-  cargoHash = "sha256-Mz8mr/RDcOfwJvXhY19rZmWHP8mUeEf9GYD+3JAPNOw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-VBqasLpxqI4kr73Mr7OVuwb2OIhUwnY9CTyZZOyEElU=";
 
   nativeBuildInputs = [
     autoreconfHook

--- a/pkgs/applications/display-managers/greetd/default.nix
+++ b/pkgs/applications/display-managers/greetd/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-jgvYnjt7j4uubpBxrYM3YiUfF1PWuHAN1kwnv6Y+bMg=";
   };
 
-  cargoHash = "sha256-M52Kj14X+vMPKeGwi5pbEuh3F9/a3eVjhsbZI06Jkzs=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-JwTLZawY9+M09IDbMPoNUcNrnW1C2OVlEVn1n7ol6dY=";
 
   nativeBuildInputs = [
     scdoc

--- a/pkgs/applications/display-managers/greetd/regreet.nix
+++ b/pkgs/applications/display-managers/greetd/regreet.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-f8Xvno5QqmWz4SUiFYDvs8lFU1ZaqQ8gpTaVzWxW4T8=";
   };
 
-  cargoHash = "sha256-XdJbghHT2NR+pWAsgayz748C8yw/Rv86lNfvjABwJws=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-abCQ3RsnZ/a1DbjQFOiA7Xs7bbqSJxwNps8yV6Q4FIw=";
 
   buildFeatures = [ "gtk4_8" ];
 

--- a/pkgs/applications/display-managers/greetd/tuigreet.nix
+++ b/pkgs/applications/display-managers/greetd/tuigreet.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-e0YtpakEaaWdgu+bMr2VFoUc6+SUMFk4hYtSyk5aApY=";
   };
 
-  cargoHash = "sha256-RkJjAmZ++4nc/lLh8g0LxGq2DjZGxQEjFOl8Yzx116A=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-w6ZOqpwogKoN4oqqI1gFqY8xAnfvhEBVaL8/6JXpKXs=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/applications/display-managers/greetd/wlgreet.nix
+++ b/pkgs/applications/display-managers/greetd/wlgreet.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-TQTHFBOTxtSuzrAG4cjZ9oirl80xc0rPdYeLJ0t39DQ=";
   };
 
-  cargoHash = "sha256-+YGhfEq2RltPq5oLLh1h+vGphDpoGZNVdvzko3P1iUQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ITo9qvcT5aOybWLV7kn9BZbux6uxx1RwRGWCGQYdZ2I=";
 
   nativeBuildInputs = [ autoPatchelfHook ];
   buildInputs = [ gcc-unwrapped ];

--- a/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/module.nix
+++ b/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/module.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-DiqC7z1AQbXsSXc77AGRilWi3HfEg0YoHrXu54O3Clo=";
   };
 
-  cargoHash = "sha256-ZRWzkojcNlgdjXUvmdR/vjJx9k3xRvV0Yz7+8TN+8qc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ygFXKniCCOyXndPOTKoRbd4W1OR2CSA2jr7yxpwkw28=";
 
   checkFlags = [
     # flaky test

--- a/pkgs/applications/editors/neovim/gnvim/default.nix
+++ b/pkgs/applications/editors/neovim/gnvim/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-VyyHlyMW/9zYECobQwngFARQYqcoXmopyCHUwHolXfo=";
   };
 
-  cargoHash = "sha256-uhObLKoQE+r0/ocWA26MpJsSt9RAzKG1XmZsXat+ohg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-+i4fFiuNmc2+aFyOW2FxRZXINN1XF0nDJVsFYnIHI24=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/editors/vim/plugins/non-generated/LanguageClient-neovim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/LanguageClient-neovim/default.nix
@@ -17,7 +17,8 @@ let
     pname = "LanguageClient-neovim-bin";
     inherit version src;
 
-    cargoHash = "sha256-H34UqJ6JOwuSABdOup5yKeIwFrGc83TUnw1ggJEx9o4=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-1tfeowqvjEjMXIfrhr388YhlZrk3ns+Y/2odQnkLw7k=";
   };
 in
 vimUtils.buildVimPlugin {

--- a/pkgs/applications/editors/vim/plugins/non-generated/avante-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/avante-nvim/default.nix
@@ -21,7 +21,8 @@ let
     pname = "avante-nvim-lib";
     inherit version src;
 
-    cargoHash = "sha256-80++U7CIu6QtH1jQCHCEpv2tnYOuoWSczZIUmKyrqJE=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-pJDk9JHcKNDZRrJM/zqrUvDom7hnhD1B5Ssa+DgitqQ=";
 
     nativeBuildInputs = [
       pkg-config

--- a/pkgs/applications/editors/vim/plugins/non-generated/codesnap-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/codesnap-nvim/default.nix
@@ -22,7 +22,8 @@ let
 
     sourceRoot = "${src.name}/generator";
 
-    cargoHash = "sha256-6n37n8oHIHrz3S1+40nuD0Ud3l0iNgXig1ZwrgsnYTI=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-tg4BO4tPzHhJTowL7RiAuBo4i440FehpGmnz9stTxfI=";
 
     nativeBuildInputs = [
       pkg-config

--- a/pkgs/applications/editors/vim/plugins/non-generated/cord-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/cord-nvim/default.nix
@@ -19,7 +19,8 @@ let
     pname = "cord.nvim-rust";
     inherit version src;
 
-    cargoHash = "sha256-unE600Uo8fXaFV0UWRhBenhQaXftDH7K+HyQ/9xo7JY=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-UJdSQNaYaZxvmfuHwePzGhQ3Pv+Cm7YaRK1L0CJhtEc=";
 
     installPhase =
       let

--- a/pkgs/applications/editors/vim/plugins/non-generated/nvim-spectre/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/nvim-spectre/default.nix
@@ -20,7 +20,8 @@ let
     inherit version src;
     sourceRoot = "${src.name}/spectre_oxi";
 
-    cargoHash = "sha256-jVNeK1BeCzQaS5G561iWB3xEupzjIgnbUpEo1IVr9nQ=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-0szVL45QRo3AuBMf+WQ0QF0CS1B9HWPxfF6l6TJtv6Q=";
 
     preCheck = ''
       mkdir tests/tmp/

--- a/pkgs/applications/editors/vim/plugins/non-generated/sg-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/sg-nvim/default.nix
@@ -21,7 +21,8 @@ let
     pname = "sg-nvim-rust";
     inherit version src;
 
-    cargoHash = "sha256-t0+0Zw8NjCD1VB1hTrSjOa1130IVanoTALdFoTloFe4=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-yY/5w2ztmTKJAYDxBJND8itCOwRNi1negiFq3PyFaSM=";
 
     nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/editors/vim/plugins/non-generated/sniprun/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/sniprun/default.nix
@@ -24,7 +24,8 @@ let
     pname = "sniprun-bin";
     inherit version src;
 
-    cargoHash = "sha256-eZcWS+DWec0V9G6hBnZRUNcb3uZeSiBhn4Ed9KodFV8=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-j3i86I5Lmt0+fQONikHnxfeLEbiyFSairgjHXmjZfTk=";
 
     nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/applications/editors/vim/plugins/non-generated/vim-markdown-composer/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/vim-markdown-composer/default.nix
@@ -17,7 +17,8 @@ let
   vim-markdown-composer-bin = rustPlatform.buildRustPackage {
     pname = "vim-markdown-composer-bin";
     inherit src version;
-    cargoHash = "sha256-z5hjY2RUbM5NLfRtyfiHi4PjMnKdAflaZsHw53lgU2E=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-xzlEIaDEYDbxJ6YqzF+lSHcB9O+brClw026YI1YeNUc=";
     # tests require network access
     doCheck = false;
   };

--- a/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/adapter.nix
+++ b/pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/adapter.nix
@@ -13,7 +13,8 @@ rustPlatform.buildRustPackage {
   pname = "${pname}-adapter";
   inherit version src;
 
-  cargoHash = "sha256-e/Jki/4pCs0qzaBVR4iiUhdBFmWlTZYREQkuFSoWYFo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-7tGX8wt2bb1segoWbBEBwZbznOaAiAyh9i/JC5FKUBU=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ lldb ];
 

--- a/pkgs/applications/editors/zee/default.nix
+++ b/pkgs/applications/editors/zee/default.nix
@@ -33,7 +33,8 @@ rustPlatform.buildRustPackage rec {
   # see https://github.com/zee-editor/zee#syntax-highlighting
   ZEE_DISABLE_GRAMMAR_BUILD = 1;
 
-  cargoHash = "sha256-fBBjtjM7AnyAL6EOFstL4h6yS+UoLgxck6Mc0tJcXaI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-auwbpavF/WZQIE/htYXJ4di6xoRtXkBBkP/Bj4lFp6U=";
 
   meta = with lib; {
     description = "Modern text editor for the terminal written in Rust";

--- a/pkgs/applications/gis/whitebox-tools/default.nix
+++ b/pkgs/applications/gis/whitebox-tools/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-kvtfEEydwonoDux1VbAxqrF/Hf8Qh8mhprYnROGOC6g=";
   };
 
-  cargoHash = "sha256-6v/3b6BHh/n7M2ZhLVKRvv0Va2xbLUSsxUb5paOStbQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-yQFGuhEGgkaa5N4uUIZ/0GFzP9CsPtiFet0hUppIQzQ=";
 
   buildInputs = [
     atk

--- a/pkgs/applications/graphics/emulsion/default.nix
+++ b/pkgs/applications/graphics/emulsion/default.nix
@@ -49,7 +49,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-0t+MUZu1cvkJSL9Ly9kblH8fMr05KuRpOo+JDn/VUc8=";
   };
 
-  cargoHash = "sha256-detJZRnxT3FubaF/A4w2pFdhW03BH0gsaeuNFYu+cBw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-1s5kCUxn4t1A40QHuygGKaqphLmcl+EYfx++RZQmL00=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/applications/graphics/menyoki/default.nix
+++ b/pkgs/applications/graphics/menyoki/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-owP3G1Rygraifdc4iPURQ1Es0msNhYZIlfrtj0CSU6Y=";
   };
 
-  cargoHash = "sha256-NtXjlGkX8AzSw98xHPymzdnTipMIunyDbpSr4eVowa0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-6FRc/kEhGJXIZ+6GXeYj5j7QVmvZgIQgtDPvt94hlho=";
 
   nativeBuildInputs = [ installShellFiles ] ++ lib.optional stdenv.hostPlatform.isLinux pkg-config;
 

--- a/pkgs/applications/misc/binocle/default.nix
+++ b/pkgs/applications/misc/binocle/default.nix
@@ -26,7 +26,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-WAk7xIrCRfVofn4w+gP5E3wnSZbXm/6MZWlNmtoLm20=";
   };
 
-  cargoHash = "sha256-ZmY88WcoQiDLSXkBbnE/+jPX713qh6n+nyNXeWWTBKA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-AUmDubbi6y1SaHZazr2xZc+16SQhI6WBnPg6I7rv3K4=";
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/applications/misc/cobalt/default.nix
+++ b/pkgs/applications/misc/cobalt/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-6fsKEIgcBu0SE/f0TNfvTdpZX3zc5Bd0F1T82COOqVQ=";
   };
 
-  cargoHash = "sha256-g25Pw3BlRbuaGjsQav6mU9zVyS1mVUKkgKDOILm8R6U=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NLSdYGZy+FWjA5N1zGf3Lajg2qo4TJ86AzlKVrHxwaU=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 

--- a/pkgs/applications/misc/eureka-ideas/default.nix
+++ b/pkgs/applications/misc/eureka-ideas/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-NJ1O8+NBG0y39bMOZeah2jSZlvnPrtpCtXrgAYmVrAc=";
   };
 
-  cargoHash = "sha256-tNUWW0HgXl+tM9uciApLSkLDDkzrvAiWmiYs2y/dEOM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-nTYMKJ5OCApqooIF1dsDLriPfYjkZkTdtzpkJya/5ag=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/misc/inherd-quake/default.nix
+++ b/pkgs/applications/misc/inherd-quake/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-HKAR4LJm0lrQgTOCqtYIRFbO3qHtPbr4Fpx2ek1oJ4Q=";
   };
 
-  cargoHash = "sha256-svvtZyfN91OT3yqxH6TgFhGYg9drpXsts4p2WqSHG8w=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-klxigm3RpTfwbENva2WmOPaiJEV2yujY323xRkAML0I=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/misc/inlyne/default.nix
+++ b/pkgs/applications/misc/inlyne/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-j4DEau7LZxIoVIIYwCUgqmkSgdRxWzF5/vOS0lvjgUk=";
   };
 
-  cargoHash = "sha256-fMovzaP+R0CUwJy1HKATH2tPrIPwzGtubF1WHUoQDRY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-9Ev/D58MU0aMleM6NFG7MsXqGlhi0eAujqYaLDuPjIY=";
 
   nativeBuildInputs =
     [

--- a/pkgs/applications/misc/klipper-estimator/default.nix
+++ b/pkgs/applications/misc/klipper-estimator/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-EjfW2qeq0ehGhjE2Psz5g/suYMZPvtQi2gaYb+NCa2U=";
   };
 
-  cargoHash = "sha256-bboXG2nBrK2hVzB43um6EUgLPlSa8huyPH7VOJ48Nkk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-wMgFkzgoHjvE+5t+cA5OW2COXbUj/5tWXz0Zp9cd5lw=";
 
   buildInputs =
     [ openssl ]

--- a/pkgs/applications/misc/mdzk/default.nix
+++ b/pkgs/applications/misc/mdzk/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     ./update-mdbook-for-rust-1.64.patch
   ];
 
-  cargoHash = "sha256-5zGUBvmf68tCk5jGrNn+ukgYbiKzrlmZvWrYgoJf2zk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-+x4pOtszvdzI/zR55ezcxlS52GrWQTuBn7vbnqDTVac=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 

--- a/pkgs/applications/misc/pastel/default.nix
+++ b/pkgs/applications/misc/pastel/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-kr2aLRd143ksVx42ZDO/NILydObinn3AwPCniXVVmY0=";
   };
 
-  cargoHash = "sha256-+Cw/aAXkSbYLqc7TGWsMUJNo88v0s1Cq1m4V84j3gXE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-u+1KDcC2KGqvmOk6k7hOHE16TMvDg92eMOdNMQQszug=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/applications/misc/pomodoro/default.nix
+++ b/pkgs/applications/misc/pomodoro/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-ZA1q1YVJcdSUF9NTikyT3vrRnqbsu5plzRI2gMu+qnQ=";
   };
 
-  cargoHash = "sha256-6ZhWStZebXSwrej36DXifrsrmR1SWW3PwGUX0hqPwE4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-oXOf9G0BMSbFFAsmRaAZzaquFva1i1gJ4ISqJkqSx4k=";
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Foundation ];
 
   meta = with lib; {

--- a/pkgs/applications/misc/pueue/default.nix
+++ b/pkgs/applications/misc/pueue/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-b4kZ//+rO70uZh1fvI4A2dbCZ7ymci9g/u5keMBWYf8=";
   };
 
-  cargoHash = "sha256-sTpxcJs5I7LzVw56ka5PlFixJSiJeCae9serS0FhmuA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-MDUBP1NI50I8sSXHYFiAdyL8C2DloCjnq8pr7PsBBIE=";
 
   nativeBuildInputs =
     [

--- a/pkgs/applications/misc/reddsaver/default.nix
+++ b/pkgs/applications/misc/reddsaver/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "07xsrc0w0z7w2w0q44aqnn1ybf9vqry01v3xr96l1xzzc5mkqdzf";
   };
 
-  cargoHash = "sha256-l+fxk9gkM+pStBVJcsN4P2tNCuFIiBaAxpq9SLlvJHk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-xYtdGhuieFudfJz+LxUjP7mV8uItaIvLahCH7vBWTtg=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ] ++ lib.optional stdenv.hostPlatform.isDarwin Security;

--- a/pkgs/applications/misc/stork/default.nix
+++ b/pkgs/applications/misc/stork/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-qGcEhoytkCkcaA5eHc8GVgWvbOIyrO6BCp+EHva6wTw=";
   };
 
-  cargoHash = "sha256-a7ADTJ0VmKiZBr951JIAOSPWucsBl5JnM8eQHWssRM4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-nN2aNNBq2YDOY9H9682hvwrlI5WTg7s1EPi68UuBTBM=";
 
   checkFlags = [
     # Fails for 1.6.0, but binary works fine

--- a/pkgs/applications/misc/terminal-typeracer/default.nix
+++ b/pkgs/applications/misc/terminal-typeracer/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-S3OW6KihRd6ReTWUXRb1OWC7+YoxehjFRBxcnJVgImU=";
   };
 
-  cargoHash = "sha256-OwbFIbKB/arj+3gq2tfEq8yTKSUPBQNYJNzrWvDv4A4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-WYqbG0iSVvnRLCy5Qs4wr72LjQ6uPgskVWP62Af0RQ8=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/networking/browsers/asuka/default.nix
+++ b/pkgs/applications/networking/browsers/asuka/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-+rj6P3ejc4Qb/uqbf3N9MqyqDT7yg9JFE0yfW/uzd6M=";
   };
 
-  cargoHash = "sha256-XrFpvH3qiMvpgbH7Q+KC1zFAqJT4rjxux6Q5KLY2ufI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-aNHkhcvOdK6sf6nWxCNPxcktYhrnmLdMrLqWb/1QBQ4=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/networking/feedreaders/tuifeed/default.nix
+++ b/pkgs/applications/networking/feedreaders/tuifeed/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-JG/l6NfN5RqBpz9NVcVY3mP/iE31TXvw+Vjq8N8rNIY=";
   };
 
-  cargoHash = "sha256-QKSNbpVRtSKp2q1jVPYTS8XCMtQAyg3AWvD/6+OjI7Y=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-UlZDT/i3UB0wGGpuSBBvVPqRbzGHneDJs57pHn11E5k=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/applications/networking/geph/default.nix
+++ b/pkgs/applications/networking/geph/default.nix
@@ -38,7 +38,8 @@ in
       hash = "sha256-6YWPsSRIZpvVCIGZ1z7srobDvVzLr0o2jBcB/7kbK7I=";
     };
 
-    cargoHash = "sha256-c9Sq3mdotvB/oNIiOLTrAAUnUdkaye7y1l+29Uwjfm8=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-igIYTlI3hqvlOTgdwouA9YussP9h0pOHUUTCjA2LE5U=";
 
     nativeBuildInputs = [ perl ];
 

--- a/pkgs/applications/networking/gopher/phetch/default.nix
+++ b/pkgs/applications/networking/gopher/phetch/default.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-J+ka7/B37WzVPPE2Krkd/TIiVwuKfI2QYWmT0JHgBGQ=";
   };
 
-  cargoHash = "sha256-y3Y5PnZ51Zc3LmVTijUGnb0KaGm28sWOSYxjuM3A1Zk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-2lbQAM3gdytXsoMFzKwLWA1hvQIJf1vBdMRpYx/VLVg=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/applications/networking/instant-messengers/twitch-tui/default.nix
+++ b/pkgs/applications/networking/instant-messengers/twitch-tui/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-uo9QEwSRIJKjWza8dEQXDCMQ/ydKBk/BX2TaVhX+k1M=";
   };
 
-  cargoHash = "sha256-QYT5Aqwl2m/+SZlw55Ep3dIfmESSNowN30JJ52mY/Lk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-H/MAbN7wCg74bNWt5xlNaukvGJLYyzuynYtIqxBOcbo=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/networking/irc/tiny/default.nix
+++ b/pkgs/applications/networking/irc/tiny/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-phjEae2SS3zkSpuhhE4iscUM8ij8DT47YLIMATMG/+Q=";
   };
 
-  cargoHash = "sha256-DvFrRH6wObMvkRxS8vh3tlCrZNAiuZHfN0ARagMfG2k=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-lyjTl0kbtfQdqSqxti1181+oDVYP4U++v2JEOYvI7aM=";
 
   nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux pkg-config;
   buildInputs =

--- a/pkgs/applications/networking/mhost/default.nix
+++ b/pkgs/applications/networking/mhost/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-6jn9jOCh96d9y2l1OZ5hgxg7sYXPUFzJiiT95OR7lD0=";
   };
 
-  cargoHash = "sha256-d2JYT/eJaGm8pfmjsuSZiQxlzcsypFH53F/9joW0J6I=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-n+ZVsdR+X7tMqZFYsjsWSUr6OkD90s44EFORqRldCNE=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     Security

--- a/pkgs/applications/networking/mujmap/default.nix
+++ b/pkgs/applications/networking/mujmap/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-Qb9fEPQrdn+Ek9bdOMfaPIxlGGpQ9RfQZOeeqoOf17E=";
   };
 
-  cargoHash = "sha256-nnAYjutjxtEpDNoWTnlESDO4Haz14wZxY4gdyzdLgBU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-LyiJYKhoSXVf1P+nu56Wgp+z8biPpt0tWgPZQrB2NNQ=";
 
   buildInputs = [
     notmuch

--- a/pkgs/applications/networking/p2p/synapse-bt/default.nix
+++ b/pkgs/applications/networking/p2p/synapse-bt/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-2irXNgEK9BjRuNu3DUMElmf2vIpGzwoFneAEe97GRh4=";
   };
 
-  cargoHash = "sha256-TwXouPYM7Hg1HEr2KnEPScYFkC52PcQ5kb5aGP1gj9U=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ebqUH01h4B3Aq3apSKpae8ncaFirbrZiDxjiQM9kzg4=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs =

--- a/pkgs/applications/office/activitywatch/default.nix
+++ b/pkgs/applications/office/activitywatch/default.nix
@@ -187,7 +187,8 @@ rec {
 
     src = "${sources}/aw-server-rust";
 
-    cargoHash = "sha256-2KnfLNVw48VVQ1Ec8MS2MaiA3BpGeFd/uIrJRHhaJR8=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-E89E/LWBPHtb6vX94swodmE+UrWMrzQnm8AO5GeyuoA=";
 
     patches = [
       # Override version string with hardcoded value as it may be outdated upstream.

--- a/pkgs/applications/science/machine-learning/finalfrontier/default.nix
+++ b/pkgs/applications/science/machine-learning/finalfrontier/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-bnRzXIYairlBjv2JxU16UXYc5BB3VeKZNiJ4+XDzub4=";
   };
 
-  cargoHash = "sha256-C/D9EPfifyajrCyXE8w/qRuzWEoyJJIcj4xii94/9l4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-AQiXRKOXV7kXiu9GbtPE0Rddy93t1Y5tuJmww4xFSaU=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
+++ b/pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-suzivynlgk4VvDOC2dQR40n5IJHoJ736+ObdrM9dIqE=";
   };
 
-  cargoHash = "sha256-HekjmctuzOWs5k/ihhsV8vVkm6906jEnFf3yvhkrA5Y=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-X8ENEtjH1RHU2+VwtkHsyVYK37O8doMlLk94O2BGqy0=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/applications/science/misc/rink/default.nix
+++ b/pkgs/applications/science/misc/rink/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-2+ZkyWhEnnO/QgCzWscbMr0u5kwdv2HqPLjtiXDfv/o=";
   };
 
-  cargoHash = "sha256-j1pQfMjDNu57otOBTVBQEZIx80p4/beEUQdUkAJhvso=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-XvtEXBsdxUMJJntzzKVbUIjg78JpwyuUlTm6J3huDPE=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/system/coolercontrol/coolercontrol-gui.nix
+++ b/pkgs/applications/system/coolercontrol/coolercontrol-gui.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage {
   inherit version src;
   sourceRoot = "${src.name}/coolercontrol-ui/src-tauri";
 
-  cargoHash = "sha256-gjR54dZjVonyznfBGb3iNNdmPalE+a53MmkOEZj3+sY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-C0oVtU6esXOkssKyJ4XzLV2vGCPbvVKgvf3wXo9L158=";
 
   buildFeatures = [ "custom-protocol" ];
 

--- a/pkgs/applications/version-management/gfold/default.nix
+++ b/pkgs/applications/version-management/gfold/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-z5E+YS2zO4zgsW7mZbVN0z4HOurqoXwXn8hQc++9tks=";
   };
 
-  cargoHash = "sha256-mSqqtHZDm1ySu48DdI2sF7i7A8rDkFS/4/9uB30JOI8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-7VPMWou23iJHzKFMXirsjlIvq8kyAnNSeQ26IKxfNZE=";
 
   passthru.tests.version = testers.testVersion {
     package = gfold;

--- a/pkgs/applications/version-management/git-absorb/default.nix
+++ b/pkgs/applications/version-management/git-absorb/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  cargoHash = "sha256-R9hh696KLoYUfJIe3X4X1VHOpPmv1fhZ55y8muVAdRI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-QQNGUlEamMPRS5sPi3VYbIU28KWxM4ibIEQnk/1sgNA=";
 
   postInstall =
     ''

--- a/pkgs/applications/version-management/git-branchless/default.nix
+++ b/pkgs/applications/version-management/git-branchless/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-8uv+sZRr06K42hmxgjrKk6FDEngUhN/9epixRYKwE3U=";
   };
 
-  cargoHash = "sha256-AEEAHMKGVYcijA+Oget+maDZwsk/RGPhHQfiv+AT4v8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-i7KpTd4fX3PrhDjj3R9u98rdI0uHkpQCxSmEF+Gu7yk=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/version-management/git-cliff/default.nix
+++ b/pkgs/applications/version-management/git-cliff/default.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-wGxxLfl+d8uTPLHPL2EKpaL36x0or7PHwdVaZTlKITE=";
   };
 
-  cargoHash = "sha256-8G6iyvnKYxiRotQH7SwLSZStJg7iDNw4zPvT9sUTvmA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-8Zybs+SlwVuF+obJD+yt36HdtDGIJWLSGUnypqOlFWU=";
 
   # attempts to run the program on .git in src which is not deterministic
   doCheck = false;

--- a/pkgs/applications/version-management/git-credential-keepassxc/default.nix
+++ b/pkgs/applications/version-management/git-credential-keepassxc/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-qxNzWuuIoK9BJLVcWtrER+MyA5cyd03xAwGljh8DZC4=";
   };
 
-  cargoHash = "sha256-jBUp0jes4wtr8cmqceEBb6noqGkJUHbIfYgWOw5KMF4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-jjexSzxRhnNPW+urG7KpZBWfGcy06Cg4lXlQogF3L/A=";
 
   buildFeatures =
     [ ]

--- a/pkgs/applications/version-management/git-gone/default.nix
+++ b/pkgs/applications/version-management/git-gone/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-j88ZnJ0V8h/fthOWwV6B0ZbzUz7THykqrI2QpOkDT4I=";
   };
 
-  cargoHash = "sha256-H41wpG5LhjJ7BtFrol0JbjTpssOPUgumgapOiZJi2lc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-fXdWwGkdMhZA9u/xbvRIV6m88q6SQDahU12ZjQZFu3Y=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/applications/version-management/git-quickfix/default.nix
+++ b/pkgs/applications/version-management/git-quickfix/default.nix
@@ -32,7 +32,8 @@ rustPlatform.buildRustPackage rec {
       libiconv
     ];
 
-  cargoHash = "sha256-eTAEf2nRrJ7i2Dw5BBZlLLu8mK2G/wUk40ivtfxk1pI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-2VhbvhGeQHAbQLW0iBAgl0ICAX/X+PnwcGdodJG2Hsw=";
 
   meta = with lib; {
     description = "Quickfix allows you to commit changes in your git repository to a new branch without leaving the current branch";

--- a/pkgs/applications/version-management/git-stack/default.nix
+++ b/pkgs/applications/version-management/git-stack/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-foItJSZ6jsLuWkO/c1Ejb45dSdzZ/ripieyVIYsEyy0=";
   };
 
-  cargoHash = "sha256-MEhUmy4ijR/zHm/qMt4PqNGYnCfIgjNaL9SlMmXCMmc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-rh0keAIEwLRvZNv+gG2OXDdrJmd6/cTXP51xA/Opc3M=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     Security

--- a/pkgs/applications/version-management/git-trim/default.nix
+++ b/pkgs/applications/version-management/git-trim/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-XAO3Qg5I2lYZVNx4+Z5jKHRIFdNwBJsUQwJXFb4CbvM=";
   };
 
-  cargoHash = "sha256-mS8kNkZs8jX99ryG4XkU+U/iWIIcmET2vOfG1YNNZFU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-irgekVTWCujzSbZQMNJw3NZ3cjaUftpSJha6iZQqYJ8=";
 
   cargoPatches = [
     # Update git2 https://github.com/foriequal0/git-trim/pull/202

--- a/pkgs/applications/version-management/git-workspace/default.nix
+++ b/pkgs/applications/version-management/git-workspace/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-sS452PCX2G49Q5tnScG+ySkUAhFctGsGZrMvQXL7WkY=";
   };
 
-  cargoHash = "sha256-OrAZ4SGhqP+cGYB2gUIh6rON67hBRmgnq1nn9cEUAU0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-iYT45iqKmx+t+xImbQuSv/nAvaiLNrLLqbe8zKAF4Jw=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/applications/version-management/gitoxide/default.nix
+++ b/pkgs/applications/version-management/gitoxide/default.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-xv4xGkrArJ/LTVLs2SYhvxhfNG6sjVm5nZWsi4s34iM=";
   };
 
-  cargoHash = "sha256-36ue3f67Btw0/AM5lTaByrJLKU5r1FJA3sFRJ1IbXXc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-SRJkI61Z8revRWoschkUAJwcJfKB/U03+YfwEcnEIm8=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/version-management/lucky-commit/default.nix
+++ b/pkgs/applications/version-management/lucky-commit/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-jxcsTtQcSuL+2vwdxIVxqTpKh8Bfvna+hkGt+Rx21FE=";
   };
 
-  cargoHash = "sha256-8JkodGtMdYP/IIBqRcJFD5syiZi+VakDyX7VcvR0HLo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-e3011CvoxoAeXrJqcjKSWbpkQBncFV5qgFLM8ByZOYI=";
 
   buildInputs = lib.optional withOpenCL (if stdenv.hostPlatform.isDarwin then OpenCL else ocl-icd);
 

--- a/pkgs/applications/virtualization/crosvm/default.nix
+++ b/pkgs/applications/virtualization/crosvm/default.nix
@@ -39,7 +39,8 @@ rustPlatform.buildRustPackage rec {
 
   separateDebugInfo = true;
 
-  cargoHash = "sha256-FvDJhmrSBShxRTpc23C0jEk9YRbtGyYgC1Z8ekxNnb8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NrRHLDRr5spB/qRvZungNL7qFTdYS32lynJNoY0EjDQ=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
+++ b/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
@@ -38,7 +38,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-hKk5pcop8rb5Q+IVchcl+XhMc3DCBBPn5P+AkAb9XxI=";
   };
 
-  cargoHash = "sha256-edi6/Md6KebKM3wHArZe1htUCg0/BqMVZKA4xEH25GI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Cl2DHKrK24uswkMiyDbn+C1Rb7ebcqSgWoAC0yG+U8Y=";
 
   # lld: error: unknown argument '-Wl,--undefined=AUDITABLE_VERSION_INFO'
   # https://github.com/cloud-hypervisor/rust-hypervisor-firmware/issues/249

--- a/pkgs/applications/window-managers/dwm/dwm-status.nix
+++ b/pkgs/applications/window-managers/dwm/dwm-status.nix
@@ -52,7 +52,8 @@ rustPlatform.buildRustPackage rec {
     xorg.libX11
   ];
 
-  cargoHash = "sha256-CNhRMJZJMMKh5L308a93YL0kJLkt6DdlmILMVPQV90Q=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-G31p8iVRUODD4hUssXaOqEOUTW+C+GZMy/L/tgumDtA=";
 
   postInstall = lib.optionalString (bins != [ ]) ''
     wrapProgram $out/bin/dwm-status --prefix "PATH" : "${lib.makeBinPath bins}"

--- a/pkgs/applications/window-managers/i3/auto-layout.nix
+++ b/pkgs/applications/window-managers/i3/auto-layout.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-gpVYVyh+2y4Tttvw1SuCf7mx/nxR330Ob2R4UmHZSJs=";
   };
 
-  cargoHash = "sha256-OxQ7S+Sqc3aRH53Bs53Y+EKOYFgboGOBsQ7KJgICcGo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-oKpcYhD9QNW+8gFVybDEnz58cZ+2Bf4bwYuflXiJ1jc=";
 
   # Currently no tests are implemented, so we avoid building the package twice
   doCheck = false;

--- a/pkgs/applications/window-managers/i3/cycle-focus.nix
+++ b/pkgs/applications/window-managers/i3/cycle-focus.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-caZKvxOqoYgPs+Zjltj8K0/ospjkLnA4kh0rsTjeU3Y=";
   };
 
-  cargoHash = "sha256-9glaxThm/ovgvUWCyrycS/Oe5t8iN5P38fF5vO5awQE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-6d3a9iaXKakbs7g/649nO39bh4Ka8jcBI/yJImTqoZs=";
 
   meta = with lib; {
     description = "Simple tool to cyclically switch between the windows on the active workspace";

--- a/pkgs/applications/window-managers/i3/i3-ratiosplit.nix
+++ b/pkgs/applications/window-managers/i3/i3-ratiosplit.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0yfmr5zk2c2il9d31yjjbr48sqgcq6hp4a99hl5mjm2ajyhy5bz3";
   };
 
-  cargoHash = "sha256-5rAg+vPlfx8eG1qkC6HQPIsgDI1PJ2on16dI0BJ7mow=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-no5fJ5nlwyS/PVi9J5Ek3c3Rp7A3MflpReo9kwJrj6U=";
 
   # Currently no tests are implemented, so we avoid building the package twice
   doCheck = false;

--- a/pkgs/applications/window-managers/i3/status-rust.nix
+++ b/pkgs/applications/window-managers/i3/status-rust.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-xJm4MsEU0OVX401WvKllg3zUwgCvjLxlAQzXE/oD1J0=";
   };
 
-  cargoHash = "sha256-9jbJVnZhFbMYldBkRVSIiorUYDNtF3AAwNEpyNJXpjo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-EFFmH9aG7DvSA5rsAuszc1B8kcLdruSk3Hhp4V9t9Gk=";
 
   nativeBuildInputs = [ pkg-config makeWrapper ]
     ++ (lib.optionals withPipewire [ rustPlatform.bindgenHook ]);

--- a/pkgs/applications/window-managers/i3/wmfocus.nix
+++ b/pkgs/applications/window-managers/i3/wmfocus.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-94MgE2j8HaS8IyzHEDtoqTls2A8xD96v2iAFx9XfMcw=";
   };
 
-  cargoHash = "sha256-sSJAlDe1vBYs1vZW/X04cU14Wj1OF4Jy8oI4uWkrEjk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-tYzJS/ApjGuvNnGuBEVr54AGcEmDhG9HtirZvtmNslY=";
 
   nativeBuildInputs = [
     python3

--- a/pkgs/applications/window-managers/i3/wsr.nix
+++ b/pkgs/applications/window-managers/i3/wsr.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-Mq4TpQDiIYePUS3EwBfOe2+QmvF6+WEDK12WahbuhSU=";
   };
 
-  cargoHash = "sha256-hybvzHwHM0rQwgZfQpww/w9wQDW5h9P2KSjpAScVTBo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ecFlektG6CcGvD2l39MuplknpXuJ5B08ydJunxI7Pvg=";
 
   nativeBuildInputs = [ python3 ];
   buildInputs = [ libxcb ];

--- a/pkgs/build-support/mitm-cache/default.nix
+++ b/pkgs/build-support/mitm-cache/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  cargoHash = "sha256-6eYOSSlswJGR2IrFo17qVnwI+h2FkyTjLFvwf62nG2c=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-6554Tf5W+7OFQw8Zm4yBQ2/rHm31MQ0Q+vTbnmZTGMQ=";
 
   setupHook = replaceVars ./setup-hook.sh {
     inherit openssl;

--- a/pkgs/development/compilers/gleam/default.nix
+++ b/pkgs/development/compilers/gleam/default.nix
@@ -38,7 +38,8 @@ rustPlatform.buildRustPackage rec {
       SystemConfiguration
     ];
 
-  cargoHash = "sha256-E1iowktT7oK259WY6AopfvinQuRT1yMnORbJn9Ly+3E=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3McEZ/qwrLm8W2Umtah5shU74iFxLfe4ihp7x4YEvKc=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/compilers/kind2/default.nix
+++ b/pkgs/development/compilers/kind2/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-X2sjfYrSSym289jDJV3hNmcwyQCMnrabmGCUKD5wfdY=";
   };
 
-  cargoHash = "sha256-KzoEh/kMKsHx9K3t1/uQZ7fdsZEM+v8UOft8JjEB1Zw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-G6UW8m/6D+hgRRceMPYFI+k4D7Ui6sDUDzI5IVWvVyc=";
 
   postPatch = ''
     substituteInPlace src/main.rs \

--- a/pkgs/development/embedded/fpga/ecpdap/default.nix
+++ b/pkgs/development/embedded/fpga/ecpdap/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-pgQqDRdewBSCm1/9/r8E9DBzwSKAaons3e6OLNv5gHM=";
   };
 
-  cargoHash = "sha256-70Aq/gNfRv9JQyYWb7amYkfzFcNGCGbmCfJH4chbyyc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-o+qm4MFZt+BzqhQsaI5EU9lZz4LI9D75eL+VKIKbIyI=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/interpreters/evcxr/default.nix
+++ b/pkgs/development/interpreters/evcxr/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-6gSJJ3ptqpYydjg+xf5Pz3iTk0D+bkC6N79OeiKxPHY=";
   };
 
-  cargoHash = "sha256-MRoEFP7VXBNBe6/e3ezPnzhKACwqTApGH9c0T4ycvg4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-U2LBesQNOa/E/NkVeLulb8JUtGsHgMne0MgY0RT9lqI=";
 
   RUST_SRC_PATH = "${rustPlatform.rustLibSrc}";
 

--- a/pkgs/development/interpreters/wasmer/default.nix
+++ b/pkgs/development/interpreters/wasmer/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-rP0qvSb9PxsTMAq0hpB+zdSTHvridyCVdukLUYxdao8=";
   };
 
-  cargoHash = "sha256-6UwFfTHhAr56K7kDAp0dCSoCjZuCHdgw2bpOD1WdvYU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Fympp2A04viibo4U79FiBSJIeGDUWS34OOwebCks6S0=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook

--- a/pkgs/development/interpreters/wasmtime/default.nix
+++ b/pkgs/development/interpreters/wasmtime/default.nix
@@ -14,7 +14,8 @@ rustPlatform.buildRustPackage rec {
 
   # Disable cargo-auditable until https://github.com/rust-secure-code/cargo-auditable/issues/124 is solved.
   auditable = false;
-  cargoHash = "sha256-h5vSdKETereFCS06HYqQPSExBWPGxJHnWCj8SJNeqE4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-5U+02G3sXXkCwcAOUZ3lY1tovE8JAW7W/YjC+s1/MXU=";
   cargoBuildFlags = [ "--package" "wasmtime-cli" "--package" "wasmtime-c-api" ];
 
   outputs = [ "out" "dev" ];

--- a/pkgs/development/tools/analysis/dotenv-linter/default.nix
+++ b/pkgs/development/tools/analysis/dotenv-linter/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-HCP1OUWm/17e73TbinmDxYUi18/KXxppstyUSixjlSo=";
   };
 
-  cargoHash = "sha256-4r4NTq2rLnpmm/nwxJ9RoN2+JrUI6XKGfYFI78NY710=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-lBHqvwZrnkSfmMXBmnhovbDn+pf5iLJepJjO/FKT1wY=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/development/tools/build-managers/fac/default.nix
+++ b/pkgs/development/tools/build-managers/fac/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
   };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
-  cargoHash = "sha256-XT4FQVE+buORuZAFZK5Qnf/Fl3QSvw4SHUuCzWhxUdk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-+2j6xH1Ww1WOLfbjknUPvCmYLAl4W3Zp/mQTaL0qnv0=";
 
   # fac includes a unit test called ls_files_works which assumes it's
   # running in a git repo. Nix's sandbox runs cargo build outside git,

--- a/pkgs/development/tools/build-managers/moon/default.nix
+++ b/pkgs/development/tools/build-managers/moon/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-2418rlM8WdQ2b4wrtUC+6yCgy+wxfApQTaVDPXbnvKo=";
   };
 
-  cargoHash = "sha256-I958/qvPqqRayvQwe8/SMgERwM+E7d3J6hpKPHfSBf0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-dnC5MsfwqZZeZsbf80KkigOYHuG3qpHRGBRH66oM0Q0=";
 
   env = {
     RUSTFLAGS = "-C strip=symbols";

--- a/pkgs/development/tools/cocogitto/default.nix
+++ b/pkgs/development/tools/cocogitto/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-VorWk7E+I1hU8Hc+WF47+V483E/xPjf7Glqp7iA1t5g=";
   };
 
-  cargoHash = "sha256-pjCLlti/6CITFLN3UxYujP/K6j2bSAu1OS1zw3YiSFM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-h6XX25uN9wBCdOYc1Bl6VWi3htopcXb7VhjNIDkmEJY=";
 
   # Test depend on git configuration that would likely exist in a normal user environment
   # and might be failing to create the test repository it works in.

--- a/pkgs/development/tools/continuous-integration/buildkite-test-collector-rust/default.nix
+++ b/pkgs/development/tools/continuous-integration/buildkite-test-collector-rust/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  cargoHash = "sha256-4eaU6dOb97/vV3NSCCpdzK2oQUIHl4kdAtgWbGsY5LU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-jymWM0DCR6jUE1Kyhbx6HHf6YlrGu1THKTyDHaPG+Vs=";
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/development/tools/database/dynein/default.nix
+++ b/pkgs/development/tools/database/dynein/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
   # Use system openssl.
   OPENSSL_NO_VENDOR = 1;
 
-  cargoHash = "sha256-QyhoYgqBfK6LCdtLuo0feVCgIMPueYeA8MMGspGLbGQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-rOfJz5G6kO1/IM6M6dZJTJmzJhx/450dIPvAVBHUp5o=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/database/indradb/default.nix
+++ b/pkgs/development/tools/database/indradb/default.nix
@@ -28,7 +28,8 @@ in
     version = "unstable-2021-01-05";
     inherit src meta;
 
-    cargoHash = "sha256-3WtiW31AkyNX7HiT/zqfNo2VSKR7Q57/wCigST066Js=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-wehQU0EOSkxQatoViqBJwgu4LG7NsbKjVZvKE6SoOFs=";
 
     buildAndTestSubdir = "server";
 
@@ -49,7 +50,8 @@ in
     version = "unstable-2021-01-05";
     inherit src meta;
 
-    cargoHash = "sha256-pxan6W/CEsOxv8DbbytEBuIqxWn/C4qT4ze/RnvESOM=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-wehQU0EOSkxQatoViqBJwgu4LG7NsbKjVZvKE6SoOFs=";
 
     PROTOC = "${protobuf}/bin/protoc";
 

--- a/pkgs/development/tools/database/surrealdb-migrations/default.nix
+++ b/pkgs/development/tools/database/surrealdb-migrations/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-zTOAwSjsgu3axq+VSnXAIGKRDeeRBaQtoNoVU2eKAIk=";
   };
 
-  cargoHash = "sha256-ZvWq3DKNAUz/6v0RjUXbEeO6+H84bbDLOVV05vD96Yk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-0O4WWBevEyPMPS59rDmYHWpgKTc713jLn9MNHoLVd0I=";
 
   buildInputs = [ ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/development/tools/dump_syms/default.nix
+++ b/pkgs/development/tools/dump_syms/default.nix
@@ -30,7 +30,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-6VDuZ5rw2N4z6wOVbaOKO6TNaq8QA5RstsIzmuE3QrI=";
   };
 
-  cargoHash = "sha256-ndRw5z4CfuX0KNqNgpA4yohG8p/cUR/Op2fIunuO6GM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-GYkkB0Z40UedPLnZZ0tHdMQR2HhuQBg75J2J9vNsMuU=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/tools/fnm/default.nix
+++ b/pkgs/development/tools/fnm/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ installShellFiles ];
 
-  cargoHash = "sha256-InukV9tey9fVBj2tDff9HMQ149mXJCPJ85B1fMKyIJ0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-mxYTV3kNetIHB8XcvFdqp7t78E9EzMdMgD4ENIAYyec=";
 
   doCheck = false;
 

--- a/pkgs/development/tools/geckodriver/default.nix
+++ b/pkgs/development/tools/geckodriver/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-3EJP+y+Egz0kj5e+1FRHPGWfneB/tCCVggmgmylMyDE=";
   };
 
-  cargoHash = "sha256-gopI5iOCSzD23mvOues76WIiBtpNf9A6X9NoOULm6Qo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-BZosk8tCHpQqQTNFe8BPArdkTHoRN/SViG10xtYs8jY=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv

--- a/pkgs/development/tools/git-ps-rs/default.nix
+++ b/pkgs/development/tools/git-ps-rs/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-4lk6AHquWKgDk0pBaswbVShZbUDA3wO6cPakhrvrwac=";
   };
 
-  cargoHash = "sha256-GS/RRPzULUla4XY4tO+eM2NAy2nG0qDxqcSq292ivgU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-QYkEBqDwspdhSliwLwMWmybS9nd41DCjGNURnMzLzBM=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/gptcommit/default.nix
+++ b/pkgs/development/tools/gptcommit/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-MB78QsJA90Au0bCUXfkcjnvfPagTPZwFhFVqxix+Clw=";
   };
 
-  cargoHash = "sha256-F4nabUeQZMnmSNC8KlHjx3IcyR2Xn36kovabmJ6g1zo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-PFpc9z45k0nlWEyjDDKG/U8V7EwR5b8rHPV4CmkRers=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/graphql-client/default.nix
+++ b/pkgs/development/tools/graphql-client/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-eQ+7Ru3au/rDQZtwFDXYyybqC5uFtNBs6cEzX2QSFI4=";
   };
 
-  cargoHash = "sha256-fEjt7ax818hlIq2+UrIG6EismQUGdaq7/C3xN+Nrw2s=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-GPUOIDKlxk2P+cPmOPlpz/EM9TCXvHo41+1fQ0xAqto=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/tools/hors/default.nix
+++ b/pkgs/development/tools/hors/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1q17i8zg7dwd8al42wfnkn891dy5hdhw4325plnihkarr50avbr0";
   };
 
-  cargoHash = "sha256-1PB/JvgfC6qABI+cIePqtsSlZXPqMGQIay9SCXJkV9o=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-JTHgOEBpGXPO3C7YUbBF0LFeSUQK+R2w1LugwMV5xyU=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/development/tools/htmlq/default.nix
+++ b/pkgs/development/tools/htmlq/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-kZtK2QuefzfxxuE1NjXphR7otr+RYfMif/RSpR6TxY0=";
   };
 
-  cargoHash = "sha256-r9EnQQPGpPIcNYb1eqGrMnRdh0snIa5iVsTYTI+YErY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-QUlR6PuOLbeAHzARtTo7Zn7fmjs2ET6TdXT4VgCYEVg=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/development/tools/jless/default.nix
+++ b/pkgs/development/tools/jless/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-76oFPUWROX389U8DeMjle/GkdItu+0eYxZkt1c6l0V4=";
   };
 
-  cargoHash = "sha256-sas94liAOSIirIJGdexdApXic2gWIBDT4uJFRM3qMw0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-moXZcPGh0+KyyeUMjH7/+hvF86Penk2o2DQWj4BEzt8=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ python3 ];
 

--- a/pkgs/development/tools/kdash/default.nix
+++ b/pkgs/development/tools/kdash/default.nix
@@ -33,7 +33,8 @@ rustPlatform.buildRustPackage rec {
     xorg.xcbutil
   ] ++ lib.optional stdenv.hostPlatform.isDarwin AppKit;
 
-  cargoHash = "sha256-jm0UCKDy6TrogMPavB86lvk8yKZXubTGGbApk+oP2RQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NRFTrSH2aorBqsvBOTqfKmer5tXEEF1ZMUtlMfZ6vD8=";
 
   meta = with lib; {
     description = "Simple and fast dashboard for Kubernetes";

--- a/pkgs/development/tools/kubie/default.nix
+++ b/pkgs/development/tools/kubie/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-h4GaOZ9wHhRq8/GRKrXkH7fJPpOdYmwZ2nQPsVzt66U=";
   };
 
-  cargoHash = "sha256-dtl1YCMZdNtgaR8TxT3UZ7+CYREzpjaxmT80C1VTTa8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-uVetaDiX5IZQt8G5iKv9ucDUOo3EEvxd2+v61xchkOA=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/development/tools/misc/dura/default.nix
+++ b/pkgs/development/tools/misc/dura/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-xAcFk7z26l4BYYBEw+MvbG6g33MpPUvnpGvgmcqhpGM=";
   };
 
-  cargoHash = "sha256-XOtPtOEKZMJzNeBZBT3Mc/KOjMOcz71byIv/ftcRP48=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Xci9168KqJf+mhx3k0d+nH6Ov5tqNtB6nxiL9BwVYjU=";
 
   cargoPatches = [
     ./Cargo.lock.patch

--- a/pkgs/development/tools/misc/pwninit/default.nix
+++ b/pkgs/development/tools/misc/pwninit/default.nix
@@ -36,7 +36,8 @@ rustPlatform.buildRustPackage rec {
   '';
   doCheck = false; # there are no tests to run
 
-  cargoHash = "sha256-J2uQoqStBl+qItaXWi17H/IailZ7P4YzhLNs17BY92Q=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-N0vje5ZU7B++f71BJKwkEfpbInpermH241f6oP1/fQE=";
 
   meta = {
     description = "Automate starting binary exploit challenges";

--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Lx7vENYuBXaMvGDOZxAPqivGZVaCXYrihaTnBn9eTm4=";
   };
 
-  cargoHash = "sha256-6JDG9Ac43AW6HV2baZH08uxdb84hjrGXgdzZiFr2Ybk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-poCLSloNPhJRDrG2HD6xn9ZxMILu9HlR2To0vbDeT2I=";
 
   outputs = [ "out" ] ++ lib.optional (!isCross) "man";
 

--- a/pkgs/development/tools/misc/tokei/default.nix
+++ b/pkgs/development/tools/misc/tokei/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-jqDsxUAMD/MCCI0hamkGuCYa8rEXNZIR8S+84S8FbgI=";
   };
 
-  cargoHash = "sha256-U7Bode8qwDsNf4FVppfEHA9uiOFz74CtKgXG6xyYlT8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-hCFFqvnbm0MXDvC5ea7Uo3xQdMO2e4tU7dEAvZxTM3s=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv

--- a/pkgs/development/tools/pactorio/default.nix
+++ b/pkgs/development/tools/pactorio/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-3+irejeDltf7x+gyJxWBgvPgpQx5uU3DewU23Z4Nr/A=";
   };
 
-  cargoHash = "sha256-sAFsG+EPSmvPDFR9R0fZ5f+y/PXVpTJlMzL61vwf4SY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-1rqYp9OZ7hkZhrU813uBQAOZNdQ3j+OQdM6ia+t5cOc=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -169,7 +169,8 @@ rustPlatform.buildRustPackage {
   pname = "tree-sitter";
   inherit src version;
 
-  cargoHash = "sha256-mk3aw1aFu7N+b4AQL5kiaHuIAuJv24KonFeGKid427Q=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-wrMqeJxOj9Jp3luy6ir6UzNQClRglqP8pfoqWk+Ky+w=";
 
   buildInputs = [ installShellFiles ];
   nativeBuildInputs = [ which ] ++ lib.optionals webUISupport [ emscripten ];

--- a/pkgs/development/tools/perseus-cli/default.nix
+++ b/pkgs/development/tools/perseus-cli/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-IYjLx9/4oWSXa4jhOtGw1GOHmrR7LQ6bWyN5zbOuEFs=";
   };
 
-  cargoHash = "sha256-i7MPmO9MoANZLzmR5gsD+v0gyDtFbzhsmE9xOsb88L0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-9McjhdS6KrFgtWIaP0qKsUYpPxGQjNX7SM9gJ/aJGwc=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/tools/py-spy/default.nix
+++ b/pkgs/development/tools/py-spy/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-T96F8xgB9HRwuvDLXi6+lfi8za/iNn1NAbG4AIpE0V0=";
   };
 
-  cargoHash = "sha256-SkHlXvhmw7swjZDdat0z0o5ATDJ1qSE/iwiwywsFOyw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-velwX7lcNQvwg3VAUTbgsOPLlA5fAcPiPvczrBBsMvs=";
 
   buildFeatures = [ "unwind" ];
 

--- a/pkgs/development/tools/rbspy/default.nix
+++ b/pkgs/development/tools/rbspy/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-6tCTrplzoiimKvXEIXd2gUOXzcZ/eQ22npBqbVv0Nv0=";
   };
 
-  cargoHash = "sha256-J+3v7O38+MhCoq1UKf0Sqaomw/SSu+JK3sWWv9rB6FI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-yb0AvWrXAyi3HOBxlF59//DrwqWwSK1LQNhzrrO4QD8=";
 
   # error: linker `aarch64-linux-gnu-gcc` not found
   postPatch = ''

--- a/pkgs/development/tools/remodel/default.nix
+++ b/pkgs/development/tools/remodel/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-tZ6ptGeNBULJaoFomMFN294wY8YUu1SrJh4UfOL/MnI=";
   };
 
-  cargoHash = "sha256-YCYs+MMTxnJEKhzjddBp7lnSYPrpf3G+ktr1ez/ZKkg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-41EkXciQZ7lGlD+gVlZEahrGPeEMmaIaiF7tYff9xXw=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/tools/rover/default.nix
+++ b/pkgs/development/tools/rover/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-uyeePAHBDCzXzwIWrKcc9LHClwSI7DMBYod/o4LfK+Y=";
   };
 
-  cargoHash = "sha256-Rf4kRXYW+WAF1rM7o8PmXBLgp/YyA8y/TqbZL22VOqI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-uR5XvkHUmZzCHZITKgScmzqjLOIvbPyrih/0B1OpsAc=";
 
   buildInputs =
     [

--- a/pkgs/development/tools/rubyfmt/default.nix
+++ b/pkgs/development/tools/rubyfmt/default.nix
@@ -68,7 +68,8 @@ rustPlatform.buildRustPackage rec {
     ./0003-ignore-warnings.patch
   ];
 
-  cargoHash = "sha256-QZ26GmsKyENkzdCGg2peie/aJhEt7KQAF/lwsibonDk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-8LgAHznxU30bbK8ivNamVD3Yi2pljgpqJg2WC0nxftk=";
 
   env.NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin "-fdeclspec";
 

--- a/pkgs/development/tools/rust/bindgen/unwrapped.nix
+++ b/pkgs/development/tools/rust/bindgen/unwrapped.nix
@@ -13,7 +13,8 @@ in rustPlatform.buildRustPackage rec {
     hash = "sha256-RL9P0dPYWLlEGgGWZuIvyULJfH+c/B+3sySVadJQS3w=";
   };
 
-  cargoHash = "sha256-i92f9grVqVqWmOKkLcBxB1Brk5KztJpPi9zSxVcgXfY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-4EyDjHreFFFSGf7UoftCh6eI/8nfIP1ANlYWq0K8a3I=";
 
   buildInputs = [ (lib.getLib clang.cc) ];
 

--- a/pkgs/development/tools/rust/cargo-audit/default.nix
+++ b/pkgs/development/tools/rust/cargo-audit/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-oMXpJE49If4QKE80ZKhRpMRPh3Bl517a2Ez/1VcaQJQ=";
   };
 
-  cargoHash = "sha256-XefJGAU3NxIyby/0lIx2xnJ00Jv1bNlKWkBe+1hapoU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-RY1cAsVi76N1jaWL+t0lfayChGPrL9T05xoFfFPTni4=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/tools/rust/cargo-bazel/default.nix
+++ b/pkgs/development/tools/rust/cargo-bazel/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-FS1WFlK0YNq1QCi3S3f5tMN+Bdcfx2dxhDKRLXLcios=";
   };
 
-  cargoHash = "sha256-+PVNB/apG5AR236Ikqt+JTz20zxc0HUi7z6BU6xq/Fw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-E/yF42Vx9tv8Ik1j23El3+fI19ZGzq6nikVMATY7m3E=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/development/tools/rust/cargo-c/default.nix
+++ b/pkgs/development/tools/rust/cargo-c/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-ltxd4n3oo8ZF/G/zmR4FSVtNOkxwCjDv6PdxkmWxZ+8=";
   };
 
-  cargoHash = "sha256-UfhIz87s0CLUDbIpWMPzGQ7qVmh14GuiFoquauSbTOw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-tCJ7Giyj7Wqowhk0N7CkvAiWvF6DBNw7G7aAnn2+mp8=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/tools/rust/cargo-cache/default.nix
+++ b/pkgs/development/tools/rust/cargo-cache/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-q9tYKXK8RqiqbDZ/lTxUI1Dm/h28/yZR8rTQuq+roZs=";
   };
 
-  cargoHash = "sha256-275QREIcncgBk4ah/CivSz5N2m6s/XPCfp6JGChpr38=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cwTHJ5Cd17ur8AhEQb8FTS0mcgqg83VGjvCQP00JY6s=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     zlib

--- a/pkgs/development/tools/rust/cargo-clone/default.nix
+++ b/pkgs/development/tools/rust/cargo-clone/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-kK0J1Vfx1T17CgZ3DV9kQbAUxk4lEfje5p6QvdBS5VQ=";
   };
 
-  cargoHash = "sha256-6UUaOwu6N/XFdGEnoAX5zM4xTsqwHwPrmZ1t5huF6nM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-IbNwlVKGsi70G+ATimRZbHbW91vFddQl//dfAM6JO8I=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-codspeed/default.nix
+++ b/pkgs/development/tools/rust/cargo-codspeed/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-pi02Bn5m4JoTtCIZvxkiUVKkjmtCShKqZw+AyhaVdyY=";
   };
 
-  cargoHash = "sha256-5Ps31Hdis+N/MT/o0IDHSJgHBM3F/ve50ovfFSviMtA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-xHA6fe1/0p/PHGV6JcyVir5uGAqJ7qkHObjVqDPGwSY=";
 
   nativeBuildInputs = [
     curl

--- a/pkgs/development/tools/rust/cargo-crev/default.nix
+++ b/pkgs/development/tools/rust/cargo-crev/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-OxE0+KK2qt06gAi7rw3hiG2lczBqbyNThb4aCpyM6q8=";
   };
 
-  cargoHash = "sha256-RtN3+TWRNsOgVb4KrCEN0cxB8ctBZ5qNUXbux3RKkqc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-MdRK4mQ09KatcgjTu/0l6Qkd3FYefiwC+UcmXOgsQ0A=";
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/pkgs/development/tools/rust/cargo-cyclonedx/default.nix
+++ b/pkgs/development/tools/rust/cargo-cyclonedx/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-T/9eHI2P8eCZAqMTeZz1yEi5nljQWfHrdNiU3h3h74U=";
   };
 
-  cargoHash = "sha256-o7ARj41a5LWwjiggFFa804ytFZRcz1OZN+QWjOytWy8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-deczbMPeJsnmXbVB60stKhJJZRIIwjY5vExS3x3b6aU=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/development/tools/rust/cargo-edit/default.nix
+++ b/pkgs/development/tools/rust/cargo-edit/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Y5tnY8EZJcVhYyVTpvcT6DFbPSmmw3+knzkMVvQxQbI=";
   };
 
-  cargoHash = "sha256-X8wQvLSvZ7rrDfX423SDB5QDDMoeDDFvJZKO92CLycg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-D5wZWFXmM3tadhL+OHAPhBu6BXJh5fAYlOLR4q+wlsQ=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-flamegraph/default.nix
+++ b/pkgs/development/tools/rust/cargo-flamegraph/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-OpneGyulSreUKhmnLfsJ2sEbkDPCcrDjkRu9ccKZcJc=";
   };
 
-  cargoHash = "sha256-gdTqObOWboNlhU+tI/z5KYSOdmgRg36v73iLuKfwVkA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-uErlNPkacAmURNKAZp1wLsV2NB1w9HfjLZl5PgeMRu0=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/tools/rust/cargo-fund/default.nix
+++ b/pkgs/development/tools/rust/cargo-fund/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-8mnCwWwReNH9s/gbxIhe7XdJRIA6BSUKm5jzykU5qMU=";
   };
 
-  cargoHash = "sha256-J4AylYE4RTRPTUz5Hek7D34q9HjlFnrc/z/ax0i6lPQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-9NozPJzQIuF2KHaT6t4qBU0qKtBbM05mHxzmHlU3Dr4=";
 
   # The tests need a GitHub API token.
   doCheck = false;

--- a/pkgs/development/tools/rust/cargo-hf2/default.nix
+++ b/pkgs/development/tools/rust/cargo-hf2/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-0o3j7YfgNNnfbrv9Gppo24DqYlDCxhtsJHIhAV214DU=";
   };
 
-  cargoHash = "sha256-zBxvpQfB9xw8+Rc1H1EaK/gQZtQ+uSs4YJwhm2o0vhI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cRliZegzRKmoGIE96pyVuNySA2L6l+imcTHbZBXXiz4=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-lambda/default.nix
+++ b/pkgs/development/tools/rust/cargo-lambda/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-21p9bo+kfqVrRAxVSuZ24XaHDU7XkIIhGXjHLUsGQOg=";
   };
 
-  cargoHash = "sha256-5AzeqJjs8Ee6ltXnXMZU47fXt1THsSERxCaT22zjK6g=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-GtlT2ek/HjRN/+1Ocp/bJgEL5Oy6Dm1p+CdWjs7NW7Q=";
 
   nativeCheckInputs = [ cacert ];
 

--- a/pkgs/development/tools/rust/cargo-ndk/default.nix
+++ b/pkgs/development/tools/rust/cargo-ndk/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-tzjiq1jjluWqTl+8MhzFs47VRp3jIRJ7EOLhUP8ydbM=";
   };
 
-  cargoHash = "sha256-UthI01fLC35BPp550LaDLoo1kjisUmQZqSud8JM/kqM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Kt4GLvbGK42RjivLpL5W5z5YBfDP5B83mCulWz6Bisw=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     CoreGraphics

--- a/pkgs/development/tools/rust/cargo-outdated/default.nix
+++ b/pkgs/development/tools/rust/cargo-outdated/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-bAo3098QxepKbvBb9uF6iGNW0+RAKCCMyWfuG5WyREo=";
   };
 
-  cargoHash = "sha256-YGGmzdcy3x4RF1S8jMPXTAglThlfG7nZTD0IATGvePw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-h+sxnTAJ1uhPUk5dRiYPgPoxvbpVggnCn0TQ6kRCzO4=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-udeps/default.nix
+++ b/pkgs/development/tools/rust/cargo-udeps/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-R4t1mzXX95rVbEuHvoAnxxEYt7XYg+Bmr8Mh4LIhnMs=";
   };
 
-  cargoHash = "sha256-DigRCz9BicNI+bkEwdJEKy9i0pT9HAhLsN56hAbEzUI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-oNWjU/KxvnKipChHPxKDxO5ZKw/44XAG3twQiZ1Lr8I=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-vet/default.nix
+++ b/pkgs/development/tools/rust/cargo-vet/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-VnOqQ1dKgNZSHTzJrD7stoCzNGrSkYxcLDJAsrJUsEQ=";
   };
 
-  cargoHash = "sha256-M8sZzgSEMIB6pPVaE+tC18MCbwYaYpHOnhrEvm9JTso=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-8QbXZtf5kry0/QDrnUVQCtqK4/6EMliOI4Z410QR2Ec=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/development/tools/rust/cargo-watch/default.nix
+++ b/pkgs/development/tools/rust/cargo-watch/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-agwK20MkvnhqSVAWMy3HLkUJbraINn12i6VAg8mTzBk=";
   };
 
-  cargoHash = "sha256-oqGc5haN8Jyi0eQf8egrRXWxi0RGVdIFhpGKgmFB8DI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-4AVZ747d6lOjxHN+co0A7APVB5Xj6g5p/Al5fLbgPnc=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     Foundation

--- a/pkgs/development/tools/rust/cargo-whatfeatures/default.nix
+++ b/pkgs/development/tools/rust/cargo-whatfeatures/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-YJ08oBTn9OwovnTOuuc1OuVsQp+/TPO3vcY4ybJ26Ms=";
   };
 
-  cargoHash = "sha256-Zi9FCNBxQ9S4S9k6hoMUOixTs6PJyxmgTB+ArrX8oBE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-p95aYXsZM9xwP/OHEFwq4vRiXoO1n1M0X3TNbleH+Zw=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/development/tools/rust/cargo-zigbuild/default.nix
+++ b/pkgs/development/tools/rust/cargo-zigbuild/default.nix
@@ -11,7 +11,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-kuzKW7ol4ZdxIhfAdvAKRb8fgwaU2LTO43dxrpke1Ow=";
   };
 
-  cargoHash = "sha256-86rxLszfr1Bi0mNf53KKowKx/i+dbFUcNVoi5Q50xc8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-WsX1noIRlMRzNqJUxR55CxdTCxJ+DVddVRIbkLtWK1Q=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/pkgs/development/tools/rust/duckscript/default.nix
+++ b/pkgs/development/tools/rust/duckscript/default.nix
@@ -29,7 +29,8 @@ rustPlatform.buildRustPackage rec {
       libiconv
     ];
 
-  cargoHash = "sha256-TX/Xi57fn85GjHc74icxhsQ6n7FwqzGIr3Qoc2o681E=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ft6EUajAj+Zw3cEhdajwwHAaMaUf+/vtTuUYni8E+o0=";
 
   meta = with lib; {
     description = "Simple, extendable and embeddable scripting language";

--- a/pkgs/development/tools/rust/rustup/default.nix
+++ b/pkgs/development/tools/rust/rustup/default.nix
@@ -33,7 +33,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-BehkJTEIbZHaM+ABaWN/grl9pX75lPqyBj1q1Kt273M=";
   };
 
-  cargoHash = "sha256-iQoMPV97V9WJqT+qVtNpQtW5g+Jyl+U2uA+JEoRYTQA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-CQHpsOGofDqsbLLTcznu5a0MSthJgy27HjBk8AYA72s=";
 
   nativeBuildInputs = [
     makeBinaryWrapper

--- a/pkgs/development/tools/rust/sqlx-cli/default.nix
+++ b/pkgs/development/tools/rust/sqlx-cli/default.nix
@@ -26,7 +26,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-kAZUconMYUF9gZbLSg7KW3fVb7pkTq/d/yQyVzscxRw=";
   };
 
-  cargoHash = "sha256-HDiWT13tknEC+Z4nVe4ZDFMP3y5VtRXozRLd68T9BuE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-d+VOtFC+OTp6MQnzEIOfIxk1ARAcNYvS7U2+IJ1hqSs=";
 
   buildNoDefaultFeatures = true;
   buildFeatures = [

--- a/pkgs/development/tools/sentry-cli/default.nix
+++ b/pkgs/development/tools/sentry-cli/default.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage rec {
   buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices Security SystemConfiguration ];
   nativeBuildInputs = [ installShellFiles pkg-config ];
 
-  cargoHash = "sha256-Mp92cEvgOj0JH7+5+hl8wN+a7zPf8heV6whaqvIcBTU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ciM4ir7MRTkfLmGUFpVVyldcxPtSbttyWLSI1pNjDkA=";
 
   postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
     installShellCompletion --cmd sentry-cli \

--- a/pkgs/development/tools/spr/default.nix
+++ b/pkgs/development/tools/spr/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-lsdWInJWcofwU3P4vAWcLQeZuV3Xn1z30B7mhODJ4Vc=";
   };
 
-  cargoHash = "sha256-VQg3HDNw+L1FsFtHXnIw6dMVUxV63ZWHCxiknzsqXW8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-4fYQM+GQ5yqES8HQ23ft4wfM5mwDdcWuE5Ed2LST9Gw=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/development/tools/viceroy/default.nix
+++ b/pkgs/development/tools/viceroy/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 
-  cargoHash = "sha256-3wkO4w66FJ996cahLvP8wFQSL4RKuw5959qo9rlbTcY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-UrfxNjKOHQCYKMr83W7XSpQIYxnZkCgIWfp/YtTKpIc=";
 
   cargoTestFlags = [
     "--package viceroy-lib"

--- a/pkgs/development/tools/wrangler_1/default.nix
+++ b/pkgs/development/tools/wrangler_1/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-GfuU+g4tPU3TorzymEa9q8n4uKYsG0ZTz8rJirGOLfQ=";
   };
 
-  cargoHash = "sha256-tPLqDm6kOVBKrLvhgZ9xD6vVBNjBBk9uLF7WOPgz8qE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-MJFXcmRzvzDJ8cd0WdcNiHr3Wxgp/hKO1xKRfmbxRLA=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/games/blightmud/default.nix
+++ b/pkgs/games/blightmud/default.nix
@@ -29,7 +29,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-9GUul5EoejcnCQqq1oX+seBtxttYIUhgcexaZk+7chk=";
   };
 
-  cargoHash = "sha256-84m5dihmiEGrFCajqaMW05MQtBceLodBzqtjW+zh6kg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-7cMd7pNWGV5DOSCLRW5fP3L1VnDTEsZZjhVz1AQLEXM=";
 
   buildFeatures = lib.optional withTTS "tts";
 

--- a/pkgs/games/ferium/default.nix
+++ b/pkgs/games/ferium/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     SystemConfiguration
   ];
 
-  cargoHash = "sha256-yBi6zyljkYEIUvSH4nXMw8fjPnt4kjqiuZ/QLT5IbqQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3YKFKngyLg2ah4GY+LlbPbnVks7/xFawnMf3D1gjmwI=";
 
   # Disable the GUI file picker so that GTK/XDG dependencies aren't used
   buildNoDefaultFeatures = true;

--- a/pkgs/misc/cliscord/default.nix
+++ b/pkgs/misc/cliscord/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
 
   nativeBuildInputs = [ pkg-config ];
 
-  cargoHash = "sha256-Z8ras6W4BnAWjHe6rPd1X1d3US5gq7CxnBAkW//OTsg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-bJA+vqbhXeygIAg9HWom3xSuPpJgJY5FLb8UMBjrh7U=";
 
   meta = with lib; {
     description = "Simple command-line tool to send text and files to discord";

--- a/pkgs/misc/t-rec/default.nix
+++ b/pkgs/misc/t-rec/default.nix
@@ -39,7 +39,8 @@ rustPlatform.buildRustPackage rec {
     wrapProgram "$out/bin/t-rec" --prefix PATH : "${binPath}"
   '';
 
-  cargoHash = "sha256-orgSmGtZwTqlWSpUjU17QRgDlbheo2DbS1YI7l4MhmM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-2ErXqQ1vRsPMJPFqdAlrmdPTuEC/h5L+DvGJf2K0ziw=";
 
   meta = with lib; {
     description = "Blazingly fast terminal recorder that generates animated gif images for the web written in rust";

--- a/pkgs/misc/wiki-tui/default.nix
+++ b/pkgs/misc/wiki-tui/default.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage rec {
     openssl
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 
-  cargoHash = "sha256-fLA7dF91mEgjTnbhujTKaHX+qmpzYaqzL8cc/x+mrUk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Pe6mNbn4GFjhpFZeWMlaRt7Bj5BLiIy789hXWkII2ps=";
 
   meta = with lib; {
     description = "Simple and easy to use Wikipedia Text User Interface";

--- a/pkgs/servers/bindle/default.nix
+++ b/pkgs/servers/bindle/default.nix
@@ -26,7 +26,8 @@ rustPlatform.buildRustPackage rec {
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
 
-  cargoHash = "sha256-RECEeo0uoGO5bBe+r++zpTjYYX3BIkT58uht2MLYkN0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cTgR1yp6TFwotm5VEG5e0O7R1zCMbQmcH2zmRmF7cjI=";
 
   cargoBuildFlags = [
     "--bin"

--- a/pkgs/servers/dns/doh-proxy-rust/default.nix
+++ b/pkgs/servers/dns/doh-proxy-rust/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-h2LwxqyyBPAXRr6XOmcLEmbet063kkM1ledULp3M2ek=";
   };
 
-  cargoHash = "sha256-eXPAn2ziSdciZa6YrOIa7y7Lms681X+yVAD9HrvsZHg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-eYJoHFIC0NF3OAbZXDWB57IOFC9JDV4IXHQgzIWMT04=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     Security

--- a/pkgs/servers/gemini/stargazer/default.nix
+++ b/pkgs/servers/gemini/stargazer/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-0vbQDHuLrgrsWiOb2hb6lYylJm5o/wOzoDIw85H8Eh0=";
   };
 
-  cargoHash = "sha256-EtRJsm6jo0fSEN9s0cS4IBWV/NnuUeDTa/x1utbh85k=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-KdHYyuH1RMLRueqYbfADUktBx9aL8yTagB0KxEGQsCs=";
 
   passthru = {
     tests.basic-functionality = nixosTests.stargazer;

--- a/pkgs/servers/geospatial/martin/default.nix
+++ b/pkgs/servers/geospatial/martin/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Jq72aEwM5bIaVywmS3HetR6nnBZnr3oa9a/4ZbgeL9E=";
   };
 
-  cargoHash = "sha256-RO9nUH2+0jOCbvGtZ5j802mL85tY+Jz7ygPrNuFeE98=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-595VKHLajoNinyv12J9qUi55hOcOFRgUeLlzvSdjESs=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/servers/krill/default.nix
+++ b/pkgs/servers/krill/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-3pkDu20vgzslJcK5KQH+GY+jnimEZgm+bQxy8QMUeCk=";
   };
 
-  cargoHash = "sha256-Z12fUK4TUgk38/vNAt8RWLFGLc8WnZAgHWz0xl1QKLI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-8K4Jn2A9OREwLRyFddHREcylapoFr+/AMT7Wq4o2Ue4=";
 
   buildInputs = [ openssl ] ++ lib.optional stdenv.hostPlatform.isDarwin Security;
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/monitoring/laurel/default.nix
+++ b/pkgs/servers/monitoring/laurel/default.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-mp1XTFD6mvH3RzvzvnJ58iJ6/EjENKYSzOavC2rVixs=";
   };
 
-  cargoHash = "sha256-F5yMNm1JaE9q0NQJ3PDmPlW4WdjfyJj/J9er18acsKw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-hqOtICFufmx7mNzinPpj2/abjKINR4QGoNZrk5I3GIQ=";
 
   postPatch = ''
     # Upstream started to redirect aarch64-unknown-linux-gnu to aarch64-linux-gnu-gcc

--- a/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
+++ b/pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-2e31ZuGJvpvu7L2Lb+n6bZWpC1JhETzEzSiNaxxsAtA=";
   };
 
-  cargoHash = "sha256-NsxGpjuZPpz4gCJRp5IOcfRFh8DTud47nV2bE0/kc2Q=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-PVjeCKGHiHo+OtjIxMZBBJ19Z3807R34Oyu/HYZO90U=";
 
   postPatch = ''
     # drop hardcoded linker names, fixing static build

--- a/pkgs/servers/oxigraph/default.nix
+++ b/pkgs/servers/oxigraph/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-O9/YvvFOaZ1F7HYO/AplWLz1vw0hysJEvGketk8zb9w=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-UnXWBq+oS7tXFCsOhlTkq0L1j8pqzXZ0QKrdYayLunA=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook

--- a/pkgs/servers/piping-server-rust/default.nix
+++ b/pkgs/servers/piping-server-rust/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-8kYaANVWmBOncTdhtjjbaYnEFQeuWjemdz/kTjwj2fw=";
   };
 
-  cargoHash = "sha256-YSiClSnjgqFqT2IGJoatcy7j3NUKcff826AvJ/+RNNU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-m6bYkewBE0ZloDVUhUslS+dgPyoK+eay7rrP3+c00mo=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     CoreServices

--- a/pkgs/servers/rtrtr/default.nix
+++ b/pkgs/servers/rtrtr/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-c1jzUP7cYjqn49gbjXLWTge8ywHBI29gSnhzWDzNCV8=";
   };
 
-  cargoHash = "sha256-2/pm/Tfn6UxFpHW6HW20yOxEtm6N3jOe8kk9k7OPppU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-RPCT2mmzuvDYSTTDM7S1yRcmCe8RlkA1i80dW7OPVO4=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
@@ -19,7 +19,8 @@ buildPgrxExtension rec {
     hash = "sha256-VdLWwkUA0sVs5Z/Lyf5oTRhcHVzPmhgnYQhIM8MWJ0c=";
   };
 
-  cargoHash = "sha256-Gn+SjzGaxnGKJYI9+WyE1+TzlF/2Ne43aKbXrSzfQKM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-OyrfwLMHn2aihfijHxE5oaz+XQC1HFlYbTp8Sw8RcK0=";
 
   postInstall = ''
     # Upstream renames the extension when packaging

--- a/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
+++ b/pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
@@ -21,7 +21,8 @@
     hash = "sha256-7yUbtWbYL4AnuUX8OXG4OVqYCY2Lf0pISSTlcFdPqog=";
   };
 
-  cargoHash = "sha256-+uD4UU7QwNISQZ7a2kDkY/y3fQWk/K0fFcrFq4yq6RU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-g5pIIifsJAs0C02o/+y+ILLnTXFqwG9tZcvY6NqfnDA=";
   buildAndTestSubdir = "extension";
 
   passthru = {

--- a/pkgs/shells/nushell/default.nix
+++ b/pkgs/shells/nushell/default.nix
@@ -36,7 +36,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-Ptctp2ECypmSd0BHa6l09/U7wEjtLsvRSQV/ISz9+3w=";
   };
 
-  cargoHash = "sha256-KOIVlF8V5bdtGIFbboTQpVSieETegA6iF7Hi6/F+2bE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-88qcDlIukhpaUJ1vl1v8KMzj4XaYvATxlU+BOMZu6tk=";
 
   nativeBuildInputs =
     [ pkg-config ]

--- a/pkgs/shells/nushell/plugins/dbus.nix
+++ b/pkgs/shells/nushell/plugins/dbus.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Ga+1zFwS/v+3iKVEz7TFmJjyBW/gq6leHeyH2vjawto=";
   };
 
-  cargoHash = "sha256-2QbsgxY82Vq7Op5kc45ejK/H14iDNpSqVWVAVaMObFY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-7pD5LA1ytO7VqFnHwgf7vW9eS3olnZBgdsj+rmcHkbU=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [ dbus ];

--- a/pkgs/shells/nushell/plugins/formats.nix
+++ b/pkgs/shells/nushell/plugins/formats.nix
@@ -12,7 +12,8 @@
 rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_formats";
   inherit (nushell) version src;
-  cargoHash = "sha256-igmSU2ziLfQbcEvHiQcuU8I8SeEN34gimBlcXtfuC0o=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-88qcDlIukhpaUJ1vl1v8KMzj4XaYvATxlU+BOMZu6tk=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/shells/nushell/plugins/gstat.nix
+++ b/pkgs/shells/nushell/plugins/gstat.nix
@@ -12,7 +12,8 @@
 rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_gstat";
   inherit (nushell) version src;
-  cargoHash = "sha256-xoiKsn3XkKkw+KpgnIPFw78JN3ERxkj+2SgrCoe9HOU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-88qcDlIukhpaUJ1vl1v8KMzj4XaYvATxlU+BOMZu6tk=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = [ openssl ] ++ lib.optionals stdenv.hostPlatform.isDarwin [ Security ];

--- a/pkgs/shells/nushell/plugins/highlight.nix
+++ b/pkgs/shells/nushell/plugins/highlight.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     fetchSubmodules = true;
   };
 
-  cargoHash = "sha256-LDVKZLktP4+W04O8EDkMs8dgViHyzA/b7k+/oJS2pro=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-yZPiDz5BMZqXD3MM8OHKwv1WgoFEmtoQZqzSogVoMnQ=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/shells/nushell/plugins/net.nix
+++ b/pkgs/shells/nushell/plugins/net.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-nKcB919M9FkDloulh9IusWYPhf8vlhUmKVs6Gd6w3Bw=";
   };
 
-  cargoHash = "sha256-bsrpdQS0wA3T0jZTG476sSkMRngEAOjgr4wX7svyMP4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-nQILwEZaVL1xJ/CKGGObogFGPmW0UPq0v3vFP2kHqWo=";
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
 

--- a/pkgs/shells/nushell/plugins/polars.nix
+++ b/pkgs/shells/nushell/plugins/polars.nix
@@ -14,7 +14,8 @@ rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_polars";
   inherit (nushell) version src;
 
-  cargoHash = "sha256-rzTXVde0ZqgJQb1Hs3nvo9v1k+0UKkgKlTym4pukvuk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-88qcDlIukhpaUJ1vl1v8KMzj4XaYvATxlU+BOMZu6tk=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs =

--- a/pkgs/shells/nushell/plugins/query.nix
+++ b/pkgs/shells/nushell/plugins/query.nix
@@ -14,7 +14,8 @@
 rustPlatform.buildRustPackage rec {
   pname = "nushell_plugin_query";
   inherit (nushell) version src;
-  cargoHash = "sha256-OuunFi3zUIgxWol30btAR71TU7Jc++IhlZuM56KpM/Q=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-88qcDlIukhpaUJ1vl1v8KMzj4XaYvATxlU+BOMZu6tk=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs =

--- a/pkgs/shells/nushell/plugins/skim.nix
+++ b/pkgs/shells/nushell/plugins/skim.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-z+NT5WjwBn5yrdQNuERswZgsfM4OJPKssWPyClIi0Fk=";
   };
 
-  cargoHash = "sha256-IcecexmlWjpmqgkuhJv58+GeLhi8cHNItKzUHC3+UCc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-ssRUUwRS21TsnBfofb53MhcqZFUJ3GlxV4AirPDdVzw=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/shells/nushell/plugins/units.nix
+++ b/pkgs/shells/nushell/plugins/units.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-iDRrA8bvufV92ADeG+eF3xu7I/4IinJcSxEkwuhkHlg=";
   };
-  cargoHash = "sha256-if8uvDRwr6p5VENdls9mIfECiu/zDybcpkphZLHRHe8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-8TYqvg+g9VmzbNwOGLfE274r1dvlKiMovJCciVgc+yw=";
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals stdenv.cc.isClang [ rustPlatform.bindgenHook ];
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/tools/X11/xidlehook/default.nix
+++ b/pkgs/tools/X11/xidlehook/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1pl7f8fhxfcy0c6c08vkagp0x1ak96vc5wgamigrk1nkd6l371lb";
   };
 
-  cargoHash = "sha256-uroO0PgnCkFRNYAZgdTZWgDDbBqq1ZM+dni/A2Qw9fg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-U1kjOWrFEp1pZnbawW2MCtC4UN7ELD/kcYWfEmn94Pg=";
 
   buildInputs = [
     xorg.libX11

--- a/pkgs/tools/admin/coldsnap/default.nix
+++ b/pkgs/tools/admin/coldsnap/default.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     hash = "sha256-NYMcCLFhX7eD6GXMP9NZDXDnXDDVbcvVwhUAqmwX+ig=";
   };
-  cargoHash = "sha256-ngkoxybl52zTH4wo+sIUtU8vtzOAp+jU1RyTO2KbCgU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-wUpLYPBACinRO9j+ZrbmJohuN27BPB6ZYu8K14XJmGw=";
 
   buildInputs = [ openssl ];
   nativeBuildInputs = [ pkg-config ];

--- a/pkgs/tools/admin/procs/default.nix
+++ b/pkgs/tools/admin/procs/default.nix
@@ -11,7 +11,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-lm9bGu2AIVulVBcMzEpxxek5g6ajQmBENHeHV210g0k=";
   };
 
-  cargoHash = "sha256-zruW6Cf7zspqv8LadCIXZ0iQdlQ7CVfWhkxLwDA+IFc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-bV59m59vEGvPYctD2pTPspH9zxSV2xg9J0QDGnXPUUA=";
 
   nativeBuildInputs = [ installShellFiles ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ rustPlatform.bindgenHook ];

--- a/pkgs/tools/backup/awsbck/default.nix
+++ b/pkgs/tools/backup/awsbck/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-6AJTNJ/vuRAMnkuOoBVmEAlJy18OZDWVr4OzFv9/oag=";
   };
 
-  cargoHash = "sha256-kJLkI+01tZMYnvxr8Gnuq7ia9iGEYrlUNvHv9Fg7L6s=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-sr9E6AbgGibOhlg+LOuYL5ysd6gHDyKOAYJTwjrzl2E=";
 
   # tests run in CI on the source repo
   doCheck = false;

--- a/pkgs/tools/backup/bupstash/default.nix
+++ b/pkgs/tools/backup/bupstash/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-Ekjxna3u+71s1q7jjXp7PxYUQIfbp2E+jAqKGuszU6g=";
   };
 
-  cargoHash = "sha256-hkGmE7WseEjMxmmPyR8C4osbdbpIt8qG9sfVGuC4d84=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-kWUAI25ag9ghIhn36NF+SunRtmbS0HzsZsxGJujmuG4=";
 
   nativeBuildInputs = [
     ronn

--- a/pkgs/tools/backup/monolith/default.nix
+++ b/pkgs/tools/backup/monolith/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-t4FdTFXbKs7Xfw8dKoME7WDn+Fpe/uHPXyr5Wj+AXSA=";
   };
 
-  cargoHash = "sha256-lBGcS1+CBYeVIG546aHSBVJ9y96rB3IDDVJPqCFUDZQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-FBxNK50ONmezXH8tVFpaBpSFVENS0uMO6mHcaeJq7Og=";
 
   OPENSSL_NO_VENDOR = true;
 

--- a/pkgs/tools/backup/rdedup/default.nix
+++ b/pkgs/tools/backup/rdedup/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-GEYP18CaCQShvCg8T7YTvlybH1LNO34KBxgmsTv2Lzs=";
   };
 
-  cargoHash = "sha256-I6d3IyPBcUsrvlzF7W0hFM4hcXi4wWro9bCeP4eArHI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-JpsUceR9Y3r6RiaLOtbgBUrb6eoan7fFt76U9ztQoM8=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/misc/aoc-cli/default.nix
+++ b/pkgs/tools/misc/aoc-cli/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = [ openssl ] ++ lib.optional stdenv.hostPlatform.isDarwin Security;
 
-  cargoHash = "sha256-EluP4N3UBQeEKVdHTs4O0THXji+nAyE52nGKsxA3AA4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cm8yt7PRjar21EVFIjXYgDkO7+VpHGIB3tJ8hkK+Phw=";
 
   meta = with lib; {
     description = "Advent of code command line tool";

--- a/pkgs/tools/misc/apkeep/default.nix
+++ b/pkgs/tools/misc/apkeep/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-YjGfnYK22RIVa8D8CWnAxHGDqXENGAPIeQQ606Q3JW8=";
   };
 
-  cargoHash = "sha256-Fx/XNmml/5opekmH1qs/f3sD45KWfNZjdOxTuNJfZiw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-CwucGAwAvxePNQu5p1OWx9o9xsvpzX1abH6HyF43nEE=";
 
   prePatch = ''
     rm .cargo/config.toml

--- a/pkgs/tools/misc/didyoumean/default.nix
+++ b/pkgs/tools/misc/didyoumean/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-PSEoh1OMElFJ8m4er1vBMkQak3JvLjd+oWNWA46cows=";
   };
 
-  cargoHash = "sha256-QERnohWpkJ0LWkdxHrY6gKxdGqxDkLla7jlG44laojk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-BASM0gBQFuJY2ze9X9HJUkiP4WrOP/inD87bVFraeAY=";
 
   nativeBuildInputs =
     [

--- a/pkgs/tools/misc/dijo/default.nix
+++ b/pkgs/tools/misc/dijo/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     rev = "v${version}";
     sha256 = "sha256-g+A8BJxqoAvm9LTLrLnClVGtFJCQ2gT0mDGAov/6vXE=";
   };
-  cargoHash = "sha256-o3+KcE7ozu6eUgwsOSr9DOoIo+/BZ3bJZe+WYQLXHpY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Pny/RBtr65jKu2DdyIrluZWeZIgGb8Ev7mxvTMWPlyI=";
 
   meta = with lib; {
     description = "Scriptable, curses-based, digital habit tracker";

--- a/pkgs/tools/misc/diskus/default.nix
+++ b/pkgs/tools/misc/diskus/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 
-  cargoHash = "sha256-7xGt+HDX20Bxwdff0Ca/D6lcT3baumeiUmIPXSh5NYM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-keBnhE4ltOVMEuxPifiB2EAHk32u3PqaPGTeVexVXWM=";
 
   meta = with lib; {
     description = "Minimal, fast alternative to 'du -sh'";

--- a/pkgs/tools/misc/eludris/default.nix
+++ b/pkgs/tools/misc/eludris/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-TVYgimkGUSITB3IaMlMd10PWomqyJRvONvJwiW85U4M=";
   };
 
-  cargoHash = "sha256-5B9D19jFh5+eNTjiho22CFsn51nmwLry08zSDWvs1OU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-JpXjnkZHz12YxgTSqTcWdQTkrMugP7ZGw48145BeBZk=";
 
   cargoBuildFlags = [ "-p eludris" ];
   cargoTestFlags = [ "-p eludris" ];

--- a/pkgs/tools/misc/fclones/default.nix
+++ b/pkgs/tools/misc/fclones/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-JgeajCubRz9hR6uvRAw1HXdKa6Ua+l/Im/bYXdx1gL0=";
   };
 
-  cargoHash = "sha256-mEgFfg8I+JJuUEvj+sia2aL3BVg3HteQorZ2EOiLo64=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-LOEsxqRlGL2B/ruBb/4XoCYZk5hBf2vPvcj+tT/UcA0=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk_11_0.frameworks.AppKit

--- a/pkgs/tools/misc/fclones/gui.nix
+++ b/pkgs/tools/misc/fclones/gui.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-ad7wyoCjSQ8i6c+4IorImqAY2Q6pwBtI2JkkbkGa46U=";
   };
 
-  cargoHash = "sha256-7+I0Tj+DcrItU2apB1iMiYiTv9AeDparke86HkJNF3A=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-01HNWhHfbun+Er39eN5tEmqXMGDsBQrZtVTA9R7kifo=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/misc/ffsend/default.nix
+++ b/pkgs/tools/misc/ffsend/default.nix
@@ -33,7 +33,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-L1j1lXPxy9nWMeED9uzQHV5y7XTE6+DB57rDnXa4kMo=";
   };
 
-  cargoHash = "sha256-r1yIPV2sW/EpHJpdaJyi6pzE+rtNkBIxSUJF+XA8kbA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Gv70H3SLgiO7SWKYfCKzBhgAHxhjx3Gv7ZPLrGeQ+HY=";
 
   cargoPatches = [
 

--- a/pkgs/tools/misc/flowgger/default.nix
+++ b/pkgs/tools/misc/flowgger/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-eybahv1A/AIpAXGj6/md8k+b9fu9gSchU16fnAWZP2s=";
   };
 
-  cargoHash = "sha256-DZGyX3UDqCjB5NwCXcR8b9pXdq8qacd3nkqGp6vYb+U=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-50/rg1Bo8wEpD9UT1EWIKNLglZLS1FigoPtZudDaL4c=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/misc/gh-cal/default.nix
+++ b/pkgs/tools/misc/gh-cal/default.nix
@@ -14,7 +14,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-x9DekflZoXxH964isWCi6YuV3v/iIyYOuRYVgKaUBx0=";
   };
 
-  cargoHash = "sha256-73gqk0DjhaLGIEP5VQQlubPomxHQyg4RnY5XTgE7msQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-myfvPAeWuFHQcHXfkTYRfXVQ5ZBrdzQlaqHljbS0ppg=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];

--- a/pkgs/tools/misc/grex/default.nix
+++ b/pkgs/tools/misc/grex/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Ut2H2H66XN1+wHpYivnuhil21lbd7bwIcIcMyIimdis=";
   };
 
-  cargoHash = "sha256-ZRE1vKgi0/UtSe2bdN0BLdtDfAauTfwcqOcl3y63fAA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-OsK6X7qwMMQ1FK3JE98J2u6pn6AixE8izFmxUVDs5GM=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/misc/hiksink/default.nix
+++ b/pkgs/tools/misc/hiksink/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-k/cBCc7DywyBbAzCRCHdrOVmo+QVCsSgDn8hcyTIUI8=";
   };
 
-  cargoHash = "sha256-vqzXpSPBwY7m/Fdob0mHH0OXnzyQwFk7x2kk9Tgez3M=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-P5h0jYSSy6i30g93Jor98vOmniJCA4eMyQkI8TLfbN8=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/misc/hyperfine/default.nix
+++ b/pkgs/tools/misc/hyperfine/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-c8yK9U8UWRWUSGGGrAds6zAqxAiBLWq/RcZ6pvYNpgk=";
   };
 
-  cargoHash = "sha256-Ia9L7RxYmhFzTVOzegxAmsgBmx30PPqyVFELayL3dq8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-eZpGqkowp/R//RqLRk3AIbTpW3i9e+lOWpfdli7S4uE=";
 
   nativeBuildInputs = [ installShellFiles ];
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;

--- a/pkgs/tools/misc/iay/default.nix
+++ b/pkgs/tools/misc/iay/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-oNUK2ROcocKoIlAuNZcJczDYtSchzpB1qaYbSYsjN50=";
   };
 
-  cargoHash = "sha256-bcMi8967dsJ3fL28XiUXfHz6CPB/RKSKsRvwMJtxEUA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-QO9gzJKSBMs5s1fCfpBuyHDK9uE1B148bMjp8RjH4nY=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/misc/jsonwatch/default.nix
+++ b/pkgs/tools/misc/jsonwatch/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-/DYKjhHjfXPWpU1RFmRUbartSxIBgVP59nbgwKMd0jg=";
   };
 
-  cargoHash = "sha256-Io51qbZOVcOKyMvo9/GTPXkGiJwjxcIPK3y7vAuTJOM=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-QVS+b/mH7hnzaZjnGg8rw6k11uOuKGFeiPoXyqwD8tk=";
 
   meta = with lib; {
     description = "Like watch -d but for JSON";

--- a/pkgs/tools/misc/killport/default.nix
+++ b/pkgs/tools/misc/killport/default.nix
@@ -13,7 +13,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-eyRI4ZVp9HPMvpzyV9sQdh2r966pCdyUPnEhxGkzH3Q=";
   };
 
-  cargoHash = "sha256-QQ43dT9BTu7qCzpnTGKzlVL6jKDXofXStYWYNLHSuVs=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-rJgbTJGRZNev5hPyH7NuRB0Utpdbh6zoYQL4rbfhn2Y=";
 
   nativeBuildInputs = [ rustPlatform.bindgenHook ];
 

--- a/pkgs/tools/misc/lighthouse-steamvr/default.nix
+++ b/pkgs/tools/misc/lighthouse-steamvr/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-uJ8U4knNKAliHjxP0JnV1lSCEsB6OHyYSbb5aWboYV4=";
   };
 
-  cargoHash = "sha256-XVPrtZNLdF9mKSl56kBepkpXRQBJsu9KlZRhb6BeG/E=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-YJgtkrDs7cBpjux0SE6TTXcduZRC+8+4SMMiCXYeCYI=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/misc/lorri/default.nix
+++ b/pkgs/tools/misc/lorri/default.nix
@@ -17,7 +17,8 @@ let
   # Also don’t forget to run `nix-build -A lorri.tests`
   version = "1.7.1";
   sha256 = "sha256-dEdKMgE4Jd8CCvtGQDZNDCYOomZAV8aR7Cmtyn8RfTo=";
-  cargoHash = "sha256-+sKxKxc2DVHn54uQa8K+CKmm0A0ym9SXgtOcfRZ6R5E=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-d1kXwb2WsF3J5AyD8wrrnGtCMYQ4P2mtiuJLMyCDPdM=";
 
 in
 (rustPlatform.buildRustPackage rec {

--- a/pkgs/tools/misc/nvfancontrol/default.nix
+++ b/pkgs/tools/misc/nvfancontrol/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-0WBQSnTYVc3sNmZf/KFzznMg9AVsyaBgdx/IvG1dZAw=";
   };
 
-  cargoHash = "sha256-fEzdghGQSSeyeyiHjw1ggQ38gsETJFl9bq/tizGxIis=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-nJc1G9R0+o22H1KiBtzfdcIIfKrD+Dksl7HsZ2ICD7U=";
 
   nativeBuildInputs = [
     libXNVCtrl

--- a/pkgs/tools/misc/octofetch/default.nix
+++ b/pkgs/tools/misc/octofetch/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-/AXE1e02NfxQzJZd0QX6gJDjmFFmuUTOndulZElgIMI=";
   };
 
-  cargoHash = "sha256-iuhJYibyQ7hdeXzqCW2PLq7FiKnZp2VHyKT4qO/6vrU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-1lnHCiRktBGYb7Bgq4p60+kikb/LApPhzNp1O0Go46Q=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/misc/owofetch/default.nix
+++ b/pkgs/tools/misc/owofetch/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-I8mzOUvm72KLLBumpgn9gNyx9FKvUrB4ze1iM1+OA18=";
   };
 
-  cargoHash = "sha256-rfN4QERs1H1G7ZZim//78vlxbYfU4Cx7SYYUz/QLKeU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-0ON1h8+ruLOvBR7Q/hOIW6j+BjfPAAuYA2wrUYj59Ow=";
 
   buildInputs = lib.optionals stdenvNoCC.hostPlatform.isDarwin [
     Foundation

--- a/pkgs/tools/misc/rust-motd/default.nix
+++ b/pkgs/tools/misc/rust-motd/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-x3dx4PdYSYd7wA/GGj9QYC8rK33FWATs2SnaOagGE80=";
   };
 
-  cargoHash = "sha256-7YvzVG3c10EJET+659F1fwgZ0SmBKMdAWD6LeWnGrNI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-12janO6zzlLge1uDLHHjGtycCPwkJXwII6LeG0586Fk=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/misc/shadowenv/default.nix
+++ b/pkgs/tools/misc/shadowenv/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-9K04g2DCADkRwjo55rDwVwkvmypqujdN1fqOmHmC09E=";
   };
 
-  cargoHash = "sha256-GBqxA49H3KG63hn8QfM4U8m9uZ1YAhJio6bGziyLvV0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-IHg36zgBF7o/O9kL6t54fV6dBJDZLYausM1u8pLR+Mk=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/tools/misc/sheldon/default.nix
+++ b/pkgs/tools/misc/sheldon/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-eyfIPO1yXvb+0SeAx+F6/z5iDUA2GfWOiElfjn6abJM=";
   };
 
-  cargoHash = "sha256-+yTX1wUfVVjsM42X0QliL+0xbzTPheADZibPh/5Czh8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-HINEhJ6xpiRAPopJDhbXlSCn4K4aPFErgIYwDOBmRX8=";
 
   buildInputs =
     [ openssl ]

--- a/pkgs/tools/misc/starship/default.nix
+++ b/pkgs/tools/misc/starship/default.nix
@@ -57,7 +57,8 @@ rustPlatform.buildRustPackage rec {
         --zsh <($out/bin/starship completions zsh)
     '';
 
-  cargoHash = "sha256-Z/dMKExGemssCMqRzQ58xXxXvbFR84WX3KI2pC20omI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-B2CCrSH2aTcGEX96oBxl/27hNMdDpdd2vxdt0/nlN6I=";
 
   nativeCheckInputs = [ git ];
 

--- a/pkgs/tools/misc/synth/default.nix
+++ b/pkgs/tools/misc/synth/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-/z2VEfeCCuffxlMh4WOpYkMSAgmh+sbx3ajcD5d4DdE=";
   };
 
-  cargoHash = "sha256-i2Pp9sfTBth3DtrQ99Vw+KLnGECrkqtlRNAKiwSWf48=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-sJSU85f4bLh89qo8fojWJNfJ9t7i/Hlg5pnLcxcwKt4=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     AppKit

--- a/pkgs/tools/misc/tab-rs/default.nix
+++ b/pkgs/tools/misc/tab-rs/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1crj0caimin667f9kz34c0sm77892dmqaf1kxryqakqm75az5wfr";
   };
 
-  cargoHash = "sha256-56gy9AH3i4OSvExMuR3n/2hF5pJgbn5JJpxZLXKfu2w=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-4bscAhYE3JNk4ikTH+Sw2kGDDsBWcCZZ88weg9USjC0=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ IOKit ];
 

--- a/pkgs/tools/misc/tmux-sessionizer/default.nix
+++ b/pkgs/tools/misc/tmux-sessionizer/default.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-4xwpenoAVGKdVO3eSS4BhaEcwpNPGA5Ozie53focDlA=";
   };
 
-  cargoHash = "sha256-ajeCB1w/JHMT5e7mSwsh++lzLNfp0qfutONStpJpFDo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NFM9tZQIR9Rw9uSlqxhbNnmwe3xqK+dv/qyJBHfEmi4=";
 
   passthru.tests.version = testers.testVersion {
     package = tmux-sessionizer;

--- a/pkgs/tools/misc/toastify/default.nix
+++ b/pkgs/tools/misc/toastify/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-hSBh1LTfe3rQDPUryo2Swdf/yLYrOQ/Fg3Dz7ZqV3gw=";
   };
 
-  cargoHash = "sha256-Ps2pRLpPxw+OS1ungQtVQ8beoKpc8pjzQEndMNni08k=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-xnmns0YXsKuoNxxax3St5pLiFwu6BD0iIYHNi9N9mO0=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     darwin.apple_sdk_11_0.frameworks.Cocoa

--- a/pkgs/tools/misc/topgrade/default.nix
+++ b/pkgs/tools/misc/topgrade/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-0wJxBFGPjJReWoeeKpHEsKaB3npR8nf7Uw8BgPQ+ccs=";
   };
 
-  cargoHash = "sha256-ac62RyjQujEYAOcoGOMlDlbx1MmVmrRKoNpgb3dFUFk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-/sN5Vl1Co2VYnG2vN170Q3hAbOYhJSvLawJDFytz+ho=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/tools/misc/tremor-rs/default.nix
+++ b/pkgs/tools/misc/tremor-rs/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-DoFqHKTu4CvgDYPT4vbwNvSZ/lNTdAF+wlHOOIBJKUw=";
   };
 
-  cargoHash = "sha256-mgg6yzjRZsDbnK19nhNmy2I95tPWD4NmGCXtI957D0M=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-w/d/MMd5JNQMRUxRaH4Tpf4Dzh14eykG+zzuM/YrU40=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/tools/misc/vrc-get/default.nix
+++ b/pkgs/tools/misc/vrc-get/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     pkg-config
   ];
 
-  cargoHash = "sha256-xfW9pIaSL9bvGXk4XxRUVyvtRwKXmjS3Gc5b7v7q17A=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cG6fcSIQ0E1htEM4H914SSKDNRGM5fj52SUoLqRYzoc=";
 
   # Execute the resulting binary to generate shell completions, using emulation if necessary when cross-compiling.
   # If no emulator is available, then give up on generating shell completions

--- a/pkgs/tools/misc/wagyu/default.nix
+++ b/pkgs/tools/misc/wagyu/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
 
   cargoPatches = [ ./fix-rustc-serialize-version.patch ];
 
-  cargoHash = "sha256-vseTtok0E0ddg9ALQ1ql3NPPxirfyMPHOSWsM2qu2jU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-vtNxRW/b8kvy21YQezCUiZNtLnlMSkdTRr/OkGy6UAw=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/tools/misc/watchexec/default.nix
+++ b/pkgs/tools/misc/watchexec/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-wm3zse5VqUNZ5d6ksCXXrngCcwrAniQbQqx9MOJoK58=";
   };
 
-  cargoHash = "sha256-92lvMka6IqzNAxvYSMUeiDfYw4uKZjjpkZOABq9Mypo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3deZMc1zrauldUZnFHYSRe2UjqWwYY7ePGBEE8g9g1g=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/tools/networking/bore-cli/default.nix
+++ b/pkgs/tools/networking/bore-cli/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Wkhcv8q/dGRJqG7ArsnsPsRBnXdScGedwxunbOzAjyY=";
   };
 
-  cargoHash = "sha256-vwvDtzShlQQO/oAnjbqDIP3fUdcH1kEmFR7fyV+uYbY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-va6d7Z5WUeokP77v/xidsMJCXHa8EKQ0gemNd1Naqdk=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     Security

--- a/pkgs/tools/networking/bore/default.nix
+++ b/pkgs/tools/networking/bore/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1fdnnx7d18gj4rkv1dc6q379dqabl66zks9i0rjarjwcci8m30d9";
   };
 
-  cargoHash = "sha256-vUKv98lfsrxBiJxjL8ZKLZ1IVCX5hHzl+F5y4Ot3i/Y=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-6uIqvX50XoWCPQ8u38rUdi4LwtMTBcNuefNmzGY+vLU=";
   cargoBuildFlags = [
     "-p"
     pname

--- a/pkgs/tools/networking/cocom/default.nix
+++ b/pkgs/tools/networking/cocom/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "0sl4ivn95sr5pgw2z877gmhyfc4mk9xr457i5g2i4wqnf2jmy14j";
   };
 
-  cargoHash = "sha256-y5/xOP5YzqsqBxG9c4r9ORyaEf5Ed6D10NFCaKQPchI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-kfseD0dYNC1IFAamLJee7LozGppE2mZgBMCUHJC0dP4=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/tools/networking/drill/default.nix
+++ b/pkgs/tools/networking/drill/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-4y5gpkQB0U6Yq92O6DDD5eq/i/36l/VfeyiE//pcZOk=";
   };
 
-  cargoHash = "sha256-96eUCg0mzgUFLOKxpwRfzj1jH2Z+aDohBTztvRVWln0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-wrfQtJHhSG53tV3R4u/Ri4iv1VoAmuT3xleAQEJOIzE=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
     pkg-config

--- a/pkgs/tools/networking/fast-ssh/default.nix
+++ b/pkgs/tools/networking/fast-ssh/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-Wn1kwuY1tRJVe9DJexyQ/h+Z1gNtluj78QpBYjeCbSE=";
   };
 
-  cargoHash = "sha256-CJ3Xx5jaTD01Ai7YAY4vB7RB5lU1BIXq7530B6+KeX4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-qkvonLuS18BBPdBUUnIAbmA+9ZJZFmTRaewrnK9PHFE=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/tools/networking/ifwifi/default.nix
+++ b/pkgs/tools/networking/ifwifi/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-DPMCwyKqGJrav0wASBky9bS1bvJ3xaGsDzsk1bKaH1U=";
   };
 
-  cargoHash = "sha256-TL7ZsRbpRdYymJHuoCUCqe/U3Vacb9mtKFh85IOl+PA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-oxuOc9FSKYq6UjimZPLayJ+5xsWzh3gZV/mVpPbPWHk=";
 
   nativeBuildInputs = [ makeWrapper ];
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;

--- a/pkgs/tools/networking/innernet/default.nix
+++ b/pkgs/tools/networking/innernet/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-dFMAzLvPO5xAfJqUXdiLf13uh5H5ay+CI9aop7Fhprk=";
   };
 
-  cargoHash = "sha256-39LryfisVtNMX2XLPh/AEQ1KzVtwdE3wuTaTbxGMaBI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-gTFvxmnh+d1pNqG0sEHFpl0m9KKCQ78sai//iiJ0aGs=";
 
   nativeBuildInputs = [
     rustPlatform.bindgenHook

--- a/pkgs/tools/networking/lychee/default.nix
+++ b/pkgs/tools/networking/lychee/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-DRGby8Ov7Mosz4FVz/w2ECkvyuBktL9PTnUYds+mCI8=";
   };
 
-  cargoHash = "sha256-pD8UQEdZwZNAeON4zKYa6nUaz87vx7n/Op8H5NtXRZo=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-B0bskG5ptUJCwRy/m0ZMo80dE2MTi39mnQLsgQjwTBY=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/networking/mozwire/default.nix
+++ b/pkgs/tools/networking/mozwire/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     Security
   ];
 
-  cargoHash = "sha256-YXVH7kx5CiurTeXiphjDgcYxxovKtTF3Q9y/XOyVPUA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-UEo/CSRg1hS/BIEQTEgqfwwz1LAMDdjKwV8bDyspX7o=";
 
   meta = with lib; {
     description = "MozillaVPN configuration manager giving Linux, macOS users (among others), access to MozillaVPN";

--- a/pkgs/tools/networking/ockam/default.nix
+++ b/pkgs/tools/networking/ockam/default.nix
@@ -26,7 +26,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-AY0i7qXA7JXfIEY0htmL+/yn71xAuh7WowXOs2fD6n8=";
   };
 
-  cargoHash = "sha256-gAl2es8UFVFv40sMY++SiDGjCMdL0XDN4PeSV7VlGmQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Mt/UFVFLZRrY8Mka4VFi6J2XjBjFsnJPi9tnBVZ6a5E=";
   nativeBuildInputs = [
     git
     pkg-config

--- a/pkgs/tools/networking/onetun/default.nix
+++ b/pkgs/tools/networking/onetun/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-bggBBl2YQUncfOYIDsPgrHPwznCJQOlIOY3bbiZz7Rw=";
   };
 
-  cargoHash = "sha256-Il/jwaQ4nu93R1fC3r6haSSF5ATSrgkv4uZmAA/RZBI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-VC7q2ZTdbBmvZ9l70uQz59paFIi8HXp5CPxfQC6cVmk=";
 
   meta = {
     description = "Cross-platform, user-space WireGuard port-forwarder that requires no root-access or system network configurations";

--- a/pkgs/tools/networking/rosenpass/default.nix
+++ b/pkgs/tools/networking/rosenpass/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-fQIeKGyTkFWUV9M1o256G4U1Os5OlVsRZu+5olEkbD4=";
   };
 
-  cargoHash = "sha256-GyeJCIE60JuZa/NuixDc3gTj9WAOpSReIyVxQqM4tDQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-vx6kSdDOXiIp2626yKVieDuS9DD5/wKyXutMiKMKn24=";
 
   nativeBuildInputs = [
     cmake # for oqs build in the oqs-sys crate

--- a/pkgs/tools/networking/s3rs/default.nix
+++ b/pkgs/tools/networking/s3rs/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-mJ1bMfv/HY74TknpRvu8RIs1d2VlNreEVtHCtQSHQw8=";
   };
 
-  cargoHash = "sha256-Q1EqEyNxWIx3wD8zuU7/MO3Qz6zsfBZbtT/IIUmJccE=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-z7de/TZXyNsb+dxWcNFdJsaGsM3Ld2A0jorNMAVOZOg=";
 
   nativeBuildInputs = [
     python3

--- a/pkgs/tools/networking/shadowsocks-rust/default.nix
+++ b/pkgs/tools/networking/shadowsocks-rust/default.nix
@@ -11,7 +11,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-bvYp25EPKtkuZzplVYK4Cwd0mm4UuyN1LMiDAkgMIAc=";
   };
 
-  cargoHash = "sha256-zmyce0Dt9ai4pNQi+b37KrCDqdjT9tQ8k2yHLDWDTXY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-TwUIyUEBe+qMKxfPxEGXcNYJmJSNfdcrOBnUbb0N6cs=";
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ pkg-config ];
 

--- a/pkgs/tools/networking/suckit/default.nix
+++ b/pkgs/tools/networking/suckit/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-M4/vD1sVny7hAf4h56Z2xy7yuCqH/H3qHYod6haZOs0=";
   };
 
-  cargoHash = "sha256-JsH7TL9iITawuECm1hzs5oXFtnoUqLT4ug2CafoO2ao=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-20Fz98mAkmhk7g0359S7Gjg6i89cXtKuS/9bVzOagBs=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/networking/wg-netmanager/default.nix
+++ b/pkgs/tools/networking/wg-netmanager/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-Mr4+TW1yOePEHa7puz6mTRJ514LGQeiEwPW3NKupV/M=";
   };
 
-  cargoHash = "sha256-cOxkWMFPVmi+/BQWIvExzX5LDyC7C8kaTf5dGwfXj+s=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-LtZTfmVVUqxc9GAM6mLLmlJXBhLqnfrvBZWh0RWrR/0=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/tools/nix/nixci/default.nix
+++ b/pkgs/tools/nix/nixci/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-49I09hXYoVo6vzv1b6mkeiFwzfj6g1SkXTL/tCEdOYc=";
   };
 
-  cargoHash = "sha256-trmWeYJNev7jYJtGp9XR/emmQiiI94NM0cPFrAuD7m0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-iRsmB+ak6pWFtAdXEmGSc9dGdIuSbgLp3UT3SdOUOGQ=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/package-management/nix-du/default.nix
+++ b/pkgs/tools/package-management/nix-du/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-WImnfkBU17SFQG1DzVUdsNq3hkiISNjAVZr2xGbgwHg=";
   };
 
-  cargoHash = "sha256-gE99nCJIi6fsuxzJuU80VWXIZqVbqwBhKM2aRlhmYco=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-HUyqkO9uPrfqTCljJzKfQ5sRCh4uj8XL4wSkwmc/Z8A=";
 
   doCheck = true;
   nativeCheckInputs = [

--- a/pkgs/tools/package-management/nix-template/default.nix
+++ b/pkgs/tools/package-management/nix-template/default.nix
@@ -23,7 +23,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-42u5FmTIKHpfQ2zZQXIrFkAN2/XvU0wWnCRrQkQzcNI=";
   };
 
-  cargoHash = "sha256-f8Th6SbV66Uukqh1Cb5uQVa844qw1PmBB9W7EMXMU4E=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cLSGWOyBQLv235TeYqSVg/f0Zmcnpj+RshINN69JYEU=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/tools/security/age-plugin-ledger/default.nix
+++ b/pkgs/tools/security/age-plugin-ledger/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-g5GbWXhaGEafiM3qkGlRXHcOzPZl2pbDWEBPg4gQWcg=";
   };
 
-  cargoHash = "sha256-SbgH67XuxBa7WFirSdOIUxfJGlIYezISCEA3LJGN3ys=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-zR7gJNIqno50bQo0kondCxEC0ZgssqXNqACF6fnLDrc=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/security/feroxbuster/default.nix
+++ b/pkgs/tools/security/feroxbuster/default.nix
@@ -25,7 +25,8 @@ rustPlatform.buildRustPackage rec {
     rm .cargo/config
   '';
 
-  cargoHash = "sha256-hOIOcz7YyZbQNScsY0jdxGLZQnWRBsFOzmRdu8oWIN8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-DjmMoATagWGK2DHMc6YB0u2X5x5hnqgCwIGe3+Wmdic=";
 
   OPENSSL_NO_VENDOR = true;
 

--- a/pkgs/tools/security/gpg-tui/default.nix
+++ b/pkgs/tools/security/gpg-tui/default.nix
@@ -28,7 +28,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-aHmLcWiDy5GMbcKi285tfBggNmGkpVAoZMm4dt8LKak=";
   };
 
-  cargoHash = "sha256-rtBvo2nX4A6K/TBl6xhW8huLXdR6xDUhzMB3KRXRYMs=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-VLBou/XNYTd8vJNT+ntShLCRy9pzjCwJlbDbfRX2ag8=";
 
   nativeBuildInputs = [
     gpgme # for gpgme-config

--- a/pkgs/tools/security/kbs2/default.nix
+++ b/pkgs/tools/security/kbs2/default.nix
@@ -21,7 +21,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-o8/ENAWzVqs7rokST6xnyu9Q/pKqq/UnKWOFRuIuGes=";
   };
 
-  cargoHash = "sha256-LcnvCWGVdBxhDgQDoGHXRppGeEpfjOv/F0dZMN2bOF8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-+TJ/QG+6ZILcSZEIXj6B4qYF0P5pQpo1kw2qEfE0FDw=";
 
   nativeBuildInputs = [ installShellFiles ] ++ lib.optionals stdenv.hostPlatform.isLinux [ python3 ];
 

--- a/pkgs/tools/security/lethe/default.nix
+++ b/pkgs/tools/security/lethe/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-y2D/80pnpYpTl+q9COTQkvtj9lzBlOWuMcnn5WFnX8E=";
   };
 
-  cargoHash = "sha256-SFNNpbHZdDJvH95f+VWyVKnQp3OJwQmCOqHtLAhhkOk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Ky39RpLoYks4xDiheSsrUj3l/ZrGcY+y5IuDZ28pH/c=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/tools/security/rblake2sum/default.nix
+++ b/pkgs/tools/security/rblake2sum/default.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-bzOjJ+/M0YWY4/r8cNARPVqbuLBeTllqFyVXhJz6ZMI=";
   };
 
-  cargoHash = "sha256-egwL3z7uB4AcRwPT0uPrenyh4FSxhbZKMdkPhRztMbs=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-wIJWwU4D0OeVa2RMgmpN512TIvNdcBdorXU8KfFRTIg=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/security/rblake3sum/default.nix
+++ b/pkgs/tools/security/rblake3sum/default.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-UFk6SJVA58WXhH1CIuT48MEF19yPUe1HD+ekn4LDj8g=";
   };
 
-  cargoHash = "sha256-SE/Zg/UEV/vhB/VDcn8Y70OUIoxbJBh6H2QgFMkWPc4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cxPNqUVNMkNY9Ov7/ajTAwnBd2j/gKDHVLXPtd1aPVA=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/security/rucredstash/default.nix
+++ b/pkgs/tools/security/rucredstash/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-trupBiinULzD8TAy3eh1MYXhQilO08xu2a4yN7wwhwk=";
   };
 
-  cargoHash = "sha256-TYobVjjzrK3gprZcYyY98EvdASkq4urB+WiLlbJbwmk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-QylZkqE8my2ldCjtg3++6TTDm0om3SVp0jwYUZ9qVes=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/tools/security/rustscan/default.nix
+++ b/pkgs/tools/security/rustscan/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-6heC/bHo4IqKNvPjch7AiyWTCZDCv4MZHC7DTEX3U5c=";
   };
 
-  cargoHash = "sha256-Fr+m4BeYvUOoSkewwdUgpmdNchweeLK7v/tKLEzFOBs=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-M3Nm1eWWofcxHcadx3cxxORWKyiOPZHVzTwY2YIAfiE=";
 
   postPatch = ''
     substituteInPlace src/scripts/mod.rs \

--- a/pkgs/tools/security/solo2-cli/default.nix
+++ b/pkgs/tools/security/solo2-cli/default.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-7tpO5ir42mIKJXD0NJzEPXi/Xe6LdyEeBQWNfOdgX5I=";
   };
 
-  cargoHash = "sha256-X+IEeztSL312Yq9Loi3cNJuVfSGk/tRRBCsy0Juji7Y=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-qD185H6wfW9yuYImTm9hqSgQpUQcKuCESM8riZwmGY0=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/tools/text/amber/default.nix
+++ b/pkgs/tools/text/amber/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-q0o2PQngbDLumck27V0bIiB35zesn55Y+MwK2GjNVWo=";
   };
 
-  cargoHash = "sha256-nBSgP30Izskq9RbhVIyqWzZgG5ZWHVdiukldw+Q0rco=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-UFuWD3phcKuayQITd85Sou4ygDBMzjrR39vWrlseYJQ=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv

--- a/pkgs/tools/text/chars/default.nix
+++ b/pkgs/tools/text/chars/default.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-mBtwdPzIc6RgEFTyReStFlhS4UhhRWjBTKT6gD3tzpQ=";
   };
 
-  cargoHash = "sha256-wqyExG4haco6jg1zpbouz3xMR7sjiVIAC16PnDU2tc8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Df+twOjzfq+Vxzuv+APiy94XmhBajgk+6+1BRFf+xm0=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/text/coloursum/default.nix
+++ b/pkgs/tools/text/coloursum/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-zA2JhSnlFccSY01WMGsgF4AmrF/3BRUCcSMfoEbEPgA=";
   };
 
-  cargoHash = "sha256-dhcTpff4h37MHNbLoYUZiolSclSGcFrMJ3kKLCZAVAw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-aZkWzJaEW6/fiCfb+RKNef0eJf/CJW8OU1N2OlHwuJM=";
 
   buildInputs = lib.optional stdenv.hostPlatform.isDarwin Security;
 

--- a/pkgs/tools/text/diffr/default.nix
+++ b/pkgs/tools/text/diffr/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-ylZE2NtTXbGqsxE72ylEQCacTyxBO+/WgvEpoXd5OZI=";
   };
 
-  cargoHash = "sha256-RmQu55OnKfeuDGcJrfjhMKnxDatdowkvh3Kh4N8I8Sg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-pbGfoEk8peWBA0F0EdiAJJtan74O5RD6TmNJUTY2ijA=";
 
   buildInputs = (lib.optional stdenv.hostPlatform.isDarwin Security);
 

--- a/pkgs/tools/text/fastmod/default.nix
+++ b/pkgs/tools/text/fastmod/default.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-A/3vzfwaStoQ9gdNM8yjmL2J/pQjj6yb68WThiTF+1E=";
   };
 
-  cargoHash = "sha256-sFrABp4oYhel+GONFsTbunq+4We2DicvF9A3FT/ZArc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-GpV7F0TQyIRowY8LqLTVuwJcRYyyu055+g7BmxT4TMQ=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     libiconv

--- a/pkgs/tools/text/igrep/default.nix
+++ b/pkgs/tools/text/igrep/default.nix
@@ -19,7 +19,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-ZZhzBGLpzd9+rok+S/ypKpWXVzXaA1CnviC7LfgP/CU=";
   };
 
-  cargoHash = "sha256-raSz/+u7P04qHmvdfYoWKOKtNtaFlgmT8Nw0ImhCMkU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NZN9pB9McZkTlpGgAbxi8bwn+aRiPMymGmBLYBc6bmw=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/text/languagetool-rust/default.nix
+++ b/pkgs/tools/text/languagetool-rust/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-YsVK72q+A9T00u9bXIUfGDhwQl5kiLMec6onbp9YKkg=";
   };
 
-  cargoHash = "sha256-Yit6zWWEcH5LXpcvy9EXUvRNz+JsyW10fauSNBf1BoU=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-R2CjzljguyzosVlq5k96/g0jHiq0/oRiTAjVzjy6xTY=";
 
   buildFeatures = [ "full" ];
 

--- a/pkgs/tools/text/mdbook-admonish/default.nix
+++ b/pkgs/tools/text/mdbook-admonish/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-GNQIOjgHCt3XPCzF0RjV9YStI8psLdHhTPuTkdgx8vA=";
   };
 
-  cargoHash = "sha256-CG4WvAFDqtRUjF4kJ29363F6jWRChIXgT5i6ozwV4pw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-GbXLlWHbLL7HbyuX223S/o1/+LwbK8FjL7lnEgVVn00=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 

--- a/pkgs/tools/text/mdbook-epub/default.nix
+++ b/pkgs/tools/text/mdbook-epub/default.nix
@@ -22,7 +22,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-ddWClkeGabvqteVUtuwy4pWZGnarrKrIbuPEe62m6es=";
   };
 
-  cargoHash = "sha256-cJS9HgbnLYXkZrAyGNEeu6q+znH+7cj8CUGIbTCbB9Y=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3R81PJCOFc22QDHH2BqGB9jjvEcMc1axoySSJLJD3wI=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/text/mdbook-footnote/default.nix
+++ b/pkgs/tools/text/mdbook-footnote/default.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-WUMgm1hwsU9BeheLfb8Di0AfvVQ6j92kXxH2SyG3ses=";
   };
 
-  cargoHash = "sha256-Ig+uVCO5oHIkkvFsKiBiUFzjUgH/Pydn4MVJHb2wKGc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3tuejWMZlEAOgnBKEqZP2a72a8QP1yamfE/g2BJDEbg=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 

--- a/pkgs/tools/text/mdbook-katex/default.nix
+++ b/pkgs/tools/text/mdbook-katex/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-O2hFv/9pqrs8cSDvHLAUnXx4mX6TN8hvPLroWgoCgwE=";
   };
 
-  cargoHash = "sha256-ONZZ6D0Ien0wakjhy6P2lhx0AnRLH0xpuYon+N9Crg8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-EoWsjuvvWeAI3OnVRJQT2hwoYq4BNqqvitH9LT0XGnA=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 

--- a/pkgs/tools/text/mdbook-mermaid/default.nix
+++ b/pkgs/tools/text/mdbook-mermaid/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-hqz2zUdDZjbe3nq4YpL68XJ64qpbjANag9S2uAM5nXg=";
   };
 
-  cargoHash = "sha256-KrvrmodsoAvNxjJqdKTXva32dtlKINPGHwfxcK1VDwY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-yb4EWSl/mQp5q9fmYUq6UEdsknqfUx//BZ8IK/BVs7g=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
     CoreServices

--- a/pkgs/tools/text/mdbook-pdf/default.nix
+++ b/pkgs/tools/text/mdbook-pdf/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-zRoO84ij7zF1I8ijXS/oApMKfS3e04+5/CgahAemqCA=";
   };
 
-  cargoHash = "sha256-eay3tl4edeM05D+0iIu8Zw4L1N2Bk1csLo0AwNdyCdA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-cZNTfhrpuEoAXviog/qq2PWii/wycxxq5l/vFHW1f6k=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/tools/text/mdbook-plantuml/default.nix
+++ b/pkgs/tools/text/mdbook-plantuml/default.nix
@@ -29,7 +29,8 @@ rustPlatform.buildRustPackage rec {
     })
   ];
 
-  cargoHash = "sha256-3HlnhRexfFcAuk1RoatWORMJvYRrnoEft5ys6j3t9S0=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-JI5UdLb2ZcPcAIvprVdpQRGMzc0Qu0awIUpMjNyaAPQ=";
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/tools/text/mdbook-toc/default.nix
+++ b/pkgs/tools/text/mdbook-toc/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-OFNp+kFDafYbzqb7xfPTO885cAjgWfNeDvUPDKq5GJU=";
   };
 
-  cargoHash = "sha256-95W0gERjwL9r0+DOgxQu+sjSFSThWeShLAqlDQiGxFw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-0x/x3TRwRinQ/uLCQoRrJOE/mc2snkL/MCz76nQqb5E=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ CoreServices ];
 

--- a/pkgs/tools/text/mdcat/default.nix
+++ b/pkgs/tools/text/mdcat/default.nix
@@ -39,7 +39,8 @@ rustPlatform.buildRustPackage rec {
       SystemConfiguration
     ];
 
-  cargoHash = "sha256-TvGGu9mSKT5y4b2JuoUUxsK8J7W/bMa9MOe1y0Idy7g=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-8A0RLbFkh3fruZAbjJzipQvuFLchqIRovPcc6MSKdOc=";
 
   nativeCheckInputs = [ ansi2html ];
   # Skip tests that use the network and that include files.

--- a/pkgs/tools/text/pinyin-tool/default.nix
+++ b/pkgs/tools/text/pinyin-tool/default.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "1gwqwxlvdrm4sdyqkvpvvfi6jh6qqn6qybn0z66wm06k62f8zj5b";
   };
 
-  cargoHash = "sha256-jeRKtKv8Lg/ritl42dMbEQpXaNlCIaHTrw0xtPQitMc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-SOeyk2uWCdO99ooQc2L1eXlV77lR4DLBK6PnV6Ur49A=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ Security ];
 

--- a/pkgs/tools/text/ruplacer/default.nix
+++ b/pkgs/tools/text/ruplacer/default.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-Zvbb9pQpxbJZi0qcDU6f2jEgavl9cA7gIYU7NRXZ9fc=";
   };
 
-  cargoHash = "sha256-vdq2nEFhvteQEqEZNbSegivvkU6cTxSmZLc6oaxLkwY=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Ko6EBASK6olMyp0kDY4wgfpH+5j9vq0dJ74l8K6HPGY=";
 
   meta = {
     description = "Find and replace text in source files";

--- a/pkgs/tools/typesetting/tex/texpresso/tectonic.nix
+++ b/pkgs/tools/typesetting/tex/texpresso/tectonic.nix
@@ -14,7 +14,8 @@ tectonic-unwrapped.override (old: {
             hash = "sha256-RPsXmp+5MF9h+H3wdL1O1hXSRZWjWTY8lXq/dWZIM1g=";
             fetchSubmodules = true;
           };
-          cargoHash = "sha256-g4iBo8r+QUOcFJ3CI2+HOi4VHxU7jKnIWlJcKx/6r5E=";
+          useFetchCargoVendor = true;
+          cargoHash = "sha256-mqhbIv5r/5EDRDfP2BymXv9se2NCKxzRGqNqwqbD9A0=";
           # binary has a different name, bundled tests won't work
           doCheck = false;
           meta.mainProgram = "texpresso-tonic";

--- a/pkgs/tools/video/yaydl/default.nix
+++ b/pkgs/tools/video/yaydl/default.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-mMV7fnl3tEM22LCTLXoXG9RQhPSQ7DXanSURdoa0+EI=";
   };
 
-  cargoHash = "sha256-HsRg8SO9c9Fomeb5B+kOW3VDNIG4W+dagEwAoWqONyA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-YWJfmC1wrl1MXXbWx2N9y//a7Jn+3rDrUseSBWkctvc=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.

It should be possible to reproduce this diff.  To generate it, I first ran:

	xargs sed -i 's/^\(. *\)\(cargoHash =\)/\1useFetchCargoVendor = true;\n\1cargoHash =/'

The following manually identified list of files were given as standard input:

<details>
<summary>Input</summary>

	pkgs/applications/audio/listenbrainz-mpd/default.nix
	pkgs/applications/audio/minidsp/default.nix
	pkgs/applications/audio/muso/default.nix
	pkgs/applications/audio/parrot/default.nix
	pkgs/applications/blockchains/electrs/default.nix
	pkgs/applications/blockchains/snarkos/default.nix
	pkgs/applications/blockchains/teos/default.nix
	pkgs/applications/blockchains/zcash/default.nix
	pkgs/applications/display-managers/greetd/default.nix
	pkgs/applications/display-managers/greetd/regreet.nix
	pkgs/applications/display-managers/greetd/tuigreet.nix
	pkgs/applications/display-managers/greetd/wlgreet.nix
	pkgs/applications/editors/emacs/elisp-packages/manual-packages/lspce/module.nix
	pkgs/applications/editors/neovim/gnvim/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/LanguageClient-neovim/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/avante-nvim/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/codesnap-nvim/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/cord-nvim/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/nvim-spectre/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/sg-nvim/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/sniprun/default.nix
	pkgs/applications/editors/vim/plugins/non-generated/vim-markdown-composer/default.nix
	pkgs/applications/editors/vscode/extensions/vadimcn.vscode-lldb/adapter.nix
	pkgs/applications/editors/zee/default.nix
	pkgs/applications/gis/whitebox-tools/default.nix
	pkgs/applications/graphics/emulsion/default.nix
	pkgs/applications/graphics/menyoki/default.nix
	pkgs/applications/misc/binocle/default.nix
	pkgs/applications/misc/cobalt/default.nix
	pkgs/applications/misc/eureka-ideas/default.nix
	pkgs/applications/misc/inherd-quake/default.nix
	pkgs/applications/misc/inlyne/default.nix
	pkgs/applications/misc/klipper-estimator/default.nix
	pkgs/applications/misc/mdzk/default.nix
	pkgs/applications/misc/pastel/default.nix
	pkgs/applications/misc/pomodoro/default.nix
	pkgs/applications/misc/pueue/default.nix
	pkgs/applications/misc/reddsaver/default.nix
	pkgs/applications/misc/stork/default.nix
	pkgs/applications/misc/terminal-typeracer/default.nix
	pkgs/applications/networking/browsers/asuka/default.nix
	pkgs/applications/networking/feedreaders/tuifeed/default.nix
	pkgs/applications/networking/geph/default.nix
	pkgs/applications/networking/gopher/phetch/default.nix
	pkgs/applications/networking/instant-messengers/twitch-tui/default.nix
	pkgs/applications/networking/irc/tiny/default.nix
	pkgs/applications/networking/mhost/default.nix
	pkgs/applications/networking/mujmap/default.nix
	pkgs/applications/networking/p2p/synapse-bt/default.nix
	pkgs/applications/office/activitywatch/default.nix
	pkgs/applications/science/machine-learning/finalfrontier/default.nix
	pkgs/applications/science/machine-learning/finalfusion-utils/default.nix
	pkgs/applications/science/misc/rink/default.nix
	pkgs/applications/system/coolercontrol/coolercontrol-gui.nix
	pkgs/applications/version-management/gfold/default.nix
	pkgs/applications/version-management/git-absorb/default.nix
	pkgs/applications/version-management/git-branchless/default.nix
	pkgs/applications/version-management/git-cliff/default.nix
	pkgs/applications/version-management/git-credential-keepassxc/default.nix
	pkgs/applications/version-management/git-gone/default.nix
	pkgs/applications/version-management/git-quickfix/default.nix
	pkgs/applications/version-management/git-stack/default.nix
	pkgs/applications/version-management/git-trim/default.nix
	pkgs/applications/version-management/git-workspace/default.nix
	pkgs/applications/version-management/gitoxide/default.nix
	pkgs/applications/version-management/lucky-commit/default.nix
	pkgs/applications/virtualization/crosvm/default.nix
	pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix
	pkgs/applications/window-managers/dwm/dwm-status.nix
	pkgs/applications/window-managers/i3/auto-layout.nix
	pkgs/applications/window-managers/i3/cycle-focus.nix
	pkgs/applications/window-managers/i3/i3-ratiosplit.nix
	pkgs/applications/window-managers/i3/status-rust.nix
	pkgs/applications/window-managers/i3/wmfocus.nix
	pkgs/applications/window-managers/i3/wsr.nix
	pkgs/build-support/mitm-cache/default.nix
	pkgs/development/compilers/gleam/default.nix
	pkgs/development/compilers/kind2/default.nix
	pkgs/development/embedded/fpga/ecpdap/default.nix
	pkgs/development/interpreters/evcxr/default.nix
	pkgs/development/interpreters/wasmer/default.nix
	pkgs/development/interpreters/wasmtime/default.nix
	pkgs/development/tools/analysis/dotenv-linter/default.nix
	pkgs/development/tools/build-managers/fac/default.nix
	pkgs/development/tools/build-managers/moon/default.nix
	pkgs/development/tools/cocogitto/default.nix
	pkgs/development/tools/continuous-integration/buildkite-test-collector-rust/default.nix
	pkgs/development/tools/database/dynein/default.nix
	pkgs/development/tools/database/indradb/default.nix
	pkgs/development/tools/database/surrealdb-migrations/default.nix
	pkgs/development/tools/dump_syms/default.nix
	pkgs/development/tools/fnm/default.nix
	pkgs/development/tools/geckodriver/default.nix
	pkgs/development/tools/git-ps-rs/default.nix
	pkgs/development/tools/gptcommit/default.nix
	pkgs/development/tools/graphql-client/default.nix
	pkgs/development/tools/hors/default.nix
	pkgs/development/tools/htmlq/default.nix
	pkgs/development/tools/jless/default.nix
	pkgs/development/tools/kdash/default.nix
	pkgs/development/tools/kubie/default.nix
	pkgs/development/tools/misc/dura/default.nix
	pkgs/development/tools/misc/pwninit/default.nix
	pkgs/development/tools/misc/texlab/default.nix
	pkgs/development/tools/misc/tokei/default.nix
	pkgs/development/tools/pactorio/default.nix
	pkgs/development/tools/parsing/tree-sitter/default.nix
	pkgs/development/tools/perseus-cli/default.nix
	pkgs/development/tools/py-spy/default.nix
	pkgs/development/tools/rbspy/default.nix
	pkgs/development/tools/remodel/default.nix
	pkgs/development/tools/rover/default.nix
	pkgs/development/tools/rover/update.sh
	pkgs/development/tools/rubyfmt/default.nix
	pkgs/development/tools/rust/bindgen/unwrapped.nix
	pkgs/development/tools/rust/cargo-audit/default.nix
	pkgs/development/tools/rust/cargo-bazel/default.nix
	pkgs/development/tools/rust/cargo-c/default.nix
	pkgs/development/tools/rust/cargo-cache/default.nix
	pkgs/development/tools/rust/cargo-clone/default.nix
	pkgs/development/tools/rust/cargo-codspeed/default.nix
	pkgs/development/tools/rust/cargo-crev/default.nix
	pkgs/development/tools/rust/cargo-cyclonedx/default.nix
	pkgs/development/tools/rust/cargo-edit/default.nix
	pkgs/development/tools/rust/cargo-flamegraph/default.nix
	pkgs/development/tools/rust/cargo-fund/default.nix
	pkgs/development/tools/rust/cargo-hf2/default.nix
	pkgs/development/tools/rust/cargo-lambda/default.nix
	pkgs/development/tools/rust/cargo-ndk/default.nix
	pkgs/development/tools/rust/cargo-outdated/default.nix
	pkgs/development/tools/rust/cargo-udeps/default.nix
	pkgs/development/tools/rust/cargo-vet/default.nix
	pkgs/development/tools/rust/cargo-watch/default.nix
	pkgs/development/tools/rust/cargo-whatfeatures/default.nix
	pkgs/development/tools/rust/cargo-zigbuild/default.nix
	pkgs/development/tools/rust/duckscript/default.nix
	pkgs/development/tools/rust/rustup/default.nix
	pkgs/development/tools/rust/sqlx-cli/default.nix
	pkgs/development/tools/sentry-cli/default.nix
	pkgs/development/tools/spr/default.nix
	pkgs/development/tools/viceroy/default.nix
	pkgs/development/tools/wrangler_1/default.nix
	pkgs/games/blightmud/default.nix
	pkgs/games/ferium/default.nix
	pkgs/kde/gear/akonadi-search/default.nix
	pkgs/kde/gear/angelfish/default.nix
	pkgs/kde/gear/kdepim-addons/default.nix
	pkgs/misc/cliscord/default.nix
	pkgs/misc/t-rec/default.nix
	pkgs/misc/wiki-tui/default.nix
	pkgs/os-specific/linux/scx/scx_rustscheds.nix
	pkgs/servers/bindle/default.nix
	pkgs/servers/dns/doh-proxy-rust/default.nix
	pkgs/servers/gemini/stargazer/default.nix
	pkgs/servers/geospatial/martin/default.nix
	pkgs/servers/krill/default.nix
	pkgs/servers/monitoring/laurel/default.nix
	pkgs/servers/monitoring/prometheus/wireguard-exporter.nix
	pkgs/servers/oxigraph/default.nix
	pkgs/servers/piping-server-rust/default.nix
	pkgs/servers/rtrtr/default.nix
	pkgs/servers/sql/postgresql/ext/pgvecto-rs/default.nix
	pkgs/servers/sql/postgresql/ext/pgx_ulid.nix
	pkgs/servers/sql/postgresql/ext/timescaledb_toolkit.nix
	pkgs/shells/nushell/default.nix
	pkgs/shells/nushell/plugins/dbus.nix
	pkgs/shells/nushell/plugins/formats.nix
	pkgs/shells/nushell/plugins/gstat.nix
	pkgs/shells/nushell/plugins/highlight.nix
	pkgs/shells/nushell/plugins/net.nix
	pkgs/shells/nushell/plugins/polars.nix
	pkgs/shells/nushell/plugins/query.nix
	pkgs/shells/nushell/plugins/skim.nix
	pkgs/shells/nushell/plugins/units.nix
	pkgs/tools/X11/xidlehook/default.nix
	pkgs/tools/admin/coldsnap/default.nix
	pkgs/tools/admin/procs/default.nix
	pkgs/tools/backup/awsbck/default.nix
	pkgs/tools/backup/bupstash/default.nix
	pkgs/tools/backup/monolith/default.nix
	pkgs/tools/backup/rdedup/default.nix
	pkgs/tools/misc/aoc-cli/default.nix
	pkgs/tools/misc/apkeep/default.nix
	pkgs/tools/misc/didyoumean/default.nix
	pkgs/tools/misc/dijo/default.nix
	pkgs/tools/misc/diskus/default.nix
	pkgs/tools/misc/eludris/default.nix
	pkgs/tools/misc/fclones/default.nix
	pkgs/tools/misc/fclones/gui.nix
	pkgs/tools/misc/ffsend/default.nix
	pkgs/tools/misc/flowgger/default.nix
	pkgs/tools/misc/gh-cal/default.nix
	pkgs/tools/misc/grex/default.nix
	pkgs/tools/misc/hiksink/default.nix
	pkgs/tools/misc/hyperfine/default.nix
	pkgs/tools/misc/iay/default.nix
	pkgs/tools/misc/jsonwatch/default.nix
	pkgs/tools/misc/killport/default.nix
	pkgs/tools/misc/lighthouse-steamvr/default.nix
	pkgs/tools/misc/lorri/default.nix
	pkgs/tools/misc/nvfancontrol/default.nix
	pkgs/tools/misc/octofetch/default.nix
	pkgs/tools/misc/owofetch/default.nix
	pkgs/tools/misc/rust-motd/default.nix
	pkgs/tools/misc/shadowenv/default.nix
	pkgs/tools/misc/sheldon/default.nix
	pkgs/tools/misc/starship/default.nix
	pkgs/tools/misc/synth/default.nix
	pkgs/tools/misc/tab-rs/default.nix
	pkgs/tools/misc/tmux-sessionizer/default.nix
	pkgs/tools/misc/toastify/default.nix
	pkgs/tools/misc/topgrade/default.nix
	pkgs/tools/misc/tremor-rs/default.nix
	pkgs/tools/misc/vrc-get/default.nix
	pkgs/tools/misc/wagyu/default.nix
	pkgs/tools/misc/watchexec/default.nix
	pkgs/tools/networking/bore-cli/default.nix
	pkgs/tools/networking/bore/default.nix
	pkgs/tools/networking/cocom/default.nix
	pkgs/tools/networking/drill/default.nix
	pkgs/tools/networking/fast-ssh/default.nix
	pkgs/tools/networking/ifwifi/default.nix
	pkgs/tools/networking/innernet/default.nix
	pkgs/tools/networking/lychee/default.nix
	pkgs/tools/networking/mozwire/default.nix
	pkgs/tools/networking/ockam/default.nix
	pkgs/tools/networking/onetun/default.nix
	pkgs/tools/networking/rosenpass/default.nix
	pkgs/tools/networking/s3rs/default.nix
	pkgs/tools/networking/shadowsocks-rust/default.nix
	pkgs/tools/networking/suckit/default.nix
	pkgs/tools/networking/wg-netmanager/default.nix
	pkgs/tools/nix/nixci/default.nix
	pkgs/tools/package-management/nix-du/default.nix
	pkgs/tools/package-management/nix-template/default.nix
	pkgs/tools/security/age-plugin-ledger/default.nix
	pkgs/tools/security/feroxbuster/default.nix
	pkgs/tools/security/genpass/default.nix
	pkgs/tools/security/gpg-tui/default.nix
	pkgs/tools/security/kbs2/default.nix
	pkgs/tools/security/lethe/default.nix
	pkgs/tools/security/rblake2sum/default.nix
	pkgs/tools/security/rblake3sum/default.nix
	pkgs/tools/security/rucredstash/default.nix
	pkgs/tools/security/rustscan/default.nix
	pkgs/tools/security/solo2-cli/default.nix
	pkgs/tools/text/amber/default.nix
	pkgs/tools/text/chars/default.nix
	pkgs/tools/text/coloursum/default.nix
	pkgs/tools/text/diffr/default.nix
	pkgs/tools/text/fastmod/default.nix
	pkgs/tools/text/igrep/default.nix
	pkgs/tools/text/languagetool-rust/default.nix
	pkgs/tools/text/mdbook-admonish/default.nix
	pkgs/tools/text/mdbook-epub/default.nix
	pkgs/tools/text/mdbook-footnote/default.nix
	pkgs/tools/text/mdbook-katex/default.nix
	pkgs/tools/text/mdbook-mermaid/default.nix
	pkgs/tools/text/mdbook-pdf/default.nix
	pkgs/tools/text/mdbook-plantuml/default.nix
	pkgs/tools/text/mdbook-toc/default.nix
	pkgs/tools/text/mdcat/default.nix
	pkgs/tools/text/pinyin-tool/default.nix
	pkgs/tools/text/ruplacer/default.nix
	pkgs/tools/typesetting/tex/texpresso/tectonic.nix
	pkgs/tools/video/yaydl/default.nix

</details>

Then I ran:

	xargs -n 1 nix-update --version=skip

With this list of attributes corresponding to the changed files given as standard input:

<details>
<summary>Input</summary>

	listenbrainz-mpd
	minidsp
	muso
	parrot
	electrs
	snarkos
	teos
	teos-watchtower-plugin
	zcash
	greetd.greetd
	greetd.regreet
	greetd.tuigreet
	greetd.wlgreet
	emacsPackages.lspce.lspce-module
	gnvim.unwrapped
	vimPlugins.LanguageClient-neovim.LanguageClient-neovim-bin
	vimPlugins.avante-nvim.avante-nvim-lib
	vimPlugins.codesnap-nvim.codesnap-lib
	vimPlugins.cord-nvim.cord-nvim-rust
	vimPlugins.nvim-spectre.spectre_oxi
	vimPlugins.sg-nvim.sg-nvim-rust
	vimPlugins.sniprun.sniprun-bin
	vimPlugins.vim-markdown-composer.vim-markdown-composer-bin
	vscode-extensions.vadimcn.vscode-lldb.adapter
	zee
	whitebox-tools
	emulsion
	menyoki
	binocle
	cobalt
	eureka-ideas
	inherd-quake
	inlyne
	klipper-estimator
	mdzk
	pastel
	pomodoro
	pueue
	reddsaver
	stork
	terminal-typeracer
	asuka
	tuifeed
	geph.cli
	phetch
	twitch-tui
	tiny
	mhost
	mujmap
	synapse-bt
	aw-server-rust
	finalfrontier
	finalfusion-utils
	rink
	coolercontrol.coolercontrol-gui
	gfold
	git-absorb
	git-branchless
	git-cliff
	git-credential-keepassxc
	git-gone
	git-quickfix
	git-stack
	git-trim
	git-workspace
	gitoxide
	lucky-commit
	crosvm
	rust-hypervisor-firmware
	dwm-status
	i3status-rust
	i3-auto-layout
	i3-cycle-focus
	i3-ratiosplit
	wmfocus
	i3wsr
	mitm-cache
	gleam
	kind2
	ecpdap
	evcxr
	wasmer
	wasmtime
	dotenv-linter
	fac-build
	moon
	cocogitto
	buildkite-test-collector-rust
	dynein
	indradb-client
	indradb-server
	surrealdb-migrations
	dump_syms
	fnm
	geckodriver
	git-ps-rs
	gptcommit
	graphql-client
	hors
	htmlq
	jless
	kdash
	kubie
	dura
	pwninit
	texlab
	tokei
	pactorio
	tree-sitter
	perseus-cli
	py-spy
	rbspy
	remodel
	rover
	rover
	rubyfmt
	rust-bindgen-unwrapped
	cargo-audit
	cargo-bazel
	cargo-c
	cargo-cache
	cargo-clone
	cargo-codspeed
	cargo-crev
	cargo-cyclonedx
	cargo-edit
	cargo-flamegraph
	cargo-fund
	cargo-hf2
	cargo-lambda
	cargo-ndk
	cargo-outdated
	cargo-udeps
	cargo-vet
	cargo-watch
	cargo-whatfeatures
	cargo-zigbuild
	duckscript
	rustup
	sqlx-cli
	sentry-cli
	spr
	viceroy
	wrangler_1
	blightmud
	ferium
	kdePackages.akonadi-search
	kdePackages.angelfish
	kdePackages.kdepim-addons
	cliscord
	t-rec
	wiki-tui
	scx.rustscheds
	bindle
	doh-proxy-rust
	stargazer
	martin
	krill
	laurel
	prometheus-wireguard-exporter
	oxigraph
	piping-server-rust
	rtrtr
	postgresql16Packages.pgvecto-rs
	postgresql16Packages.pgx_ulid
	postgresql16Packages.timescaledb_toolkit
	nushell
	nushellPlugins.dbus
	nushellPlugins.formats
	nushellPlugins.gstat
	nushellPlugins.highlight
	nushellPlugins.net
	nushellPlugins.polars
	nushellPlugins.query
	nushellPlugins.skim
	nushellPlugins.units
	xidlehook
	coldsnap
	procs
	awsbck
	bupstash
	monolith
	rdedup
	aoc-cli
	apkeep
	didyoumean
	dijo
	diskus
	eludris
	fclones
	fclones-gui
	ffsend
	flowgger
	gh-cal
	grex
	hiksink
	hyperfine
	iay
	jsonwatch
	killport
	lighthouse-steamvr
	lorri
	nvfancontrol
	octofetch
	owofetch
	rust-motd
	shadowenv
	sheldon
	starship
	synth
	tab-rs
	tmux-sessionizer
	toastify
	topgrade
	tremor-rs
	vrc-get
	wagyu
	watchexec
	bore-cli
	bore
	cocom
	drill
	fast-ssh
	ifwifi
	innernet
	lychee
	mozwire
	ockam
	onetun
	rosenpass
	s3rs
	shadowsocks-rust
	suckit
	wg-netmanager
	nixci
	nix-du
	nix-template
	age-plugin-ledger
	feroxbuster
	genpass
	gpg-tui
	kbs2
	lethe
	rblake2sum
	rblake3sum
	rucredstash
	rustscan
	solo2-cli
	amber
	chars
	coloursum
	diffr
	fastmod
	igrep
	languagetool-rust
	mdbook-admonish
	mdbook-epub
	mdbook-footnote
	mdbook-katex
	mdbook-mermaid
	mdbook-pdf
	mdbook-plantuml
	mdbook-toc
	mdcat
	pinyin-tool
	ruplacer
	texpresso.tectonic
	yaydl

</details>

The list of files for the first command and the list of attributes for the second command are in the same order, so it should be easy enough to check their correspondence by putting them side by side.

It might be possible to parallelize the nix-update operations using xargs' -P option.  I haven't tested it.

This is obviously very prone to merge conflicts. When merge conflicts appear, I'll just drop them from this patch and we can revisit them in a future one.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
