### PR TITLE
tre: fix cross build

### DIFF
--- a/pkgs/by-name/tr/tre/package.nix
+++ b/pkgs/by-name/tr/tre/package.nix
@@ -29,16 +29,13 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     autoconf
     automake
+    gettext # autopoint
     libtool
   ];
 
-  buildInputs =
-    [
-      gettext
-    ]
-    ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      libiconv
-    ];
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    libiconv
+  ];
 
   preConfigure = ''
     ./utils/autogen.sh


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).