### PR TITLE
quartus-prime-lite: add missing runtime dependency xorg.libXscrnSaver

### DIFF
--- a/pkgs/by-name/qu/quartus-prime-lite/package.nix
+++ b/pkgs/by-name/qu/quartus-prime-lite/package.nix
@@ -54,6 +54,7 @@ buildFHSEnv rec {
       xorg.libSM
       xorg.libXau
       xorg.libXdmcp
+      xorg.libXScrnSaver
       libudev0-shim
       bzip2
       brotli


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Fixes this error when selecting "Tools -> Run Simulation Tool -> RTL Simulation":

  $ quartus
  [...]
  Info: Command: quartus_sh -t /nix/store/bqibb4d2273cg13fzyc9n2xcry60102k-quartus-prime-lite-unwrapped-23.1std.1.993/quartus/common/tcl/internal/nativelink/qnativesim.tcl --rtl_sim test2 test2
  Info: Quartus(args): --rtl_sim test2 test2
  Internal Error: Sub-system: ATCL, File: /quartus/ccl/atcl/atcl_root.cpp, Line: 508
  Unable to load Tk library
  Stack Trace:
       0x8063: err_report_internal_error(char const*, char const*, char const*, int) + 0x1a (ccl_err)
      0x1a4fe: atcl_init_tk_window(Tcl_Interp*, char const*) + 0xf9 (ccl_atcl)
      0x2f19b: atcl_init_tk + 0xa3 (ccl_atcl)
      0x4753b: TclInvokeStringCommand + 0x7b (tcl8.6)
      0x4bb47: TclNRRunCallbacks + 0x67 (tcl8.6)
      0x4cf29: TclEvalEx + 0x599 (tcl8.6)
      0xf40fe: Tcl_FSEvalFileEx + 0x21e (tcl8.6)
      0xf4246: Tcl_EvalFile + 0x26 (tcl8.6)
      0x1879f: qexe_evaluate_tcl_script(std::string const&) + 0x388 (comp_qexe)
      0x19ecb: qexe_do_tcl(QEXE_FRAMEWORK*, std::string const&, std::string const&, std::list<std::string, std::allocator<std::string> > const&, bool, bool) + 0x7ff (comp_qexe)
      0x1da75: qexe_standard_main(QEXE_FRAMEWORK*, QEXE_OPTION_DEFINITION const**, int, char const**) + 0x51d (comp_qexe)
       0x3a1c: qsh_main(int, char const**) + 0x78 (quartus_sh)
      0x3e5c0: msg_main_thread(void*) + 0x10 (ccl_msg)
       0x5cac: thr_final_wrapper + 0xc (ccl_thr)
      0x3e68a: msg_thread_wrapper(void* (*)(void*), void*) + 0x6e (ccl_msg)
       0xc096: mem_thread_wrapper(void* (*)(void*), void*) + 0x96 (ccl_mem)
       0x91a8: err_thread_wrapper(void* (*)(void*), void*) + 0x27 (ccl_err)
       0x5cef: thr_thread_wrapper + 0x15 (ccl_thr)
      0x4058a: msg_exe_main(int, char const**, int (*)(int, char const**)) + 0xa8 (ccl_msg)
       0xb18f: main + 0x26 (quartus_sh)
      0x2a1fc: __libc_start_call_main + 0x7c (c.so.6)
      0x2a2b9: __libc_start_main + 0x89 (c.so.6)
       0x3669: _start + 0x29 (quartus_sh)

  End-trace

The libtk*.so files shipped with quartus are 64-bit[1], so I think adding the
dependency to targetPkgs should be enough.

[1] `NIXPKGS_ALLOW_UNFREE=1 nix-build -A quartus-prime-lite.unwrapped && find ./result/ -name "libtk*.so" | xargs file`
  shows all "ELF 64-bit LSB shared object[...]".

Fixes https://github.com/NixOS/nixpkgs/issues/375852.



<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
