### PR TITLE
treewide: correct versionCheckHook use

### DIFF
--- a/pkgs/by-name/ae/aerospace/package.nix
+++ b/pkgs/by-name/ae/aerospace/package.nix
@@ -39,7 +39,10 @@ stdenv.mkDerivation {
     installShellCompletion --zsh  shell-completion/zsh/_aerospace
   '';
 
-  passthru.tests.can-print-version = [ versionCheckHook ];
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
 
   passthru.updateScript = gitUpdater {
     url = "https://github.com/nikitabobko/AeroSpace.git";

--- a/pkgs/by-name/as/astroterm/package.nix
+++ b/pkgs/by-name/as/astroterm/package.nix
@@ -31,11 +31,15 @@ stdenv.mkDerivation (finalAttrs: {
     meson
     ninja
     xxd
-    versionCheckHook
   ];
   buildInputs = [
     argtable
     ncurses
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
   ];
 
   postPatch = ''

--- a/pkgs/by-name/cl/cloudpan189-go/package.nix
+++ b/pkgs/by-name/cl/cloudpan189-go/package.nix
@@ -22,6 +22,7 @@ buildGo122Module rec {
     '';
   };
 
+  doInstallCheck = true;
   nativeInstallCheckInputs = [
     versionCheckHook
   ];

--- a/pkgs/by-name/de/deepsource/package.nix
+++ b/pkgs/by-name/de/deepsource/package.nix
@@ -48,6 +48,8 @@ buildGoModule rec {
       --zsh <($out/bin/deepsource completion zsh)
   '';
 
+  doInstallCheck = true;
+  versionCheckProgramArg = [ "version" ];
   nativeInstallCheckInputs = [
     versionCheckHook
   ];

--- a/pkgs/by-name/en/envision-unwrapped/package.nix
+++ b/pkgs/by-name/en/envision-unwrapped/package.nix
@@ -67,7 +67,6 @@ stdenv.mkDerivation (finalAttrs: {
     pkg-config
     rustPlatform.cargoSetupHook
     rustc
-    versionCheckHook
     wrapGAppsHook4
   ];
 
@@ -85,6 +84,14 @@ stdenv.mkDerivation (finalAttrs: {
     pango
     vte-gtk4
     zlib
+  ];
+
+  # FIXME: error when running `env -i envision`:
+  # "HOME env var not defined: NotPresent"
+  doInstallCheck = false;
+  versionCheckProgram = "${placeholder "out"}/bin/envision";
+  nativeInstallCheckInputs = [
+    versionCheckHook
   ];
 
   postInstall = ''

--- a/pkgs/by-name/go/gollama/package.nix
+++ b/pkgs/by-name/go/gollama/package.nix
@@ -16,6 +16,11 @@ buildGoModule rec {
     hash = "sha256-7wCBflX34prZJl4HhZUU2a2qHxaBs1fMKHpwE0vX1GE=";
   };
 
+  postPatch = ''
+    substituteInPlace main.go \
+      --replace-fail 'Version = "1.28.0"' 'Version = "${version}"'
+  '';
+
   vendorHash = "sha256-Y5yg54em+vqoWXxS3JVQVPEM+fLXgoblmY+48WpxSCQ=";
 
   doCheck = false;
@@ -25,7 +30,10 @@ buildGoModule rec {
     "-w"
   ];
 
-  nativeInputChecks = [
+  # FIXME: error when running `env -i gollama`:
+  # "Error initializing logging: $HOME is not defined"
+  doInstallCheck = false;
+  nativeInstallCheckInputs = [
     versionCheckHook
   ];
 

--- a/pkgs/by-name/me/mergiraf/package.nix
+++ b/pkgs/by-name/me/mergiraf/package.nix
@@ -26,6 +26,10 @@ rustPlatform.buildRustPackage rec {
 
   nativeCheckInputs = [
     git
+  ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
     versionCheckHook
   ];
 

--- a/pkgs/by-name/ni/nixpkgs-review/package.nix
+++ b/pkgs/by-name/ni/nixpkgs-review/package.nix
@@ -70,7 +70,8 @@ python3Packages.buildPythonApplication rec {
     done
   '';
 
-  nativeCheckInputs = [
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
     versionCheckHook
   ];
   versionCheckProgramArg = [ "--version" ];

--- a/pkgs/by-name/nv/nvitop/package.nix
+++ b/pkgs/by-name/nv/nvitop/package.nix
@@ -25,7 +25,8 @@ python3Packages.buildPythonApplication rec {
     nvidia-ml-py
   ];
 
-  nativeCheckInputs = [
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
     versionCheckHook
   ];
   versionCheckProgramArg = [ "--version" ];

--- a/pkgs/by-name/up/upbound/package.nix
+++ b/pkgs/by-name/up/upbound/package.nix
@@ -50,6 +50,10 @@ stdenvNoCC.mkDerivation {
     installShellCompletion --bash --name up <(echo complete -C up up)
   '';
 
+  # FIXME: error when running `env -i up`:
+  # "up: error: $HOME is not defined"
+  doInstallCheck = false;
+  versionCheckProgram = "${placeholder "out"}/bin/up";
   versionCheckProgramArg = "version";
 
   nativeInstallCheckInputs = [
@@ -62,10 +66,6 @@ stdenvNoCC.mkDerivation {
     ./update.sh
     "${version-channel}"
   ];
-
-  passthru.tests = {
-    versionCheck = versionCheckHook;
-  };
 
   meta = {
     description = "CLI for interacting with Upbound Cloud, Upbound Enterprise, and Universal Crossplane (UXP)";


### PR DESCRIPTION
Lots of packages don't put `versionCheckHook` in `nativeInstallCheckInputs`, or forget to enable the phase.

Candidates where located using `rg versionCheckHook -l | xargs grep doInstallCheck -L | xargs grep buildPythonApplication -L`


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
