### PR TITLE
stenc: fix updateScript

### DIFF
--- a/pkgs/by-name/st/stenc/package.nix
+++ b/pkgs/by-name/st/stenc/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  gitUpdater,
+  nix-update-script,
   autoreconfHook,
   pkg-config,
   pandoc,
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
     installShellCompletion --bash bash-completion/stenc
   '';
 
-  passthru.updateScript = gitUpdater { };
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "SCSI Tape Encryption Manager";


### PR DESCRIPTION
switch from gitUpdater to nix-update-script to avoid choosing rc versions

closes #373877
