### PR TITLE
swayfx-unwrapped: backport fix to support updated libinput

### DIFF
--- a/nixos/tests/swayfx.nix
+++ b/nixos/tests/swayfx.nix
@@ -12,79 +12,77 @@ import ./make-test-python.nix (
     # Found 1 error in 1 file (checked 1 source file)
     skipTypeCheck = true;
 
-    nodes.machine =
-      { config, ... }:
-      {
-        # Automatically login on tty1 as a normal user:
-        imports = [ ./common/user-account.nix ];
-        services.getty.autologinUser = "alice";
+    nodes.machine = {
+      # Automatically login on tty1 as a normal user:
+      imports = [ ./common/user-account.nix ];
+      services.getty.autologinUser = "alice";
 
-        environment = {
-          # For glinfo and wayland-info:
-          systemPackages = with pkgs; [
-            mesa-demos
-            wayland-utils
-            alacritty
-          ];
-          # Use a fixed SWAYSOCK path (for swaymsg):
-          variables = {
-            "SWAYSOCK" = "/tmp/sway-ipc.sock";
-            # TODO: Investigate if we can get hardware acceleration to work (via
-            # virtio-gpu and Virgil). We currently have to use the Pixman software
-            # renderer since the GLES2 renderer doesn't work inside the VM (even
-            # with WLR_RENDERER_ALLOW_SOFTWARE):
-            # "WLR_RENDERER_ALLOW_SOFTWARE" = "1";
-            "WLR_RENDERER" = "pixman";
-          };
-          # For convenience:
-          shellAliases = {
-            test-x11 = "glinfo | tee /tmp/test-x11.out && touch /tmp/test-x11-exit-ok";
-            test-wayland = "wayland-info | tee /tmp/test-wayland.out && touch /tmp/test-wayland-exit-ok";
-          };
-
-          # To help with OCR:
-          etc."xdg/foot/foot.ini".text = lib.generators.toINI { } {
-            main = {
-              font = "inconsolata:size=14";
-            };
-            colors = rec {
-              foreground = "000000";
-              background = "ffffff";
-              regular2 = foreground;
-            };
-          };
-
-          etc."gpg-agent.conf".text = ''
-            pinentry-timeout 86400
-          '';
+      environment = {
+        # For glinfo and wayland-info:
+        systemPackages = with pkgs; [
+          mesa-demos
+          wayland-utils
+          alacritty
+        ];
+        # Use a fixed SWAYSOCK path (for swaymsg):
+        variables = {
+          "SWAYSOCK" = "/tmp/sway-ipc.sock";
+          # TODO: Investigate if we can get hardware acceleration to work (via
+          # virtio-gpu and Virgil). We currently have to use the Pixman software
+          # renderer since the GLES2 renderer doesn't work inside the VM (even
+          # with WLR_RENDERER_ALLOW_SOFTWARE):
+          # "WLR_RENDERER_ALLOW_SOFTWARE" = "1";
+          "WLR_RENDERER" = "pixman";
+        };
+        # For convenience:
+        shellAliases = {
+          test-x11 = "glinfo | tee /tmp/test-x11.out && touch /tmp/test-x11-exit-ok";
+          test-wayland = "wayland-info | tee /tmp/test-wayland.out && touch /tmp/test-wayland-exit-ok";
         };
 
-        fonts.packages = [ pkgs.inconsolata ];
+        # To help with OCR:
+        etc."xdg/foot/foot.ini".text = lib.generators.toINI { } {
+          main = {
+            font = "inconsolata:size=14";
+          };
+          colors = rec {
+            foreground = "000000";
+            background = "ffffff";
+            regular2 = foreground;
+          };
+        };
 
-        # Automatically configure and start Sway when logging in on tty1:
-        programs.bash.loginShellInit = ''
-          if [ "$(tty)" = "/dev/tty1" ]; then
-            set -e
-
-            mkdir -p ~/.config/sway
-            sed s/Mod4/Mod1/ /etc/sway/config > ~/.config/sway/config
-
-            sway --validate
-            sway && touch /tmp/sway-exit-ok
-          fi
+        etc."gpg-agent.conf".text = ''
+          pinentry-timeout 86400
         '';
-
-        programs.sway = {
-          enable = true;
-          package = pkgs.swayfx.override { isNixOS = true; };
-        };
-
-        # To test pinentry via gpg-agent:
-        programs.gnupg.agent.enable = true;
-
-        # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
-        virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
       };
+
+      fonts.packages = [ pkgs.inconsolata ];
+
+      # Automatically configure and start Sway when logging in on tty1:
+      programs.bash.loginShellInit = ''
+        if [ "$(tty)" = "/dev/tty1" ]; then
+          set -e
+
+          mkdir -p ~/.config/sway
+          sed s/Mod4/Mod1/ /etc/sway/config > ~/.config/sway/config
+
+          sway --validate
+          sway && touch /tmp/sway-exit-ok
+        fi
+      '';
+
+      programs.sway = {
+        enable = true;
+        package = pkgs.swayfx.override { isNixOS = true; };
+      };
+
+      # To test pinentry via gpg-agent:
+      programs.gnupg.agent.enable = true;
+
+      # Need to switch to a different GPU driver than the default one (-vga std) so that Sway can launch:
+      virtualisation.qemu.options = [ "-vga none -device virtio-gpu-pci" ];
+    };
 
     testScript =
       { nodes, ... }:
@@ -194,7 +192,7 @@ import ./make-test-python.nix (
         swaymsg("exec swaylock")
         machine.wait_until_succeeds("pgrep -x swaylock")
         machine.sleep(3)
-        machine.send_chars("${nodes.machine.config.users.users.alice.password}")
+        machine.send_chars("${nodes.machine.users.users.alice.password}")
         machine.send_key("ret")
         machine.wait_until_fails("pgrep -x swaylock")
 

--- a/pkgs/by-name/sw/swayfx-unwrapped/package.nix
+++ b/pkgs/by-name/sw/swayfx-unwrapped/package.nix
@@ -33,6 +33,7 @@
   enableXWayland ? true,
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
   trayEnabled ? systemdSupport,
+  fetchpatch2,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -56,6 +57,12 @@ stdenv.mkDerivation (finalAttrs: {
   patches =
     [
       ./load-configuration-from-etc.patch
+
+      (fetchpatch2 {
+        # fix missing switch statement for newer libinput
+        url = "https://github.com/swaywm/sway/pull/8470.patch?full_index=1";
+        hash = "sha256-UTZ2DNEsGi5RYrgZThHkYz3AnnIl/KxieinA1WUZRq4=";
+      })
 
       (substituteAll {
         src = ./fix-paths.patch;


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This fix was previously included in a PR to sway in https://github.com/swaywm/sway/pull/8470 to support newer libinput library versions.

fixes https://github.com/NixOS/nixpkgs/issues/375862

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
