### PR TITLE
qemu-utils: enable crypto support

### DIFF
--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv, fetchurl, fetchpatch, python3Packages, zlib, pkg-config, glib, overrideSDK, buildPackages
 , pixman, vde2, alsa-lib, flex, pcre2
-, bison, lzo, snappy, libaio, libtasn1, gnutls, nettle, curl, dtc, ninja, meson, perl
+, bison, lzo, snappy, libaio, libtasn1, gnutls, curl, dtc, ninja, meson, perl
 , sigtool
 , makeWrapper, removeReferencesTo
 , attr, libcap, libcap_ng, socat, libslirp
@@ -94,8 +94,9 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optionals stdenv.hostPlatform.isDarwin [ sigtool rez setfile ]
     ++ lib.optionals (!userOnly) [ dtc ];
 
-  buildInputs = [ glib zlib ]
-    ++ lib.optionals (!minimal) [ dtc pixman vde2 lzo snappy libtasn1 gnutls nettle libslirp ]
+  # gnutls is required for crypto support (luks) in qemu-img
+  buildInputs = [ glib gnutls zlib ]
+    ++ lib.optionals (!minimal) [ dtc pixman vde2 lzo snappy libtasn1 libslirp ]
     ++ lib.optionals (!userOnly) [ curl ]
     ++ lib.optionals ncursesSupport [ ncurses ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin darwinSDK
@@ -166,6 +167,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags = [
     "--disable-strip" # We'll strip ourselves after separating debug info.
+    "--enable-gnutls" # auto detection only works when building with --enable-system
     (lib.enableFeature enableDocs "docs")
     (lib.enableFeature enableTools "tools")
     "--localstatedir=/var"

--- a/pkgs/applications/virtualization/qemu/default.nix
+++ b/pkgs/applications/virtualization/qemu/default.nix
@@ -1,5 +1,5 @@
-{ lib, stdenv, fetchurl, fetchpatch, python3Packages, zlib, pkg-config, glib, overrideSDK, buildPackages
-, pixman, vde2, alsa-lib, flex, pcre2
+{ lib, stdenv, fetchurl, fetchpatch, python3Packages, zlib, pkg-config, glib, buildPackages
+, pixman, vde2, alsa-lib, flex
 , bison, lzo, snappy, libaio, libtasn1, gnutls, curl, dtc, ninja, meson, perl
 , sigtool
 , makeWrapper, removeReferencesTo


### PR DESCRIPTION
This is required for qemu-img to support luks.
This was discovered when trying to fix a failing build with python3Packages.oslo-utils on at least version 7.4.0.

Both (lib)gcrypt and nettle together with hogweed are fallbacks when gnutls is not found and are not used despite the convoluted build script suggesting it.

Configure output before this patch:

...
  Crypto
    TLS priority                    : NORMAL
    GNUTLS support                  : YES 3.8.6
      GNUTLS crypto                 : YES
    libgcrypt                       : NO
    nettle                          : NO
    SM4 ALG support                 : NO
    SM3 ALG support                 : NO
    AF_ALG support                  : NO
    rng-none                        : NO
    Linux keyring                   : YES
    Linux keyutils                  : NO
...

and after this patch:

...
  Crypto
    TLS priority                    : NORMAL
    GNUTLS support                  : YES 3.8.6
      GNUTLS crypto                 : YES
    libgcrypt                       : NO
    nettle                          : NO
    SM4 ALG support                 : NO
    SM3 ALG support                 : NO
    AF_ALG support                  : NO
    rng-none                        : NO
    Linux keyring                   : YES
    Linux keyutils                  : NO
...

This can be easily tested by building qemu-utils and running

qemu-img create -f luks --object secret,id=sec0,data=secret-passphrase -o key-secret=sec0 tmp.img 536870912

which is the command that failed in oslo-utils

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
