### PR TITLE
foundationdb: pin Boost 1.86 and fix Makefile

### DIFF
--- a/nixos/modules/services/databases/foundationdb.md
+++ b/nixos/modules/services/databases/foundationdb.md
@@ -18,7 +18,7 @@ To enable FoundationDB, add the following to your
 ```nix
 {
   services.foundationdb.enable = true;
-  services.foundationdb.package = pkgs.foundationdb73; # FoundationDB 7.r3.x
+  services.foundationdb.package = pkgs.foundationdb73; # FoundationDB 7.3.x
 }
 ```
 

--- a/pkgs/servers/foundationdb/cmake.nix
+++ b/pkgs/servers/foundationdb/cmake.nix
@@ -135,6 +135,8 @@ let
           license     = licenses.asl20;
           platforms   = [ "x86_64-linux" ]
             ++ lib.optionals (!(avxEnabled version)) [ "aarch64-linux" ];
+          # Fails when cross-compiling with "/bin/sh: gcc-ar: not found"
+          broken = stdenv.buildPlatform != stdenv.hostPlatform;
           maintainers = with maintainers; [ thoughtpolice lostnet ];
        };
     };

--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -38,6 +38,12 @@ in
         url = "https://github.com/apple/foundationdb/commit/c35a23d3f6b65698c3b888d76de2d93a725bff9c.patch";
         hash = "sha256-bneRoZvCzJp0Hp/G0SzAyUyuDrWErSpzv+ickZQJR5w=";
       })
+      # Add a dependency that prevents bindingtester to run before the python bindings are generated
+      # https://github.com/apple/foundationdb/pull/11859
+      (fetchpatch {
+        url = "https://github.com/apple/foundationdb/commit/8d04c97a74c6b83dd8aa6ff5af67587044c2a572.patch";
+        hash = "sha256-ZLIcmcfirm1+96DtTIr53HfM5z38uTLZrRNHAmZL6rc=";
+      })
     ];
   };
 }

--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -11,7 +11,7 @@
   openjdk,
   mono,
   openssl,
-  boost,
+  boost186,
   pkg-config,
   msgpack-cxx,
   toml11,
@@ -26,7 +26,7 @@ in
   foundationdb73 = cmakeBuild {
     version = "7.3.42";
     hash = "sha256-jQcm+HLai5da2pZZ7iLdN6fpQZxf5+/kkfv9OSXQ57c=";
-    inherit boost;
+    boost = boost186;
     ssl = openssl;
 
     patches = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Pin boost to 1.86, the most recent boost lead to errors like `error: 'io_service' in namespace 'boost::asio' does not name a type; did you mean 'use_service'?`
- Apply an upstream patch that adds a dependency between bindingtester and the generation of python bindings: https://github.com/apple/foundationdb/pull/11859. The missing dependency was the reason for failing builds of foundationdb  recently.

Closes: https://github.com/NixOS/nixpkgs/issues/370345

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
