### PR TITLE
positron-bin: adding support for aarch64-linux

### DIFF
--- a/pkgs/by-name/po/positron-bin/package.nix
+++ b/pkgs/by-name/po/positron-bin/package.nix
@@ -21,7 +21,7 @@
 }:
 let
   pname = "positron-bin";
-  version = "2024.11.0-116";
+  version = "2025.02.0-79";
 in
 stdenv.mkDerivation {
   inherit version pname;
@@ -30,12 +30,12 @@ stdenv.mkDerivation {
     if stdenv.hostPlatform.isDarwin then
       fetchurl {
         url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}.dmg";
-        hash = "sha256-5Ym42InDgFLGdZk0LYV1H0eC5WzmsYToG1KLdiGgTto=";
+        hash = "sha256-eqThNxOLxxoysOaYQPwGFFG7tCESBDERxbYzwBoIbxI=";
       }
     else
       fetchurl {
-        url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}.deb";
-        hash = "sha256-pE25XVYFW8WwyQ7zmox2mmXy6ZCSaXk2gSnPimg7xtU=";
+        url = "https://github.com/posit-dev/positron/releases/download/${version}/Positron-${version}-x64.deb";
+        hash = "sha256-XJ5otDdqMGKitCl6oSECT8al6ZE/MEBrt/EE2wS/Ayg=";
       };
 
   buildInputs =
@@ -99,8 +99,8 @@ stdenv.mkDerivation {
         install -m 444 -D usr/share/applications/positron.desktop "$out/share/applications/positron.desktop"
         substituteInPlace "$out/share/applications/positron.desktop" \
           --replace-fail \
-          "Icon=com.visualstudio.code.oss" \
-          "Icon=$out/share/pixmaps/com.visualstudio.code.oss.png" \
+          "Icon=co.posit.positron" \
+          "Icon=$out/share/pixmaps/co.posit.positron.png" \
           --replace-fail \
           "Exec=/usr/share/positron/positron %F" \
           "Exec=$out/share/positron/.positron-wrapped %F" \

--- a/pkgs/by-name/po/positron-bin/update.sh
+++ b/pkgs/by-name/po/positron-bin/update.sh
@@ -33,7 +33,7 @@ current_hash=$(nix store prefetch-file --json --hash-type sha256 \
     | jq -r .hash)
 
 new_hash=$(nix store prefetch-file --json --hash-type sha256 \
-    "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}.deb" \
+    "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}-x64.deb" \
     | jq -r .hash)
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix

--- a/pkgs/by-name/po/positron-bin/update.sh
+++ b/pkgs/by-name/po/positron-bin/update.sh
@@ -27,16 +27,27 @@ new_hash=$(nix store prefetch-file --json --hash-type sha256 \
 
 sed -i "s|$current_hash|$new_hash|g" $positron_nix
 
-# Update Linux hash.
-current_hash=$(nix store prefetch-file --json --hash-type sha256 \
+# Update Linux hash for x64.
+current_hash_x64=$(nix store prefetch-file --json --hash-type sha256 \
     "https://github.com/posit-dev/positron/releases/download/${current_version}/Positron-${current_version}.deb" \
     | jq -r .hash)
 
-new_hash=$(nix store prefetch-file --json --hash-type sha256 \
+new_hash_x64=$(nix store prefetch-file --json --hash-type sha256 \
     "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}-x64.deb" \
     | jq -r .hash)
 
-sed -i "s|$current_hash|$new_hash|g" $positron_nix
+sed -i "s|$current_hash_x64|$new_hash_x64|g" $positron_nix
+
+# Update Linux hash for arm64.
+current_hash_arm64=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://github.com/posit-dev/positron/releases/download/${current_version}/Positron-${current_version}.deb" \
+    | jq -r .hash)
+
+new_hash_arm64=$(nix store prefetch-file --json --hash-type sha256 \
+    "https://github.com/posit-dev/positron/releases/download/${new_version}/Positron-${new_version}-arm64.deb" \
+    | jq -r .hash)
+
+sed -i "s|$current_hash_arm64|$new_hash_arm64|g" $positron_nix
 
 # Update version
 sed -i "s|$current_version|$new_version|g" $positron_nix


### PR DESCRIPTION
Stacked on https://github.com/NixOS/nixpkgs/pull/373551

Trying to add support for aarch64-linux but getting the following error
 
```
[18361:0124/151602.057556:FATAL:setuid_sandbox_host.cc(163)] The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /nix/store/8zj8jpsvdsq20699sw33mh1a9k6p3pdg-positron-bin-2025.02.0-79/share/positron/chrome-sandbox is owned by root and has mode 4755.
Trace/breakpoint trap (core dumped)
```

tried to add the following unpackPhase to deal with this:

```
 unpackPhase =
    if stdenv.hostPlatform.isLinux then
      ''
        runHook preUnpack
        # The deb file contains a setuid binary, so 'dpkg -x' doesn't work here
        dpkg-deb --fsys-tarfile $src | tar -x --no-same-permissions --no-same-owner
        runHook postUnpack
      ''
    else
      "";
```

but no dice. Any ideas welcome.

@fyi @detroyejr 


- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
