### PR TITLE
bluez: set dontCheckForBrokenSymlinks

### DIFF
--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -132,6 +132,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   doCheck = stdenv.hostPlatform.isx86_64;
 
+  # TODO(@connorbaker):
+  # This is a quick fix to unblock builds broken by https://github.com/NixOS/nixpkgs/pull/370750.
+  # Fails due to dangling symlinks:
+  # bluez> ERROR: noBrokenSymlinks: the symlink $out/etc/bluetooth/main.conf points to a missing target /etc/bluetooth/main.conf
+  # bluez> ERROR: noBrokenSymlinks: the symlink $out/etc/bluetooth/input.conf points to a missing target /etc/bluetooth/input.conf
+  # bluez> ERROR: noBrokenSymlinks: the symlink $out/etc/bluetooth/network.conf points to a missing target /etc/bluetooth/network.conf
+  dontCheckForBrokenSymlinks = true;
+
   postInstall =
     let
       pythonPath = with python3Packages; [


### PR DESCRIPTION
Followup for #370750.

Should fix https://github.com/NixOS/nixpkgs/pull/370750#issuecomment-2610866000.

## Future work

Followup efforts involve finding out why there are broken symlinks in the output. The pattern of the symlinks (`/etc/`) seem similar to those observed in the `systemdMinimal` breakage, which was caused by a missing conditional in a Meson build file (https://github.com/NixOS/nixpkgs/pull/376218). Alternatively, perhaps we need to explicitly set an installation directory rather than relying on a default?

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
