### PR TITLE
hylafaxplus: 7.0.9 -> 7.0.10, misc improvements (also module)

### DIFF
--- a/nixos/modules/services/networking/hylafax/default.nix
+++ b/nixos/modules/services/networking/hylafax/default.nix
@@ -13,7 +13,7 @@
   ];
 
   config = lib.modules.mkIf config.services.hylafax.enable {
-    environment.systemPackages = [ pkgs.hylafaxplus ];
+    environment.systemPackages = [ config.services.hylafax.package ];
     users.users.uucp = {
       uid = config.ids.uids.uucp;
       group = "uucp";

--- a/nixos/modules/services/networking/hylafax/modem-default.nix
+++ b/nixos/modules/services/networking/hylafax/modem-default.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 # see man:hylafax-config(5)
 
@@ -16,7 +16,7 @@
   SessionTracing = "0x78701";
   UUCPLockDir = "/var/lock";
 
-  SendPageCmd = "${pkgs.coreutils}/bin/false"; # prevent pager transmit
-  SendUUCPCmd = "${pkgs.coreutils}/bin/false"; # prevent UUCP transmit
+  SendPageCmd = lib.getExe' pkgs.coreutils "false"; # prevent pager transmit
+  SendUUCPCmd = lib.getExe' pkgs.coreutils "false"; # prevent UUCP transmit
 
 }

--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -8,6 +8,7 @@
 let
 
   inherit (lib)
+    getExe'
     literalExpression
     mkDefault
     mkEnableOption
@@ -110,11 +111,11 @@ let
       # Otherwise, we use `false` to provoke
       # an error if hylafax tries to use it.
       c.sendmailPath = mkMerge [
-        (mkIfDefault noWrapper "${pkgs.coreutils}/bin/false")
+        (mkIfDefault noWrapper (getExe' pkgs.coreutils "false"))
         (mkIfDefault (!noWrapper) "${wrapperDir}/${program}")
       ];
       importDefaultConfig =
-        file: lib.attrsets.mapAttrs (lib.trivial.const mkDefault) (import file { inherit pkgs; });
+        file: lib.attrsets.mapAttrs (lib.trivial.const mkDefault) (import file { inherit lib pkgs; });
       c.commonModemConfig = importDefaultConfig ./modem-default.nix;
       c.faxqConfig = importDefaultConfig ./faxq-default.nix;
       c.hfaxdConfig = importDefaultConfig ./hfaxd-default.nix;

--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -7,20 +7,26 @@
 
 let
 
-  inherit (lib.options) literalExpression mkEnableOption mkOption;
+  inherit (lib)
+    literalExpression
+    mkDefault
+    mkEnableOption
+    mkIf
+    mkMerge
+    mkOption
+    ;
   inherit (lib.types)
+    attrsOf
     bool
     enum
     ints
     lines
-    attrsOf
     nonEmptyStr
     nullOr
     path
     str
     submodule
     ;
-  inherit (lib.modules) mkDefault mkIf mkMerge;
 
   commonDescr = ''
     Values can be either strings or integers

--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -15,6 +15,7 @@ let
     mkIf
     mkMerge
     mkOption
+    mkPackageOption
     ;
   inherit (lib.types)
     attrsOf
@@ -142,6 +143,8 @@ in
   options.services.hylafax = {
 
     enable = mkEnableOption "HylaFAX server";
+
+    package = mkPackageOption pkgs "HylaFAX" { default = "hylafaxplus"; };
 
     autostart = mkOption {
       type = bool;

--- a/nixos/modules/services/networking/hylafax/spool.sh
+++ b/nixos/modules/services/networking/hylafax/spool.sh
@@ -80,7 +80,7 @@ touch clientlog faxcron.lastrun xferfaxlog
 chown @faxuser@:@faxgroup@ clientlog faxcron.lastrun xferfaxlog
 
 # create symlinks for frozen directories/files
-lnsym --target-directory=. "@hylafaxplus@"/spool/{COPYRIGHT,bin,config}
+lnsym --target-directory=. "@package@"/spool/{COPYRIGHT,bin,config}
 
 # create empty temporary directories
 update --mode=0700 -d client dev status
@@ -93,7 +93,7 @@ install -d "@spoolAreaPath@/etc"
 cd "@spoolAreaPath@/etc"
 
 # create symlinks to all files in template's etc
-lnsym --target-directory=. "@hylafaxplus@/spool/etc"/*
+lnsym --target-directory=. "@package@/spool/etc"/*
 
 # set LOCKDIR in setup.cache
 sed --regexp-extended 's|^(UUCP_LOCKDIR=).*$|\1'"'@lockPath@'|g" --in-place setup.cache

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -22,7 +22,7 @@ let
   mkSpoolCmd =
     prefix: program: posArg: options:
     let
-      start = "${prefix}${pkgs.hylafaxplus}/spool/bin/${program}";
+      start = "${prefix}${cfg.package}/spool/bin/${program}";
       optionsList = toGNUCommandLine { mkOptionName = k: "-${k}"; } (
         { q = cfg.spoolAreaPath; } // options
       );
@@ -54,7 +54,7 @@ let
         { name, type, ... }@modem:
         ''
           # check if modem config file exists:
-          test -f "${pkgs.hylafaxplus}/spool/config/${type}"
+          test -f "${cfg.package}/spool/config/${type}"
           ln \
             --symbolic \
             --no-target-directory \
@@ -75,8 +75,8 @@ let
       faxgroup = "uucp";
       lockPath = "/var/lock";
       inherit globalConfigPath modemConfigPath;
-      inherit (cfg) spoolAreaPath userAccessFile;
-      inherit (pkgs) hylafaxplus runtimeShell;
+      inherit (cfg) package spoolAreaPath userAccessFile;
+      inherit (pkgs) runtimeShell;
     };
   };
 

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -9,14 +9,26 @@ let
 
   inherit (lib)
     concatLines
-    concatStringsSep
+    escapeShellArgs
     mkIf
     mkMerge
-    optionalString
+    optional
     ;
+  inherit (lib.cli) toGNUCommandLine;
 
   cfg = config.services.hylafax;
   mapModems = lib.forEach (lib.attrValues cfg.modems);
+
+  mkSpoolCmd =
+    prefix: program: posArg: options:
+    let
+      start = "${prefix}${pkgs.hylafaxplus}/spool/bin/${program}";
+      optionsList = toGNUCommandLine { mkOptionName = k: "-${k}"; } (
+        { q = cfg.spoolAreaPath; } // options
+      );
+      posArgList = optional (posArg != null) posArg;
+    in
+    "${start} ${escapeShellArgs (optionsList ++ posArgList)}";
 
   mkConfigFile =
     name: conf:
@@ -160,7 +172,7 @@ let
     wants = mapModems ({ name, ... }: "hylafax-faxgetty@${name}.service");
     wantedBy = mkIf cfg.autostart [ "multi-user.target" ];
     serviceConfig.Type = "forking";
-    serviceConfig.ExecStart = ''${pkgs.hylafaxplus}/spool/bin/faxq -q "${cfg.spoolAreaPath}"'';
+    serviceConfig.ExecStart = mkSpoolCmd "" "faxq" null { };
     # This delays the "readiness" of this service until
     # all modems are initialized (or a timeout is reached).
     # Otherwise, sending a fax with the fax service
@@ -170,7 +182,7 @@ let
     serviceConfig.ExecStartPost = [ "${waitFaxqScript}" ];
     # faxquit fails if the pipe is already gone
     # (e.g. the service is already stopping)
-    serviceConfig.ExecStop = ''-${pkgs.hylafaxplus}/spool/bin/faxquit -q "${cfg.spoolAreaPath}"'';
+    serviceConfig.ExecStop = mkSpoolCmd "-" "faxquit" null { };
     # disable some systemd hardening settings
     serviceConfig.PrivateDevices = null;
     serviceConfig.RestrictRealtime = null;
@@ -183,7 +195,10 @@ let
     requires = [ "hylafax-faxq.service" ];
     serviceConfig.StandardInput = "socket";
     serviceConfig.StandardOutput = "socket";
-    serviceConfig.ExecStart = ''${pkgs.hylafaxplus}/spool/bin/hfaxd -q "${cfg.spoolAreaPath}" -d -I'';
+    serviceConfig.ExecStart = mkSpoolCmd "" "hfaxd" null {
+      d = true;
+      I = true;
+    };
     unitConfig.RequiresMountsFor = [ cfg.userAccessFile ];
     # disable some systemd hardening settings
     serviceConfig.PrivateDevices = null;
@@ -197,13 +212,11 @@ let
     requires = [ "hylafax-spool.service" ];
     wantedBy = mkIf cfg.faxcron.enable.spoolInit requires;
     startAt = mkIf (cfg.faxcron.enable.frequency != null) cfg.faxcron.enable.frequency;
-    serviceConfig.ExecStart = concatStringsSep " " [
-      "${pkgs.hylafaxplus}/spool/bin/faxcron"
-      ''-q "${cfg.spoolAreaPath}"''
-      ''-info ${toString cfg.faxcron.infoDays}''
-      ''-log  ${toString cfg.faxcron.logDays}''
-      ''-rcv  ${toString cfg.faxcron.rcvDays}''
-    ];
+    serviceConfig.ExecStart = mkSpoolCmd "" "faxcron" null {
+      info = cfg.faxcron.infoDays;
+      log = cfg.faxcron.logDays;
+      rcv = cfg.faxcron.rcvDays;
+    };
   };
 
   services.hylafax-faxqclean = rec {
@@ -213,15 +226,13 @@ let
     requires = [ "hylafax-spool.service" ];
     wantedBy = mkIf cfg.faxqclean.enable.spoolInit requires;
     startAt = mkIf (cfg.faxqclean.enable.frequency != null) cfg.faxqclean.enable.frequency;
-    serviceConfig.ExecStart = concatStringsSep " " [
-      "${pkgs.hylafaxplus}/spool/bin/faxqclean"
-      ''-q "${cfg.spoolAreaPath}"''
-      "-v"
-      (optionalString (cfg.faxqclean.archiving != "never") "-a")
-      (optionalString (cfg.faxqclean.archiving == "always") "-A")
-      ''-j ${toString (cfg.faxqclean.doneqMinutes * 60)}''
-      ''-d ${toString (cfg.faxqclean.docqMinutes * 60)}''
-    ];
+    serviceConfig.ExecStart = mkSpoolCmd "" "faxqclean" null {
+      v = true;
+      a = cfg.faxqclean.archiving != "never";
+      A = cfg.faxqclean.archiving == "always";
+      j = 60 * cfg.faxqclean.doneqMinutes;
+      d = 60 * cfg.faxqclean.docqMinutes;
+    };
   };
 
   mkFaxgettyService =
@@ -243,10 +254,10 @@ let
       serviceConfig.Restart = "always";
       serviceConfig.KillMode = "process";
       serviceConfig.IgnoreSIGPIPE = false;
-      serviceConfig.ExecStart = ''-${pkgs.hylafaxplus}/spool/bin/faxgetty -q "${cfg.spoolAreaPath}" /dev/%I'';
+      serviceConfig.ExecStart = mkSpoolCmd "-" "faxgetty" "/dev/%I" { };
       # faxquit fails if the pipe is already gone
       # (e.g. the service is already stopping)
-      serviceConfig.ExecStop = ''-${pkgs.hylafaxplus}/spool/bin/faxquit -q "${cfg.spoolAreaPath}" %I'';
+      serviceConfig.ExecStop = mkSpoolCmd "-" "faxquit" "%I" { };
       # disable some systemd hardening settings
       serviceConfig.PrivateDevices = null;
       serviceConfig.RestrictRealtime = null;

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -7,8 +7,12 @@
 
 let
 
-  inherit (lib) mkIf mkMerge;
-  inherit (lib) concatStringsSep optionalString;
+  inherit (lib)
+    concatStringsSep
+    mkIf
+    mkMerge
+    optionalString
+    ;
 
   cfg = config.services.hylafax;
   mapModems = lib.forEach (lib.attrValues cfg.modems);

--- a/nixos/modules/services/networking/hylafax/systemd.nix
+++ b/nixos/modules/services/networking/hylafax/systemd.nix
@@ -8,6 +8,7 @@
 let
 
   inherit (lib)
+    concatLines
     concatStringsSep
     mkIf
     mkMerge
@@ -29,7 +30,7 @@ let
       include = mkLines { Include = conf.Include or [ ]; };
       other = mkLines (conf // { Include = [ ]; });
     in
-    pkgs.writeText "hylafax-config${name}" (concatStringsSep "\n" (include ++ other));
+    pkgs.writeText "hylafax-config${name}" (concatLines (include ++ other));
 
   globalConfigPath = mkConfigFile "" cfg.faxqConfig;
 
@@ -51,7 +52,7 @@ let
     in
     pkgs.runCommand "hylafax-config-modems" {
       preferLocalBuild = true;
-    } ''mkdir --parents "$out/" ${concatStringsSep "\n" (mapModems mkLine)}'';
+    } ''mkdir --parents "$out/" ${concatLines (mapModems mkLine)}'';
 
   setupSpoolScript = pkgs.replaceVarsWith {
     name = "hylafax-setup-spool.sh";

--- a/pkgs/by-name/hy/hylafaxplus/package.nix
+++ b/pkgs/by-name/hy/hylafaxplus/package.nix
@@ -91,9 +91,6 @@ stdenv.mkDerivation (finalAttrs: {
     openldap # optional
     pam # optional
   ];
-  # Disable parallel build, errors:
-  #  *** No rule to make target '../util/libfaxutil.so.7.0.4', needed by 'faxmsg'.  Stop.
-  enableParallelBuilding = false;
 
   postPatch = ". ${postPatch}";
   dontAddPrefix = true;

--- a/pkgs/by-name/hy/hylafaxplus/package.nix
+++ b/pkgs/by-name/hy/hylafaxplus/package.nix
@@ -64,10 +64,10 @@ in
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "hylafaxplus";
-  version = "7.0.9";
+  version = "7.0.10";
   src = fetchurl {
     url = "mirror://sourceforge/hylafax/hylafax-${finalAttrs.version}.tar.gz";
-    hash = "sha512-3OJwM4vFC9pzPozPobFLiNNx/Qnkl8BpNNziRUpJNBDLBxjtg/eDm3GnprS2hpt7VUoV4PCsFvp1hxhNnhlUwQ==";
+    hash = "sha512-6HdYMHq4cLbS06UXs+FEg3XtsMRyXflrgn/NEsgyMFkTS/MoGW8RVXgbXxAhcArpFvMsY0NUPLE3jdbqqWWQCw==";
   };
   patches = [
     # adjust configure check to work with libtiff > 4.1

--- a/pkgs/by-name/hy/hylafaxplus/package.nix
+++ b/pkgs/by-name/hy/hylafaxplus/package.nix
@@ -32,10 +32,6 @@
 
 let
 
-  pname = "hylafaxplus";
-  version = "7.0.9";
-  hash = "sha512-3OJwM4vFC9pzPozPobFLiNNx/Qnkl8BpNNziRUpJNBDLBxjtg/eDm3GnprS2hpt7VUoV4PCsFvp1hxhNnhlUwQ==";
-
   configSite = replaceVars ./config.site {
     config_maxgid = lib.optionalString (maxgid != null) ''CONFIG_MAXGID=${builtins.toString maxgid}'';
     ghostscript_version = ghostscript.version;
@@ -66,11 +62,12 @@ let
 
 in
 
-stdenv.mkDerivation {
-  inherit pname version;
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hylafaxplus";
+  version = "7.0.9";
   src = fetchurl {
-    url = "mirror://sourceforge/hylafax/hylafax-${version}.tar.gz";
-    inherit hash;
+    url = "mirror://sourceforge/hylafax/hylafax-${finalAttrs.version}.tar.gz";
+    hash = "sha512-3OJwM4vFC9pzPozPobFLiNNx/Qnkl8BpNNziRUpJNBDLBxjtg/eDm3GnprS2hpt7VUoV4PCsFvp1hxhNnhlUwQ==";
   };
   patches = [
     # adjust configure check to work with libtiff > 4.1
@@ -103,7 +100,7 @@ stdenv.mkDerivation {
   postInstall = ". ${postInstall}";
   postInstallCheck = ". ${./post-install-check.sh}";
   meta = {
-    changelog = "https://hylafax.sourceforge.io/news/${version}.php";
+    changelog = "https://hylafax.sourceforge.io/news/${finalAttrs.version}.php";
     description = "enterprise-class system for sending and receiving facsimiles";
     downloadPage = "https://hylafax.sourceforge.io/download.php";
     homepage = "https://hylafax.sourceforge.io";
@@ -127,4 +124,4 @@ stdenv.mkDerivation {
       and the server parts of HylaFAX+.
     '';
   };
-}
+})


### PR DESCRIPTION
`hylafaxplus` package:

* update to newest release: [release notes](https://hylafax.sourceforge.io/news/7.0.10.php)
* use `finalAttrs` for `version`
* enable parallel build: This works great on my machine.  If it fails on hydra, we have to revert that commit.

`hylafax` module:

* use `lib.getExe'`, `lib.concatLines` and `lib.toGNUCommandLine` where appropriate

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

More tests, tested on x86-64:

* [x] `hylafaxplus` builds successfully
* [x] sending and receiving faxes works
* [x] sending to unresponsive or busy number returns the expected error
* [x] sending over a flaky line (random connection interruptions) causes automatic retries as expected

Somehow `nixpkgs-review rev HEAD` wants to recompile 5254 packages.  Might be related to https://github.com/Mic92/nixpkgs-review/issues/446 , but I can't tell for sure.

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
