### PR TITLE
python3Packages.torcheval: init at 0.0.7

### DIFF
--- a/pkgs/development/python-modules/torcheval/default.nix
+++ b/pkgs/development/python-modules/torcheval/default.nix
@@ -1,0 +1,113 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  setuptools,
+
+  # dependencies
+  typing-extensions,
+
+  # tests
+  cython,
+  numpy,
+  pytest-timeout,
+  pytest-xdist,
+  pytestCheckHook,
+  scikit-image,
+  scikit-learn,
+  torchtnt-nightly,
+  torchvision,
+}:
+let
+  pname = "torcheval";
+  version = "0.0.7";
+in
+buildPythonPackage {
+  inherit pname version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "pytorch";
+    repo = "torcheval";
+    # Upstream has not created a tag for this version
+    # https://github.com/pytorch/torcheval/issues/215
+    rev = "f1bc22fc67ec2c77ee519aa4af8079f4fdaa41bb";
+    hash = "sha256-aVr4qKKE+dpBcJEi1qZJBljFLUl8d7D306Dy8uOojJE=";
+  };
+
+  # Patches are only applied to usages of numpy within tests,
+  # which are only used for testing purposes (see dev-requirements.txt)
+  postPatch =
+    # numpy's `np.NAN` was changed to `np.nan` when numpy 2 was released
+    ''
+      substituteInPlace tests/metrics/classification/test_accuracy.py tests/metrics/functional/classification/test_accuracy.py \
+        --replace-fail "np.NAN" "np.nan"
+    ''
+
+    # `unittest.TestCase.assertEquals` does not exist;
+    # the correct symbol is `unittest.TestCase.assertEqual`
+    + ''
+      substituteInPlace tests/metrics/test_synclib.py \
+        --replace-fail "tc.assertEquals" "tc.assertEqual"
+    '';
+
+  build-system = [ setuptools ];
+
+  dependencies = [ typing-extensions ];
+
+  pythonImportsCheck = [ "torcheval" ];
+
+  nativeCheckInputs = [
+    cython
+    numpy
+    pytest-timeout
+    pytest-xdist
+    pytestCheckHook
+    scikit-image
+    scikit-learn
+    torchtnt-nightly
+    torchvision
+  ];
+
+  pytestFlagsArray = [
+    "-v"
+    "tests/"
+
+    # -- tests/metrics/audio/test_fad.py --
+    # Touch filesystem and require network access.
+    # torchaudio.utils.download_asset("models/vggish.pt") -> PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
+    "--deselect=tests/metrics/audio/test_fad.py::TestFAD::test_vggish_fad"
+    "--deselect=tests/metrics/audio/test_fad.py::TestFAD::test_vggish_fad_merge"
+
+    # -- tests/metrics/image/test_fid.py --
+    # Touch filesystem and require network access.
+    # models.inception_v3(weights=weights) -> PermissionError: [Errno 13] Permission denied: '/homeless-shelter'
+    "--deselect=tests/metrics/image/test_fid.py::TestFrechetInceptionDistance::test_fid_invalid_input"
+    "--deselect=tests/metrics/image/test_fid.py::TestFrechetInceptionDistance::test_fid_random_data_custom_model"
+    "--deselect=tests/metrics/image/test_fid.py::TestFrechetInceptionDistance::test_fid_random_data_default_model"
+    "--deselect=tests/metrics/image/test_fid.py::TestFrechetInceptionDistance::test_fid_with_dissimilar_inputs"
+    "--deselect=tests/metrics/image/test_fid.py::TestFrechetInceptionDistance::test_fid_with_similar_inputs"
+
+    # -- tests/metrics/functional/text/test_perplexity.py --
+    # AssertionError: Scalars are not close!
+    # Expected 3.537154912949 but got 3.53715443611145
+    "--deselect=tests/metrics/functional/text/test_perplexity.py::Perplexity::test_perplexity_with_ignore_index"
+
+    # -- tests/metrics/image/test_psnr.py --
+    # AssertionError: Scalars are not close!
+    # Expected 7.781850814819336 but got 7.781772613525391
+    "--deselect=tests/metrics/image/test_psnr.py::TestPeakSignalNoiseRatio::test_psnr_with_random_data"
+  ];
+
+  meta = {
+    description = "Rich collection of performant PyTorch model metrics and tools for PyTorch model evaluations";
+    homepage = "https://pytorch.org/torcheval";
+    changelog = "https://github.com/pytorch/torcheval/releases/tag/${version}";
+
+    platforms = lib.platforms.linux;
+    license = with lib.licenses; [ bsd3 ];
+    maintainers = with lib.maintainers; [ bengsparks ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -16514,6 +16514,8 @@ self: super: with self; {
 
   torchdiffeq = callPackage ../development/python-modules/torchdiffeq { };
 
+  torcheval = callPackage ../development/python-modules/torcheval { };
+
   torchmetrics = callPackage ../development/python-modules/torchmetrics { };
 
   torchio = callPackage ../development/python-modules/torchio { };


### PR DESCRIPTION
A library that contains a rich collection of performant PyTorch model metrics, a simple interface to create new metrics, a toolkit to facilitate metric computation in distributed training and tools for PyTorch model evaluations.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
