### PR TITLE
{ungoogled-,}chromium,chromedriver: 132.0.6834.83 -> 132.0.6834.110

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -766,7 +766,7 @@
     }
   },
   "ungoogled-chromium": {
-    "version": "132.0.6834.83",
+    "version": "132.0.6834.110",
     "deps": {
       "depot_tools": {
         "rev": "41d43a2a2290450aeab946883542f8049b155c87",
@@ -777,16 +777,16 @@
         "hash": "sha256-zZoD5Bx7wIEP2KJkHef6wHrxU3px+8Vseq29QcK32bg="
       },
       "ungoogled-patches": {
-        "rev": "132.0.6834.83-1",
-        "hash": "sha256-yL7eMNTL1FDoqXcwuHx5BzjjESjzsIfdzHCTZW9jXUo="
+        "rev": "132.0.6834.110-1",
+        "hash": "sha256-pFuRsGnOXAECat5B0fUi9aw8Wdqbu1EBwyHNCBMoOpw="
       },
       "npmHash": "sha256-H1/h3x+Cgp1x94Ze3UPPHxRVpylZDvpMXMOuS+jk2dw="
     },
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "03d59cf5ecf1d8444838ff9a1e96231304d4ff9c",
-        "hash": "sha256-2FuT20iW8Mp4AehdEFT5Ua3La5z8bmT1FdLaUZRL0CE=",
+        "rev": "df453a35f099772fdb954e33551388add2ca3cde",
+        "hash": "sha256-deLCukHvNv6mUp33hHHFgeKD45SQs517xoRfCfReLAA=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -1526,8 +1526,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "e51f1d7dbd113aa01ddfb30890c8a89b11fcd96c",
-        "hash": "sha256-KJirPTvmC6vRTvrl6Nl0SQSieX/OhgfIiTblMxgoAvU="
+        "rev": "625e932f21c984db3f9fba8b56b9afa4e977994c",
+        "hash": "sha256-19uEppABiuh+zHjgwAj/BPee/ClB/FKfzHxLKrdNhOE="
       }
     }
   }

--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "132.0.6834.83",
+    "version": "132.0.6834.110",
     "chromedriver": {
-      "hash_darwin": "sha256-gLpWPzuJXnYatvRFDdssgB7rMSUCFv2GIPaV+YRNiZ0=",
-      "hash_darwin_aarch64": "sha256-8uhDySh2cWogVFX6LzCRTTHTUHTk+vxdbVxyOIHHLxA="
+      "hash_darwin": "sha256-TEy3go3cMHlv8+XRUWJhPVlLSgk+2DifW1LNStqh+nU=",
+      "hash_darwin_aarch64": "sha256-gpqA5zYbhrdVoaAH1m6xHmH0k7jiC7sGicqpKhVaytw="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "03d59cf5ecf1d8444838ff9a1e96231304d4ff9c",
-        "hash": "sha256-2FuT20iW8Mp4AehdEFT5Ua3La5z8bmT1FdLaUZRL0CE=",
+        "rev": "df453a35f099772fdb954e33551388add2ca3cde",
+        "hash": "sha256-deLCukHvNv6mUp33hHHFgeKD45SQs517xoRfCfReLAA=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -760,8 +760,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "e51f1d7dbd113aa01ddfb30890c8a89b11fcd96c",
-        "hash": "sha256-KJirPTvmC6vRTvrl6Nl0SQSieX/OhgfIiTblMxgoAvU="
+        "rev": "625e932f21c984db3f9fba8b56b9afa4e977994c",
+        "hash": "sha256-19uEppABiuh+zHjgwAj/BPee/ClB/FKfzHxLKrdNhOE="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/01/stable-channel-update-for-desktop_22.html

This update includes 3 security fixes.

CVEs:
CVE-2025-0611 CVE-2025-0612

## Things done

- Built on platform(s)
  - [x] x86_64-linux (only `ungoogled-chromium`)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`) (only `ungoogled-chromium`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
