### PR TITLE
nixos/wrappers: add per-wrapper enable option

### DIFF
--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -1,7 +1,9 @@
 { config, lib, pkgs, ... }:
 let
 
-  inherit (config.security) wrapperDir wrappers;
+  inherit (config.security) wrapperDir;
+
+  wrappers = lib.filterAttrs (name: value: value.enable) config.security.wrappers;
 
   parentWrapperDir = dirOf wrapperDir;
 
@@ -41,6 +43,11 @@ let
      // { description = "file mode string"; };
 
   wrapperType = lib.types.submodule ({ name, config, ... }: {
+    options.enable = lib.mkOption
+      { type = lib.types.bool;
+        default = true;
+        description = "Whether to enable the wrapper.";
+      };
     options.source = lib.mkOption
       { type = lib.types.path;
         description = "The absolute path to the program to be wrapped.";

--- a/nixos/tests/wrappers.nix
+++ b/nixos/tests/wrappers.nix
@@ -29,6 +29,14 @@ import ./make-test-python.nix (
         security.apparmor.enable = true;
 
         security.wrappers = {
+          disabled = {
+            enable = false;
+            owner = "root";
+            group = "root";
+            setuid = true;
+            source = "${busybox pkgs}/bin/busybox";
+            program = "disabled_busybox";
+          };
           suidRoot = {
             owner = "root";
             group = "root";
@@ -112,6 +120,9 @@ import ./make-test-python.nix (
       # actually makes the apparmor policy for ping, but there's no convenient
       # test for that one.
       machine.succeed("ping -c 1 127.0.0.1")
+
+      # Test that the disabled wrapper is not present.
+      machine.fail("test -e /run/wrappers/bin/disabled_busybox")
     '';
   }
 )


### PR DESCRIPTION
While it is possible to globally enable or disable security wrappers, it isn't possible to disable only a subset of them. Consequently, users will have to overwrite the security wrappers completely and re-add the desired subset in case they want to disable a subset of those set up by the NixOS modules.

Address this usecase by adding a new per-wrapper enable option.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
