### PR TITLE
no-broken-symlinks: restrict checks to symlinks pointing inside the store

### DIFF
--- a/doc/stdenv/stdenv.chapter.md
+++ b/doc/stdenv/stdenv.chapter.md
@@ -1378,6 +1378,10 @@ This setup hook checks for, reports, and (by default) fails builds when "broken"
 This hook can be disabled by setting `dontCheckForBrokenSymlinks`.
 
 ::: {.note}
+The hook only considers symlinks with targets inside the Nix store.
+:::
+
+::: {.note}
 The check for reflexivity is direct and does not account for transitivity, so this hook will not prevent cycles in symlinks.
 :::
 

--- a/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
+++ b/pkgs/build-support/setup-hooks/no-broken-symlinks.sh
@@ -45,6 +45,11 @@ noBrokenSymlinks() {
       symlinkTarget="$(realpath --no-symlinks --canonicalize-missing "$pathParent/$symlinkTarget")"
     fi
 
+    if [[ $symlinkTarget != "$NIX_STORE"/* ]]; then
+      nixInfoLog "symlink $path points outside the Nix store; ignoring"
+      continue
+    fi
+
     if [[ $path == "$symlinkTarget" ]]; then
       nixErrorLog "the symlink $path is reflexive $symlinkTarget"
       numReflexiveSymlinks+=1

--- a/pkgs/test/stdenv/no-broken-symlinks.nix
+++ b/pkgs/test/stdenv/no-broken-symlinks.nix
@@ -22,6 +22,10 @@ let
     ln -s${if absolute then "r" else ""} "$out/valid" "$out/valid-symlink"
   '';
 
+  mkValidSymlinkOutsideNixStore = absolute: ''
+    ln -s${if absolute then "r" else ""} "/etc/my_file" "$out/valid-symlink"
+  '';
+
   testBuilder =
     {
       name,
@@ -187,5 +191,15 @@ in
   pass-valid-symlink-absolute = testBuilder {
     name = "pass-valid-symlink-absolute";
     commands = [ (mkValidSymlink true) ];
+  };
+
+  pass-valid-symlink-outside-nix-store-relative = testBuilder {
+    name = "pass-valid-symlink-outside-nix-store-relative";
+    commands = [ (mkValidSymlinkOutsideNixStore false) ];
+  };
+
+  pass-valid-symlink-outside-nix-store-absolute = testBuilder {
+    name = "pass-valid-symlink-outside-nix-store-absolute";
+    commands = [ (mkValidSymlinkOutsideNixStore true) ];
   };
 }

--- a/pkgs/test/stdenv/no-broken-symlinks.nix
+++ b/pkgs/test/stdenv/no-broken-symlinks.nix
@@ -5,25 +5,25 @@
 }:
 
 let
-  inherit (lib.strings) concatStringsSep;
+  inherit (lib.strings) concatStringsSep optionalString;
   inherit (pkgs) runCommand;
   inherit (pkgs.testers) testBuildFailure;
 
   mkDanglingSymlink = absolute: ''
-    ln -s${if absolute then "r" else ""} "$out/dangling" "$out/dangling-symlink"
+    ln -s${optionalString (!absolute) "r"} "$out/dangling" "$out/dangling-symlink"
   '';
 
   mkReflexiveSymlink = absolute: ''
-    ln -s${if absolute then "r" else ""} "$out/reflexive-symlink" "$out/reflexive-symlink"
+    ln -s${optionalString (!absolute) "r"} "$out/reflexive-symlink" "$out/reflexive-symlink"
   '';
 
   mkValidSymlink = absolute: ''
     touch "$out/valid"
-    ln -s${if absolute then "r" else ""} "$out/valid" "$out/valid-symlink"
+    ln -s${optionalString (!absolute) "r"} "$out/valid" "$out/valid-symlink"
   '';
 
   mkValidSymlinkOutsideNixStore = absolute: ''
-    ln -s${if absolute then "r" else ""} "/etc/my_file" "$out/valid-symlink"
+    ln -s${optionalString (!absolute) "r"} "/etc/my_file" "$out/valid-symlink"
   '';
 
   testBuilder =


### PR DESCRIPTION
Followup for #370750.

Given some packages purposefully create symlinks which point out of the store, it makes sense to skip them in the check rather than error or warn because the hooks is limited to sandbox.

The two additional tests I've added succeed, and `systemdMinimal` succeeds without disabling the hook (like in #376218, which I have closed).

This PR additionally fixes the flags passed to `ln` when the `absolute` option is provided in the tests -- previously, passing a value of `true` for `absolute` would create a relative symlink! Thank you @emilazy for spotting that!

This issue wasn't caught by the tests because they would need to build with `NIX_DEBUG` set to a high value and grep for a logging statement, since the hook canonicalizes relative symlinks to absolute paths when evaluating them, and the only difference in code-path is a single logging statement.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
