### PR TITLE
Revert "check-meta: Expose checkValidity and add to all-packages"

### DIFF
--- a/pkgs/stdenv/generic/check-meta.nix
+++ b/pkgs/stdenv/generic/check-meta.nix
@@ -517,4 +517,4 @@ let
         );
   };
 
-in { inherit assertValidity commonMeta checkValidity; }
+in { inherit assertValidity commonMeta; }

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -213,8 +213,6 @@ with pkgs;
       }
     '');
 
-  checkMeta = callPackage ../stdenv/generic/check-meta.nix { };
-
   # addDriverRunpath is the preferred package name, as this enables
   # many more scenarios than just opengl now.
   anime-downloader = callPackage ../applications/video/anime-downloader { };


### PR DESCRIPTION
Reverts NixOS/nixpkgs#339597

Breaks eval. Feel free to reapply once fixed.