### PR TITLE
treewide: migrate to fetchCargoVendor, batch 4

### DIFF
--- a/pkgs/applications/graphics/drawpile/default.nix
+++ b/pkgs/applications/graphics/drawpile/default.nix
@@ -76,9 +76,9 @@ mkDerivation rec {
     sha256 = "sha256-NS1aQlWpn3f+SW0oUjlYwHtOS9ZgbjFTrE9grjK5REM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-V36yiwraXK7qlJd1r8EtEA4ULxlgvMEmpn/ka3m9GjA=";
+    hash = "sha256-rY4zWSCBfVXvl6p9GvtDg/PFZfLkWTl8FTYdlKTzWYM=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/graphics/gnome-decoder/default.nix
+++ b/pkgs/applications/graphics/gnome-decoder/default.nix
@@ -38,10 +38,10 @@ clangStdenv.mkDerivation rec {
     hash = "sha256-qSPuEVW+FwC9OJa+dseIy4/2bhVdTryJSJNSpes9tpY=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-MbfukvqlzZPnWNtWCwYn7lABqBxtZWvPDba9Deah+w8=";
+    hash = "sha256-xQlzSsvwDNK3Z8xnUQgCU6Q8+ls0Urks778pYwN2X1Y=";
   };
 
   preFixup = ''

--- a/pkgs/applications/graphics/gnome-obfuscate/default.nix
+++ b/pkgs/applications/graphics/gnome-obfuscate/default.nix
@@ -33,10 +33,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-/Plvvn1tle8t/bsPcsamn5d81CqnyGCyGYPF6j6U5NI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "${finalAttrs.pname}-${finalAttrs.version}";
-    hash = "sha256-9lrxK2psdIPGsOC6p8T+3AGPrX6PjrK9mFirdJqBSMM=";
+    hash = "sha256-Llgn+dYNKZ9Mles9f9Xor+GZoCCQ0cERkXz4MicZglY=";
   };
 
   env = lib.optionalAttrs stdenv.hostPlatform.isDarwin {

--- a/pkgs/applications/misc/openbangla-keyboard/default.nix
+++ b/pkgs/applications/misc/openbangla-keyboard/default.nix
@@ -61,13 +61,13 @@ stdenv.mkDerivation rec {
       zstd
     ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     postPatch = ''
       cp ${./Cargo.lock} Cargo.lock
     '';
     sourceRoot = "${src.name}/${cargoRoot}";
-    hash = "sha256-XMleyP2h1aBhtjXhuGHyU0BN+tuL12CGoj+kLY5uye0=";
+    hash = "sha256-qZMTZi7eqEp5kSmVx7qdS7eDKOzSv9fMjWT0h/MGyeY=";
   };
 
   cmakeFlags =

--- a/pkgs/applications/version-management/git-cinnabar/default.nix
+++ b/pkgs/applications/version-management/git-cinnabar/default.nix
@@ -36,9 +36,9 @@ stdenv.mkDerivation (finalAttrs: {
     zstd
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
-    hash = "sha256-fTwHwZsBvp2F4w5reF94imaXnsw7xfgJQlGRZ3ztnK8=";
+    hash = "sha256-B2wLxSedFEgL+DPH4D6qL46ovcBZhPSacsYJKscKDYQ=";
   };
 
   ZSTD_SYS_USE_PKG_CONFIG = true;

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -52,10 +52,10 @@ let
 
     cargoDeps =
       if rustSupport then
-        rustPlatform.fetchCargoTarball {
+        rustPlatform.fetchCargoVendor {
           inherit src;
           name = "mercurial-${version}";
-          hash = "sha256-E8Q0hMLPLkUZ5W5iqe4w5t/71HQuRBTF3SRUBN8EMik=";
+          hash = "sha256-k/K1BupCqnlB++2T7hJxu82yID0jG8HwLNmb2eyx29o=";
           sourceRoot = "mercurial-${version}/rust";
         }
       else

--- a/pkgs/applications/version-management/silver-platter/default.nix
+++ b/pkgs/applications/version-management/silver-platter/default.nix
@@ -30,10 +30,10 @@ buildPythonApplication rec {
     hash = "sha256-k+C4jrC4FO/yy9Eb6x4lv1zyyp/eGkpMcDqZ0KoxfBs=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-+EUj6iBnHF4zlOAAfaHy5V/z6CCD/LFksBClE4FaHHc=";
+    hash = "sha256-hZQfzaLvHSN/hGR5vn+/2TRH6GwDTTp+UcnePXY7JlM=";
   };
 
   propagatedBuildInputs = [

--- a/pkgs/applications/virtualization/krunvm/default.nix
+++ b/pkgs/applications/virtualization/krunvm/default.nix
@@ -25,9 +25,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-IXofYsOmbrjq8Zq9+a6pvBYsvZFcKzN5IvCuHaxwazI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-Y0FNi/+HuN5SqexHTKjcW6lEaeis7xZDYc2/FOAANIA=";
+    hash = "sha256-Vmb5IgGyKGekuL018/Xiz9QroWIwTIUxVB57fb0X7Kw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -61,11 +61,10 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-SfKaCpL0wtGaLLQelqsvzn61veQYUMipFPz2VeMRCUQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit (finalAttrs) src;
     name = "librsvg-deps-${finalAttrs.version}";
-    hash = "sha256-pTd3H4ZYwsCb4C6gijE0gRWZ4Mq6gGGmwXE3nKGILhw=";
-    # TODO: move this to fetchCargoTarball
+    hash = "sha256-cO79X3M0B6WN4w0JeBh00EyaIdHcthOkeKhaYdTn2BQ=";
     dontConfigure = true;
   };
 

--- a/pkgs/development/python-modules/aardwolf/default.nix
+++ b/pkgs/development/python-modules/aardwolf/default.nix
@@ -36,11 +36,11 @@ buildPythonPackage rec {
     hash = "sha256-daDxkQ7N0+yS2JOLfXJq4jv+5VQNnwtqIMy2p8j+Sag=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     sourceRoot = "${src.name}/aardwolf/utils/rlers";
     name = "${pname}-${version}";
-    hash = "sha256-dGWPgyg8Ibyz3KcrMUI7xL7gTJ7iZ4sN0zOxFxcIrhM=";
+    hash = "sha256-doBraJQtekrO/ZZV9KFz7BdIgBVVWtQztUS2Gz8dDdA=";
   };
 
   cargoRoot = "aardwolf/utils/rlers";

--- a/pkgs/development/python-modules/adblock/default.nix
+++ b/pkgs/development/python-modules/adblock/default.nix
@@ -45,10 +45,10 @@ buildPythonPackage rec {
       --replace "0.0.0" "${version}"
   '';
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-1xmYmF5P7a5O9MilxDy+CVhmWMGRetdM2fGvTPy7JmM=";
+    hash = "sha256-fetJX6HQxRZ/Az7rJeU9S+s8ttgNPnJEvTLfzGt4xjk=";
   };
 
   nativeBuildInputs =

--- a/pkgs/development/python-modules/ahocorasick-rs/default.nix
+++ b/pkgs/development/python-modules/ahocorasick-rs/default.nix
@@ -23,10 +23,10 @@ buildPythonPackage rec {
     hash = "sha256-lzRwODlJlymMSih3CqNIeR+HrUbgVhroM1JuHFfW848=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-CIt/ChNcoqKln6PgeTGp9pfmIWlJj+c5SCPtBhsnT6U=";
+    hash = "sha256-Oslf85uI3pO9br7s1J9Y9I/UZ5KDOvJZ/30BMudVBZ0=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/bcrypt/default.nix
+++ b/pkgs/development/python-modules/bcrypt/default.nix
@@ -32,11 +32,11 @@ buildPythonPackage rec {
   };
 
   cargoRoot = "src/_bcrypt";
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
     name = "${pname}-${version}";
-    hash = "sha256-dOS9A3pTwXYkzPFFNh5emxJw7pSdDyY+mNIoHdwNdmg=";
+    hash = "sha256-TD1Qacr2BS3CutGzDcUSweTrlMuKy0U/eIS/oBLxTlI=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/biliass/default.nix
+++ b/pkgs/development/python-modules/biliass/default.nix
@@ -23,14 +23,14 @@ buildPythonPackage rec {
   sourceRoot = "source/packages/biliass";
   cargoRoot = "rust";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit
       pname
       version
       src
       ;
     sourceRoot = "${sourceRoot}/${cargoRoot}";
-    hash = "sha256-fXYjIJNrNQSXEACSa/FwxGlBYq5SxfIVIt4LtP0taFc=";
+    hash = "sha256-yR2eVsomepIh9ILon7PrAj2EBgI/vwN3JgRSR/3R1Mk=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/chromadb/default.nix
+++ b/pkgs/development/python-modules/chromadb/default.nix
@@ -64,10 +64,10 @@ buildPythonPackage rec {
     hash = "sha256-DQHkgCHtrn9xi7Kp7TZ5NP1EtFtTH5QOvne9PUvxsWc=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-vHH7Uq4Jf8/5Vc8oZ5nvAeq/dFVWywsQYbp7yJkfX7Q=";
+    hash = "sha256-ZtCTg8qNCiqlH7RsZxaWUNAoazdgmXP2GtpjDpRdvbk=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/clarabel/default.nix
+++ b/pkgs/development/python-modules/clarabel/default.nix
@@ -20,10 +20,10 @@ buildPythonPackage rec {
     hash = "sha256-DW0/6IAL5bS11AqOFL1JJmez5GzF2+N2d85e0l8HGdQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-NNvrDXBodrO3bxr4X1HEn5uHmHDJ1s9C70lPv7OkSCo=";
+    hash = "sha256-a8BXdA5rOjQRvacPRmobHxedHWNFZVyNN1xit+N8q3Y=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/cmsis-pack-manager/default.nix
+++ b/pkgs/development/python-modules/cmsis-pack-manager/default.nix
@@ -27,9 +27,9 @@ buildPythonPackage rec {
     hash = "sha256-PeyJf3TGUxv8/MKIQUgWrenrK4Hb+4cvtDA2h3r6kGg=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-dO4qw5Jx0exwb4RuOhu6qvGxQZ+LayHtXDHZKADLTEI=";
+    hash = "sha256-OBh5WWSekrqdLLmxEXS0LfPIfy4QWKYgO+8o6PYWjN4=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/copykitten/default.nix
+++ b/pkgs/development/python-modules/copykitten/default.nix
@@ -18,9 +18,9 @@ buildPythonPackage rec {
     hash = "sha256-S4IPVhYk/o15LQK1AB8VpdrHwIwTZyvmI2+e27/vDLs=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-Qgg2S1nRwWs2O81huj1g4wq7v4G377T+V8/1rjhz1ZE=";
+    hash = "sha256-kWhZzX/OI+05rvVFD+lOFvpKbNH/gMROFufcCzYDyko=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/cramjam/default.nix
+++ b/pkgs/development/python-modules/cramjam/default.nix
@@ -23,9 +23,9 @@ buildPythonPackage rec {
     hash = "sha256-1KD5/oZjfdXav1ZByQoyyiDSzbmY4VJsSJg/FtUFdDE=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-Bp7EtyuLdLUfU3yvouNVE42klfqYt9QOwt+iGe521yI=";
+    hash = "sha256-Gpj/LUCx/ivYlmxNJnEZr8caEfV4OaQwEPNjz7vobsw=";
   };
 
   buildAndTestSubdir = "cramjam-python";

--- a/pkgs/development/python-modules/cryptg/default.nix
+++ b/pkgs/development/python-modules/cryptg/default.nix
@@ -24,9 +24,9 @@ buildPythonPackage rec {
     hash = "sha256-GCTVxCJQvpvHpzaU+OaFM/AKoRvxLyA0u6VIV+94UTY=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-BqtswBTurZoKw7DR3S7woDKLqAqIjKdSS5TBwCI+Bps=";
+    hash = "sha256-+RNH9h40UTGUcr0PPJLllhAg81LM1IQnYKmrNxfPPv8=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/cryptography/default.nix
+++ b/pkgs/development/python-modules/cryptography/default.nix
@@ -36,10 +36,10 @@ buildPythonPackage rec {
     hash = "sha256-A+qYW8GksYk+FQG8ZJHNYrjcouE1CsVH0Lko2ahoYUI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-LJIY2O8ul36JQmhiW8VhLCQ0BaX+j+HGr3e8RUkZpc8=";
+    hash = "sha256-Ni/i21JgAemDXsJOXLL6IKjrJdBkw5jxBB0IdETBPcs=";
   };
 
   postPatch = ''

--- a/pkgs/development/python-modules/css-inline/default.nix
+++ b/pkgs/development/python-modules/css-inline/default.nix
@@ -36,14 +36,14 @@ buildPythonPackage rec {
 
   # call `cargo build --release` in bindings/python and copy the
   # resulting lock file
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     postPatch = ''
       cd bindings/python
       ln -s ${./Cargo.lock} Cargo.lock
     '';
     name = "${pname}-${version}";
-    hash = "sha256-FvkVwd681EhEHRJ8ip97moEkRE3VcuIPbi+F1SjXz8E=";
+    hash = "sha256-IQDICT/etlwnVqAo7es9PqwOqna48QdVYrHJq/aRsJo=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/deebot-client/default.nix
+++ b/pkgs/development/python-modules/deebot-client/default.nix
@@ -34,9 +34,9 @@ buildPythonPackage rec {
     hash = "sha256-G8NLirz81+b2YJBvxmfCEPpy2M9MMvs3n6JmdXR+3oc=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-9rXd5FFR+Ma0LJfKXwkDqZp096PA34V7TzPe/tahE7c=";
+    hash = "sha256-mpm5TYYWb8hENhRPAiE9KbprdtdlKZx12cLZQ+UbziE=";
   };
 
   pythonRelaxDeps = [

--- a/pkgs/development/python-modules/deltalake/default.nix
+++ b/pkgs/development/python-modules/deltalake/default.nix
@@ -28,9 +28,9 @@ buildPythonPackage rec {
     hash = "sha256-serMb6Rirmw+QLpET3NT2djBoFBW/TGu1/5qYjiYpKE=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-NkXovFsX+qbca+gYeBMQnacNzubloWNW/GrXNeWquE8=";
+    hash = "sha256-WGnjVYws8ZZMv0MvBrohozxQuyOImktaLxuvAIiH+U0=";
   };
 
   env.OPENSSL_NO_VENDOR = 1;

--- a/pkgs/development/python-modules/etebase/default.nix
+++ b/pkgs/development/python-modules/etebase/default.nix
@@ -41,10 +41,10 @@ buildPythonPackage rec {
     })
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-We19laZd6b2fLSPNLegyNp0eQSeCvUJeTIXqvG7o08c=";
+    hash = "sha256-tFOZJFrNge3N+ux2Hp4Mlm9K/AXYxuuBzEQdQYGGDjg=";
     inherit patches;
   };
 

--- a/pkgs/development/python-modules/evtx/default.nix
+++ b/pkgs/development/python-modules/evtx/default.nix
@@ -23,10 +23,10 @@ buildPythonPackage rec {
     hash = "sha256-wo6CeHlEBbu3klzzC4dUbjSfu7XwLo/cmtmZsVIKgS8=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-qBpc3PwvAceOMuRH4vrgURCsvKYhG2Id62n7sxW5AAg=";
+    hash = "sha256-Zdj0trB0wIVC9xg64wVOIrstdG7LGMOhWcRFXQJGNls=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/fastcrc/default.nix
+++ b/pkgs/development/python-modules/fastcrc/default.nix
@@ -30,10 +30,10 @@ buildPythonPackage {
     maturinBuildHook
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-wSE7548L+ymNjN9TfygAGY1BrssXOPGXlmE83wV7zb4=";
+    hash = "sha256-9Vap8E71TkBIf4eIB2lapUqcMukdsHX4LR7U8AD77SU=";
   };
 
   pythonImportsCheck = [ "fastcrc" ];

--- a/pkgs/development/python-modules/flaxlib/default.nix
+++ b/pkgs/development/python-modules/flaxlib/default.nix
@@ -28,14 +28,14 @@ buildPythonPackage rec {
     fi
   '';
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit
       pname
       version
       src
       sourceRoot
       ;
-    hash = "sha256-RPbMHnRdJaWKLU9Rkz39lmfibO20dnfZmLZqehHM3w4=";
+    hash = "sha256-CN/ZbDxdCQPEuLfxPh/m+JtlFDkerO8aWgAaUwhixjQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/gb-io/default.nix
+++ b/pkgs/development/python-modules/gb-io/default.nix
@@ -22,10 +22,10 @@ buildPythonPackage rec {
     hash = "sha256-1B7BUJ8H+pTtmDtazfPfYtlXzL/x4rAHtRIFAAsSoWs=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src sourceRoot;
     name = "${pname}-${version}";
-    hash = "sha256-lPnOFbEJgcaPPl9bTngugubhW//AUFp9RAjyiFHxC70=";
+    hash = "sha256-xHptfXQXtIz7swaPIgua8VpHHMqDtlDerTNtIL6VGSo=";
   };
 
   sourceRoot = src.name;

--- a/pkgs/development/python-modules/glean-sdk/default.nix
+++ b/pkgs/development/python-modules/glean-sdk/default.nix
@@ -23,10 +23,10 @@ buildPythonPackage rec {
     hash = "sha256-C3wQdxPNBPQN6eUK6Vq0bA6Wpqb28e9BTBf7c/hTQxU=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-XqOCHnvM64kZNifU5Wt/bFAvyRVy28ozWSwlvm/sMk8=";
+    hash = "sha256-KYli1SxrWAm6TnU0dAKOXzBtBInnschCEHZmYctPlhI=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/hf-transfer/default.nix
+++ b/pkgs/development/python-modules/hf-transfer/default.nix
@@ -28,10 +28,10 @@ buildPythonPackage rec {
     hash = "sha256-Uh8q14OeN0fYsywYyNrH8C3wq/qRjQKEAIufi/a5RXA=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-I4APdz1r2KJ8pTfKAg8g240wYy8gtMlHwmBye4796Tk=";
+    hash = "sha256-q+tAqpPubQ7P/KiBcVpAjOh8i12EfIcdcRjyEQNQQFI=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/jh2/default.nix
+++ b/pkgs/development/python-modules/jh2/default.nix
@@ -25,10 +25,10 @@ buildPythonPackage rec {
     fetchSubmodules = true;
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-E/Ah1sEqKrJd49ZvvbhqWtV1Abd0S1Ab/AF4tOn2RPY=";
+    hash = "sha256-nzLU6QhoJGNCqFF6pzzMr7FHbrLnNq7PvPC42VOrYo8=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/johnnycanencrypt/default.nix
+++ b/pkgs/development/python-modules/johnnycanencrypt/default.nix
@@ -29,10 +29,10 @@ buildPythonPackage rec {
     hash = "sha256-tbHW3x+vwFz0nqFGWvgxjhw8XH6/YKz1uagU339SZyk=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-vDlMdzZgmaRkviEk8IjIN+Q5x95gnpQiW5c8fT+dats=";
+    hash = "sha256-2kgp3RD2QbxL/Xk4iljjJZ8yEfo2umFtcN5CEtheyw8=";
   };
 
   build-system = with rustPlatform; [

--- a/pkgs/development/python-modules/kurbopy/default.nix
+++ b/pkgs/development/python-modules/kurbopy/default.nix
@@ -23,10 +23,10 @@ buildPythonPackage rec {
     rustPlatform.maturinBuildHook
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-W0BebCXC1wqwtQP+zHjISxSJjXHD9U6p9eNS12Nfb2Y=";
+    hash = "sha256-EPSaMIZqXrFzXAwNr1AtvmntkCLePXwAVzGMj8dWbTQ=";
   };
 
   nativeCheckInputs = [ pytestCheckHook ];

--- a/pkgs/development/python-modules/libcst/default.nix
+++ b/pkgs/development/python-modules/libcst/default.nix
@@ -35,10 +35,10 @@ buildPythonPackage rec {
     hash = "sha256-OuokZvdaCTgZI1VoXInqs6YNLsVUohaat5IjYYvUeVE=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
     sourceRoot = "${src.name}/${cargoRoot}";
-    hash = "sha256-+sCBkCR2CxgG/NuWch8sZTCitKynZmF221mR16TbQKI=";
+    hash = "sha256-PrWcnhfhc3ZTVwTjzp7cIVlUYeXo164AO687rBI/IoY=";
   };
 
   cargoRoot = "native";

--- a/pkgs/development/python-modules/lzallright/default.nix
+++ b/pkgs/development/python-modules/lzallright/default.nix
@@ -19,10 +19,10 @@ buildPythonPackage rec {
     hash = "sha256-6Dez14qlZ7cnVQfaiTHGuiTSAHvBoKtolgKF7ne9ASw=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-ZYFAWkcDdX10024hc+gdARyaJFpNNcXf+gGLxBP5VlA=";
+    hash = "sha256-pMYmPnL2bCqYkE3FJhZLOO4fGUXmDaFeDzTeAGRDRuI=";
   };
 
   format = "pyproject";

--- a/pkgs/development/python-modules/netifaces2/default.nix
+++ b/pkgs/development/python-modules/netifaces2/default.nix
@@ -23,9 +23,9 @@ buildPythonPackage {
 
   disabled = pythonOlder "3.7";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-dkqI0P61ciGqPtBc/6my7osaxxO9pEgovZhlpo1HdkU=";
+    hash = "sha256-n8IDl1msu2wn6YSsRJDy48M8qo96cXD8n+2HeU2WspE=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/nlpo3/default.nix
+++ b/pkgs/development/python-modules/nlpo3/default.nix
@@ -32,9 +32,9 @@ buildPythonPackage rec {
 
   sourceRoot = "${src.name}/nlpo3-python";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src sourceRoot;
-    hash = "sha256-PDDlG5nLedgA+HFZzkrxtfUjTwwioQhpsk5qlbAe3ws=";
+    hash = "sha256-S5nDOz/3ZenvMs8ruybEu5ULefeYGPIKO8kCW3dTa+E=";
   };
 
   preCheck = ''

--- a/pkgs/development/python-modules/nutils-poly/default.nix
+++ b/pkgs/development/python-modules/nutils-poly/default.nix
@@ -24,10 +24,10 @@ buildPythonPackage rec {
     hash = "sha256-dxFv4Az3uz6Du5dk5KZJ+unVbt3aZjxXliAQZhmBWDM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     name = "${pname}-${version}";
     inherit src;
-    hash = "sha256-+fnKvlSwM197rsyusFH7rs1W6livxel45UGbi1sB05k=";
+    hash = "sha256-3UBQJfMPVo37V7mJnN9loF1+vKh3JxFJWgynwsOnAg4=";
   };
 
   nativeBuildInputs = [ rustPlatform.cargoSetupHook ];

--- a/pkgs/development/python-modules/nutpie/default.nix
+++ b/pkgs/development/python-modules/nutpie/default.nix
@@ -40,10 +40,10 @@ buildPythonPackage rec {
     hash = "sha256-XyUMCnHm5V7oFaf3W+nGpcHfq1ZFppeGMIMCU5OB87s=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-9lM1S42Bmnlb0opstZN2aOKYhBnP87Frq+fQxk0ez+c=";
+    hash = "sha256-mLoMbIy3Chmby+c6j3dg+bQvIHuhDgt3ZzPIXB3WxuE=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/orjson/default.nix
+++ b/pkgs/development/python-modules/orjson/default.nix
@@ -42,10 +42,10 @@ buildPythonPackage rec {
     hash = "sha256-RJcTyLf2pLb1kHd7+5K9dGMWja4KFdKIwdRAp6Ud+Ps=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-HlvsV3Bsxa4Ud1+RrEnDWKX82DRyfgBS7GvK9827/wE=";
+    hash = "sha256-sxUp3q9S1PmwUmbmXWj235MB+qAFzTCu8x1OXOzVUpY=";
   };
 
   nativeBuildInputs =

--- a/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
+++ b/pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
@@ -20,9 +20,9 @@ buildPythonPackage rec {
     hash = "sha256-ZGMo7WgymkSDQu8tc4rTfWNsIWO0AlDPG0OzpKRq3oA=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-KrEBr998AV/bKcIoq0tX72/QwPD9bQplrS0Zw+JiSMQ=";
+    hash = "sha256-XqXkheK8OEzlLEbq09KMRFxrjJBnFaxvj4rIL2gmydA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/pendulum/default.nix
+++ b/pkgs/development/python-modules/pendulum/default.nix
@@ -43,11 +43,11 @@ buildPythonPackage rec {
   '';
 
   cargoRoot = "rust";
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     sourceRoot = "${src.name}/rust";
     name = "${pname}-${version}";
-    hash = "sha256-6fw0KgnPIMfdseWcunsGjvjVB+lJNoG3pLDqkORPJ0I=";
+    hash = "sha256-6WgGIfz9I+xRJqXWhjfGDZM1umYwVlUEpLAiecZNZmI=";
     postPatch = ''
       substituteInPlace Cargo.lock \
         --replace "3.0.0-beta-1" "3.0.0"

--- a/pkgs/development/python-modules/primp/default.nix
+++ b/pkgs/development/python-modules/primp/default.nix
@@ -35,10 +35,10 @@ buildPythonPackage rec {
     hash = "sha256-dexJdeNGpRsPLk8b/gNeQc1dsQLOiXNL5zgDEN9qHfQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-0mkrs50l0JEUH1WsM/Bp8AblCy6nkuohZKDsp6OVQpM=";
+    hash = "sha256-s+LAuZmnmTDPIFDSi9AkyWposFFnboJCmog1kiEBnrw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/py-sr25519-bindings/default.nix
+++ b/pkgs/development/python-modules/py-sr25519-bindings/default.nix
@@ -24,10 +24,10 @@ buildPythonPackage rec {
     hash = "sha256-mxNmiFvMbV9WQhGNIQXxTkOcJHYs0vyOPM6Nd5367RE=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-7fDlEYWOiRVpG3q0n3ZSS1dfNCOh0/4pX/PbcDBvoMI=";
+    hash = "sha256-OSnPGRZwuAzcvu80GgTXdc740SfhDIsXrQZq9a/BCdE=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/pycddl/default.nix
+++ b/pkgs/development/python-modules/pycddl/default.nix
@@ -39,10 +39,10 @@ buildPythonPackage rec {
     rm tests/test_benchmarks.py
   '';
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-VpJ/PLAwwuakwsNAtLDdWGXCxl6jGMTvsEhzIHk6a0g=";
+    hash = "sha256-Qep5YD4LQ+r118L5H+hUqeS00SibyvsbtLWDrJJBNc0=";
   };
 
   nativeCheckInputs = [

--- a/pkgs/development/python-modules/pydantic-core/default.nix
+++ b/pkgs/development/python-modules/pydantic-core/default.nix
@@ -30,10 +30,10 @@ let
 
     patches = [ ./01-remove-benchmark-flags.patch ];
 
-    cargoDeps = rustPlatform.fetchCargoTarball {
+    cargoDeps = rustPlatform.fetchCargoVendor {
       inherit src;
       name = "${pname}-${version}";
-      hash = "sha256-kY+XSiwfh1ao0vvqz1M23CONeh/T8uN8YpHf/GOphTk=";
+      hash = "sha256-4mwhe+e2xgFMYZAv+Nblj3AAnDinLvuGGYs8KAHT2Sw=";
     };
 
     nativeBuildInputs = [

--- a/pkgs/development/python-modules/pyperscan/default.nix
+++ b/pkgs/development/python-modules/pyperscan/default.nix
@@ -21,10 +21,10 @@ buildPythonPackage rec {
     hash = "sha256-uGZ0XFxnZHSLEWcwoHVd+xMulDRqEIrQ5Lf7886GdlM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-a4jNofPIHoKwsD82y2hG2QPu+eM5D7FSGCm2nDo2cLA=";
+    hash = "sha256-9kKHLYD0tXMGJFhsCBgO/NpWB4J5QZh0qKIuI3PFn2c=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/pysequoia/default.nix
+++ b/pkgs/development/python-modules/pysequoia/default.nix
@@ -25,10 +25,10 @@ buildPythonPackage rec {
     hash = "sha256-sLGPVyUVh1MxAJz8933xGAxaI9+0L/D6wViy5ARLe44=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-DLMAL1pJwJ5xU9XzJXlrqfNGloK9VNGxnapnh34bRhI=";
+    hash = "sha256-Qch6g39iuTEdHHehaBrbiVX5PcnEwwzdJmWgkmBSdCU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/python-bidi/default.nix
+++ b/pkgs/development/python-modules/python-bidi/default.nix
@@ -19,10 +19,10 @@ buildPythonPackage rec {
     hash = "sha256-LrXt9qaXfy8Rn9HjU4YSTFT4WsqzwCgh0flcxXOTF6E=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-34R8T8cXiX1iRx/Zb51Eb/nf0wLpN38hz0VnsmzPzws=";
+    hash = "sha256-4uNdglNaOpIX55xWTr7GkzhjgcyqOTUz4KUGy1fJx4A=";
   };
 
   buildInputs = [ libiconv ];

--- a/pkgs/development/python-modules/python-kadmin-rs/default.nix
+++ b/pkgs/development/python-modules/python-kadmin-rs/default.nix
@@ -27,9 +27,9 @@ buildPythonPackage rec {
     hash = "sha256-5sbYnEoT0/3BTJBipEy+DpIDbX6mRIpAE6CuAoJ5bw4=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-QLj7RDoyn8QzExUSnofT8XqHZmh72j87HlzOksBvk7Q=";
+    hash = "sha256-1J2aaEj/G7TE+EptWNwb5Vj048W6DOJNUBWPd9F4DqU=";
   };
 
   buildInputs = [

--- a/pkgs/development/python-modules/qiskit-terra/default.nix
+++ b/pkgs/development/python-modules/qiskit-terra/default.nix
@@ -82,10 +82,10 @@ buildPythonPackage rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-f5VLNxv9DKwfRy5zacydfz4Zrkbiee7JecOAbVelSto=";
+    hash = "sha256-nTYrNH3h1kAwwPx7OMw6eI61vYy8iFhm4eWDTGhWxt4=";
   };
 
   propagatedBuildInputs =

--- a/pkgs/development/python-modules/regress/default.nix
+++ b/pkgs/development/python-modules/regress/default.nix
@@ -25,10 +25,10 @@ buildPythonPackage rec {
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ libiconv ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-wHObfXWgcbSYxk5d17s44+1qIGYD/Ygefxp+el0fsEc=";
+    hash = "sha256-I6aUSGeosVYrFcHw0w6hprIL++c7ocYEorrQhe4ib+Y=";
   };
 
   meta = with lib; {

--- a/pkgs/development/python-modules/rpds-py/default.nix
+++ b/pkgs/development/python-modules/rpds-py/default.nix
@@ -21,10 +21,10 @@ buildPythonPackage rec {
     hash = "sha256-4y/uirRdPC222hmlMjvDNiI3yLZTxwGUQUuJL9BqCA0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-m01OB4CqDowlTAiDQx6tJ7SeP3t+EtS9UZ7Jad6Ccvc=";
+    hash = "sha256-2skrDC80g0EKvTEeBI4t4LD7ZXb6jp2Gw+owKFrkZzc=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/rtoml/default.nix
+++ b/pkgs/development/python-modules/rtoml/default.nix
@@ -24,10 +24,10 @@ buildPythonPackage rec {
     hash = "sha256-1movtKMQkQ6PEpKpSkK0Oy4AV0ee7XrS0P9m6QwZTaM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-BWcOIZMl4yHxxKxCn6Qh69MlMdz3REp3izN0A1eFX3o=";
+    hash = "sha256-/elui0Rf3XwvD2jX+NGoJgf9S3XSp16qzdwkGZbKaZg=";
   };
 
   build-system = with rustPlatform; [

--- a/pkgs/development/python-modules/rustworkx/default.nix
+++ b/pkgs/development/python-modules/rustworkx/default.nix
@@ -28,9 +28,9 @@ buildPythonPackage rec {
     hash = "sha256-0WYgShihTBM0e+MIhON0dnhZug6l280tZcVp3KF1Jq0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-AgHfCKLna30WERAFGEs8yRxxZHwvLzR+/S+ivwKHXXE=";
+    hash = "sha256-TfBDyh4cc1gt29I6wEKuF1QWczgeK+naApSD1aFDcvs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/safetensors/default.nix
+++ b/pkgs/development/python-modules/safetensors/default.nix
@@ -29,10 +29,10 @@ buildPythonPackage rec {
     hash = "sha256-dtHHLiTgrg/a/SQ/Z1w0BsuFDClgrMsGiSTCpbJasUs=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     sourceRoot = "${src.name}/bindings/python";
-    hash = "sha256-GL8tSXyP9xIWOLPCWiI5lUyfZXQRo77lJ2BmJCcj3uw=";
+    hash = "sha256-hjV2cfS/0WFyAnATt+A8X8sQLzQViDzkNI7zN0ltgpU=";
   };
 
   sourceRoot = "${src.name}/bindings/python";

--- a/pkgs/development/python-modules/skytemple-rust/default.nix
+++ b/pkgs/development/python-modules/skytemple-rust/default.nix
@@ -24,10 +24,10 @@ buildPythonPackage rec {
     hash = "sha256-0hIwFJn/cwtKHKoD+upeorC52YnDlej3TrWf3PmAQAQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-Gdypi9DJAXQgNaRCLEt4LTqUhBJC8plH0YhgNOIOGvA=";
+    hash = "sha256-CU1z+N9GK/mcMomkyQI+gNsYQbE2MQ/tg7lKhj949kw=";
   };
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [

--- a/pkgs/development/python-modules/sourmash/default.nix
+++ b/pkgs/development/python-modules/sourmash/default.nix
@@ -37,10 +37,10 @@ buildPythonPackage rec {
     hash = "sha256-M/0Z+yVwoDxN1wSM0yqurUl2AKAIDNZV5nvRy8bwBSQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-5MCAnWtbs6+UkJLcxyfwwxnSA4wcbDWewgNqKqu42n0=";
+    hash = "sha256-vzt5z3OoMrtMDZTCfVHhUd7N6m/kyVbbizfMwvlVlRY=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/spacy-alignments/default.nix
+++ b/pkgs/development/python-modules/spacy-alignments/default.nix
@@ -23,10 +23,10 @@ buildPythonPackage rec {
     hash = "sha256-jcNYghWR9Xbu97/hAYe8ewa5oMQ4ofNGFwY4cY7/EmM=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-I5uI+qFyb4/ArpUZi4yS/E/bmwoW7+CalMq02Gnm9S8=";
+    hash = "sha256-0U1ELUMh4YV6M+zrrZGuzvY8SdgyN66F7bJ6sMhOdXs=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/sudachipy/default.nix
+++ b/pkgs/development/python-modules/sudachipy/default.nix
@@ -18,10 +18,10 @@ buildPythonPackage rec {
   pname = "sudachipy";
   inherit (sudachi-rs) src version;
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-VuwDZaPtAgyMQGQ2eYyLAlXB8M8ZwGD5J/Nv+yysfiU=";
+    hash = "sha256-/VKveTtB8BbWgRBEzWBjrSrW84uFcz08cz6tZTuMMeE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/test-results-parser/default.nix
+++ b/pkgs/development/python-modules/test-results-parser/default.nix
@@ -17,9 +17,9 @@ buildPythonPackage rec {
     hash = "sha256-DaUSTu4Hg9SbJwBd3PlMcIAm/o63Q1yM5E7dVxbOwM8=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-dhreAWm/Hses/N3XocYX7IZru9nYJqDrmTnJPkKaOwY=";
+    hash = "sha256-BpklLxmtw+ztaOPlR6czDR9H6mnNpH5iodgLqi5+6hA=";
   };
 
   nativeBuildInputs = with rustPlatform; [

--- a/pkgs/development/python-modules/tiktoken/default.nix
+++ b/pkgs/development/python-modules/tiktoken/default.nix
@@ -41,10 +41,10 @@ buildPythonPackage {
     setuptools-rust
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src postPatch;
     name = "${pname}-${version}";
-    hash = "sha256-XzUEqiUdi70bgQwARGHsgti36cFOh7QDiEkccjxlwls=";
+    hash = "sha256-/JwhH0Is2yNwJ0CAY3SKoH1JWhmY3JtGusQkj3k5bQY=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/tokenizers/default.nix
+++ b/pkgs/development/python-modules/tokenizers/default.nix
@@ -80,14 +80,14 @@ buildPythonPackage rec {
     hash = "sha256-G65XiVlvJXOC9zqcVr9vWamUnpC0aa4kyYkE2v1K2iY=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit
       pname
       version
       src
       sourceRoot
       ;
-    hash = "sha256-5cw63ydyhpMup2tOe/hpG2W6YZ+cvT75MJBkE5Wap4s=";
+    hash = "sha256-jj5nuwxlfJm1ugYd5zW+wjyczOZHWCmRGYpmiMDqFlk=";
   };
 
   sourceRoot = "${src.name}/bindings/python";

--- a/pkgs/development/python-modules/tree-sitter-make/default.nix
+++ b/pkgs/development/python-modules/tree-sitter-make/default.nix
@@ -20,10 +20,10 @@ buildPythonPackage rec {
     hash = "sha256-WiuhAp9JZKLd0wKCui9MV7AYFOW9dCbUp+kkVl1OEz0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-RI/wBnapWdr4kYshx9d9iN9nB30bR91uQ063yqNy4aA=";
+    hash = "sha256-75jtur5rmG4zpNXSE3OpPVR+/lf4SICsh+kgzIKfbd4=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/whenever/default.nix
+++ b/pkgs/development/python-modules/whenever/default.nix
@@ -32,9 +32,9 @@ buildPythonPackage rec {
     hash = "sha256-aTFbO3mBcX+a9Zqp7SXjEx2+ix+J8g4n8V3KEyatAXY=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
-    hash = "sha256-8xSw7VEfRKXMpwn7HKhrvgLV3Sy3TAmLHjm0WZF/2aY=";
+    hash = "sha256-32IQYJSSzBl3Uew+4jYt2tk0Q8Yf1Gn35EYWN/V7xng=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/y-py/default.nix
+++ b/pkgs/development/python-modules/y-py/default.nix
@@ -21,10 +21,10 @@ buildPythonPackage rec {
     hash = "sha256-R1eoKlBAags6MzqgEiAZozG9bxbkn+1n3KQj+Siz/U0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     name = "${pname}-${version}";
-    hash = "sha256-RXwrDSPU0wiprsUJwoDzti14H/+bSwy4hK4tYhNVfYw=";
+    hash = "sha256-Wh25tLOVhAYFLqjOrKSu4klB1hGSOMconC1xZG31Dbw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/development/python-modules/zxcvbn-rs-py/default.nix
+++ b/pkgs/development/python-modules/zxcvbn-rs-py/default.nix
@@ -26,10 +26,10 @@ buildPythonPackage rec {
     rustPlatform.maturinBuildHook
   ];
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     name = "${pname}-${version}";
     inherit src;
-    hash = "sha256-OA6iyojBMAG9GtjHaIQ9cM0SEMwMa2bKFRIXmqp4OBE=";
+    hash = "sha256-Tzd0XEbrvXrX7oMT41R5kUJi7equhdL7/pUHp7ghyeg=";
   };
 
   pythonImportsCheck = [ "zxcvbn_rs_py" ];

--- a/pkgs/development/r-modules/default.nix
+++ b/pkgs/development/r-modules/default.nix
@@ -1044,10 +1044,10 @@ let
     });
 
     gifski = old.gifski.overrideAttrs (attrs: {
-      cargoDeps = pkgs.rustPlatform.fetchCargoTarball {
+      cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
         src = attrs.src;
         sourceRoot = "gifski/src/myrustlib";
-        hash = "sha256-tVbuYzGdBzWVeQ26Imq6y5gA0R/CjuNCZtQgfd3/qwA=";
+        hash = "sha256-yz6M3qDQPfT0HJHyK2wgzgl5sBh7EmdJ5zW8SJkk+wY=";
       };
 
       cargoRoot = "src/myrustlib";
@@ -1061,10 +1061,10 @@ let
 
     timeless = old.timeless.overrideAttrs (attrs: {
       preConfigure = "patchShebangs configure";
-      cargoDeps = pkgs.rustPlatform.fetchCargoTarball {
+      cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
         src = attrs.src;
         sourceRoot = "timeless/src/rust";
-        hash = "sha256-AccuRY3lfTXzaMnaYieKCEJErKo5132oSXgILbFhePI=";
+        hash = "sha256-5TV7iCzaaFwROfJNO6pvSUbJBzV+wZlU5+ZK4AMT6X0=";
       };
 
       cargoRoot = "src/rust";

--- a/pkgs/games/ddnet/default.nix
+++ b/pkgs/games/ddnet/default.nix
@@ -41,10 +41,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-aJzNfo7K5OOo14XJRmDOYzXFF5fZK0aXgIfVvjvzjrU=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     name = "${pname}-${version}";
     inherit src;
-    hash = "sha256-WN8hYl3L1z+yAfxQnDKnr/zC+0GOYvjzM8YL5XQgVJg=";
+    hash = "sha256-VKGc4LQjt2FHbELLBKtV8rKpxjGBrzlA3m9BSdZ/6Z0=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/matrix-synapse/plugins/rendezvous.nix
+++ b/pkgs/servers/matrix-synapse/plugins/rendezvous.nix
@@ -22,10 +22,10 @@ buildPythonPackage rec {
     cp ${./rendezvous-Cargo.lock} Cargo.lock
   '';
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src postPatch;
     name = "${pname}-${version}";
-    hash = "sha256-TyxDq6YxZUArRj5gpjB1afDQgtUlCVer3Uhq6YKvVYM=";
+    hash = "sha256-CDUyH08s96xUy0VhK+4ym0w9IgAq9P1UjUipVjlpl9c=";
   };
 
   nativeBuildInputs =

--- a/pkgs/tools/filesystems/ceph/default.nix
+++ b/pkgs/tools/filesystems/ceph/default.nix
@@ -231,11 +231,11 @@ let
             hash = "sha256-J9N1kDrIJhz+QEf2cJ0W99GNObHskqr3KvmJVSplDr0=";
           };
           cargoRoot = "src/_bcrypt";
-          cargoDeps = rustPlatform.fetchCargoTarball {
+          cargoDeps = rustPlatform.fetchCargoVendor {
             inherit src;
             sourceRoot = "${pname}-${version}/${cargoRoot}";
             name = "${pname}-${version}";
-            hash = "sha256-lDWX69YENZFMu7pyBmavUZaalGvFqbHSHfkwkzmDQaY=";
+            hash = "sha256-8PyCgh/rUO8uynzGdgylAsb5k55dP9fCnf40UOTCR/M=";
           };
         });
 

--- a/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
+++ b/pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix
@@ -41,11 +41,11 @@ buildPythonPackage rec {
     hash = "sha256-KAPy+LHpX2FEGZJsfm9V2CivxhTKXtYVQ4d65mjMNHI=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
     name = "${pname}-${version}";
-    hash = "sha256-gFfDTc2QWBWHBCycVH1dYlCsWQMVcRZfOBIau+njtDU=";
+    hash = "sha256-pZHu3Oo9DWRAtldU0UvrH1FIg0bEvyfizPUhj9IBL58=";
   };
 
   # Since Cryptography v40 is quite outdated, we need to backport


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.

It should be possible to reproduce this diff.  To generate it, I first ran:

	xargs sed -i 's/fetchCargoTarball/fetchCargoVendor/g'

The following manually identified list of files were given as standard input:

<details>
<summary>Input</summary>

	pkgs/applications/graphics/drawpile/default.nix
	pkgs/applications/graphics/gnome-decoder/default.nix
	pkgs/applications/graphics/gnome-obfuscate/default.nix
	pkgs/applications/misc/openbangla-keyboard/default.nix
	pkgs/applications/version-management/git-cinnabar/default.nix
	pkgs/applications/version-management/mercurial/default.nix
	pkgs/applications/version-management/silver-platter/default.nix
	pkgs/applications/virtualization/krunvm/default.nix
	pkgs/development/libraries/librsvg/default.nix
	pkgs/development/python-modules/aardwolf/default.nix
	pkgs/development/python-modules/adblock/default.nix
	pkgs/development/python-modules/ahocorasick-rs/default.nix
	pkgs/development/python-modules/bcrypt/default.nix
	pkgs/development/python-modules/biliass/default.nix
	pkgs/development/python-modules/chromadb/default.nix
	pkgs/development/python-modules/clarabel/default.nix
	pkgs/development/python-modules/cmsis-pack-manager/default.nix
	pkgs/development/python-modules/copykitten/default.nix
	pkgs/development/python-modules/cramjam/default.nix
	pkgs/development/python-modules/cryptg/default.nix
	pkgs/development/python-modules/cryptography/default.nix
	pkgs/development/python-modules/css-inline/default.nix
	pkgs/development/python-modules/deebot-client/default.nix
	pkgs/development/python-modules/deltalake/default.nix
	pkgs/development/python-modules/etebase/default.nix
	pkgs/development/python-modules/evtx/default.nix
	pkgs/development/python-modules/fastcrc/default.nix
	pkgs/development/python-modules/flaxlib/default.nix
	pkgs/development/python-modules/gb-io/default.nix
	pkgs/development/python-modules/glean-sdk/default.nix
	pkgs/development/python-modules/hf-transfer/default.nix
	pkgs/development/python-modules/jh2/default.nix
	pkgs/development/python-modules/johnnycanencrypt/default.nix
	pkgs/development/python-modules/kurbopy/default.nix
	pkgs/development/python-modules/libcst/default.nix
	pkgs/development/python-modules/lzallright/default.nix
	pkgs/development/python-modules/netifaces2/default.nix
	pkgs/development/python-modules/nlpo3/default.nix
	pkgs/development/python-modules/nutils-poly/default.nix
	pkgs/development/python-modules/nutpie/default.nix
	pkgs/development/python-modules/orjson/default.nix
	pkgs/development/python-modules/pdoc-pyo3-sample-library/default.nix
	pkgs/development/python-modules/pendulum/default.nix
	pkgs/development/python-modules/primp/default.nix
	pkgs/development/python-modules/py-sr25519-bindings/default.nix
	pkgs/development/python-modules/pycddl/default.nix
	pkgs/development/python-modules/pydantic-core/default.nix
	pkgs/development/python-modules/pyperscan/default.nix
	pkgs/development/python-modules/pysequoia/default.nix
	pkgs/development/python-modules/python-bidi/default.nix
	pkgs/development/python-modules/python-kadmin-rs/default.nix
	pkgs/development/python-modules/qiskit-terra/default.nix
	pkgs/development/python-modules/regress/default.nix
	pkgs/development/python-modules/rpds-py/default.nix
	pkgs/development/python-modules/rtoml/default.nix
	pkgs/development/python-modules/rustworkx/default.nix
	pkgs/development/python-modules/safetensors/default.nix
	pkgs/development/python-modules/skytemple-rust/default.nix
	pkgs/development/python-modules/sourmash/default.nix
	pkgs/development/python-modules/spacy-alignments/default.nix
	pkgs/development/python-modules/sudachipy/default.nix
	pkgs/development/python-modules/test-results-parser/default.nix
	pkgs/development/python-modules/tiktoken/default.nix
	pkgs/development/python-modules/tokenizers/default.nix
	pkgs/development/python-modules/tree-sitter-make/default.nix
	pkgs/development/python-modules/whenever/default.nix
	pkgs/development/python-modules/y-py/default.nix
	pkgs/development/python-modules/zxcvbn-rs-py/default.nix
	pkgs/development/r-modules/default.nix
	pkgs/games/ddnet/default.nix
	pkgs/servers/matrix-synapse/plugins/rendezvous.nix
	pkgs/tools/filesystems/ceph/default.nix
	pkgs/tools/filesystems/ceph/old-python-packages/cryptography.nix

</details>

Then I ran:

	xargs -n 1 nix-update --version=skip

With this list of attributes corresponding to the changed files given as standard input:

<details>
<summary>Input</summary>

	drawpile
	gnome-decoder
	gnome-obfuscate
	ibus-engines.openbangla-keyboard
	git-cinnabar
	mercurial
	silver-platter
	krunvm
	librsvg
	python3Packages.aardwolf
	python3Packages.adblock
	python3Packages.ahocorasick-rs
	python3Packages.bcrypt
	python3Packages.biliass
	python3Packages.chromadb
	python3Packages.clarabel
	python3Packages.cmsis-pack-manager
	python3Packages.copykitten
	python3Packages.cramjam
	python3Packages.cryptg
	python3Packages.cryptography
	python3Packages.css-inline
	python3Packages.deebot-client
	python3Packages.deltalake
	python3Packages.etebase
	python3Packages.evtx
	python3Packages.fastcrc
	python3Packages.flaxlib
	python3Packages.gb-io
	python3Packages.glean-sdk
	python3Packages.hf-transfer
	python3Packages.jh2
	python3Packages.johnnycanencrypt
	python3Packages.kurbopy
	python3Packages.libcst
	python3Packages.lzallright
	python3Packages.netifaces2
	python3Packages.nlpo3
	python3Packages.nutils-poly
	python3Packages.nutpie
	python3Packages.orjson
	python3Packages.pdoc-pyo3-sample-library
	python3Packages.pendulum
	python3Packages.primp
	python3Packages.py-sr25519-bindings
	python3Packages.pycddl
	python3Packages.pydantic-core
	python3Packages.pyperscan
	python3Packages.pysequoia
	python3Packages.python-bidi
	python3Packages.python-kadmin-rs
	python3Packages.qiskit-terra
	python3Packages.regress
	python3Packages.rpds-py
	python3Packages.rtoml
	python3Packages.rustworkx
	python3Packages.safetensors
	python3Packages.skytemple-rust
	python3Packages.sourmash
	python3Packages.spacy-alignments
	python3Packages.sudachipy
	python3Packages.test-results-parser
	python3Packages.tiktoken
	python3Packages.tokenizers
	python3Packages.tree-sitter-make
	python3Packages.whenever
	python3Packages.y-py
	python3Packages.zxcvbn-rs-py
	rPackages.gifski
	rPackages.timeless
	ddnet
	matrix-synapse-plugins.matrix-http-rendezvous-synapse
	ceph.python.pkgs.bcrypt
	ceph.python.pkgs.cryptography

</details>

The list of files for the first command and the list of attributes for the second command are in the same order, so it should be easy enough to check their correspondence by putting them side by side.

It might be possible to parallelize the nix-update operations using xargs' -P option.  I haven't tested it.

I also manually removed the now-outdated comment in pkgs/development/libraries/librsvg/default.nix.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
