### PR TITLE
mkBinaryCache: support zstd and none as compression methods

### DIFF
--- a/doc/build-helpers/images/binarycache.section.md
+++ b/doc/build-helpers/images/binarycache.section.md
@@ -11,6 +11,14 @@ It can also be a convenient way to make some Nix packages available inside a con
 `rootPaths` must be a list of derivations.
 The transitive closure of these derivations' outputs will be copied into the cache.
 
+## Optional arguments {#sec-pkgs-binary-cache-arguments}
+
+`compression` (`"none"` or `"xz"` or `"zstd"`; _optional_)
+
+: The compression algorithm to use.
+
+  _Default value:_ `zstd`.
+
 ::: {.note}
 This function is meant for advanced use cases.
 The more idiomatic way to work with flat-file binary caches is via the [nix-copy-closure](https://nixos.org/manual/nix/stable/command-ref/nix-copy-closure.html) command.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -1959,6 +1959,9 @@
   "sec-pkgs-binary-cache": [
     "index.html#sec-pkgs-binary-cache"
   ],
+  "sec-pkgs-binary-cache-arguments": [
+    "index.html#sec-pkgs-binary-cache-arguments"
+  ],
   "sec-pkgs-binary-cache-example": [
     "index.html#sec-pkgs-binary-cache-example"
   ],

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -154,7 +154,9 @@ in {
   beanstalkd = handleTest ./beanstalkd.nix {};
   bees = handleTest ./bees.nix {};
   benchexec = handleTest ./benchexec.nix {};
-  binary-cache = handleTest ./binary-cache.nix {};
+  binary-cache = handleTest ./binary-cache.nix { compression = "zstd"; };
+  binary-cache-no-compression = handleTest ./binary-cache.nix { compression = "none"; };
+  binary-cache-xz = handleTest ./binary-cache.nix { compression = "xz"; };
   bind = handleTest ./bind.nix {};
   bird = handleTest ./bird.nix {};
   birdwatcher = handleTest ./birdwatcher.nix {};

--- a/nixos/tests/binary-cache.nix
+++ b/nixos/tests/binary-cache.nix
@@ -1,8 +1,10 @@
+{ compression, ... }@args:
+
 import ./make-test-python.nix (
   { lib, pkgs, ... }:
 
   {
-    name = "binary-cache";
+    name = "binary-cache-" + compression;
     meta.maintainers = with lib.maintainers; [ thomasjm ];
 
     nodes.machine =
@@ -24,7 +26,12 @@ import ./make-test-python.nix (
               nativeBuildInputs = [ openssl ];
             }
             ''
-              tar -czf tmp.tar.gz -C "${mkBinaryCache { rootPaths = [ hello ]; }}" .
+              tar -czf tmp.tar.gz -C "${
+                mkBinaryCache {
+                  rootPaths = [ hello ];
+                  inherit compression;
+                }
+              }" .
               openssl enc -aes-256-cbc -salt -in tmp.tar.gz -out $out -k mysecretpassword
             '';
 
@@ -78,4 +85,4 @@ import ./make-test-python.nix (
       machine.succeed("[ -d %s ] || exit 1" % storePath)
     '';
   }
-)
+) args

--- a/pkgs/build-support/binary-cache/default.nix
+++ b/pkgs/build-support/binary-cache/default.nix
@@ -6,6 +6,7 @@
   python3,
   nix,
   xz,
+  zstd,
 }:
 
 # This function is for creating a flat-file binary cache, i.e. the kind created by
@@ -16,8 +17,15 @@
 
 {
   name ? "binary-cache",
+  compression ? "zstd", # one of ["none" "xz" "zstd"]
   rootPaths,
 }:
+
+assert lib.elem compression [
+  "none"
+  "xz"
+  "zstd"
+];
 
 stdenv.mkDerivation {
   inherit name;
@@ -28,18 +36,20 @@ stdenv.mkDerivation {
 
   preferLocalBuild = true;
 
-  nativeBuildInputs = [
-    coreutils
-    jq
-    python3
-    nix
-    xz
-  ];
+  nativeBuildInputs =
+    [
+      coreutils
+      jq
+      python3
+      nix
+    ]
+    ++ lib.optional (compression == "xz") xz
+    ++ lib.optional (compression == "zstd") zstd;
 
   buildCommand = ''
     mkdir -p $out/nar
 
-    python ${./make-binary-cache.py}
+    python ${./make-binary-cache.py} --compression "${compression}"
 
     # These directories must exist, or Nix might try to create them in LocalBinaryCacheStore::init(),
     # which fails if mounted read-only

--- a/pkgs/build-support/binary-cache/make-binary-cache.py
+++ b/pkgs/build-support/binary-cache/make-binary-cache.py
@@ -1,3 +1,4 @@
+import argparse
 from functools import partial
 import json
 from multiprocessing import Pool
@@ -10,13 +11,15 @@ def dropPrefix(path, nixPrefix):
     return path[len(nixPrefix + "/") :]
 
 
-def processItem(item, nixPrefix, outDir):
+def processItem(
+    item, nixPrefix, outDir, compression, compressionCommand, compressionExtension
+):
     narInfoHash = dropPrefix(item["path"], nixPrefix).split("-")[0]
 
-    xzFile = outDir / "nar" / f"{narInfoHash}.nar.xz"
-    with open(xzFile, "wb") as f:
+    narFile = outDir / "nar" / f"{narInfoHash}{compressionExtension}"
+    with open(narFile, "wb") as f:
         subprocess.run(
-            f"nix-store --dump {item['path']} | xz -c",
+            f"nix-store --dump {item['path']} {compressionCommand}",
             stdout=f,
             shell=True,
             check=True,
@@ -24,30 +27,48 @@ def processItem(item, nixPrefix, outDir):
 
     fileHash = (
         subprocess.run(
-            ["nix-hash", "--base32", "--type", "sha256", "--flat", xzFile],
+            ["nix-hash", "--base32", "--type", "sha256", "--flat", narFile],
             capture_output=True,
             check=True,
         )
         .stdout.decode()
         .strip()
     )
-    fileSize = os.path.getsize(xzFile)
+    fileSize = os.path.getsize(narFile)
 
-    finalXzFileName = Path("nar") / f"{fileHash}.nar.xz"
-    os.rename(xzFile, outDir / finalXzFileName)
+    finalNarFileName = Path("nar") / f"{fileHash}{compressionExtension}"
+    os.rename(narFile, outDir / finalNarFileName)
 
     with open(outDir / f"{narInfoHash}.narinfo", "wt") as f:
         f.write(f"StorePath: {item['path']}\n")
-        f.write(f"URL: {finalXzFileName}\n")
-        f.write("Compression: xz\n")
+        f.write(f"URL: {finalNarFileName}\n")
+        f.write(f"Compression: {compression}\n")
         f.write(f"FileHash: sha256:{fileHash}\n")
         f.write(f"FileSize: {fileSize}\n")
         f.write(f"NarHash: {item['narHash']}\n")
         f.write(f"NarSize: {item['narSize']}\n")
-        f.write(f"References: {' '.join(dropPrefix(ref, nixPrefix) for ref in item['references'])}\n")
+        f.write(
+            f"References: {' '.join(dropPrefix(ref, nixPrefix) for ref in item['references'])}\n"
+        )
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compression", choices=["none", "xz", "zstd"])
+    args = parser.parse_args()
+
+    compressionCommand = {
+        "none": "",
+        "xz": "| xz -c",
+        "zstd": "| zstd",
+    }[args.compression]
+
+    compressionExtension = {
+        "none": "",
+        "xz": ".xz",
+        "zstd": ".zst",
+    }[args.compression]
+
     outDir = Path(os.environ["out"])
     nixPrefix = os.environ["NIX_STORE"]
     numWorkers = int(os.environ.get("NIX_BUILD_CORES", "4"))
@@ -61,7 +82,14 @@ def main():
         f.write(f"StoreDir: {nixPrefix}\n")
 
     with Pool(processes=numWorkers) as pool:
-        worker = partial(processItem, nixPrefix=nixPrefix, outDir=outDir)
+        worker = partial(
+            processItem,
+            nixPrefix=nixPrefix,
+            outDir=outDir,
+            compression=args.compression,
+            compressionCommand=compressionCommand,
+            compressionExtension=compressionExtension,
+        )
         pool.map(worker, closures)
 
 


### PR DESCRIPTION
This is the third and final PR in my recent series improving the speed and correctness of `mkBinaryCache`, following on from https://github.com/NixOS/nixpkgs/pull/371082. This PR adds a `compression` argument to `mkBinaryCache`, allowing you to specify one of the following options: `xz`, `zstd`, or `none`. It also changes the default to `zstd`.

Nix has supported ZSTD compression since version 2.4, and Cachix switched over to it entirely in 2022; see [here](https://blog.cachix.org/posts/2022-12-19-zstd-compression/). It is much more performant than `xz`, the previous default. With this PR, we have the following results for building the following test expression:

```
time nix build --impure --expr 'with import ./. {}; mkBinaryCache { rootPaths = [hello curl emacs htop]; compression = "XXX"; }'
```

* `xz`: 18.82 seconds
* `zstd`: 2.35 seconds (**8x speedup** over xz)

I ran the same tests on a Mac Mini and got even more of a speedup:

* `xz`: 66.27s
* `zstd`: 5.67s (**11.7x speedup** over xz)

I added a couple new NixOS tests to test the new configurations. To fully test this PR, you can run:

```shell
nix-build -A nixosTests.binary-cache
nix-build -A nixosTests.binary-cache-no-compression
nix-build -A nixosTests.binary-cache-xz
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [X] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
