### PR TITLE
mysql80: 8.0.40 -> 8.0.41, mysql84: 8.4.3 -> 8.4.4

### DIFF
--- a/pkgs/by-name/my/mysql84/package.nix
+++ b/pkgs/by-name/my/mysql84/package.nix
@@ -27,11 +27,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.4.3";
+  version = "8.4.4";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-eslWTEeAIvcwBf+Ju7QPZ7OB/AbVUYQWvf/sdeYluBg=";
+    hash = "sha256-+ykO90iJRDQIUknDG8pSrHGFMSREarIYuzvFAr8AgqU=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/servers/sql/mysql/8.0.x.nix
+++ b/pkgs/servers/sql/mysql/8.0.x.nix
@@ -31,11 +31,11 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mysql";
-  version = "8.0.40";
+  version = "8.0.41";
 
   src = fetchurl {
     url = "https://dev.mysql.com/get/Downloads/MySQL-${lib.versions.majorMinor finalAttrs.version}/mysql-${finalAttrs.version}.tar.gz";
-    hash = "sha256-At/ZQ/lnQvf5zXiFWzJwjqTfVIycFK+Sc4F/O72dIrI=";
+    hash = "sha256-AV0gj3OOKfRjQr9i4Hq1Oxg/MEQq/YE1SnkxrSP+jPc=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
Changes:
https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-4.html
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-41.html

Fixes:
* CVE-2024-11053
* CVE-2025-21500
* CVE-2025-21501
* CVE-2025-21518
* CVE-2025-21497
* CVE-2025-21555
* CVE-2025-21559
* CVE-2025-21540
* CVE-2025-21490
* CVE-2025-21491
* CVE-2025-21503
* CVE-2025-21523
* CVE-2025-21531
* CVE-2025-21505
* CVE-2025-21529
* CVE-2025-21543
* CVE-2025-21519
* CVE-2025-21546
* CVE-2025-21520
* CVE-2025-21499
* CVE-2025-21493


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


No new build failures.

## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 376225`

---
### `x86_64-linux`
<details>
  <summary>:x: 1 package failed to build:</summary>
  <ul>
    <li>vep</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 45 packages built:</summary>
  <ul>
    <li>exim</li>
    <li>libmysqlconnectorcpp</li>
    <li>longview</li>
    <li>mylvmbackup</li>
    <li>mysql-workbench</li>
    <li>mysql80</li>
    <li>mysql80.static</li>
    <li>mysql84</li>
    <li>mysql84.static</li>
    <li>opendmarc</li>
    <li>opendmarc.bin</li>
    <li>opendmarc.dev</li>
    <li>opendmarc.doc</li>
    <li>percona-toolkit</li>
    <li>percona-xtrabackup (percona-xtrabackup_8_4)</li>
    <li>percona-xtrabackup_8_0</li>
    <li>perl538Packages.DBDmysql</li>
    <li>perl538Packages.DBDmysql.devdoc</li>
    <li>perl538Packages.MinionBackendmysql</li>
    <li>perl538Packages.MinionBackendmysql.devdoc</li>
    <li>perl538Packages.Mojomysql</li>
    <li>perl538Packages.Mojomysql.devdoc</li>
    <li>perl538Packages.PerconaToolkit</li>
    <li>perl538Packages.Testmysqld</li>
    <li>perl538Packages.Testmysqld.devdoc</li>
    <li>perl538Packages.maatkit</li>
    <li>perl540Packages.DBDmysql</li>
    <li>perl540Packages.DBDmysql.devdoc</li>
    <li>perl540Packages.MinionBackendmysql</li>
    <li>perl540Packages.MinionBackendmysql.devdoc</li>
    <li>perl540Packages.Mojomysql</li>
    <li>perl540Packages.Mojomysql.devdoc</li>
    <li>perl540Packages.PerconaToolkit</li>
    <li>perl540Packages.Testmysqld</li>
    <li>perl540Packages.Testmysqld.devdoc</li>
    <li>perl540Packages.maatkit</li>
    <li>python312Packages.mysql-connector</li>
    <li>python312Packages.mysql-connector.dist</li>
    <li>python313Packages.mysql-connector</li>
    <li>python313Packages.mysql-connector.dist</li>
    <li>sqitchMysql</li>
    <li>sqlite3-to-mysql</li>
    <li>sqlite3-to-mysql.dist</li>
    <li>sympa</li>
    <li>zoneminder</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
