### PR TITLE
ansible-cmdb: add a patch to use importlib instead of imp module

### DIFF
--- a/pkgs/by-name/an/ansible-cmdb/importlib.patch
+++ b/pkgs/by-name/an/ansible-cmdb/importlib.patch
@@ -1,0 +1,47 @@
+diff --git a/src/ansiblecmdb/parser.py b/src/ansiblecmdb/parser.py
+index 3b3a885..5194b20 100644
+--- a/src/ansiblecmdb/parser.py
++++ b/src/ansiblecmdb/parser.py
+@@ -115,7 +115,7 @@ class HostsParser(object):
+         Returns:
+             ('children', 'prod')
+         """
+-        m = re.match("\[(.*)\]", line)
++        m = re.match(r"\[(.*)\]", line)
+         group_def = m.groups()[0]
+         if ':' in group_def:
+             group_name, group_type = group_def.split(':')
+diff --git a/src/ansiblecmdb/render.py b/src/ansiblecmdb/render.py
+index 6909457..f198b96 100644
+--- a/src/ansiblecmdb/render.py
++++ b/src/ansiblecmdb/render.py
+@@ -1,5 +1,5 @@
+ import os
+-import imp
++from importlib.util import spec_from_file_location, module_from_spec
+ from mako.template import Template
+ from mako.lookup import TemplateLookup
+ 
+@@ -59,5 +59,7 @@ class Render:
+         return template.render(hosts=hosts, **vars)
+ 
+     def _render_py(self, hosts, vars={}):
+-        module = imp.load_source('r', self.tpl_file)
++        spec = spec_from_file_location('r', self.tpl_file)
++        module = module_from_spec(spec)
++        spec.loader.exec_module(module)
+         return module.render(hosts, vars=vars, tpl_dirs=self.tpl_dirs)
+diff --git a/test/test.py b/test/test.py
+index 667c7a1..9867351 100644
+--- a/test/test.py
++++ b/test/test.py
+@@ -1,6 +1,5 @@
+ import sys
+ import unittest
+-import imp
+ import os
+ 
+ sys.path.insert(0, os.path.realpath('../lib'))
+-- 
+2.44.1
+

--- a/pkgs/by-name/an/ansible-cmdb/package.nix
+++ b/pkgs/by-name/an/ansible-cmdb/package.nix
@@ -34,6 +34,9 @@ buildPythonApplication {
     (replaceVars ./setup.patch {
       inherit version;
     })
+
+    # Use importlib instead of deprecated imp module.
+    ./importlib.patch
   ];
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Recent Python versions removed imp module in favor of importlib. While ansible-cmdb project hasn’t seen any updates for a few years and still uses imp module upstream, we can apply a small patch to use importlib instead.

This change fixes failing tests for this package due to a Python version bump in Nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
