### PR TITLE
fortune: fix cross build

### DIFF
--- a/pkgs/by-name/fo/fortune/package.nix
+++ b/pkgs/by-name/fo/fortune/package.nix
@@ -6,6 +6,7 @@
   recode,
   perl,
   rinutils,
+  fortune,
   withOffensive ? false,
 }:
 
@@ -20,11 +21,16 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-Hzh4dyVOleq2H5NyV7QmCfKbmU7wVxUxZVu/w6KsdKw=";
   };
 
-  nativeBuildInputs = [
-    cmake
-    perl
-    rinutils
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      perl
+      rinutils
+    ]
+    ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      # "strfile" must be in PATH for cross-compiling builds.
+      fortune
+    ];
 
   buildInputs = [ recode ];
 


### PR DESCRIPTION
Previously failing with the error message mentioned in the comment: https://paste.fliegendewurst.eu/P0mpaa.log

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).