### PR TITLE
lib.systems: replace gcc attributes with cpu options

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -26,7 +26,7 @@ rec {
   };
   ppc64-musl = {
     config = "powerpc64-unknown-linux-musl";
-    gcc = { abi = "elfv2"; };
+    abi = "elfv2";
   };
 
   sheevaplug = {
@@ -198,7 +198,7 @@ rec {
     libc = "newlib";
     # GCC8+ does not build without this
     # (https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg552339.html):
-    gcc = {
+    cpu = {
       arch = "armv5t";
       fpu = "vfp";
     };

--- a/lib/systems/platforms.nix
+++ b/lib/systems/platforms.nix
@@ -67,9 +67,7 @@ rec {
       # TODO reenable once manual-config's config actually builds a .dtb and this is checked to be working
       #DTB = true;
     };
-    gcc = {
-      arch = "armv5te";
-    };
+    cpu.model = "armv5te";
   };
 
   sheevaplug = {
@@ -180,9 +178,7 @@ rec {
       target = "uImage";
       DTB = true; # Beyond 3.10
     };
-    gcc = {
-      arch = "armv5te";
-    };
+    cpu.model = "armv5te";
   };
 
   raspberrypi = {
@@ -200,9 +196,9 @@ rec {
       '';
       target = "zImage";
     };
-    gcc = {
+    cpu = {
       # https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications
-      arch = "armv6kz";
+      model = "armv6kz";
       fpu = "vfpv2";
     };
   };
@@ -212,9 +208,7 @@ rec {
 
   # Nvidia Bluefield 2 (w. crypto support)
   bluefield2 = {
-    gcc = {
-      arch = "armv8-a+fp+simd+crc+crypto";
-    };
+    cpu.model = "armv8-a+fp+simd+crc+crypto";
   };
 
   zero-gravitas = {
@@ -227,9 +221,9 @@ rec {
       autoModules = false;
       DTB = true;
     };
-    gcc = {
+    cpu = {
+      model = "cortex-a9";
       fpu = "neon";
-      cpu = "cortex-a9";
     };
   };
 
@@ -243,8 +237,8 @@ rec {
       preferBuiltin = true;
       target = "zImage";
     };
-    gcc = {
-      cpu = "cortex-a7";
+    cpu = {
+      model = "cortex-a7";
       fpu = "neon-vfpv4";
       float-abi = "hard";
     };
@@ -269,8 +263,8 @@ rec {
       target = "uImage";
       DTB = true;
     };
-    gcc = {
-      cpu = "cortex-a9";
+    cpu = {
+      model = "cortex-a9";
       fpu = "neon";
     };
   };
@@ -296,8 +290,8 @@ rec {
   # https://developer.android.com/ndk/guides/abis#v7a
   armv7a-android = {
     linux-kernel.name = "armeabi-v7a";
-    gcc = {
-      arch = "armv7-a";
+    cpu = {
+      model = "armv7-a";
       float-abi = "softfp";
       fpu = "vfpv3-d16";
     };
@@ -333,7 +327,7 @@ rec {
         KS8851_MLL y
       '';
     };
-    gcc = {
+    cpu = {
       # Some table about fpu flags:
       # http://community.arm.com/servlet/JiveServlet/showImage/38-1981-3827/blogentry-103749-004812900+1365712953_thumb.png
       # Cortex-A5: -mfpu=neon-fp16
@@ -347,11 +341,11 @@ rec {
 
       # vfpv3-d16 is what Debian uses and seems to be the best compromise: NEON is not supported in e.g. Scaleway or Tegra 2,
       # and the above page suggests NEON is only an improvement with hand-written assembly.
-      arch = "armv7-a";
+      model = "armv7-a";
       fpu = "vfpv3-d16";
 
       # For Raspberry Pi the 2 the best would be:
-      #   cpu = "cortex-a7";
+      #   model = "cortex-a7";
       #   fpu = "neon-vfpv4";
     };
   };
@@ -386,16 +380,11 @@ rec {
       '';
       target = "Image";
     };
-    gcc = {
-      arch = "armv8-a";
-    };
+    cpu.model = "armv8-a";
   };
 
   apple-m1 = {
-    gcc = {
-      arch = "armv8.3-a+crypto+sha2+aes+crc+fp16+lse+simd+ras+rdm+rcpc";
-      cpu = "apple-a13";
-    };
+    cpu.model = "apple-m1";
   };
 
   ##
@@ -406,8 +395,8 @@ rec {
     linux-kernel = {
       name = "ben_nanonote";
     };
-    gcc = {
-      arch = "mips32";
+    cpu = {
+      model = "mips32";
       float = "soft";
     };
   };
@@ -483,49 +472,37 @@ rec {
       '';
       target = "vmlinux";
     };
-    gcc = {
-      arch = "loongson2f";
+    cpu = {
+      model = "loongson2f";
       float = "hard";
-      abi = "n32";
     };
+    abi = "n32";
   };
 
   # can execute on 32bit chip
   gcc_mips32r2_o32 = {
-    gcc = {
-      arch = "mips32r2";
-      abi = "32";
-    };
+    cpu.model = "mips32r2";
+    abi = "32";
   };
   gcc_mips32r6_o32 = {
-    gcc = {
-      arch = "mips32r6";
-      abi = "32";
-    };
+    cpu.model = "mips32r6";
+    abi = "32";
   };
   gcc_mips64r2_n32 = {
-    gcc = {
-      arch = "mips64r2";
-      abi = "n32";
-    };
+    cpu.model = "mips64r2";
+    abi = "n32";
   };
   gcc_mips64r6_n32 = {
-    gcc = {
-      arch = "mips64r6";
-      abi = "n32";
-    };
+    cpu.model = "mips64r6";
+    abi = "n32";
   };
   gcc_mips64r2_64 = {
-    gcc = {
-      arch = "mips64r2";
-      abi = "64";
-    };
+    cpu.model = "mips64r2";
+    abi = "64";
   };
   gcc_mips64r6_64 = {
-    gcc = {
-      arch = "mips64r6";
-      abi = "64";
-    };
+    cpu.model = "mips64r6";
+    abi = "64";
   };
 
   # based on:


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Replaces #313539, this is a better attempt and will include backwards compatibility. Still WIP.

Goals & motivations:
- Kill `lib.systems.architectures`
- Always specifying the CPU model inside the stdenv
- Compiler flag checks within nixpkgs during the eval phase
- Multiple toolchain compatibility

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
