### PR TITLE
glibc: 2.40-36 -> 2.40-66

### DIFF
--- a/pkgs/development/libraries/glibc/2.40-master.patch
+++ b/pkgs/development/libraries/glibc/2.40-master.patch
@@ -5125,3 +5125,21094 @@ index 35d8b30710..6f20d49669 100644
  	_IO_free_wbackup_area (fp);
  
        if (! (fp->_flags & _IO_UNBUFFERED)
+
+commit 77018fd9f99f86a354387219fdf099915857a527
+Author: Sergey Kolosov <skolosov@redhat.com>
+Date:   Wed Sep 25 15:51:23 2024 +0200
+
+    stdio-common: Add new test for fdopen
+    
+    This commit adds fdopen test with all modes.
+    Reviewed-by: DJ Delorie <dj@redhat.com>
+    
+    (cherry picked from commit 1d72fa3cfa046f7293421a7e58f2a272474ea901)
+
+diff --git a/stdio-common/Makefile b/stdio-common/Makefile
+index a91754f52d..5af53d61fd 100644
+--- a/stdio-common/Makefile
++++ b/stdio-common/Makefile
+@@ -207,6 +207,7 @@ tests := \
+   tst-cookie \
+   tst-dprintf-length \
+   tst-fdopen \
++  tst-fdopen2 \
+   tst-ferror \
+   tst-fgets \
+   tst-fileno \
+diff --git a/stdio-common/tst-fdopen2.c b/stdio-common/tst-fdopen2.c
+new file mode 100644
+index 0000000000..0c6625f258
+--- /dev/null
++++ b/stdio-common/tst-fdopen2.c
+@@ -0,0 +1,246 @@
++/* Test the fdopen function.
++   Copyright (C) 2024 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <stdio.h>
++#include <errno.h>
++#include <fcntl.h>
++#include <support/check.h>
++#include <support/support.h>
++#include <support/xunistd.h>
++#include <support/temp_file.h>
++
++char *tmp_dir;
++char *path_to_file;
++
++void
++prepare_tmp_dir (void)
++{
++  tmp_dir = support_create_temp_directory ("tst-fdopen2");
++  path_to_file = xasprintf ("%s/tst-fdopen2.txt", tmp_dir);
++}
++
++/* open temp file descriptor with mode.  */
++int
++open_tmp_fd (int mode)
++{
++  int fd = xopen (path_to_file, mode, 0644);
++  return fd;
++}
++
++
++/* close and remove temp file with close.  */
++void
++close_tmp_fd (int fd)
++{
++  xclose (fd);
++  xunlink (path_to_file);
++}
++
++/* close and remove temp file with fclose.  */
++void
++close_tmp_fp (FILE *fp)
++{
++  fclose (fp);
++  xunlink (path_to_file);
++}
++
++/* test "w" fdopen mode.  */
++void
++do_test_fdopen_w (void)
++{
++  int fd, ret;
++  FILE *fp;
++  fd = open_tmp_fd (O_WRONLY | O_CREAT | O_TRUNC);
++
++  /* test mode mismatch.  */
++  fp = fdopen (fd, "r");
++  if (fp != NULL || errno != EINVAL)
++    {
++      close_tmp_fd (fd);
++      FAIL_EXIT1 ("fdopen (%d, r) should fail with EINVAL: %m", fd);
++    }
++
++  fp = fdopen (fd, "w");
++  if (fp == NULL)
++    {
++      close_tmp_fd (fd);
++      FAIL_EXIT1 ("fdopen (%d, w): %m", fd);
++    }
++
++  const void *buf = "AAAA";
++  ret = fwrite (buf, 1, 4, fp);
++  if (ret != 4)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fwrite (): %m");
++    }
++
++  unsigned char buf2[4];
++  rewind (fp);
++  clearerr (fp);
++  /* fread should fail in "w" mode  */
++  ret = fread (buf2, 1, 4, fp);
++  if (ret != 0 || ferror (fp) == 0)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fread should fail in \"w\" mode");
++    }
++
++  fclose (fp);
++}
++
++/* test "r" fdopen mode. */
++void
++do_test_fdopen_r (void)
++{
++  int fd, ret;
++  FILE *fp;
++  fd = open_tmp_fd (O_RDONLY);
++
++  /* test mode mismatch. */
++  fp = fdopen (fd, "w");
++  if (fp != NULL || errno != EINVAL)
++    {
++      close_tmp_fd (fd);
++      FAIL_EXIT1 ("fdopen (%d, w) should fail with EINVAL: %m", fd);
++    }
++
++  fp = fdopen (fd, "r");
++  if (fp == NULL)
++    {
++      close_tmp_fd (fd);
++      FAIL_EXIT1 ("fdopen (%d, w): %m", fd);
++    }
++
++  const void *buf = "BBBB";
++  /* fwrite should fail in "r" mode.  */
++  ret = fwrite (buf, 1, 4, fp);
++  if (ret != 0 || ferror (fp) == 0)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fwrite should fail in \"r\" mode");
++    }
++
++  unsigned char buf2[4];
++  ret = fread (buf2, 1, 4, fp);
++  if (ret != 4)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fread (): %m");
++    }
++
++  fclose (fp);
++}
++
++/* test "a" fdopen mode.  */
++void
++do_test_fdopen_a (void)
++{
++  int fd, ret;
++  FILE *fp;
++  fd = open_tmp_fd (O_WRONLY | O_CREAT | O_APPEND);
++
++  /* test mode mismatch.  */
++  fp = fdopen (fd, "r+");
++  if (fp != NULL || errno != EINVAL)
++    {
++      close_tmp_fd (fd);
++      FAIL_EXIT1 ("fdopen (%d, \"r+\") should fail with EINVAL: %m", fd);
++    }
++
++  fp = fdopen (fd, "a");
++  if (fp == NULL)
++    {
++      close_tmp_fd (fd);
++      FAIL_EXIT1 ("fdopen (%d, w): %m", fd);
++    }
++
++  const void *buf = "CCCC";
++  ret = fwrite (buf, 1, 4, fp);
++  if (ret != 4)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fwrite (): %m");
++    }
++
++  /* fread should fail in "a" mode.  */
++  unsigned char buf2[4];
++  clearerr (fp);
++  ret = fread (buf2, 1, 4, fp);
++  if (ret != 0 || ferror (fp) == 0)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fread should fail \"a\" mode");
++    }
++
++  fclose (fp);
++}
++
++void
++do_test_fdopen_mode (int mode, const char *fmode)
++{
++  int fd, ret;
++  FILE *fp;
++  fd = open_tmp_fd (mode);
++
++  fp = fdopen (fd, fmode);
++  if (fp == NULL)
++    {
++      close_tmp_fd (fd);
++      FAIL_EXIT1 ("fdopen (%d, %s): %m", fd, fmode);
++    }
++
++  const void *buf = "EEEE";
++  ret = fwrite (buf, 1, 4, fp);
++  if (ret != 4)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fwrite () in mode:%s returns %d: %m", fmode, ret);
++    }
++
++  rewind (fp);
++  unsigned char buf2[4];
++  ret = fread (buf2, 1, 4, fp);
++  if (ret != 4)
++    {
++      close_tmp_fp (fp);
++      FAIL_EXIT1 ("fread () in mode:%s returns %d: %m", fmode, ret);
++    }
++
++  fclose (fp);
++}
++
++static int
++do_test (void)
++{
++
++  prepare_tmp_dir ();
++
++  do_test_fdopen_w ();
++  do_test_fdopen_r ();
++  do_test_fdopen_a ();
++
++  /* test r+ w+ a+ fdopen modes.  */
++  do_test_fdopen_mode (O_RDWR, "r+");
++  do_test_fdopen_mode (O_RDWR | O_CREAT | O_TRUNC, "w+");
++  do_test_fdopen_mode (O_RDWR | O_CREAT | O_APPEND, "a+");
++  xunlink (path_to_file);
++  return 0;
++}
++
++#include <support/test-driver.c>
+
+commit 61b6464f8d72aef520ee769a2ae317b4f68d5e1d
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Tue Sep 24 14:06:22 2024 +0000
+
+    Add tests of fread
+    
+    There seem to be no glibc tests specifically for the fread function.
+    Add basic tests of that function.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit d14c977c65aac7db35bb59380ef99d6582c4f930)
+
+diff --git a/stdio-common/Makefile b/stdio-common/Makefile
+index 5af53d61fd..3396090be1 100644
+--- a/stdio-common/Makefile
++++ b/stdio-common/Makefile
+@@ -217,6 +217,7 @@ tests := \
+   tst-fmemopen4 \
+   tst-fphex \
+   tst-fphex-wide \
++  tst-fread \
+   tst-fseek \
+   tst-fwrite \
+   tst-gets \
+diff --git a/stdio-common/tst-fread.c b/stdio-common/tst-fread.c
+new file mode 100644
+index 0000000000..4d9a7895f6
+--- /dev/null
++++ b/stdio-common/tst-fread.c
+@@ -0,0 +1,134 @@
++/* Test fread.
++   Copyright (C) 2024 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include <support/check.h>
++#include <support/support.h>
++#include <support/temp_file.h>
++#include <support/test-driver.h>
++#include <support/xstdio.h>
++#include <support/xunistd.h>
++
++int
++do_test (void)
++{
++  char *temp_dir = support_create_temp_directory ("tst-fread");
++  char *file1 = xasprintf ("%s/file1", temp_dir);
++  support_write_file_string (file1, "file1");
++  add_temp_file (file1);
++  FILE *fp;
++  size_t ret;
++  char buf[1024];
++
++  verbose_printf ("test single-byte reads\n");
++  fp = xfopen (file1, "r");
++  memset (buf, 0, sizeof buf);
++  ret = fread (buf, 1, 2, fp);
++  TEST_COMPARE (ret, 2);
++  TEST_COMPARE (buf[0], 'f');
++  TEST_COMPARE (buf[1], 'i');
++  TEST_COMPARE (feof (fp), 0);
++  TEST_COMPARE (ftell (fp), 2);
++  memset (buf, 0, sizeof buf);
++  ret = fread (buf, 1, 3, fp);
++  TEST_COMPARE (ret, 3);
++  TEST_COMPARE (buf[0], 'l');
++  TEST_COMPARE (buf[1], 'e');
++  TEST_COMPARE (buf[2], '1');
++  TEST_COMPARE (ftell (fp), 5);
++  TEST_COMPARE (feof (fp), 0);
++  memset (buf, 0, sizeof buf);
++  ret = fread (buf, 1, 1, fp);
++  TEST_COMPARE (ret, 0);
++  TEST_COMPARE (!!feof (fp), 1);
++  TEST_COMPARE (ferror (fp), 0);
++  TEST_COMPARE (ftell (fp), 5);
++  xfclose (fp);
++
++  verbose_printf ("test single-byte reads, EOF part way through\n");
++  fp = xfopen (file1, "r");
++  memset (buf, 0, sizeof buf);
++  ret = fread (buf, 1, sizeof buf, fp);
++  TEST_COMPARE (ret, 5);
++  TEST_COMPARE (buf[0], 'f');
++  TEST_COMPARE (buf[1], 'i');
++  TEST_COMPARE (buf[2], 'l');
++  TEST_COMPARE (buf[3], 'e');
++  TEST_COMPARE (buf[4], '1');
++  TEST_COMPARE (!!feof (fp), 1);
++  TEST_COMPARE (ferror (fp), 0);
++  TEST_COMPARE (ftell (fp), 5);
++  xfclose (fp);
++
++  verbose_printf ("test multi-byte reads\n");
++  fp = xfopen (file1, "r");
++  memset (buf, 0, sizeof buf);
++  ret = fread (buf, 2, 2, fp);
++  TEST_COMPARE (ret, 2);
++  TEST_COMPARE (buf[0], 'f');
++  TEST_COMPARE (buf[1], 'i');
++  TEST_COMPARE (buf[2], 'l');
++  TEST_COMPARE (buf[3], 'e');
++  TEST_COMPARE (feof (fp), 0);
++  TEST_COMPARE (ftell (fp), 4);
++  memset (buf, 0, sizeof buf);
++  ret = fread (buf, 3, 3, fp);
++  TEST_COMPARE (ret, 0);
++  /* The bytes written for a partial element read are unspecified.  */
++  TEST_COMPARE (!!feof (fp), 1);
++  TEST_COMPARE (ferror (fp), 0);
++  TEST_COMPARE (ftell (fp), 5);
++  xfclose (fp);
++
++  verbose_printf ("test read error\n");
++  fp = xfopen (file1, "r");
++  xclose (fileno (fp));
++  memset (buf, 0, sizeof buf);
++  ret = fread (buf, 1, sizeof buf, fp);
++  TEST_COMPARE (ret, 0);
++  TEST_COMPARE (feof (fp), 0);
++  TEST_COMPARE (!!ferror (fp), 1);
++  fclose (fp);
++
++  verbose_printf ("test zero size\n");
++  fp = xfopen (file1, "r");
++  ret = fread (buf, 0, SIZE_MAX, fp);
++  TEST_COMPARE (ret, 0);
++  TEST_COMPARE (feof (fp), 0);
++  TEST_COMPARE (ferror (fp), 0);
++  TEST_COMPARE (ftell (fp), 0);
++  xfclose (fp);
++
++  verbose_printf ("test zero items\n");
++  fp = xfopen (file1, "r");
++  ret = fread (buf, SIZE_MAX, 0, fp);
++  TEST_COMPARE (ret, 0);
++  TEST_COMPARE (feof (fp), 0);
++  TEST_COMPARE (ferror (fp), 0);
++  TEST_COMPARE (ftell (fp), 0);
++  xfclose (fp);
++
++  free (temp_dir);
++  free (file1);
++  return 0;
++}
++
++#include <support/test-driver.c>
+
+commit 9bc76c7ca4d6022fd588c274d139813f99e04f35
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Wed Aug 14 17:15:46 2024 +0000
+
+    Test errno setting on strtod overflow in tst-strtod-round
+    
+    We have no tests that errno is set to ERANGE on overflow of
+    strtod-family functions (we do have some tests for underflow, in
+    tst-strtod-underflow).  Add such tests to tst-strtod-round.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit 207d64feb26279e152c50744e3c37e68491aca99)
+
+diff --git a/stdlib/tst-strtod-round-skeleton.c b/stdlib/tst-strtod-round-skeleton.c
+index 6fba4b5228..c3cc0201d4 100644
+--- a/stdlib/tst-strtod-round-skeleton.c
++++ b/stdlib/tst-strtod-round-skeleton.c
+@@ -21,6 +21,7 @@
+    declared in the headers.  */
+ #define _LIBC_TEST 1
+ #define __STDC_WANT_IEC_60559_TYPES_EXT__
++#include <errno.h>
+ #include <fenv.h>
+ #include <float.h>
+ #include <math.h>
+@@ -205,7 +206,9 @@ struct test {
+ #define GEN_ONE_TEST(FSUF, FTYPE, FTOSTR, LSUF, CSUF)		\
+ {								\
+   feclearexcept (FE_ALL_EXCEPT);				\
++  errno = 0;							\
+   FTYPE f = STRTO (FSUF) (s, NULL);				\
++  int new_errno = errno;					\
+   if (f != expected->FSUF					\
+       || (copysign ## CSUF) (1.0 ## LSUF, f)			\
+ 	 != (copysign ## CSUF) (1.0 ## LSUF, expected->FSUF))	\
+@@ -254,6 +257,14 @@ struct test {
+ 		printf ("ignoring this exception error\n");	\
+ 	    }							\
+ 	}							\
++      if (overflow->FSUF && new_errno != ERANGE)		\
++	{							\
++	  printf (FNPFXS "to" #FSUF				\
++		  " (" STRM ") left errno == %d,"		\
++		  " not %d (ERANGE)\n",				\
++		  s, new_errno, ERANGE);			\
++	  result = 1;						\
++	}							\
+     }								\
+ }
+ 
+
+commit e06153665fa931e4c7d2a3ecc14e5197e96143a7
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Tue Aug 27 12:38:01 2024 +0000
+
+    More thoroughly test underflow / errno in tst-strtod-round
+    
+    Add tests of underflow in tst-strtod-round, and thus also test for
+    errno being unchanged when there is neither overflow nor underflow.
+    The errno setting before the function call to test for being unchanged
+    is adjusted to set errno to 12345 instead of 0, so that any bugs where
+    strtod sets errno to 0 would be detected.
+    
+    This doesn't add any new test inputs for tst-strtod-round, and in
+    particular doesn't cover the edge cases of underflow the way
+    tst-strtod-underflow does (none of the existing test inputs for
+    tst-strtod-round actually exercise cases that have underflow with
+    before-rounding tininess detection but not with after-rounding
+    tininess detection), but at least it provides some coverage (as per
+    the recent discussions) that ordinary non-overflowing non-underflowing
+    inputs to these functions do not set errno.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit d73ed2601b7c3c93c3529149a3d7f7b6177900a8)
+
+diff --git a/stdlib/gen-tst-strtod-round.c b/stdlib/gen-tst-strtod-round.c
+index e48bf4d6ea..7ce735f81d 100644
+--- a/stdlib/gen-tst-strtod-round.c
++++ b/stdlib/gen-tst-strtod-round.c
+@@ -46,6 +46,7 @@ static int
+ string_to_fp (mpfr_t f, const char *s, mpfr_rnd_t rnd)
+ {
+   mpfr_clear_overflow ();
++  mpfr_clear_underflow ();
+ #ifdef WORKAROUND
+   mpfr_t f2;
+   mpfr_init2 (f2, 100000);
+@@ -53,12 +54,16 @@ string_to_fp (mpfr_t f, const char *s, mpfr_rnd_t rnd)
+   int r = mpfr_set (f, f2, rnd);
+   r |= mpfr_subnormalize (f, r, rnd);
+   mpfr_clear (f2);
+-  return r0 | r;
++  r |= r0;
+ #else
+   int r = mpfr_strtofr (f, s, NULL, 0, rnd);
+   r |= mpfr_subnormalize (f, r, rnd);
+-  return r;
+ #endif
++  if (r == 0)
++    /* The MPFR underflow flag is set for exact subnormal results,
++       which is not wanted here.  */
++    mpfr_clear_underflow ();
++  return r;
+ }
+ 
+ void
+@@ -70,6 +75,21 @@ print_fp (FILE *fout, mpfr_t f, const char *suffix)
+     mpfr_fprintf (fout, "\t%Ra%s", f, suffix);
+ }
+ 
++static const char *
++suffix_to_print (bool overflow, bool underflow, bool underflow_before_rounding,
++		 bool with_comma)
++{
++  if (overflow)
++    return with_comma ? ", true, false,\n" : ", true, false";
++  if (underflow)
++    return with_comma ? ", false, true,\n" : ", false, true";
++  if (underflow_before_rounding)
++    return (with_comma
++	    ? ", false, !TININESS_AFTER_ROUNDING,\n"
++	    : ", false, !TININESS_AFTER_ROUNDING");
++  return with_comma ? ", false, false,\n" : ", false, false";
++}
++
+ static void
+ round_str (FILE *fout, const char *s, int prec, int emin, int emax,
+ 	   bool ibm_ld)
+@@ -80,8 +100,11 @@ round_str (FILE *fout, const char *s, int prec, int emin, int emax,
+   mpfr_set_emin (emin);
+   mpfr_set_emax (emax);
+   mpfr_init (f);
++  string_to_fp (f, s, MPFR_RNDZ);
++  bool underflow_before_rounding = mpfr_underflow_p () != 0;
+   int r = string_to_fp (f, s, MPFR_RNDD);
+   bool overflow = mpfr_overflow_p () != 0;
++  bool underflow = mpfr_underflow_p () != 0;
+   if (ibm_ld)
+     {
+       assert (prec == 106 && emin == -1073 && emax == 1024);
+@@ -97,19 +120,27 @@ round_str (FILE *fout, const char *s, int prec, int emin, int emax,
+ 	}
+     }
+   mpfr_fprintf (fout, "\t%s,\n", r ? "false" : "true");
+-  print_fp (fout, f, overflow ? ", true,\n" : ", false,\n");
++  print_fp (fout, f,
++	    suffix_to_print (overflow, underflow, underflow_before_rounding,
++			     true));
+   string_to_fp (f, s, MPFR_RNDN);
+   overflow = (mpfr_overflow_p () != 0
+ 	      || (ibm_ld && mpfr_cmpabs (f, max_value) > 0));
+-  print_fp (fout, f, overflow ? ", true,\n" : ", false,\n");
++  print_fp (fout, f,
++	    suffix_to_print (overflow, underflow, underflow_before_rounding,
++			     true));
+   string_to_fp (f, s, MPFR_RNDZ);
+   overflow = (mpfr_overflow_p () != 0
+ 	      || (ibm_ld && mpfr_cmpabs (f, max_value) > 0));
+-  print_fp (fout, f, overflow ? ", true,\n" : ", false,\n");
++  print_fp (fout, f,
++	    suffix_to_print (overflow, underflow, underflow_before_rounding,
++			     true));
+   string_to_fp (f, s, MPFR_RNDU);
+   overflow = (mpfr_overflow_p () != 0
+ 	      || (ibm_ld && mpfr_cmpabs (f, max_value) > 0));
+-  print_fp (fout, f, overflow ? ", true" : ", false");
++  print_fp (fout, f,
++	    suffix_to_print (overflow, underflow, underflow_before_rounding,
++			     false));
+   mpfr_clear (f);
+   if (ibm_ld)
+     mpfr_clear (max_value);
+diff --git a/stdlib/tst-strtod-round-data.h b/stdlib/tst-strtod-round-data.h
+index 8899d15f9b..13e62dd2b0 100644
+--- a/stdlib/tst-strtod-round-data.h
++++ b/stdlib/tst-strtod-round-data.h
+@@ -2,1852 +2,1852 @@
+ static const struct test tests[] = {
+   TEST ("3.518437208883201171875E+013",
+ 	false,
+-	0x2p+44, false,
+-	0x2p+44, false,
+-	0x2p+44, false,
+-	0x2.000004p+44, false,
+-	false,
+-	0x2.0000000000002p+44, false,
+-	0x2.0000000000004p+44, false,
+-	0x2.0000000000002p+44, false,
+-	0x2.0000000000004p+44, false,
+-	true,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	true,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	true,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	true,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false,
+-	0x2.0000000000003p+44, false),
++	0x2p+44, false, false,
++	0x2p+44, false, false,
++	0x2p+44, false, false,
++	0x2.000004p+44, false, false,
++	false,
++	0x2.0000000000002p+44, false, false,
++	0x2.0000000000004p+44, false, false,
++	0x2.0000000000002p+44, false, false,
++	0x2.0000000000004p+44, false, false,
++	true,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	true,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	true,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	true,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false,
++	0x2.0000000000003p+44, false, false),
+   TEST ("1.00000005960464477550",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000004p+0, false,
+-	false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000004p+0, false,
+-	false,
+-	0x1.0000010000000002048242f2ffp+0, false,
+-	0x1.0000010000000002048242f2ff8p+0, false,
+-	0x1.0000010000000002048242f2ffp+0, false,
+-	0x1.0000010000000002048242f2ff8p+0, false,
+-	false,
+-	0x1.0000010000000002048242f2ff66p+0, false,
+-	0x1.0000010000000002048242f2ff67p+0, false,
+-	0x1.0000010000000002048242f2ff66p+0, false,
+-	0x1.0000010000000002048242f2ff67p+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000004p+0, false, false,
++	false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000004p+0, false, false,
++	false,
++	0x1.0000010000000002048242f2ffp+0, false, false,
++	0x1.0000010000000002048242f2ff8p+0, false, false,
++	0x1.0000010000000002048242f2ffp+0, false, false,
++	0x1.0000010000000002048242f2ff8p+0, false, false,
++	false,
++	0x1.0000010000000002048242f2ff66p+0, false, false,
++	0x1.0000010000000002048242f2ff67p+0, false, false,
++	0x1.0000010000000002048242f2ff66p+0, false, false,
++	0x1.0000010000000002048242f2ff67p+0, false, false),
+   TEST ("1.0000000596046447755",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000004p+0, false,
+-	false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	0x1.0000010000000004p+0, false,
+-	false,
+-	0x1.0000010000000002048242f2ffp+0, false,
+-	0x1.0000010000000002048242f2ff8p+0, false,
+-	0x1.0000010000000002048242f2ffp+0, false,
+-	0x1.0000010000000002048242f2ff8p+0, false,
+-	false,
+-	0x1.0000010000000002048242f2ff66p+0, false,
+-	0x1.0000010000000002048242f2ff67p+0, false,
+-	0x1.0000010000000002048242f2ff66p+0, false,
+-	0x1.0000010000000002048242f2ff67p+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000004p+0, false, false,
++	false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	0x1.0000010000000004p+0, false, false,
++	false,
++	0x1.0000010000000002048242f2ffp+0, false, false,
++	0x1.0000010000000002048242f2ff8p+0, false, false,
++	0x1.0000010000000002048242f2ffp+0, false, false,
++	0x1.0000010000000002048242f2ff8p+0, false, false,
++	false,
++	0x1.0000010000000002048242f2ff66p+0, false, false,
++	0x1.0000010000000002048242f2ff67p+0, false, false,
++	0x1.0000010000000002048242f2ff66p+0, false, false,
++	0x1.0000010000000002048242f2ff67p+0, false, false),
+   TEST ("1.000000059604644776",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	false,
+-	0x1.000001000000000ap+0, false,
+-	0x1.000001000000000cp+0, false,
+-	0x1.000001000000000ap+0, false,
+-	0x1.000001000000000cp+0, false,
+-	false,
+-	0x1.000001000000000ap+0, false,
+-	0x1.000001000000000cp+0, false,
+-	0x1.000001000000000ap+0, false,
+-	0x1.000001000000000cp+0, false,
+-	false,
+-	0x1.000001000000000b3db12bdc21p+0, false,
+-	0x1.000001000000000b3db12bdc21p+0, false,
+-	0x1.000001000000000b3db12bdc21p+0, false,
+-	0x1.000001000000000b3db12bdc218p+0, false,
+-	false,
+-	0x1.000001000000000b3db12bdc213cp+0, false,
+-	0x1.000001000000000b3db12bdc213dp+0, false,
+-	0x1.000001000000000b3db12bdc213cp+0, false,
+-	0x1.000001000000000b3db12bdc213dp+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	false,
++	0x1.000001000000000ap+0, false, false,
++	0x1.000001000000000cp+0, false, false,
++	0x1.000001000000000ap+0, false, false,
++	0x1.000001000000000cp+0, false, false,
++	false,
++	0x1.000001000000000ap+0, false, false,
++	0x1.000001000000000cp+0, false, false,
++	0x1.000001000000000ap+0, false, false,
++	0x1.000001000000000cp+0, false, false,
++	false,
++	0x1.000001000000000b3db12bdc21p+0, false, false,
++	0x1.000001000000000b3db12bdc21p+0, false, false,
++	0x1.000001000000000b3db12bdc21p+0, false, false,
++	0x1.000001000000000b3db12bdc218p+0, false, false,
++	false,
++	0x1.000001000000000b3db12bdc213cp+0, false, false,
++	0x1.000001000000000b3db12bdc213dp+0, false, false,
++	0x1.000001000000000b3db12bdc213cp+0, false, false,
++	0x1.000001000000000b3db12bdc213dp+0, false, false),
+   TEST ("1.000000059604644775",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000000fffffffp+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000000fffffffp+0, false,
+-	0x1.000001p+0, false,
+-	false,
+-	0x1.000000fffffffff8p+0, false,
+-	0x1.000000fffffffff8p+0, false,
+-	0x1.000000fffffffff8p+0, false,
+-	0x1.000000fffffffffap+0, false,
+-	false,
+-	0x1.000000fffffffff8p+0, false,
+-	0x1.000000fffffffff8p+0, false,
+-	0x1.000000fffffffff8p+0, false,
+-	0x1.000000fffffffffap+0, false,
+-	false,
+-	0x1.000000fffffffff8cb535a09dd8p+0, false,
+-	0x1.000000fffffffff8cb535a09dd8p+0, false,
+-	0x1.000000fffffffff8cb535a09dd8p+0, false,
+-	0x1.000000fffffffff8cb535a09dep+0, false,
+-	false,
+-	0x1.000000fffffffff8cb535a09dd9p+0, false,
+-	0x1.000000fffffffff8cb535a09dd91p+0, false,
+-	0x1.000000fffffffff8cb535a09dd9p+0, false,
+-	0x1.000000fffffffff8cb535a09dd91p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000000fffffffp+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000000fffffffp+0, false, false,
++	0x1.000001p+0, false, false,
++	false,
++	0x1.000000fffffffff8p+0, false, false,
++	0x1.000000fffffffff8p+0, false, false,
++	0x1.000000fffffffff8p+0, false, false,
++	0x1.000000fffffffffap+0, false, false,
++	false,
++	0x1.000000fffffffff8p+0, false, false,
++	0x1.000000fffffffff8p+0, false, false,
++	0x1.000000fffffffff8p+0, false, false,
++	0x1.000000fffffffffap+0, false, false,
++	false,
++	0x1.000000fffffffff8cb535a09dd8p+0, false, false,
++	0x1.000000fffffffff8cb535a09dd8p+0, false, false,
++	0x1.000000fffffffff8cb535a09dd8p+0, false, false,
++	0x1.000000fffffffff8cb535a09dep+0, false, false,
++	false,
++	0x1.000000fffffffff8cb535a09dd9p+0, false, false,
++	0x1.000000fffffffff8cb535a09dd91p+0, false, false,
++	0x1.000000fffffffff8cb535a09dd9p+0, false, false,
++	0x1.000000fffffffff8cb535a09dd91p+0, false, false),
+   TEST ("1.00000005960464478",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	false,
+-	0x1.0000010000000054p+0, false,
+-	0x1.0000010000000056p+0, false,
+-	0x1.0000010000000054p+0, false,
+-	0x1.0000010000000056p+0, false,
+-	false,
+-	0x1.0000010000000054p+0, false,
+-	0x1.0000010000000056p+0, false,
+-	0x1.0000010000000054p+0, false,
+-	0x1.0000010000000056p+0, false,
+-	false,
+-	0x1.0000010000000055072873252f8p+0, false,
+-	0x1.0000010000000055072873253p+0, false,
+-	0x1.0000010000000055072873252f8p+0, false,
+-	0x1.0000010000000055072873253p+0, false,
+-	false,
+-	0x1.0000010000000055072873252febp+0, false,
+-	0x1.0000010000000055072873252febp+0, false,
+-	0x1.0000010000000055072873252febp+0, false,
+-	0x1.0000010000000055072873252fecp+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	false,
++	0x1.0000010000000054p+0, false, false,
++	0x1.0000010000000056p+0, false, false,
++	0x1.0000010000000054p+0, false, false,
++	0x1.0000010000000056p+0, false, false,
++	false,
++	0x1.0000010000000054p+0, false, false,
++	0x1.0000010000000056p+0, false, false,
++	0x1.0000010000000054p+0, false, false,
++	0x1.0000010000000056p+0, false, false,
++	false,
++	0x1.0000010000000055072873252f8p+0, false, false,
++	0x1.0000010000000055072873253p+0, false, false,
++	0x1.0000010000000055072873252f8p+0, false, false,
++	0x1.0000010000000055072873253p+0, false, false,
++	false,
++	0x1.0000010000000055072873252febp+0, false, false,
++	0x1.0000010000000055072873252febp+0, false, false,
++	0x1.0000010000000055072873252febp+0, false, false,
++	0x1.0000010000000055072873252fecp+0, false, false),
+   TEST ("1.0000000596046448",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	false,
+-	0x1.00000100000001c4p+0, false,
+-	0x1.00000100000001c6p+0, false,
+-	0x1.00000100000001c4p+0, false,
+-	0x1.00000100000001c6p+0, false,
+-	false,
+-	0x1.00000100000001c4p+0, false,
+-	0x1.00000100000001c6p+0, false,
+-	0x1.00000100000001c4p+0, false,
+-	0x1.00000100000001c6p+0, false,
+-	false,
+-	0x1.00000100000001c5f67cd79279p+0, false,
+-	0x1.00000100000001c5f67cd792798p+0, false,
+-	0x1.00000100000001c5f67cd79279p+0, false,
+-	0x1.00000100000001c5f67cd792798p+0, false,
+-	false,
+-	0x1.00000100000001c5f67cd7927953p+0, false,
+-	0x1.00000100000001c5f67cd7927954p+0, false,
+-	0x1.00000100000001c5f67cd7927953p+0, false,
+-	0x1.00000100000001c5f67cd7927954p+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	false,
++	0x1.00000100000001c4p+0, false, false,
++	0x1.00000100000001c6p+0, false, false,
++	0x1.00000100000001c4p+0, false, false,
++	0x1.00000100000001c6p+0, false, false,
++	false,
++	0x1.00000100000001c4p+0, false, false,
++	0x1.00000100000001c6p+0, false, false,
++	0x1.00000100000001c4p+0, false, false,
++	0x1.00000100000001c6p+0, false, false,
++	false,
++	0x1.00000100000001c5f67cd79279p+0, false, false,
++	0x1.00000100000001c5f67cd792798p+0, false, false,
++	0x1.00000100000001c5f67cd79279p+0, false, false,
++	0x1.00000100000001c5f67cd792798p+0, false, false,
++	false,
++	0x1.00000100000001c5f67cd7927953p+0, false, false,
++	0x1.00000100000001c5f67cd7927954p+0, false, false,
++	0x1.00000100000001c5f67cd7927953p+0, false, false,
++	0x1.00000100000001c5f67cd7927954p+0, false, false),
+   TEST ("1.000000059604645",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.0000010000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	0x1.0000010000002p+0, false,
+-	false,
+-	0x1.000001000000102ep+0, false,
+-	0x1.000001000000103p+0, false,
+-	0x1.000001000000102ep+0, false,
+-	0x1.000001000000103p+0, false,
+-	false,
+-	0x1.000001000000102ep+0, false,
+-	0x1.000001000000103p+0, false,
+-	0x1.000001000000102ep+0, false,
+-	0x1.000001000000103p+0, false,
+-	false,
+-	0x1.000001000000102f4fc8c3d757p+0, false,
+-	0x1.000001000000102f4fc8c3d7578p+0, false,
+-	0x1.000001000000102f4fc8c3d757p+0, false,
+-	0x1.000001000000102f4fc8c3d7578p+0, false,
+-	false,
+-	0x1.000001000000102f4fc8c3d75769p+0, false,
+-	0x1.000001000000102f4fc8c3d75769p+0, false,
+-	0x1.000001000000102f4fc8c3d75769p+0, false,
+-	0x1.000001000000102f4fc8c3d7576ap+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.0000010000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	0x1.0000010000002p+0, false, false,
++	false,
++	0x1.000001000000102ep+0, false, false,
++	0x1.000001000000103p+0, false, false,
++	0x1.000001000000102ep+0, false, false,
++	0x1.000001000000103p+0, false, false,
++	false,
++	0x1.000001000000102ep+0, false, false,
++	0x1.000001000000103p+0, false, false,
++	0x1.000001000000102ep+0, false, false,
++	0x1.000001000000103p+0, false, false,
++	false,
++	0x1.000001000000102f4fc8c3d757p+0, false, false,
++	0x1.000001000000102f4fc8c3d7578p+0, false, false,
++	0x1.000001000000102f4fc8c3d757p+0, false, false,
++	0x1.000001000000102f4fc8c3d7578p+0, false, false,
++	false,
++	0x1.000001000000102f4fc8c3d75769p+0, false, false,
++	0x1.000001000000102f4fc8c3d75769p+0, false, false,
++	0x1.000001000000102f4fc8c3d75769p+0, false, false,
++	0x1.000001000000102f4fc8c3d7576ap+0, false, false),
+   TEST ("1.00000005960464",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000000fffffeap+0, false,
+-	0x1.000000fffffeap+0, false,
+-	0x1.000000fffffeap+0, false,
+-	0x1.000000fffffebp+0, false,
+-	false,
+-	0x1.000000fffffea7e4p+0, false,
+-	0x1.000000fffffea7e6p+0, false,
+-	0x1.000000fffffea7e4p+0, false,
+-	0x1.000000fffffea7e6p+0, false,
+-	false,
+-	0x1.000000fffffea7e4p+0, false,
+-	0x1.000000fffffea7e6p+0, false,
+-	0x1.000000fffffea7e4p+0, false,
+-	0x1.000000fffffea7e6p+0, false,
+-	false,
+-	0x1.000000fffffea7e5975eb11da7p+0, false,
+-	0x1.000000fffffea7e5975eb11da78p+0, false,
+-	0x1.000000fffffea7e5975eb11da7p+0, false,
+-	0x1.000000fffffea7e5975eb11da78p+0, false,
+-	false,
+-	0x1.000000fffffea7e5975eb11da74ap+0, false,
+-	0x1.000000fffffea7e5975eb11da74bp+0, false,
+-	0x1.000000fffffea7e5975eb11da74ap+0, false,
+-	0x1.000000fffffea7e5975eb11da74bp+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000000fffffeap+0, false, false,
++	0x1.000000fffffeap+0, false, false,
++	0x1.000000fffffeap+0, false, false,
++	0x1.000000fffffebp+0, false, false,
++	false,
++	0x1.000000fffffea7e4p+0, false, false,
++	0x1.000000fffffea7e6p+0, false, false,
++	0x1.000000fffffea7e4p+0, false, false,
++	0x1.000000fffffea7e6p+0, false, false,
++	false,
++	0x1.000000fffffea7e4p+0, false, false,
++	0x1.000000fffffea7e6p+0, false, false,
++	0x1.000000fffffea7e4p+0, false, false,
++	0x1.000000fffffea7e6p+0, false, false,
++	false,
++	0x1.000000fffffea7e5975eb11da7p+0, false, false,
++	0x1.000000fffffea7e5975eb11da78p+0, false, false,
++	0x1.000000fffffea7e5975eb11da7p+0, false, false,
++	0x1.000000fffffea7e5975eb11da78p+0, false, false,
++	false,
++	0x1.000000fffffea7e5975eb11da74ap+0, false, false,
++	0x1.000000fffffea7e5975eb11da74bp+0, false, false,
++	0x1.000000fffffea7e5975eb11da74ap+0, false, false,
++	0x1.000000fffffea7e5975eb11da74bp+0, false, false),
+   TEST ("1.0000000596046",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000000fffff36p+0, false,
+-	0x1.000000fffff36p+0, false,
+-	0x1.000000fffff36p+0, false,
+-	0x1.000000fffff37p+0, false,
+-	false,
+-	0x1.000000fffff36596p+0, false,
+-	0x1.000000fffff36598p+0, false,
+-	0x1.000000fffff36596p+0, false,
+-	0x1.000000fffff36598p+0, false,
+-	false,
+-	0x1.000000fffff36596p+0, false,
+-	0x1.000000fffff36598p+0, false,
+-	0x1.000000fffff36596p+0, false,
+-	0x1.000000fffff36598p+0, false,
+-	false,
+-	0x1.000000fffff36597d40e1b5026p+0, false,
+-	0x1.000000fffff36597d40e1b50268p+0, false,
+-	0x1.000000fffff36597d40e1b5026p+0, false,
+-	0x1.000000fffff36597d40e1b50268p+0, false,
+-	false,
+-	0x1.000000fffff36597d40e1b502655p+0, false,
+-	0x1.000000fffff36597d40e1b502656p+0, false,
+-	0x1.000000fffff36597d40e1b502655p+0, false,
+-	0x1.000000fffff36597d40e1b502656p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000000fffff36p+0, false, false,
++	0x1.000000fffff36p+0, false, false,
++	0x1.000000fffff36p+0, false, false,
++	0x1.000000fffff37p+0, false, false,
++	false,
++	0x1.000000fffff36596p+0, false, false,
++	0x1.000000fffff36598p+0, false, false,
++	0x1.000000fffff36596p+0, false, false,
++	0x1.000000fffff36598p+0, false, false,
++	false,
++	0x1.000000fffff36596p+0, false, false,
++	0x1.000000fffff36598p+0, false, false,
++	0x1.000000fffff36596p+0, false, false,
++	0x1.000000fffff36598p+0, false, false,
++	false,
++	0x1.000000fffff36597d40e1b5026p+0, false, false,
++	0x1.000000fffff36597d40e1b50268p+0, false, false,
++	0x1.000000fffff36597d40e1b5026p+0, false, false,
++	0x1.000000fffff36597d40e1b50268p+0, false, false,
++	false,
++	0x1.000000fffff36597d40e1b502655p+0, false, false,
++	0x1.000000fffff36597d40e1b502656p+0, false, false,
++	0x1.000000fffff36597d40e1b502655p+0, false, false,
++	0x1.000000fffff36597d40e1b502656p+0, false, false),
+   TEST ("1.000000059605",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001000063fp+0, false,
+-	0x1.000001000064p+0, false,
+-	0x1.000001000063fp+0, false,
+-	0x1.000001000064p+0, false,
+-	false,
+-	0x1.000001000063fcap+0, false,
+-	0x1.000001000063fca2p+0, false,
+-	0x1.000001000063fcap+0, false,
+-	0x1.000001000063fca2p+0, false,
+-	false,
+-	0x1.000001000063fcap+0, false,
+-	0x1.000001000063fca2p+0, false,
+-	0x1.000001000063fcap+0, false,
+-	0x1.000001000063fca2p+0, false,
+-	false,
+-	0x1.000001000063fca17533f5572f8p+0, false,
+-	0x1.000001000063fca17533f5573p+0, false,
+-	0x1.000001000063fca17533f5572f8p+0, false,
+-	0x1.000001000063fca17533f5573p+0, false,
+-	false,
+-	0x1.000001000063fca17533f5572fe9p+0, false,
+-	0x1.000001000063fca17533f5572feap+0, false,
+-	0x1.000001000063fca17533f5572fe9p+0, false,
+-	0x1.000001000063fca17533f5572feap+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001000063fp+0, false, false,
++	0x1.000001000064p+0, false, false,
++	0x1.000001000063fp+0, false, false,
++	0x1.000001000064p+0, false, false,
++	false,
++	0x1.000001000063fcap+0, false, false,
++	0x1.000001000063fca2p+0, false, false,
++	0x1.000001000063fcap+0, false, false,
++	0x1.000001000063fca2p+0, false, false,
++	false,
++	0x1.000001000063fcap+0, false, false,
++	0x1.000001000063fca2p+0, false, false,
++	0x1.000001000063fcap+0, false, false,
++	0x1.000001000063fca2p+0, false, false,
++	false,
++	0x1.000001000063fca17533f5572f8p+0, false, false,
++	0x1.000001000063fca17533f5573p+0, false, false,
++	0x1.000001000063fca17533f5572f8p+0, false, false,
++	0x1.000001000063fca17533f5573p+0, false, false,
++	false,
++	0x1.000001000063fca17533f5572fe9p+0, false, false,
++	0x1.000001000063fca17533f5572feap+0, false, false,
++	0x1.000001000063fca17533f5572fe9p+0, false, false,
++	0x1.000001000063fca17533f5572feap+0, false, false),
+   TEST ("1.00000005960",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000000fffae49p+0, false,
+-	0x1.000000fffae4ap+0, false,
+-	0x1.000000fffae49p+0, false,
+-	0x1.000000fffae4ap+0, false,
+-	false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	false,
+-	0x1.000000fffae49ca916dacfff38p+0, false,
+-	0x1.000000fffae49ca916dacfff38p+0, false,
+-	0x1.000000fffae49ca916dacfff38p+0, false,
+-	0x1.000000fffae49ca916dacfff388p+0, false,
+-	false,
+-	0x1.000000fffae49ca916dacfff382dp+0, false,
+-	0x1.000000fffae49ca916dacfff382dp+0, false,
+-	0x1.000000fffae49ca916dacfff382dp+0, false,
+-	0x1.000000fffae49ca916dacfff382ep+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000000fffae49p+0, false, false,
++	0x1.000000fffae4ap+0, false, false,
++	0x1.000000fffae49p+0, false, false,
++	0x1.000000fffae4ap+0, false, false,
++	false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	false,
++	0x1.000000fffae49ca916dacfff38p+0, false, false,
++	0x1.000000fffae49ca916dacfff38p+0, false, false,
++	0x1.000000fffae49ca916dacfff38p+0, false, false,
++	0x1.000000fffae49ca916dacfff388p+0, false, false,
++	false,
++	0x1.000000fffae49ca916dacfff382dp+0, false, false,
++	0x1.000000fffae49ca916dacfff382dp+0, false, false,
++	0x1.000000fffae49ca916dacfff382dp+0, false, false,
++	0x1.000000fffae49ca916dacfff382ep+0, false, false),
+   TEST ("1.0000000596",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000000fffae49p+0, false,
+-	0x1.000000fffae4ap+0, false,
+-	0x1.000000fffae49p+0, false,
+-	0x1.000000fffae4ap+0, false,
+-	false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	0x1.000000fffae49ca8p+0, false,
+-	0x1.000000fffae49caap+0, false,
+-	false,
+-	0x1.000000fffae49ca916dacfff38p+0, false,
+-	0x1.000000fffae49ca916dacfff38p+0, false,
+-	0x1.000000fffae49ca916dacfff38p+0, false,
+-	0x1.000000fffae49ca916dacfff388p+0, false,
+-	false,
+-	0x1.000000fffae49ca916dacfff382dp+0, false,
+-	0x1.000000fffae49ca916dacfff382dp+0, false,
+-	0x1.000000fffae49ca916dacfff382dp+0, false,
+-	0x1.000000fffae49ca916dacfff382ep+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000000fffae49p+0, false, false,
++	0x1.000000fffae4ap+0, false, false,
++	0x1.000000fffae49p+0, false, false,
++	0x1.000000fffae4ap+0, false, false,
++	false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	0x1.000000fffae49ca8p+0, false, false,
++	0x1.000000fffae49caap+0, false, false,
++	false,
++	0x1.000000fffae49ca916dacfff38p+0, false, false,
++	0x1.000000fffae49ca916dacfff38p+0, false, false,
++	0x1.000000fffae49ca916dacfff38p+0, false, false,
++	0x1.000000fffae49ca916dacfff388p+0, false, false,
++	false,
++	0x1.000000fffae49ca916dacfff382dp+0, false, false,
++	0x1.000000fffae49ca916dacfff382dp+0, false, false,
++	0x1.000000fffae49ca916dacfff382dp+0, false, false,
++	0x1.000000fffae49ca916dacfff382ep+0, false, false),
+   TEST ("1.000000060",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.00000101b2b29p+0, false,
+-	0x1.00000101b2b2ap+0, false,
+-	0x1.00000101b2b29p+0, false,
+-	0x1.00000101b2b2ap+0, false,
+-	false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a48p+0, false,
+-	false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a48p+0, false,
+-	false,
+-	0x1.00000101b2b29a4692b67b7ca3p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca3p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca3p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca38p+0, false,
+-	false,
+-	0x1.00000101b2b29a4692b67b7ca313p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca314p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca313p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca314p+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.00000101b2b29p+0, false, false,
++	0x1.00000101b2b2ap+0, false, false,
++	0x1.00000101b2b29p+0, false, false,
++	0x1.00000101b2b2ap+0, false, false,
++	false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a48p+0, false, false,
++	false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a48p+0, false, false,
++	false,
++	0x1.00000101b2b29a4692b67b7ca3p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca3p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca3p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca38p+0, false, false,
++	false,
++	0x1.00000101b2b29a4692b67b7ca313p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca314p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca313p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca314p+0, false, false),
+   TEST ("1.00000006",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.00000101b2b29p+0, false,
+-	0x1.00000101b2b2ap+0, false,
+-	0x1.00000101b2b29p+0, false,
+-	0x1.00000101b2b2ap+0, false,
+-	false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a48p+0, false,
+-	false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a46p+0, false,
+-	0x1.00000101b2b29a48p+0, false,
+-	false,
+-	0x1.00000101b2b29a4692b67b7ca3p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca3p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca3p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca38p+0, false,
+-	false,
+-	0x1.00000101b2b29a4692b67b7ca313p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca314p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca313p+0, false,
+-	0x1.00000101b2b29a4692b67b7ca314p+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.00000101b2b29p+0, false, false,
++	0x1.00000101b2b2ap+0, false, false,
++	0x1.00000101b2b29p+0, false, false,
++	0x1.00000101b2b2ap+0, false, false,
++	false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a48p+0, false, false,
++	false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a46p+0, false, false,
++	0x1.00000101b2b29a48p+0, false, false,
++	false,
++	0x1.00000101b2b29a4692b67b7ca3p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca3p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca3p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca38p+0, false, false,
++	false,
++	0x1.00000101b2b29a4692b67b7ca313p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca314p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca313p+0, false, false,
++	0x1.00000101b2b29a4692b67b7ca314p+0, false, false),
+   TEST ("1.0000001",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001ad7f29ap+0, false,
+-	0x1.000001ad7f29bp+0, false,
+-	0x1.000001ad7f29ap+0, false,
+-	0x1.000001ad7f29bp+0, false,
+-	false,
+-	0x1.000001ad7f29abcap+0, false,
+-	0x1.000001ad7f29abcap+0, false,
+-	0x1.000001ad7f29abcap+0, false,
+-	0x1.000001ad7f29abccp+0, false,
+-	false,
+-	0x1.000001ad7f29abcap+0, false,
+-	0x1.000001ad7f29abcap+0, false,
+-	0x1.000001ad7f29abcap+0, false,
+-	0x1.000001ad7f29abccp+0, false,
+-	false,
+-	0x1.000001ad7f29abcaf485787a65p+0, false,
+-	0x1.000001ad7f29abcaf485787a65p+0, false,
+-	0x1.000001ad7f29abcaf485787a65p+0, false,
+-	0x1.000001ad7f29abcaf485787a658p+0, false,
+-	false,
+-	0x1.000001ad7f29abcaf485787a652p+0, false,
+-	0x1.000001ad7f29abcaf485787a6521p+0, false,
+-	0x1.000001ad7f29abcaf485787a652p+0, false,
+-	0x1.000001ad7f29abcaf485787a6521p+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001ad7f29ap+0, false, false,
++	0x1.000001ad7f29bp+0, false, false,
++	0x1.000001ad7f29ap+0, false, false,
++	0x1.000001ad7f29bp+0, false, false,
++	false,
++	0x1.000001ad7f29abcap+0, false, false,
++	0x1.000001ad7f29abcap+0, false, false,
++	0x1.000001ad7f29abcap+0, false, false,
++	0x1.000001ad7f29abccp+0, false, false,
++	false,
++	0x1.000001ad7f29abcap+0, false, false,
++	0x1.000001ad7f29abcap+0, false, false,
++	0x1.000001ad7f29abcap+0, false, false,
++	0x1.000001ad7f29abccp+0, false, false,
++	false,
++	0x1.000001ad7f29abcaf485787a65p+0, false, false,
++	0x1.000001ad7f29abcaf485787a65p+0, false, false,
++	0x1.000001ad7f29abcaf485787a65p+0, false, false,
++	0x1.000001ad7f29abcaf485787a658p+0, false, false,
++	false,
++	0x1.000001ad7f29abcaf485787a652p+0, false, false,
++	0x1.000001ad7f29abcaf485787a6521p+0, false, false,
++	0x1.000001ad7f29abcaf485787a652p+0, false, false,
++	0x1.000001ad7f29abcaf485787a6521p+0, false, false),
+   TEST ("1.000000",
+ 	true,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	true,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	true,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	true,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	true,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	true,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	true,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	true,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	true,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	true,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	true,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false),
+   TEST ("1.00000000000000011113",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	false,
+-	0x1.0000000000000801fc96557232p+0, false,
+-	0x1.0000000000000801fc96557232p+0, false,
+-	0x1.0000000000000801fc96557232p+0, false,
+-	0x1.0000000000000801fc965572328p+0, false,
+-	false,
+-	0x1.0000000000000801fc9655723222p+0, false,
+-	0x1.0000000000000801fc9655723222p+0, false,
+-	0x1.0000000000000801fc9655723222p+0, false,
+-	0x1.0000000000000801fc9655723223p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	false,
++	0x1.0000000000000801fc96557232p+0, false, false,
++	0x1.0000000000000801fc96557232p+0, false, false,
++	0x1.0000000000000801fc96557232p+0, false, false,
++	0x1.0000000000000801fc965572328p+0, false, false,
++	false,
++	0x1.0000000000000801fc9655723222p+0, false, false,
++	0x1.0000000000000801fc9655723222p+0, false, false,
++	0x1.0000000000000801fc9655723222p+0, false, false,
++	0x1.0000000000000801fc9655723223p+0, false, false),
+   TEST ("1.00000000000000011103",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	false,
+-	0x1.00000000000008002459c076c48p+0, false,
+-	0x1.00000000000008002459c076c5p+0, false,
+-	0x1.00000000000008002459c076c48p+0, false,
+-	0x1.00000000000008002459c076c5p+0, false,
+-	false,
+-	0x1.00000000000008002459c076c4f7p+0, false,
+-	0x1.00000000000008002459c076c4f8p+0, false,
+-	0x1.00000000000008002459c076c4f7p+0, false,
+-	0x1.00000000000008002459c076c4f8p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	false,
++	0x1.00000000000008002459c076c48p+0, false, false,
++	0x1.00000000000008002459c076c5p+0, false, false,
++	0x1.00000000000008002459c076c48p+0, false, false,
++	0x1.00000000000008002459c076c5p+0, false, false,
++	false,
++	0x1.00000000000008002459c076c4f7p+0, false, false,
++	0x1.00000000000008002459c076c4f8p+0, false, false,
++	0x1.00000000000008002459c076c4f7p+0, false, false,
++	0x1.00000000000008002459c076c4f8p+0, false, false),
+   TEST ("1.00000000000000011102",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	false,
+-	0x1.00000000000007fff5207e5dap+0, false,
+-	0x1.00000000000007fff5207e5da08p+0, false,
+-	0x1.00000000000007fff5207e5dap+0, false,
+-	0x1.00000000000007fff5207e5da08p+0, false,
+-	false,
+-	0x1.00000000000007fff5207e5da073p+0, false,
+-	0x1.00000000000007fff5207e5da073p+0, false,
+-	0x1.00000000000007fff5207e5da073p+0, false,
+-	0x1.00000000000007fff5207e5da074p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	false,
++	0x1.00000000000007fff5207e5dap+0, false, false,
++	0x1.00000000000007fff5207e5da08p+0, false, false,
++	0x1.00000000000007fff5207e5dap+0, false, false,
++	0x1.00000000000007fff5207e5da08p+0, false, false,
++	false,
++	0x1.00000000000007fff5207e5da073p+0, false, false,
++	0x1.00000000000007fff5207e5da073p+0, false, false,
++	0x1.00000000000007fff5207e5da073p+0, false, false,
++	0x1.00000000000007fff5207e5da074p+0, false, false),
+   TEST ("1.00000000000000011101",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	false,
+-	0x1.00000000000007ffc5e73c447b8p+0, false,
+-	0x1.00000000000007ffc5e73c447cp+0, false,
+-	0x1.00000000000007ffc5e73c447b8p+0, false,
+-	0x1.00000000000007ffc5e73c447cp+0, false,
+-	false,
+-	0x1.00000000000007ffc5e73c447befp+0, false,
+-	0x1.00000000000007ffc5e73c447befp+0, false,
+-	0x1.00000000000007ffc5e73c447befp+0, false,
+-	0x1.00000000000007ffc5e73c447bfp+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	false,
++	0x1.00000000000007ffc5e73c447b8p+0, false, false,
++	0x1.00000000000007ffc5e73c447cp+0, false, false,
++	0x1.00000000000007ffc5e73c447b8p+0, false, false,
++	0x1.00000000000007ffc5e73c447cp+0, false, false,
++	false,
++	0x1.00000000000007ffc5e73c447befp+0, false, false,
++	0x1.00000000000007ffc5e73c447befp+0, false, false,
++	0x1.00000000000007ffc5e73c447befp+0, false, false,
++	0x1.00000000000007ffc5e73c447bfp+0, false, false),
+   TEST ("1.0000000000000001111",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.0000000000000802p+0, false,
+-	false,
+-	0x1.00000000000008016eea8f26c48p+0, false,
+-	0x1.00000000000008016eea8f26c48p+0, false,
+-	0x1.00000000000008016eea8f26c48p+0, false,
+-	0x1.00000000000008016eea8f26c5p+0, false,
+-	false,
+-	0x1.00000000000008016eea8f26c495p+0, false,
+-	0x1.00000000000008016eea8f26c496p+0, false,
+-	0x1.00000000000008016eea8f26c495p+0, false,
+-	0x1.00000000000008016eea8f26c496p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.0000000000000802p+0, false, false,
++	false,
++	0x1.00000000000008016eea8f26c48p+0, false, false,
++	0x1.00000000000008016eea8f26c48p+0, false, false,
++	0x1.00000000000008016eea8f26c48p+0, false, false,
++	0x1.00000000000008016eea8f26c5p+0, false, false,
++	false,
++	0x1.00000000000008016eea8f26c495p+0, false, false,
++	0x1.00000000000008016eea8f26c496p+0, false, false,
++	0x1.00000000000008016eea8f26c495p+0, false, false,
++	0x1.00000000000008016eea8f26c496p+0, false, false),
+   TEST ("1.000000000000000111",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000007fep+0, false,
+-	0x1.00000000000008p+0, false,
+-	false,
+-	0x1.00000000000007ff96adfa2b57p+0, false,
+-	0x1.00000000000007ff96adfa2b578p+0, false,
+-	0x1.00000000000007ff96adfa2b57p+0, false,
+-	0x1.00000000000007ff96adfa2b578p+0, false,
+-	false,
+-	0x1.00000000000007ff96adfa2b576ap+0, false,
+-	0x1.00000000000007ff96adfa2b576bp+0, false,
+-	0x1.00000000000007ff96adfa2b576ap+0, false,
+-	0x1.00000000000007ff96adfa2b576bp+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000007fep+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	false,
++	0x1.00000000000007ff96adfa2b57p+0, false, false,
++	0x1.00000000000007ff96adfa2b578p+0, false, false,
++	0x1.00000000000007ff96adfa2b57p+0, false, false,
++	0x1.00000000000007ff96adfa2b578p+0, false, false,
++	false,
++	0x1.00000000000007ff96adfa2b576ap+0, false, false,
++	0x1.00000000000007ff96adfa2b576bp+0, false, false,
++	0x1.00000000000007ff96adfa2b576ap+0, false, false,
++	0x1.00000000000007ff96adfa2b576bp+0, false, false),
+   TEST ("1.00000000000000011",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.00000000000007ecp+0, false,
+-	0x1.00000000000007eep+0, false,
+-	0x1.00000000000007ecp+0, false,
+-	0x1.00000000000007eep+0, false,
+-	false,
+-	0x1.00000000000007ecp+0, false,
+-	0x1.00000000000007eep+0, false,
+-	0x1.00000000000007ecp+0, false,
+-	0x1.00000000000007eep+0, false,
+-	false,
+-	0x1.00000000000007ed24502859138p+0, false,
+-	0x1.00000000000007ed24502859138p+0, false,
+-	0x1.00000000000007ed24502859138p+0, false,
+-	0x1.00000000000007ed2450285914p+0, false,
+-	false,
+-	0x1.00000000000007ed2450285913bfp+0, false,
+-	0x1.00000000000007ed2450285913bfp+0, false,
+-	0x1.00000000000007ed2450285913bfp+0, false,
+-	0x1.00000000000007ed2450285913cp+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.00000000000007ecp+0, false, false,
++	0x1.00000000000007eep+0, false, false,
++	0x1.00000000000007ecp+0, false, false,
++	0x1.00000000000007eep+0, false, false,
++	false,
++	0x1.00000000000007ecp+0, false, false,
++	0x1.00000000000007eep+0, false, false,
++	0x1.00000000000007ecp+0, false, false,
++	0x1.00000000000007eep+0, false, false,
++	false,
++	0x1.00000000000007ed24502859138p+0, false, false,
++	0x1.00000000000007ed24502859138p+0, false, false,
++	0x1.00000000000007ed24502859138p+0, false, false,
++	0x1.00000000000007ed2450285914p+0, false, false,
++	false,
++	0x1.00000000000007ed2450285913bfp+0, false, false,
++	0x1.00000000000007ed2450285913bfp+0, false, false,
++	0x1.00000000000007ed2450285913bfp+0, false, false,
++	0x1.00000000000007ed2450285913cp+0, false, false),
+   TEST ("1.0000000000000001",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1.0000000000000734p+0, false,
+-	0x1.0000000000000734p+0, false,
+-	0x1.0000000000000734p+0, false,
+-	0x1.0000000000000736p+0, false,
+-	false,
+-	0x1.0000000000000734p+0, false,
+-	0x1.0000000000000734p+0, false,
+-	0x1.0000000000000734p+0, false,
+-	0x1.0000000000000736p+0, false,
+-	false,
+-	0x1.0000000000000734aca5f6226fp+0, false,
+-	0x1.0000000000000734aca5f6226fp+0, false,
+-	0x1.0000000000000734aca5f6226fp+0, false,
+-	0x1.0000000000000734aca5f6226f8p+0, false,
+-	false,
+-	0x1.0000000000000734aca5f6226f0ap+0, false,
+-	0x1.0000000000000734aca5f6226f0bp+0, false,
+-	0x1.0000000000000734aca5f6226f0ap+0, false,
+-	0x1.0000000000000734aca5f6226f0bp+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1.0000000000000734p+0, false, false,
++	0x1.0000000000000734p+0, false, false,
++	0x1.0000000000000734p+0, false, false,
++	0x1.0000000000000736p+0, false, false,
++	false,
++	0x1.0000000000000734p+0, false, false,
++	0x1.0000000000000734p+0, false, false,
++	0x1.0000000000000734p+0, false, false,
++	0x1.0000000000000736p+0, false, false,
++	false,
++	0x1.0000000000000734aca5f6226fp+0, false, false,
++	0x1.0000000000000734aca5f6226fp+0, false, false,
++	0x1.0000000000000734aca5f6226fp+0, false, false,
++	0x1.0000000000000734aca5f6226f8p+0, false, false,
++	false,
++	0x1.0000000000000734aca5f6226f0ap+0, false, false,
++	0x1.0000000000000734aca5f6226f0bp+0, false, false,
++	0x1.0000000000000734aca5f6226f0ap+0, false, false,
++	0x1.0000000000000734aca5f6226f0bp+0, false, false),
+   TEST ("3929201589819414e-25",
+ 	false,
+-	0x1.b0053p-32, false,
+-	0x1.b00532p-32, false,
+-	0x1.b0053p-32, false,
+-	0x1.b00532p-32, false,
+-	false,
+-	0x1.b005314e2421ep-32, false,
+-	0x1.b005314e2421ep-32, false,
+-	0x1.b005314e2421ep-32, false,
+-	0x1.b005314e2421fp-32, false,
+-	false,
+-	0x1.b005314e2421e7fep-32, false,
+-	0x1.b005314e2421e8p-32, false,
+-	0x1.b005314e2421e7fep-32, false,
+-	0x1.b005314e2421e8p-32, false,
+-	false,
+-	0x1.b005314e2421e7fep-32, false,
+-	0x1.b005314e2421e8p-32, false,
+-	0x1.b005314e2421e7fep-32, false,
+-	0x1.b005314e2421e8p-32, false,
+-	false,
+-	0x1.b005314e2421e7ffb472840c5ap-32, false,
+-	0x1.b005314e2421e7ffb472840c5a8p-32, false,
+-	0x1.b005314e2421e7ffb472840c5ap-32, false,
+-	0x1.b005314e2421e7ffb472840c5a8p-32, false,
+-	false,
+-	0x1.b005314e2421e7ffb472840c5a6ep-32, false,
+-	0x1.b005314e2421e7ffb472840c5a6fp-32, false,
+-	0x1.b005314e2421e7ffb472840c5a6ep-32, false,
+-	0x1.b005314e2421e7ffb472840c5a6fp-32, false),
++	0x1.b0053p-32, false, false,
++	0x1.b00532p-32, false, false,
++	0x1.b0053p-32, false, false,
++	0x1.b00532p-32, false, false,
++	false,
++	0x1.b005314e2421ep-32, false, false,
++	0x1.b005314e2421ep-32, false, false,
++	0x1.b005314e2421ep-32, false, false,
++	0x1.b005314e2421fp-32, false, false,
++	false,
++	0x1.b005314e2421e7fep-32, false, false,
++	0x1.b005314e2421e8p-32, false, false,
++	0x1.b005314e2421e7fep-32, false, false,
++	0x1.b005314e2421e8p-32, false, false,
++	false,
++	0x1.b005314e2421e7fep-32, false, false,
++	0x1.b005314e2421e8p-32, false, false,
++	0x1.b005314e2421e7fep-32, false, false,
++	0x1.b005314e2421e8p-32, false, false,
++	false,
++	0x1.b005314e2421e7ffb472840c5ap-32, false, false,
++	0x1.b005314e2421e7ffb472840c5a8p-32, false, false,
++	0x1.b005314e2421e7ffb472840c5ap-32, false, false,
++	0x1.b005314e2421e7ffb472840c5a8p-32, false, false,
++	false,
++	0x1.b005314e2421e7ffb472840c5a6ep-32, false, false,
++	0x1.b005314e2421e7ffb472840c5a6fp-32, false, false,
++	0x1.b005314e2421e7ffb472840c5a6ep-32, false, false,
++	0x1.b005314e2421e7ffb472840c5a6fp-32, false, false),
+   TEST ("0.0000000000000000000000000000000000000000000021019476964872"
+ 	"256063855943749348741969203929128147736576356024258346866240"
+ 	"28790902229957282543182373046875",
+ 	false,
+-	0x8p-152, false,
+-	0x1p-148, false,
+-	0x8p-152, false,
+-	0x1p-148, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false),
++	0x8p-152, false, true,
++	0x1p-148, false, true,
++	0x8p-152, false, true,
++	0x1p-148, false, true,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false),
+   TEST ("1.00000005960464477539062499",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000000fffffffp+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000000fffffffp+0, false,
+-	0x1.000001p+0, false,
+-	false,
+-	0x1.000000fffffffffep+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000000fffffffffep+0, false,
+-	0x1.000001p+0, false,
+-	false,
+-	0x1.000000fffffffffep+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000000fffffffffep+0, false,
+-	0x1.000001p+0, false,
+-	false,
+-	0x1.000000fffffffffffffffce7b78p+0, false,
+-	0x1.000000fffffffffffffffce7b8p+0, false,
+-	0x1.000000fffffffffffffffce7b78p+0, false,
+-	0x1.000000fffffffffffffffce7b8p+0, false,
+-	false,
+-	0x1.000000fffffffffffffffce7b7e7p+0, false,
+-	0x1.000000fffffffffffffffce7b7e7p+0, false,
+-	0x1.000000fffffffffffffffce7b7e7p+0, false,
+-	0x1.000000fffffffffffffffce7b7e8p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000000fffffffp+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000000fffffffp+0, false, false,
++	0x1.000001p+0, false, false,
++	false,
++	0x1.000000fffffffffep+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000000fffffffffep+0, false, false,
++	0x1.000001p+0, false, false,
++	false,
++	0x1.000000fffffffffep+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000000fffffffffep+0, false, false,
++	0x1.000001p+0, false, false,
++	false,
++	0x1.000000fffffffffffffffce7b78p+0, false, false,
++	0x1.000000fffffffffffffffce7b8p+0, false, false,
++	0x1.000000fffffffffffffffce7b78p+0, false, false,
++	0x1.000000fffffffffffffffce7b8p+0, false, false,
++	false,
++	0x1.000000fffffffffffffffce7b7e7p+0, false, false,
++	0x1.000000fffffffffffffffce7b7e7p+0, false, false,
++	0x1.000000fffffffffffffffce7b7e7p+0, false, false,
++	0x1.000000fffffffffffffffce7b7e8p+0, false, false),
+   TEST ("1.000000059604644775390625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	true,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	true,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	true,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	true,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	true,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	true,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	true,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	true,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false),
+   TEST ("1.00000005960464477539062501",
+ 	false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000001p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.000001p+0, false,
+-	0x1.0000010000000002p+0, false,
+-	false,
+-	0x1.00000100000000000000031848p+0, false,
+-	0x1.00000100000000000000031848p+0, false,
+-	0x1.00000100000000000000031848p+0, false,
+-	0x1.000001000000000000000318488p+0, false,
+-	false,
+-	0x1.0000010000000000000003184818p+0, false,
+-	0x1.0000010000000000000003184819p+0, false,
+-	0x1.0000010000000000000003184818p+0, false,
+-	0x1.0000010000000000000003184819p+0, false),
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000001p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.000001p+0, false, false,
++	0x1.0000010000000002p+0, false, false,
++	false,
++	0x1.00000100000000000000031848p+0, false, false,
++	0x1.00000100000000000000031848p+0, false, false,
++	0x1.00000100000000000000031848p+0, false, false,
++	0x1.000001000000000000000318488p+0, false, false,
++	false,
++	0x1.0000010000000000000003184818p+0, false, false,
++	0x1.0000010000000000000003184819p+0, false, false,
++	0x1.0000010000000000000003184818p+0, false, false,
++	0x1.0000010000000000000003184819p+0, false, false),
+   TEST ("1.00000011920928955078125",
+ 	true,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false),
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false),
+   TEST ("1.00000017881393432617187499",
+ 	false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000004p+0, false,
+-	false,
+-	0x1.000002fffffffp+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000002fffffffp+0, false,
+-	0x1.000003p+0, false,
+-	false,
+-	0x1.000002fffffffffep+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000002fffffffffep+0, false,
+-	0x1.000003p+0, false,
+-	false,
+-	0x1.000002fffffffffep+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000002fffffffffep+0, false,
+-	0x1.000003p+0, false,
+-	false,
+-	0x1.000002fffffffffffffffce7b78p+0, false,
+-	0x1.000002fffffffffffffffce7b8p+0, false,
+-	0x1.000002fffffffffffffffce7b78p+0, false,
+-	0x1.000002fffffffffffffffce7b8p+0, false,
+-	false,
+-	0x1.000002fffffffffffffffce7b7e7p+0, false,
+-	0x1.000002fffffffffffffffce7b7e7p+0, false,
+-	0x1.000002fffffffffffffffce7b7e7p+0, false,
+-	0x1.000002fffffffffffffffce7b7e8p+0, false),
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000004p+0, false, false,
++	false,
++	0x1.000002fffffffp+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000002fffffffp+0, false, false,
++	0x1.000003p+0, false, false,
++	false,
++	0x1.000002fffffffffep+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000002fffffffffep+0, false, false,
++	0x1.000003p+0, false, false,
++	false,
++	0x1.000002fffffffffep+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000002fffffffffep+0, false, false,
++	0x1.000003p+0, false, false,
++	false,
++	0x1.000002fffffffffffffffce7b78p+0, false, false,
++	0x1.000002fffffffffffffffce7b8p+0, false, false,
++	0x1.000002fffffffffffffffce7b78p+0, false, false,
++	0x1.000002fffffffffffffffce7b8p+0, false, false,
++	false,
++	0x1.000002fffffffffffffffce7b7e7p+0, false, false,
++	0x1.000002fffffffffffffffce7b7e7p+0, false, false,
++	0x1.000002fffffffffffffffce7b7e7p+0, false, false,
++	0x1.000002fffffffffffffffce7b7e8p+0, false, false),
+   TEST ("1.000000178813934326171875",
+ 	false,
+-	0x1.000002p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000004p+0, false,
+-	true,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	true,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	true,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	true,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	true,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false),
++	0x1.000002p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000004p+0, false, false,
++	true,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	true,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	true,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	true,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	true,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false),
+   TEST ("1.00000017881393432617187501",
+ 	false,
+-	0x1.000002p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000002p+0, false,
+-	0x1.000004p+0, false,
+-	false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.0000030000001p+0, false,
+-	false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.0000030000000002p+0, false,
+-	false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.000003p+0, false,
+-	0x1.0000030000000002p+0, false,
+-	false,
+-	0x1.00000300000000000000031848p+0, false,
+-	0x1.00000300000000000000031848p+0, false,
+-	0x1.00000300000000000000031848p+0, false,
+-	0x1.000003000000000000000318488p+0, false,
+-	false,
+-	0x1.0000030000000000000003184818p+0, false,
+-	0x1.0000030000000000000003184819p+0, false,
+-	0x1.0000030000000000000003184818p+0, false,
+-	0x1.0000030000000000000003184819p+0, false),
++	0x1.000002p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000002p+0, false, false,
++	0x1.000004p+0, false, false,
++	false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.0000030000001p+0, false, false,
++	false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.0000030000000002p+0, false, false,
++	false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.000003p+0, false, false,
++	0x1.0000030000000002p+0, false, false,
++	false,
++	0x1.00000300000000000000031848p+0, false, false,
++	0x1.00000300000000000000031848p+0, false, false,
++	0x1.00000300000000000000031848p+0, false, false,
++	0x1.000003000000000000000318488p+0, false, false,
++	false,
++	0x1.0000030000000000000003184818p+0, false, false,
++	0x1.0000030000000000000003184819p+0, false, false,
++	0x1.0000030000000000000003184818p+0, false, false,
++	0x1.0000030000000000000003184819p+0, false, false),
+   TEST ("1.0000002384185791015625",
+ 	true,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	true,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	true,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	true,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	true,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	true,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false,
+-	0x1.000004p+0, false),
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	true,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	true,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	true,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	true,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	true,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false,
++	0x1.000004p+0, false, false),
+   TEST ("1.08420217248550443400745280086994171142578125e-19",
+ 	true,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	true,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	true,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	true,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	true,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	true,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false),
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	true,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	true,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	true,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	true,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	true,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false),
+   TEST ("1.0842022371089897897127399001987457793916291848290711641311"
+ 	"645507812499e-19",
+ 	false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2.000004p-64, false,
+-	false,
+-	0x2.000001ffffffep-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000001ffffffep-64, false,
+-	0x2.000002p-64, false,
+-	false,
+-	0x2.000001fffffffffcp-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000001fffffffffcp-64, false,
+-	0x2.000002p-64, false,
+-	false,
+-	0x2.000001fffffffffcp-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000001fffffffffcp-64, false,
+-	0x2.000002p-64, false,
+-	false,
+-	0x2.000001ffffffffffffffffffffp-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000001ffffffffffffffffffffp-64, false,
+-	0x2.000002p-64, false,
+-	false,
+-	0x2.000001fffffffffffffffffffffep-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000001fffffffffffffffffffffep-64, false,
+-	0x2.000002p-64, false),
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2.000004p-64, false, false,
++	false,
++	0x2.000001ffffffep-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000001ffffffep-64, false, false,
++	0x2.000002p-64, false, false,
++	false,
++	0x2.000001fffffffffcp-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000001fffffffffcp-64, false, false,
++	0x2.000002p-64, false, false,
++	false,
++	0x2.000001fffffffffcp-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000001fffffffffcp-64, false, false,
++	0x2.000002p-64, false, false,
++	false,
++	0x2.000001ffffffffffffffffffffp-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000001ffffffffffffffffffffp-64, false, false,
++	0x2.000002p-64, false, false,
++	false,
++	0x2.000001fffffffffffffffffffffep-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000001fffffffffffffffffffffep-64, false, false,
++	0x2.000002p-64, false, false),
+   TEST ("1.0842022371089897897127399001987457793916291848290711641311"
+ 	"6455078125e-19",
+ 	false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2p-64, false,
+-	0x2.000004p-64, false,
+-	true,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	true,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	true,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	true,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	true,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false),
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2p-64, false, false,
++	0x2.000004p-64, false, false,
++	true,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	true,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	true,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	true,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	true,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false),
+   TEST ("1.0842022371089897897127399001987457793916291848290711641311"
+ 	"645507812501e-19",
+ 	false,
+-	0x2p-64, false,
+-	0x2.000004p-64, false,
+-	0x2p-64, false,
+-	0x2.000004p-64, false,
+-	false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.0000020000002p-64, false,
+-	false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.0000020000000004p-64, false,
+-	false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.0000020000000004p-64, false,
+-	false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.00000200000000000000000001p-64, false,
+-	false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.000002p-64, false,
+-	0x2.0000020000000000000000000002p-64, false),
++	0x2p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2p-64, false, false,
++	0x2.000004p-64, false, false,
++	false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.0000020000002p-64, false, false,
++	false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.0000020000000004p-64, false, false,
++	false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.0000020000000004p-64, false, false,
++	false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.00000200000000000000000001p-64, false, false,
++	false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.000002p-64, false, false,
++	0x2.0000020000000000000000000002p-64, false, false),
+   TEST ("1.0842023017324751454180269995275498473574771196581423282623"
+ 	"291015625e-19",
+ 	true,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	true,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	true,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	true,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	true,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	true,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false),
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	true,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	true,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	true,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	true,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	true,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false),
+   TEST ("1.0842023663559605011233140988563539153233250544872134923934"
+ 	"936523437499e-19",
+ 	false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000008p-64, false,
+-	false,
+-	0x2.000005ffffffep-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000005ffffffep-64, false,
+-	0x2.000006p-64, false,
+-	false,
+-	0x2.000005fffffffffcp-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000005fffffffffcp-64, false,
+-	0x2.000006p-64, false,
+-	false,
+-	0x2.000005fffffffffcp-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000005fffffffffcp-64, false,
+-	0x2.000006p-64, false,
+-	false,
+-	0x2.000005ffffffffffffffffffffp-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000005ffffffffffffffffffffp-64, false,
+-	0x2.000006p-64, false,
+-	false,
+-	0x2.000005fffffffffffffffffffffep-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000005fffffffffffffffffffffep-64, false,
+-	0x2.000006p-64, false),
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000008p-64, false, false,
++	false,
++	0x2.000005ffffffep-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000005ffffffep-64, false, false,
++	0x2.000006p-64, false, false,
++	false,
++	0x2.000005fffffffffcp-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000005fffffffffcp-64, false, false,
++	0x2.000006p-64, false, false,
++	false,
++	0x2.000005fffffffffcp-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000005fffffffffcp-64, false, false,
++	0x2.000006p-64, false, false,
++	false,
++	0x2.000005ffffffffffffffffffffp-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000005ffffffffffffffffffffp-64, false, false,
++	0x2.000006p-64, false, false,
++	false,
++	0x2.000005fffffffffffffffffffffep-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000005fffffffffffffffffffffep-64, false, false,
++	0x2.000006p-64, false, false),
+   TEST ("1.0842023663559605011233140988563539153233250544872134923934"
+ 	"9365234375e-19",
+ 	false,
+-	0x2.000004p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000008p-64, false,
+-	true,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	true,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	true,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	true,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	true,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false),
++	0x2.000004p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000008p-64, false, false,
++	true,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	true,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	true,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	true,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	true,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false),
+   TEST ("1.0842023663559605011233140988563539153233250544872134923934"
+ 	"936523437501e-19",
+ 	false,
+-	0x2.000004p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000004p-64, false,
+-	0x2.000008p-64, false,
+-	false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.0000060000002p-64, false,
+-	false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.0000060000000004p-64, false,
+-	false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.0000060000000004p-64, false,
+-	false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.00000600000000000000000001p-64, false,
+-	false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.000006p-64, false,
+-	0x2.0000060000000000000000000002p-64, false),
++	0x2.000004p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000004p-64, false, false,
++	0x2.000008p-64, false, false,
++	false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.0000060000002p-64, false, false,
++	false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.0000060000000004p-64, false, false,
++	false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.0000060000000004p-64, false, false,
++	false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.00000600000000000000000001p-64, false, false,
++	false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.000006p-64, false, false,
++	0x2.0000060000000000000000000002p-64, false, false),
+   TEST ("1.0842024309794458568286011981851579832891729893162846565246"
+ 	"58203125e-19",
+ 	true,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	true,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	true,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	true,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	true,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	true,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false,
+-	0x2.000008p-64, false),
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	true,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	true,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	true,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	true,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	true,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false,
++	0x2.000008p-64, false, false),
+   TEST ("7.5231638452626400509999138382223723380394595633413601376560"
+ 	"1092018187046051025390625e-37",
+ 	true,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	true,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	true,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	true,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	true,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	true,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false),
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	true,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	true,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	true,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	true,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	true,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false),
+   TEST ("7.5231642936781486349413765338158389908126215730251815381410"
+ 	"578824437213052434003657253924757242202758789062499e-37",
+ 	false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1.000002p-120, false,
+-	false,
+-	0x1.000000fffffffp-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000000fffffffp-120, false,
+-	0x1.000001p-120, false,
+-	false,
+-	0x1.000000fffffffffep-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000000fffffffffep-120, false,
+-	0x1.000001p-120, false,
+-	false,
+-	0x1.000000fffffffffep-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000000fffffffffep-120, false,
+-	0x1.000001p-120, false,
+-	false,
+-	0x1.000000ffffffffffffffffffff8p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000000ffffffffffffffffffff8p-120, false,
+-	0x1.000001p-120, false,
+-	false,
+-	0x1.000000ffffffffffffffffffffffp-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000000ffffffffffffffffffffffp-120, false,
+-	0x1.000001p-120, false),
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1.000002p-120, false, false,
++	false,
++	0x1.000000fffffffp-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000000fffffffp-120, false, false,
++	0x1.000001p-120, false, false,
++	false,
++	0x1.000000fffffffffep-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000000fffffffffep-120, false, false,
++	0x1.000001p-120, false, false,
++	false,
++	0x1.000000fffffffffep-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000000fffffffffep-120, false, false,
++	0x1.000001p-120, false, false,
++	false,
++	0x1.000000ffffffffffffffffffff8p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000000ffffffffffffffffffff8p-120, false, false,
++	0x1.000001p-120, false, false,
++	false,
++	0x1.000000ffffffffffffffffffffffp-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000000ffffffffffffffffffffffp-120, false, false,
++	0x1.000001p-120, false, false),
+   TEST ("7.5231642936781486349413765338158389908126215730251815381410"
+ 	"5788244372130524340036572539247572422027587890625e-37",
+ 	false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1p-120, false,
+-	0x1.000002p-120, false,
+-	true,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	true,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	true,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	true,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	true,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false),
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1p-120, false, false,
++	0x1.000002p-120, false, false,
++	true,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	true,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	true,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	true,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	true,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false),
+   TEST ("7.5231642936781486349413765338158389908126215730251815381410"
+ 	"578824437213052434003657253924757242202758789062501e-37",
+ 	false,
+-	0x1p-120, false,
+-	0x1.000002p-120, false,
+-	0x1p-120, false,
+-	0x1.000002p-120, false,
+-	false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.0000010000001p-120, false,
+-	false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.0000010000000002p-120, false,
+-	false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.0000010000000002p-120, false,
+-	false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001000000000000000000008p-120, false,
+-	false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.000001p-120, false,
+-	0x1.0000010000000000000000000001p-120, false),
++	0x1p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1p-120, false, false,
++	0x1.000002p-120, false, false,
++	false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.0000010000001p-120, false, false,
++	false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.0000010000000002p-120, false, false,
++	false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.0000010000000002p-120, false, false,
++	false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001000000000000000000008p-120, false, false,
++	false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.000001p-120, false, false,
++	0x1.0000010000000000000000000001p-120, false, false),
+   TEST ("7.5231647420936572188828392294093056435857835827090029386261"
+ 	"048447055721499765468252007849514484405517578125e-37",
+ 	true,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	true,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	true,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	true,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	true,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	true,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false),
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	true,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	true,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	true,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	true,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	true,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false),
+   TEST ("7.5231651905091658028243019250027722963589455923928243391111"
+ 	"518069674229947096932846761774271726608276367187499e-37",
+ 	false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000004p-120, false,
+-	false,
+-	0x1.000002fffffffp-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000002fffffffp-120, false,
+-	0x1.000003p-120, false,
+-	false,
+-	0x1.000002fffffffffep-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000002fffffffffep-120, false,
+-	0x1.000003p-120, false,
+-	false,
+-	0x1.000002fffffffffep-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000002fffffffffep-120, false,
+-	0x1.000003p-120, false,
+-	false,
+-	0x1.000002ffffffffffffffffffff8p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000002ffffffffffffffffffff8p-120, false,
+-	0x1.000003p-120, false,
+-	false,
+-	0x1.000002ffffffffffffffffffffffp-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000002ffffffffffffffffffffffp-120, false,
+-	0x1.000003p-120, false),
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000004p-120, false, false,
++	false,
++	0x1.000002fffffffp-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000002fffffffp-120, false, false,
++	0x1.000003p-120, false, false,
++	false,
++	0x1.000002fffffffffep-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000002fffffffffep-120, false, false,
++	0x1.000003p-120, false, false,
++	false,
++	0x1.000002fffffffffep-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000002fffffffffep-120, false, false,
++	0x1.000003p-120, false, false,
++	false,
++	0x1.000002ffffffffffffffffffff8p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000002ffffffffffffffffffff8p-120, false, false,
++	0x1.000003p-120, false, false,
++	false,
++	0x1.000002ffffffffffffffffffffffp-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000002ffffffffffffffffffffffp-120, false, false,
++	0x1.000003p-120, false, false),
+   TEST ("7.5231651905091658028243019250027722963589455923928243391111"
+ 	"5180696742299470969328467617742717266082763671875e-37",
+ 	false,
+-	0x1.000002p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000004p-120, false,
+-	true,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	true,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	true,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	true,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	true,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false),
++	0x1.000002p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000004p-120, false, false,
++	true,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	true,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	true,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	true,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	true,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false),
+   TEST ("7.5231651905091658028243019250027722963589455923928243391111"
+ 	"518069674229947096932846761774271726608276367187501e-37",
+ 	false,
+-	0x1.000002p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000002p-120, false,
+-	0x1.000004p-120, false,
+-	false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.0000030000001p-120, false,
+-	false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.0000030000000002p-120, false,
+-	false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.0000030000000002p-120, false,
+-	false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003000000000000000000008p-120, false,
+-	false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.000003p-120, false,
+-	0x1.0000030000000000000000000001p-120, false),
++	0x1.000002p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000002p-120, false, false,
++	0x1.000004p-120, false, false,
++	false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.0000030000001p-120, false, false,
++	false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.0000030000000002p-120, false, false,
++	false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.0000030000000002p-120, false, false,
++	false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003000000000000000000008p-120, false, false,
++	false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.000003p-120, false, false,
++	0x1.0000030000000000000000000001p-120, false, false),
+   TEST ("7.5231656389246743867657646205962389491321076020766457395961"
+ 	"98769229273839442839744151569902896881103515625e-37",
+ 	true,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	true,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	true,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	true,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	true,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	true,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false,
+-	0x1.000004p-120, false),
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	true,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	true,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	true,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	true,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	true,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false,
++	0x1.000004p-120, false, false),
+   TEST ("340282356779733661637539395458142568447.999",
+ 	false,
+-	0xf.fffffp+124, false,
+-	0xf.fffffp+124, false,
+-	0xf.fffffp+124, false,
+-	INF, true,
+-	false,
+-	0xf.fffff7ffffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff7ffffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	false,
+-	0xf.fffff7fffffffffp+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff7fffffffffp+124, false,
+-	0xf.fffff8p+124, false,
+-	false,
+-	0xf.fffff7fffffffffp+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff7fffffffffp+124, false,
+-	0xf.fffff8p+124, false,
+-	false,
+-	0xf.fffff7fffffffffffffffffffcp+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff7fffffffffffffffffffcp+124, false,
+-	0xf.fffff8p+124, false,
+-	false,
+-	0xf.fffff7fffffffffffffffffffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff7fffffffffffffffffffff8p+124, false,
+-	0xf.fffff8p+124, false),
++	0xf.fffffp+124, false, false,
++	0xf.fffffp+124, false, false,
++	0xf.fffffp+124, false, false,
++	INF, true, false,
++	false,
++	0xf.fffff7ffffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff7ffffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	false,
++	0xf.fffff7fffffffffp+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff7fffffffffp+124, false, false,
++	0xf.fffff8p+124, false, false,
++	false,
++	0xf.fffff7fffffffffp+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff7fffffffffp+124, false, false,
++	0xf.fffff8p+124, false, false,
++	false,
++	0xf.fffff7fffffffffffffffffffcp+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff7fffffffffffffffffffcp+124, false, false,
++	0xf.fffff8p+124, false, false,
++	false,
++	0xf.fffff7fffffffffffffffffffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff7fffffffffffffffffffff8p+124, false, false,
++	0xf.fffff8p+124, false, false),
+   TEST ("340282356779733661637539395458142568448",
+ 	false,
+-	0xf.fffffp+124, false,
+-	INF, true,
+-	0xf.fffffp+124, false,
+-	INF, true,
+-	true,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	true,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	true,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	true,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	true,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false),
++	0xf.fffffp+124, false, false,
++	INF, true, false,
++	0xf.fffffp+124, false, false,
++	INF, true, false,
++	true,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	true,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	true,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	true,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	true,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false),
+   TEST ("340282356779733661637539395458142568448.001",
+ 	false,
+-	0xf.fffffp+124, false,
+-	INF, true,
+-	0xf.fffffp+124, false,
+-	INF, true,
+-	false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff80000008p+124, false,
+-	false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8000000001p+124, false,
+-	false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8000000001p+124, false,
+-	false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff800000000000000000004p+124, false,
+-	false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff8p+124, false,
+-	0xf.fffff80000000000000000000008p+124, false),
++	0xf.fffffp+124, false, false,
++	INF, true, false,
++	0xf.fffffp+124, false, false,
++	INF, true, false,
++	false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff80000008p+124, false, false,
++	false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8000000001p+124, false, false,
++	false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8000000001p+124, false, false,
++	false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff800000000000000000004p+124, false, false,
++	false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff8p+124, false, false,
++	0xf.fffff80000000000000000000008p+124, false, false),
+   TEST ("-340282356779733661637539395458142568447.999",
+ 	false,
+-	-INF, true,
+-	-0xf.fffffp+124, false,
+-	-0xf.fffffp+124, false,
+-	-0xf.fffffp+124, false,
+-	false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff7ffffff8p+124, false,
+-	-0xf.fffff7ffffff8p+124, false,
+-	false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff7fffffffffp+124, false,
+-	-0xf.fffff7fffffffffp+124, false,
+-	false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff7fffffffffp+124, false,
+-	-0xf.fffff7fffffffffp+124, false,
+-	false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff7fffffffffffffffffffcp+124, false,
+-	-0xf.fffff7fffffffffffffffffffcp+124, false,
+-	false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff7fffffffffffffffffffff8p+124, false,
+-	-0xf.fffff7fffffffffffffffffffff8p+124, false),
++	-INF, true, false,
++	-0xf.fffffp+124, false, false,
++	-0xf.fffffp+124, false, false,
++	-0xf.fffffp+124, false, false,
++	false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff7ffffff8p+124, false, false,
++	-0xf.fffff7ffffff8p+124, false, false,
++	false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff7fffffffffp+124, false, false,
++	-0xf.fffff7fffffffffp+124, false, false,
++	false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff7fffffffffp+124, false, false,
++	-0xf.fffff7fffffffffp+124, false, false,
++	false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff7fffffffffffffffffffcp+124, false, false,
++	-0xf.fffff7fffffffffffffffffffcp+124, false, false,
++	false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff7fffffffffffffffffffff8p+124, false, false,
++	-0xf.fffff7fffffffffffffffffffff8p+124, false, false),
+   TEST ("-340282356779733661637539395458142568448",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, false,
+-	-0xf.fffffp+124, false,
+-	true,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	true,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	true,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	true,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	true,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, false, false,
++	-0xf.fffffp+124, false, false,
++	true,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	true,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	true,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	true,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	true,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false),
+   TEST ("-340282356779733661637539395458142568448.001",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, false,
+-	-0xf.fffffp+124, false,
+-	false,
+-	-0xf.fffff80000008p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	false,
+-	-0xf.fffff8000000001p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	false,
+-	-0xf.fffff8000000001p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	false,
+-	-0xf.fffff800000000000000000004p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	false,
+-	-0xf.fffff80000000000000000000008p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false,
+-	-0xf.fffff8p+124, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, false, false,
++	-0xf.fffffp+124, false, false,
++	false,
++	-0xf.fffff80000008p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	false,
++	-0xf.fffff8000000001p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	false,
++	-0xf.fffff8000000001p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	false,
++	-0xf.fffff800000000000000000004p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	false,
++	-0xf.fffff80000000000000000000008p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false,
++	-0xf.fffff8p+124, false, false),
+   TEST ("179769313486231580793728971405303415079934132710037826936173"
+ 	"778980444968292764750946649017977587207096330286416692887910"
+ 	"946555547851940402630657488671505820681908902000708383676273"
+@@ -1855,35 +1855,35 @@ static const struct test tests[] = {
+ 	"936475292719074168444365510704342711559699508093042880177904"
+ 	"174497791.999",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, false,
+-	0xf.ffffffffffff8p+1020, false,
+-	0xf.ffffffffffff8p+1020, false,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffffbffp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffbffp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	false,
+-	0xf.ffffffffffffbffp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffbffp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	false,
+-	0xf.ffffffffffffbffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, true,
+-	0xf.ffffffffffffbffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, true,
+-	false,
+-	0xf.ffffffffffffbffffffffffffff8p+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffbffffffffffffff8p+1020, false,
+-	0xf.ffffffffffffcp+1020, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, false, false,
++	0xf.ffffffffffff8p+1020, false, false,
++	0xf.ffffffffffff8p+1020, false, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffffbffp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffbffp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	false,
++	0xf.ffffffffffffbffp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffbffp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	false,
++	0xf.ffffffffffffbffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, true, false,
++	0xf.ffffffffffffbffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, true, false,
++	false,
++	0xf.ffffffffffffbffffffffffffff8p+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffbffffffffffffff8p+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false),
+   TEST ("179769313486231580793728971405303415079934132710037826936173"
+ 	"778980444968292764750946649017977587207096330286416692887910"
+ 	"946555547851940402630657488671505820681908902000708383676273"
+@@ -1891,35 +1891,35 @@ static const struct test tests[] = {
+ 	"936475292719074168444365510704342711559699508093042880177904"
+ 	"174497792",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, false,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, false,
+-	INF, true,
+-	true,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	true,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	false,
+-	0xf.ffffffffffffcp+1020, true,
+-	0xf.ffffffffffffcp+1020, true,
+-	0xf.ffffffffffffcp+1020, true,
+-	0xf.ffffffffffffcp+1020, true,
+-	true,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, false, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, false, false,
++	INF, true, false,
++	true,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	true,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	false,
++	0xf.ffffffffffffcp+1020, true, false,
++	0xf.ffffffffffffcp+1020, true, false,
++	0xf.ffffffffffffcp+1020, true, false,
++	0xf.ffffffffffffcp+1020, true, false,
++	true,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false),
+   TEST ("179769313486231580793728971405303415079934132710037826936173"
+ 	"778980444968292764750946649017977587207096330286416692887910"
+ 	"946555547851940402630657488671505820681908902000708383676273"
+@@ -1927,35 +1927,35 @@ static const struct test tests[] = {
+ 	"936475292719074168444365510704342711559699508093042880177904"
+ 	"174497792.001",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, false,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, false,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffc01p+1020, false,
+-	false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffc01p+1020, false,
+-	false,
+-	0xf.ffffffffffffcp+1020, true,
+-	0xf.ffffffffffffcp+1020, true,
+-	0xf.ffffffffffffcp+1020, true,
+-	0xf.ffffffffffffc0000000000004p+1020, true,
+-	false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffcp+1020, false,
+-	0xf.ffffffffffffc000000000000008p+1020, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, false, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, false, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffc01p+1020, false, false,
++	false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffc01p+1020, false, false,
++	false,
++	0xf.ffffffffffffcp+1020, true, false,
++	0xf.ffffffffffffcp+1020, true, false,
++	0xf.ffffffffffffcp+1020, true, false,
++	0xf.ffffffffffffc0000000000004p+1020, true, false,
++	false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffcp+1020, false, false,
++	0xf.ffffffffffffc000000000000008p+1020, false, false),
+   TEST ("-17976931348623158079372897140530341507993413271003782693617"
+ 	"377898044496829276475094664901797758720709633028641669288791"
+ 	"094655554785194040263065748867150582068190890200070838367627"
+@@ -1963,35 +1963,35 @@ static const struct test tests[] = {
+ 	"493647529271907416844436551070434271155969950809304288017790"
+ 	"4174497791.999",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, false,
+-	-0xf.ffffffffffff8p+1020, false,
+-	-0xf.ffffffffffff8p+1020, false,
+-	false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffbffp+1020, false,
+-	-0xf.ffffffffffffbffp+1020, false,
+-	false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffbffp+1020, false,
+-	-0xf.ffffffffffffbffp+1020, false,
+-	false,
+-	-0xf.ffffffffffffcp+1020, true,
+-	-0xf.ffffffffffffcp+1020, true,
+-	-0xf.ffffffffffffbffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffbffffffffffffcp+1020, false,
+-	false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffbffffffffffffff8p+1020, false,
+-	-0xf.ffffffffffffbffffffffffffff8p+1020, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffbffp+1020, false, false,
++	-0xf.ffffffffffffbffp+1020, false, false,
++	false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffbffp+1020, false, false,
++	-0xf.ffffffffffffbffp+1020, false, false,
++	false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	-0xf.ffffffffffffbffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffbffffffffffffcp+1020, false, false,
++	false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffbffffffffffffff8p+1020, false, false,
++	-0xf.ffffffffffffbffffffffffffff8p+1020, false, false),
+   TEST ("-17976931348623158079372897140530341507993413271003782693617"
+ 	"377898044496829276475094664901797758720709633028641669288791"
+ 	"094655554785194040263065748867150582068190890200070838367627"
+@@ -1999,35 +1999,35 @@ static const struct test tests[] = {
+ 	"493647529271907416844436551070434271155969950809304288017790"
+ 	"4174497792",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, false,
+-	-0xf.ffffffffffff8p+1020, false,
+-	true,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	true,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	false,
+-	-0xf.ffffffffffffcp+1020, true,
+-	-0xf.ffffffffffffcp+1020, true,
+-	-0xf.ffffffffffffcp+1020, true,
+-	-0xf.ffffffffffffcp+1020, true,
+-	true,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	true,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	true,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	true,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false),
+   TEST ("-17976931348623158079372897140530341507993413271003782693617"
+ 	"377898044496829276475094664901797758720709633028641669288791"
+ 	"094655554785194040263065748867150582068190890200070838367627"
+@@ -2035,35 +2035,35 @@ static const struct test tests[] = {
+ 	"493647529271907416844436551070434271155969950809304288017790"
+ 	"4174497792.001",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, false,
+-	-0xf.ffffffffffff8p+1020, false,
+-	false,
+-	-0xf.ffffffffffffc01p+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	false,
+-	-0xf.ffffffffffffc01p+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	false,
+-	-0xf.ffffffffffffc0000000000004p+1020, true,
+-	-0xf.ffffffffffffcp+1020, true,
+-	-0xf.ffffffffffffcp+1020, true,
+-	-0xf.ffffffffffffcp+1020, true,
+-	false,
+-	-0xf.ffffffffffffc000000000000008p+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false,
+-	-0xf.ffffffffffffcp+1020, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	false,
++	-0xf.ffffffffffffc01p+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	false,
++	-0xf.ffffffffffffc01p+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	false,
++	-0xf.ffffffffffffc0000000000004p+1020, true, false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	-0xf.ffffffffffffcp+1020, true, false,
++	false,
++	-0xf.ffffffffffffc000000000000008p+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false,
++	-0xf.ffffffffffffcp+1020, false, false),
+   TEST ("118973149535723176505351158982948866796625400469556721895649"
+ 	"927756249918185172720476044944290457046138433056764616744328"
+ 	"666255526748948793023632513609765434237723241753648908036202"
+@@ -2148,35 +2148,35 @@ static const struct test tests[] = {
+ 	"578031503869424406179027994752890226443351619365453243328968"
+ 	"8740976918527.999",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	0xf.fffffffffffffffp+16380, false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	0xf.fffffffffffffffp+16380, false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffff7fffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffff7fffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8p+16380, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffff7fffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff7fffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8p+16380, false, false),
+   TEST ("118973149535723176505351158982948866796625400469556721895649"
+ 	"927756249918185172720476044944290457046138433056764616744328"
+ 	"666255526748948793023632513609765434237723241753648908036202"
+@@ -2261,35 +2261,35 @@ static const struct test tests[] = {
+ 	"578031503869424406179027994752890226443351619365453243328968"
+ 	"8740976918528",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	true,
+-	0xf.fffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8p+16380, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	true,
++	0xf.fffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8p+16380, false, false),
+   TEST ("118973149535723176505351158982948866796625400469556721895649"
+ 	"927756249918185172720476044944290457046138433056764616744328"
+ 	"666255526748948793023632513609765434237723241753648908036202"
+@@ -2374,35 +2374,35 @@ static const struct test tests[] = {
+ 	"578031503869424406179027994752890226443351619365453243328968"
+ 	"8740976918528.001",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffff8000000000008p+16380, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffff8000000000008p+16380, false, false),
+   TEST ("-11897314953572317650535115898294886679662540046955672189564"
+ 	"992775624991818517272047604494429045704613843305676461674432"
+ 	"866625552674894879302363251360976543423772324175364890803620"
+@@ -2487,35 +2487,35 @@ static const struct test tests[] = {
+ 	"557803150386942440617902799475289022644335161936545324332896"
+ 	"88740976918527.999",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	false,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	false,
+-	-0xf.fffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff7fffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff7fffffffffff8p+16380, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	false,
++	-0xf.fffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff7fffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff7fffffffffff8p+16380, false, false),
+   TEST ("-11897314953572317650535115898294886679662540046955672189564"
+ 	"992775624991818517272047604494429045704613843305676461674432"
+ 	"866625552674894879302363251360976543423772324175364890803620"
+@@ -2600,35 +2600,35 @@ static const struct test tests[] = {
+ 	"557803150386942440617902799475289022644335161936545324332896"
+ 	"88740976918528",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	true,
+-	-0xf.fffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff8p+16380, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	true,
++	-0xf.fffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff8p+16380, false, false),
+   TEST ("-11897314953572317650535115898294886679662540046955672189564"
+ 	"992775624991818517272047604494429045704613843305676461674432"
+ 	"866625552674894879302363251360976543423772324175364890803620"
+@@ -2713,35 +2713,35 @@ static const struct test tests[] = {
+ 	"557803150386942440617902799475289022644335161936545324332896"
+ 	"88740976918528.001",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	false,
+-	-0xf.fffffffffffffff8000000000008p+16380, false,
+-	-0xf.fffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffff8p+16380, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	false,
++	-0xf.fffffffffffffff8000000000008p+16380, false, false,
++	-0xf.fffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffff8p+16380, false, false),
+   TEST ("118973149535723176508575932662800707347995686986910214150118"
+ 	"685272271246896789803961473130416053705672050873552479421805"
+ 	"932646640744124594447361172514341324846716679654551308018400"
+@@ -2826,35 +2826,35 @@ static const struct test tests[] = {
+ 	"972233447491583165728635513802591543441145939539353470970452"
+ 	"5536550715391.999",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	INF, true),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	INF, true, false),
+   TEST ("118973149535723176508575932662800707347995686986910214150118"
+ 	"685272271246896789803961473130416053705672050873552479421805"
+ 	"932646640744124594447361172514341324846716679654551308018400"
+@@ -2939,35 +2939,35 @@ static const struct test tests[] = {
+ 	"972233447491583165728635513802591543441145939539353470970452"
+ 	"5536550715392",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	INF, true),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	INF, true, false),
+   TEST ("118973149535723176508575932662800707347995686986910214150118"
+ 	"685272271246896789803961473130416053705672050873552479421805"
+ 	"932646640744124594447361172514341324846716679654551308018400"
+@@ -3052,35 +3052,35 @@ static const struct test tests[] = {
+ 	"972233447491583165728635513802591543441145939539353470970452"
+ 	"5536550715392.001",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	INF, true),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	INF, true, false),
+   TEST ("-11897314953572317650857593266280070734799568698691021415011"
+ 	"868527227124689678980396147313041605370567205087355247942180"
+ 	"593264664074412459444736117251434132484671667965455130801840"
+@@ -3165,35 +3165,35 @@ static const struct test tests[] = {
+ 	"097223344749158316572863551380259154344114593953935347097045"
+ 	"25536550715391.999",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	false,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false),
+   TEST ("-11897314953572317650857593266280070734799568698691021415011"
+ 	"868527227124689678980396147313041605370567205087355247942180"
+ 	"593264664074412459444736117251434132484671667965455130801840"
+@@ -3278,35 +3278,35 @@ static const struct test tests[] = {
+ 	"097223344749158316572863551380259154344114593953935347097045"
+ 	"25536550715392",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false),
+   TEST ("-11897314953572317650857593266280070734799568698691021415011"
+ 	"868527227124689678980396147313041605370567205087355247942180"
+ 	"593264664074412459444736117251434132484671667965455130801840"
+@@ -3391,419 +3391,419 @@ static const struct test tests[] = {
+ 	"097223344749158316572863551380259154344114593953935347097045"
+ 	"25536550715392.001",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false),
+   TEST ("2.1019476964872256063855943749348741969203929128147736576356"
+ 	"0242583468662402879090222995728254318237304687499e-45",
+ 	false,
+-	0x8p-152, false,
+-	0x8p-152, false,
+-	0x8p-152, false,
+-	0x1p-148, false,
+-	false,
+-	0xb.ffffffffffff8p-152, false,
+-	0xcp-152, false,
+-	0xb.ffffffffffff8p-152, false,
+-	0xcp-152, false,
+-	false,
+-	0xb.fffffffffffffffp-152, false,
+-	0xcp-152, false,
+-	0xb.fffffffffffffffp-152, false,
+-	0xcp-152, false,
+-	false,
+-	0xb.fffffffffffffffp-152, false,
+-	0xcp-152, false,
+-	0xb.fffffffffffffffp-152, false,
+-	0xcp-152, false,
+-	false,
+-	0xb.fffffffffffffffffffffffffcp-152, false,
+-	0xcp-152, false,
+-	0xb.fffffffffffffffffffffffffcp-152, false,
+-	0xcp-152, false,
+-	false,
+-	0xb.fffffffffffffffffffffffffff8p-152, false,
+-	0xcp-152, false,
+-	0xb.fffffffffffffffffffffffffff8p-152, false,
+-	0xcp-152, false),
++	0x8p-152, false, true,
++	0x8p-152, false, true,
++	0x8p-152, false, true,
++	0x1p-148, false, true,
++	false,
++	0xb.ffffffffffff8p-152, false, false,
++	0xcp-152, false, false,
++	0xb.ffffffffffff8p-152, false, false,
++	0xcp-152, false, false,
++	false,
++	0xb.fffffffffffffffp-152, false, false,
++	0xcp-152, false, false,
++	0xb.fffffffffffffffp-152, false, false,
++	0xcp-152, false, false,
++	false,
++	0xb.fffffffffffffffp-152, false, false,
++	0xcp-152, false, false,
++	0xb.fffffffffffffffp-152, false, false,
++	0xcp-152, false, false,
++	false,
++	0xb.fffffffffffffffffffffffffcp-152, false, false,
++	0xcp-152, false, false,
++	0xb.fffffffffffffffffffffffffcp-152, false, false,
++	0xcp-152, false, false,
++	false,
++	0xb.fffffffffffffffffffffffffff8p-152, false, false,
++	0xcp-152, false, false,
++	0xb.fffffffffffffffffffffffffff8p-152, false, false,
++	0xcp-152, false, false),
+   TEST ("2.1019476964872256063855943749348741969203929128147736576356"
+ 	"02425834686624028790902229957282543182373046875e-45",
+ 	false,
+-	0x8p-152, false,
+-	0x1p-148, false,
+-	0x8p-152, false,
+-	0x1p-148, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	true,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false),
++	0x8p-152, false, true,
++	0x1p-148, false, true,
++	0x8p-152, false, true,
++	0x1p-148, false, true,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	true,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false),
+   TEST ("2.1019476964872256063855943749348741969203929128147736576356"
+ 	"0242583468662402879090222995728254318237304687501e-45",
+ 	false,
+-	0x8p-152, false,
+-	0x1p-148, false,
+-	0x8p-152, false,
+-	0x1p-148, false,
+-	false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xc.0000000000008p-152, false,
+-	false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xc.000000000000001p-152, false,
+-	false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xc.000000000000001p-152, false,
+-	false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xc.00000000000000000000000004p-152, false,
+-	false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xcp-152, false,
+-	0xc.0000000000000000000000000008p-152, false),
++	0x8p-152, false, true,
++	0x1p-148, false, true,
++	0x8p-152, false, true,
++	0x1p-148, false, true,
++	false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xc.0000000000008p-152, false, false,
++	false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xc.000000000000001p-152, false, false,
++	false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xc.000000000000001p-152, false, false,
++	false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xc.00000000000000000000000004p-152, false, false,
++	false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xcp-152, false, false,
++	0xc.0000000000000000000000000008p-152, false, false),
+   TEST ("-2.101947696487225606385594374934874196920392912814773657635"
+ 	"60242583468662402879090222995728254318237304687499e-45",
+ 	false,
+-	-0x1p-148, false,
+-	-0x8p-152, false,
+-	-0x8p-152, false,
+-	-0x8p-152, false,
+-	false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xb.ffffffffffff8p-152, false,
+-	-0xb.ffffffffffff8p-152, false,
+-	false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xb.fffffffffffffffp-152, false,
+-	-0xb.fffffffffffffffp-152, false,
+-	false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xb.fffffffffffffffp-152, false,
+-	-0xb.fffffffffffffffp-152, false,
+-	false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xb.fffffffffffffffffffffffffcp-152, false,
+-	-0xb.fffffffffffffffffffffffffcp-152, false,
+-	false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xb.fffffffffffffffffffffffffff8p-152, false,
+-	-0xb.fffffffffffffffffffffffffff8p-152, false),
++	-0x1p-148, false, true,
++	-0x8p-152, false, true,
++	-0x8p-152, false, true,
++	-0x8p-152, false, true,
++	false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xb.ffffffffffff8p-152, false, false,
++	-0xb.ffffffffffff8p-152, false, false,
++	false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xb.fffffffffffffffp-152, false, false,
++	-0xb.fffffffffffffffp-152, false, false,
++	false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xb.fffffffffffffffp-152, false, false,
++	-0xb.fffffffffffffffp-152, false, false,
++	false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xb.fffffffffffffffffffffffffcp-152, false, false,
++	-0xb.fffffffffffffffffffffffffcp-152, false, false,
++	false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xb.fffffffffffffffffffffffffff8p-152, false, false,
++	-0xb.fffffffffffffffffffffffffff8p-152, false, false),
+   TEST ("-2.101947696487225606385594374934874196920392912814773657635"
+ 	"602425834686624028790902229957282543182373046875e-45",
+ 	false,
+-	-0x1p-148, false,
+-	-0x1p-148, false,
+-	-0x8p-152, false,
+-	-0x8p-152, false,
+-	true,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	true,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	true,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	true,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	true,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false),
++	-0x1p-148, false, true,
++	-0x1p-148, false, true,
++	-0x8p-152, false, true,
++	-0x8p-152, false, true,
++	true,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	true,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	true,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	true,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	true,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false),
+   TEST ("-2.101947696487225606385594374934874196920392912814773657635"
+ 	"60242583468662402879090222995728254318237304687501e-45",
+ 	false,
+-	-0x1p-148, false,
+-	-0x1p-148, false,
+-	-0x8p-152, false,
+-	-0x8p-152, false,
+-	false,
+-	-0xc.0000000000008p-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	false,
+-	-0xc.000000000000001p-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	false,
+-	-0xc.000000000000001p-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	false,
+-	-0xc.00000000000000000000000004p-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	false,
+-	-0xc.0000000000000000000000000008p-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false,
+-	-0xcp-152, false),
++	-0x1p-148, false, true,
++	-0x1p-148, false, true,
++	-0x8p-152, false, true,
++	-0x8p-152, false, true,
++	false,
++	-0xc.0000000000008p-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	false,
++	-0xc.000000000000001p-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	false,
++	-0xc.000000000000001p-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	false,
++	-0xc.00000000000000000000000004p-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	false,
++	-0xc.0000000000000000000000000008p-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false,
++	-0xcp-152, false, false),
+   TEST ("3.5032461608120426773093239582247903282006548546912894293926"
+ 	"7070972447770671465150371659547090530395507812499e-45",
+ 	false,
+-	0x1p-148, false,
+-	0x1p-148, false,
+-	0x1p-148, false,
+-	0x1.8p-148, false,
+-	false,
+-	0x1.3ffffffffffffp-148, false,
+-	0x1.4p-148, false,
+-	0x1.3ffffffffffffp-148, false,
+-	0x1.4p-148, false,
+-	false,
+-	0x1.3ffffffffffffffep-148, false,
+-	0x1.4p-148, false,
+-	0x1.3ffffffffffffffep-148, false,
+-	0x1.4p-148, false,
+-	false,
+-	0x1.3ffffffffffffffep-148, false,
+-	0x1.4p-148, false,
+-	0x1.3ffffffffffffffep-148, false,
+-	0x1.4p-148, false,
+-	false,
+-	0x1.3fffffffffffffffffffffffff8p-148, false,
+-	0x1.4p-148, false,
+-	0x1.3fffffffffffffffffffffffff8p-148, false,
+-	0x1.4p-148, false,
+-	false,
+-	0x1.3fffffffffffffffffffffffffffp-148, false,
+-	0x1.4p-148, false,
+-	0x1.3fffffffffffffffffffffffffffp-148, false,
+-	0x1.4p-148, false),
++	0x1p-148, false, true,
++	0x1p-148, false, true,
++	0x1p-148, false, true,
++	0x1.8p-148, false, true,
++	false,
++	0x1.3ffffffffffffp-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.3ffffffffffffp-148, false, false,
++	0x1.4p-148, false, false,
++	false,
++	0x1.3ffffffffffffffep-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.3ffffffffffffffep-148, false, false,
++	0x1.4p-148, false, false,
++	false,
++	0x1.3ffffffffffffffep-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.3ffffffffffffffep-148, false, false,
++	0x1.4p-148, false, false,
++	false,
++	0x1.3fffffffffffffffffffffffff8p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.3fffffffffffffffffffffffff8p-148, false, false,
++	0x1.4p-148, false, false,
++	false,
++	0x1.3fffffffffffffffffffffffffffp-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.3fffffffffffffffffffffffffffp-148, false, false,
++	0x1.4p-148, false, false),
+   TEST ("3.5032461608120426773093239582247903282006548546912894293926"
+ 	"70709724477706714651503716595470905303955078125e-45",
+ 	false,
+-	0x1p-148, false,
+-	0x1p-148, false,
+-	0x1p-148, false,
+-	0x1.8p-148, false,
+-	true,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	true,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	true,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	true,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	true,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false),
++	0x1p-148, false, true,
++	0x1p-148, false, true,
++	0x1p-148, false, true,
++	0x1.8p-148, false, true,
++	true,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	true,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	true,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	true,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	true,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false),
+   TEST ("3.5032461608120426773093239582247903282006548546912894293926"
+ 	"7070972447770671465150371659547090530395507812501e-45",
+ 	false,
+-	0x1p-148, false,
+-	0x1.8p-148, false,
+-	0x1p-148, false,
+-	0x1.8p-148, false,
+-	false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4000000000001p-148, false,
+-	false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4000000000000002p-148, false,
+-	false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4000000000000002p-148, false,
+-	false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.400000000000000000000000008p-148, false,
+-	false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4p-148, false,
+-	0x1.4000000000000000000000000001p-148, false),
++	0x1p-148, false, true,
++	0x1.8p-148, false, true,
++	0x1p-148, false, true,
++	0x1.8p-148, false, true,
++	false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4000000000001p-148, false, false,
++	false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4000000000000002p-148, false, false,
++	false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4000000000000002p-148, false, false,
++	false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.400000000000000000000000008p-148, false, false,
++	false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4p-148, false, false,
++	0x1.4000000000000000000000000001p-148, false, false),
+   TEST ("-3.503246160812042677309323958224790328200654854691289429392"
+ 	"67070972447770671465150371659547090530395507812499e-45",
+ 	false,
+-	-0x1.8p-148, false,
+-	-0x1p-148, false,
+-	-0x1p-148, false,
+-	-0x1p-148, false,
+-	false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.3ffffffffffffp-148, false,
+-	-0x1.3ffffffffffffp-148, false,
+-	false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.3ffffffffffffffep-148, false,
+-	-0x1.3ffffffffffffffep-148, false,
+-	false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.3ffffffffffffffep-148, false,
+-	-0x1.3ffffffffffffffep-148, false,
+-	false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.3fffffffffffffffffffffffff8p-148, false,
+-	-0x1.3fffffffffffffffffffffffff8p-148, false,
+-	false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.3fffffffffffffffffffffffffffp-148, false,
+-	-0x1.3fffffffffffffffffffffffffffp-148, false),
++	-0x1.8p-148, false, true,
++	-0x1p-148, false, true,
++	-0x1p-148, false, true,
++	-0x1p-148, false, true,
++	false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.3ffffffffffffp-148, false, false,
++	-0x1.3ffffffffffffp-148, false, false,
++	false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.3ffffffffffffffep-148, false, false,
++	-0x1.3ffffffffffffffep-148, false, false,
++	false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.3ffffffffffffffep-148, false, false,
++	-0x1.3ffffffffffffffep-148, false, false,
++	false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.3fffffffffffffffffffffffff8p-148, false, false,
++	-0x1.3fffffffffffffffffffffffff8p-148, false, false,
++	false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.3fffffffffffffffffffffffffffp-148, false, false,
++	-0x1.3fffffffffffffffffffffffffffp-148, false, false),
+   TEST ("-3.503246160812042677309323958224790328200654854691289429392"
+ 	"670709724477706714651503716595470905303955078125e-45",
+ 	false,
+-	-0x1.8p-148, false,
+-	-0x1p-148, false,
+-	-0x1p-148, false,
+-	-0x1p-148, false,
+-	true,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	true,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	true,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	true,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	true,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false),
++	-0x1.8p-148, false, true,
++	-0x1p-148, false, true,
++	-0x1p-148, false, true,
++	-0x1p-148, false, true,
++	true,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	true,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	true,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	true,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	true,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false),
+   TEST ("-3.503246160812042677309323958224790328200654854691289429392"
+ 	"67070972447770671465150371659547090530395507812501e-45",
+ 	false,
+-	-0x1.8p-148, false,
+-	-0x1.8p-148, false,
+-	-0x1p-148, false,
+-	-0x1p-148, false,
+-	false,
+-	-0x1.4000000000001p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	false,
+-	-0x1.4000000000000002p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	false,
+-	-0x1.4000000000000002p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	false,
+-	-0x1.400000000000000000000000008p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	false,
+-	-0x1.4000000000000000000000000001p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false,
+-	-0x1.4p-148, false),
++	-0x1.8p-148, false, true,
++	-0x1.8p-148, false, true,
++	-0x1p-148, false, true,
++	-0x1p-148, false, true,
++	false,
++	-0x1.4000000000001p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	false,
++	-0x1.4000000000000002p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	false,
++	-0x1.4000000000000002p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	false,
++	-0x1.400000000000000000000000008p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	false,
++	-0x1.4000000000000000000000000001p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false,
++	-0x1.4p-148, false, false),
+   TEST ("7.4109846876186981626485318930233205854758970392148714663837"
+ 	"852375101326090531312779794975454245398856969484704316857659"
+ 	"638998506553390969459816219401617281718945106978546710679176"
+@@ -3818,35 +3818,35 @@ static const struct test tests[] = {
+ 	"337560846003984904972149117463085539556354188641513168478436"
+ 	"31308023759629577398300170898437499e-324",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x4p-1076, false,
+-	0x4p-1076, false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	false,
+-	0x5.fffffffffffffff8p-1076, false,
+-	0x6p-1076, false,
+-	0x5.fffffffffffffff8p-1076, false,
+-	0x6p-1076, false,
+-	false,
+-	0x5.fffffffffffffff8p-1076, false,
+-	0x6p-1076, false,
+-	0x5.fffffffffffffff8p-1076, false,
+-	0x6p-1076, false,
+-	false,
+-	0x4p-1076, false,
+-	0x4p-1076, false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	false,
+-	0x5.fffffffffffffffffffffffffffcp-1076, false,
+-	0x6p-1076, false,
+-	0x5.fffffffffffffffffffffffffffcp-1076, false,
+-	0x6p-1076, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x4p-1076, false, true,
++	0x4p-1076, false, true,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	false,
++	0x5.fffffffffffffff8p-1076, false, false,
++	0x6p-1076, false, false,
++	0x5.fffffffffffffff8p-1076, false, false,
++	0x6p-1076, false, false,
++	false,
++	0x5.fffffffffffffff8p-1076, false, false,
++	0x6p-1076, false, false,
++	0x5.fffffffffffffff8p-1076, false, false,
++	0x6p-1076, false, false,
++	false,
++	0x4p-1076, false, true,
++	0x4p-1076, false, true,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	false,
++	0x5.fffffffffffffffffffffffffffcp-1076, false, false,
++	0x6p-1076, false, false,
++	0x5.fffffffffffffffffffffffffffcp-1076, false, false,
++	0x6p-1076, false, false),
+   TEST ("7.4109846876186981626485318930233205854758970392148714663837"
+ 	"852375101326090531312779794975454245398856969484704316857659"
+ 	"638998506553390969459816219401617281718945106978546710679176"
+@@ -3861,35 +3861,35 @@ static const struct test tests[] = {
+ 	"337560846003984904972149117463085539556354188641513168478436"
+ 	"313080237596295773983001708984375e-324",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	true,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	true,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	true,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	true,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	true,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	false,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	true,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false),
+   TEST ("7.4109846876186981626485318930233205854758970392148714663837"
+ 	"852375101326090531312779794975454245398856969484704316857659"
+ 	"638998506553390969459816219401617281718945106978546710679176"
+@@ -3904,35 +3904,35 @@ static const struct test tests[] = {
+ 	"337560846003984904972149117463085539556354188641513168478436"
+ 	"31308023759629577398300170898437501e-324",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6.0000000000000008p-1076, false,
+-	false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6.0000000000000008p-1076, false,
+-	false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	0x4p-1076, false,
+-	0x8p-1076, false,
+-	false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6p-1076, false,
+-	0x6.0000000000000000000000000004p-1076, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6.0000000000000008p-1076, false, false,
++	false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6.0000000000000008p-1076, false, false,
++	false,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	0x4p-1076, false, true,
++	0x8p-1076, false, true,
++	false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6p-1076, false, false,
++	0x6.0000000000000000000000000004p-1076, false, false),
+   TEST ("-7.410984687618698162648531893023320585475897039214871466383"
+ 	"785237510132609053131277979497545424539885696948470431685765"
+ 	"963899850655339096945981621940161728171894510697854671067917"
+@@ -3947,35 +3947,35 @@ static const struct test tests[] = {
+ 	"433756084600398490497214911746308553955635418864151316847843"
+ 	"631308023759629577398300170898437499e-324",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x5.fffffffffffffff8p-1076, false,
+-	-0x5.fffffffffffffff8p-1076, false,
+-	false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x5.fffffffffffffff8p-1076, false,
+-	-0x5.fffffffffffffff8p-1076, false,
+-	false,
+-	-0x8p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x5.fffffffffffffffffffffffffffcp-1076, false,
+-	-0x5.fffffffffffffffffffffffffffcp-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x5.fffffffffffffff8p-1076, false, false,
++	-0x5.fffffffffffffff8p-1076, false, false,
++	false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x5.fffffffffffffff8p-1076, false, false,
++	-0x5.fffffffffffffff8p-1076, false, false,
++	false,
++	-0x8p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x5.fffffffffffffffffffffffffffcp-1076, false, false,
++	-0x5.fffffffffffffffffffffffffffcp-1076, false, false),
+   TEST ("-7.410984687618698162648531893023320585475897039214871466383"
+ 	"785237510132609053131277979497545424539885696948470431685765"
+ 	"963899850655339096945981621940161728171894510697854671067917"
+@@ -3990,35 +3990,35 @@ static const struct test tests[] = {
+ 	"433756084600398490497214911746308553955635418864151316847843"
+ 	"6313080237596295773983001708984375e-324",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-1076, false,
+-	-0x8p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	true,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	true,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	false,
+-	-0x8p-1076, false,
+-	-0x8p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	true,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-1076, false, true,
++	-0x8p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	true,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	true,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	false,
++	-0x8p-1076, false, true,
++	-0x8p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	true,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false),
+   TEST ("-7.410984687618698162648531893023320585475897039214871466383"
+ 	"785237510132609053131277979497545424539885696948470431685765"
+ 	"963899850655339096945981621940161728171894510697854671067917"
+@@ -4033,35 +4033,35 @@ static const struct test tests[] = {
+ 	"433756084600398490497214911746308553955635418864151316847843"
+ 	"631308023759629577398300170898437501e-324",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-1076, false,
+-	-0x8p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	false,
+-	-0x6.0000000000000008p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	false,
+-	-0x6.0000000000000008p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	false,
+-	-0x8p-1076, false,
+-	-0x8p-1076, false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	false,
+-	-0x6.0000000000000000000000000004p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false,
+-	-0x6p-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-1076, false, true,
++	-0x8p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	false,
++	-0x6.0000000000000008p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	false,
++	-0x6.0000000000000008p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	false,
++	-0x8p-1076, false, true,
++	-0x8p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	false,
++	-0x6.0000000000000000000000000004p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false,
++	-0x6p-1076, false, false),
+   TEST ("5.4677992978237119037926089004291297245985762235403450155814"
+ 	"707305425575329500966052143410629387408077958710210208052966"
+ 	"529504784489330482549602621133847135082257338717668975178538"
+@@ -4255,35 +4255,35 @@ static const struct test tests[] = {
+ 	"866268925981702690270202829595794350800918257913991744455922"
+ 	"683343374046671669930219650268554687499e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x8p-16448, false,
+-	0x8p-16448, false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	false,
+-	0x8p-16448, false,
+-	0xcp-16448, false,
+-	0x8p-16448, false,
+-	0xcp-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0xb.fffffffffffcp-16448, false,
+-	0xcp-16448, false,
+-	0xb.fffffffffffcp-16448, false,
+-	0xcp-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x8p-16448, false, true,
++	0x8p-16448, false, true,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	false,
++	0x8p-16448, false, true,
++	0xcp-16448, false, true,
++	0x8p-16448, false, true,
++	0xcp-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0xb.fffffffffffcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xb.fffffffffffcp-16448, false, true,
++	0xcp-16448, false, true),
+   TEST ("5.4677992978237119037926089004291297245985762235403450155814"
+ 	"707305425575329500966052143410629387408077958710210208052966"
+ 	"529504784489330482549602621133847135082257338717668975178538"
+@@ -4477,35 +4477,35 @@ static const struct test tests[] = {
+ 	"866268925981702690270202829595794350800918257913991744455922"
+ 	"6833433740466716699302196502685546875e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	true,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	true,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false),
+   TEST ("5.4677992978237119037926089004291297245985762235403450155814"
+ 	"707305425575329500966052143410629387408077958710210208052966"
+ 	"529504784489330482549602621133847135082257338717668975178538"
+@@ -4699,35 +4699,35 @@ static const struct test tests[] = {
+ 	"866268925981702690270202829595794350800918257913991744455922"
+ 	"683343374046671669930219650268554687501e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0x1p-16444, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xc.000000000004p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	false,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0x1p-16444, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xc.000000000004p-16448, false, true),
+   TEST ("-5.467799297823711903792608900429129724598576223540345015581"
+ 	"470730542557532950096605214341062938740807795871021020805296"
+ 	"652950478448933048254960262113384713508225733871766897517853"
+@@ -4921,35 +4921,35 @@ static const struct test tests[] = {
+ 	"386626892598170269027020282959579435080091825791399174445592"
+ 	"2683343374046671669930219650268554687499e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xb.fffffffffffcp-16448, false,
+-	-0xb.fffffffffffcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	false,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xb.fffffffffffcp-16448, false, true,
++	-0xb.fffffffffffcp-16448, false, true),
+   TEST ("-5.467799297823711903792608900429129724598576223540345015581"
+ 	"470730542557532950096605214341062938740807795871021020805296"
+ 	"652950478448933048254960262113384713508225733871766897517853"
+@@ -5143,35 +5143,35 @@ static const struct test tests[] = {
+ 	"386626892598170269027020282959579435080091825791399174445592"
+ 	"26833433740466716699302196502685546875e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0x1p-16444, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	true,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0x1p-16444, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	true,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false),
+   TEST ("-5.467799297823711903792608900429129724598576223540345015581"
+ 	"470730542557532950096605214341062938740807795871021020805296"
+ 	"652950478448933048254960262113384713508225733871766897517853"
+@@ -5365,35 +5365,35 @@ static const struct test tests[] = {
+ 	"386626892598170269027020282959579435080091825791399174445592"
+ 	"2683343374046671669930219650268554687501e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0x1p-16444, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0xc.000000000004p-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0x1p-16444, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0xc.000000000004p-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true),
+   TEST ("5.4677992978237119037926089004291297245985762235403450155814"
+ 	"707305425575329500966052143410629387408077958710210208052966"
+ 	"529504784489330482549602621133847135082257338717668975178538"
+@@ -5587,35 +5587,35 @@ static const struct test tests[] = {
+ 	"866268925981702690270202829595794350800918257913991744455922"
+ 	"683343374046671669930219650268554687499e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x8p-16448, false,
+-	0x8p-16448, false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	false,
+-	0x8p-16448, false,
+-	0xcp-16448, false,
+-	0x8p-16448, false,
+-	0xcp-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0xb.fffffffffffcp-16448, false,
+-	0xcp-16448, false,
+-	0xb.fffffffffffcp-16448, false,
+-	0xcp-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x8p-16448, false, true,
++	0x8p-16448, false, true,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	false,
++	0x8p-16448, false, true,
++	0xcp-16448, false, true,
++	0x8p-16448, false, true,
++	0xcp-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0xb.fffffffffffcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xb.fffffffffffcp-16448, false, true,
++	0xcp-16448, false, true),
+   TEST ("5.4677992978237119037926089004291297245985762235403450155814"
+ 	"707305425575329500966052143410629387408077958710210208052966"
+ 	"529504784489330482549602621133847135082257338717668975178538"
+@@ -5809,35 +5809,35 @@ static const struct test tests[] = {
+ 	"866268925981702690270202829595794350800918257913991744455922"
+ 	"6833433740466716699302196502685546875e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	true,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	true,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false,
++	0xcp-16448, false, false),
+   TEST ("5.4677992978237119037926089004291297245985762235403450155814"
+ 	"707305425575329500966052143410629387408077958710210208052966"
+ 	"529504784489330482549602621133847135082257338717668975178538"
+@@ -6031,35 +6031,35 @@ static const struct test tests[] = {
+ 	"866268925981702690270202829595794350800918257913991744455922"
+ 	"683343374046671669930219650268554687501e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	0x8p-16448, false,
+-	0x1p-16444, false,
+-	false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0x1p-16444, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xcp-16448, false,
+-	0xc.000000000004p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	0x8p-16448, false, true,
++	0x1p-16444, false, true,
++	false,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0x1p-16444, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xcp-16448, false, true,
++	0xc.000000000004p-16448, false, true),
+   TEST ("-5.467799297823711903792608900429129724598576223540345015581"
+ 	"470730542557532950096605214341062938740807795871021020805296"
+ 	"652950478448933048254960262113384713508225733871766897517853"
+@@ -6253,35 +6253,35 @@ static const struct test tests[] = {
+ 	"386626892598170269027020282959579435080091825791399174445592"
+ 	"2683343374046671669930219650268554687499e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xb.fffffffffffcp-16448, false,
+-	-0xb.fffffffffffcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	false,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xb.fffffffffffcp-16448, false, true,
++	-0xb.fffffffffffcp-16448, false, true),
+   TEST ("-5.467799297823711903792608900429129724598576223540345015581"
+ 	"470730542557532950096605214341062938740807795871021020805296"
+ 	"652950478448933048254960262113384713508225733871766897517853"
+@@ -6475,35 +6475,35 @@ static const struct test tests[] = {
+ 	"386626892598170269027020282959579435080091825791399174445592"
+ 	"26833433740466716699302196502685546875e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0x1p-16444, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	true,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0x1p-16444, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	true,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false,
++	-0xcp-16448, false, false),
+   TEST ("-5.467799297823711903792608900429129724598576223540345015581"
+ 	"470730542557532950096605214341062938740807795871021020805296"
+ 	"652950478448933048254960262113384713508225733871766897517853"
+@@ -6697,630 +6697,630 @@ static const struct test tests[] = {
+ 	"386626892598170269027020282959579435080091825791399174445592"
+ 	"2683343374046671669930219650268554687501e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0x1p-16444, false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	false,
+-	-0x1p-16444, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0xc.000000000004p-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false,
+-	-0xcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0x1p-16444, false, true,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	false,
++	-0x1p-16444, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0xc.000000000004p-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true,
++	-0xcp-16448, false, true),
+   TEST ("-0x0.7p-149",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	true,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	true,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	true,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	true,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false,
+-	-0x3.8p-152, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	true,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	true,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	true,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	true,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false,
++	-0x3.8p-152, false, false),
+   TEST ("-0x0.7p-1074",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	true,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false,
+-	-0x1.cp-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	true,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false,
++	-0x1.cp-1076, false, false),
+   TEST ("-0x0.7p-16445",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x3.8p-16448, false,
+-	-0x3.8p-16448, false,
+-	-0x3.8p-16448, false,
+-	-0x3.8p-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x3.8p-16448, false, false,
++	-0x3.8p-16448, false, false,
++	-0x3.8p-16448, false, false,
++	-0x3.8p-16448, false, false),
+   TEST ("-0x0.7p-16494",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16496, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16496, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true),
+   TEST ("0x1p-150",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false),
+   TEST ("0x1p-1075",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	true,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	true,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false),
+   TEST ("0x1p-16446",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	true,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	true,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false),
+   TEST ("0x1p-16495",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16496, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16496, false, true),
+   TEST ("-0x1p-150",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false),
+   TEST ("-0x1p-1075",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	true,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	true,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false),
+   TEST ("-0x1p-16446",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false),
+   TEST ("-0x1p-16495",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16496, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16496, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true),
+   TEST (".70064923216240853546186479164495807e-45",
+ 	false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000004p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000000008p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000000008p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.00000000000000000000000002p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000000000000000000004p-152, false),
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000004p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000000008p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000000008p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.00000000000000000000000002p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000000000000000000004p-152, false, false),
+   TEST ("7.0064923216240853546186479164495806564013097093825788587853"
+ 	"4141944895541342930300743319094181060791015624e-46",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x3.ffffffffffffep-152, false,
+-	0x4p-152, false,
+-	0x3.ffffffffffffep-152, false,
+-	0x4p-152, false,
+-	false,
+-	0x3.fffffffffffffffcp-152, false,
+-	0x4p-152, false,
+-	0x3.fffffffffffffffcp-152, false,
+-	0x4p-152, false,
+-	false,
+-	0x3.fffffffffffffffcp-152, false,
+-	0x4p-152, false,
+-	0x3.fffffffffffffffcp-152, false,
+-	0x4p-152, false,
+-	false,
+-	0x3.ffffffffffffffffffffffffffp-152, false,
+-	0x4p-152, false,
+-	0x3.ffffffffffffffffffffffffffp-152, false,
+-	0x4p-152, false,
+-	false,
+-	0x3.fffffffffffffffffffffffffffep-152, false,
+-	0x4p-152, false,
+-	0x3.fffffffffffffffffffffffffffep-152, false,
+-	0x4p-152, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x3.ffffffffffffep-152, false, false,
++	0x4p-152, false, false,
++	0x3.ffffffffffffep-152, false, false,
++	0x4p-152, false, false,
++	false,
++	0x3.fffffffffffffffcp-152, false, false,
++	0x4p-152, false, false,
++	0x3.fffffffffffffffcp-152, false, false,
++	0x4p-152, false, false,
++	false,
++	0x3.fffffffffffffffcp-152, false, false,
++	0x4p-152, false, false,
++	0x3.fffffffffffffffcp-152, false, false,
++	0x4p-152, false, false,
++	false,
++	0x3.ffffffffffffffffffffffffffp-152, false, false,
++	0x4p-152, false, false,
++	0x3.ffffffffffffffffffffffffffp-152, false, false,
++	0x4p-152, false, false,
++	false,
++	0x3.fffffffffffffffffffffffffffep-152, false, false,
++	0x4p-152, false, false,
++	0x3.fffffffffffffffffffffffffffep-152, false, false,
++	0x4p-152, false, false),
+   TEST ("7.0064923216240853546186479164495806564013097093825788587853"
+ 	"4141944895541342930300743319094181060791015625e-46",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	true,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	true,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false),
+   TEST ("7.0064923216240853546186479164495806564013097093825788587853"
+ 	"4141944895541342930300743319094181060791015626e-46",
+ 	false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000004p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000000008p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000000008p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.00000000000000000000000002p-152, false,
+-	false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4p-152, false,
+-	0x4.0000000000000000000000000004p-152, false),
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000004p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000000008p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000000008p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.00000000000000000000000002p-152, false, false,
++	false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4p-152, false, false,
++	0x4.0000000000000000000000000004p-152, false, false),
+   TEST ("-7.006492321624085354618647916449580656401309709382578858785"
+ 	"34141944895541342930300743319094181060791015624e-46",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x3.ffffffffffffep-152, false,
+-	-0x3.ffffffffffffep-152, false,
+-	false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x3.fffffffffffffffcp-152, false,
+-	-0x3.fffffffffffffffcp-152, false,
+-	false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x3.fffffffffffffffcp-152, false,
+-	-0x3.fffffffffffffffcp-152, false,
+-	false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x3.ffffffffffffffffffffffffffp-152, false,
+-	-0x3.ffffffffffffffffffffffffffp-152, false,
+-	false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x3.fffffffffffffffffffffffffffep-152, false,
+-	-0x3.fffffffffffffffffffffffffffep-152, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x3.ffffffffffffep-152, false, false,
++	-0x3.ffffffffffffep-152, false, false,
++	false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x3.fffffffffffffffcp-152, false, false,
++	-0x3.fffffffffffffffcp-152, false, false,
++	false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x3.fffffffffffffffcp-152, false, false,
++	-0x3.fffffffffffffffcp-152, false, false,
++	false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x3.ffffffffffffffffffffffffffp-152, false, false,
++	-0x3.ffffffffffffffffffffffffffp-152, false, false,
++	false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x3.fffffffffffffffffffffffffffep-152, false, false,
++	-0x3.fffffffffffffffffffffffffffep-152, false, false),
+   TEST ("-7.006492321624085354618647916449580656401309709382578858785"
+ 	"34141944895541342930300743319094181060791015625e-46",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	true,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	true,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false),
+   TEST ("-7.006492321624085354618647916449580656401309709382578858785"
+ 	"34141944895541342930300743319094181060791015626e-46",
+ 	false,
+-	-0x8p-152, false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4.0000000000004p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	false,
+-	-0x4.0000000000000008p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	false,
+-	-0x4.0000000000000008p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	false,
+-	-0x4.00000000000000000000000002p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	false,
+-	-0x4.0000000000000000000000000004p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false,
+-	-0x4p-152, false),
++	-0x8p-152, false, true,
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4.0000000000004p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	false,
++	-0x4.0000000000000008p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	false,
++	-0x4.0000000000000008p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	false,
++	-0x4.00000000000000000000000002p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	false,
++	-0x4.0000000000000000000000000004p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false,
++	-0x4p-152, false, false),
+   TEST ("2.4703282292062327208828439643411068618252990130716238221279"
+ 	"284125033775363510437593264991818081799618989828234772285886"
+ 	"546332835517796989819938739800539093906315035659515570226392"
+@@ -7335,35 +7335,35 @@ static const struct test tests[] = {
+ 	"779186948667994968324049705821028513185451396213837722826145"
+ 	"437693412532098591327667236328124e-324",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x1.fffffffffffffffep-1076, false,
+-	0x2p-1076, false,
+-	0x1.fffffffffffffffep-1076, false,
+-	0x2p-1076, false,
+-	false,
+-	0x1.fffffffffffffffep-1076, false,
+-	0x2p-1076, false,
+-	0x1.fffffffffffffffep-1076, false,
+-	0x2p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x1.ffffffffffffffffffffffffffffp-1076, false,
+-	0x2p-1076, false,
+-	0x1.ffffffffffffffffffffffffffffp-1076, false,
+-	0x2p-1076, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.fffffffffffffffep-1076, false, false,
++	0x2p-1076, false, false,
++	0x1.fffffffffffffffep-1076, false, false,
++	0x2p-1076, false, false,
++	false,
++	0x1.fffffffffffffffep-1076, false, false,
++	0x2p-1076, false, false,
++	0x1.fffffffffffffffep-1076, false, false,
++	0x2p-1076, false, false,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.ffffffffffffffffffffffffffffp-1076, false, false,
++	0x2p-1076, false, false,
++	0x1.ffffffffffffffffffffffffffffp-1076, false, false,
++	0x2p-1076, false, false),
+   TEST ("2.4703282292062327208828439643411068618252990130716238221279"
+ 	"284125033775363510437593264991818081799618989828234772285886"
+ 	"546332835517796989819938739800539093906315035659515570226392"
+@@ -7378,35 +7378,35 @@ static const struct test tests[] = {
+ 	"779186948667994968324049705821028513185451396213837722826145"
+ 	"437693412532098591327667236328125e-324",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	true,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	true,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false),
+   TEST ("2.4703282292062327208828439643411068618252990130716238221279"
+ 	"284125033775363510437593264991818081799618989828234772285886"
+ 	"546332835517796989819938739800539093906315035659515570226392"
+@@ -7421,35 +7421,35 @@ static const struct test tests[] = {
+ 	"779186948667994968324049705821028513185451396213837722826145"
+ 	"437693412532098591327667236328126e-324",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2.0000000000000004p-1076, false,
+-	false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2.0000000000000004p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2p-1076, false,
+-	0x2.0000000000000000000000000002p-1076, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2.0000000000000004p-1076, false, false,
++	false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2.0000000000000004p-1076, false, false,
++	false,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2p-1076, false, false,
++	0x2.0000000000000000000000000002p-1076, false, false),
+   TEST ("-2.470328229206232720882843964341106861825299013071623822127"
+ 	"928412503377536351043759326499181808179961898982823477228588"
+ 	"654633283551779698981993873980053909390631503565951557022639"
+@@ -7464,35 +7464,35 @@ static const struct test tests[] = {
+ 	"477918694866799496832404970582102851318545139621383772282614"
+ 	"5437693412532098591327667236328124e-324",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x1.fffffffffffffffep-1076, false,
+-	-0x1.fffffffffffffffep-1076, false,
+-	false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x1.fffffffffffffffep-1076, false,
+-	-0x1.fffffffffffffffep-1076, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x1.ffffffffffffffffffffffffffffp-1076, false,
+-	-0x1.ffffffffffffffffffffffffffffp-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x1.fffffffffffffffep-1076, false, false,
++	-0x1.fffffffffffffffep-1076, false, false,
++	false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x1.fffffffffffffffep-1076, false, false,
++	-0x1.fffffffffffffffep-1076, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x1.ffffffffffffffffffffffffffffp-1076, false, false,
++	-0x1.ffffffffffffffffffffffffffffp-1076, false, false),
+   TEST ("-2.470328229206232720882843964341106861825299013071623822127"
+ 	"928412503377536351043759326499181808179961898982823477228588"
+ 	"654633283551779698981993873980053909390631503565951557022639"
+@@ -7507,35 +7507,35 @@ static const struct test tests[] = {
+ 	"477918694866799496832404970582102851318545139621383772282614"
+ 	"5437693412532098591327667236328125e-324",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	true,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	true,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false),
+   TEST ("-2.470328229206232720882843964341106861825299013071623822127"
+ 	"928412503377536351043759326499181808179961898982823477228588"
+ 	"654633283551779698981993873980053909390631503565951557022639"
+@@ -7550,35 +7550,35 @@ static const struct test tests[] = {
+ 	"477918694866799496832404970582102851318545139621383772282614"
+ 	"5437693412532098591327667236328126e-324",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x2.0000000000000004p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	false,
+-	-0x2.0000000000000004p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x2.0000000000000000000000000002p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false,
+-	-0x2p-1076, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x2.0000000000000004p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	false,
++	-0x2.0000000000000004p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x2.0000000000000000000000000002p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false,
++	-0x2p-1076, false, false),
+   TEST ("1.8225997659412373012642029668097099081995254078467816718604"
+ 	"902435141858443166988684047803543129136025986236736736017655"
+ 	"509834928163110160849867540377949045027419112905889658392846"
+@@ -7772,35 +7772,35 @@ static const struct test tests[] = {
+ 	"622089641993900896756734276531931450266972752637997248151974"
+ 	"2277811246822238899767398834228515624e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x3.fffffffffffcp-16448, false,
+-	0x4p-16448, false,
+-	0x3.fffffffffffcp-16448, false,
+-	0x4p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x3.fffffffffffcp-16448, false, true,
++	0x4p-16448, false, true,
++	0x3.fffffffffffcp-16448, false, true,
++	0x4p-16448, false, true),
+   TEST ("1.8225997659412373012642029668097099081995254078467816718604"
+ 	"902435141858443166988684047803543129136025986236736736017655"
+ 	"509834928163110160849867540377949045027419112905889658392846"
+@@ -7994,35 +7994,35 @@ static const struct test tests[] = {
+ 	"622089641993900896756734276531931450266972752637997248151974"
+ 	"2277811246822238899767398834228515625e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	true,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	true,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false,
++	0x4p-16448, false, false),
+   TEST ("1.8225997659412373012642029668097099081995254078467816718604"
+ 	"902435141858443166988684047803543129136025986236736736017655"
+ 	"509834928163110160849867540377949045027419112905889658392846"
+@@ -8216,35 +8216,35 @@ static const struct test tests[] = {
+ 	"622089641993900896756734276531931450266972752637997248151974"
+ 	"2277811246822238899767398834228515626e-4951",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4p-16448, false,
+-	0x4.000000000004p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x4p-16448, false, true,
++	0x4p-16448, false, true,
++	0x4p-16448, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x4p-16448, false, true,
++	0x4p-16448, false, true,
++	0x4p-16448, false, true,
++	0x4.000000000004p-16448, false, true),
+   TEST ("-1.822599765941237301264202966809709908199525407846781671860"
+ 	"490243514185844316698868404780354312913602598623673673601765"
+ 	"550983492816311016084986754037794904502741911290588965839284"
+@@ -8438,35 +8438,35 @@ static const struct test tests[] = {
+ 	"462208964199390089675673427653193145026697275263799724815197"
+ 	"42277811246822238899767398834228515624e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x3.fffffffffffcp-16448, false,
+-	-0x3.fffffffffffcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x3.fffffffffffcp-16448, false, true,
++	-0x3.fffffffffffcp-16448, false, true),
+   TEST ("-1.822599765941237301264202966809709908199525407846781671860"
+ 	"490243514185844316698868404780354312913602598623673673601765"
+ 	"550983492816311016084986754037794904502741911290588965839284"
+@@ -8660,35 +8660,35 @@ static const struct test tests[] = {
+ 	"462208964199390089675673427653193145026697275263799724815197"
+ 	"42277811246822238899767398834228515625e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false,
++	-0x4p-16448, false, false),
+   TEST ("-1.822599765941237301264202966809709908199525407846781671860"
+ 	"490243514185844316698868404780354312913602598623673673601765"
+ 	"550983492816311016084986754037794904502741911290588965839284"
+@@ -8882,35 +8882,35 @@ static const struct test tests[] = {
+ 	"462208964199390089675673427653193145026697275263799724815197"
+ 	"42277811246822238899767398834228515626e-4951",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4.000000000004p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4.000000000004p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true),
+   TEST ("9.1129988297061865063210148340485495409976270392339083593024"
+ 	"512175709292215834943420239017715645680129931183683680088277"
+ 	"549174640815550804249337701889745225137095564529448291964230"
+@@ -9104,35 +9104,35 @@ static const struct test tests[] = {
+ 	"110448209969504483783671382659657251334863763189986240759871"
+ 	"1389056234111194498836994171142578124e-4952",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x1.fffffffffffcp-16448, false,
+-	0x2p-16448, false,
+-	0x1.fffffffffffcp-16448, false,
+-	0x2p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.fffffffffffcp-16448, false, true,
++	0x2p-16448, false, true,
++	0x1.fffffffffffcp-16448, false, true,
++	0x2p-16448, false, true),
+   TEST ("9.1129988297061865063210148340485495409976270392339083593024"
+ 	"512175709292215834943420239017715645680129931183683680088277"
+ 	"549174640815550804249337701889745225137095564529448291964230"
+@@ -9326,35 +9326,35 @@ static const struct test tests[] = {
+ 	"110448209969504483783671382659657251334863763189986240759871"
+ 	"1389056234111194498836994171142578125e-4952",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	true,
+-	0x2p-16448, false,
+-	0x2p-16448, false,
+-	0x2p-16448, false,
+-	0x2p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x2p-16448, false, false,
++	0x2p-16448, false, false,
++	0x2p-16448, false, false,
++	0x2p-16448, false, false),
+   TEST ("9.1129988297061865063210148340485495409976270392339083593024"
+ 	"512175709292215834943420239017715645680129931183683680088277"
+ 	"549174640815550804249337701889745225137095564529448291964230"
+@@ -9548,35 +9548,35 @@ static const struct test tests[] = {
+ 	"110448209969504483783671382659657251334863763189986240759871"
+ 	"1389056234111194498836994171142578126e-4952",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x2p-16448, false,
+-	0x2p-16448, false,
+-	0x2p-16448, false,
+-	0x2.000000000004p-16448, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x2p-16448, false, true,
++	0x2p-16448, false, true,
++	0x2p-16448, false, true,
++	0x2.000000000004p-16448, false, true),
+   TEST ("-9.112998829706186506321014834048549540997627039233908359302"
+ 	"451217570929221583494342023901771564568012993118368368008827"
+ 	"754917464081555080424933770188974522513709556452944829196423"
+@@ -9770,35 +9770,35 @@ static const struct test tests[] = {
+ 	"311044820996950448378367138265965725133486376318998624075987"
+ 	"11389056234111194498836994171142578124e-4952",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x2p-16448, false,
+-	-0x2p-16448, false,
+-	-0x1.fffffffffffcp-16448, false,
+-	-0x1.fffffffffffcp-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x2p-16448, false, true,
++	-0x2p-16448, false, true,
++	-0x1.fffffffffffcp-16448, false, true,
++	-0x1.fffffffffffcp-16448, false, true),
+   TEST ("-9.112998829706186506321014834048549540997627039233908359302"
+ 	"451217570929221583494342023901771564568012993118368368008827"
+ 	"754917464081555080424933770188974522513709556452944829196423"
+@@ -9992,35 +9992,35 @@ static const struct test tests[] = {
+ 	"311044820996950448378367138265965725133486376318998624075987"
+ 	"11389056234111194498836994171142578125e-4952",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	true,
+-	-0x2p-16448, false,
+-	-0x2p-16448, false,
+-	-0x2p-16448, false,
+-	-0x2p-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	true,
++	-0x2p-16448, false, false,
++	-0x2p-16448, false, false,
++	-0x2p-16448, false, false,
++	-0x2p-16448, false, false),
+   TEST ("-9.112998829706186506321014834048549540997627039233908359302"
+ 	"451217570929221583494342023901771564568012993118368368008827"
+ 	"754917464081555080424933770188974522513709556452944829196423"
+@@ -10214,35 +10214,35 @@ static const struct test tests[] = {
+ 	"311044820996950448378367138265965725133486376318998624075987"
+ 	"11389056234111194498836994171142578126e-4952",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x2.000000000004p-16448, false,
+-	-0x2p-16448, false,
+-	-0x2p-16448, false,
+-	-0x2p-16448, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x2.000000000004p-16448, false, true,
++	-0x2p-16448, false, true,
++	-0x2p-16448, false, true,
++	-0x2p-16448, false, true),
+   TEST ("3.2375875597190125554622194791138232762497846690173405048449"
+ 	"421945985197700620596855088357456383249701279390707384240598"
+ 	"382936099431912710233425550359863089915213963553756674672083"
+@@ -10437,35 +10437,35 @@ static const struct test tests[] = {
+ 	"182358152808745703724362178773168996492870519432472065091133"
+ 	"11767578124e-4966",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16496, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16496, false, true),
+   TEST ("3.2375875597190125554622194791138232762497846690173405048449"
+ 	"421945985197700620596855088357456383249701279390707384240598"
+ 	"382936099431912710233425550359863089915213963553756674672083"
+@@ -10660,35 +10660,35 @@ static const struct test tests[] = {
+ 	"182358152808745703724362178773168996492870519432472065091133"
+ 	"11767578125e-4966",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16496, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16496, false, true),
+   TEST ("3.2375875597190125554622194791138232762497846690173405048449"
+ 	"421945985197700620596855088357456383249701279390707384240598"
+ 	"382936099431912710233425550359863089915213963553756674672083"
+@@ -10883,35 +10883,35 @@ static const struct test tests[] = {
+ 	"182358152808745703724362178773168996492870519432472065091133"
+ 	"11767578126e-4966",
+ 	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-152, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x8p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-16448, false,
+-	false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x0p+0, false,
+-	0x4p-1076, false,
+-	false,
+-	0x0p+0, false,
+-	0x4p-16496, false,
+-	0x0p+0, false,
+-	0x4p-16496, false),
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-16448, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x0p+0, false, true,
++	0x4p-16496, false, true,
++	0x0p+0, false, true,
++	0x4p-16496, false, true),
+   TEST ("-3.237587559719012555462219479113823276249784669017340504844"
+ 	"942194598519770062059685508835745638324970127939070738424059"
+ 	"838293609943191271023342555035986308991521396355375667467208"
+@@ -11106,35 +11106,35 @@ static const struct test tests[] = {
+ 	"218235815280874570372436217877316899649287051943247206509113"
+ 	"311767578124e-4966",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16496, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16496, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true),
+   TEST ("-3.237587559719012555462219479113823276249784669017340504844"
+ 	"942194598519770062059685508835745638324970127939070738424059"
+ 	"838293609943191271023342555035986308991521396355375667467208"
+@@ -11329,35 +11329,35 @@ static const struct test tests[] = {
+ 	"218235815280874570372436217877316899649287051943247206509113"
+ 	"311767578125e-4966",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16496, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16496, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true),
+   TEST ("-3.237587559719012555462219479113823276249784669017340504844"
+ 	"942194598519770062059685508835745638324970127939070738424059"
+ 	"838293609943191271023342555035986308991521396355375667467208"
+@@ -11552,66 +11552,66 @@ static const struct test tests[] = {
+ 	"218235815280874570372436217877316899649287051943247206509113"
+ 	"311767578126e-4966",
+ 	false,
+-	-0x8p-152, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x8p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16448, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-1076, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false,
+-	false,
+-	-0x4p-16496, false,
+-	-0x4p-16496, false,
+-	-0x0p+0, false,
+-	-0x0p+0, false),
++	-0x8p-152, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x8p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16448, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-1076, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true,
++	false,
++	-0x4p-16496, false, true,
++	-0x4p-16496, false, true,
++	-0x0p+0, false, true,
++	-0x0p+0, false, true),
+   TEST ("340282366920938463463374607431768211455",
+ 	false,
+-	0xf.fffffp+124, false,
+-	INF, true,
+-	0xf.fffffp+124, false,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+124, false,
+-	0x1p+128, false,
+-	0xf.ffffffffffff8p+124, false,
+-	0x1p+128, false,
+-	false,
+-	0xf.fffffffffffffffp+124, false,
+-	0x1p+128, false,
+-	0xf.fffffffffffffffp+124, false,
+-	0x1p+128, false,
+-	false,
+-	0xf.fffffffffffffffp+124, false,
+-	0x1p+128, false,
+-	0xf.fffffffffffffffp+124, false,
+-	0x1p+128, false,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+124, false,
+-	0x1p+128, false,
+-	0xf.fffffffffffffffffffffffffcp+124, false,
+-	0x1p+128, false,
+-	false,
+-	0xf.fffffffffffffffffffffffffff8p+124, false,
+-	0x1p+128, false,
+-	0xf.fffffffffffffffffffffffffff8p+124, false,
+-	0x1p+128, false),
++	0xf.fffffp+124, false, false,
++	INF, true, false,
++	0xf.fffffp+124, false, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+124, false, false,
++	0x1p+128, false, false,
++	0xf.ffffffffffff8p+124, false, false,
++	0x1p+128, false, false,
++	false,
++	0xf.fffffffffffffffp+124, false, false,
++	0x1p+128, false, false,
++	0xf.fffffffffffffffp+124, false, false,
++	0x1p+128, false, false,
++	false,
++	0xf.fffffffffffffffp+124, false, false,
++	0x1p+128, false, false,
++	0xf.fffffffffffffffp+124, false, false,
++	0x1p+128, false, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+124, false, false,
++	0x1p+128, false, false,
++	0xf.fffffffffffffffffffffffffcp+124, false, false,
++	0x1p+128, false, false,
++	false,
++	0xf.fffffffffffffffffffffffffff8p+124, false, false,
++	0x1p+128, false, false,
++	0xf.fffffffffffffffffffffffffff8p+124, false, false,
++	0x1p+128, false, false),
+   TEST ("179769313486231590772930519078902473361797697894230657273430"
+ 	"081157732675805500963132708477322407536021120113879871393357"
+ 	"658789768814416622492847430639474124377767893424865485276302"
+@@ -11619,35 +11619,35 @@ static const struct test tests[] = {
+ 	"540827237163350510684586298239947245938479716304835356329624"
+ 	"224137215",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, false,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+1020, false,
+-	0x1p+1024, false,
+-	0xf.fffffffffffffffp+1020, false,
+-	0x1p+1024, false,
+-	false,
+-	0xf.fffffffffffffffp+1020, false,
+-	0x1p+1024, false,
+-	0xf.fffffffffffffffp+1020, false,
+-	0x1p+1024, false,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffff8p+1020, false,
+-	0x1p+1024, false,
+-	0xf.fffffffffffffffffffffffffff8p+1020, false,
+-	0x1p+1024, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, false, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+1020, false, false,
++	0x1p+1024, false, false,
++	0xf.fffffffffffffffp+1020, false, false,
++	0x1p+1024, false, false,
++	false,
++	0xf.fffffffffffffffp+1020, false, false,
++	0x1p+1024, false, false,
++	0xf.fffffffffffffffp+1020, false, false,
++	0x1p+1024, false, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffff8p+1020, false, false,
++	0x1p+1024, false, false,
++	0xf.fffffffffffffffffffffffffff8p+1020, false, false,
++	0x1p+1024, false, false),
+   TEST ("118973149535723176508575932662800713076344468709651023747267"
+ 	"482123326135818048368690448859547261203991511543748483930925"
+ 	"889766738130868742627452469834156500608087163436600489752214"
+@@ -11732,66 +11732,66 @@ static const struct test tests[] = {
+ 	"047398248889922809181821393428829567971736994315246044702729"
+ 	"0669964066815",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffp+16380, false,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	INF, true),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffp+16380, false, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	INF, true, false),
+   TEST ("-340282366920938463463374607431768211455",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, false,
+-	-0xf.fffffp+124, false,
+-	false,
+-	-0x1p+128, false,
+-	-0x1p+128, false,
+-	-0xf.ffffffffffff8p+124, false,
+-	-0xf.ffffffffffff8p+124, false,
+-	false,
+-	-0x1p+128, false,
+-	-0x1p+128, false,
+-	-0xf.fffffffffffffffp+124, false,
+-	-0xf.fffffffffffffffp+124, false,
+-	false,
+-	-0x1p+128, false,
+-	-0x1p+128, false,
+-	-0xf.fffffffffffffffp+124, false,
+-	-0xf.fffffffffffffffp+124, false,
+-	false,
+-	-0x1p+128, false,
+-	-0x1p+128, false,
+-	-0xf.fffffffffffffffffffffffffcp+124, false,
+-	-0xf.fffffffffffffffffffffffffcp+124, false,
+-	false,
+-	-0x1p+128, false,
+-	-0x1p+128, false,
+-	-0xf.fffffffffffffffffffffffffff8p+124, false,
+-	-0xf.fffffffffffffffffffffffffff8p+124, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, false, false,
++	-0xf.fffffp+124, false, false,
++	false,
++	-0x1p+128, false, false,
++	-0x1p+128, false, false,
++	-0xf.ffffffffffff8p+124, false, false,
++	-0xf.ffffffffffff8p+124, false, false,
++	false,
++	-0x1p+128, false, false,
++	-0x1p+128, false, false,
++	-0xf.fffffffffffffffp+124, false, false,
++	-0xf.fffffffffffffffp+124, false, false,
++	false,
++	-0x1p+128, false, false,
++	-0x1p+128, false, false,
++	-0xf.fffffffffffffffp+124, false, false,
++	-0xf.fffffffffffffffp+124, false, false,
++	false,
++	-0x1p+128, false, false,
++	-0x1p+128, false, false,
++	-0xf.fffffffffffffffffffffffffcp+124, false, false,
++	-0xf.fffffffffffffffffffffffffcp+124, false, false,
++	false,
++	-0x1p+128, false, false,
++	-0x1p+128, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+124, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+124, false, false),
+   TEST ("-17976931348623159077293051907890247336179769789423065727343"
+ 	"008115773267580550096313270847732240753602112011387987139335"
+ 	"765878976881441662249284743063947412437776789342486548527630"
+@@ -11799,35 +11799,35 @@ static const struct test tests[] = {
+ 	"054082723716335051068458629823994724593847971630483535632962"
+ 	"4224137215",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, false,
+-	-0xf.ffffffffffff8p+1020, false,
+-	false,
+-	-0x1p+1024, false,
+-	-0x1p+1024, false,
+-	-0xf.fffffffffffffffp+1020, false,
+-	-0xf.fffffffffffffffp+1020, false,
+-	false,
+-	-0x1p+1024, false,
+-	-0x1p+1024, false,
+-	-0xf.fffffffffffffffp+1020, false,
+-	-0xf.fffffffffffffffp+1020, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	false,
+-	-0x1p+1024, false,
+-	-0x1p+1024, false,
+-	-0xf.fffffffffffffffffffffffffff8p+1020, false,
+-	-0xf.fffffffffffffffffffffffffff8p+1020, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	-0xf.ffffffffffff8p+1020, false, false,
++	false,
++	-0x1p+1024, false, false,
++	-0x1p+1024, false, false,
++	-0xf.fffffffffffffffp+1020, false, false,
++	-0xf.fffffffffffffffp+1020, false, false,
++	false,
++	-0x1p+1024, false, false,
++	-0x1p+1024, false, false,
++	-0xf.fffffffffffffffp+1020, false, false,
++	-0xf.fffffffffffffffp+1020, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	false,
++	-0x1p+1024, false, false,
++	-0x1p+1024, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+1020, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+1020, false, false),
+   TEST ("-11897314953572317650857593266280071307634446870965102374726"
+ 	"748212332613581804836869044885954726120399151154374848393092"
+ 	"588976673813086874262745246983415650060808716343660048975221"
+@@ -11912,3529 +11912,3529 @@ static const struct test tests[] = {
+ 	"904739824888992280918182139342882956797173699431524604470272"
+ 	"90669964066815",
+ 	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffp+124, true,
+-	-0xf.fffffp+124, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	-0xf.ffffffffffff8p+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffp+16380, false,
+-	-0xf.fffffffffffffffp+16380, false,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	-0xf.fffffffffffffffffffffffffcp+1020, true,
+-	false,
+-	-INF, true,
+-	-INF, true,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false,
+-	-0xf.fffffffffffffffffffffffffff8p+16380, false),
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffp+124, true, false,
++	-0xf.fffffp+124, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	-0xf.ffffffffffff8p+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	-0xf.fffffffffffffffp+16380, false, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	-0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	false,
++	-INF, true, false,
++	-INF, true, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false,
++	-0xf.fffffffffffffffffffffffffff8p+16380, false, false),
+   TEST ("+0x.80000000000000000000000000000001p1025",
+ 	false,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	0xf.fffffp+124, true,
+-	INF, true,
+-	false,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	0xf.ffffffffffff8p+1020, true,
+-	INF, true,
+-	false,
+-	0x1p+1024, false,
+-	0x1p+1024, false,
+-	0x1p+1024, false,
+-	0x1.0000000000000002p+1024, false,
+-	false,
+-	0x1p+1024, false,
+-	0x1p+1024, false,
+-	0x1p+1024, false,
+-	0x1.0000000000000002p+1024, false,
+-	false,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	0xf.fffffffffffffffffffffffffcp+1020, true,
+-	INF, true,
+-	false,
+-	0x1p+1024, false,
+-	0x1p+1024, false,
+-	0x1p+1024, false,
+-	0x1.0000000000000000000000000001p+1024, false),
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	0xf.fffffp+124, true, false,
++	INF, true, false,
++	false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	0xf.ffffffffffff8p+1020, true, false,
++	INF, true, false,
++	false,
++	0x1p+1024, false, false,
++	0x1p+1024, false, false,
++	0x1p+1024, false, false,
++	0x1.0000000000000002p+1024, false, false,
++	false,
++	0x1p+1024, false, false,
++	0x1p+1024, false, false,
++	0x1p+1024, false, false,
++	0x1.0000000000000002p+1024, false, false,
++	false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	0xf.fffffffffffffffffffffffffcp+1020, true, false,
++	INF, true, false,
++	false,
++	0x1p+1024, false, false,
++	0x1p+1024, false, false,
++	0x1p+1024, false, false,
++	0x1.0000000000000000000000000001p+1024, false, false),
+   TEST ("1.5",
+ 	true,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	true,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	true,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	true,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	true,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	true,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false,
+-	0x1.8p+0, false),
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	true,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	true,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	true,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	true,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	true,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false,
++	0x1.8p+0, false, false),
+   TEST ("1.25",
+ 	true,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	true,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	true,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	true,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	true,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	true,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false,
+-	0x1.4p+0, false),
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	true,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	true,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	true,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	true,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	true,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false,
++	0x1.4p+0, false, false),
+   TEST ("1.125",
+ 	true,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	true,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	true,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	true,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	true,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	true,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false,
+-	0x1.2p+0, false),
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	true,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	true,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	true,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	true,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	true,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false,
++	0x1.2p+0, false, false),
+   TEST ("1.0625",
+ 	true,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	true,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	true,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	true,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	true,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	true,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false,
+-	0x1.1p+0, false),
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	true,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	true,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	true,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	true,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	true,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false,
++	0x1.1p+0, false, false),
+   TEST ("1.03125",
+ 	true,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	true,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	true,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	true,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	true,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	true,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false,
+-	0x1.08p+0, false),
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	true,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	true,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	true,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	true,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	true,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false,
++	0x1.08p+0, false, false),
+   TEST ("1.015625",
+ 	true,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	true,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	true,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	true,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	true,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	true,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false,
+-	0x1.04p+0, false),
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	true,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	true,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	true,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	true,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	true,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false,
++	0x1.04p+0, false, false),
+   TEST ("1.0078125",
+ 	true,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	true,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	true,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	true,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	true,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	true,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false,
+-	0x1.02p+0, false),
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	true,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	true,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	true,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	true,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	true,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false,
++	0x1.02p+0, false, false),
+   TEST ("1.00390625",
+ 	true,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	true,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	true,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	true,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	true,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	true,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false,
+-	0x1.01p+0, false),
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	true,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	true,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	true,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	true,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	true,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false,
++	0x1.01p+0, false, false),
+   TEST ("1.001953125",
+ 	true,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	true,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	true,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	true,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	true,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	true,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false,
+-	0x1.008p+0, false),
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	true,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	true,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	true,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	true,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	true,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false,
++	0x1.008p+0, false, false),
+   TEST ("1.0009765625",
+ 	true,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	true,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	true,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	true,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	true,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	true,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false,
+-	0x1.004p+0, false),
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	true,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	true,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	true,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	true,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	true,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false,
++	0x1.004p+0, false, false),
+   TEST ("1.00048828125",
+ 	true,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	true,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	true,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	true,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	true,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	true,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false,
+-	0x1.002p+0, false),
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	true,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	true,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	true,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	true,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	true,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false,
++	0x1.002p+0, false, false),
+   TEST ("1.000244140625",
+ 	true,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	true,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	true,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	true,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	true,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	true,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false,
+-	0x1.001p+0, false),
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	true,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	true,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	true,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	true,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	true,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false,
++	0x1.001p+0, false, false),
+   TEST ("1.0001220703125",
+ 	true,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	true,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	true,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	true,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	true,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	true,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false,
+-	0x1.0008p+0, false),
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	true,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	true,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	true,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	true,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	true,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false,
++	0x1.0008p+0, false, false),
+   TEST ("1.00006103515625",
+ 	true,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	true,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	true,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	true,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	true,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	true,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false,
+-	0x1.0004p+0, false),
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	true,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	true,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	true,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	true,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	true,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false,
++	0x1.0004p+0, false, false),
+   TEST ("1.000030517578125",
+ 	true,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	true,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	true,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	true,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	true,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	true,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false,
+-	0x1.0002p+0, false),
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	true,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	true,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	true,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	true,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	true,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false,
++	0x1.0002p+0, false, false),
+   TEST ("1.0000152587890625",
+ 	true,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	true,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	true,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	true,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	true,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	true,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false,
+-	0x1.0001p+0, false),
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	true,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	true,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	true,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	true,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	true,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false,
++	0x1.0001p+0, false, false),
+   TEST ("1.00000762939453125",
+ 	true,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	true,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	true,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	true,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	true,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	true,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false,
+-	0x1.00008p+0, false),
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	true,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	true,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	true,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	true,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	true,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false,
++	0x1.00008p+0, false, false),
+   TEST ("1.000003814697265625",
+ 	true,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	true,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	true,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	true,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	true,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	true,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false,
+-	0x1.00004p+0, false),
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	true,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	true,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	true,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	true,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	true,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false,
++	0x1.00004p+0, false, false),
+   TEST ("1.0000019073486328125",
+ 	true,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	true,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	true,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	true,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	true,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	true,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false,
+-	0x1.00002p+0, false),
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	true,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	true,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	true,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	true,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	true,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false,
++	0x1.00002p+0, false, false),
+   TEST ("1.00000095367431640625",
+ 	true,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	true,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	true,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	true,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	true,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	true,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false,
+-	0x1.00001p+0, false),
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	true,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	true,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	true,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	true,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	true,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false,
++	0x1.00001p+0, false, false),
+   TEST ("1.000000476837158203125",
+ 	true,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	true,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	true,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	true,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	true,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	true,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false,
+-	0x1.000008p+0, false),
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	true,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	true,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	true,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	true,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	true,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false,
++	0x1.000008p+0, false, false),
+   TEST ("1.0000000298023223876953125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	true,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	true,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	true,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	true,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false,
+-	0x1.0000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	true,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	true,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	true,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	true,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false,
++	0x1.0000008p+0, false, false),
+   TEST ("1.00000001490116119384765625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	true,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	true,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	true,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	true,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false,
+-	0x1.0000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	true,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	true,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	true,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	true,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false,
++	0x1.0000004p+0, false, false),
+   TEST ("1.000000007450580596923828125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	true,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	true,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	true,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	true,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false,
+-	0x1.0000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	true,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	true,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	true,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	true,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false,
++	0x1.0000002p+0, false, false),
+   TEST ("1.0000000037252902984619140625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	true,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	true,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	true,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	true,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false,
+-	0x1.0000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	true,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	true,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	true,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	true,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false,
++	0x1.0000001p+0, false, false),
+   TEST ("1.00000000186264514923095703125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	true,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	true,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	true,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	true,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false,
+-	0x1.00000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	true,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	true,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	true,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	true,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false,
++	0x1.00000008p+0, false, false),
+   TEST ("1.000000000931322574615478515625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	true,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	true,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	true,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	true,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false,
+-	0x1.00000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	true,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	true,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	true,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	true,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false,
++	0x1.00000004p+0, false, false),
+   TEST ("1.0000000004656612873077392578125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	true,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	true,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	true,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	true,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false,
+-	0x1.00000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	true,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	true,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	true,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	true,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false,
++	0x1.00000002p+0, false, false),
+   TEST ("1.00000000023283064365386962890625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	true,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	true,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	true,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	true,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false,
+-	0x1.00000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	true,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	true,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	true,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	true,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false,
++	0x1.00000001p+0, false, false),
+   TEST ("1.000000000116415321826934814453125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	true,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	true,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	true,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	true,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false,
+-	0x1.000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	true,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	true,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	true,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	true,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false,
++	0x1.000000008p+0, false, false),
+   TEST ("1.0000000000582076609134674072265625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	true,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	true,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	true,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	true,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false,
+-	0x1.000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	true,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	true,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	true,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	true,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false,
++	0x1.000000004p+0, false, false),
+   TEST ("1.00000000002910383045673370361328125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	true,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	true,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	true,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	true,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false,
+-	0x1.000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	true,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	true,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	true,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	true,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false,
++	0x1.000000002p+0, false, false),
+   TEST ("1.000000000014551915228366851806640625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	true,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	true,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	true,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	true,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false,
+-	0x1.000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	true,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	true,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	true,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	true,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false,
++	0x1.000000001p+0, false, false),
+   TEST ("1.0000000000072759576141834259033203125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	true,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	true,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	true,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	true,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false,
+-	0x1.0000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	true,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	true,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	true,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	true,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false,
++	0x1.0000000008p+0, false, false),
+   TEST ("1.00000000000363797880709171295166015625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	true,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	true,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	true,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	true,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false,
+-	0x1.0000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	true,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	true,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	true,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	true,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false,
++	0x1.0000000004p+0, false, false),
+   TEST ("1.000000000001818989403545856475830078125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	true,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	true,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	true,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	true,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false,
+-	0x1.0000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	true,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	true,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	true,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	true,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false,
++	0x1.0000000002p+0, false, false),
+   TEST ("1.0000000000009094947017729282379150390625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	true,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	true,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	true,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	true,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false,
+-	0x1.0000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	true,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	true,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	true,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	true,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false,
++	0x1.0000000001p+0, false, false),
+   TEST ("1.00000000000045474735088646411895751953125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	true,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	true,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	true,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	true,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false,
+-	0x1.00000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	true,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	true,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	true,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	true,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false,
++	0x1.00000000008p+0, false, false),
+   TEST ("1.000000000000227373675443232059478759765625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	true,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	true,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	true,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	true,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false,
+-	0x1.00000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	true,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	true,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	true,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	true,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false,
++	0x1.00000000004p+0, false, false),
+   TEST ("1.0000000000001136868377216160297393798828125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	true,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	true,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	true,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	true,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false,
+-	0x1.00000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	true,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	true,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	true,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	true,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false,
++	0x1.00000000002p+0, false, false),
+   TEST ("1.00000000000005684341886080801486968994140625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	true,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	true,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	true,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	true,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false,
+-	0x1.00000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	true,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	true,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	true,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	true,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false,
++	0x1.00000000001p+0, false, false),
+   TEST ("1.000000000000028421709430404007434844970703125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	true,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	true,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	true,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	true,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false,
+-	0x1.000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	true,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	true,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	true,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	true,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false,
++	0x1.000000000008p+0, false, false),
+   TEST ("1.0000000000000142108547152020037174224853515625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	true,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	true,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	true,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	true,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false,
+-	0x1.000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	true,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	true,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	true,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	true,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false,
++	0x1.000000000004p+0, false, false),
+   TEST ("1.00000000000000710542735760100185871124267578125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	true,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	true,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	true,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	true,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false,
+-	0x1.000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	true,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	true,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	true,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	true,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false,
++	0x1.000000000002p+0, false, false),
+   TEST ("1.000000000000003552713678800500929355621337890625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	true,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	true,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	true,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	true,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false,
+-	0x1.000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	true,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	true,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	true,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	true,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false,
++	0x1.000000000001p+0, false, false),
+   TEST ("1.0000000000000017763568394002504646778106689453125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	true,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	true,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	true,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	true,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false,
+-	0x1.0000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	true,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	true,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	true,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	true,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false,
++	0x1.0000000000008p+0, false, false),
+   TEST ("1.00000000000000088817841970012523233890533447265625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	true,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	true,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	true,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	true,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false,
+-	0x1.0000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	true,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	true,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	true,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	true,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false,
++	0x1.0000000000004p+0, false, false),
+   TEST ("1.000000000000000444089209850062616169452667236328125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	true,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	true,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	true,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	true,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false,
+-	0x1.0000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	true,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	true,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	true,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	true,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false,
++	0x1.0000000000002p+0, false, false),
+   TEST ("1.0000000000000002220446049250313080847263336181640625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	true,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false,
+-	0x1.0000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	true,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	0x1.0000000000001p+0, false, false),
+   TEST ("1.00000000000000011102230246251565404236316680908203125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	true,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	true,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	true,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false,
+-	0x1.00000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	true,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	true,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	true,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false,
++	0x1.00000000000008p+0, false, false),
+   TEST ("1.000000000000000055511151231257827021181583404541015625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	true,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	true,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	true,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false,
+-	0x1.00000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	true,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	true,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	true,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false,
++	0x1.00000000000004p+0, false, false),
+   TEST ("1.0000000000000000277555756156289135105907917022705078125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	true,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	true,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	true,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false,
+-	0x1.00000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	true,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	true,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	true,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false,
++	0x1.00000000000002p+0, false, false),
+   TEST ("1.00000000000000001387778780781445675529539585113525390625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	true,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	true,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	true,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false,
+-	0x1.00000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	true,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	true,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	true,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false,
++	0x1.00000000000001p+0, false, false),
+   TEST ("1.000000000000000006938893903907228377647697925567626953125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	true,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	true,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	true,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false,
+-	0x1.000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	true,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	true,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	true,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false,
++	0x1.000000000000008p+0, false, false),
+   TEST ("1.0000000000000000034694469519536141888238489627838134765625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	true,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	true,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	true,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false,
+-	0x1.000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	true,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	true,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	true,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false,
++	0x1.000000000000004p+0, false, false),
+   TEST ("1.0000000000000000017347234759768070944119244813919067382812"
+ 	"5",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	true,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	true,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	true,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false,
+-	0x1.000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	true,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	true,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	true,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false,
++	0x1.000000000000002p+0, false, false),
+   TEST ("1.0000000000000000008673617379884035472059622406959533691406"
+ 	"25",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	true,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	true,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	true,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false,
+-	0x1.000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	true,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	true,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	true,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false,
++	0x1.000000000000001p+0, false, false),
+   TEST ("1.0000000000000000004336808689942017736029811203479766845703"
+ 	"125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false,
+-	0x1.0000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false,
++	0x1.0000000000000008p+0, false, false),
+   TEST ("1.0000000000000000002168404344971008868014905601739883422851"
+ 	"5625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	true,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	true,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	true,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false,
+-	0x1.0000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	true,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	true,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	true,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false,
++	0x1.0000000000000004p+0, false, false),
+   TEST ("1.0000000000000000001084202172485504434007452800869941711425"
+ 	"78125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	true,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	0x1.0000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	true,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	0x1.0000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000542101086242752217003726400434970855712"
+ 	"890625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000001p+0, false,
+-	0x1.0000000000000001p+0, false,
+-	0x1.0000000000000001p+0, false,
+-	0x1.0000000000000001p+0, false,
+-	true,
+-	0x1.0000000000000001p+0, false,
+-	0x1.0000000000000001p+0, false,
+-	0x1.0000000000000001p+0, false,
+-	0x1.0000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000001p+0, false, false,
++	0x1.0000000000000001p+0, false, false,
++	0x1.0000000000000001p+0, false, false,
++	0x1.0000000000000001p+0, false, false,
++	true,
++	0x1.0000000000000001p+0, false, false,
++	0x1.0000000000000001p+0, false, false,
++	0x1.0000000000000001p+0, false, false,
++	0x1.0000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000271050543121376108501863200217485427856"
+ 	"4453125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000008p+0, false,
+-	0x1.00000000000000008p+0, false,
+-	0x1.00000000000000008p+0, false,
+-	0x1.00000000000000008p+0, false,
+-	true,
+-	0x1.00000000000000008p+0, false,
+-	0x1.00000000000000008p+0, false,
+-	0x1.00000000000000008p+0, false,
+-	0x1.00000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000008p+0, false, false,
++	0x1.00000000000000008p+0, false, false,
++	0x1.00000000000000008p+0, false, false,
++	0x1.00000000000000008p+0, false, false,
++	true,
++	0x1.00000000000000008p+0, false, false,
++	0x1.00000000000000008p+0, false, false,
++	0x1.00000000000000008p+0, false, false,
++	0x1.00000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000135525271560688054250931600108742713928"
+ 	"22265625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000004p+0, false,
+-	0x1.00000000000000004p+0, false,
+-	0x1.00000000000000004p+0, false,
+-	0x1.00000000000000004p+0, false,
+-	true,
+-	0x1.00000000000000004p+0, false,
+-	0x1.00000000000000004p+0, false,
+-	0x1.00000000000000004p+0, false,
+-	0x1.00000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000004p+0, false, false,
++	0x1.00000000000000004p+0, false, false,
++	0x1.00000000000000004p+0, false, false,
++	0x1.00000000000000004p+0, false, false,
++	true,
++	0x1.00000000000000004p+0, false, false,
++	0x1.00000000000000004p+0, false, false,
++	0x1.00000000000000004p+0, false, false,
++	0x1.00000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000067762635780344027125465800054371356964"
+ 	"111328125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000002p+0, false,
+-	0x1.00000000000000002p+0, false,
+-	0x1.00000000000000002p+0, false,
+-	0x1.00000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000002p+0, false,
+-	0x1.00000000000000002p+0, false,
+-	0x1.00000000000000002p+0, false,
+-	0x1.00000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000002p+0, false, false,
++	0x1.00000000000000002p+0, false, false,
++	0x1.00000000000000002p+0, false, false,
++	0x1.00000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000002p+0, false, false,
++	0x1.00000000000000002p+0, false, false,
++	0x1.00000000000000002p+0, false, false,
++	0x1.00000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000033881317890172013562732900027185678482"
+ 	"0556640625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000001p+0, false,
+-	0x1.00000000000000001p+0, false,
+-	0x1.00000000000000001p+0, false,
+-	0x1.00000000000000001p+0, false,
+-	true,
+-	0x1.00000000000000001p+0, false,
+-	0x1.00000000000000001p+0, false,
+-	0x1.00000000000000001p+0, false,
+-	0x1.00000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000001p+0, false, false,
++	0x1.00000000000000001p+0, false, false,
++	0x1.00000000000000001p+0, false, false,
++	0x1.00000000000000001p+0, false, false,
++	true,
++	0x1.00000000000000001p+0, false, false,
++	0x1.00000000000000001p+0, false, false,
++	0x1.00000000000000001p+0, false, false,
++	0x1.00000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000016940658945086006781366450013592839241"
+ 	"02783203125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000008p+0, false,
+-	0x1.000000000000000008p+0, false,
+-	0x1.000000000000000008p+0, false,
+-	0x1.000000000000000008p+0, false,
+-	true,
+-	0x1.000000000000000008p+0, false,
+-	0x1.000000000000000008p+0, false,
+-	0x1.000000000000000008p+0, false,
+-	0x1.000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000008p+0, false, false,
++	0x1.000000000000000008p+0, false, false,
++	0x1.000000000000000008p+0, false, false,
++	0x1.000000000000000008p+0, false, false,
++	true,
++	0x1.000000000000000008p+0, false, false,
++	0x1.000000000000000008p+0, false, false,
++	0x1.000000000000000008p+0, false, false,
++	0x1.000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000008470329472543003390683225006796419620"
+ 	"513916015625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000004p+0, false,
+-	0x1.000000000000000004p+0, false,
+-	0x1.000000000000000004p+0, false,
+-	0x1.000000000000000004p+0, false,
+-	true,
+-	0x1.000000000000000004p+0, false,
+-	0x1.000000000000000004p+0, false,
+-	0x1.000000000000000004p+0, false,
+-	0x1.000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000004p+0, false, false,
++	0x1.000000000000000004p+0, false, false,
++	0x1.000000000000000004p+0, false, false,
++	0x1.000000000000000004p+0, false, false,
++	true,
++	0x1.000000000000000004p+0, false, false,
++	0x1.000000000000000004p+0, false, false,
++	0x1.000000000000000004p+0, false, false,
++	0x1.000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000004235164736271501695341612503398209810"
+ 	"2569580078125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000002p+0, false,
+-	0x1.000000000000000002p+0, false,
+-	0x1.000000000000000002p+0, false,
+-	0x1.000000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000002p+0, false,
+-	0x1.000000000000000002p+0, false,
+-	0x1.000000000000000002p+0, false,
+-	0x1.000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000002p+0, false, false,
++	0x1.000000000000000002p+0, false, false,
++	0x1.000000000000000002p+0, false, false,
++	0x1.000000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000002p+0, false, false,
++	0x1.000000000000000002p+0, false, false,
++	0x1.000000000000000002p+0, false, false,
++	0x1.000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000002117582368135750847670806251699104905"
+ 	"12847900390625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000001p+0, false,
+-	0x1.000000000000000001p+0, false,
+-	0x1.000000000000000001p+0, false,
+-	0x1.000000000000000001p+0, false,
+-	true,
+-	0x1.000000000000000001p+0, false,
+-	0x1.000000000000000001p+0, false,
+-	0x1.000000000000000001p+0, false,
+-	0x1.000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000001p+0, false, false,
++	0x1.000000000000000001p+0, false, false,
++	0x1.000000000000000001p+0, false, false,
++	0x1.000000000000000001p+0, false, false,
++	true,
++	0x1.000000000000000001p+0, false, false,
++	0x1.000000000000000001p+0, false, false,
++	0x1.000000000000000001p+0, false, false,
++	0x1.000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000001058791184067875423835403125849552452"
+ 	"564239501953125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000008p+0, false,
+-	0x1.0000000000000000008p+0, false,
+-	0x1.0000000000000000008p+0, false,
+-	0x1.0000000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000000008p+0, false,
+-	0x1.0000000000000000008p+0, false,
+-	0x1.0000000000000000008p+0, false,
+-	0x1.0000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000008p+0, false, false,
++	0x1.0000000000000000008p+0, false, false,
++	0x1.0000000000000000008p+0, false, false,
++	0x1.0000000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000000008p+0, false, false,
++	0x1.0000000000000000008p+0, false, false,
++	0x1.0000000000000000008p+0, false, false,
++	0x1.0000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000529395592033937711917701562924776226"
+ 	"2821197509765625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000004p+0, false,
+-	0x1.0000000000000000004p+0, false,
+-	0x1.0000000000000000004p+0, false,
+-	0x1.0000000000000000004p+0, false,
+-	true,
+-	0x1.0000000000000000004p+0, false,
+-	0x1.0000000000000000004p+0, false,
+-	0x1.0000000000000000004p+0, false,
+-	0x1.0000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000004p+0, false, false,
++	0x1.0000000000000000004p+0, false, false,
++	0x1.0000000000000000004p+0, false, false,
++	0x1.0000000000000000004p+0, false, false,
++	true,
++	0x1.0000000000000000004p+0, false, false,
++	0x1.0000000000000000004p+0, false, false,
++	0x1.0000000000000000004p+0, false, false,
++	0x1.0000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000264697796016968855958850781462388113"
+ 	"14105987548828125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000002p+0, false,
+-	0x1.0000000000000000002p+0, false,
+-	0x1.0000000000000000002p+0, false,
+-	0x1.0000000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000002p+0, false,
+-	0x1.0000000000000000002p+0, false,
+-	0x1.0000000000000000002p+0, false,
+-	0x1.0000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000002p+0, false, false,
++	0x1.0000000000000000002p+0, false, false,
++	0x1.0000000000000000002p+0, false, false,
++	0x1.0000000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000002p+0, false, false,
++	0x1.0000000000000000002p+0, false, false,
++	0x1.0000000000000000002p+0, false, false,
++	0x1.0000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000132348898008484427979425390731194056"
+ 	"570529937744140625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000001p+0, false,
+-	0x1.0000000000000000001p+0, false,
+-	0x1.0000000000000000001p+0, false,
+-	0x1.0000000000000000001p+0, false,
+-	true,
+-	0x1.0000000000000000001p+0, false,
+-	0x1.0000000000000000001p+0, false,
+-	0x1.0000000000000000001p+0, false,
+-	0x1.0000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000001p+0, false, false,
++	0x1.0000000000000000001p+0, false, false,
++	0x1.0000000000000000001p+0, false, false,
++	0x1.0000000000000000001p+0, false, false,
++	true,
++	0x1.0000000000000000001p+0, false, false,
++	0x1.0000000000000000001p+0, false, false,
++	0x1.0000000000000000001p+0, false, false,
++	0x1.0000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000066174449004242213989712695365597028"
+ 	"2852649688720703125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000008p+0, false,
+-	0x1.00000000000000000008p+0, false,
+-	0x1.00000000000000000008p+0, false,
+-	0x1.00000000000000000008p+0, false,
+-	true,
+-	0x1.00000000000000000008p+0, false,
+-	0x1.00000000000000000008p+0, false,
+-	0x1.00000000000000000008p+0, false,
+-	0x1.00000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000008p+0, false, false,
++	0x1.00000000000000000008p+0, false, false,
++	0x1.00000000000000000008p+0, false, false,
++	0x1.00000000000000000008p+0, false, false,
++	true,
++	0x1.00000000000000000008p+0, false, false,
++	0x1.00000000000000000008p+0, false, false,
++	0x1.00000000000000000008p+0, false, false,
++	0x1.00000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000033087224502121106994856347682798514"
+ 	"14263248443603515625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000004p+0, false,
+-	0x1.00000000000000000004p+0, false,
+-	0x1.00000000000000000004p+0, false,
+-	0x1.00000000000000000004p+0, false,
+-	true,
+-	0x1.00000000000000000004p+0, false,
+-	0x1.00000000000000000004p+0, false,
+-	0x1.00000000000000000004p+0, false,
+-	0x1.00000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000004p+0, false, false,
++	0x1.00000000000000000004p+0, false, false,
++	0x1.00000000000000000004p+0, false, false,
++	0x1.00000000000000000004p+0, false, false,
++	true,
++	0x1.00000000000000000004p+0, false, false,
++	0x1.00000000000000000004p+0, false, false,
++	0x1.00000000000000000004p+0, false, false,
++	0x1.00000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000016543612251060553497428173841399257"
+ 	"071316242218017578125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000002p+0, false,
+-	0x1.00000000000000000002p+0, false,
+-	0x1.00000000000000000002p+0, false,
+-	0x1.00000000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000002p+0, false,
+-	0x1.00000000000000000002p+0, false,
+-	0x1.00000000000000000002p+0, false,
+-	0x1.00000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000002p+0, false, false,
++	0x1.00000000000000000002p+0, false, false,
++	0x1.00000000000000000002p+0, false, false,
++	0x1.00000000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000002p+0, false, false,
++	0x1.00000000000000000002p+0, false, false,
++	0x1.00000000000000000002p+0, false, false,
++	0x1.00000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000008271806125530276748714086920699628"
+ 	"5356581211090087890625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000001p+0, false,
+-	0x1.00000000000000000001p+0, false,
+-	0x1.00000000000000000001p+0, false,
+-	0x1.00000000000000000001p+0, false,
+-	true,
+-	0x1.00000000000000000001p+0, false,
+-	0x1.00000000000000000001p+0, false,
+-	0x1.00000000000000000001p+0, false,
+-	0x1.00000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000001p+0, false, false,
++	0x1.00000000000000000001p+0, false, false,
++	0x1.00000000000000000001p+0, false, false,
++	0x1.00000000000000000001p+0, false, false,
++	true,
++	0x1.00000000000000000001p+0, false, false,
++	0x1.00000000000000000001p+0, false, false,
++	0x1.00000000000000000001p+0, false, false,
++	0x1.00000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000004135903062765138374357043460349814"
+ 	"26782906055450439453125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000008p+0, false,
+-	0x1.000000000000000000008p+0, false,
+-	0x1.000000000000000000008p+0, false,
+-	0x1.000000000000000000008p+0, false,
+-	true,
+-	0x1.000000000000000000008p+0, false,
+-	0x1.000000000000000000008p+0, false,
+-	0x1.000000000000000000008p+0, false,
+-	0x1.000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000008p+0, false, false,
++	0x1.000000000000000000008p+0, false, false,
++	0x1.000000000000000000008p+0, false, false,
++	0x1.000000000000000000008p+0, false, false,
++	true,
++	0x1.000000000000000000008p+0, false, false,
++	0x1.000000000000000000008p+0, false, false,
++	0x1.000000000000000000008p+0, false, false,
++	0x1.000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000002067951531382569187178521730174907"
+ 	"133914530277252197265625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000004p+0, false,
+-	0x1.000000000000000000004p+0, false,
+-	0x1.000000000000000000004p+0, false,
+-	0x1.000000000000000000004p+0, false,
+-	true,
+-	0x1.000000000000000000004p+0, false,
+-	0x1.000000000000000000004p+0, false,
+-	0x1.000000000000000000004p+0, false,
+-	0x1.000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000004p+0, false, false,
++	0x1.000000000000000000004p+0, false, false,
++	0x1.000000000000000000004p+0, false, false,
++	0x1.000000000000000000004p+0, false, false,
++	true,
++	0x1.000000000000000000004p+0, false, false,
++	0x1.000000000000000000004p+0, false, false,
++	0x1.000000000000000000004p+0, false, false,
++	0x1.000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000001033975765691284593589260865087453"
+ 	"5669572651386260986328125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000002p+0, false,
+-	0x1.000000000000000000002p+0, false,
+-	0x1.000000000000000000002p+0, false,
+-	0x1.000000000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000002p+0, false,
+-	0x1.000000000000000000002p+0, false,
+-	0x1.000000000000000000002p+0, false,
+-	0x1.000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000002p+0, false, false,
++	0x1.000000000000000000002p+0, false, false,
++	0x1.000000000000000000002p+0, false, false,
++	0x1.000000000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000002p+0, false, false,
++	0x1.000000000000000000002p+0, false, false,
++	0x1.000000000000000000002p+0, false, false,
++	0x1.000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000516987882845642296794630432543726"
+ 	"78347863256931304931640625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000001p+0, false,
+-	0x1.000000000000000000001p+0, false,
+-	0x1.000000000000000000001p+0, false,
+-	0x1.000000000000000000001p+0, false,
+-	true,
+-	0x1.000000000000000000001p+0, false,
+-	0x1.000000000000000000001p+0, false,
+-	0x1.000000000000000000001p+0, false,
+-	0x1.000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000001p+0, false, false,
++	0x1.000000000000000000001p+0, false, false,
++	0x1.000000000000000000001p+0, false, false,
++	0x1.000000000000000000001p+0, false, false,
++	true,
++	0x1.000000000000000000001p+0, false, false,
++	0x1.000000000000000000001p+0, false, false,
++	0x1.000000000000000000001p+0, false, false,
++	0x1.000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000258493941422821148397315216271863"
+ 	"391739316284656524658203125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000008p+0, false,
+-	0x1.0000000000000000000008p+0, false,
+-	0x1.0000000000000000000008p+0, false,
+-	0x1.0000000000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000000000008p+0, false,
+-	0x1.0000000000000000000008p+0, false,
+-	0x1.0000000000000000000008p+0, false,
+-	0x1.0000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000008p+0, false, false,
++	0x1.0000000000000000000008p+0, false, false,
++	0x1.0000000000000000000008p+0, false, false,
++	0x1.0000000000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000000000008p+0, false, false,
++	0x1.0000000000000000000008p+0, false, false,
++	0x1.0000000000000000000008p+0, false, false,
++	0x1.0000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000000129246970711410574198657608135931"
+ 	"6958696581423282623291015625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000004p+0, false,
+-	0x1.0000000000000000000004p+0, false,
+-	0x1.0000000000000000000004p+0, false,
+-	0x1.0000000000000000000004p+0, false,
+-	true,
+-	0x1.0000000000000000000004p+0, false,
+-	0x1.0000000000000000000004p+0, false,
+-	0x1.0000000000000000000004p+0, false,
+-	0x1.0000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000004p+0, false, false,
++	0x1.0000000000000000000004p+0, false, false,
++	0x1.0000000000000000000004p+0, false, false,
++	0x1.0000000000000000000004p+0, false, false,
++	true,
++	0x1.0000000000000000000004p+0, false, false,
++	0x1.0000000000000000000004p+0, false, false,
++	0x1.0000000000000000000004p+0, false, false,
++	0x1.0000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000000064623485355705287099328804067965"
+ 	"84793482907116413116455078125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000002p+0, false,
+-	0x1.0000000000000000000002p+0, false,
+-	0x1.0000000000000000000002p+0, false,
+-	0x1.0000000000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000002p+0, false,
+-	0x1.0000000000000000000002p+0, false,
+-	0x1.0000000000000000000002p+0, false,
+-	0x1.0000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000002p+0, false, false,
++	0x1.0000000000000000000002p+0, false, false,
++	0x1.0000000000000000000002p+0, false, false,
++	0x1.0000000000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000002p+0, false, false,
++	0x1.0000000000000000000002p+0, false, false,
++	0x1.0000000000000000000002p+0, false, false,
++	0x1.0000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000032311742677852643549664402033982"
+ 	"923967414535582065582275390625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000001p+0, false,
+-	0x1.0000000000000000000001p+0, false,
+-	0x1.0000000000000000000001p+0, false,
+-	0x1.0000000000000000000001p+0, false,
+-	true,
+-	0x1.0000000000000000000001p+0, false,
+-	0x1.0000000000000000000001p+0, false,
+-	0x1.0000000000000000000001p+0, false,
+-	0x1.0000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000001p+0, false, false,
++	0x1.0000000000000000000001p+0, false, false,
++	0x1.0000000000000000000001p+0, false, false,
++	0x1.0000000000000000000001p+0, false, false,
++	true,
++	0x1.0000000000000000000001p+0, false, false,
++	0x1.0000000000000000000001p+0, false, false,
++	0x1.0000000000000000000001p+0, false, false,
++	0x1.0000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000016155871338926321774832201016991"
+ 	"4619837072677910327911376953125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000008p+0, false,
+-	0x1.00000000000000000000008p+0, false,
+-	0x1.00000000000000000000008p+0, false,
+-	0x1.00000000000000000000008p+0, false,
+-	true,
+-	0x1.00000000000000000000008p+0, false,
+-	0x1.00000000000000000000008p+0, false,
+-	0x1.00000000000000000000008p+0, false,
+-	0x1.00000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000008p+0, false, false,
++	0x1.00000000000000000000008p+0, false, false,
++	0x1.00000000000000000000008p+0, false, false,
++	0x1.00000000000000000000008p+0, false, false,
++	true,
++	0x1.00000000000000000000008p+0, false, false,
++	0x1.00000000000000000000008p+0, false, false,
++	0x1.00000000000000000000008p+0, false, false,
++	0x1.00000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000000008077935669463160887416100508495"
+ 	"73099185363389551639556884765625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000004p+0, false,
+-	0x1.00000000000000000000004p+0, false,
+-	0x1.00000000000000000000004p+0, false,
+-	0x1.00000000000000000000004p+0, false,
+-	true,
+-	0x1.00000000000000000000004p+0, false,
+-	0x1.00000000000000000000004p+0, false,
+-	0x1.00000000000000000000004p+0, false,
+-	0x1.00000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000004p+0, false, false,
++	0x1.00000000000000000000004p+0, false, false,
++	0x1.00000000000000000000004p+0, false, false,
++	0x1.00000000000000000000004p+0, false, false,
++	true,
++	0x1.00000000000000000000004p+0, false, false,
++	0x1.00000000000000000000004p+0, false, false,
++	0x1.00000000000000000000004p+0, false, false,
++	0x1.00000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000000004038967834731580443708050254247"
+ 	"865495926816947758197784423828125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000002p+0, false,
+-	0x1.00000000000000000000002p+0, false,
+-	0x1.00000000000000000000002p+0, false,
+-	0x1.00000000000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000002p+0, false,
+-	0x1.00000000000000000000002p+0, false,
+-	0x1.00000000000000000000002p+0, false,
+-	0x1.00000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000002p+0, false, false,
++	0x1.00000000000000000000002p+0, false, false,
++	0x1.00000000000000000000002p+0, false, false,
++	0x1.00000000000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000002p+0, false, false,
++	0x1.00000000000000000000002p+0, false, false,
++	0x1.00000000000000000000002p+0, false, false,
++	0x1.00000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000002019483917365790221854025127123"
+ 	"9327479634084738790988922119140625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000001p+0, false,
+-	0x1.00000000000000000000001p+0, false,
+-	0x1.00000000000000000000001p+0, false,
+-	0x1.00000000000000000000001p+0, false,
+-	true,
+-	0x1.00000000000000000000001p+0, false,
+-	0x1.00000000000000000000001p+0, false,
+-	0x1.00000000000000000000001p+0, false,
+-	0x1.00000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000001p+0, false, false,
++	0x1.00000000000000000000001p+0, false, false,
++	0x1.00000000000000000000001p+0, false, false,
++	0x1.00000000000000000000001p+0, false, false,
++	true,
++	0x1.00000000000000000000001p+0, false, false,
++	0x1.00000000000000000000001p+0, false, false,
++	0x1.00000000000000000000001p+0, false, false,
++	0x1.00000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000001009741958682895110927012563561"
+ 	"96637398170423693954944610595703125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000000008p+0, false,
+-	0x1.000000000000000000000008p+0, false,
+-	0x1.000000000000000000000008p+0, false,
+-	0x1.000000000000000000000008p+0, false,
+-	true,
+-	0x1.000000000000000000000008p+0, false,
+-	0x1.000000000000000000000008p+0, false,
+-	0x1.000000000000000000000008p+0, false,
+-	0x1.000000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000008p+0, false, false,
++	true,
++	0x1.000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000000000504870979341447555463506281780"
+ 	"983186990852118469774723052978515625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000000004p+0, false,
+-	0x1.000000000000000000000004p+0, false,
+-	0x1.000000000000000000000004p+0, false,
+-	0x1.000000000000000000000004p+0, false,
+-	true,
+-	0x1.000000000000000000000004p+0, false,
+-	0x1.000000000000000000000004p+0, false,
+-	0x1.000000000000000000000004p+0, false,
+-	0x1.000000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000004p+0, false, false,
++	true,
++	0x1.000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000000000252435489670723777731753140890"
+ 	"4915934954260592348873615264892578125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000000002p+0, false,
+-	0x1.000000000000000000000002p+0, false,
+-	0x1.000000000000000000000002p+0, false,
+-	0x1.000000000000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000000002p+0, false,
+-	0x1.000000000000000000000002p+0, false,
+-	0x1.000000000000000000000002p+0, false,
+-	0x1.000000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000000126217744835361888865876570445"
+ 	"24579674771302961744368076324462890625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000000001p+0, false,
+-	0x1.000000000000000000000001p+0, false,
+-	0x1.000000000000000000000001p+0, false,
+-	0x1.000000000000000000000001p+0, false,
+-	true,
+-	0x1.000000000000000000000001p+0, false,
+-	0x1.000000000000000000000001p+0, false,
+-	0x1.000000000000000000000001p+0, false,
+-	0x1.000000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000001p+0, false, false,
++	true,
++	0x1.000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000000063108872417680944432938285222"
+ 	"622898373856514808721840381622314453125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000000000031554436208840472216469142611"
+ 	"3114491869282574043609201908111572265625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000004p+0, false,
+-	true,
+-	0x1.0000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000004p+0, false, false,
++	true,
++	0x1.0000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000000000015777218104420236108234571305"
+ 	"65572459346412870218046009540557861328125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000000007888609052210118054117285652"
+ 	"827862296732064351090230047702789306640625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.0000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000001p+0, false,
+-	true,
+-	0x1.0000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.0000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000001p+0, false, false,
++	true,
++	0x1.0000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000000003944304526105059027058642826"
+ 	"4139311483660321755451150238513946533203125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000000008p+0, false,
+-	0x1.00000000000000000000000008p+0, false,
+-	0x1.00000000000000000000000008p+0, false,
+-	0x1.00000000000000000000000008p+0, false,
+-	true,
+-	0x1.00000000000000000000000008p+0, false,
+-	0x1.00000000000000000000000008p+0, false,
+-	0x1.00000000000000000000000008p+0, false,
+-	0x1.00000000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000000008p+0, false, false,
++	0x1.00000000000000000000000008p+0, false, false,
++	0x1.00000000000000000000000008p+0, false, false,
++	0x1.00000000000000000000000008p+0, false, false,
++	true,
++	0x1.00000000000000000000000008p+0, false, false,
++	0x1.00000000000000000000000008p+0, false, false,
++	0x1.00000000000000000000000008p+0, false, false,
++	0x1.00000000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000000000001972152263052529513529321413"
+ 	"20696557418301608777255751192569732666015625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000000004p+0, false,
+-	0x1.00000000000000000000000004p+0, false,
+-	0x1.00000000000000000000000004p+0, false,
+-	0x1.00000000000000000000000004p+0, false,
+-	true,
+-	0x1.00000000000000000000000004p+0, false,
+-	0x1.00000000000000000000000004p+0, false,
+-	0x1.00000000000000000000000004p+0, false,
+-	0x1.00000000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000000004p+0, false, false,
++	0x1.00000000000000000000000004p+0, false, false,
++	0x1.00000000000000000000000004p+0, false, false,
++	0x1.00000000000000000000000004p+0, false, false,
++	true,
++	0x1.00000000000000000000000004p+0, false, false,
++	0x1.00000000000000000000000004p+0, false, false,
++	0x1.00000000000000000000000004p+0, false, false,
++	0x1.00000000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000000000000986076131526264756764660706"
+ 	"603482787091508043886278755962848663330078125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000000002p+0, false,
+-	0x1.00000000000000000000000002p+0, false,
+-	0x1.00000000000000000000000002p+0, false,
+-	0x1.00000000000000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000000002p+0, false,
+-	0x1.00000000000000000000000002p+0, false,
+-	0x1.00000000000000000000000002p+0, false,
+-	0x1.00000000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000000002p+0, false, false,
++	0x1.00000000000000000000000002p+0, false, false,
++	0x1.00000000000000000000000002p+0, false, false,
++	0x1.00000000000000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000000002p+0, false, false,
++	0x1.00000000000000000000000002p+0, false, false,
++	0x1.00000000000000000000000002p+0, false, false,
++	0x1.00000000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000000000493038065763132378382330353"
+ 	"3017413935457540219431393779814243316650390625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.00000000000000000000000001p+0, false,
+-	0x1.00000000000000000000000001p+0, false,
+-	0x1.00000000000000000000000001p+0, false,
+-	0x1.00000000000000000000000001p+0, false,
+-	true,
+-	0x1.00000000000000000000000001p+0, false,
+-	0x1.00000000000000000000000001p+0, false,
+-	0x1.00000000000000000000000001p+0, false,
+-	0x1.00000000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.00000000000000000000000001p+0, false, false,
++	0x1.00000000000000000000000001p+0, false, false,
++	0x1.00000000000000000000000001p+0, false, false,
++	0x1.00000000000000000000000001p+0, false, false,
++	true,
++	0x1.00000000000000000000000001p+0, false, false,
++	0x1.00000000000000000000000001p+0, false, false,
++	0x1.00000000000000000000000001p+0, false, false,
++	0x1.00000000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000000000246519032881566189191165176"
+ 	"65087069677287701097156968899071216583251953125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	true,
+-	0x1.000000000000000000000000008p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.000000000000000000000000008p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	0x1.000000000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	true,
++	0x1.000000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.000000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000000000000123259516440783094595582588"
+ 	"325435348386438505485784844495356082916259765625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.000000000000000000000000004p+0, false,
+-	0x1.000000000000000000000000004p+0, false,
+-	0x1.000000000000000000000000004p+0, false,
+-	0x1.000000000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.000000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000000004p+0, false, false,
++	0x1.000000000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000000000000061629758220391547297791294"
+ 	"1627176741932192527428924222476780414581298828125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.000000000000000000000000002p+0, false,
+-	0x1.000000000000000000000000002p+0, false,
+-	0x1.000000000000000000000000002p+0, false,
+-	0x1.000000000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.000000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000000002p+0, false, false,
++	0x1.000000000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000000000030814879110195773648895647"
+ 	"08135883709660962637144621112383902072906494140625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.000000000000000000000000001p+0, false,
+-	0x1.000000000000000000000000001p+0, false,
+-	0x1.000000000000000000000000001p+0, false,
+-	0x1.000000000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.000000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000000001p+0, false, false,
++	0x1.000000000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000000000015407439555097886824447823"
+ 	"540679418548304813185723105561919510364532470703125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000000008p+0, false,
+-	0x1.0000000000000000000000000008p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000000008p+0, false, false,
++	0x1.0000000000000000000000000008p+0, false, false),
+   TEST ("1.0000000000000000000000000000000007703719777548943412223911"
+ 	"7703397092741524065928615527809597551822662353515625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000000004p+0, false,
+-	0x1.0000000000000000000000000004p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000000004p+0, false, false,
++	0x1.0000000000000000000000000004p+0, false, false),
+   TEST ("1.0000000000000000000000000000000003851859888774471706111955"
+ 	"88516985463707620329643077639047987759113311767578125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000000002p+0, false,
+-	0x1.0000000000000000000000000002p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000000002p+0, false, false,
++	0x1.0000000000000000000000000002p+0, false, false),
+   TEST ("1.0000000000000000000000000000000001925929944387235853055977"
+ 	"942584927318538101648215388195239938795566558837890625",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	true,
+-	0x1.0000000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000000001p+0, false,
+-	0x1.0000000000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	true,
++	0x1.0000000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000000001p+0, false, false,
++	0x1.0000000000000000000000000001p+0, false, false),
+   TEST ("1.0000000000000000000000000000000000962964972193617926527988"
+ 	"9712924636592690508241076940976199693977832794189453125",
+ 	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000001p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000002p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.000000000000000000000000008p+0, false,
+-	false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1p+0, false,
+-	0x1.0000000000000000000000000001p+0, false),
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000001p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000002p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.000000000000000000000000008p+0, false, false,
++	false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1p+0, false, false,
++	0x1.0000000000000000000000000001p+0, false, false),
+ };
+diff --git a/stdlib/tst-strtod-round-skeleton.c b/stdlib/tst-strtod-round-skeleton.c
+index c3cc0201d4..be081ba416 100644
+--- a/stdlib/tst-strtod-round-skeleton.c
++++ b/stdlib/tst-strtod-round-skeleton.c
+@@ -30,6 +30,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <math-tests.h>
++#include <tininess.h>
+ 
+ #include "tst-strtod.h"
+ 
+@@ -139,16 +140,26 @@
+    gen-tst-strtod-round utility to select the appropriately
+    rounded long double value for a given format.  */
+ #define TEST(s,							\
+-	     fx, fd, fdo, fn, fno, fz, fzo, fu, fuo,		\
+-	     dx, dd, ddo, dn, dno, dz, dzo, du, duo,		\
+-	     ld64ix, ld64id, ld64ido, ld64in, ld64ino,		\
+-	     ld64iz, ld64izo, ld64iu, ld64iuo,			\
+-	     ld64mx, ld64md, ld64mdo, ld64mn, ld64mno,		\
+-	     ld64mz, ld64mzo, ld64mu, ld64muo,			\
+-	     ld106x, ld106d, ld106do, ld106n, ld106no,		\
+-	     ld106z, ld106zo, ld106u, ld106uo,			\
+-	     ld113x, ld113d, ld113do, ld113n, ld113no,		\
+-	     ld113z, ld113zo, ld113u, ld113uo)			\
++	     fx, fd, fdo, fdu, fn, fno, fnu,			\
++	     fz, fzo, fzu, fu, fuo, fuu,			\
++	     dx, dd, ddo, ddu, dn, dno, dnu,			\
++	     dz, dzo, dzu, du, duo, duu,			\
++	     ld64ix, ld64id, ld64ido, ld64idu,			\
++	     ld64in, ld64ino, ld64inu,				\
++	     ld64iz, ld64izo, ld64izu,				\
++	     ld64iu, ld64iuo, ld64iuu,				\
++	     ld64mx, ld64md, ld64mdo, ld64mdu,			\
++	     ld64mn, ld64mno, ld64mnu,				\
++	     ld64mz, ld64mzo, ld64mzu,				\
++	     ld64mu, ld64muo, ld64muu,				\
++	     ld106x, ld106d, ld106do, ld106du,			\
++	     ld106n, ld106no, ld106nu,				\
++	     ld106z, ld106zo, ld106zu,				\
++	     ld106u, ld106uo, ld106uu,				\
++	     ld113x, ld113d, ld113do, ld113du,			\
++	     ld113n, ld113no, ld113nu,				\
++	     ld113z, ld113zo, ld113zu,				\
++	     ld113u, ld113uo, ld113uu)				\
+   {								\
+     L_ (s),							\
+     { XNTRY (fx, dx, ld64ix, ld64mx, ld106x, ld113x) },		\
+@@ -163,6 +174,12 @@
+     { XNTRY (fdo, ddo, ld64ido, ld64mdo, ld106do, ld113do) },	\
+     { XNTRY (fzo, dzo, ld64izo, ld64mzo, ld106zo, ld113zo) },	\
+     { XNTRY (fuo, duo, ld64iuo, ld64muo, ld106uo, ld113uo) }	\
++    },								\
++    {								\
++    { XNTRY (fnu, dnu, ld64inu, ld64mnu, ld106nu, ld113nu) },	\
++    { XNTRY (fdu, ddu, ld64idu, ld64mdu, ld106du, ld113du) },	\
++    { XNTRY (fzu, dzu, ld64izu, ld64mzu, ld106zu, ld113zu) },	\
++    { XNTRY (fuu, duu, ld64iuu, ld64muu, ld106uu, ld113uu) }	\
+     }								\
+   }
+ 
+@@ -181,11 +198,17 @@ struct test_overflow
+   STRUCT_FOREACH_FLOAT_BOOL
+   };
+ 
++struct test_underflow
++  {
++  STRUCT_FOREACH_FLOAT_BOOL
++  };
++
+ struct test {
+   const CHAR *s;
+   struct test_exactness exact;
+   struct test_results r[4];
+   struct test_overflow o[4];
++  struct test_underflow u[4];
+ };
+ 
+ /* Include the generated test data.  */
+@@ -203,10 +226,14 @@ struct test {
+ # define FE_OVERFLOW 0
+ #endif
+ 
++#ifndef FE_UNDERFLOW
++# define FE_UNDERFLOW 0
++#endif
++
+ #define GEN_ONE_TEST(FSUF, FTYPE, FTOSTR, LSUF, CSUF)		\
+ {								\
+   feclearexcept (FE_ALL_EXCEPT);				\
+-  errno = 0;							\
++  errno = 12345;						\
+   FTYPE f = STRTO (FSUF) (s, NULL);				\
+   int new_errno = errno;					\
+   if (f != expected->FSUF					\
+@@ -265,6 +292,40 @@ struct test {
+ 		  s, new_errno, ERANGE);			\
+ 	  result = 1;						\
+ 	}							\
++      if (FE_UNDERFLOW != 0)					\
++	{							\
++	  bool underflow_raised					\
++	    = fetestexcept (FE_UNDERFLOW) != 0;			\
++	  if (underflow_raised != underflow->FSUF)		\
++	    {							\
++	      printf (FNPFXS "to" #FSUF				\
++		      " (" STRM ") underflow %d "		\
++		      "not %d\n", s, underflow_raised,		\
++		      underflow->FSUF);				\
++	      if (EXCEPTION_TESTS (FTYPE))			\
++		result = 1;					\
++	      else						\
++		printf ("ignoring this exception error\n");	\
++	    }							\
++	}							\
++      if (underflow->FSUF && new_errno != ERANGE)		\
++	{							\
++	  printf (FNPFXS "to" #FSUF				\
++		  " (" STRM ") left errno == %d,"		\
++		  " not %d (ERANGE)\n",				\
++		  s, new_errno, ERANGE);			\
++	  result = 1;						\
++	}							\
++      if (!overflow->FSUF					\
++	  && !underflow->FSUF					\
++	  && new_errno != 12345)				\
++	{							\
++	  printf (FNPFXS "to" #FSUF				\
++		  " (" STRM ") set errno == %d,"		\
++		  " should be unchanged\n",			\
++		  s, new_errno);				\
++	  result = 1;						\
++	}							\
+     }								\
+ }
+ 
+@@ -272,6 +333,7 @@ static int
+ test_in_one_mode (const CHAR *s, const struct test_results *expected,
+ 		    const struct test_exactness *exact,
+ 		    const struct test_overflow *overflow,
++		    const struct test_underflow *underflow,
+ 		    const char *mode_name, int rnd_mode)
+ {
+   int result = 0;
+@@ -307,6 +369,7 @@ do_test (void)
+     {
+       result |= test_in_one_mode (tests[i].s, &tests[i].r[modes[0].rnd_i],
+ 				  &tests[i].exact, &tests[i].o[modes[0].rnd_i],
++				  &tests[i].u[modes[0].rnd_i],
+ 				  modes[0].mode_name, modes[0].rnd_mode);
+       for (const struct fetestmodes *m = &modes[1]; m->mode_name != NULL; m++)
+ 	{
+@@ -314,7 +377,9 @@ do_test (void)
+ 	    {
+ 	      result |= test_in_one_mode (tests[i].s, &tests[i].r[m->rnd_i],
+ 					  &tests[i].exact,
+-					  &tests[i].o[m->rnd_i], m->mode_name,
++					  &tests[i].o[m->rnd_i],
++					  &tests[i].u[m->rnd_i],
++					  m->mode_name,
+ 					  m->rnd_mode);
+ 	      fesetround (save_round_mode);
+ 	    }
+
+commit d0c1792ad269566f877208ffda91c21dcd1a72e6
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Tue Aug 27 12:41:02 2024 +0000
+
+    Fix strtod subnormal rounding (bug 30220)
+    
+    As reported in bug 30220, the implementation of strtod-family
+    functions has a bug in the following case: the input string would,
+    with infinite exponent range, take one more bit to represent than is
+    available in the normal precision of the return type; the value
+    represented is in the subnormal range; and there are no nonzero bits
+    in the value, below those that can be represented in subnormal
+    precision, other than the least significant bit and possibly the
+    0.5ulp bit.  In this case, round_and_return ends up discarding the
+    least significant bit.
+    
+    Fix by saving that bit to merge into more_bits (it can't be merged in
+    at the time it's computed, because more_bits mustn't include this bit
+    in the case of after-rounding tininess detection checking if the
+    result is still subnormal when rounded to normal precision, so merging
+    this bit into more_bits needs to take place after that check).
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit 457622c2fa8f9f7435822d5287a437bc8be8090d)
+
+diff --git a/stdlib/strtod_l.c b/stdlib/strtod_l.c
+index be515ce659..beb97b3d0c 100644
+--- a/stdlib/strtod_l.c
++++ b/stdlib/strtod_l.c
+@@ -222,6 +222,7 @@ round_and_return (mp_limb_t *retval, intmax_t exponent, int negative,
+ 
+       mp_size_t shift = MIN_EXP - 1 - exponent;
+       bool is_tiny = true;
++      bool old_half_bit = (round_limb & (((mp_limb_t) 1) << round_bit)) != 0;
+ 
+       more_bits |= (round_limb & ((((mp_limb_t) 1) << round_bit) - 1)) != 0;
+       if (shift == MANT_DIG)
+@@ -292,6 +293,7 @@ round_and_return (mp_limb_t *retval, intmax_t exponent, int negative,
+ 	  round_bit = shift - 1;
+ 	  (void) __mpn_rshift (retval, retval, RETURN_LIMB_SIZE, shift);
+ 	}
++      more_bits |= old_half_bit;
+       /* This is a hook for the m68k long double format, where the
+ 	 exponent bias is the same for normalized and denormalized
+ 	 numbers.  */
+diff --git a/stdlib/tst-strtod-round-data b/stdlib/tst-strtod-round-data
+index 84ab705709..9489fbcc9c 100644
+--- a/stdlib/tst-strtod-round-data
++++ b/stdlib/tst-strtod-round-data
+@@ -265,3 +265,15 @@
+ 1.000000000000000000000000000000000385185988877447170611195588516985463707620329643077639047987759113311767578125
+ 1.0000000000000000000000000000000001925929944387235853055977942584927318538101648215388195239938795566558837890625
+ 1.00000000000000000000000000000000009629649721936179265279889712924636592690508241076940976199693977832794189453125
++0x30000002222225p-1077
++0x0.7fffffffffffeap-1022
++0x0.7fffffffffffe9p-1022
++0x0.7ffffd4p-126
++0x0.7ffffffffffffffd4p-16382
++0x0.7ffffffffffffffd4p-16383
++0x0.7ffffffffffffffffffffffffffeap-16382
++0x0.7000004p-126
++0x0.70000000000002p-1022
++0x0.70000000000000004p-16382
++0x0.70000000000000004p-16383
++0x0.70000000000000000000000000002p-16382
+diff --git a/stdlib/tst-strtod-round-data.h b/stdlib/tst-strtod-round-data.h
+index 13e62dd2b0..ed50eb2537 100644
+--- a/stdlib/tst-strtod-round-data.h
++++ b/stdlib/tst-strtod-round-data.h
+@@ -15437,4 +15437,376 @@ static const struct test tests[] = {
+ 	0x1p+0, false, false,
+ 	0x1p+0, false, false,
+ 	0x1.0000000000000000000000000001p+0, false, false),
++  TEST ("0x30000002222225p-1077",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x1.800000111111p-1024, false, true,
++	0x1.8000001111114p-1024, false, true,
++	0x1.800000111111p-1024, false, true,
++	0x1.8000001111114p-1024, false, true,
++	true,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	true,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	false,
++	0x1.800000111111p-1024, false, true,
++	0x1.8000001111114p-1024, false, true,
++	0x1.800000111111p-1024, false, true,
++	0x1.8000001111114p-1024, false, true,
++	true,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false,
++	0x1.80000011111128p-1024, false, false),
++  TEST ("0x0.7fffffffffffeap-1022",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	true,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	true,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	false,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	true,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false,
++	0x1.ffffffffffffa8p-1024, false, false),
++  TEST ("0x0.7fffffffffffe9p-1022",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	true,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	true,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	false,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	0x1.ffffffffffff8p-1024, false, true,
++	0x1.ffffffffffffcp-1024, false, true,
++	true,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false,
++	0x1.ffffffffffffa4p-1024, false, false),
++  TEST ("0x0.7ffffd4p-126",
++	false,
++	0x1.fffffp-128, false, true,
++	0x1.fffff8p-128, false, true,
++	0x1.fffffp-128, false, true,
++	0x1.fffff8p-128, false, true,
++	true,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	true,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	true,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	true,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	true,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false,
++	0x1.fffff5p-128, false, false),
++  TEST ("0x0.7ffffffffffffffd4p-16382",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.fffffffffffffffp-16384, false, true,
++	0x1.fffffffffffffff8p-16384, false, true,
++	0x1.fffffffffffffffp-16384, false, true,
++	0x1.fffffffffffffff8p-16384, false, true,
++	false,
++	0x1.fffffffffffffff4p-16384, false, true,
++	0x1.fffffffffffffff4p-16384, false, true,
++	0x1.fffffffffffffff4p-16384, false, true,
++	0x1.fffffffffffffff8p-16384, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x1.fffffffffffffff5p-16384, false, false,
++	0x1.fffffffffffffff5p-16384, false, false,
++	0x1.fffffffffffffff5p-16384, false, false,
++	0x1.fffffffffffffff5p-16384, false, false),
++  TEST ("0x0.7ffffffffffffffd4p-16383",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0xf.ffffffffffffff8p-16388, false, true,
++	0xf.ffffffffffffff8p-16388, false, true,
++	0xf.ffffffffffffff8p-16388, false, true,
++	0x1p-16384, false, true,
++	false,
++	0xf.ffffffffffffff8p-16388, false, true,
++	0xf.ffffffffffffffcp-16388, false, true,
++	0xf.ffffffffffffff8p-16388, false, true,
++	0xf.ffffffffffffffcp-16388, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0xf.ffffffffffffffa8p-16388, false, false,
++	0xf.ffffffffffffffa8p-16388, false, false,
++	0xf.ffffffffffffffa8p-16388, false, false,
++	0xf.ffffffffffffffa8p-16388, false, false),
++  TEST ("0x0.7ffffffffffffffffffffffffffeap-16382",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.fffffffffffffff8p-16384, false, true,
++	0x2p-16384, false, true,
++	0x1.fffffffffffffff8p-16384, false, true,
++	0x2p-16384, false, true,
++	false,
++	0x1.fffffffffffffffcp-16384, false, true,
++	0x2p-16384, false, true,
++	0x1.fffffffffffffffcp-16384, false, true,
++	0x2p-16384, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.fffffffffffffffffffffffffff8p-16384, false, true,
++	0x1.fffffffffffffffffffffffffffcp-16384, false, true,
++	0x1.fffffffffffffffffffffffffff8p-16384, false, true,
++	0x1.fffffffffffffffffffffffffffcp-16384, false, true),
++  TEST ("0x0.7000004p-126",
++	false,
++	0x1.cp-128, false, true,
++	0x1.cp-128, false, true,
++	0x1.cp-128, false, true,
++	0x1.c00008p-128, false, true,
++	true,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	true,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	true,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	true,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	true,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false,
++	0x1.c00001p-128, false, false),
++  TEST ("0x0.70000000000002p-1022",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x1.cp-1024, false, true,
++	0x1.cp-1024, false, true,
++	0x1.cp-1024, false, true,
++	0x1.c000000000004p-1024, false, true,
++	true,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	true,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	false,
++	0x1.cp-1024, false, true,
++	0x1.cp-1024, false, true,
++	0x1.cp-1024, false, true,
++	0x1.c000000000004p-1024, false, true,
++	true,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false,
++	0x1.c0000000000008p-1024, false, false),
++  TEST ("0x0.70000000000000004p-16382",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.c000000000000008p-16384, false, true,
++	false,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.c000000000000004p-16384, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0x1.c000000000000001p-16384, false, false,
++	0x1.c000000000000001p-16384, false, false,
++	0x1.c000000000000001p-16384, false, false,
++	0x1.c000000000000001p-16384, false, false),
++  TEST ("0x0.70000000000000004p-16383",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0xep-16388, false, true,
++	0xep-16388, false, true,
++	0xep-16388, false, true,
++	0xe.000000000000008p-16388, false, true,
++	false,
++	0xep-16388, false, true,
++	0xep-16388, false, true,
++	0xep-16388, false, true,
++	0xe.000000000000004p-16388, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	true,
++	0xe.0000000000000008p-16388, false, false,
++	0xe.0000000000000008p-16388, false, false,
++	0xe.0000000000000008p-16388, false, false,
++	0xe.0000000000000008p-16388, false, false),
++  TEST ("0x0.70000000000000000000000000002p-16382",
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x8p-152, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.c000000000000008p-16384, false, true,
++	false,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.c000000000000004p-16384, false, true,
++	false,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x0p+0, false, true,
++	0x4p-1076, false, true,
++	false,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.cp-16384, false, true,
++	0x1.c000000000000000000000000004p-16384, false, true),
+ };
+
+commit cac10d88c684c0171e549d813bfef7a31029f257
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Tue Aug 27 20:41:54 2024 +0000
+
+    Make __strtod_internal tests type-generic
+    
+    Some of the strtod tests use type-generic machinery in tst-strtod.h to
+    test the strto* functions for all floating types, while others only
+    test double even when the tests are in fact meaningful for all
+    floating types.
+    
+    Convert the tests of the internal __strtod_internal interface to cover
+    all floating types.  I haven't tried to convert them to use newer test
+    interfaces in other ways, just made the changes necessary to use the
+    type-generic machinery.  As an internal interface, there are no
+    aliases for different types with the same ABI (however,
+    __strtold_internal is defined even if long double has the same ABI as
+    double), so macros used by the type-generic testing code are redefined
+    as needed to avoid expecting such aliases to be present.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit 3fc063dee01da4f80920a14b7db637c8501d6fd4)
+
+diff --git a/stdlib/tst-strtod1i.c b/stdlib/tst-strtod1i.c
+index 9d6bb760fb..44ae0264f4 100644
+--- a/stdlib/tst-strtod1i.c
++++ b/stdlib/tst-strtod1i.c
+@@ -25,60 +25,91 @@
+ #include <string.h>
+ #include <math.h>
+ 
+-/* Perform a few tests in a locale with thousands separators.  */
+-static int
+-do_test (void)
+-{
+-  static const struct
+-  {
+-    const char *loc;
+-    const char *str;
+-    double exp;
+-    ptrdiff_t nread;
+-  } tests[] =
+-    {
+-      { "de_DE.UTF-8", "1,5", 1.5, 3 },
+-      { "de_DE.UTF-8", "1.5", 1.0, 1 },
+-      { "de_DE.UTF-8", "1.500", 1500.0, 5 },
+-      { "de_DE.UTF-8", "36.893.488.147.419.103.232", 0x1.0p65, 26 }
+-    };
+-#define ntests (sizeof (tests) / sizeof (tests[0]))
+-  size_t n;
+-  int result = 0;
+-
+-  puts ("\nLocale tests");
++#include "tst-strtod.h"
+ 
+-  for (n = 0; n < ntests; ++n)
+-    {
+-      double d;
+-      char *endp;
++/* This tests internal interfaces, which are only defined for types
++   with distinct ABIs, so disable testing for types without distinct
++   ABIs.  */
++#undef IF_FLOAT32
++#define IF_FLOAT32(x)
++#undef IF_FLOAT64
++#define IF_FLOAT64(x)
++#undef IF_FLOAT32X
++#define IF_FLOAT32X(x)
++#undef IF_FLOAT64X
++#define IF_FLOAT64X(x)
++#if !__HAVE_DISTINCT_FLOAT128
++# undef IF_FLOAT128
++# define IF_FLOAT128(x)
++#endif
+ 
+-      if (setlocale (LC_ALL, tests[n].loc) == NULL)
+-	{
+-	  printf ("cannot set locale %s\n", tests[n].loc);
+-	  result = 1;
+-	  continue;
+-	}
++#define ntests (sizeof (tests) / sizeof (tests[0]))
+ 
+-      d = __strtod_internal (tests[n].str, &endp, 1);
+-      if (d != tests[n].exp)
+-	{
+-	  printf ("strtod(\"%s\") returns %g and not %g\n",
+-		  tests[n].str, d, tests[n].exp);
+-	  result = 1;
+-	}
+-      else if (endp - tests[n].str != tests[n].nread)
+-	{
+-	  printf ("strtod(\"%s\") read %td bytes and not %td\n",
+-		  tests[n].str, endp - tests[n].str, tests[n].nread);
+-	  result = 1;
+-	}
+-    }
++/* Perform a few tests in a locale with thousands separators.  */
++#define TEST_STRTOD(FSUF, FTYPE, FTOSTR, LSUF, CSUF)			\
++static int								\
++test_strto ## FSUF (void)						\
++{									\
++  static const struct							\
++  {									\
++    const char *loc;							\
++    const char *str;							\
++    FTYPE exp;								\
++    ptrdiff_t nread;							\
++  } tests[] =								\
++    {									\
++      { "de_DE.UTF-8", "1,5", 1.5 ## LSUF, 3 },				\
++      { "de_DE.UTF-8", "1.5", 1.0 ## LSUF, 1 },				\
++      { "de_DE.UTF-8", "1.500", 1500.0 ## LSUF, 5 },			\
++      { "de_DE.UTF-8", "36.893.488.147.419.103.232", 0x1.0p65 ## LSUF, 26 } \
++    };									\
++  size_t n;								\
++  int result = 0;							\
++									\
++  puts ("\nLocale tests");						\
++									\
++  for (n = 0; n < ntests; ++n)						\
++    {									\
++      FTYPE d;								\
++      char *endp;							\
++									\
++      if (setlocale (LC_ALL, tests[n].loc) == NULL)			\
++	{								\
++	  printf ("cannot set locale %s\n", tests[n].loc);		\
++	  result = 1;							\
++	  continue;							\
++	}								\
++									\
++      d = __strto ## FSUF ## _internal (tests[n].str, &endp, 1);	\
++      if (d != tests[n].exp)						\
++	{								\
++	  char buf1[FSTRLENMAX], buf2[FSTRLENMAX];			\
++	  FTOSTR (buf1, sizeof (buf1), "%g", d);			\
++	  FTOSTR (buf2, sizeof (buf2), "%g", tests[n].exp);		\
++	  printf ("strto" # FSUF "(\"%s\") returns %s and not %s\n",	\
++		  tests[n].str, buf1, buf2);				\
++	  result = 1;							\
++	}								\
++      else if (endp - tests[n].str != tests[n].nread)			\
++	{								\
++	  printf ("strto" # FSUF "(\"%s\") read %td bytes and not %td\n", \
++		  tests[n].str, endp - tests[n].str, tests[n].nread);	\
++	  result = 1;							\
++	}								\
++    }									\
++									\
++  if (result == 0)							\
++    puts ("all OK");							\
++									\
++  return result ? EXIT_FAILURE : EXIT_SUCCESS;				\
++}
+ 
+-  if (result == 0)
+-    puts ("all OK");
++GEN_TEST_STRTOD_FOREACH (TEST_STRTOD)
+ 
+-  return result ? EXIT_FAILURE : EXIT_SUCCESS;
++static int
++do_test (void)
++{
++  return STRTOD_TEST_FOREACH (test_strto);
+ }
+ 
+ #include <support/test-driver.c>
+diff --git a/stdlib/tst-strtod3.c b/stdlib/tst-strtod3.c
+index 23abec1896..0d662d8be8 100644
+--- a/stdlib/tst-strtod3.c
++++ b/stdlib/tst-strtod3.c
+@@ -3,19 +3,73 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-static const struct
+-{
+-  const char *in;
+-  const char *out;
+-  double expected;
+-} tests[] =
+-  {
+-    { "000,,,e1", ",,,e1", 0.0 },
+-    { "000e1", "", 0.0 },
+-    { "000,1e1", ",1e1", 0.0 }
+-  };
+-#define NTESTS (sizeof (tests) / sizeof (tests[0]))
++#include "tst-strtod.h"
++
++/* This tests internal interfaces, which are only defined for types
++   with distinct ABIs, so disable testing for types without distinct
++   ABIs.  */
++#undef IF_FLOAT32
++#define IF_FLOAT32(x)
++#undef IF_FLOAT64
++#define IF_FLOAT64(x)
++#undef IF_FLOAT32X
++#define IF_FLOAT32X(x)
++#undef IF_FLOAT64X
++#define IF_FLOAT64X(x)
++#if !__HAVE_DISTINCT_FLOAT128
++# undef IF_FLOAT128
++# define IF_FLOAT128(x)
++#endif
+ 
++#define TEST_STRTOD(FSUF, FTYPE, FTOSTR, LSUF, CSUF)			\
++static const struct							\
++{									\
++  const char *in;							\
++  const char *out;							\
++  FTYPE expected;							\
++} tests_strto ## FSUF[] =						\
++  {									\
++    { "000,,,e1", ",,,e1", 0.0 ## LSUF },				\
++    { "000e1", "", 0.0 ## LSUF },					\
++    { "000,1e1", ",1e1", 0.0 ## LSUF }					\
++  };									\
++									\
++static int								\
++test_strto ## FSUF (void)						\
++{									\
++  int status = 0;							\
++									\
++  for (int i = 0;							\
++       i < sizeof (tests_strto ## FSUF) / sizeof (tests_strto ## FSUF[0]); \
++       ++i)								\
++    {									\
++      char *ep;								\
++      FTYPE r = __strto ## FSUF ## _internal (tests_strto ## FSUF[i].in, \
++					      &ep, 1);			\
++									\
++      if (strcmp (ep, tests_strto ## FSUF[i].out) != 0)			\
++	{								\
++	  printf ("%d: got rest string \"%s\", expected \"%s\"\n",	\
++		  i, ep, tests_strto ## FSUF[i].out);			\
++	  status = 1;							\
++	}								\
++									\
++      if (r != tests_strto ## FSUF[i].expected)				\
++	{								\
++	  char buf1[FSTRLENMAX], buf2[FSTRLENMAX];			\
++	  FTOSTR (buf1, sizeof (buf1), "%g", r);			\
++	  FTOSTR (buf2, sizeof (buf2), "%g",				\
++		  tests_strto ## FSUF[i].expected);			\
++	  printf ("%d: got wrong results %s, expected %s\n",		\
++		  i, buf1, buf2);					\
++	  status = 1;							\
++	}								\
++    }									\
++									\
++  return status;							\
++}
++
++GEN_TEST_STRTOD_FOREACH (TEST_STRTOD)
+ 
+ static int
+ do_test (void)
+@@ -26,29 +80,7 @@ do_test (void)
+       return 1;
+     }
+ 
+-  int status = 0;
+-
+-  for (int i = 0; i < NTESTS; ++i)
+-    {
+-      char *ep;
+-      double r = __strtod_internal (tests[i].in, &ep, 1);
+-
+-      if (strcmp (ep, tests[i].out) != 0)
+-	{
+-	  printf ("%d: got rest string \"%s\", expected \"%s\"\n",
+-		  i, ep, tests[i].out);
+-	  status = 1;
+-	}
+-
+-      if (r != tests[i].expected)
+-	{
+-	  printf ("%d: got wrong results %g, expected %g\n",
+-		  i, r, tests[i].expected);
+-	  status = 1;
+-	}
+-    }
+-
+-  return status;
++  return STRTOD_TEST_FOREACH (test_strto);
+ }
+ 
+ #define TEST_FUNCTION do_test ()
+diff --git a/stdlib/tst-strtod4.c b/stdlib/tst-strtod4.c
+index 6cc4e843c7..dfd3f05027 100644
+--- a/stdlib/tst-strtod4.c
++++ b/stdlib/tst-strtod4.c
+@@ -3,22 +3,76 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
++#include "tst-strtod.h"
++
++/* This tests internal interfaces, which are only defined for types
++   with distinct ABIs, so disable testing for types without distinct
++   ABIs.  */
++#undef IF_FLOAT32
++#define IF_FLOAT32(x)
++#undef IF_FLOAT64
++#define IF_FLOAT64(x)
++#undef IF_FLOAT32X
++#define IF_FLOAT32X(x)
++#undef IF_FLOAT64X
++#define IF_FLOAT64X(x)
++#if !__HAVE_DISTINCT_FLOAT128
++# undef IF_FLOAT128
++# define IF_FLOAT128(x)
++#endif
++
+ #define NNBSP "\xe2\x80\xaf"
+ 
+-static const struct
+-{
+-  const char *in;
+-  const char *out;
+-  double expected;
+-} tests[] =
+-  {
+-    { "000"NNBSP"000"NNBSP"000", "", 0.0 },
+-    { "1"NNBSP"000"NNBSP"000,5x", "x", 1000000.5 },
+-    /* Bug 30964 */
+-    { "10"NNBSP NNBSP"200", NNBSP NNBSP"200", 10.0 }
+-  };
+-#define NTESTS (sizeof (tests) / sizeof (tests[0]))
++#define TEST_STRTOD(FSUF, FTYPE, FTOSTR, LSUF, CSUF)			\
++static const struct							\
++{									\
++  const char *in;							\
++  const char *out;							\
++  FTYPE expected;							\
++} tests_strto ## FSUF[] =						\
++  {									\
++    { "000"NNBSP"000"NNBSP"000", "", 0.0 ## LSUF },			\
++    { "1"NNBSP"000"NNBSP"000,5x", "x", 1000000.5 ## LSUF },		\
++    /* Bug 30964 */							\
++    { "10"NNBSP NNBSP"200", NNBSP NNBSP"200", 10.0 ## LSUF }		\
++  };									\
++									\
++static int								\
++test_strto ## FSUF (void)						\
++{									\
++  int status = 0;							\
++									\
++  for (int i = 0;							\
++       i < sizeof (tests_strto ## FSUF) / sizeof (tests_strto ## FSUF[0]); \
++       ++i)								\
++    {									\
++      char *ep;								\
++      FTYPE r = __strto ## FSUF ## _internal (tests_strto ## FSUF[i].in, \
++					      &ep, 1);			\
++									\
++      if (strcmp (ep, tests_strto ## FSUF[i].out) != 0)			\
++	{								\
++	  printf ("%d: got rest string \"%s\", expected \"%s\"\n",	\
++		  i, ep, tests_strto ## FSUF[i].out);			\
++	  status = 1;							\
++	}								\
++									\
++      if (r != tests_strto ## FSUF[i].expected)				\
++	{								\
++	  char buf1[FSTRLENMAX], buf2[FSTRLENMAX];			\
++	  FTOSTR (buf1, sizeof (buf1), "%g", r);			\
++	  FTOSTR (buf2, sizeof (buf2), "%g",				\
++		  tests_strto ## FSUF[i].expected);			\
++	  printf ("%d: got wrong results %s, expected %s\n",		\
++		  i, buf1, buf2);					\
++	  status = 1;							\
++	}								\
++    }									\
++									\
++  return status;							\
++}
+ 
++GEN_TEST_STRTOD_FOREACH (TEST_STRTOD)
+ 
+ static int
+ do_test (void)
+@@ -29,29 +83,7 @@ do_test (void)
+       return 1;
+     }
+ 
+-  int status = 0;
+-
+-  for (int i = 0; i < NTESTS; ++i)
+-    {
+-      char *ep;
+-      double r = __strtod_internal (tests[i].in, &ep, 1);
+-
+-      if (strcmp (ep, tests[i].out) != 0)
+-	{
+-	  printf ("%d: got rest string \"%s\", expected \"%s\"\n",
+-		  i, ep, tests[i].out);
+-	  status = 1;
+-	}
+-
+-      if (r != tests[i].expected)
+-	{
+-	  printf ("%d: got wrong results %g, expected %g\n",
+-		  i, r, tests[i].expected);
+-	  status = 1;
+-	}
+-    }
+-
+-  return status;
++  return STRTOD_TEST_FOREACH (test_strto);
+ }
+ 
+ #define TEST_FUNCTION do_test ()
+diff --git a/stdlib/tst-strtod5i.c b/stdlib/tst-strtod5i.c
+index ee54e3404c..136aedea68 100644
+--- a/stdlib/tst-strtod5i.c
++++ b/stdlib/tst-strtod5i.c
+@@ -16,52 +16,112 @@
+    License along with the GNU C Library; if not, see
+    <https://www.gnu.org/licenses/>.  */
+ 
++/* Defining _LIBC_TEST ensures long double math functions are
++   declared in the headers.  */
++#define _LIBC_TEST 1
+ #include <locale.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <math.h>
+ 
++#include "tst-strtod.h"
++
++/* This tests internal interfaces, which are only defined for types
++   with distinct ABIs, so disable testing for types without distinct
++   ABIs.  */
++#undef IF_FLOAT32
++#define IF_FLOAT32(x)
++#undef IF_FLOAT64
++#define IF_FLOAT64(x)
++#undef IF_FLOAT32X
++#define IF_FLOAT32X(x)
++#undef IF_FLOAT64X
++#define IF_FLOAT64X(x)
++#if !__HAVE_DISTINCT_FLOAT128
++# undef IF_FLOAT128
++# define IF_FLOAT128(x)
++#endif
++
+ #define NNBSP "\xe2\x80\xaf"
+ 
+-static const struct
+-{
+-  const char *in;
+-  int group;
+-  double expected;
+-} tests[] =
+-  {
+-    { "0", 0, 0.0 },
+-    { "000", 0, 0.0 },
+-    { "-0", 0, -0.0 },
+-    { "-000", 0, -0.0 },
+-    { "0,", 0, 0.0 },
+-    { "-0,", 0, -0.0 },
+-    { "0,0", 0, 0.0 },
+-    { "-0,0", 0, -0.0 },
+-    { "0e-10", 0, 0.0 },
+-    { "-0e-10", 0, -0.0 },
+-    { "0,e-10", 0, 0.0 },
+-    { "-0,e-10", 0, -0.0 },
+-    { "0,0e-10", 0, 0.0 },
+-    { "-0,0e-10", 0, -0.0 },
+-    { "0e-1000000", 0, 0.0 },
+-    { "-0e-1000000", 0, -0.0 },
+-    { "0,0e-1000000", 0, 0.0 },
+-    { "-0,0e-1000000", 0, -0.0 },
+-    { "0", 1, 0.0 },
+-    { "000", 1, 0.0 },
+-    { "-0", 1, -0.0 },
+-    { "-000", 1, -0.0 },
+-    { "0e-10", 1, 0.0 },
+-    { "-0e-10", 1, -0.0 },
+-    { "0e-1000000", 1, 0.0 },
+-    { "-0e-1000000", 1, -0.0 },
+-    { "000"NNBSP"000"NNBSP"000", 1, 0.0 },
+-    { "-000"NNBSP"000"NNBSP"000", 1, -0.0 }
+-  };
+-#define NTESTS (sizeof (tests) / sizeof (tests[0]))
++#define TEST_STRTOD(FSUF, FTYPE, FTOSTR, LSUF, CSUF)			\
++static const struct							\
++{									\
++  const char *in;							\
++  int group;								\
++  FTYPE expected;							\
++} tests_strto ## FSUF[] =						\
++  {									\
++    { "0", 0, 0.0 ## LSUF },						\
++    { "000", 0, 0.0 ## LSUF },						\
++    { "-0", 0, -0.0 ## LSUF },						\
++    { "-000", 0, -0.0 ## LSUF },					\
++    { "0,", 0, 0.0 ## LSUF },						\
++    { "-0,", 0, -0.0 ## LSUF },						\
++    { "0,0", 0, 0.0 ## LSUF },						\
++    { "-0,0", 0, -0.0 ## LSUF },					\
++    { "0e-10", 0, 0.0 ## LSUF },					\
++    { "-0e-10", 0, -0.0 ## LSUF },					\
++    { "0,e-10", 0, 0.0 ## LSUF },					\
++    { "-0,e-10", 0, -0.0 ## LSUF },					\
++    { "0,0e-10", 0, 0.0 ## LSUF },					\
++    { "-0,0e-10", 0, -0.0 ## LSUF },					\
++    { "0e-1000000", 0, 0.0 ## LSUF },					\
++    { "-0e-1000000", 0, -0.0 ## LSUF },					\
++    { "0,0e-1000000", 0, 0.0 ## LSUF },					\
++    { "-0,0e-1000000", 0, -0.0 ## LSUF },				\
++    { "0", 1, 0.0 ## LSUF },						\
++    { "000", 1, 0.0 ## LSUF },						\
++    { "-0", 1, -0.0 ## LSUF },						\
++    { "-000", 1, -0.0 ## LSUF },					\
++    { "0e-10", 1, 0.0 ## LSUF },					\
++    { "-0e-10", 1, -0.0 ## LSUF },					\
++    { "0e-1000000", 1, 0.0 ## LSUF },					\
++    { "-0e-1000000", 1, -0.0 ## LSUF },					\
++    { "000"NNBSP"000"NNBSP"000", 1, 0.0 ## LSUF },			\
++    { "-000"NNBSP"000"NNBSP"000", 1, -0.0 ## LSUF }			\
++  };									\
++									\
++static int								\
++test_strto ## FSUF (void)						\
++{									\
++  int status = 0;							\
++									\
++  for (int i = 0;							\
++       i < sizeof (tests_strto ## FSUF) / sizeof (tests_strto ## FSUF[0]); \
++       ++i)								\
++    {									\
++      char *ep;								\
++      FTYPE r = __strto ## FSUF ## _internal (tests_strto ## FSUF[i].in, \
++					      &ep,			\
++					      tests_strto ## FSUF[i].group); \
++									\
++      if (*ep != '\0')							\
++	{								\
++	  printf ("%d: got rest string \"%s\", expected \"\"\n", i, ep); \
++	  status = 1;							\
++	}								\
++									\
++      if (r != tests_strto ## FSUF[i].expected				\
++	  || (copysign ## CSUF (10.0 ## LSUF, r)			\
++	      != copysign ## CSUF (10.0 ## LSUF,			\
++				   tests_strto ## FSUF[i].expected)))	\
++	{								\
++	  char buf1[FSTRLENMAX], buf2[FSTRLENMAX];			\
++	  FTOSTR (buf1, sizeof (buf1), "%g", r);			\
++	  FTOSTR (buf2, sizeof (buf2), "%g",				\
++		  tests_strto ## FSUF[i].expected);			\
++	  printf ("%d: got wrong results %s, expected %s\n",		\
++		  i, buf1, buf2);					\
++	  status = 1;							\
++	}								\
++    }									\
++									\
++  return status;							\
++}
+ 
++GEN_TEST_STRTOD_FOREACH (TEST_STRTOD)
+ 
+ static int
+ do_test (void)
+@@ -72,29 +132,7 @@ do_test (void)
+       return 1;
+     }
+ 
+-  int status = 0;
+-
+-  for (int i = 0; i < NTESTS; ++i)
+-    {
+-      char *ep;
+-      double r = __strtod_internal (tests[i].in, &ep, tests[i].group);
+-
+-      if (*ep != '\0')
+-	{
+-	  printf ("%d: got rest string \"%s\", expected \"\"\n", i, ep);
+-	  status = 1;
+-	}
+-
+-      if (r != tests[i].expected
+-	  || copysign (10.0, r) != copysign (10.0, tests[i].expected))
+-	{
+-	  printf ("%d: got wrong results %g, expected %g\n",
+-		  i, r, tests[i].expected);
+-	  status = 1;
+-	}
+-    }
+-
+-  return status;
++  return STRTOD_TEST_FOREACH (test_strto);
+ }
+ 
+ #include <support/test-driver.c>
+
+commit ad93c2047d791044d45e8f65070d821b0b918993
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Wed Sep 4 13:20:18 2024 +0000
+
+    Improve NaN payload testing
+    
+    There are two separate sets of tests of NaN payloads in glibc:
+    
+    * libm-test-{get,set}payload* verify that getpayload, setpayload,
+      setpayloadsig and __builtin_nan functions are consistent in their
+      payload handling.
+    
+    * test-nan-payload verifies that strtod-family functions and the
+      not-built-in nan functions are consistent in their payload handling.
+    
+    Nothing, however, connects the two sets of functions (i.e., verifies
+    that strtod / nan are consistent with getpayload / setpayload /
+    __builtin_nan).
+    
+    Improve test-nan-payload to check actual payload value with getpayload
+    rather than just verifying that the strtod and nan functions produce
+    the same NaN.  Also check that the NaNs produced aren't signaling and
+    extend the tests to cover _FloatN / _FloatNx.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit be77d5ae417236883c02d3d67c0716e3f669fa41)
+
+diff --git a/math/test-nan-payload.c b/math/test-nan-payload.c
+index 4a81dc348b..55c13de14e 100644
+--- a/math/test-nan-payload.c
++++ b/math/test-nan-payload.c
+@@ -16,6 +16,8 @@
+    License along with the GNU C Library; if not, see
+    <https://www.gnu.org/licenses/>.  */
+ 
++#define _LIBC_TEST 1
++#define __STDC_WANT_IEC_60559_TYPES_EXT__
+ #include <float.h>
+ #include <math.h>
+ #include <stdio.h>
+@@ -31,7 +33,7 @@
+ #define CHECK_IS_NAN(TYPE, A)			\
+   do						\
+     {						\
+-      if (isnan (A))				\
++      if (isnan (A) && !issignaling (A))	\
+ 	puts ("PASS: " #TYPE " " #A);		\
+       else					\
+ 	{					\
+@@ -41,6 +43,19 @@
+     }						\
+   while (0)
+ 
++#define CHECK_PAYLOAD(TYPE, FUNC, A, P)		\
++  do						\
++    {						\
++      if (FUNC (&(A)) == (P))			\
++	puts ("PASS: " #TYPE " payload " #A);	\
++      else					\
++	{					\
++	  puts ("FAIL: " #TYPE " payload " #A);	\
++	  result = 1;				\
++	}					\
++    }						\
++  while (0)
++
+ #define CHECK_SAME_NAN(TYPE, A, B)			\
+   do							\
+     {							\
+@@ -71,7 +86,7 @@
+    bits.  */
+ #define CAN_TEST_EQ(MANT_DIG) ((MANT_DIG) != 64 && (MANT_DIG) != 106)
+ 
+-#define RUN_TESTS(TYPE, SFUNC, FUNC, MANT_DIG)		\
++#define RUN_TESTS(TYPE, SFUNC, FUNC, PLFUNC, MANT_DIG)	\
+   do							\
+     {							\
+      TYPE n123 = WRAP_NAN (FUNC, "123");		\
+@@ -82,6 +97,10 @@
+      CHECK_IS_NAN (TYPE, n456);				\
+      TYPE s456 = WRAP_STRTO (SFUNC, "NAN(456)");	\
+      CHECK_IS_NAN (TYPE, s456);				\
++     TYPE nh123 = WRAP_NAN (FUNC, "0x123");		\
++     CHECK_IS_NAN (TYPE, nh123);			\
++     TYPE sh123 = WRAP_STRTO (SFUNC, "NAN(0x123)");	\
++     CHECK_IS_NAN (TYPE, sh123);			\
+      TYPE n123x = WRAP_NAN (FUNC, "123)");		\
+      CHECK_IS_NAN (TYPE, n123x);			\
+      TYPE nemp = WRAP_NAN (FUNC, "");			\
+@@ -92,8 +111,16 @@
+      CHECK_IS_NAN (TYPE, sx);				\
+      if (CAN_TEST_EQ (MANT_DIG))			\
+        CHECK_SAME_NAN (TYPE, n123, s123);		\
++     CHECK_PAYLOAD (TYPE, PLFUNC, n123, 123);		\
++     CHECK_PAYLOAD (TYPE, PLFUNC, s123, 123);		\
+      if (CAN_TEST_EQ (MANT_DIG))			\
+        CHECK_SAME_NAN (TYPE, n456, s456);		\
++     CHECK_PAYLOAD (TYPE, PLFUNC, n456, 456);		\
++     CHECK_PAYLOAD (TYPE, PLFUNC, s456, 456);		\
++     if (CAN_TEST_EQ (MANT_DIG))			\
++       CHECK_SAME_NAN (TYPE, nh123, sh123);		\
++     CHECK_PAYLOAD (TYPE, PLFUNC, nh123, 0x123);	\
++     CHECK_PAYLOAD (TYPE, PLFUNC, sh123, 0x123);	\
+      if (CAN_TEST_EQ (MANT_DIG))			\
+        CHECK_SAME_NAN (TYPE, nemp, semp);		\
+      if (CAN_TEST_EQ (MANT_DIG))			\
+@@ -110,9 +137,31 @@ static int
+ do_test (void)
+ {
+   int result = 0;
+-  RUN_TESTS (float, strtof, nanf, FLT_MANT_DIG);
+-  RUN_TESTS (double, strtod, nan, DBL_MANT_DIG);
+-  RUN_TESTS (long double, strtold, nanl, LDBL_MANT_DIG);
++  RUN_TESTS (float, strtof, nanf, getpayloadf, FLT_MANT_DIG);
++  RUN_TESTS (double, strtod, nan, getpayload, DBL_MANT_DIG);
++  RUN_TESTS (long double, strtold, nanl, getpayloadl, LDBL_MANT_DIG);
++#if __HAVE_FLOAT16
++  RUN_TESTS (_Float16, strtof16, nanf16, getpayloadf16, FLT16_MANT_DIG);
++#endif
++#if __HAVE_FLOAT32
++  RUN_TESTS (_Float32, strtof32, nanf32, getpayloadf32, FLT32_MANT_DIG);
++#endif
++#if __HAVE_FLOAT64
++  RUN_TESTS (_Float64, strtof64, nanf64, getpayloadf64, FLT64_MANT_DIG);
++#endif
++#if __HAVE_FLOAT128
++  RUN_TESTS (_Float128, strtof128, nanf128, getpayloadf128, FLT128_MANT_DIG);
++#endif
++#if __HAVE_FLOAT32X
++  RUN_TESTS (_Float32x, strtof32x, nanf32x, getpayloadf32x, FLT32X_MANT_DIG);
++#endif
++#if __HAVE_FLOAT64X
++  RUN_TESTS (_Float64x, strtof64x, nanf64x, getpayloadf64x, FLT64X_MANT_DIG);
++#endif
++#if __HAVE_FLOAT128X
++  RUN_TESTS (_Float128x, strtof128x, nanf128x, getpayloadf128x,
++	     FLT128X_MANT_DIG);
++#endif
+   return result;
+ }
+ 
+
+commit c4cc72d2efc741872d65ae1fd77572e47042d179
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Wed Sep 4 13:21:23 2024 +0000
+
+    Do not set errno for overflowing NaN payload in strtod/nan (bug 32045)
+    
+    As reported in bug 32045, it's incorrect for strtod/nan functions to
+    set errno based on overflowing payload (strtod should only set errno
+    for overflow / underflow of its actual result, and potentially if
+    nothing in the string can be parsed as a number at all; nan should be
+    a pure function that never sets it).  Save and restore errno around
+    the internal strtoull call and add associated test coverage.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit 64f62c47e9c350f353336f2df6714e1d48ec50d8)
+
+diff --git a/math/Makefile b/math/Makefile
+index f06d370383..b64c3eedd5 100644
+--- a/math/Makefile
++++ b/math/Makefile
+@@ -1077,6 +1077,7 @@ CFLAGS-test-flt-eval-method.c += -fexcess-precision=standard
+ CFLAGS-test-fe-snans-always-signal.c += $(config-cflags-signaling-nans)
+ 
+ CFLAGS-test-nan-const.c += -fno-builtin
++CFLAGS-test-nan-payload.c += -fno-builtin
+ 
+ CFLAGS-test-ceil-except-2.c += -fno-builtin
+ CFLAGS-test-floor-except-2.c += -fno-builtin
+diff --git a/math/test-nan-payload.c b/math/test-nan-payload.c
+index 55c13de14e..413791e09f 100644
+--- a/math/test-nan-payload.c
++++ b/math/test-nan-payload.c
+@@ -18,6 +18,7 @@
+ 
+ #define _LIBC_TEST 1
+ #define __STDC_WANT_IEC_60559_TYPES_EXT__
++#include <errno.h>
+ #include <float.h>
+ #include <math.h>
+ #include <stdio.h>
+@@ -82,6 +83,26 @@
+     }							\
+   while (0)
+ 
++#define CLEAR_ERRNO				\
++  do						\
++    {						\
++      errno = 12345;				\
++    }						\
++  while (0)
++
++#define CHECK_ERRNO(TYPE, A)				\
++  do							\
++    {							\
++      if (errno == 12345)				\
++	puts ("PASS: " #TYPE " " #A " errno");		\
++      else						\
++	{						\
++	  puts ("FAIL: " #TYPE " " #A " errno");	\
++	  result = 1;					\
++	}						\
++    }							\
++  while (0)
++
+ /* Cannot test payloads by memcmp for formats where NaNs have padding
+    bits.  */
+ #define CAN_TEST_EQ(MANT_DIG) ((MANT_DIG) != 64 && (MANT_DIG) != 106)
+@@ -89,26 +110,58 @@
+ #define RUN_TESTS(TYPE, SFUNC, FUNC, PLFUNC, MANT_DIG)	\
+   do							\
+     {							\
++     CLEAR_ERRNO;					\
+      TYPE n123 = WRAP_NAN (FUNC, "123");		\
++     CHECK_ERRNO (TYPE, n123);				\
+      CHECK_IS_NAN (TYPE, n123);				\
++     CLEAR_ERRNO;					\
+      TYPE s123 = WRAP_STRTO (SFUNC, "NAN(123)");	\
++     CHECK_ERRNO (TYPE, s123);				\
+      CHECK_IS_NAN (TYPE, s123);				\
++     CLEAR_ERRNO;					\
+      TYPE n456 = WRAP_NAN (FUNC, "456");		\
++     CHECK_ERRNO (TYPE, n456);				\
+      CHECK_IS_NAN (TYPE, n456);				\
++     CLEAR_ERRNO;					\
+      TYPE s456 = WRAP_STRTO (SFUNC, "NAN(456)");	\
++     CHECK_ERRNO (TYPE, s456);				\
+      CHECK_IS_NAN (TYPE, s456);				\
++     CLEAR_ERRNO;					\
+      TYPE nh123 = WRAP_NAN (FUNC, "0x123");		\
++     CHECK_ERRNO (TYPE, nh123);				\
+      CHECK_IS_NAN (TYPE, nh123);			\
++     CLEAR_ERRNO;					\
+      TYPE sh123 = WRAP_STRTO (SFUNC, "NAN(0x123)");	\
++     CHECK_ERRNO (TYPE, sh123);				\
+      CHECK_IS_NAN (TYPE, sh123);			\
++     CLEAR_ERRNO;					\
+      TYPE n123x = WRAP_NAN (FUNC, "123)");		\
++     CHECK_ERRNO (TYPE, n123x);				\
+      CHECK_IS_NAN (TYPE, n123x);			\
++     CLEAR_ERRNO;					\
+      TYPE nemp = WRAP_NAN (FUNC, "");			\
++     CHECK_ERRNO (TYPE, nemp);				\
+      CHECK_IS_NAN (TYPE, nemp);				\
++     CLEAR_ERRNO;					\
+      TYPE semp = WRAP_STRTO (SFUNC, "NAN()");		\
++     CHECK_ERRNO (TYPE, semp);				\
+      CHECK_IS_NAN (TYPE, semp);				\
++     CLEAR_ERRNO;					\
+      TYPE sx = WRAP_STRTO (SFUNC, "NAN");		\
++     CHECK_ERRNO (TYPE, sx);				\
+      CHECK_IS_NAN (TYPE, sx);				\
++     CLEAR_ERRNO;					\
++     TYPE novf = WRAP_NAN (FUNC, "9999999999"		\
++			   "99999999999999999999"	\
++			   "9999999999");		\
++     CHECK_ERRNO (TYPE, novf);				\
++     CHECK_IS_NAN (TYPE, novf);				\
++     CLEAR_ERRNO;					\
++     TYPE sovf = WRAP_STRTO (SFUNC, "NAN(9999999999"	\
++			     "99999999999999999999"	\
++			     "9999999999)");		\
++     CHECK_ERRNO (TYPE, sovf);				\
++     CHECK_IS_NAN (TYPE, sovf);				\
+      if (CAN_TEST_EQ (MANT_DIG))			\
+        CHECK_SAME_NAN (TYPE, n123, s123);		\
+      CHECK_PAYLOAD (TYPE, PLFUNC, n123, 123);		\
+diff --git a/stdlib/strtod_nan_main.c b/stdlib/strtod_nan_main.c
+index 4cb286d2b3..39fb7e9f75 100644
+--- a/stdlib/strtod_nan_main.c
++++ b/stdlib/strtod_nan_main.c
+@@ -16,6 +16,7 @@
+    License along with the GNU C Library; if not, see
+    <https://www.gnu.org/licenses/>.  */
+ 
++#include <errno.h>
+ #include <ieee754.h>
+ #include <locale.h>
+ #include <math.h>
+@@ -50,7 +51,9 @@ STRTOD_NAN (const STRING_TYPE *str, STRING_TYPE **endptr, STRING_TYPE endc)
+   STRING_TYPE *endp;
+   unsigned long long int mant;
+ 
++  int save_errno = errno;
+   mant = STRTOULL (str, &endp, 0);
++  __set_errno (save_errno);
+   if (endp == cp)
+     SET_NAN_PAYLOAD (retval, mant);
+ 
+
+commit 5a10d05c39689dcf7ee694ec94cd2fd069c747ee
+Author: Florian Weimer <fweimer@redhat.com>
+Date:   Thu Sep 5 21:18:23 2024 +0200
+
+    powerpc64le: Build new strtod tests with long double ABI flags (bug 32145)
+    
+    This fixes several test failures:
+    
+    =====FAIL: stdlib/tst-strtod1i.out=====
+    Locale tests
+    all OK
+    Locale tests
+    all OK
+    Locale tests
+    strtold("1,5") returns -6,38643e+367 and not 1,5
+    strtold("1.5") returns 1,5 and not 1
+    strtold("1.500") returns 1 and not 1500
+    strtold("36.893.488.147.419.103.232") returns 1500 and not 3,68935e+19
+    Locale tests
+    all OK
+    
+    =====FAIL: stdlib/tst-strtod3.out=====
+    0: got wrong results -2.5937e+4826, expected 0
+    
+    =====FAIL: stdlib/tst-strtod4.out=====
+    0: got wrong results -6,38643e+367, expected 0
+    1: got wrong results 0, expected 1e+06
+    2: got wrong results 1e+06, expected 10
+    
+    =====FAIL: stdlib/tst-strtod5i.out=====
+    0: got wrong results -6,38643e+367, expected 0
+    2: got wrong results 0, expected -0
+    4: got wrong results -0, expected 0
+    5: got wrong results 0, expected -0
+    6: got wrong results -0, expected 0
+    7: got wrong results 0, expected -0
+    8: got wrong results -0, expected 0
+    9: got wrong results 0, expected -0
+    10: got wrong results -0, expected 0
+    11: got wrong results 0, expected -0
+    12: got wrong results -0, expected 0
+    13: got wrong results 0, expected -0
+    14: got wrong results -0, expected 0
+    15: got wrong results 0, expected -0
+    16: got wrong results -0, expected 0
+    17: got wrong results 0, expected -0
+    18: got wrong results -0, expected 0
+    20: got wrong results 0, expected -0
+    22: got wrong results -0, expected 0
+    23: got wrong results 0, expected -0
+    24: got wrong results -0, expected 0
+    25: got wrong results 0, expected -0
+    26: got wrong results -0, expected 0
+    27: got wrong results 0, expected -0
+    
+    Fixes commit 3fc063dee01da4f80920a14b7db637c8501d6fd4
+    ("Make __strtod_internal tests type-generic").
+    
+    Suggested-by: Joseph Myers <josmyers@redhat.com>
+    Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+    (cherry picked from commit cc3e743fc09ee6fca45767629df9cbcbe1feba82)
+
+diff --git a/sysdeps/powerpc/powerpc64/le/Makefile b/sysdeps/powerpc/powerpc64/le/Makefile
+index 9d568d4f44..b77775cf95 100644
+--- a/sysdeps/powerpc/powerpc64/le/Makefile
++++ b/sysdeps/powerpc/powerpc64/le/Makefile
+@@ -129,6 +129,10 @@ CFLAGS-tst-strtod-round.c += $(type-float128-CFLAGS)
+ CFLAGS-tst-wcstod-round.c += $(type-float128-CFLAGS)
+ CFLAGS-tst-strtod-nan-locale.c += $(type-float128-CFLAGS)
+ CFLAGS-tst-wcstod-nan-locale.c += $(type-float128-CFLAGS)
++CFLAGS-tst-strtod1i.c += $(type-float128-CFLAGS)
++CFLAGS-tst-strtod3.c += $(type-float128-CFLAGS)
++CFLAGS-tst-strtod4.c += $(type-float128-CFLAGS)
++CFLAGS-tst-strtod5i.c += $(type-float128-CFLAGS)
+ CFLAGS-tst-strtod6.c += $(type-float128-CFLAGS)
+ CFLAGS-tst-strfrom.c += $(type-float128-CFLAGS)
+ CFLAGS-tst-strfrom-locale.c += $(type-float128-CFLAGS)
+
+commit 4a9b6cdc88335e2a7291418563073a58fe97346e
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Fri Sep 20 23:23:13 2024 +0000
+
+    Make tst-strtod2 and tst-strtod5 type-generic
+    
+    Some of the strtod tests use type-generic machinery in tst-strtod.h to
+    test the strto* functions for all floating types, while others only
+    test double even when the tests are in fact meaningful for all
+    floating types.
+    
+    Convert tst-strtod2 and tst-strtod5 to use the type-generic machinery
+    so they test all floating types.  I haven't tried to convert them to
+    use newer test interfaces in other ways, just made the changes
+    necessary to use the type-generic machinery.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit 8de031bcb9adfa736c0caed2c79d10947b8d8f48)
+
+diff --git a/stdlib/tst-strtod2.c b/stdlib/tst-strtod2.c
+index a7df82ebbd..2cb0953fa9 100644
+--- a/stdlib/tst-strtod2.c
++++ b/stdlib/tst-strtod2.c
+@@ -1,43 +1,61 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
+-struct test
+-{
+-  const char *str;
+-  double result;
+-  size_t offset;
+-} tests[] =
+-{
+-  { "0xy", 0.0, 1 },
+-  { "0x.y", 0.0, 1 },
+-  { "0x0.y", 0.0, 4 },
+-  { "0x.0y", 0.0, 4 },
+-  { ".y", 0.0, 0 },
+-  { "0.y", 0.0, 2 },
+-  { ".0y", 0.0, 2 }
+-};
++#include "tst-strtod.h"
++
++#define TEST_STRTOD(FSUF, FTYPE, FTOSTR, LSUF, CSUF)			\
++struct test_strto ## FSUF						\
++{									\
++  const char *str;							\
++  FTYPE result;								\
++  size_t offset;							\
++} tests_strto ## FSUF[] =						\
++{									\
++  { "0xy", 0.0 ## LSUF, 1 },						\
++  { "0x.y", 0.0 ## LSUF, 1 },						\
++  { "0x0.y", 0.0 ## LSUF, 4 },						\
++  { "0x.0y", 0.0 ## LSUF, 4 },						\
++  { ".y", 0.0 ## LSUF, 0 },						\
++  { "0.y", 0.0 ## LSUF, 2 },						\
++  { ".0y", 0.0 ## LSUF, 2 }						\
++};									\
++									\
++static int								\
++test_strto ## FSUF (void)						\
++{									\
++  int status = 0;							\
++  for (size_t i = 0;							\
++       i < sizeof (tests_strto ## FSUF) / sizeof (tests_strto ## FSUF[0]); \
++       ++i)								\
++    {									\
++      char *ep;								\
++      FTYPE r = strto ## FSUF (tests_strto ## FSUF[i].str, &ep);	\
++      if (r != tests_strto ## FSUF[i].result)				\
++	{								\
++	  char buf1[FSTRLENMAX], buf2[FSTRLENMAX];			\
++	  FTOSTR (buf1, sizeof (buf1), "%g", r);			\
++	  FTOSTR (buf2, sizeof (buf2), "%g", tests_strto ## FSUF[i].result); \
++	  printf ("test %zu r = %s, expect %s\n", i, buf1, buf2);	\
++	  status = 1;							\
++	}								\
++      if (ep != tests_strto ## FSUF[i].str + tests_strto ## FSUF[i].offset) \
++	{								\
++	  printf ("test %zu strto" #FSUF				\
++		  " parsed %tu characters, expected %zu\n",		\
++		  i, ep - tests_strto ## FSUF[i].str,			\
++		  tests_strto ## FSUF[i].offset);			\
++	  status = 1;							\
++	}								\
++    }									\
++  return status;							\
++}
++
++GEN_TEST_STRTOD_FOREACH (TEST_STRTOD)
+ 
+ static int
+ do_test (void)
+ {
+-  int status = 0;
+-  for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); ++i)
+-    {
+-      char *ep;
+-      double r = strtod (tests[i].str, &ep);
+-      if (r != tests[i].result)
+-	{
+-	  printf ("test %zu r = %g, expect %g\n", i, r, tests[i].result);
+-	  status = 1;
+-	}
+-      if (ep != tests[i].str + tests[i].offset)
+-	{
+-	  printf ("test %zu strtod parsed %tu characters, expected %zu\n",
+-		  i, ep - tests[i].str, tests[i].offset);
+-	  status = 1;
+-	}
+-    }
+-  return status;
++  return STRTOD_TEST_FOREACH (test_strto);
+ }
+ 
+ #define TEST_FUNCTION do_test ()
+diff --git a/stdlib/tst-strtod5.c b/stdlib/tst-strtod5.c
+index 29153ec005..7eb9b3a2d7 100644
+--- a/stdlib/tst-strtod5.c
++++ b/stdlib/tst-strtod5.c
+@@ -22,35 +22,75 @@
+ #include <string.h>
+ #include <math.h>
+ 
++#include "tst-strtod.h"
++
+ #define NBSP "\xc2\xa0"
+ 
+-static const struct
+-{
+-  const char *in;
+-  double expected;
+-} tests[] =
+-  {
+-    { "0", 0.0 },
+-    { "000", 0.0 },
+-    { "-0", -0.0 },
+-    { "-000", -0.0 },
+-    { "0,", 0.0 },
+-    { "-0,", -0.0 },
+-    { "0,0", 0.0 },
+-    { "-0,0", -0.0 },
+-    { "0e-10", 0.0 },
+-    { "-0e-10", -0.0 },
+-    { "0,e-10", 0.0 },
+-    { "-0,e-10", -0.0 },
+-    { "0,0e-10", 0.0 },
+-    { "-0,0e-10", -0.0 },
+-    { "0e-1000000", 0.0 },
+-    { "-0e-1000000", -0.0 },
+-    { "0,0e-1000000", 0.0 },
+-    { "-0,0e-1000000", -0.0 },
+-  };
+-#define NTESTS (sizeof (tests) / sizeof (tests[0]))
++#define TEST_STRTOD(FSUF, FTYPE, FTOSTR, LSUF, CSUF)			\
++static const struct							\
++{									\
++  const char *in;							\
++  FTYPE expected;							\
++} tests_strto ## FSUF[] =						\
++  {									\
++    { "0", 0.0 ## LSUF },						\
++    { "000", 0.0 ## LSUF },						\
++    { "-0", -0.0 ## LSUF },						\
++    { "-000", -0.0 ## LSUF },						\
++    { "0,", 0.0 ## LSUF },						\
++    { "-0,", -0.0 ## LSUF },						\
++    { "0,0", 0.0 ## LSUF },						\
++    { "-0,0", -0.0 ## LSUF },						\
++    { "0e-10", 0.0 ## LSUF },						\
++    { "-0e-10", -0.0 ## LSUF },						\
++    { "0,e-10", 0.0 ## LSUF },						\
++    { "-0,e-10", -0.0 ## LSUF },					\
++    { "0,0e-10", 0.0 ## LSUF },						\
++    { "-0,0e-10", -0.0 ## LSUF },					\
++    { "0e-1000000", 0.0 ## LSUF },					\
++    { "-0e-1000000", -0.0 ## LSUF },					\
++    { "0,0e-1000000", 0.0 ## LSUF },					\
++    { "-0,0e-1000000", -0.0 ## LSUF },					\
++  };									\
++									\
++									\
++static int								\
++test_strto ## FSUF (void)						\
++{									\
++  int status = 0;							\
++									\
++  for (int i = 0;							\
++       i < sizeof (tests_strto ## FSUF) / sizeof (tests_strto ## FSUF[0]); \
++       ++i)								\
++    {									\
++      char *ep;								\
++      FTYPE r = strto ## FSUF (tests_strto ## FSUF[i].in, &ep);		\
++									\
++      if (*ep != '\0')							\
++	{								\
++	  printf ("%d: got rest string \"%s\", expected \"\"\n", i, ep); \
++	  status = 1;							\
++	}								\
++									\
++      if (r != tests_strto ## FSUF[i].expected				\
++	  || (copysign ## CSUF (10.0 ## LSUF, r)			\
++	      != copysign ## CSUF (10.0 ## LSUF,			\
++				   tests_strto ## FSUF[i].expected)))	\
++	{								\
++	  char buf1[FSTRLENMAX], buf2[FSTRLENMAX];			\
++	  FTOSTR (buf1, sizeof (buf1), "%g", r);			\
++	  FTOSTR (buf2, sizeof (buf2), "%g",				\
++		  tests_strto ## FSUF[i].expected);			\
++	  printf ("%d: got wrong results %s, expected %s\n",		\
++		  i, buf1, buf2);					\
++	  status = 1;							\
++	}								\
++    }									\
++									\
++  return status;							\
++}
+ 
++GEN_TEST_STRTOD_FOREACH (TEST_STRTOD)
+ 
+ static int
+ do_test (void)
+@@ -61,29 +101,7 @@ do_test (void)
+       return 1;
+     }
+ 
+-  int status = 0;
+-
+-  for (int i = 0; i < NTESTS; ++i)
+-    {
+-      char *ep;
+-      double r = strtod (tests[i].in, &ep);
+-
+-      if (*ep != '\0')
+-	{
+-	  printf ("%d: got rest string \"%s\", expected \"\"\n", i, ep);
+-	  status = 1;
+-	}
+-
+-      if (r != tests[i].expected
+-	  || copysign (10.0, r) != copysign (10.0, tests[i].expected))
+-	{
+-	  printf ("%d: got wrong results %g, expected %g\n",
+-		  i, r, tests[i].expected);
+-	  status = 1;
+-	}
+-    }
+-
+-  return status;
++  return STRTOD_TEST_FOREACH (test_strto);
+ }
+ 
+ #include <support/test-driver.c>
+
+commit 8f40dfbe2ad8a4a2d2fc3bbe01d289037d113ced
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Fri Sep 20 23:24:02 2024 +0000
+
+    Add more tests of strtod end pointer
+    
+    Although there are some tests in tst-strtod2 and tst-strtod3 for the
+    end pointer provided by strtod when it doesn't parse the whole string,
+    they aren't very thorough.  Add tests of more such cases to
+    tst-strtod2.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit b5d3737b305525315e0c7c93ca49eadc868eabd5)
+
+diff --git a/stdlib/tst-strtod2.c b/stdlib/tst-strtod2.c
+index 2cb0953fa9..c84bd792c1 100644
+--- a/stdlib/tst-strtod2.c
++++ b/stdlib/tst-strtod2.c
+@@ -1,3 +1,4 @@
++#include <math.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
+@@ -17,10 +18,46 @@ struct test_strto ## FSUF						\
+   { "0x.0y", 0.0 ## LSUF, 4 },						\
+   { ".y", 0.0 ## LSUF, 0 },						\
+   { "0.y", 0.0 ## LSUF, 2 },						\
+-  { ".0y", 0.0 ## LSUF, 2 }						\
++  { ".0y", 0.0 ## LSUF, 2 },						\
++  { "1.0e", 1.0 ## LSUF, 3 },						\
++  { "1.0e+", 1.0 ## LSUF, 3 },						\
++  { "1.0e-", 1.0 ## LSUF, 3 },						\
++  { "1.0ex", 1.0 ## LSUF, 3 },						\
++  { "1.0e+x", 1.0 ## LSUF, 3 },						\
++  { "1.0e-x", 1.0 ## LSUF, 3 },						\
++  { "0x1p", 1.0 ## LSUF, 3 },						\
++  { "0x1p+", 1.0 ## LSUF, 3 },						\
++  { "0x1p-", 1.0 ## LSUF, 3 },						\
++  { "0x1px", 1.0 ## LSUF, 3 },						\
++  { "0x1p+x", 1.0 ## LSUF, 3 },						\
++  { "0x1p-x", 1.0 ## LSUF, 3 },						\
++  { "INFx", INFINITY, 3 },						\
++  { "infx", INFINITY, 3 },						\
++  { "INFINITx", INFINITY, 3 },						\
++  { "infinitx", INFINITY, 3 },						\
++  { "INFINITYY", INFINITY, 8 },						\
++  { "infinityy", INFINITY, 8 },						\
++  { "NANx", NAN, 3 },							\
++  { "nanx", NAN, 3 },							\
++  { "NAN(", NAN, 3 },							\
++  { "nan(", NAN, 3 },							\
++  { "NAN(x", NAN, 3 },							\
++  { "nan(x", NAN, 3 },							\
++  { "NAN(x)y", NAN, 6 },						\
++  { "nan(x)y", NAN, 6 },						\
++  { "NAN(*)y", NAN, 3 },						\
++  { "nan(*)y", NAN, 3 }							\
+ };									\
+ 									\
+ static int								\
++compare_strto ## FSUF (FTYPE x, FTYPE y)				\
++{									\
++  if (isnan (x) && isnan (y))						\
++    return 1;								\
++  return x == y;							\
++}									\
++									\
++static int								\
+ test_strto ## FSUF (void)						\
+ {									\
+   int status = 0;							\
+@@ -30,7 +67,7 @@ test_strto ## FSUF (void)						\
+     {									\
+       char *ep;								\
+       FTYPE r = strto ## FSUF (tests_strto ## FSUF[i].str, &ep);	\
+-      if (r != tests_strto ## FSUF[i].result)				\
++      if (!compare_strto ## FSUF (r, tests_strto ## FSUF[i].result))	\
+ 	{								\
+ 	  char buf1[FSTRLENMAX], buf2[FSTRLENMAX];			\
+ 	  FTOSTR (buf1, sizeof (buf1), "%g", r);			\
+
+commit cc256952ecb07789c423dff9712eb7a38f80e963
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Fri Sep 20 23:24:45 2024 +0000
+
+    Add tests of more strtod special cases
+    
+    There is very little test coverage of inputs to strtod-family
+    functions that don't contain anything that can be parsed as a number
+    (one test of ".y" in tst-strtod2), and none that I can see of skipping
+    initial whitespace.  Add some tests of these things to tst-strtod2.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit 378039ca578c2ea93095a1e710d96f58c68a3997)
+
+diff --git a/stdlib/tst-strtod2.c b/stdlib/tst-strtod2.c
+index c84bd792c1..d00bc13323 100644
+--- a/stdlib/tst-strtod2.c
++++ b/stdlib/tst-strtod2.c
+@@ -31,6 +31,20 @@ struct test_strto ## FSUF						\
+   { "0x1px", 1.0 ## LSUF, 3 },						\
+   { "0x1p+x", 1.0 ## LSUF, 3 },						\
+   { "0x1p-x", 1.0 ## LSUF, 3 },						\
++  { "", 0.0 ## LSUF, 0 },						\
++  { ".", 0.0 ## LSUF, 0 },						\
++  { "-", 0.0 ## LSUF, 0 },						\
++  { "-.", 0.0 ## LSUF, 0 },						\
++  { ".e", 0.0 ## LSUF, 0 },						\
++  { "-.e", 0.0 ## LSUF, 0 },						\
++  { " \t", 0.0 ## LSUF, 0 },						\
++  { " \t.", 0.0 ## LSUF, 0 },						\
++  { " \t-", 0.0 ## LSUF, 0 },						\
++  { " \t-.", 0.0 ## LSUF, 0 },						\
++  { " \t.e", 0.0 ## LSUF, 0 },						\
++  { " \t-.e", 0.0 ## LSUF, 0 },						\
++  { " \t\f\r\n\v1", 1.0 ## LSUF, 7 },					\
++  { " \t\f\r\n\v-1.5e2", -150.0 ## LSUF, 12 },				\
+   { "INFx", INFINITY, 3 },						\
+   { "infx", INFINITY, 3 },						\
+   { "INFINITx", INFINITY, 3 },						\
+
+commit 5c06c6e0b5078ffb0aa0c09bac79f086145e0897
+Author: H.J. Lu <hjl.tools@gmail.com>
+Date:   Sat Sep 7 08:32:32 2024 -0700
+
+    libio: Set _vtable_offset before calling _IO_link_in [BZ #32148]
+    
+    Since _IO_vtable_offset is used to detect the old binaries, set it
+    in _IO_old_file_init_internal before calling _IO_link_in which checks
+    _IO_vtable_offset.  Add a glibc 2.0 test with copy relocation on
+    _IO_stderr_@GLIBC_2.0 to verify that fopen won't cause memory corruption.
+    This fixes BZ #32148.
+    
+    Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+    Reviewed-by: Noah Goldstein <goldstein.w.n@gmail.com>
+    (cherry picked from commit 9dfea3de7f690bff70e3c6eb346b9ad082bb2e35)
+
+diff --git a/libio/Makefile b/libio/Makefile
+index 6a507b67ea..5292baa4e0 100644
+--- a/libio/Makefile
++++ b/libio/Makefile
+@@ -286,11 +286,18 @@ endif
+ ifeq ($(build-shared),yes)
+ aux	+= oldfileops oldstdfiles
+ tests += \
++  tst-fopen-compat \
+   tst-stderr-compat \
+ # tests
+ tests-2.0 += \
++  tst-fopen-compat \
+   tst-stderr-compat \
+ # tests-2.0
++
++tst-fopen-compat-ARGS = tst-fopen-compat.c
++# Disable PIE to trigger copy relocation.
++CFLAGS-tst-fopen-compat.c += -fno-pie
++tst-fopen-compat-no-pie = yes
+ endif
+ 
+ shared-only-routines = oldiofopen oldiofdopen oldiofclose oldfileops	\
+diff --git a/libio/oldfileops.c b/libio/oldfileops.c
+index 97148dba9b..8f775c9094 100644
+--- a/libio/oldfileops.c
++++ b/libio/oldfileops.c
+@@ -103,9 +103,11 @@ _IO_old_file_init_internal (struct _IO_FILE_plus *fp)
+   fp->file._old_offset = _IO_pos_BAD;
+   fp->file._flags |= CLOSED_FILEBUF_FLAGS;
+ 
+-  _IO_link_in (fp);
++  /* NB: _vtable_offset must be set before calling _IO_link_in since
++     _IO_vtable_offset is used to detect the old binaries.  */
+   fp->file._vtable_offset = ((int) sizeof (struct _IO_FILE)
+ 			     - (int) sizeof (struct _IO_FILE_complete));
++  _IO_link_in (fp);
+   fp->file._fileno = -1;
+ 
+   if (&_IO_stdin_used != NULL || !_IO_legacy_file ((FILE *) fp))
+diff --git a/libio/tst-fopen-compat.c b/libio/tst-fopen-compat.c
+new file mode 100644
+index 0000000000..f241b61043
+--- /dev/null
++++ b/libio/tst-fopen-compat.c
+@@ -0,0 +1,85 @@
++/* Verify that fopen works with copy relocation on _IO_stderr_ in binaries
++   linked with glibc 2.0.
++   Copyright (C) 2024 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <shlib-compat.h>
++
++#if TEST_COMPAT (libc, GLIBC_2_0, GLIBC_2_1)
++# define _LIBC
++# define _IO_USE_OLD_IO_FILE
++# include <stdio.h>
++# include <string.h>
++# include <unistd.h>
++# include <limits.h>
++# include <sys/stat.h>
++# include <support/check.h>
++
++struct _IO_jump_t;
++
++struct _IO_FILE_plus
++{
++  FILE file;
++  const struct _IO_jump_t *vtable;
++};
++
++extern struct _IO_FILE_plus _IO_stderr_;
++compat_symbol_reference (libc, _IO_stderr_, _IO_stderr_, GLIBC_2_0);
++compat_symbol_reference (libc, fopen, fopen, GLIBC_2_0);
++compat_symbol_reference (libc, fclose, fclose, GLIBC_2_0);
++
++static int
++do_test (int argc, char *argv[])
++{
++  static char filename[PATH_MAX + 1];
++  struct stat st;
++  char *name = NULL;
++  int i;
++
++  /* Try to trigger copy relocation.  */
++  TEST_VERIFY_EXIT (_IO_stderr_.file._fileno == STDERR_FILENO);
++
++  for (i = 1; i < argc; i++)
++    {
++      name = argv[i];
++      if (stat (name, &st) == 0)
++	{
++	  TEST_VERIFY_EXIT (strlen (name) <= PATH_MAX);
++	  break;
++	}
++    }
++  TEST_VERIFY_EXIT (name != NULL);
++
++  strcpy (filename, name);
++  FILE *fp = fopen (filename, "r");
++  TEST_VERIFY_EXIT (strcmp (filename, name) == 0);
++  TEST_VERIFY_EXIT (fp != NULL);
++  TEST_VERIFY_EXIT (fclose (fp) == 0);
++  return 0;
++}
++#else
++# include <support/test-driver.h>
++
++static int
++do_test (int argc, char *argv[])
++{
++  return EXIT_UNSUPPORTED;
++}
++#endif
++
++#define TEST_FUNCTION_ARGV do_test
++#include <support/test-driver.c>
+
+commit 85e5850f2f4ea5f304be5356ecb7a15998766a4e
+Author: Joseph Myers <josmyers@redhat.com>
+Date:   Fri Sep 20 23:25:32 2024 +0000
+
+    Make tst-strtod-underflow type-generic
+    
+    The test tst-strtod-underflow covers various edge cases close to the
+    underflow threshold for strtod (especially cases where underflow on
+    architectures with after-rounding tininess detection depends on the
+    rounding mode).  Make it use the type-generic machinery, with
+    corresponding test inputs for each supported floating-point format, so
+    that other functions in the strtod family are tested for underflow
+    edge cases as well.
+    
+    Tested for x86_64.
+    
+    (cherry picked from commit 94ca2c0894f0e1b62625c369cc598a2b9236622c)
+
+diff --git a/stdlib/tst-strtod-underflow.c b/stdlib/tst-strtod-underflow.c
+index a5ced18599..8598b95b6d 100644
+--- a/stdlib/tst-strtod-underflow.c
++++ b/stdlib/tst-strtod-underflow.c
+@@ -17,6 +17,10 @@
+    License along with the GNU C Library; if not, see
+    <https://www.gnu.org/licenses/>.  */
+ 
++/* Defining _LIBC_TEST ensures long double math functions are
++   declared in the headers.  */
++#define _LIBC_TEST 1
++#define __STDC_WANT_IEC_60559_TYPES_EXT__
+ #include <errno.h>
+ #include <fenv.h>
+ #include <float.h>
+@@ -25,6 +29,60 @@
+ #include <stdlib.h>
+ #include <tininess.h>
+ 
++#include "tst-strtod.h"
++
++/* Logic for selecting between tests for different formats is as in
++   tst-strtod-skeleton.c, but here it is selecting string inputs with
++   different underflow properties, rather than generated test
++   data.  */
++
++#define _CONCAT(a, b) a ## b
++#define CONCAT(a, b) _CONCAT (a, b)
++
++#define MEMBER(FSUF, FTYPE, FTOSTR, LSUF, CSUF)	\
++  const char *s_ ## FSUF;
++
++#if LDBL_MANT_DIG == 53 && LDBL_MAX_EXP == 1024
++# define CHOOSE_ld(f,d,...) d
++#elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && LDBL_MIN_EXP == -16381
++# define CHOOSE_ld(f,d,ld64i,...) ld64i
++#elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384 && LDBL_MIN_EXP == -16382
++# define CHOOSE_ld(f,d,ld64i,ld64m,...) ld64m
++#elif LDBL_MANT_DIG == 106 && LDBL_MAX_EXP == 1024
++# define CHOOSE_ld(f,d,ld64i,ld64m,ld106,...) ld106
++#elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384
++# define CHOOSE_ld(f,d,ld64i,ld64m,ld106,ld113,...) ld113
++#else
++# error "unknown long double format"
++#endif
++
++#define CHOOSE_f(f,...) f
++#define CHOOSE_f32(f,...) f
++#define CHOOSE_d(f,d,...) d
++#define CHOOSE_f64(f,d,...) d
++#define CHOOSE_f32x(f,d,...) d
++#define CHOOSE_f128(f,d,ld64i,ld64m,ld106,ld113,...) ld113
++
++#if __HAVE_FLOAT64X
++# if FLT64X_MANT_DIG == 113 && FLT64X_MAX_EXP == 16384
++#  define CHOOSE_f64x(f,d,ld64i,ld64m,ld106,ld113,...) ld113
++# elif (FLT64X_MANT_DIG == 64			\
++	&& FLT64X_MAX_EXP == 16384		\
++	&& FLT64X_MIN_EXP == -16381)
++#  define CHOOSE_f64x(f,d,ld64i,...) ld64i
++# else
++#  error "unknown _Float64x format"
++# endif
++#endif
++
++#define _XNTRY(FSUF, FTYPE, FTOSTR, LSUF, CSUF, ...)	\
++  CHOOSE_ ## FSUF (__VA_ARGS__),
++#define XNTRY(...) \
++  GEN_TEST_STRTOD_FOREACH (_XNTRY, __VA_ARGS__)
++
++#define TEST(f, d, ld64i, ld64m, ld106, ld113, u) \
++  { XNTRY(f, d, ld64i, ld64m, ld106, ld113) u }
++
+ enum underflow_case
+   {
+     /* Result is exact or outside the subnormal range.  */
+@@ -55,38 +113,194 @@ enum underflow_case
+ 
+ struct test
+ {
+-  const char *s;
++  GEN_TEST_STRTOD_FOREACH (MEMBER)
+   enum underflow_case c;
+ };
+ 
+ static const struct test tests[] =
+   {
+-    { "0x1p-1022", UNDERFLOW_NONE },
+-    { "-0x1p-1022", UNDERFLOW_NONE },
+-    { "0x0p-10000000000000000000000000", UNDERFLOW_NONE },
+-    { "-0x0p-10000000000000000000000000", UNDERFLOW_NONE },
+-    { "0x1p-10000000000000000000000000", UNDERFLOW_ALWAYS },
+-    { "-0x1p-10000000000000000000000000", UNDERFLOW_ALWAYS },
+-    { "0x1.000000000000000000001p-1022", UNDERFLOW_NONE },
+-    { "-0x1.000000000000000000001p-1022", UNDERFLOW_NONE },
+-    { "0x1p-1075", UNDERFLOW_ALWAYS },
+-    { "-0x1p-1075", UNDERFLOW_ALWAYS },
+-    { "0x1p-1023", UNDERFLOW_NONE },
+-    { "-0x1p-1023", UNDERFLOW_NONE },
+-    { "0x1p-1074", UNDERFLOW_NONE },
+-    { "-0x1p-1074", UNDERFLOW_NONE },
+-    { "0x1.ffffffffffffep-1023", UNDERFLOW_NONE },
+-    { "-0x1.ffffffffffffep-1023", UNDERFLOW_NONE },
+-    { "0x1.fffffffffffffp-1023", UNDERFLOW_ALWAYS },
+-    { "-0x1.fffffffffffffp-1023", UNDERFLOW_ALWAYS },
+-    { "0x1.fffffffffffff0001p-1023", UNDERFLOW_EXCEPT_UPWARD },
+-    { "-0x1.fffffffffffff0001p-1023", UNDERFLOW_EXCEPT_DOWNWARD },
+-    { "0x1.fffffffffffff7fffp-1023", UNDERFLOW_EXCEPT_UPWARD },
+-    { "-0x1.fffffffffffff7fffp-1023", UNDERFLOW_EXCEPT_DOWNWARD },
+-    { "0x1.fffffffffffff8p-1023", UNDERFLOW_ONLY_DOWNWARD_ZERO },
+-    { "-0x1.fffffffffffff8p-1023", UNDERFLOW_ONLY_UPWARD_ZERO },
+-    { "0x1.fffffffffffffffffp-1023", UNDERFLOW_ONLY_DOWNWARD_ZERO },
+-    { "-0x1.fffffffffffffffffp-1023", UNDERFLOW_ONLY_UPWARD_ZERO },
++    TEST ("0x1p-126",
++	  "0x1p-1022",
++	  "0x1p-16382",
++	  "0x1p-16383",
++	  "0x1p-969",
++	  "0x1p-16382",
++	  UNDERFLOW_NONE),
++    TEST ("-0x1p-126",
++	  "-0x1p-1022",
++	  "-0x1p-16382",
++	  "-0x1p-16383",
++	  "-0x1p-969",
++	  "-0x1p-16382",
++	  UNDERFLOW_NONE),
++    TEST ("0x0p-10000000000000000000000000",
++	  "0x0p-10000000000000000000000000",
++	  "0x0p-10000000000000000000000000",
++	  "0x0p-10000000000000000000000000",
++	  "0x0p-10000000000000000000000000",
++	  "0x0p-10000000000000000000000000",
++	  UNDERFLOW_NONE),
++    TEST ("-0x0p-10000000000000000000000000",
++	  "-0x0p-10000000000000000000000000",
++	  "-0x0p-10000000000000000000000000",
++	  "-0x0p-10000000000000000000000000",
++	  "-0x0p-10000000000000000000000000",
++	  "-0x0p-10000000000000000000000000",
++	  UNDERFLOW_NONE),
++    TEST ("0x1p-10000000000000000000000000",
++	  "0x1p-10000000000000000000000000",
++	  "0x1p-10000000000000000000000000",
++	  "0x1p-10000000000000000000000000",
++	  "0x1p-10000000000000000000000000",
++	  "0x1p-10000000000000000000000000",
++	  UNDERFLOW_ALWAYS),
++    TEST ("-0x1p-10000000000000000000000000",
++	  "-0x1p-10000000000000000000000000",
++	  "-0x1p-10000000000000000000000000",
++	  "-0x1p-10000000000000000000000000",
++	  "-0x1p-10000000000000000000000000",
++	  "-0x1p-10000000000000000000000000",
++	  UNDERFLOW_ALWAYS),
++    TEST ("0x1.000000000000000000001p-126",
++	  "0x1.000000000000000000001p-1022",
++	  "0x1.000000000000000000001p-16382",
++	  "0x1.000000000000000000001p-16383",
++	  "0x1.000000000000000000001p-969",
++	  "0x1.00000000000000000000000000000000000000001p-16382",
++	  UNDERFLOW_NONE),
++    TEST ("-0x1.000000000000000000001p-126",
++	  "-0x1.000000000000000000001p-1022",
++	  "-0x1.000000000000000000001p-16382",
++	  "-0x1.000000000000000000001p-16383",
++	  "-0x1.000000000000000000001p-969",
++	  "-0x1.00000000000000000000000000000000000000001p-16382",
++	  UNDERFLOW_NONE),
++    TEST ("0x1p-150",
++	  "0x1p-1075",
++	  "0x1p-16446",
++	  "0x1p-16447",
++	  "0x1p-1075",
++	  "0x1p-16495",
++	  UNDERFLOW_ALWAYS),
++    TEST ("-0x1p-150",
++	  "-0x1p-1075",
++	  "-0x1p-16446",
++	  "-0x1p-16447",
++	  "-0x1p-1075",
++	  "-0x1p-16495",
++	  UNDERFLOW_ALWAYS),
++    TEST ("0x1p-127",
++	  "0x1p-1023",
++	  "0x1p-16383",
++	  "0x1p-16384",
++	  "0x1p-970",
++	  "0x1p-16383",
++	  UNDERFLOW_NONE),
++    TEST ("-0x1p-127",
++	  "-0x1p-1023",
++	  "-0x1p-16383",
++	  "-0x1p-16384",
++	  "-0x1p-970",
++	  "-0x1p-16383",
++	  UNDERFLOW_NONE),
++    TEST ("0x1p-149",
++	  "0x1p-1074",
++	  "0x1p-16445",
++	  "0x1p-16446",
++	  "0x1p-1074",
++	  "0x1p-16494",
++	  UNDERFLOW_NONE),
++    TEST ("-0x1p-149",
++	  "-0x1p-1074",
++	  "-0x1p-16445",
++	  "-0x1p-16446",
++	  "-0x1p-1074",
++	  "-0x1p-16494",
++	  UNDERFLOW_NONE),
++    TEST ("0x1.fffffcp-127",
++	  "0x1.ffffffffffffep-1023",
++	  "0x1.fffffffffffffffcp-16383",
++	  "0x1.fffffffffffffffcp-16384",
++	  "0x1.ffffffffffffffffffffffffffp-970",
++	  "0x1.fffffffffffffffffffffffffffep-16383",
++	  UNDERFLOW_NONE),
++    TEST ("-0x1.fffffcp-127",
++	  "-0x1.ffffffffffffep-1023",
++	  "-0x1.fffffffffffffffcp-16383",
++	  "-0x1.fffffffffffffffcp-16384",
++	  "-0x1.ffffffffffffffffffffffffffp-970",
++	  "-0x1.fffffffffffffffffffffffffffep-16383",
++	  UNDERFLOW_NONE),
++    TEST ("0x1.fffffep-127",
++	  "0x1.fffffffffffffp-1023",
++	  "0x1.fffffffffffffffep-16383",
++	  "0x1.fffffffffffffffep-16384",
++	  "0x1.ffffffffffffffffffffffffff8p-970",
++	  "0x1.ffffffffffffffffffffffffffffp-16383",
++	  UNDERFLOW_ALWAYS),
++    TEST ("-0x1.fffffep-127",
++	  "-0x1.fffffffffffffp-1023",
++	  "-0x1.fffffffffffffffep-16383",
++	  "-0x1.fffffffffffffffep-16384",
++	  "-0x1.ffffffffffffffffffffffffff8p-970",
++	  "-0x1.ffffffffffffffffffffffffffffp-16383",
++	  UNDERFLOW_ALWAYS),
++    TEST ("0x1.fffffe0001p-127",
++	  "0x1.fffffffffffff0001p-1023",
++	  "0x1.fffffffffffffffe0001p-16383",
++	  "0x1.fffffffffffffffe0001p-16384",
++	  "0x1.ffffffffffffffffffffffffff80001p-970",
++	  "0x1.ffffffffffffffffffffffffffff0001p-16383",
++	  UNDERFLOW_EXCEPT_UPWARD),
++    TEST ("-0x1.fffffe0001p-127",
++	  "-0x1.fffffffffffff0001p-1023",
++	  "-0x1.fffffffffffffffe0001p-16383",
++	  "-0x1.fffffffffffffffe0001p-16384",
++	  "-0x1.ffffffffffffffffffffffffff80001p-970",
++	  "-0x1.ffffffffffffffffffffffffffff0001p-16383",
++	  UNDERFLOW_EXCEPT_DOWNWARD),
++    TEST ("0x1.fffffeffffp-127",
++	  "0x1.fffffffffffff7fffp-1023",
++	  "0x1.fffffffffffffffeffffp-16383",
++	  "0x1.fffffffffffffffeffffp-16384",
++	  "0x1.ffffffffffffffffffffffffffbffffp-970",
++	  "0x1.ffffffffffffffffffffffffffff7fffp-16383",
++	  UNDERFLOW_EXCEPT_UPWARD),
++    TEST ("-0x1.fffffeffffp-127",
++	  "-0x1.fffffffffffff7fffp-1023",
++	  "-0x1.fffffffffffffffeffffp-16383",
++	  "-0x1.fffffffffffffffeffffp-16384",
++	  "-0x1.ffffffffffffffffffffffffffbffffp-970",
++	  "-0x1.ffffffffffffffffffffffffffff7fffp-16383",
++	  UNDERFLOW_EXCEPT_DOWNWARD),
++    TEST ("0x1.ffffffp-127",
++	  "0x1.fffffffffffff8p-1023",
++	  "0x1.ffffffffffffffffp-16383",
++	  "0x1.ffffffffffffffffp-16384",
++	  "0x1.ffffffffffffffffffffffffffcp-970",
++	  "0x1.ffffffffffffffffffffffffffff8p-16383",
++	  UNDERFLOW_ONLY_DOWNWARD_ZERO),
++    TEST ("-0x1.ffffffp-127",
++	  "-0x1.fffffffffffff8p-1023",
++	  "-0x1.ffffffffffffffffp-16383",
++	  "-0x1.ffffffffffffffffp-16384",
++	  "-0x1.ffffffffffffffffffffffffffcp-970",
++	  "-0x1.ffffffffffffffffffffffffffff8p-16383",
++	  UNDERFLOW_ONLY_UPWARD_ZERO),
++    TEST ("0x1.ffffffffffp-127",
++	  "0x1.fffffffffffffffffp-1023",
++	  "0x1.ffffffffffffffffffffp-16383",
++	  "0x1.ffffffffffffffffffffp-16384",
++	  "0x1.ffffffffffffffffffffffffffffffp-970",
++	  "0x1.ffffffffffffffffffffffffffffffffp-16383",
++	  UNDERFLOW_ONLY_DOWNWARD_ZERO),
++    TEST ("-0x1.ffffffffffp-127",
++	  "-0x1.fffffffffffffffffp-1023",
++	  "-0x1.ffffffffffffffffffffp-16383",
++	  "-0x1.ffffffffffffffffffffp-16384",
++	  "-0x1.ffffffffffffffffffffffffffffffp-970",
++	  "-0x1.ffffffffffffffffffffffffffffffffp-16383",
++	  UNDERFLOW_ONLY_UPWARD_ZERO),
+   };
+ 
+ /* Return whether to expect underflow from a particular testcase, in a
+@@ -133,39 +347,62 @@ static bool support_underflow_exception = false;
+ volatile double d = DBL_MIN;
+ volatile double dd;
+ 
+-static int
+-test_in_one_mode (const char *s, enum underflow_case c, int rm,
+-		  const char *mode_name)
++static bool
++test_got_fe_underflow (void)
+ {
+-  int result = 0;
+-  feclearexcept (FE_ALL_EXCEPT);
+-  errno = 0;
+-  double d = strtod (s, NULL);
+-  int got_errno = errno;
+ #ifdef FE_UNDERFLOW
+-  bool got_fe_underflow = fetestexcept (FE_UNDERFLOW) != 0;
++  return fetestexcept (FE_UNDERFLOW) != 0;
+ #else
+-  bool got_fe_underflow = false;
++  return false;
+ #endif
+-  printf ("strtod (%s) (%s) returned %a, errno = %d, %sunderflow exception\n",
+-	  s, mode_name, d, got_errno, got_fe_underflow ? "" : "no ");
+-  bool this_expect_underflow = expect_underflow (c, rm);
+-  if (got_errno != 0 && got_errno != ERANGE)
+-    {
+-      puts ("FAIL: errno neither 0 nor ERANGE");
+-      result = 1;
+-    }
+-  else if (this_expect_underflow != (errno == ERANGE))
+-    {
+-      puts ("FAIL: underflow from errno differs from expectations");
+-      result = 1;
+-    }
+-  if (support_underflow_exception && got_fe_underflow != this_expect_underflow)
+-    {
+-      puts ("FAIL: underflow from exceptions differs from expectations");
+-      result = 1;
+-    }
+-  return result;
++}
++
++#define TEST_STRTOD(FSUF, FTYPE, FTOSTR, LSUF, CSUF)			\
++static int								\
++test_strto ## FSUF (int i, int rm, const char *mode_name)		\
++{									\
++  const char *s = tests[i].s_ ## FSUF;					\
++  enum underflow_case c = tests[i].c;					\
++  int result = 0;							\
++  feclearexcept (FE_ALL_EXCEPT);					\
++  errno = 0;								\
++  FTYPE d = strto ## FSUF (s, NULL);					\
++  int got_errno = errno;						\
++  bool got_fe_underflow = test_got_fe_underflow ();			\
++  char buf[FSTRLENMAX];							\
++  FTOSTR (buf, sizeof (buf), "%a", d);					\
++  printf ("strto" #FSUF							\
++	  " (%s) (%s) returned %s, errno = %d, "			\
++	  "%sunderflow exception\n",					\
++	  s, mode_name, buf, got_errno,					\
++	  got_fe_underflow ? "" : "no ");				\
++  bool this_expect_underflow = expect_underflow (c, rm);		\
++  if (got_errno != 0 && got_errno != ERANGE)				\
++    {									\
++      puts ("FAIL: errno neither 0 nor ERANGE");			\
++      result = 1;							\
++    }									\
++  else if (this_expect_underflow != (errno == ERANGE))			\
++    {									\
++      puts ("FAIL: underflow from errno differs from expectations");	\
++      result = 1;							\
++    }									\
++  if (support_underflow_exception					\
++      && got_fe_underflow != this_expect_underflow)			\
++    {									\
++      puts ("FAIL: underflow from exceptions "				\
++	    "differs from expectations");				\
++      result = 1;							\
++    }									\
++  return result;							\
++}
++
++GEN_TEST_STRTOD_FOREACH (TEST_STRTOD)
++
++static int
++test_in_one_mode (size_t i, int rm, const char *mode_name)
++{
++  return STRTOD_TEST_FOREACH (test_strto, i, rm, mode_name);
+ }
+ 
+ static int
+@@ -191,12 +428,12 @@ do_test (void)
+ #endif
+   for (size_t i = 0; i < sizeof (tests) / sizeof (tests[0]); i++)
+     {
+-      result |= test_in_one_mode (tests[i].s, tests[i].c, fe_tonearest,
++      result |= test_in_one_mode (i, fe_tonearest,
+ 				  "default rounding mode");
+ #ifdef FE_DOWNWARD
+       if (!fesetround (FE_DOWNWARD))
+ 	{
+-	  result |= test_in_one_mode (tests[i].s, tests[i].c, FE_DOWNWARD,
++	  result |= test_in_one_mode (i, FE_DOWNWARD,
+ 				      "FE_DOWNWARD");
+ 	  fesetround (save_round_mode);
+ 	}
+@@ -204,7 +441,7 @@ do_test (void)
+ #ifdef FE_TOWARDZERO
+       if (!fesetround (FE_TOWARDZERO))
+ 	{
+-	  result |= test_in_one_mode (tests[i].s, tests[i].c, FE_TOWARDZERO,
++	  result |= test_in_one_mode (i, FE_TOWARDZERO,
+ 				      "FE_TOWARDZERO");
+ 	  fesetround (save_round_mode);
+ 	}
+@@ -212,7 +449,7 @@ do_test (void)
+ #ifdef FE_UPWARD
+       if (!fesetround (FE_UPWARD))
+ 	{
+-	  result |= test_in_one_mode (tests[i].s, tests[i].c, FE_UPWARD,
++	  result |= test_in_one_mode (i, FE_UPWARD,
+ 				      "FE_UPWARD");
+ 	  fesetround (save_round_mode);
+ 	}
+
+commit 3a34851103d554b2c9b269ecae111648f9d7bb6d
+Author: Florian Weimer <fweimer@redhat.com>
+Date:   Mon Oct 28 14:45:30 2024 +0100
+
+    elf: Change ldconfig auxcache magic number (bug 32231)
+    
+    In commit c628c2296392ed3bf2cb8d8470668e64fe53389f (elf: Remove
+    ldconfig kernel version check), the layout of auxcache entries
+    changed because the osversion field was removed from
+    struct aux_cache_file_entry.  However, AUX_CACHEMAGIC was not
+    changed, so existing files are still used, potentially leading
+    to unintended ldconfig behavior.  This commit changes AUX_CACHEMAGIC,
+    so that the file is regenerated.
+    
+    Reported-by: DJ Delorie <dj@redhat.com>
+    Reviewed-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+    (cherry picked from commit 0a536f6e2f76e3ef581b3fd9af1e5cf4ddc7a5a2)
+
+diff --git a/NEWS b/NEWS
+index 9033335db1..928c516bec 100644
+--- a/NEWS
++++ b/NEWS
+@@ -17,6 +17,7 @@ The following bugs are resolved with this release:
+   [32026] strerror/strsignal TLS not handled correctly for secondary namespaces
+   [32052] Name space violation in fortify wrappers
+   [32137] libio: Attempt wide backup free only for non-legacy code
++  [32231] elf: Change ldconfig auxcache magic number
+ 
+ Version 2.40
+ 
+diff --git a/elf/cache.c b/elf/cache.c
+index 8a618e11fa..62d681df42 100644
+--- a/elf/cache.c
++++ b/elf/cache.c
+@@ -820,7 +820,7 @@ struct aux_cache_entry
+   struct aux_cache_entry *next;
+ };
+ 
+-#define AUX_CACHEMAGIC		"glibc-ld.so.auxcache-1.0"
++#define AUX_CACHEMAGIC		"glibc-ld.so.auxcache-2.0"
+ 
+ struct aux_cache_file_entry
+ {
+
+commit 234458024300f0b4b430785999f33eddf059af6a
+Author: Michael Karcher <Michael.Karcher@fu-berlin.de>
+Date:   Sun Jul 28 15:30:57 2024 +0200
+
+    Mitigation for "clone on sparc might fail with -EFAULT for no valid reason" (bz 31394)
+    
+    It seems the kernel can not deal with uncommitted stack space in the area intended
+    for the register window when executing the clone() system call. So create a nested
+    frame (proxy for the kernel frame) and flush it from the processor to memory to
+    force committing pages to the stack before invoking the system call.
+    
+    Bug: https://www.mail-archive.com/debian-glibc@lists.debian.org/msg62592.html
+    Bug: https://sourceware.org/bugzilla/show_bug.cgi?id=31394
+    See-also: https://lore.kernel.org/sparclinux/62f9be9d-a086-4134-9a9f-5df8822708af@mkarcher.dialup.fu-berlin.de/
+    Signed-off-by: Michael Karcher <sourceware-bugzilla@mkarcher.dialup.fu-berlin.de>
+    Reviewed-by: DJ Delorie <dj@redhat.com>
+    (cherry picked from commit faeaa3bc9f76030b9882ccfdee232fc0ca6dcb06)
+
+diff --git a/NEWS b/NEWS
+index 928c516bec..dc815fb6d3 100644
+--- a/NEWS
++++ b/NEWS
+@@ -11,6 +11,7 @@ The following bugs are resolved with this release:
+ 
+   [27821] ungetc: Fix backup buffer leak on program exit
+   [30081] resolv: Do not wait for non-existing second DNS response after error
++  [31394] clone on sparc might fail with -EFAULT for no valid reason
+   [31717] elf: Avoid re-initializing already allocated TLS in dlopen
+   [31890] resolv: Allow short error responses to match any DNS query
+   [31968] mremap implementation in C does not handle arguments correctly
+diff --git a/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S b/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S
+index 748d25fcfe..c9cf9bb055 100644
+--- a/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S
++++ b/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S
+@@ -28,6 +28,9 @@
+ 	.text
+ ENTRY (__clone)
+ 	save	%sp,-96,%sp
++	save	%sp,-96,%sp
++	flushw
++	restore
+ 	cfi_def_cfa_register(%fp)
+ 	cfi_window_save
+ 	cfi_register(%o7, %i7)
+diff --git a/sysdeps/unix/sysv/linux/sparc/sparc64/clone.S b/sysdeps/unix/sysv/linux/sparc/sparc64/clone.S
+index e5ff2cf1a0..370d51fda2 100644
+--- a/sysdeps/unix/sysv/linux/sparc/sparc64/clone.S
++++ b/sysdeps/unix/sysv/linux/sparc/sparc64/clone.S
+@@ -32,6 +32,9 @@
+ 
+ ENTRY (__clone)
+ 	save	%sp, -192, %sp
++	save	%sp, -192, %sp
++	flushw
++	restore
+ 	cfi_def_cfa_register(%fp)
+ 	cfi_window_save
+ 	cfi_register(%o7, %i7)
+
+commit efb710034e4c5e734d100cc4ef1b1e27d4315825
+Author: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date:   Mon Sep 2 16:58:51 2024 -0300
+
+    linux: sparc: Fix clone for LEON/sparcv8 (BZ 31394)
+    
+    The sparc clone mitigation (faeaa3bc9f76030) added the use of
+    flushw, which is not support by LEON/sparcv8.  As discussed on
+    the libc-alpha, 'ta 3' is a working alternative [1].
+    
+    [1] https://sourceware.org/pipermail/libc-alpha/2024-August/158905.html
+    
+    Checked with a build for sparcv8-linux-gnu targetting leon.
+    
+    Acked-by: John Paul Adrian Glaubitz <glaubitz@physik.fu-berlin.de>
+    (cherry picked from commit 5e8cfc5d625e6dd000a0371d21d792836ea7951a)
+
+diff --git a/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S b/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S
+index c9cf9bb055..c84244f56b 100644
+--- a/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S
++++ b/sysdeps/unix/sysv/linux/sparc/sparc32/clone.S
+@@ -29,7 +29,11 @@
+ ENTRY (__clone)
+ 	save	%sp,-96,%sp
+ 	save	%sp,-96,%sp
++#ifdef __sparcv9
+ 	flushw
++#else
++	ta 3
++#endif
+ 	restore
+ 	cfi_def_cfa_register(%fp)
+ 	cfi_window_save
+
+commit 626c048f32a979f77662bdcb1cca477c11d3f9c1
+Author: Aurelien Jarno <aurelien@aurel32.net>
+Date:   Sun Nov 10 10:50:34 2024 +0100
+
+    elf: handle addition overflow in _dl_find_object_update_1 [BZ #32245]
+    
+    The remaining_to_add variable can be 0 if (current_used + count) wraps,
+    This is caught by GCC 14+ on hppa, which determines from there that
+    target_seg could be be NULL when remaining_to_add is zero, which in
+    turns causes a -Wstringop-overflow warning:
+    
+     In file included from ../include/atomic.h:49,
+                      from dl-find_object.c:20:
+     In function '_dlfo_update_init_seg',
+         inlined from '_dl_find_object_update_1' at dl-find_object.c:689:30,
+         inlined from '_dl_find_object_update' at dl-find_object.c:805:13:
+     ../sysdeps/unix/sysv/linux/hppa/atomic-machine.h:44:4: error: '__atomic_store_4' writing 4 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
+        44 |    __atomic_store_n ((mem), (val), __ATOMIC_RELAXED);                        \
+           |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     dl-find_object.c:644:3: note: in expansion of macro 'atomic_store_relaxed'
+       644 |   atomic_store_relaxed (&seg->size, new_seg_size);
+           |   ^~~~~~~~~~~~~~~~~~~~
+     In function '_dl_find_object_update':
+     cc1: note: destination object is likely at address zero
+    
+    In practice, this is not possible as it represent counts of link maps.
+    Link maps have sizes larger than 1 byte, so the sum of any two link map
+    counts will always fit within a size_t without wrapping around.
+    
+    This patch therefore adds a check on remaining_to_add == 0 and tell GCC
+    that this can not happen using __builtin_unreachable.
+    
+    Thanks to Andreas Schwab for the investigation.
+    
+    Closes: BZ #32245
+    Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>
+    Tested-by: John David Anglin <dave.anglin@bell.net>
+    Reviewed-by: Florian Weimer <fweimer@redhat.com>
+    (cherry picked from commit 6c915c73d08028987232f6dc718f218c61113240)
+
+diff --git a/NEWS b/NEWS
+index dc815fb6d3..bd0b3bd66a 100644
+--- a/NEWS
++++ b/NEWS
+@@ -19,6 +19,7 @@ The following bugs are resolved with this release:
+   [32052] Name space violation in fortify wrappers
+   [32137] libio: Attempt wide backup free only for non-legacy code
+   [32231] elf: Change ldconfig auxcache magic number
++  [32245] glibc -Wstringop-overflow= build failure on hppa
+ 
+ Version 2.40
+ 
+diff --git a/elf/dl-find_object.c b/elf/dl-find_object.c
+index 449302eda3..ae18b438d3 100644
+--- a/elf/dl-find_object.c
++++ b/elf/dl-find_object.c
+@@ -662,6 +662,14 @@ _dl_find_object_update_1 (struct link_map **loaded, size_t count)
+     = _dlfo_loaded_mappings[!active_idx];
+   size_t remaining_to_add = current_used + count;
+ 
++  /* remaining_to_add can be 0 if (current_used + count) wraps, but in practice
++     this is not possible as it represent counts of link maps.  Link maps have
++     sizes larger than 1 byte, so the sum of any two link map counts will
++     always fit within a size_t without wrapping around.  This check ensures
++     that target_seg is not erroneously considered potentially NULL by GCC. */
++  if (remaining_to_add == 0)
++    __builtin_unreachable ();
++
+   /* Ensure that the new segment chain has enough space.  */
+   {
+     size_t new_allocated
+
+commit 9b9545ba27613fa41efdfa7965b6fc580bf1b919
+Author: Michael Jeanson <mjeanson@efficios.com>
+Date:   Thu Nov 7 22:23:49 2024 +0100
+
+    nptl: initialize rseq area prior to registration
+    
+    Per the rseq syscall documentation, 3 fields are required to be
+    initialized by userspace prior to registration, they are 'cpu_id',
+    'rseq_cs' and 'flags'. Since we have no guarantee that 'struct pthread'
+    is cleared on all architectures, explicitly set those 3 fields prior to
+    registration.
+    
+    Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+    Reviewed-by: Florian Weimer <fweimer@redhat.com>
+    (cherry picked from commit 97f60abd25628425971f07e9b0e7f8eec0741235)
+
+diff --git a/nptl/descr.h b/nptl/descr.h
+index 8cef95810c..c4bdd7757a 100644
+--- a/nptl/descr.h
++++ b/nptl/descr.h
+@@ -414,6 +414,8 @@ struct pthread
+     {
+       uint32_t cpu_id_start;
+       uint32_t cpu_id;
++      uint64_t rseq_cs;
++      uint32_t flags;
+     };
+     char pad[32];		/* Original rseq area size.  */
+   } rseq_area __attribute__ ((aligned (32)));
+diff --git a/sysdeps/unix/sysv/linux/rseq-internal.h b/sysdeps/unix/sysv/linux/rseq-internal.h
+index 7ea935b4ad..37a8f630b6 100644
+--- a/sysdeps/unix/sysv/linux/rseq-internal.h
++++ b/sysdeps/unix/sysv/linux/rseq-internal.h
+@@ -51,11 +51,21 @@ rseq_register_current_thread (struct pthread *self, bool do_rseq)
+         /* The initial implementation used only 20 bytes out of 32,
+            but still expected size 32.  */
+         size = RSEQ_AREA_SIZE_INITIAL;
++
++      /* Initialize the rseq fields that are read by the kernel on
++         registration, there is no guarantee that struct pthread is
++         cleared on all architectures.  */
++      THREAD_SETMEM (self, rseq_area.cpu_id, RSEQ_CPU_ID_UNINITIALIZED);
++      THREAD_SETMEM (self, rseq_area.rseq_cs, 0);
++      THREAD_SETMEM (self, rseq_area.flags, 0);
++
+       int ret = INTERNAL_SYSCALL_CALL (rseq, &self->rseq_area,
+                                        size, 0, RSEQ_SIG);
+       if (!INTERNAL_SYSCALL_ERROR_P (ret))
+         return true;
+     }
++  /* When rseq is disabled by tunables or the registration fails, inform
++     userspace by setting 'cpu_id' to RSEQ_CPU_ID_REGISTRATION_FAILED.  */
+   THREAD_SETMEM (self, rseq_area.cpu_id, RSEQ_CPU_ID_REGISTRATION_FAILED);
+   return false;
+ }
+
+commit 091dd12831792cef16eee24fe240c73a25b47a1d
+Author: Michael Jeanson <mjeanson@efficios.com>
+Date:   Wed Nov 20 14:15:42 2024 -0500
+
+    nptl: initialize cpu_id_start prior to rseq registration
+    
+    When adding explicit initialization of rseq fields prior to
+    registration, I glossed over the fact that 'cpu_id_start' is also
+    documented as initialized by user-space.
+    
+    While current kernels don't validate the content of this field on
+    registration, future ones could.
+    
+    Signed-off-by: Michael Jeanson <mjeanson@efficios.com>
+    Reviewed-by: Mathieu Desnoyers <mathieu.desnoyers@efficios.com>
+    (cherry picked from commit d9f40387d3305d97e30a8cf8724218c42a63680a)
+
+diff --git a/sysdeps/unix/sysv/linux/rseq-internal.h b/sysdeps/unix/sysv/linux/rseq-internal.h
+index 37a8f630b6..ef3eab1fef 100644
+--- a/sysdeps/unix/sysv/linux/rseq-internal.h
++++ b/sysdeps/unix/sysv/linux/rseq-internal.h
+@@ -56,6 +56,7 @@ rseq_register_current_thread (struct pthread *self, bool do_rseq)
+          registration, there is no guarantee that struct pthread is
+          cleared on all architectures.  */
+       THREAD_SETMEM (self, rseq_area.cpu_id, RSEQ_CPU_ID_UNINITIALIZED);
++      THREAD_SETMEM (self, rseq_area.cpu_id_start, 0);
+       THREAD_SETMEM (self, rseq_area.rseq_cs, 0);
+       THREAD_SETMEM (self, rseq_area.flags, 0);
+ 
+
+commit c6cdab1e01bc11bc4036dc5b1be6086f6259c123
+Author: Sam James <sam@gentoo.org>
+Date:   Mon Dec 9 23:11:25 2024 +0000
+
+    malloc: add indirection for malloc(-like) functions in tests [BZ #32366]
+    
+    GCC 15 introduces allocation dead code removal (DCE) for PR117370 in
+    r15-5255-g7828dc070510f8. This breaks various glibc tests which want
+    to assert various properties of the allocator without doing anything
+    obviously useful with the allocated memory.
+    
+    Alexander Monakov rightly pointed out that we can and should do better
+    than passing -fno-malloc-dce to paper over the problem. Not least because
+    GCC 14 already does such DCE where there's no testing of malloc's return
+    value against NULL, and LLVM has such optimisations too.
+    
+    Handle this by providing malloc (and friends) wrappers with a volatile
+    function pointer to obscure that we're calling malloc (et. al) from the
+    compiler.
+    
+    Reviewed-by: Paul Eggert <eggert@cs.ucla.edu>
+    (cherry picked from commit a9944a52c967ce76a5894c30d0274b824df43c7a)
+
+diff --git a/malloc/tst-aligned-alloc.c b/malloc/tst-aligned-alloc.c
+index 91167d1392..b0f05a8fec 100644
+--- a/malloc/tst-aligned-alloc.c
++++ b/malloc/tst-aligned-alloc.c
+@@ -25,6 +25,8 @@
+ #include <libc-diag.h>
+ #include <support/check.h>
+ 
++#include "tst-malloc-aux.h"
++
+ static int
+ do_test (void)
+ {
+diff --git a/malloc/tst-compathooks-off.c b/malloc/tst-compathooks-off.c
+index d0106f3fb7..4cce6e5a80 100644
+--- a/malloc/tst-compathooks-off.c
++++ b/malloc/tst-compathooks-off.c
+@@ -25,6 +25,8 @@
+ #include <support/check.h>
+ #include <support/support.h>
+ 
++#include "tst-malloc-aux.h"
++
+ extern void (*volatile __free_hook) (void *, const void *);
+ extern void *(*volatile __malloc_hook)(size_t, const void *);
+ extern void *(*volatile __realloc_hook)(void *, size_t, const void *);
+diff --git a/malloc/tst-malloc-aux.h b/malloc/tst-malloc-aux.h
+new file mode 100644
+index 0000000000..54908b4a24
+--- /dev/null
++++ b/malloc/tst-malloc-aux.h
+@@ -0,0 +1,41 @@
++/* Wrappers for malloc-like functions to allow testing the implementation
++   without optimization.
++   Copyright (C) 2024 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public License as
++   published by the Free Software Foundation; either version 2.1 of the
++   License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; see the file COPYING.LIB.  If
++   not, see <https://www.gnu.org/licenses/>.  */
++
++#ifndef TST_MALLOC_AUX_H
++#define TST_MALLOC_AUX_H
++
++#include <stddef.h>
++#include <stdlib.h>
++
++static void *(*volatile aligned_alloc_indirect)(size_t, size_t) = aligned_alloc;
++static void *(*volatile calloc_indirect)(size_t, size_t) = calloc;
++static void *(*volatile malloc_indirect)(size_t) = malloc;
++static void *(*volatile realloc_indirect)(void*, size_t) = realloc;
++
++#undef aligned_alloc
++#undef calloc
++#undef malloc
++#undef realloc
++
++#define aligned_alloc aligned_alloc_indirect
++#define calloc calloc_indirect
++#define malloc malloc_indirect
++#define realloc realloc_indirect
++
++#endif /* TST_MALLOC_AUX_H */
+diff --git a/malloc/tst-malloc-check.c b/malloc/tst-malloc-check.c
+index fde8863ad7..cc88bff3b3 100644
+--- a/malloc/tst-malloc-check.c
++++ b/malloc/tst-malloc-check.c
+@@ -20,6 +20,8 @@
+ #include <stdlib.h>
+ #include <libc-diag.h>
+ 
++#include "tst-malloc-aux.h"
++
+ static int errors = 0;
+ 
+ static void
+diff --git a/malloc/tst-malloc-too-large.c b/malloc/tst-malloc-too-large.c
+index 8e9e0d5fa2..2b91377e54 100644
+--- a/malloc/tst-malloc-too-large.c
++++ b/malloc/tst-malloc-too-large.c
+@@ -43,6 +43,7 @@
+ #include <unistd.h>
+ #include <sys/param.h>
+ 
++#include "tst-malloc-aux.h"
+ 
+ /* This function prepares for each 'too-large memory allocation' test by
+    performing a small successful malloc/free and resetting errno prior to
+diff --git a/malloc/tst-malloc.c b/malloc/tst-malloc.c
+index f7a6e4654c..68af399022 100644
+--- a/malloc/tst-malloc.c
++++ b/malloc/tst-malloc.c
+@@ -22,6 +22,8 @@
+ #include <libc-diag.h>
+ #include <time.h>
+ 
++#include "tst-malloc-aux.h"
++
+ static int errors = 0;
+ 
+ static void
+diff --git a/malloc/tst-realloc.c b/malloc/tst-realloc.c
+index f50499ecb1..74a28fb45e 100644
+--- a/malloc/tst-realloc.c
++++ b/malloc/tst-realloc.c
+@@ -23,6 +23,8 @@
+ #include <libc-diag.h>
+ #include <support/check.h>
+ 
++#include "tst-malloc-aux.h"
++
+ static int
+ do_test (void)
+ {
+diff --git a/support/support.h b/support/support.h
+index ba21ec9b5a..1a77f79793 100644
+--- a/support/support.h
++++ b/support/support.h
+@@ -113,7 +113,7 @@ void *xposix_memalign (size_t alignment, size_t n)
+   __attribute_malloc__ __attribute_alloc_align__ ((1))
+   __attribute_alloc_size__ ((2)) __attr_dealloc_free __returns_nonnull;
+ char *xasprintf (const char *format, ...)
+-  __attribute__ ((format (printf, 1, 2), malloc)) __attr_dealloc_free
++  __attribute__ ((format (printf, 1, 2), __malloc__)) __attr_dealloc_free
+   __returns_nonnull;
+ char *xstrdup (const char *) __attr_dealloc_free __returns_nonnull;
+ char *xstrndup (const char *, size_t) __attr_dealloc_free __returns_nonnull;
+diff --git a/test-skeleton.c b/test-skeleton.c
+index ae185a4f28..690f26e7cf 100644
+--- a/test-skeleton.c
++++ b/test-skeleton.c
+@@ -27,7 +27,6 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <getopt.h>
+-#include <malloc.h>
+ #include <paths.h>
+ #include <search.h>
+ #include <signal.h>
+
+commit 846e64257e5fc9b5b723c2eec2b7155ab5944d1f
+Author: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date:   Fri Sep 13 11:10:05 2024 -0300
+
+    support: Make support_process_state_wait return the found state
+    
+    So caller can check which state was found if multiple ones are
+    asked.
+    
+    Checked on x86_64-linux-gnu.
+    
+    Reviewed-by: Florian Weimer <fweimer@redhat.com>
+    (cherry picked from commit 38316352e0f742f3a2b5816a61a4b603cb5573f8)
+    (cherry picked from commit 2e38c5a090b3a54040b6e508d42e5a76e492c6e8)
+
+diff --git a/support/process_state.h b/support/process_state.h
+index 1cf902e91b..9541d8c343 100644
+--- a/support/process_state.h
++++ b/support/process_state.h
+@@ -31,13 +31,16 @@ enum support_process_state
+   support_process_state_dead         = 0x20,  /* X (dead).  */
+   support_process_state_zombie       = 0x40,  /* Z (zombie).  */
+   support_process_state_parked       = 0x80,  /* P (parked).  */
++  support_process_state_invalid      = 0x100  /* Invalid state.  */
+ };
+ 
+ /* Wait for process PID to reach state STATE.  It can be a combination of
+    multiple possible states ('process_state_running | process_state_sleeping')
+    where the function return when any of these state are observed.
+    For an invalid state not represented by SUPPORT_PROCESS_STATE, it fallbacks
+-   to a 2 second sleep.  */
+-void support_process_state_wait (pid_t pid, enum support_process_state state);
++   to a 2 second sleep.
++   Return the found process state.  */
++enum support_process_state
++support_process_state_wait (pid_t pid, enum support_process_state state);
+ 
+ #endif
+diff --git a/support/support_process_state.c b/support/support_process_state.c
+index 062335234f..ae8e0a531c 100644
+--- a/support/support_process_state.c
++++ b/support/support_process_state.c
+@@ -27,7 +27,7 @@
+ #include <support/xstdio.h>
+ #include <support/check.h>
+ 
+-void
++enum support_process_state
+ support_process_state_wait (pid_t pid, enum support_process_state state)
+ {
+ #ifdef __linux__
+@@ -75,7 +75,7 @@ support_process_state_wait (pid_t pid, enum support_process_state state)
+ 	  {
+ 	    free (line);
+ 	    xfclose (fstatus);
+-	    return;
++	    return process_states[i].s;
+ 	  }
+ 
+       rewind (fstatus);
+@@ -90,4 +90,6 @@ support_process_state_wait (pid_t pid, enum support_process_state state)
+   /* Fallback to nanosleep if an invalid state is found.  */
+ #endif
+   nanosleep (&(struct timespec) { 1, 0 }, NULL);
++
++  return support_process_state_invalid;
+ }
+diff --git a/support/tst-support-process_state.c b/support/tst-support-process_state.c
+index d73269320f..4a88eae3a7 100644
+--- a/support/tst-support-process_state.c
++++ b/support/tst-support-process_state.c
+@@ -68,28 +68,39 @@ do_test (void)
+   if (test_verbose)
+     printf ("info: waiting pid %d, state_stopped/state_tracing_stop\n",
+ 	    (int) pid);
+-  support_process_state_wait (pid, stop_state);
++  {
++    enum support_process_state state =
++      support_process_state_wait (pid, stop_state);
++    TEST_VERIFY (state == support_process_state_stopped
++		 || state == support_process_state_tracing_stop);
++  }
+ 
+   if (kill (pid, SIGCONT) != 0)
+     FAIL_RET ("kill (%d, SIGCONT): %m\n", pid);
+ 
+   if (test_verbose)
+     printf ("info: waiting pid %d, state_sleeping\n", (int) pid);
+-  support_process_state_wait (pid, support_process_state_sleeping);
++  TEST_COMPARE (support_process_state_wait (pid,
++					    support_process_state_sleeping),
++		support_process_state_sleeping);
+ 
+   if (kill (pid, SIGUSR1) != 0)
+     FAIL_RET ("kill (%d, SIGUSR1): %m\n", pid);
+ 
+   if (test_verbose)
+     printf ("info: waiting pid %d, state_running\n", (int) pid);
+-  support_process_state_wait (pid, support_process_state_running);
++  TEST_COMPARE (support_process_state_wait (pid,
++					    support_process_state_running),
++		support_process_state_running);
+ 
+   if (kill (pid, SIGKILL) != 0)
+     FAIL_RET ("kill (%d, SIGKILL): %m\n", pid);
+ 
+   if (test_verbose)
+     printf ("info: waiting pid %d, state_zombie\n", (int) pid);
+-  support_process_state_wait (pid, support_process_state_zombie);
++  TEST_COMPARE (support_process_state_wait (pid,
++					    support_process_state_zombie),
++		support_process_state_zombie);;
+ 
+   siginfo_t info;
+   int r = waitid (P_PID, pid, &info, WEXITED);
+
+commit 11d9f49cebe64939f50e16a59c9ebefb80a294ab
+Author: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date:   Fri Sep 13 11:11:56 2024 -0300
+
+    sparc: Fix restartable syscalls (BZ 32173)
+    
+    The commit 'sparc: Use Linux kABI for syscall return'
+    (86c5d2cf0ce046279baddc7faa27da71f1a89fde) did not take into account
+    a subtle sparc syscall kABI constraint.  For syscalls that might block
+    indefinitely, on an interrupt (like SIGCONT) the kernel will set the
+    instruction pointer to just before the syscall:
+    
+    arch/sparc/kernel/signal_64.c
+    476 static void do_signal(struct pt_regs *regs, unsigned long orig_i0)
+    477 {
+    [...]
+    525                 if (restart_syscall) {
+    526                         switch (regs->u_regs[UREG_I0]) {
+    527                         case ERESTARTNOHAND:
+    528                         case ERESTARTSYS:
+    529                         case ERESTARTNOINTR:
+    530                                 /* replay the system call when we are done */
+    531                                 regs->u_regs[UREG_I0] = orig_i0;
+    532                                 regs->tpc -= 4;
+    533                                 regs->tnpc -= 4;
+    534                                 pt_regs_clear_syscall(regs);
+    535                                 fallthrough;
+    536                         case ERESTART_RESTARTBLOCK:
+    537                                 regs->u_regs[UREG_G1] = __NR_restart_syscall;
+    538                                 regs->tpc -= 4;
+    539                                 regs->tnpc -= 4;
+    540                                 pt_regs_clear_syscall(regs);
+    541                         }
+    
+    However, on a SIGCONT it seems that 'g1' register is being clobbered after the
+    syscall returns.  Before 86c5d2cf0ce046279, the 'g1' was always placed jus
+    before the 'ta' instruction which then reloads the syscall number and restarts
+    the syscall.
+    
+    On master, where 'g1' might be placed before 'ta':
+    
+      $ cat test.c
+      #include <unistd.h>
+    
+      int main ()
+      {
+        pause ();
+      }
+      $ gcc test.c -o test
+      $ strace -f ./t
+      [...]
+      ppoll(NULL, 0, NULL, NULL, 0
+    
+    On another terminal
+    
+      $ kill -STOP 2262828
+    
+      $ strace -f ./t
+      [...]
+      --- SIGSTOP {si_signo=SIGSTOP, si_code=SI_USER, si_pid=2521813, si_uid=8289} ---
+      --- stopped by SIGSTOP ---
+    
+    And then
+    
+      $ kill -CONT 2262828
+    
+    Results in:
+    
+      --- SIGCONT {si_signo=SIGCONT, si_code=SI_USER, si_pid=2521813, si_uid=8289} ---
+      restart_syscall(<... resuming interrupted ppoll ...>) = -1 EINTR (Interrupted system call)
+    
+    Where the expected behaviour would be:
+    
+      $ strace -f ./t
+      [...]
+      ppoll(NULL, 0, NULL, NULL, 0)           = ? ERESTARTNOHAND (To be restarted if no handler)
+      --- SIGSTOP {si_signo=SIGSTOP, si_code=SI_USER, si_pid=2521813, si_uid=8289} ---
+      --- stopped by SIGSTOP ---
+      --- SIGCONT {si_signo=SIGCONT, si_code=SI_USER, si_pid=2521813, si_uid=8289} ---
+      ppoll(NULL, 0, NULL, NULL, 0
+    
+    Just moving the 'g1' setting near the syscall asm is not suffice,
+    the compiler might optimize it away (as I saw on cancellation.c by
+    trying this fix).  Instead, I have change the inline asm to put the
+    'g1' setup in ithe asm block.  This would require to change the asm
+    constraint for INTERNAL_SYSCALL_NCS, since the syscall number is not
+    constant.
+    
+    Checked on sparc64-linux-gnu.
+    
+    Reported-by: René Rebe <rene@exactcode.de>
+    Tested-by: Sam James <sam@gentoo.org>
+    Reviewed-by: Sam James <sam@gentoo.org>
+    (cherry picked from commit 2c1903cbbac0022153a67776f474c221250ad6ed)
+    (cherry picked from commit 1cd7e13289b91e1495a1865c1f678196d1bb7be4)
+
+diff --git a/sysdeps/unix/sysv/linux/Makefile b/sysdeps/unix/sysv/linux/Makefile
+index 59998c7af4..34890ef69a 100644
+--- a/sysdeps/unix/sysv/linux/Makefile
++++ b/sysdeps/unix/sysv/linux/Makefile
+@@ -227,6 +227,7 @@ tests += \
+   tst-scm_rights \
+   tst-sigtimedwait \
+   tst-sync_file_range \
++  tst-syscall-restart \
+   tst-sysconf-iov_max \
+   tst-sysvmsg-linux \
+   tst-sysvsem-linux \
+diff --git a/sysdeps/unix/sysv/linux/sparc/sparc32/sysdep.h b/sysdeps/unix/sysv/linux/sparc/sparc32/sysdep.h
+index d2d68f5312..c2ffbb5c8f 100644
+--- a/sysdeps/unix/sysv/linux/sparc/sparc32/sysdep.h
++++ b/sysdeps/unix/sysv/linux/sparc/sparc32/sysdep.h
+@@ -107,6 +107,7 @@ ENTRY(name);					\
+ #else  /* __ASSEMBLER__ */
+ 
+ #define __SYSCALL_STRING						\
++	"mov	%[scn], %%g1;"						\
+ 	"ta	0x10;"							\
+ 	"bcc	1f;"							\
+ 	" nop;"								\
+@@ -114,7 +115,7 @@ ENTRY(name);					\
+ 	"1:"
+ 
+ #define __SYSCALL_CLOBBERS						\
+-	"f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7",			\
++	"g1", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7",		\
+ 	"f8", "f9", "f10", "f11", "f12", "f13", "f14", "f15",		\
+ 	"f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",		\
+ 	"f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31",		\
+diff --git a/sysdeps/unix/sysv/linux/sparc/sparc64/sysdep.h b/sysdeps/unix/sysv/linux/sparc/sparc64/sysdep.h
+index 96047424e9..5598fab08a 100644
+--- a/sysdeps/unix/sysv/linux/sparc/sparc64/sysdep.h
++++ b/sysdeps/unix/sysv/linux/sparc/sparc64/sysdep.h
+@@ -106,6 +106,7 @@ ENTRY(name);					\
+ #else  /* __ASSEMBLER__ */
+ 
+ #define __SYSCALL_STRING						\
++	"mov	%[scn], %%g1;"						\
+ 	"ta	0x6d;"							\
+ 	"bcc,pt	%%xcc, 1f;"						\
+ 	" nop;"								\
+@@ -113,7 +114,7 @@ ENTRY(name);					\
+ 	"1:"
+ 
+ #define __SYSCALL_CLOBBERS						\
+-	"f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7",			\
++	"g1", "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7",		\
+ 	"f8", "f9", "f10", "f11", "f12", "f13", "f14", "f15",		\
+ 	"f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",		\
+ 	"f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31",		\
+diff --git a/sysdeps/unix/sysv/linux/sparc/sysdep.h b/sysdeps/unix/sysv/linux/sparc/sysdep.h
+index dcabb57fe2..c287740a8c 100644
+--- a/sysdeps/unix/sysv/linux/sparc/sysdep.h
++++ b/sysdeps/unix/sysv/linux/sparc/sysdep.h
+@@ -50,97 +50,109 @@
+ 
+ #undef INTERNAL_SYSCALL_NCS
+ #define INTERNAL_SYSCALL_NCS(name, nr, args...) \
+-  internal_syscall##nr(__SYSCALL_STRING, name, args)
++  _internal_syscall##nr(__SYSCALL_STRING, "p", name, args)
+ 
+-#define internal_syscall0(string,name,dummy...)			\
++#define _internal_syscall0(string,nc,name,dummy...)	\
+ ({									\
+-	register long int __g1 __asm__ ("g1") = (name);			\
+ 	register long __o0 __asm__ ("o0");				\
++	long int _name = (long int) (name);				\
+ 	__asm __volatile (string : "=r" (__o0) :			\
+-			  "r" (__g1) :					\
++			  [scn] nc (_name) :				\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	__o0;								\
+ })
++#define internal_syscall0(string,name,args...)				\
++  _internal_syscall0(string, "i", name, args)
+ 
+-#define internal_syscall1(string,name,arg1)				\
++#define _internal_syscall1(string,nc,name,arg1)				\
+ ({									\
+ 	long int _arg1 = (long int) (arg1);				\
+-	register long int __g1 __asm__("g1") = (name);			\
++	long int _name = (long int) (name);				\
+ 	register long int  __o0 __asm__ ("o0") = _arg1;			\
+-	__asm __volatile (string : "=r" (__o0) :			\
+-			  "r" (__g1), "0" (__o0) :			\
++	__asm __volatile (string : "+r" (__o0) :			\
++			  [scn] nc (_name) :				\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	__o0;								\
+ })
++#define internal_syscall1(string,name,args...)				\
++  _internal_syscall1(string, "i", name, args)
+ 
+-#define internal_syscall2(string,name,arg1,arg2)			\
++#define _internal_syscall2(string,nc,name,arg1,arg2)			\
+ ({									\
+ 	long int _arg1 = (long int) (arg1);				\
+ 	long int _arg2 = (long int) (arg2);				\
+-	register long int __g1 __asm__("g1") = (name);			\
++	long int _name = (long int) (name);				\
+ 	register long int __o0 __asm__ ("o0") = _arg1;			\
+ 	register long int __o1 __asm__ ("o1") = _arg2;			\
+-	__asm __volatile (string : "=r" (__o0) :			\
+-			  "r" (__g1), "0" (__o0), "r" (__o1) :		\
++	__asm __volatile (string : "+r" (__o0) :			\
++			  [scn] nc (_name), "r" (__o1) :		\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	__o0;								\
+ })
++#define internal_syscall2(string,name,args...)				\
++  _internal_syscall2(string, "i", name, args)
+ 
+-#define internal_syscall3(string,name,arg1,arg2,arg3)			\
++#define _internal_syscall3(string,nc,name,arg1,arg2,arg3)		\
+ ({									\
+ 	long int _arg1 = (long int) (arg1);				\
+ 	long int _arg2 = (long int) (arg2);				\
+ 	long int _arg3 = (long int) (arg3);				\
+-	register long int __g1 __asm__("g1") = (name);			\
++	long int _name = (long int) (name);				\
+ 	register long int __o0 __asm__ ("o0") = _arg1;			\
+ 	register long int __o1 __asm__ ("o1") = _arg2;			\
+ 	register long int __o2 __asm__ ("o2") = _arg3;			\
+-	__asm __volatile (string : "=r" (__o0) :			\
+-			  "r" (__g1), "0" (__o0), "r" (__o1),		\
++	__asm __volatile (string : "+r" (__o0) :			\
++			  [scn] nc (_name), "r" (__o1),			\
+ 			  "r" (__o2) :					\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	__o0;								\
+ })
++#define internal_syscall3(string,name,args...)				\
++  _internal_syscall3(string, "i", name, args)
+ 
+-#define internal_syscall4(string,name,arg1,arg2,arg3,arg4)		\
++#define _internal_syscall4(string,nc,name,arg1,arg2,arg3,arg4)		\
+ ({									\
+ 	long int _arg1 = (long int) (arg1);				\
+ 	long int _arg2 = (long int) (arg2);				\
+ 	long int _arg3 = (long int) (arg3);				\
+ 	long int _arg4 = (long int) (arg4);				\
+-	register long int __g1 __asm__("g1") = (name);			\
++	long int _name = (long int) (name);				\
+ 	register long int __o0 __asm__ ("o0") = _arg1;			\
+ 	register long int __o1 __asm__ ("o1") = _arg2;			\
+ 	register long int __o2 __asm__ ("o2") = _arg3;			\
+ 	register long int __o3 __asm__ ("o3") = _arg4;			\
+-	__asm __volatile (string : "=r" (__o0) :			\
+-			  "r" (__g1), "0" (__o0), "r" (__o1),		\
++	__asm __volatile (string : "+r" (__o0) :			\
++			  [scn] nc (_name), "r" (__o1),			\
+ 			  "r" (__o2), "r" (__o3) :			\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	__o0;								\
+ })
++#define internal_syscall4(string,name,args...)				\
++  _internal_syscall4(string, "i", name, args)
+ 
+-#define internal_syscall5(string,name,arg1,arg2,arg3,arg4,arg5)		\
++#define _internal_syscall5(string,nc,name,arg1,arg2,arg3,arg4,arg5)	\
+ ({									\
+ 	long int _arg1 = (long int) (arg1);				\
+ 	long int _arg2 = (long int) (arg2);				\
+ 	long int _arg3 = (long int) (arg3);				\
+ 	long int _arg4 = (long int) (arg4);				\
+ 	long int _arg5 = (long int) (arg5);				\
+-	register long int __g1 __asm__("g1") = (name);			\
++	long int _name = (long int) (name);				\
+ 	register long int __o0 __asm__ ("o0") = _arg1;			\
+ 	register long int __o1 __asm__ ("o1") = _arg2;			\
+ 	register long int __o2 __asm__ ("o2") = _arg3;			\
+ 	register long int __o3 __asm__ ("o3") = _arg4;			\
+ 	register long int __o4 __asm__ ("o4") = _arg5;			\
+-	__asm __volatile (string : "=r" (__o0) :			\
+-			  "r" (__g1), "0" (__o0), "r" (__o1),		\
++	__asm __volatile (string : "+r" (__o0) :			\
++			  [scn] nc (_name), "r" (__o1),			\
+ 			  "r" (__o2), "r" (__o3), "r" (__o4) :		\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	__o0;								\
+ })
++#define internal_syscall5(string,name,args...)				\
++  _internal_syscall5(string, "i", name, args)
+ 
+-#define internal_syscall6(string,name,arg1,arg2,arg3,arg4,arg5,arg6)	\
++#define _internal_syscall6(string,nc,name,arg1,arg2,arg3,arg4,arg5,arg6)\
+ ({									\
+ 	long int _arg1 = (long int) (arg1);				\
+ 	long int _arg2 = (long int) (arg2);				\
+@@ -148,20 +160,22 @@
+ 	long int _arg4 = (long int) (arg4);				\
+ 	long int _arg5 = (long int) (arg5);				\
+ 	long int _arg6 = (long int) (arg6);				\
+-	register long int __g1 __asm__("g1") = (name);			\
++	long int _name = (long int) (name);				\
+ 	register long int __o0 __asm__ ("o0") = _arg1;			\
+ 	register long int __o1 __asm__ ("o1") = _arg2;			\
+ 	register long int __o2 __asm__ ("o2") = _arg3;			\
+ 	register long int __o3 __asm__ ("o3") = _arg4;			\
+ 	register long int __o4 __asm__ ("o4") = _arg5;			\
+ 	register long int __o5 __asm__ ("o5") = _arg6;			\
+-	__asm __volatile (string : "=r" (__o0) :			\
+-			  "r" (__g1), "0" (__o0), "r" (__o1),		\
++	__asm __volatile (string : "+r" (__o0) :			\
++			  [scn] nc (_name), "r" (__o1),			\
+ 			  "r" (__o2), "r" (__o3), "r" (__o4),		\
+ 			  "r" (__o5) :					\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	__o0;								\
+ })
++#define internal_syscall6(string,name,args...)				\
++  _internal_syscall6(string, "i", name, args)
+ 
+ #define INLINE_CLONE_SYSCALL(arg1,arg2,arg3,arg4,arg5)			\
+ ({									\
+@@ -170,15 +184,15 @@
+ 	long int _arg3 = (long int) (arg3);				\
+ 	long int _arg4 = (long int) (arg4);				\
+ 	long int _arg5 = (long int) (arg5);				\
++	long int _name = __NR_clone;					\
+ 	register long int __o0 __asm__ ("o0") = _arg1;			\
+ 	register long int __o1 __asm__ ("o1") = _arg2;			\
+ 	register long int __o2 __asm__ ("o2") = _arg3;			\
+ 	register long int __o3 __asm__ ("o3") = _arg4;			\
+ 	register long int __o4 __asm__ ("o4") = _arg5;			\
+-	register long int __g1 __asm__ ("g1") = __NR_clone;		\
+ 	__asm __volatile (__SYSCALL_STRING :				\
+ 			  "=r" (__o0), "=r" (__o1) :			\
+-			  "r" (__g1), "0" (__o0), "1" (__o1),		\
++			  [scn] "i" (_name), "0" (__o0), "1" (__o1),	\
+ 			  "r" (__o2), "r" (__o3), "r" (__o4) :		\
+ 			  __SYSCALL_CLOBBERS);				\
+ 	if (__glibc_unlikely ((unsigned long int) (__o0) > -4096UL))	\
+diff --git a/sysdeps/unix/sysv/linux/tst-syscall-restart.c b/sysdeps/unix/sysv/linux/tst-syscall-restart.c
+new file mode 100644
+index 0000000000..84a8a41b5c
+--- /dev/null
++++ b/sysdeps/unix/sysv/linux/tst-syscall-restart.c
+@@ -0,0 +1,112 @@
++/* Test if a syscall is correctly restarted.
++   Copyright (C) 2024 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <support/xsignal.h>
++#include <support/check.h>
++#include <support/process_state.h>
++#include <support/xunistd.h>
++#include <support/xthread.h>
++#include <sys/wait.h>
++
++static int
++check_pid (pid_t pid)
++{
++  /* Wait until the child has called pause and it blocking on kernel.  */
++  support_process_state_wait (pid, support_process_state_sleeping);
++
++  TEST_COMPARE (kill (pid, SIGSTOP), 0);
++
++  /* Adding process_state_tracing_stop ('t') allows the test to work under
++     trace programs such as ptrace.  */
++  support_process_state_wait (pid, support_process_state_stopped
++				   | support_process_state_tracing_stop);
++
++  TEST_COMPARE (kill (pid, SIGCONT), 0);
++
++  enum support_process_state state
++    = support_process_state_wait (pid, support_process_state_sleeping
++				       | support_process_state_zombie);
++
++  TEST_COMPARE (state, support_process_state_sleeping);
++
++  TEST_COMPARE (kill (pid, SIGTERM), 0);
++
++  siginfo_t info;
++  TEST_COMPARE (waitid (P_PID, pid, &info, WEXITED), 0);
++  TEST_COMPARE (info.si_signo, SIGCHLD);
++  TEST_COMPARE (info.si_code, CLD_KILLED);
++  TEST_COMPARE (info.si_status, SIGTERM);
++  TEST_COMPARE (info.si_pid, pid);
++
++  return 0;
++}
++
++static void *
++tf (void *)
++{
++  pause ();
++  return NULL;
++}
++
++static void
++child_mt (void)
++{
++  /* Let only the created thread to handle signals.  */
++  sigset_t set;
++  sigfillset (&set);
++  xpthread_sigmask (SIG_BLOCK, &set, NULL);
++
++  sigdelset (&set, SIGSTOP);
++  sigdelset (&set, SIGCONT);
++  sigdelset (&set, SIGTERM);
++
++  pthread_attr_t attr;
++  xpthread_attr_init (&attr);
++  TEST_COMPARE (pthread_attr_setsigmask_np (&attr, &set), 0);
++
++  xpthread_join (xpthread_create (&attr, tf, NULL));
++}
++
++static void
++do_test_syscall (bool multithread)
++{
++  pid_t pid = xfork ();
++  if (pid == 0)
++    {
++      if (multithread)
++	child_mt ();
++      else
++	pause ();
++      _exit (127);
++    }
++
++  check_pid (pid);
++}
++
++static int
++do_test (void)
++{
++  /* Check for both single and multi thread, since they use different syscall
++     mechanisms.  */
++  do_test_syscall (false);
++  do_test_syscall (true);
++
++  return 0;
++}
++
++#include <support/test-driver.c>
+
+commit 9af64ca64c532b7e42a40b48fe5e01726a9b7943
+Author: H.J. Lu <hjl.tools@gmail.com>
+Date:   Thu Dec 5 08:39:44 2024 +0800
+
+    math: Exclude internal math symbols for tests [BZ #32414]
+    
+    Since internal tests don't have access to internal symbols in libm,
+    exclude them for internal tests.  Also make tst-strtod5 and tst-strtod5i
+    depend on $(libm) to support older versions of GCC which can't inline
+    copysign family functions.  This fixes BZ #32414.
+    
+    Signed-off-by: H.J. Lu <hjl.tools@gmail.com>
+    Reviewed-by: Sunil K Pandey <skpgkp2@gmail.com>
+    (cherry picked from commit 5df09b444835fca6e64b3d4b4a5beb19b3b2ba21)
+
+diff --git a/include/math.h b/include/math.h
+index fa11a710a6..035fd160ff 100644
+--- a/include/math.h
++++ b/include/math.h
+@@ -130,7 +130,10 @@ fabsf128 (_Float128 x)
+ }
+ # endif
+ 
+-# if !(defined __FINITE_MATH_ONLY__ && __FINITE_MATH_ONLY__ > 0)
++
++/* NB: Internal tests don't have access to internal symbols.  */
++# if !IS_IN (testsuite_internal) \
++     && !(defined __FINITE_MATH_ONLY__ && __FINITE_MATH_ONLY__ > 0)
+ #  ifndef NO_MATH_REDIRECT
+ /* Declare some functions for use within GLIBC.  Compilers typically
+    inline those functions as a single instruction.  Use an asm to
+diff --git a/stdlib/Makefile b/stdlib/Makefile
+index 8b0ac63ddb..8213fa83ef 100644
+--- a/stdlib/Makefile
++++ b/stdlib/Makefile
+@@ -603,6 +603,8 @@ $(objpfx)bug-strtod2: $(libm)
+ $(objpfx)tst-strtod-round: $(libm)
+ $(objpfx)tst-tininess: $(libm)
+ $(objpfx)tst-strtod-underflow: $(libm)
++$(objpfx)tst-strtod5: $(libm)
++$(objpfx)tst-strtod5i: $(libm)
+ $(objpfx)tst-strtod6: $(libm)
+ $(objpfx)tst-strtod-nan-locale: $(libm)
+ $(objpfx)tst-strtod-nan-sign: $(libm)
+
+commit 0b39fe801208e805cc911f64a2fdd25d04b7151e
+Author: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date:   Fri Oct 18 08:48:22 2024 -0300
+
+    linux: Fix tst-syscall-restart.c on old gcc (BZ 32283)
+    
+    To avoid a parameter name omitted error.
+    
+    (cherry picked from commit ab564362d0470d10947c24155ec048c4e14a009d)
+
+diff --git a/sysdeps/unix/sysv/linux/tst-syscall-restart.c b/sysdeps/unix/sysv/linux/tst-syscall-restart.c
+index 84a8a41b5c..0ee7dc8517 100644
+--- a/sysdeps/unix/sysv/linux/tst-syscall-restart.c
++++ b/sysdeps/unix/sysv/linux/tst-syscall-restart.c
+@@ -57,7 +57,7 @@ check_pid (pid_t pid)
+ }
+ 
+ static void *
+-tf (void *)
++tf (void *closure)
+ {
+   pause ();
+   return NULL;
+
+commit 94e4a8c7d68129075f1b494a0b26151a4f989b36
+Author: Florian Weimer <fweimer@redhat.com>
+Date:   Tue Dec 17 18:12:03 2024 +0100
+
+    x86: Avoid integer truncation with large cache sizes (bug 32470)
+    
+    Some hypervisors report 1 TiB L3 cache size.  This results
+    in some variables incorrectly getting zeroed, causing crashes
+    in memcpy/memmove because invariants are violated.
+    
+    (cherry picked from commit 61c3450db96dce96ad2b24b4f0b548e6a46d68e5)
+
+diff --git a/NEWS b/NEWS
+index bd0b3bd66a..97a1e1f5d4 100644
+--- a/NEWS
++++ b/NEWS
+@@ -20,6 +20,7 @@ The following bugs are resolved with this release:
+   [32137] libio: Attempt wide backup free only for non-legacy code
+   [32231] elf: Change ldconfig auxcache magic number
+   [32245] glibc -Wstringop-overflow= build failure on hppa
++  [32470] x86: Avoid integer truncation with large cache sizes
+ 
+ Version 2.40
+ 
+diff --git a/sysdeps/x86/dl-cacheinfo.h b/sysdeps/x86/dl-cacheinfo.h
+index a1c03b8903..ac97414b5b 100644
+--- a/sysdeps/x86/dl-cacheinfo.h
++++ b/sysdeps/x86/dl-cacheinfo.h
+@@ -961,11 +961,11 @@ dl_init_cacheinfo (struct cpu_features *cpu_features)
+     non_temporal_threshold = maximum_non_temporal_threshold;
+ 
+   /* NB: The REP MOVSB threshold must be greater than VEC_SIZE * 8.  */
+-  unsigned int minimum_rep_movsb_threshold;
++  unsigned long int minimum_rep_movsb_threshold;
+   /* NB: The default REP MOVSB threshold is 4096 * (VEC_SIZE / 16) for
+      VEC_SIZE == 64 or 32.  For VEC_SIZE == 16, the default REP MOVSB
+      threshold is 2048 * (VEC_SIZE / 16).  */
+-  unsigned int rep_movsb_threshold;
++  unsigned long int rep_movsb_threshold;
+   if (CPU_FEATURE_USABLE_P (cpu_features, AVX512F)
+       && !CPU_FEATURE_PREFERRED_P (cpu_features, Prefer_No_AVX512))
+     {
+
+commit 9fbfbd924f718663d5303858f34d1f857c375093
+Author: John David Anglin <danglin@gcc.gnu.org>
+Date:   Thu Dec 19 11:30:09 2024 -0500
+
+    hppa: Fix strace detach-vfork test
+    
+    This change implements vfork.S for direct support of the vfork
+    syscall.  clone.S is revised to correct child support for the
+    vfork case.
+    
+    The main bug was creating a frame prior to the clone syscall.
+    This was done to allow the rp and r4 registers to be saved and
+    restored from the stack frame.  r4 was used to save and restore
+    the PIC register, r19, across the system call and the call to
+    set errno.  But in the vfork case, it is undefined behavior
+    for the child to return from the function in which vfork was
+    called.  It is surprising that this usually worked.
+    
+    Syscalls on hppa save and restore rp and r19, so we don't need
+    to create a frame prior to the clone syscall.  We only need a
+    frame when __syscall_error is called.  We also don't need to
+    save and restore r19 around the call to $$dyncall as r19 is not
+    used in the code after $$dyncall.
+    
+    This considerably simplifies clone.S.
+    
+    Signed-off-by: John David Anglin <dave.anglin@bell.net>
+
+diff --git a/sysdeps/unix/sysv/linux/hppa/clone.S b/sysdeps/unix/sysv/linux/hppa/clone.S
+index a31afea429..c18163d0f7 100644
+--- a/sysdeps/unix/sysv/linux/hppa/clone.S
++++ b/sysdeps/unix/sysv/linux/hppa/clone.S
+@@ -59,16 +59,6 @@
+ 
+         .text
+ ENTRY(__clone)
+-	/* Prologue */
+-	stwm	%r4, 64(%sp)
+-	.cfi_def_cfa_offset -64
+-	.cfi_offset 4, 0
+-	stw	%sp, -4(%sp)
+-#ifdef PIC
+-	stw	%r19, -32(%sp)
+-	.cfi_offset 19, 32
+-#endif
+-
+ 	/* Sanity check arguments.  */
+ 	comib,=,n	0,%arg0,.LerrorSanity	/* no NULL function pointers */
+ 	comib,=,n	0,%arg1,.LerrorSanity	/* no NULL stack pointers */
+@@ -87,54 +77,34 @@ ENTRY(__clone)
+ 	/* User stack pointer is in the correct register already */
+ 
+ 	/* Load args from stack... */
+-	ldw	-116(%sp), %r24		/* Load parent_tidptr */
+-	ldw	-120(%sp), %r23 	/* Load newtls */
+-	ldw	-124(%sp), %r22		/* Load child_tidptr */
+-
+-	/* Save the PIC register. */
+-#ifdef PIC
+-	copy	%r19, %r4		/* parent */
+-#endif
++	ldw	-52(%sp), %r24		/* Load parent_tidptr */
++	ldw	-56(%sp), %r23	 	/* Load newtls */
++	ldw	-60(%sp), %r22		/* Load child_tidptr */
+ 
+ 	/* Do the system call */
+ 	ble     0x100(%sr2, %r0)
+ 	ldi	__NR_clone, %r20
+ 
+ 	ldi	-4096, %r1
+-	comclr,>>= %r1, %ret0, %r0	/* Note: unsigned compare. */
+-	b,n	.LerrorRest
+-
+-	/* Restore the PIC register.  */
+-#ifdef PIC
+-	copy	%r4, %r19		/* parent */
+-#endif
+-
++	comb,<<,n	%r1, %ret0, .LerrorRest /* Note: unsigned compare. */
+ 	comib,=,n 0, %ret0, .LthreadStart
+-
+-	/* Successful return from the parent
+-	   No need to restore the PIC register,
+-	   since we return immediately. */
+-
+-	ldw	-84(%sp), %rp
+-	bv	%r0(%rp)
+-	ldwm	-64(%sp), %r4
++	bv,n	%r0(%rp)
+ 
+ .LerrorRest:
+-	/* Something bad happened -- no child created */
++	/* Something bad happened -- no child created -- need a frame */
++	ldo	64(%sp),%sp
++	.cfi_def_cfa_offset -64
+ 	bl	__syscall_error, %rp
+ 	sub     %r0, %ret0, %arg0
+ 	ldw	-84(%sp), %rp
+ 	/* Return after setting errno, ret0 is set to -1 by __syscall_error. */
+ 	bv	%r0(%rp)
+-	ldwm	-64(%sp), %r4
++	ldo	-64(%sp), %sp
+ 
+ .LerrorSanity:
+ 	/* Sanity checks failed, return -1, and set errno to EINVAL. */
+-	bl	__syscall_error, %rp
+-	ldi     EINVAL, %arg0
+-	ldw	-84(%sp), %rp
+-	bv	%r0(%rp)
+-	ldwm	-64(%sp), %r4
++	b	.LerrorRest
++	ldi	-EINVAL, %ret0
+ 
+ .LthreadStart:
+ 	/* Load up the arguments.  */
+@@ -144,14 +114,8 @@ ENTRY(__clone)
+ 	/* $$dyncall fixes child's PIC register */
+ 
+ 	/* Call the user's function */
+-#ifdef PIC
+-	copy	%r19, %r4
+-#endif
+ 	bl	$$dyncall, %r31
+ 	copy	%r31, %rp
+-#ifdef PIC
+-	copy	%r4, %r19
+-#endif
+ 	copy	%r28, %r26
+ 	ble     0x100(%sr2, %r0)
+ 	ldi	__NR_exit, %r20
+diff --git a/sysdeps/unix/sysv/linux/hppa/vfork.S b/sysdeps/unix/sysv/linux/hppa/vfork.S
+new file mode 100644
+index 0000000000..5fd368f3cf
+--- /dev/null
++++ b/sysdeps/unix/sysv/linux/hppa/vfork.S
+@@ -0,0 +1,53 @@
++/* Copyright (C) 1999-2024 Free Software Foundation, Inc.
++
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public License as
++   published by the Free Software Foundation; either version 2.1 of the
++   License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <sysdep.h>
++#define _ERRNO_H	1
++#include <bits/errno.h>
++
++/* Clone the calling process, but without copying the whole address space.
++   The calling process is suspended until the new process exits or is
++   replaced by a call to `execve'.  Return -1 for errors, 0 to the new process,
++   and the process ID of the new process to the old process.  */
++
++ENTRY (__vfork)
++	ble	0x100(%sr2, %r0)
++	ldi	__NR_vfork, %r20
++
++	ldi	-4096, %r1
++	comclr,<<	%r1, %ret0, %r0      /* Note: unsigned compare. */
++	bv,n	%r0(%rp)
++
++	/* Something bad happened -- no child created -- we need a frame */
++	ldo	64(%sp), %sp
++	.cfi_def_cfa_offset -64
++
++	/* Set errno */
++	bl	__syscall_error, %rp
++	sub	%r0, %ret0, %arg0
++
++	/* ret0 is set to -1 by __syscall_error */
++	ldw	-84(%sp), %rp
++	bv	%r0(%rp)
++	ldo	-64(%sp), %sp
++
++PSEUDO_END (__vfork)
++libc_hidden_def (__vfork)
++
++weak_alias (__vfork, vfork)
++strong_alias (__vfork, __libc_vfork)
+
+commit 7648e3c8e80b3f1b3b43506b2fbe370e4824ab97
+Author: John David Anglin <danglin@gcc.gnu.org>
+Date:   Sun Dec 22 09:58:02 2024 -0500
+
+    hppa: Simplify handling of sanity check errors in clone.S.
+    
+    This simplifies the handling of sanity check errors in clone.S.
+    Adjusted a couple of comments to reflect current code.
+    
+    Signed-off-by: John David Anglin <dave.anglin@bell.net>
+
+diff --git a/sysdeps/unix/sysv/linux/hppa/clone.S b/sysdeps/unix/sysv/linux/hppa/clone.S
+index c18163d0f7..e85e7f517f 100644
+--- a/sysdeps/unix/sysv/linux/hppa/clone.S
++++ b/sysdeps/unix/sysv/linux/hppa/clone.S
+@@ -90,6 +90,10 @@ ENTRY(__clone)
+ 	comib,=,n 0, %ret0, .LthreadStart
+ 	bv,n	%r0(%rp)
+ 
++.LerrorSanity:
++	/* Sanity checks failed, set errno to EINVAL.  */
++	ldi	-EINVAL, %ret0
++
+ .LerrorRest:
+ 	/* Something bad happened -- no child created -- need a frame */
+ 	ldo	64(%sp),%sp
+@@ -101,11 +105,6 @@ ENTRY(__clone)
+ 	bv	%r0(%rp)
+ 	ldo	-64(%sp), %sp
+ 
+-.LerrorSanity:
+-	/* Sanity checks failed, return -1, and set errno to EINVAL. */
+-	b	.LerrorRest
+-	ldi	-EINVAL, %ret0
+-
+ .LthreadStart:
+ 	/* Load up the arguments.  */
+ 	ldw	-60(%sp), %arg0
+@@ -121,7 +120,7 @@ ENTRY(__clone)
+ 	ldi	__NR_exit, %r20
+ 
+ 	/* We should not return from exit.
+-           We do not restore r4, or the stack state.  */
++           We do not restore the stack state.  */
+ 	iitlbp	%r0, (%sr0, %r0)
+ 
+ PSEUDO_END(__clone)
+
+commit 473597d8167f86afee3544215db108b170ec13c0
+Author: Andreas Schwab <schwab@suse.de>
+Date:   Wed Sep 25 11:49:30 2024 +0200
+
+    Fix missing randomness in __gen_tempname (bug 32214)
+    
+    Make sure to update the random value also if getrandom fails.
+    
+    Fixes: 686d542025 ("posix: Sync tempname with gnulib")
+    (cherry picked from commit 5f62cf88c4530c11904482775b7582bd7f6d80d2)
+
+diff --git a/NEWS b/NEWS
+index 97a1e1f5d4..57feba81cd 100644
+--- a/NEWS
++++ b/NEWS
+@@ -18,6 +18,7 @@ The following bugs are resolved with this release:
+   [32026] strerror/strsignal TLS not handled correctly for secondary namespaces
+   [32052] Name space violation in fortify wrappers
+   [32137] libio: Attempt wide backup free only for non-legacy code
++  [32214] Fix missing randomness in __gen_tempname
+   [32231] elf: Change ldconfig auxcache magic number
+   [32245] glibc -Wstringop-overflow= build failure on hppa
+   [32470] x86: Avoid integer truncation with large cache sizes
+diff --git a/sysdeps/posix/tempname.c b/sysdeps/posix/tempname.c
+index c00fe0c181..fc30958a0c 100644
+--- a/sysdeps/posix/tempname.c
++++ b/sysdeps/posix/tempname.c
+@@ -117,6 +117,8 @@ random_bits (random_value *r, random_value s)
+      succeed.  */
+ #if !_LIBC
+   *r = mix_random_values (v, clock ());
++#else
++  *r = v;
+ #endif
+   return false;
+ }
+
+commit 7d4b6bcae91f29d7b4daf15bab06b66cf1d2217c
+Author: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date:   Tue Jan 21 16:11:06 2025 -0500
+
+    Fix underallocation of abort_msg_s struct (CVE-2025-0395)
+    
+    Include the space needed to store the length of the message itself, in
+    addition to the message string.  This resolves BZ #32582.
+    
+    Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+    Reviewed: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+    (cherry picked from commit 68ee0f704cb81e9ad0a78c644a83e1e9cd2ee578)
+
+diff --git a/assert/assert.c b/assert/assert.c
+index c29629f5f6..b6e37d694c 100644
+--- a/assert/assert.c
++++ b/assert/assert.c
+@@ -18,6 +18,7 @@
+ #include <assert.h>
+ #include <atomic.h>
+ #include <ldsodefs.h>
++#include <libc-pointer-arith.h>
+ #include <libintl.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -65,7 +66,8 @@ __assert_fail_base (const char *fmt, const char *assertion, const char *file,
+       (void) __fxprintf (NULL, "%s", str);
+       (void) fflush (stderr);
+ 
+-      total = (total + 1 + GLRO(dl_pagesize) - 1) & ~(GLRO(dl_pagesize) - 1);
++      total = ALIGN_UP (total + sizeof (struct abort_msg_s) + 1,
++			GLRO(dl_pagesize));
+       struct abort_msg_s *buf = __mmap (NULL, total, PROT_READ | PROT_WRITE,
+ 					MAP_ANON | MAP_PRIVATE, -1, 0);
+       if (__glibc_likely (buf != MAP_FAILED))
+diff --git a/sysdeps/posix/libc_fatal.c b/sysdeps/posix/libc_fatal.c
+index f9e3425e04..089c47b04b 100644
+--- a/sysdeps/posix/libc_fatal.c
++++ b/sysdeps/posix/libc_fatal.c
+@@ -20,6 +20,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <ldsodefs.h>
++#include <libc-pointer-arith.h>
+ #include <paths.h>
+ #include <stdarg.h>
+ #include <stdbool.h>
+@@ -105,7 +106,8 @@ __libc_message_impl (const char *fmt, ...)
+     {
+       WRITEV_FOR_FATAL (fd, iov, iovcnt, total);
+ 
+-      total = (total + 1 + GLRO(dl_pagesize) - 1) & ~(GLRO(dl_pagesize) - 1);
++      total = ALIGN_UP (total + sizeof (struct abort_msg_s) + 1,
++			GLRO(dl_pagesize));
+       struct abort_msg_s *buf = __mmap (NULL, total,
+ 					PROT_READ | PROT_WRITE,
+ 					MAP_ANON | MAP_PRIVATE, -1, 0);

--- a/pkgs/development/libraries/glibc/common.nix
+++ b/pkgs/development/libraries/glibc/common.nix
@@ -50,7 +50,7 @@
 
 let
   version = "2.40";
-  patchSuffix = "-36";
+  patchSuffix = "-66";
   sha256 = "sha256-GaiQF16SY9dI9ieZPeb0sa+c0h4D8IDkv7Oh+sECBaI=";
 in
 
@@ -68,8 +68,8 @@ stdenv.mkDerivation (
       [
         /*
           No tarballs for stable upstream branch, only https://sourceware.org/git/glibc.git and using git would complicate bootstrapping.
-           $ git fetch --all -p && git checkout origin/release/2.39/master && git describe
-           glibc-2.40-36-g7073164add
+           $ git fetch --all -p && git checkout origin/release/2.40/master && git describe
+           glibc-2.40-66-g7d4b6bcae9
            $ git show --minimal --reverse glibc-2.40.. ':!ADVISORIES' > 2.40-master.patch
 
           To compare the archive contents zdiff can be used.


### PR DESCRIPTION
Fixes CVE-2025-0395 / GLIBC-SA-2025-0001
https://sourceware.org/git/?p=glibc.git;a=blob;f=advisories/GLIBC-SA-2025-0001;h=45f8b8f181fa024611452518ca0147ede1b88c47;hb=d9dcfe766eb9adcf9b1143112b569ac34ea9a9e6 https://www.openwall.com/lists/oss-security/2025/01/22/4


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
