### PR TITLE
vst2-sdk: init at 2018-06-11

### DIFF
--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -12,6 +12,7 @@
   file,
   libX11,
   qt5,
+  vst2-sdk,
 }:
 
 let
@@ -22,18 +23,6 @@ let
     repo = "airwave";
     rev = version;
     sha256 = "1ban59skw422mak3cp57lj27hgq5d3a4f6y79ysjnamf8rpz9x4s";
-  };
-
-  vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk369_01_03_2018_build_132";
-    src = requireFile {
-      name = "${name}.zip";
-      url = "http://www.steinberg.net/en/company/developers.html";
-      sha256 = "0r29fv6yhm2m5yznn8m4my7fq01w1lpphax4sshagy6b1dgjlv3w";
-    };
-    nativeBuildInputs = [ unzip ];
-    installPhase = "cp -r . $out";
-    meta.license = lib.licenses.unfree;
   };
 
   wine-wow64 = wine.override {
@@ -84,7 +73,7 @@ multiStdenv.mkDerivation {
   # Cf. https://github.com/phantom-code/airwave/issues/57
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = [ "-DVSTSDK_PATH=${vst-sdk}/VST2_SDK" ];
+  cmakeFlags = [ "-DVSTSDK_PATH=${vst2-sdk}" ];
 
   postInstall = ''
     mv $out/bin $out/libexec

--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -83,7 +83,7 @@ multiStdenv.mkDerivation {
     wrapProgram $out/libexec/airwave-host-64.exe --set WINELOADER ${wine-xembed}/bin/wine64
   '';
 
-  meta = with lib; {
+  meta = {
     description = "WINE-based VST bridge for Linux VST hosts";
     longDescription = ''
       Airwave is a wine based VST bridge, that allows for the use of
@@ -94,9 +94,9 @@ multiStdenv.mkDerivation {
       window.
     '';
     homepage = "https://github.com/phantom-code/airwave";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     platforms = [ "x86_64-linux" ];
-    maintainers = with maintainers; [ michalrus ];
+    maintainers = with lib.maintainers; [ michalrus ];
     hydraPlatforms = [ ];
   };
 }

--- a/pkgs/by-name/ai/airwindows/package.nix
+++ b/pkgs/by-name/ai/airwindows/package.nix
@@ -5,27 +5,8 @@
   lib,
   cmake,
   nix-update-script,
+  vst2-sdk,
 }:
-let
-  # adapted from oxefmsynth
-  vst-sdk = stdenv.mkDerivation {
-    dontConfigure = true;
-    dontPatch = true;
-    dontBuild = true;
-    dontStrip = true;
-    dontPatchELF = true;
-
-    name = "vstsdk3610_11_06_2018_build_37";
-    src = fetchzip {
-      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/vstsdk3610_11_06_2018_build_37.zip";
-      sha256 = "0da16iwac590wphz2sm5afrfj42jrsnkr1bxcy93lj7a369ildkj";
-    };
-
-    installPhase = ''
-      cp -r VST2_SDK $out
-    '';
-  };
-in
 stdenv.mkDerivation {
   pname = "airwindows";
   version = "0-unstable-2025-01-06";
@@ -41,7 +22,7 @@ stdenv.mkDerivation {
   # came from.
   prePatch = ''
     mkdir -p plugins/LinuxVST/include
-    ln -s ${vst-sdk.out} plugins/LinuxVST/include/vstsdk
+    ln -s ${vst2-sdk} plugins/LinuxVST/include/vstsdk
   '';
 
   patches = [
@@ -62,7 +43,7 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    vst-sdk
+    vst2-sdk
   ];
 
   installPhase = ''
@@ -82,7 +63,6 @@ stdenv.mkDerivation {
     platforms = lib.platforms.linux;
     license = [
       lib.licenses.mit
-      lib.licenses.unfree
     ];
     maintainers = [ lib.maintainers.l1npengtul ];
   };

--- a/pkgs/by-name/be/bespokesynth/package.nix
+++ b/pkgs/by-name/be/bespokesynth/package.nix
@@ -23,6 +23,7 @@
   libXScrnSaver,
   libGL,
   libxcb,
+  vst2-sdk,
   xcbutil,
   libxkbcommon,
   xcbutilkeysyms,
@@ -40,20 +41,6 @@
   enableVST2 ? false,
 }:
 
-let
-  # equal to vst-sdk in ../oxefmsynth/default.nix
-  vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk3610_11_06_2018_build_37";
-    src = fetchzip {
-      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/${name}.zip";
-      sha256 = "0da16iwac590wphz2sm5afrfj42jrsnkr1bxcy93lj7a369ildkj";
-    };
-    installPhase = ''
-      cp -r . $out
-    '';
-  };
-
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "bespokesynth";
   version = "1.3.0";
@@ -88,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.cmakeBool "BESPOKE_SYSTEM_JSONCPP" true)
     ]
     ++ lib.optionals enableVST2 [
-      (lib.cmakeFeature "BESPOKE_VST2_SDK_LOCATION" "${vst-sdk}/VST2_SDK")
+      (lib.cmakeFeature "BESPOKE_VST2_SDK_LOCATION" "${vst2-sdk}")
     ];
 
   strictDeps = true;
@@ -185,12 +172,7 @@ stdenv.mkDerivation (finalAttrs: {
   meta = {
     description = "Software modular synth with controllers support, scripting and VST";
     homepage = "https://www.bespokesynth.com/";
-    license =
-      with lib.licenses;
-      [
-        gpl3Plus
-      ]
-      ++ lib.optional enableVST2 unfree;
+    license = [ lib.licenses.gpl3Plus ];
     maintainers = with lib.maintainers; [
       astro
       tobiasBora

--- a/pkgs/by-name/ja/jackass/package.nix
+++ b/pkgs/by-name/ja/jackass/package.nix
@@ -4,26 +4,11 @@
   fetchFromGitHub,
   fetchzip,
   pkg-config,
+  vst2-sdk,
   wine64,
   enableJackAssWine64 ? false,
 }:
 
-let
-  # equal to vst-sdk in ../oxefmsynth/default.nix
-  vst-sdk = stdenv.mkDerivation (finalAttrs: {
-    name = "vstsdk3610_11_06_2018_build_37";
-    src = fetchzip {
-      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/${finalAttrs.name}.zip";
-      hash = "sha256-cjYakxnqSDqSZ32FPK3OUhDpslOlavHh5SAVpng0QTU=";
-    };
-    installPhase = ''
-      runHook preInstall
-      cp -r . $out
-      runHook postInstall
-    '';
-  });
-
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jackass";
   version = "1.1";
@@ -36,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    cp -r ${vst-sdk}/VST2_SDK/{public.sdk,pluginterfaces} vstsdk2.4
+    cp -r ${vst2-sdk}/{public.sdk,pluginterfaces} vstsdk2.4
   '';
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals enableJackAssWine64 [ wine64 ];
@@ -59,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "JackAss is a VST plugin that provides JACK-MIDI support for VST hosts";
     longDescription = ''
       Simply load the plugin in your favourite host to get a JACK-MIDI port.
@@ -67,11 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
       applications. Set enableJackAssWine64 to true to enable this output.
     '';
     homepage = "https://github.com/falkTX/JackAss";
-    maintainers = with maintainers; [ PowerUser64 ];
-    license = with licenses; [
-      mit
-      unfree
-    ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ PowerUser64 ];
+    license = [ lib.licenses.mit ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ox/oxefmsynth/package.nix
+++ b/pkgs/by-name/ox/oxefmsynth/package.nix
@@ -4,20 +4,8 @@
   fetchFromGitHub,
   fetchzip,
   libX11,
+  vst2-sdk,
 }:
-
-let
-
-  vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk3610_11_06_2018_build_37";
-    src = fetchzip {
-      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/${name}.zip";
-      sha256 = "0da16iwac590wphz2sm5afrfj42jrsnkr1bxcy93lj7a369ildkj";
-    };
-    installPhase = "cp -r . $out";
-  };
-
-in
 stdenv.mkDerivation rec {
   pname = "oxefmsynth";
   version = "1.3.5";
@@ -31,7 +19,7 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-narrowing" ];
 
-  buildFlags = [ "VSTSDK_PATH=${vst-sdk}/VST2_SDK" ];
+  buildFlags = [ "VSTSDK_PATH=${vst2-sdk}" ];
 
   buildInputs = [ libX11 ];
 
@@ -40,11 +28,11 @@ stdenv.mkDerivation rec {
     install -Dm644 oxevst64.so -t $out/lib/lxvst
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/oxesoft/oxefmsynth";
     description = "Open source VST 2.4 instrument plugin";
-    maintainers = [ maintainers.hirenashah ];
+    maintainers = [ lib.maintainers.hirenashah ];
     platforms = [ "x86_64-linux" ];
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
   };
 }

--- a/pkgs/by-name/vs/vst2-sdk/package.nix
+++ b/pkgs/by-name/vs/vst2-sdk/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchzip,
+}:
+fetchzip rec {
+  name = "vst2-sdk-${version}"; # cannot be `pname`, as `fetchzip` expects `name`
+  version = "2018-06-11";
+  url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/vstsdk3610_11_06_2018_build_37.zip";
+  hash = "sha256-TyPy8FsXWB8LRz0yr38t3d5xxAxGufAn0dsyrg1JXBA=";
+
+  # Only keep the VST2_SDK directory
+  stripRoot = false;
+  postFetch = ''
+    mv $out/VST_SDK/VST2_SDK/* $out/
+    rm -rf $out/VST_SDK
+  '';
+
+  meta = {
+    description = "The VST2 source development kit";
+    longDescription = ''
+      VST2 is proprietary, and deprecated by Steinberg.
+      As such, it should only be used for legacy reasons.
+    '';
+    license = [ lib.licenses.unfree ];
+  };
+}


### PR DESCRIPTION
- Package `vst-sdk` as a reusable derivation
- Remove duplicates in `airwave`, `airwindows`, `bespokesynth`, `jackass` and `oxefmsynth`
  Fixes packages mistakenly labelled as free: `airwave` and `oxefmsynth`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
