### PR TITLE
pandoc_3_6: fix incorrect dependency versions

### DIFF
--- a/pkgs/by-name/pa/pandoc/package.nix
+++ b/pkgs/by-name/pa/pandoc/package.nix
@@ -39,6 +39,9 @@ in
       remove-references-to \
         -t ${pandoc-cli.scope.pandoc} \
         $out/bin/pandoc
+    ''
+    # https://github.com/jgm/typst-hs/commit/9707b74ce60d71c2ba0f35249ffbd01dea197a6e
+    + lib.optionalString (lib.versionAtLeast pandoc-cli.scope.typst.version "0.6.1") ''
       remove-references-to \
         -t ${pandoc-cli.scope.typst} \
         $out/bin/pandoc

--- a/pkgs/by-name/pa/pandoc/package.nix
+++ b/pkgs/by-name/pa/pandoc/package.nix
@@ -39,6 +39,9 @@ in
       remove-references-to \
         -t ${pandoc-cli.scope.pandoc} \
         $out/bin/pandoc
+      remove-references-to \
+        -t ${pandoc-cli.scope.typst} \
+        $out/bin/pandoc
     '' + lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
       mkdir -p $out/share/bash-completion/completions
       $out/bin/pandoc --bash-completion > $out/share/bash-completion/completions/pandoc

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -2004,17 +2004,22 @@ self: super: {
   # https://github.com/NixOS/nixpkgs/pull/349683
   pandoc-cli_3_6 = super.pandoc-cli_3_6.overrideScope (
     self: super: {
+      commonmark-extensions = self.commonmark-extensions_0_2_5_6;
+      commonmark-pandoc = self.commonmark-pandoc_0_2_2_3;
       doclayout = self.doclayout_0_5;
       hslua-module-doclayout = self.hslua-module-doclayout_1_2_0;
       lpeg = self.lpeg_1_1_0;
       pandoc = self.pandoc_3_6;
       pandoc-lua-engine = self.pandoc-lua-engine_0_4;
+      pandoc-lua-marshal = self.pandoc-lua-marshal_0_3_0;
       pandoc-server = self.pandoc-server_0_1_0_10;
+      skylighting = self.skylighting_0_14_5;
+      skylighting-core = self.skylighting-core_0_14_5;
       texmath = self.texmath_0_12_8_12;
       tls = self.tls_2_0_6;
       toml-parser = self.toml-parser_2_0_1_0;
       typst = self.typst_0_6_1;
-      typst-symbols = self.typst-symbols_0_1_6;
+      typst-symbols = self.typst-symbols_0_1_7;
     }
   );
 

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -116,7 +116,6 @@ extra-packages:
   - tls < 2.1.0                         # 2024-07-19: requested by darcs == 2.18.3
   - extensions == 0.1.0.2               # 2024-10-20: for GHC 9.10/Cabal 3.12
   - network-run == 0.4.0                # 2024-10-20: for GHC 9.10/network == 3.1.*
-  - typst-symbols >=0.1.6 && <0.1.7     # 2024-11-20: for pandoc 3.5 and quarto
   - ghc-source-gen < 0.4.6.0            # 2024-12-31: support GHC < 9.0
 
 package-maintainers:


### PR DESCRIPTION
5dfa2d6f55793aa9a2b397a4215e1e4e9037c934 missed the fact that pandoc 3.6 newly requests non Stackage LTS 22 versions of some packages. Since pandoc_3_6 wasn't actually tested in CI, this was missed.

On haskell-updates, no pandoc_3_* exists anymore, so we don't need to do anything. We may want to add quarto to the jobset, but it's quite heavy…

Resolves #375884.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
