### PR TITLE
python312Packages.pyerfa: fix cross build

### DIFF
--- a/pkgs/development/python-modules/pyerfa/default.nix
+++ b/pkgs/development/python-modules/pyerfa/default.nix
@@ -24,6 +24,7 @@ buildPythonPackage rec {
 
   build-system = [
     jinja2
+    numpy
     packaging
     setuptools
     setuptools-scm


### PR DESCRIPTION
numpy is imported at build time, presumably to aid building the CPython extension.
When cross-compiling the package we must provide the builder's numpy.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).