### PR TITLE
treewide: migrate to fetchCargoVendor, batch 3

### DIFF
--- a/pkgs/by-name/_3/_389-ds-base/package.nix
+++ b/pkgs/by-name/_3/_389-ds-base/package.nix
@@ -49,11 +49,11 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-OPtyeF1D46X6DslP3NewbjVgqPXngWUz943UsTqgWRo=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/src";
     name = "389-ds-base-${finalAttrs.version}";
-    hash = "sha256-xI0T+Riw+6gjBGVYg5SI3GWH7MyAzt5At54fI7PH010=";
+    hash = "sha256-8A2xnJI22mjupX5FVsvRa5RfWyOE+VLH2aJwBHjDOME=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/am/amberol/package.nix
+++ b/pkgs/by-name/am/amberol/package.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-FK0TJFjknEFraY8T+PQ/ABiid36kEYIEhekgyx0y3aI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "amberol-${version}";
-    hash = "sha256-9YRd1iOh+l+Jy8eSwJP6pxonEofBkMpFqb+JAAFDbCA=";
+    hash = "sha256-OsQMiye/sUsnmfx2V49ZUMGS/HQH9m9i5/qvho0jTD8=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/as/ashpd-demo/package.nix
+++ b/pkgs/by-name/as/ashpd-demo/package.nix
@@ -30,9 +30,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-fIyJEUcyTcjTbBycjuJb99wALQelMT7Zq6PHKcL2F80=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = "${finalAttrs.src}/ashpd-demo";
-    hash = "sha256-ldflCBErM9w3eO2DwWfYTrdO7lowZtqfj7Fft6Crl1w=";
+    hash = "sha256-iluV24uSEHDcYi6pO2HNrKs4ShwFvZ/ryv8ioopaNMI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/au/audio-sharing/package.nix
+++ b/pkgs/by-name/au/audio-sharing/package.nix
@@ -32,10 +32,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-yUMiy5DaCPfCmBIGCXpqtvSSmQl5wo6vsLdW7Tt/Wfo=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-FfjSttXf6WF2w59CP6L/+BIuuXp2yKPTku7FMvdIHg0=";
+    hash = "sha256-ePgEAVYXLOHWQXG92Grb9nmenyGj0JkgVy1UDsQF0xw=";
   };
 
   nativeBuildInputs =

--- a/pkgs/by-name/au/authenticator/package.nix
+++ b/pkgs/by-name/au/authenticator/package.nix
@@ -36,10 +36,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-g4+ntBuAEH9sj61CiS5t95nMfCgaWJTgiwRXtwrUTs0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-XNAC1eA+11gAvMRu95huRM+YHdsrg5Sqpzb6F3Rgu5U=";
+    hash = "sha256-fG0xABK/qzoACFEYhMeDF6Qbucx0FCPpuTuInDFHnu8=";
   };
 
   preFixup = ''

--- a/pkgs/by-name/bc/bcachefs-tools/package.nix
+++ b/pkgs/by-name/bc/bcachefs-tools/package.nix
@@ -70,9 +70,9 @@ stdenv.mkDerivation (finalAttrs: {
     udev
   ] ++ lib.optional fuseSupport fuse3;
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
-    hash = "sha256-rO4AjCnxmHQPk0hxgXK4yxUK5eag/+Q+fRG/BsRi0i0=";
+    hash = "sha256-xP3V3Cqb+F33I1fVhp7ru/qBl22ww4oZDUCb1OHBiag=";
   };
 
   makeFlags = [

--- a/pkgs/by-name/bu/bustle/package.nix
+++ b/pkgs/by-name/bu/bustle/package.nix
@@ -31,9 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-5ZZiRD64OOMtTNxI0uvilGM22rsJv7vU3yPDY8ROrxU=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-tUSGldWeCLEHi35bDLMnfjnfofF2Qse5uBu2mDGJrsE=";
+    hash = "sha256-XCKKzgSqTGF9WoaYnNtXB7e8BvtElmAfKH6s/7h8cGs=";
   };
 
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {

--- a/pkgs/by-name/ca/cargo-tauri_1/package.nix
+++ b/pkgs/by-name/ca/cargo-tauri_1/package.nix
@@ -26,14 +26,14 @@ cargo-tauri.overrideAttrs (
     # https://discourse.nixos.org/t/difficulty-using-buildrustpackage-with-a-src-containing-multiple-cargo-workspaces/10202
     sourceRoot = "${newAttrs.src.name}/tooling/cli";
 
-    cargoDeps = rustPlatform.fetchCargoTarball {
+    cargoDeps = rustPlatform.fetchCargoVendor {
       inherit (newAttrs)
         pname
         version
         src
         sourceRoot
         ;
-      hash = "sha256-OIXC4kwGIemIL8KaqK5SUDZZrOX3PX0w3h9bNiM/pCw=";
+      hash = "sha256-t5sR02qC06H7A2vukwyZYKA2XMVUzJrgIOYuNSf42mE=";
     };
 
     buildInputs =

--- a/pkgs/by-name/ca/cartero/package.nix
+++ b/pkgs/by-name/ca/cartero/package.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-fXFrxaqHgf7XWX1guySsaP6PxmAPwVxoPaEOTpz4OqY=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-hbByC2r48+Zm/On99m9VWj4TJi6aeM/km2vcfvMMz38=";
+    hash = "sha256-+HygFNqW2CDksFTX9qdac6615zxCav0/sNLbICwTaKw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/cc/ccextractor/package.nix
+++ b/pkgs/by-name/cc/ccextractor/package.nix
@@ -48,12 +48,12 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoRoot = "src/rust";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
     patches = [ ./use-rsmpeg-0.15.patch ];
     patchFlags = [ "-p3" ];
-    hash = "sha256-jh8hHKAad+tCJGwuGdoJp/TMm/IsMrZmz8aag9lj0BA=";
+    hash = "sha256-7v3gQghByUDWZLJRRGa/7X2ivUumirq6BbexNQcCXCk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ch/chance/package.nix
+++ b/pkgs/by-name/ch/chance/package.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-25+/TvTba/QF7+QE8+O7u4yc9BNi0pcZeNj11dGkEfg=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-Jy/Tc5Rmqh6NIcLzGSIxQg1dLiAkw+xbrdo6qfqrRSg=";
+    hash = "sha256-ObT3l/Exk6UzUGmzCed7mJ7hVzg8CsQIT3fe1RIUfIM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ch/chromatic/package.nix
+++ b/pkgs/by-name/ch/chromatic/package.nix
@@ -33,11 +33,11 @@ stdenv.mkDerivation rec {
     ./rustc_serialize_update.patch
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
     patches = [ ./rustc_serialize_update.patch ];
-    hash = "sha256-1Zb0J2tO/gIifDymmoXxZf6RNV8foE9QiQqZcrHrWzE=";
+    hash = "sha256-9fdOOkxs4L0sYZIRT9wbgp169mQc2IyFRZlAcOHcOcg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ci/citations/package.nix
+++ b/pkgs/by-name/ci/citations/package.nix
@@ -34,9 +34,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-WYy6cyPmyWL/11yHf+dRbcZGBfvVfELeTwKvpJMu5ns=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
-    hash = "sha256-SmKt3oPzeJRAFjgZvJubNCTsjhqCrGZfE1LfDQ8AxZA=";
+    hash = "sha256-bqZZIA7sE0viAhI5GUFIVCXTkK+U9aWPvCPCug5SR94=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/co/contrast/package.nix
+++ b/pkgs/by-name/co/contrast/package.nix
@@ -32,10 +32,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-8A1qX1H0cET5AUvMoHC1/VyIQiaTysEY5RJRrVYvGng=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-Z5Gn1J/ziDlSowUk3HYLdx1PDg0WlQJQDjto2xYYK44=";
+    hash = "sha256-Nj5MkYDeYUzgqegCbPt/XofSCw8ULFXAD7XHNecPznc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/de/delfin/package.nix
+++ b/pkgs/by-name/de/delfin/package.nix
@@ -32,10 +32,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-2ussvPXMX4wGE9N+Zh8KYIjbbqEKkPaNymN1Oqj8w8U=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-JEHiLdEU9QkCxWPoTFVn2c6UDqnRbTG1WPetdsW/N8g=";
+    hash = "sha256-zZc2+0oskptpWZE4fyVcR4QHxqzpj71GXMXNXMK4an0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/di/diebahn/package.nix
+++ b/pkgs/by-name/di/diebahn/package.nix
@@ -34,9 +34,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-jk2Pn/kqjMx5reMkIL8nLMWMZylwdoVq4FmnzaohnjU=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-UE+N6cvcWVJTxE8m4hHmBLyd5RBecDQy1kR4zDzPyf0=";
+    hash = "sha256-WiFW+xz5kxFKe9y8vHaFD9xW7f9iHc9hyCBWW4uMquU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/do/done/package.nix
+++ b/pkgs/by-name/do/done/package.nix
@@ -31,10 +31,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-SbeP7PnJd7jjdXa9uDIAlMAJLOrYHqNP5p9gQclb6RU=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-YJJGQR1tkK5z7vQQgkd8xPSqYhtiZIN+s9Xnwjn0z5A=";
+    hash = "sha256-yEpaQa9hKOq0k9MurihbFM4tDB//TPCJdOgKA9tyqVc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/em/emblem/package.nix
+++ b/pkgs/by-name/em/emblem/package.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-pW+2kQANZ9M1f0jMoBqCxMjLCu0xAnuEE2EdzDq4ZCE=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-2mxDXDGQA2YB+gnGwy6VSZP/RRBKg0RiR1GlXIkio9E=";
+    hash = "sha256-j9PrnXt0GyyfCKmcq1zYmDNlrvogtK5n316MIC+z+w0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/en/envision-unwrapped/package.nix
+++ b/pkgs/by-name/en/envision-unwrapped/package.nix
@@ -48,13 +48,13 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version;
     # TODO: Use srcOnly instead
     src = applyPatches {
       inherit (finalAttrs) src patches;
     };
-    hash = "sha256-zWaw6K2H67PEmFISDNce5jDUXKV39qu35SO+Ai0DP90=";
+    hash = "sha256-O3+urY2FlnHfxoJLn4iehnVWf1Y0uATEteyQVnZLxTQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ey/eyedropper/package.nix
+++ b/pkgs/by-name/ey/eyedropper/package.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-FyGj0180Wn8iIDTdDqnNEvFYegwdWCsCq+hmyTTUIo4=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-jXo7Aq+pXWySe6MyH9GCTQVNwbboER7RwJe6Asqbxxc=";
+    hash = "sha256-nYmH7Nu43TDJKvwfSaBKSihD0acLPmIUQpQM6kV4CAk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fo/fontfinder/package.nix
+++ b/pkgs/by-name/fo/fontfinder/package.nix
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-C4KqEdqToVnPXFPWvNkl/md9L2W4NxRd5jvZ4E7CtfA=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-PXO8E41KHPNOR527gs2vM3J9JMG0PWi8Eg/13UCkr3U=";
+    hash = "sha256-g6PRGHrkHA0JTekKaQs+8mtyOCj99m0zPbgP8AnP7GU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fo/footage/package.nix
+++ b/pkgs/by-name/fo/footage/package.nix
@@ -38,10 +38,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-VEL96JrJ5eJEoX2miiB4dqGUXizNlYWCUZkkYkh09B8=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-RWMNeMrctIlcA4MiRx9t7OfzKeHtw3phrYsYFZH7z4c=";
+    hash = "sha256-H8sv7faI/qbmcP7ir++/vIpN+cvRQ254rXmAvGyjdsY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fr/fragments/package.nix
+++ b/pkgs/by-name/fr/fragments/package.nix
@@ -34,10 +34,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-lTOO6ZQWImaFqYZ3qerYYHWj/eOLYU/2k2Wh/ju9Njw=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-7TIjd1ewazJGY8uG6f1B97ol+7+uLjnZVGC2/2DlUdQ=";
+    hash = "sha256-i77LHbaAURxWrEpuR40jRkUGPk8wZR+q3DB+rzH3sEc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fr/fretboard/package.nix
+++ b/pkgs/by-name/fr/fretboard/package.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-8xINlVhWgg73DrRi8S5rhNc1sbG4DbWOsiEBjU8NSXo=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-LSL7VvRgA8MaFXn/vi5Zf1sY4cqv0a9PNnZ3JlDNIaE=";
+    hash = "sha256-wYDlJ5n878Apv+ywnHnDy1Rgn+WJtcuePsGYEWSNvs4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/fu/furtherance/package.nix
+++ b/pkgs/by-name/fu/furtherance/package.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-TxYARpCqqjjwinoRU2Wjihp+FYIvcI0YCGlOuumX6To=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-VGBxBHs/kqW0mvOiz0UQRg0duDmW8ee9cSh6EOT9aaY=";
+    hash = "sha256-SFp9YCmneOll2pItWmg2b2jrpRqPnvV9vwz4mjjvwM4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ga/gale/package.nix
+++ b/pkgs/by-name/ga/gale/package.nix
@@ -39,14 +39,14 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-xKg/ABUdtylFpT3EisXVvyv38++KjucrZ+s3/fFjzmM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs)
       pname
       version
       src
       cargoRoot
       ;
-    hash = "sha256-xaqNps2AimGWKSwtnfkP3RkLgTNlkaAUtOgDWpB2yEg=";
+    hash = "sha256-OocLkYAdmnAwvojzywNlg6BirkItoopX36aDYfqeeTA=";
   };
 
   cargoRoot = "src-tauri";

--- a/pkgs/by-name/ge/geopard/package.nix
+++ b/pkgs/by-name/ge/geopard/package.nix
@@ -26,9 +26,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-etx8YPEFGSNyiSLpTNIXTZZiLSgAntQsM93On7dPGI0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-YVbaXGGwQaqjUkA47ryW1VgJpZTx5ApRGdCcB5aA71M=";
+    hash = "sha256-FHYWpMmJvcHuAHr9fFKl1qIhJb32NJEA/0j3R6/mVgQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gg/gg-jj/package.nix
+++ b/pkgs/by-name/gg/gg-jj/package.nix
@@ -36,10 +36,10 @@ stdenv.mkDerivation (finalAttrs: {
   buildAndTestSubdir = "src-tauri";
 
   # FIXME: Switch back to cargoHash when https://github.com/NixOS/nixpkgs/issues/356811 is fixed
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
-    hash = "sha256-Lr/0GkWHvfDy/leRLxisuTzGPZYFo2beHq9UCl6XlDo=";
+    hash = "sha256-IyU8dqtQbKcoymTOP01givB1968MUNas2znqsdbcqdw=";
 
     nativeBuildInputs = [ yq ];
 

--- a/pkgs/by-name/gl/glide-media-player/package.nix
+++ b/pkgs/by-name/gl/glide-media-player/package.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-gmBXUj6LxC7VDH/ni8neYivysagqcbI/UCUq9Ly3D24=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-u41H746/nPX2PmpyweUp4Y9k+XIruazgMdU6B4ig708=";
+    hash = "sha256-5cohhm8/QP+vYzVf8iz3hLtu0ej7lQiHpDAC9I52+ME=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/gn/gnome-commander/package.nix
+++ b/pkgs/by-name/gn/gnome-commander/package.nix
@@ -40,9 +40,9 @@ stdenv.mkDerivation (finalAttrs: {
         '/share/gsettings-schemas/${finalAttrs.finalPackage.name}/glib-2.0/schemas'
   '';
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-Nx/e2H9NxCTj62xVDlKTpPdjlxAx2YAcQJh1kHByrd4=";
+    hash = "sha256-dOd/4n8G/zEsF0ClqhI2QBLosEz3uyzC9q5sHDVWAx4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-podcasts/package.nix
+++ b/pkgs/by-name/gn/gnome-podcasts/package.nix
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-KCjHT/4AeJ+RXCtawkhs6f4D8NCJotYIPk3tGr5YG9M=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-XTfKqKs7874ak7Lzscxw8E2qcnJOWMZaaol8TpIB6Vw=";
+    hash = "sha256-L9/PCYanv8AgxD/fkEsNXQA1Zyz2+ia88lVahg9IOdA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-robots/package.nix
+++ b/pkgs/by-name/gn/gnome-robots/package.nix
@@ -31,10 +31,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-K4BQcFrIPpOL56iREyYB62XHk/IJzX6RDGzWQphzBHg=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "gnome-robots-${finalAttrs.version}";
-    hash = "sha256-rn/rs0D2qKDYf8oxpegQalPQIVuT8rSrHTzeZqWGn44=";
+    hash = "sha256-7kwjpZJqAqqKlt6mOFyjaaxZ1Tr2WuhE72jwjCZpX9E=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/gn/gnome-solanum/package.nix
+++ b/pkgs/by-name/gn/gnome-solanum/package.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-Xf/b/9o6zHF1hjHSyAXb90ySoBj+DMMe31e6RfF8C4Y=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-POvKpwzi+bkEkfSDhi/vjs/ey+A2vNN5ta4Q7Ma/RBQ=";
+    hash = "sha256-jtMTW9tIf0UGbE9bJU31maub+o0agf0pDRO4s9QReyc=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/gr/granian/package.nix
+++ b/pkgs/by-name/gr/granian/package.nix
@@ -18,10 +18,10 @@ python3Packages.buildPythonApplication rec {
     hash = "sha256-OjyDwfp0d779oFQ7wUdR1eRPP35kcJa3wIdcYGrGGME=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-NiDGVQGKo+aku1is8OpRavuSalxLc5XfLai0XdtxUMA=";
+    hash = "sha256-jAjHvVyFhGGE/OwfusUE/GdrNrEgvh48lmC5tla4lhI=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/by-name/he/health/package.nix
+++ b/pkgs/by-name/he/health/package.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-PrNPprSS98yN8b8yw2G6hzTSaoE65VbsM3q7FVB4mds=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-8fa3fa+sFi5H+49B5sr2vYPkp9C9s6CcE0zv4xB8gww=";
+    hash = "sha256-eR1ZGtTZQNhofFUEjI7IX16sMKPJmAl7aIFfPJukecg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/he/helvum/package.nix
+++ b/pkgs/by-name/he/helvum/package.nix
@@ -28,10 +28,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-9vlzLPpyZ9qtCEbCDvYhWDcV+8T63ukdos1l2U6fD+E=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-Xebm3XlsO6kBoMnxJsOk/3SO7avVoaGqi2CVWBRzr88=";
+    hash = "sha256-rwhhbEaUg7IiszmJUFh4vQV7cYyyh3tqr1z4QgmwIDY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/id/identity/package.nix
+++ b/pkgs/by-name/id/identity/package.nix
@@ -36,9 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-h8/mWGuosBiQRpoW8rINJht/7UBVEnUnTKY5HBCAyw4=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-oO7l4zVKR93fFLqkY67DfzrAA9kUN06ov9ogwDuaVlE=";
+    hash = "sha256-YkbhZQUpe8ffBpHcYl7wjFgs3krAXlvHgcBdP/6uvek=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/im/impression/package.nix
+++ b/pkgs/by-name/im/impression/package.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-F2ZyATDKnUgEOAI++54fR6coJOr9rtyGm5TzsKzkDmg=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-H4x7D25UzDdAEad7QEsZZGLXhfiUupm3mTrNho+ShFo=";
+    hash = "sha256-mQyGQXEFmMkTvkZcniws/11u1RqnsxgNi9dvYn1Mx0o=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/in/intiface-central/package.nix
+++ b/pkgs/by-name/in/intiface-central/package.nix
@@ -25,11 +25,11 @@ flutterPackages.stable.buildFlutterApplication rec {
 
   pubspecLock = lib.importJSON ./pubspec.lock.json;
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     name = "${pname}-${version}-cargo-deps";
     inherit src;
     sourceRoot = "${src.name}/intiface-engine-flutter-bridge";
-    hash = "sha256-S3Yy0IIMiRUUpFNlLvS1PGwpvxePMB1sO5M6mpm1OgY=";
+    hash = "sha256-1j1maTrR7V/Tlu7uimTJuoEtxhn5Hn0VmR0GnJuKIoo=";
   };
   cargoRoot = "intiface-engine-flutter-bridge";
 

--- a/pkgs/by-name/ip/iplan/package.nix
+++ b/pkgs/by-name/ip/iplan/package.nix
@@ -24,10 +24,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-BIoxaE8c3HmvPjgj4wcZK9YFTZ0wr9338AIdYEoAiqs=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-p8ETWWvjtP9f/lc347ORPqTai5p/TWQCCMRe+c0FyFk=";
+    hash = "sha256-ATEm7RYfW9nYtTDAx580tvokVUIS7BL9mA65aEeJJvk=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/jo/jogger/package.nix
+++ b/pkgs/by-name/jo/jogger/package.nix
@@ -31,9 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-bju9XXMT6HRHG9QViO+FQCYQ+llrC+GP/AlIha0mxkM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-YCLIxKl4QCmqHx/WXwxpqOqIMx1Ab16QyAi+j542eoY=";
+    hash = "sha256-k4nUtFdwCWa8flSkOEQe7UqorpYPCGrcXHTvVOqoAQI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ka/kana/package.nix
+++ b/pkgs/by-name/ka/kana/package.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-/Ri723ub8LMlhbPObC83bay63JuWIQpgxAT5UUYuwZI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "kana-${version}";
-    hash = "sha256-Z7DpPe8/Tt8AcLjCwKbwzQTsLe6YvWBCG7DlDkkklew=";
+    hash = "sha256-3ODkAstBZQE3eqGmRUdm3xyCoBXV41hK4ndxeDK8+Yc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ke/key-rack/package.nix
+++ b/pkgs/by-name/ke/key-rack/package.nix
@@ -31,9 +31,9 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs --build build-aux/{checks.sh,read-manifest.py}
   '';
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-wCJTm0W+g3+O1t1fR4maqJoxpPM0NeJG7d54MMAH33c=";
+    hash = "sha256-iV9ILi3/Uqi8lDHh1Uf2caz6Kc129CDThnqTN9VfUHc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ke/keypunch/package.nix
+++ b/pkgs/by-name/ke/keypunch/package.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-C0WD8vBPlKvCJHVJHSfEbMIxNARoRrCn7PNebJ0rkoI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-RufJy5mHuirAO056p5/w63jw5h00E41t+H4VQP3kPks=";
+    hash = "sha256-SQ1BI9BuUfUvafsBnC1P5YQ8qVAaer6ywuRQkfS/V1w=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/ki/kime/package.nix
+++ b/pkgs/by-name/ki/kime/package.nix
@@ -45,9 +45,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-apQkxAUve7+2h9XACZZgroqBK1sCUYMNfsX/4nEnCPA=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-2MG6xigiKdvQX8PR457d6AXswTRPRJBPERvZqemjv24=";
+    hash = "sha256-U3SOHZvgyPwv98wY41dnwSCUg+DTkb/LY6woffrAli8=";
   };
 
   # Replace autostart path

--- a/pkgs/by-name/ko/kooha/package.nix
+++ b/pkgs/by-name/ko/kooha/package.nix
@@ -32,10 +32,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-Z+PMSV6fipfHBrqGS24SOgGJS173Vct12sVzCGZL0IA=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-m5y/VfjTJgK+/ZjsMo/9zPVxcV3kuwXb+HNdXR6hkV4=";
+    hash = "sha256-3LYoNQquYbyiEd9ZXRr4UPIcl3gultsBYWCWaCYshwQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/li/libkrun/package.nix
+++ b/pkgs/by-name/li/libkrun/package.nix
@@ -35,9 +35,9 @@ stdenv.mkDerivation (finalAttrs: {
     "dev"
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-oa3M/HL0hWoXlqY0Wxy9jf6hIvMqevtpuYiTCrS1Q74=";
+    hash = "sha256-X1NPZQaXFBw9IKD2DbBCPug0WDjv8XnpefbA2RNJgFU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/lo/lorem/package.nix
+++ b/pkgs/by-name/lo/lorem/package.nix
@@ -28,10 +28,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-6+kDKKK1bkIOZlqzKWpzpjAS5o7bkbVFITMZVmJijuU=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-nzP2Jp9l1QgL7Wk9SWlsSVNaeVe3t48MmeX7Xuz+PKM=";
+    hash = "sha256-l6vd521DmV019Yu5O1Kf5RKan2ROCBHlPiEDhf34Grc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/me/metronome/package.nix
+++ b/pkgs/by-name/me/metronome/package.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-Sn2Ua/XxPnJjcQvWeOPkphl+BE7/BdOrUIpf+tLt20U=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "metronome-${version}";
-    hash = "sha256-HYO/IY5yGW8JLBxD/SZz16GFnwvv77kFl/x+QXhV+V0=";
+    hash = "sha256-T/x5LpODpKWGA40W1je6jw1DS9attVUK4ZjAnRAyf6k=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mo/mousai/package.nix
+++ b/pkgs/by-name/mo/mousai/package.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-lib2rPUTKudzbZQIGZxxxzvWNlbLkLdWtb9h7+C05QE=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-KrOvPeT8zhxSTNDRJPrAbUnSgnIQegRmNe5TEgGE8+s=";
+    hash = "sha256-59mxTtXQaGiHHbS4vOtwm5py/1BWwaSf+CBdKEtUpno=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/mo/mozillavpn/package.nix
+++ b/pkgs/by-name/mo/mozillavpn/package.nix
@@ -56,9 +56,9 @@ stdenv.mkDerivation (finalAttrs: {
     vendorHash = "sha256-Cmo0wnl0z5r1paaEf1MhCPbInWeoMhGjnxCxGh0cyO8=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src patches;
-    hash = "sha256-ryJFvnJIiDKf2EqlzHj79hSPYrD+3UtZ5lT/QeFv6V0=";
+    hash = "sha256-EUD6eAhe5Qjom60EZ9LTRmBsfDyIJV1Kx7PBU4ikR0w=";
   };
 
   buildInputs = [

--- a/pkgs/by-name/no/notify-client/package.nix
+++ b/pkgs/by-name/no/notify-client/package.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-0p/XIGaawreGHbMRoHNmUEIxgwEgigtrubeJpndHsug=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-uZRAGnydPGwyzAyHIyY+UlT42m+GyEasM0cSa8Bp9Hs=";
+    hash = "sha256-hnv4XXsx/kmhH4YUTdTvvxxjbguHBx3TnUKacGwnCTw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pa/paleta/package.nix
+++ b/pkgs/by-name/pa/paleta/package.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-c+X49bMywstRg7cSAbbpG/vd8OUB7RhdQVRumTIBDDk=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-2/ZfKvlvAY4pfUU3F9pEw+OR5oRSsSAAi3/W5x4zVs0=";
+    hash = "sha256-RuzqU06iyK+IN7aO+Lq/IaRLh2oFpWM1rz69Koiicgg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pa/papers/package.nix
+++ b/pkgs/by-name/pa/papers/package.nix
@@ -64,14 +64,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   cargoRoot = "shell-rs";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs)
       src
       pname
       version
       cargoRoot
       ;
-    hash = "sha256-/5IySNEUkwiQezLx4n4jlPJdqJhlcgt5bXIelUFftZI=";
+    hash = "sha256-66pOdZxgzbvXkvF07rNvWtcF/dJ2+RuS24IeI/VWykE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/pd/pdns-recursor/package.nix
+++ b/pkgs/by-name/pd/pdns-recursor/package.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-s6N+uyAoWrmsu7DhNw5iO7OY7TCH8OZ48j/6OwBjmD0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     sourceRoot = "pdns-recursor-${finalAttrs.version}/settings/rust";
-    hash = "sha256-1CHhnW8s4AA06HAgW+A/mx1jGTynj4CvIc/I7n0h+VY";
+    hash = "sha256-/fxFqs5lDzOhatc6KBc7Zwsq3A7N5AOanGOebttr1l8=";
   };
 
   cargoRoot = "settings/rust";

--- a/pkgs/by-name/pi/pika-backup/package.nix
+++ b/pkgs/by-name/pi/pika-backup/package.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-DtLGD7+Ydj2fvEHU+bDQDMC/E/9VgrlVNMCG6OlPmfg=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-8nFkc77FiLxMA1hMm8k5VB84l+pQeL0JSzYDytXrNUE=";
+    hash = "sha256-1JFXSVs9HPPzh+IjH4RGugrZEifPVcQho9B3hLSTL6s=";
   };
 
   patches = [

--- a/pkgs/by-name/re/read-it-later/package.nix
+++ b/pkgs/by-name/re/read-it-later/package.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-A8u1fecJAsVlordgZmUJt/KZWxx6EWMhfdayKWHTTFY=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-wK7cegcjiu8i1Grey6ELoqAn2BrvElDXlCwafTLuFv0=";
+    hash = "sha256-DgqFdihMVKWMdbGEmyGH9yXkC9Ywmh7FcmFtLBCJeDc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/re/resonance/package.nix
+++ b/pkgs/by-name/re/resonance/package.nix
@@ -33,9 +33,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-DgNUjb8+2WTw91OGgFf97YL6lnODtkftYAP/c05RUPI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
-    hash = "sha256-/v3OokClOk95GOzidBHRkUG7kjHQm35yPeC1n3PzcyM=";
+    hash = "sha256-g0gNgTw9zpC9sWAKy/jFNGVtPH/6a84v6r6pRuS0NpU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/re/resources/package.nix
+++ b/pkgs/by-name/re/resources/package.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-SHawaH09+mDovFiznZ+ZkUgUbv5tQGcXBgUGrdetOcA=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "resources-${finalAttrs.version}";
-    hash = "sha256-tUD+gx9nQiGWKKRPcR7OHbPvU2j1dQjYck7FF9vYqSQ=";
+    hash = "sha256-zqCqbQAUAIhjntX4gcV1aoJwjozZFlF7Sr49w7uIgaI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ro/rofi-games/package.nix
+++ b/pkgs/by-name/ro/rofi-games/package.nix
@@ -23,9 +23,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-4L3gk/RG9g5QnUW1AJkZIl0VkBiO/L0HUBC3pibN/qo=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-cU7gp/c1yx3ZLaZuGs1bvOV4AKgLusraILVJ2EhH1iA=";
+    hash = "sha256-jTc4dAp7OogjYZWqtxVcjJc2sPozRLM5WcgMe7QS09s=";
   };
 
   patches = [

--- a/pkgs/by-name/ru/rustls-ffi/package.nix
+++ b/pkgs/by-name/ru/rustls-ffi/package.nix
@@ -25,10 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-ZKAyKcKwhnPE6PrfBFjLJKkTlGbdLcmW1EP/xSv2cpM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-IaOhQfDEgLhGmes0xzhLVym29aP691TY0EXdOIgXEMA=";
+    hash = "sha256-cZ92wSKoygt9x6O/ginOEiCiarlR5qGVFOHrIFdWOWE=";
   };
 
   propagatedBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/by-name/ru/rutabaga_gfx/package.nix
+++ b/pkgs/by-name/ru/rutabaga_gfx/package.nix
@@ -59,9 +59,9 @@ stdenv.mkDerivation (finalAttrs: {
       ]
     );
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-wuF3Isrp+u5J8jPQoPsIOWYGNKLSNa2pLfvladAWkLs=";
+    hash = "sha256-53xCzKuXtnnbS0TWdQrh4Rwy+V+D9soK41ycYd656Uc=";
   };
 
   CARGO_BUILD_TARGET = stdenv.hostPlatform.rust.rustcTargetSpec;

--- a/pkgs/by-name/sh/share-preview/package.nix
+++ b/pkgs/by-name/sh/share-preview/package.nix
@@ -27,10 +27,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-FqualaTkirB+gBcgkThQpSBHhM4iaXkiGujwBUnUX0E=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "share-preview-${finalAttrs.version}";
-    hash = "sha256-Gh6bQZD1mlkj3XeGp+fF/NShC4PZCZSEqymrsSdX4Ec=";
+    hash = "sha256-XY48fQ5HLvZ1nxLk6rbuxSBAHAPUcnwu/5AwgTWhfbg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sh/shortwave/package.nix
+++ b/pkgs/by-name/sh/shortwave/package.nix
@@ -38,10 +38,10 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-W1eOMyiooDesI13lOze/JcxzhSSxYOW6FOY85NkVyps=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-O5K5aNcWwUYkaJbGzTzS3FdNbEsQsdliyi0YShw+6PU=";
+    hash = "sha256-vtQRt8/eWwMA1+tKULpStLR7E1+R7LkNutS2Joz7zeI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sp/spot/package.nix
+++ b/pkgs/by-name/sp/spot/package.nix
@@ -35,9 +35,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-7zWK0wkh53ojnoznv4T/X//JeyKJVKOrfYF0IkvciIY=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-AaRmTOgFmBi0s1zdIVHc6bLjrUopy9YuB3GJOCnbjU4=";
+    hash = "sha256-731aD+yJkyrNMmYtgKYzXIAyLegDBzTT2XqZs5usXiI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sq/squeekboard/package.nix
+++ b/pkgs/by-name/sq/squeekboard/package.nix
@@ -34,10 +34,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-UsUr4UnYNo2ybEdNyOD/IiafEZ1YJFwRQ3CVy76X2H0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-1yBGn8cZxwpEOeF2BcUIIcI4Uxn80vRau/MvlufX9GU=";
+    hash = "sha256-3K1heokPYxYbiAGha9TrrjQXguzGv/djIB4eWa8dVjg=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/st/stratisd/package.nix
+++ b/pkgs/by-name/st/stratisd/package.nix
@@ -38,9 +38,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-W8ssLTFU36t6iLrt9S9V8qcN7EP4IsL7VbhNPLpftio=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-Qv2qknWNx2OQeucUFwL1veu3MSF+fd19jFfHCCVGprM=";
+    hash = "sha256-blhB+UfvG22Xe2O0csZ00/jgnVcLTUIkDJG5P22mffQ=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/su/surrealist/package.nix
+++ b/pkgs/by-name/su/surrealist/package.nix
@@ -69,10 +69,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./0001-Cargo.patch
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) patches src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
-    hash = "sha256-8rw3x17f5pLLyvxozFPWq9pJNHy4wXwV9CcaUGAbdd0=";
+    hash = "sha256-qrPIcWpdrvTmaFcfKAfz+n8a6lp6IcIMq9ZCHaa7AHQ=";
     patchFlags = [ "-p2" ];
   };
 

--- a/pkgs/by-name/sw/swayosd/package.nix
+++ b/pkgs/by-name/sw/swayosd/package.nix
@@ -29,9 +29,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-GyvRWEzTxQxTAk+xCLFsHdd1SttBliOgJ6eZqAxQMME=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-EUxJ+aGtYAO0kNggNXIZqj2DmPzc4serj0/V+fvH7ds=";
+    hash = "sha256-oeLhJwlOITp8YHJdZQY7oo8Z31WUT4Y70dHd3tDDsk8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/sw/switcheroo/package.nix
+++ b/pkgs/by-name/sw/switcheroo/package.nix
@@ -30,10 +30,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-AwecOA8HWGimhQyCEG3Z3hhwa9RVWssykUXsdvqqs9U=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
     name = "switcheroo-${finalAttrs.version}";
-    hash = "sha256-fpI4ue30DhkeWAolyeots+LkaRyaIPhYmIqRmx08i2s=";
+    hash = "sha256-Ose1gx6vwKZCdtMDkyM9Y+f6wt7VDKTI3Wc7kep1428=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/tailor-gui/package.nix
+++ b/pkgs/by-name/ta/tailor-gui/package.nix
@@ -29,10 +29,10 @@ stdenv.mkDerivation {
     version
     ;
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src sourceRoot;
     name = "${pname}-${version}";
-    hash = "sha256-jcjq0uls28V8Ka2CMM8oOQmZZRUr9eEQeVtW56AmU28=";
+    hash = "sha256-9jMy23VD+C87hg/TMXGbzAoqx76dhVOkWcQNudSwsYA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ta/taskwarrior3/package.nix
+++ b/pkgs/by-name/ta/taskwarrior3/package.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-aKDwRCJ1yopRdsPxnHhgOpSho1i8/dcAurI+XhpSbn4=";
     fetchSubmodules = true;
   };
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     name = "${finalAttrs.pname}-${finalAttrs.version}-cargo-deps";
     inherit (finalAttrs) src;
-    hash = "sha256-mzmrbsUuIjUVuNEa33EgtOTl9r+0xYj2WkKqFjxX1oU=";
+    hash = "sha256-UbJodQBCrmXbw5+ahusBnEcoCYGFHRA6bg5hf9/prmA=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/ta/taterclient-ddnet/package.nix
+++ b/pkgs/by-name/ta/taterclient-ddnet/package.nix
@@ -43,9 +43,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-RhOZuPsjyXq5UcM+5dawDi1BfjMMQ3K9O3PHkCg5sDI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname src version;
-    hash = "sha256-NDeHpf1iYApP/Y/DE7FGBu67ld6A0+8227oTVlOMe1M=";
+    hash = "sha256-VKGc4LQjt2FHbELLBKtV8rKpxjGBrzlA3m9BSdZ/6Z0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/te/televido/package.nix
+++ b/pkgs/by-name/te/televido/package.nix
@@ -26,10 +26,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-pMrMXRnfvpDLFkL2IqYJKRao/OF78mXUCBqBgT97+hc=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-wavxkhDS0hspGMw5ZKTxjZ07TiZ67OkbMhicB8h5y64=";
+    hash = "sha256-o857QBRfANkk6e/zIwc0JLpsiP2+wCb5U7Umlx4xMdI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/uu/uutils-coreutils/package.nix
+++ b/pkgs/by-name/uu/uutils-coreutils/package.nix
@@ -23,10 +23,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-B6lz75uxROo7npiZNCdTt0NCxVvsaIgtWnuGOKevDQQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "uutils-coreutils-${version}";
-    hash = "sha256-BSRYL9qsa+FUjfXTP/vx7VZwOyjhBM7DREvI6/X2tCA=";
+    hash = "sha256-Z5A1Tyf7SbvIBVGG3YPxh4q/SLU+yNlVv2jBRNumNwM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/va/vaults/package.nix
+++ b/pkgs/by-name/va/vaults/package.nix
@@ -31,10 +31,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-USVP/7TNdpUNx1kDsCReGYIP8gHUeij2dqy8TR4R+CE=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-h25YRqQ4Z+Af+zHITnmnwpg09V7sik88YRGbG8BZUjg=";
+    hash = "sha256-93X2BCn6Ih2DqYJNvYvUCYrC1E6wpCT5X8Hyux/8mno=";
   };
 
   postPatch = ''

--- a/pkgs/by-name/vi/video-trimmer/package.nix
+++ b/pkgs/by-name/vi/video-trimmer/package.nix
@@ -30,9 +30,9 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-4B3NNGww+UjI/VbsKL62vWlKye7NYXYPzlJ4TfywJDw=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-vtV5TrF81TK4PUwzOF/CuDsKH1vTLO+4PFufyIOp2zk=";
+    hash = "sha256-H7KB4O3Wyp2YdMLFwvQuYLhk7Ei7SecnMN9wg60FIm8=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vp/vpv/package.nix
+++ b/pkgs/by-name/vp/vpv/package.nix
@@ -25,10 +25,10 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   cargoRoot = "src/fuzzy-finder";
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     src = finalAttrs.src;
     sourceRoot = "${finalAttrs.src.name}/src/fuzzy-finder";
-    hash = "sha256-CDKlmwA2Wj78xPaSiYPmIJ7xmiE5Co+oGGejZU3v1zI=";
+    hash = "sha256-5QjKvndExImVn+w6OZNSD5n7K3C+tmN2jJOcDCVEW8I=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/wa/waypipe/package.nix
+++ b/pkgs/by-name/wa/waypipe/package.nix
@@ -31,9 +31,9 @@ llvmPackages.stdenv.mkDerivation rec {
     tag = "v${version}";
     hash = "sha256-l9gZ7FtLxGKBRlMem3VGJGTvOkVAtLBa7eF9+gA5Vfo=";
   };
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-DjqyKXbCQ6kzb1138wNWPnRXIgUaaE1nnCExLeLX6pw=";
+    hash = "sha256-CTLSMm8GN21L+5WtPBWSTTbeD3WoeScKV27TCu7tovI=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/we/wealthfolio/package.nix
+++ b/pkgs/by-name/we/wealthfolio/package.nix
@@ -35,10 +35,10 @@ stdenv.mkDerivation (finalAttrs: {
   cargoRoot = "src-tauri";
   buildAndTestSubdir = finalAttrs.cargoRoot;
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) pname version src;
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
-    hash = "sha256-Teno9y+busOGbreer2RzT+3sigRKvJbO1obfo0QpcPU=";
+    hash = "sha256-UyVIBctAbzslqID44+9zTXyx7wL4UosTQHqMdAX9mmE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/wi/wildcard/package.nix
+++ b/pkgs/by-name/wi/wildcard/package.nix
@@ -28,9 +28,9 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-8jNNCcZRoLyOHdaWmYTOGD7Nf7NkmJ1MIxBXLJGrm5Y=";
+    hash = "sha256-eUT3K7DJk0U4GZ/oqvMAGUjTctcDMaRdsjq1sD+fitg=";
     name = "wildcard-${finalAttrs.version}";
   };
 


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.

It should be possible to reproduce this diff.  To do so, get the list of files changed by this commit, e.g. with git diff --name-only, then run the following two commands, each with that list of files as their standard input:

	xargs sed -i 's/fetchCargoTarball/fetchCargoVendor/'
	cut -d / -f 4 | xargs -n 1 nix-update --version=skip

This will take a long time.  It might be possible to parallelize it using xargs' -P option.  I haven't tested it.

This is obviously very prone to merge conflicts. When merge conflicts appear, I'll just drop them from this patch and we can revisit them in a future one.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
