### PR TITLE
waytrogen: 0.5.8 -> 0.6.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16426,6 +16426,12 @@
     github = "NiklasVousten";
     githubId = 24965952;
   };
+  nikolaizombie1 = {
+    name = "Fabio J. Matos Nieves";
+    email = "fabio.matos999@gmail.com";
+    githubId = 70602908;
+    github = "nikolaizombie1";
+  };
   nikstur = {
     email = "nikstur@outlook.com";
     name = "nikstur";

--- a/pkgs/by-name/wa/waytrogen/package.nix
+++ b/pkgs/by-name/wa/waytrogen/package.nix
@@ -10,25 +10,27 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "waytrogen";
-  version = "0.5.8";
+  version = "0.6.3";
 
   src = fetchFromGitHub {
     owner = "nikolaizombie1";
     repo = "waytrogen";
     tag = version;
-    hash = "sha256-tq5cC0Z0kmrYopOGbdoAERBHQXrAw799zWdQP06rTYw=";
+    hash = "sha256-jkrvtwkzlsQgbw8/N4uzeqQ3fVSur2oa21IOXRRgh9I=";
   };
 
-  cargoHash = "sha256-05YfQBezDbQ8KfNvl/4Av5vf/rxJU3Ej6RDgSnSfjtM=";
+  cargoHash = "sha256-UkYQ/oN1+C9WQ+4hbhXxORw5J3Ypwe7DaDg5LhgP2d0=";
 
   nativeBuildInputs = [
     pkg-config
     wrapGAppsHook4
   ];
 
-  buildInputs = [
-    glib
-  ];
+  buildInputs = [ glib ];
+
+  env = {
+    OPENSSL_NO_VENDOR = 1;
+  };
 
   postBuild = ''
     install -Dm644 org.Waytrogen.Waytrogen.gschema.xml -t $out/share/gsettings-schemas/$name/glib-2.0/schemas
@@ -38,6 +40,10 @@ rustPlatform.buildRustPackage rec {
   postInstall = ''
     install -Dm644 waytrogen.desktop $out/share/applications/waytrogen.desktop
     install -Dm644 README-Assets/WaytrogenLogo.svg $out/share/icons/hicolor/scalable/apps/waytrogen.svg
+    while IFS= read -r lang; do
+          mkdir -p $out/share/locale/$lang/LC_MESSAGES
+          msgfmt locales/$lang/LC_MESSAGES/waytrogen.po -o $out/share/locale/$lang/LC_MESSAGES/waytrogen.mo
+    done < locales/LINGUAS
   '';
 
   passthru.updateScript = nix-update-script { };
@@ -52,7 +58,10 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://github.com/nikolaizombie1/waytrogen";
     changelog = "https://github.com/nikolaizombie1/waytrogen/releases/tag/${version}";
     license = lib.licenses.unlicense;
-    maintainers = with lib.maintainers; [ genga898 ];
+    maintainers = with lib.maintainers; [
+      genga898
+      nikolaizombie1
+    ];
     mainProgram = "waytrogen";
     platforms = lib.platforms.linux;
   };


### PR DESCRIPTION
<!--
Fix hyprpaper support.
Added support for external scripts after a wallpaper has been changed as a command line option.
Added listing of wallpaper state in JSON format.
Added random wallpaper setting based on last set wallpaper changer.
Reduced memory footprint while changing in the same wallpaper changer.
Fixed bug where restore and Killall_changers did not function for swaybg and mpvpaper
Added flake.nix for flake support.
Enabled wallpaper folder button when images are loading.
Fix bug where window would be the smallest size possible when floating
Remove kill all dependency.
Code cleanup and streamline locale generation.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
