### PR TITLE
zig: fix darwin SDK lookup

### DIFF
--- a/pkgs/development/compilers/zig/generic.nix
+++ b/pkgs/development/compilers/zig/generic.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   cmake,
   llvmPackages,
+  xcbuild,
   targetPackages,
   libxml2,
   zlib,
@@ -30,10 +31,15 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = args.patches or [ ];
 
-  nativeBuildInputs = [
-    cmake
-    (lib.getDev llvmPackages.llvm.dev)
-  ];
+  nativeBuildInputs =
+    [
+      cmake
+      (lib.getDev llvmPackages.llvm.dev)
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # provides xcode-select, which is required for SDK detection
+      xcbuild
+    ];
 
   buildInputs =
     [
@@ -81,16 +87,29 @@ stdenv.mkDerivation (finalAttrs: {
   # Zig's build looks at /usr/bin/env to find dynamic linking info. This doesn't
   # work in Nix's sandbox. Use env from our coreutils instead.
   postPatch =
-    if lib.versionAtLeast finalAttrs.version "0.12" then
-      ''
-        substituteInPlace lib/std/zig/system.zig \
-          --replace-fail "/usr/bin/env" "${coreutils}/bin/env"
-      ''
-    else
-      ''
-        substituteInPlace lib/std/zig/system/NativeTargetInfo.zig \
-          --replace-fail "/usr/bin/env" "${coreutils}/bin/env"
-      '';
+    (
+      if lib.versionAtLeast finalAttrs.version "0.12" then
+        ''
+          substituteInPlace lib/std/zig/system.zig \
+            --replace-fail "/usr/bin/env" "${coreutils}/bin/env"
+        ''
+      else
+        ''
+          substituteInPlace lib/std/zig/system/NativeTargetInfo.zig \
+            --replace-fail "/usr/bin/env" "${coreutils}/bin/env"
+        ''
+    )
+    # Zig tries to access xcrun and xcode-select at the absolute system path to query the macOS SDK
+    # location, which does not work in the darwin sandbox.
+    # Upstream issue: https://github.com/ziglang/zig/issues/22600
+    # Note that while this fix is already merged upstream and will be included in 0.14+,
+    # we can't fetchpatch the upstream commit as it won't cleanly apply on older versions,
+    # so we substitute the paths instead.
+    + lib.optionalString (stdenv.hostPlatform.isDarwin && lib.versionOlder finalAttrs.version "0.14") ''
+      substituteInPlace lib/std/zig/system/darwin.zig \
+        --replace-fail /usr/bin/xcrun xcrun \
+        --replace-fail /usr/bin/xcode-select xcode-select
+    '';
 
   postBuild =
     if lib.versionAtLeast finalAttrs.version "0.13" then

--- a/pkgs/development/compilers/zig/hook.nix
+++ b/pkgs/development/compilers/zig/hook.nix
@@ -2,12 +2,18 @@
   lib,
   makeSetupHook,
   zig,
+  stdenv,
+  xcbuild,
 }:
 
 makeSetupHook {
   name = "zig-hook";
 
-  propagatedBuildInputs = [ zig ];
+  propagatedBuildInputs =
+    [ zig ]
+    # while xcrun is already included in the darwin stdenv, Zig also needs
+    # xcode-select (provided by xcbuild) for SDK detection
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
 
   substitutions = {
     # This zig_default_flags below is meant to avoid CPU feature impurity in


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Building Zig packages on darwin can [currently fail](https://github.com/NixOS/nixpkgs/pull/373289#issuecomment-2607859906) because of the hardcoded `/usr/bin/xcrun` call in Zig's macOS SDK lookup method (https://github.com/ziglang/zig/issues/22600).

https://github.com/ziglang/zig/blob/f3c29dcb247be5e50d2d05f9fb2e814ebf115a86/lib/std/zig/system/darwin.zig#L51

This is fixed by replacing it with just `xcrun`, which will then use the `xcrun` provided by the nixpkgs darwin stdenv. I decided against using an absolute nix store path for `xcrun` as replacement as @reckenrode raised concerns about that causing issues in Nix development shells.

Zig also calls `/usr/bin/xcode-select`, which I have replaced by `xcode-select` in the `xcbuild` package. In this case, the absolute path to the nix store is acceptable even for devShells as Zig discards the output of `xcode-select` and just checks if the command is successful:

https://github.com/ziglang/zig/blob/f77e1b86225cd49c2d04dfa6ca4a7ede315dc0b1/lib/std/zig/system/darwin.zig#L18

~~I also removed the by now rather old Zig versions 0.9 and 0.10 (not completely arbitrarily, they are the only releases marked as "pre-release" on https://github.com/ziglang/zig/releases and had either no or only one dependant in nixpkgs). For `zig_0_9`, there was a single dependant [colorstorm](https://github.com/benbusby/colorstorm) which already is Zig 0.13 compatible in its HEAD state. I opened [an issue](https://github.com/benbusby/colorstorm/issues/16) requesting a new tagged release for colorstorm as the last one is three years old, and in the meanwhile bumped colorstorm to the commit bringing Zig 0.13 compatibility.~~ This part has been moved to a separate PR: #376540

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
