### PR TITLE
mathematica: allow user to provide version info

### DIFF
--- a/pkgs/by-name/ma/mathematica/generic.nix
+++ b/pkgs/by-name/ma/mathematica/generic.nix
@@ -3,8 +3,6 @@
   autoPatchelfHook,
   lib,
   makeWrapper,
-  requireFile,
-  runCommand,
   stdenv,
   symlinkJoin,
   # arguments from default.nix
@@ -91,8 +89,12 @@ stdenv.mkDerivation {
     meta
     pname
     src
-    version
     ;
+
+  version =
+    version # a comment to trick nixfmt
+    + lib.optionalString cudaSupport "-cuda"
+    + lib.optionalString (lang != "en") "-${lang}";
 
   nativeBuildInputs = [
     autoPatchelfHook

--- a/pkgs/by-name/ma/mathematica/package.nix
+++ b/pkgs/by-name/ma/mathematica/package.nix
@@ -1,34 +1,61 @@
 {
   callPackage,
+  requireFile,
   config,
   lib,
   cudaPackages,
   cudaSupport ? config.cudaSupport,
+  /*
+    If you want an older version or a version with web documentation or different language,
+    you can override any of the following attributes:
+    ```nix
+    my_mathematica = mathematica.override {
+      version = "X.Y.Z";
+      lang = "??";
+      webdoc = true;
+    };
+    ```
+    This, however, requires that the version you are requesting is known to nixpkgs
+    and is added as an entry in `./versions.nix`.
+    If it is not, you can manually specify all the necessary information:
+    ```nix
+    my_mathematica = mathematica.override {
+      versionInfo = {
+        version = "X.Y.Z";
+        lang = "en";
+        language = "English";
+        # Get this hash via a command similar to this:
+        # nix-hash --type sha256 --sri \
+        # $(nix store add-path Wolfram_XX.X.X_BNDL_LINUX.sh --name 'Wolfram_XX.X.X_BNDL_LINUX.sh')
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        installer = "Installer_File_Name.sh";
+      };
+    };
+    ```
+    `versionInfo` will take precedence over `version`, `lang`, & `webdoc`.
+  */
   lang ? "en",
   webdoc ? false,
   version ? null,
+  versionInfo ? null,
   /*
-    If you wish to completely override the src, use:
+    By default, this nix expression will try to find the installer in the Nix Store
+    based on the filename and hash (either found in ./versions.nix or provided by user in `versionInfo`).
+    But you can completely override the `src`:
+    ```nix
     my_mathematica = mathematica.override {
-      source = pkgs.requireFile {
-        name = "Mathematica_XX.X.X_BNDL_LINUX.sh";
-        # Get this hash via a command similar to this:
-        # nix-store --query --hash \
-        # $(nix store add-path Mathematica_XX.X.X_BNDL_LINUX.sh --name 'Mathematica_XX.X.X_BNDL_LINUX.sh')
-        sha256 = "0000000000000000000000000000000000000000000000000000";
-        message = ''
-          Your override for Mathematica includes a different src for the installer,
-          and it is missing.
-        '';
-        hashMode = "recursive";
+      source = pkgs.fetchurl {
+        url = "https://example.com/Wolfram_XX.X.X_BNDL_LINUX.sh";
+        hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
       };
-    }
+    };
+    ```
   */
   source ? null,
 }:
 
 let
-  versions = callPackage ./versions.nix { };
+  versions = import ./versions.nix;
 
   matching-versions = lib.sort (v1: v2: lib.versionOlder v2.version v1.version) (
     lib.filter (
@@ -56,19 +83,31 @@ let
     in
     lib.compareLists lib.compare (sublist as) (sublist bs) == 0;
 
-  matchesDoc = v: (builtins.match ".*[0-9]_LIN(UX)?.sh" v.src.name != null) == webdoc;
+  matchesDoc = v: (builtins.match ".*[0-9]_LIN(UX)?.sh" v.installer != null) == webdoc;
+
+  selected = lib.defaultTo found-version versionInfo;
+
+  defaultSource = requireFile {
+    name = selected.installer;
+    message = ''
+      This nix expression requires that ${selected.installer} is
+      already part of the store. Find the file on your Mathematica CD
+      and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
+    '';
+    inherit (selected) hash;
+  };
 
 in
 
 callPackage ./generic.nix {
   inherit cudaSupport cudaPackages;
-  inherit (found-version) lang;
-  src = if source == null then found-version.src else source;
+
   pname = "mathematica";
-  version =
-    found-version.version
-    + lib.optionalString cudaSupport "-cuda"
-    + lib.optionalString (lang != "en") "-${lang}";
+
+  inherit (selected) version lang;
+
+  src = lib.defaultTo defaultSource source;
+
   meta = {
     description = "Wolfram Mathematica computational software system";
     homepage = "https://www.wolfram.com/mathematica/";

--- a/pkgs/by-name/ma/mathematica/versions.nix
+++ b/pkgs/by-name/ma/mathematica/versions.nix
@@ -1,231 +1,203 @@
-{ lib, requireFile }:
-
 /*
   To calculate the hash of an installer, use a command like this:
 
     nix --extra-experimental-features nix-command hash file <installer-file>
 */
-
-let
-  versions = [
-    {
-      version = "14.3.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-F4Rl4xz3vso+N//Uz7ZXvh5CrM6nsKMQxrRR11o/aNA=";
-      installer = "Wolfram_14.3.0_LIN.sh";
-    }
-    {
-      version = "14.3.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-FvcXXijGOcuRA1UFyVvPIyR1YaK/qrkMpLxf+mz+A/c=";
-      installer = "Wolfram_14.3.0_LIN_Bndl.sh";
-    }
-    {
-      version = "14.2.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-WNLuq9RviYF3Mj8uOALhmvcxGGHVq/TAGFMTGWoYBcc=";
-      installer = "Wolfram_14.2.1_LIN.sh";
-    }
-    {
-      version = "14.2.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-DcZbetr5wO3i/DkchgpsW3RGHfa1PslA4fK+bRQ68Bg=";
-      installer = "Wolfram_14.2.1_LIN_Bndl.sh";
-    }
-    {
-      version = "14.2.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-wIuyWufKuchPl7phCxVM9vIIkjUHfRxIECfDyGJliqs=";
-      installer = "Wolfram_14.2.0_LIN.sh";
-    }
-    {
-      version = "14.2.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-wY6acGoUc7y22enSi7RrcRFLvvPGaeYTta4yWExlXho=";
-      installer = "Wolfram_14.2.0_LIN_Bndl.sh";
-    }
-    {
-      version = "14.1.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-PCpjwqA6NC+iwvYxddYBlmF5+vl76r+MoIYAL91WFns=";
-      installer = "Wolfram_14.1.0_LIN.sh";
-    }
-    {
-      version = "14.1.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-pnu60Pv3xo3+MAkDLiU3yTPVbbQ00diV45vSVL8B310=";
-      installer = "Wolfram_14.1.0_LIN_Bndl.sh";
-    }
-    {
-      version = "14.0.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-NzMhGQZq6o6V4UdtJxUH/yyP2s7wjTR86SRA7lW7JfI=";
-      installer = "Mathematica_14.0.0_LINUX.sh";
-    }
-    {
-      version = "14.0.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-UrcBEg6G6nbVX++X0z0oG5JjieXL0AquAqtjzY5EBn4=";
-      installer = "Mathematica_14.0.0_BNDL_LINUX.sh";
-    }
-    {
-      version = "13.3.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-0+mYVGiF4Qn3eiLIoINSHVIqT8GtlBPFRYIOF+nHyQo=";
-      installer = "Mathematica_13.3.1_LINUX.sh";
-    }
-    {
-      version = "13.3.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-03R4s05fmTcZnlZIMSI6xlLER58MIoccoCr27F8BXOk=";
-      installer = "Mathematica_13.3.1_BNDL_LINUX.sh";
-    }
-    {
-      version = "13.3.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-24MC0O+kBUe3TrwXUb+7QZt8tQHvWVIT8F9B6Ih+4k8=";
-      installer = "Mathematica_13.3.0_LINUX.sh";
-    }
-    {
-      version = "13.3.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-91bw7+4ht+7g+eF32BNYf77yEQWyuPffisj4kB63pcI=";
-      installer = "Mathematica_13.3.0_BNDL_LINUX.sh";
-    }
-    {
-      version = "13.2.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-GA2k+jvE4mTJsIbMHce5c516h/glHLnXdthEfnNmk0w=";
-      installer = "Mathematica_13.2.1_LINUX.sh";
-    }
-    {
-      version = "13.2.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-ZvgG2W/gjQIo4hyXHsGta5FyTslrz/ltOe/ZK/U2Sx8=";
-      installer = "Mathematica_13.2.1_BNDL_LINUX.sh";
-    }
-    {
-      version = "13.2.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-T9XOXA6jpgN6bcO/do9sw1L73ABtyxuZCLzftv4Cl6o=";
-      installer = "Mathematica_13.2.0_LINUX.sh";
-    }
-    {
-      version = "13.2.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-YRUvl2H9SwpwDZx04ugd7ZnK5G+t88bzAObXsGGVhk0=";
-      installer = "Mathematica_13.2.0_BNDL_LINUX.sh";
-    }
-    {
-      version = "13.1.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-GZyUYslx/M4aFI3Pj9Osw3/w79/Jp/4T3mRE277pNuM=";
-      installer = "Mathematica_13.1.0_LINUX.sh";
-    }
-    {
-      version = "13.1.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-LIpGAJ3uTkZgjc0YykwusyyHQKlCnTvrZGStFfSOz60=";
-      installer = "Mathematica_13.1.0_BNDL_LINUX.sh";
-    }
-    {
-      version = "13.0.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-NnKpIMG0rxr9SAcz9tZ2Zbr4JYdX3+WabtbXRAzybbo=";
-      installer = "Mathematica_13.0.1_BNDL_LINUX.sh";
-    }
-    {
-      version = "13.0.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-FbutOaWZUDEyXR0Xj2OwDnFwbT7JAB66bRaB+8mR0+E=";
-      installer = "Mathematica_13.0.0_BNDL_LINUX.sh";
-    }
-    {
-      version = "12.3.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-UbnKsS/ZGwCep61JaKLIpZ6U3FXS5swdcSrNW6LE1Qk=";
-      installer = "Mathematica_12.3.1_LINUX.sh";
-    }
-    {
-      version = "12.3.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-BF3wRfbnlt7Vn2TrLg8ZSayI3LodW24F+1PqCkrtchU=";
-      installer = "Mathematica_12.3.0_LINUX.sh";
-    }
-    {
-      version = "12.2.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-O2Z2ogPGrbfpxBilSEsDeXQoe1vgnGTn3+p03cDkANc=";
-      installer = "Mathematica_12.2.0_LINUX.sh";
-    }
-    {
-      version = "12.1.1";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-rUe4hr5KmGTXD1I/eSYVoFHU68mH2aD2VLZFtOtDswo=";
-      installer = "Mathematica_12.1.1_LINUX.sh";
-    }
-    {
-      version = "12.1.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-56P1KKOTJkQj+K9wppAsnYpej/YB3VUNL7DPLYGgqZY=";
-      installer = "Mathematica_12.1.0_LINUX.sh";
-    }
-    {
-      version = "12.0.0";
-      lang = "en";
-      language = "English";
-      sha256 = "sha256-uftx4a/MHXLCABlv+kNFEtII+ikg4geHhDP1BOWK6dc=";
-      installer = "Mathematica_12.0.0_LINUX.sh";
-    }
-  ];
-
-in
-
-lib.flip map versions (
+[
   {
-    version,
-    lang,
-    language,
-    sha256,
-    installer,
-  }:
-  {
-    inherit version lang;
-    src = requireFile {
-      name = installer;
-      message = ''
-        This nix expression requires that ${installer} is
-        already part of the store. Find the file on your Mathematica CD
-        and add it to the nix store with nix-store --add-fixed sha256 <FILE>.
-      '';
-      inherit sha256;
-    };
+    version = "14.3.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-F4Rl4xz3vso+N//Uz7ZXvh5CrM6nsKMQxrRR11o/aNA=";
+    installer = "Wolfram_14.3.0_LIN.sh";
   }
-)
+  {
+    version = "14.3.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-FvcXXijGOcuRA1UFyVvPIyR1YaK/qrkMpLxf+mz+A/c=";
+    installer = "Wolfram_14.3.0_LIN_Bndl.sh";
+  }
+  {
+    version = "14.2.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-WNLuq9RviYF3Mj8uOALhmvcxGGHVq/TAGFMTGWoYBcc=";
+    installer = "Wolfram_14.2.1_LIN.sh";
+  }
+  {
+    version = "14.2.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-DcZbetr5wO3i/DkchgpsW3RGHfa1PslA4fK+bRQ68Bg=";
+    installer = "Wolfram_14.2.1_LIN_Bndl.sh";
+  }
+  {
+    version = "14.2.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-wIuyWufKuchPl7phCxVM9vIIkjUHfRxIECfDyGJliqs=";
+    installer = "Wolfram_14.2.0_LIN.sh";
+  }
+  {
+    version = "14.2.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-wY6acGoUc7y22enSi7RrcRFLvvPGaeYTta4yWExlXho=";
+    installer = "Wolfram_14.2.0_LIN_Bndl.sh";
+  }
+  {
+    version = "14.1.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-PCpjwqA6NC+iwvYxddYBlmF5+vl76r+MoIYAL91WFns=";
+    installer = "Wolfram_14.1.0_LIN.sh";
+  }
+  {
+    version = "14.1.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-pnu60Pv3xo3+MAkDLiU3yTPVbbQ00diV45vSVL8B310=";
+    installer = "Wolfram_14.1.0_LIN_Bndl.sh";
+  }
+  {
+    version = "14.0.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-NzMhGQZq6o6V4UdtJxUH/yyP2s7wjTR86SRA7lW7JfI=";
+    installer = "Mathematica_14.0.0_LINUX.sh";
+  }
+  {
+    version = "14.0.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-UrcBEg6G6nbVX++X0z0oG5JjieXL0AquAqtjzY5EBn4=";
+    installer = "Mathematica_14.0.0_BNDL_LINUX.sh";
+  }
+  {
+    version = "13.3.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-0+mYVGiF4Qn3eiLIoINSHVIqT8GtlBPFRYIOF+nHyQo=";
+    installer = "Mathematica_13.3.1_LINUX.sh";
+  }
+  {
+    version = "13.3.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-03R4s05fmTcZnlZIMSI6xlLER58MIoccoCr27F8BXOk=";
+    installer = "Mathematica_13.3.1_BNDL_LINUX.sh";
+  }
+  {
+    version = "13.3.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-24MC0O+kBUe3TrwXUb+7QZt8tQHvWVIT8F9B6Ih+4k8=";
+    installer = "Mathematica_13.3.0_LINUX.sh";
+  }
+  {
+    version = "13.3.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-91bw7+4ht+7g+eF32BNYf77yEQWyuPffisj4kB63pcI=";
+    installer = "Mathematica_13.3.0_BNDL_LINUX.sh";
+  }
+  {
+    version = "13.2.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-GA2k+jvE4mTJsIbMHce5c516h/glHLnXdthEfnNmk0w=";
+    installer = "Mathematica_13.2.1_LINUX.sh";
+  }
+  {
+    version = "13.2.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-ZvgG2W/gjQIo4hyXHsGta5FyTslrz/ltOe/ZK/U2Sx8=";
+    installer = "Mathematica_13.2.1_BNDL_LINUX.sh";
+  }
+  {
+    version = "13.2.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-T9XOXA6jpgN6bcO/do9sw1L73ABtyxuZCLzftv4Cl6o=";
+    installer = "Mathematica_13.2.0_LINUX.sh";
+  }
+  {
+    version = "13.2.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-YRUvl2H9SwpwDZx04ugd7ZnK5G+t88bzAObXsGGVhk0=";
+    installer = "Mathematica_13.2.0_BNDL_LINUX.sh";
+  }
+  {
+    version = "13.1.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-GZyUYslx/M4aFI3Pj9Osw3/w79/Jp/4T3mRE277pNuM=";
+    installer = "Mathematica_13.1.0_LINUX.sh";
+  }
+  {
+    version = "13.1.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-LIpGAJ3uTkZgjc0YykwusyyHQKlCnTvrZGStFfSOz60=";
+    installer = "Mathematica_13.1.0_BNDL_LINUX.sh";
+  }
+  {
+    version = "13.0.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-NnKpIMG0rxr9SAcz9tZ2Zbr4JYdX3+WabtbXRAzybbo=";
+    installer = "Mathematica_13.0.1_BNDL_LINUX.sh";
+  }
+  {
+    version = "13.0.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-FbutOaWZUDEyXR0Xj2OwDnFwbT7JAB66bRaB+8mR0+E=";
+    installer = "Mathematica_13.0.0_BNDL_LINUX.sh";
+  }
+  {
+    version = "12.3.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-UbnKsS/ZGwCep61JaKLIpZ6U3FXS5swdcSrNW6LE1Qk=";
+    installer = "Mathematica_12.3.1_LINUX.sh";
+  }
+  {
+    version = "12.3.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-BF3wRfbnlt7Vn2TrLg8ZSayI3LodW24F+1PqCkrtchU=";
+    installer = "Mathematica_12.3.0_LINUX.sh";
+  }
+  {
+    version = "12.2.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-O2Z2ogPGrbfpxBilSEsDeXQoe1vgnGTn3+p03cDkANc=";
+    installer = "Mathematica_12.2.0_LINUX.sh";
+  }
+  {
+    version = "12.1.1";
+    lang = "en";
+    language = "English";
+    hash = "sha256-rUe4hr5KmGTXD1I/eSYVoFHU68mH2aD2VLZFtOtDswo=";
+    installer = "Mathematica_12.1.1_LINUX.sh";
+  }
+  {
+    version = "12.1.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-56P1KKOTJkQj+K9wppAsnYpej/YB3VUNL7DPLYGgqZY=";
+    installer = "Mathematica_12.1.0_LINUX.sh";
+  }
+  {
+    version = "12.0.0";
+    lang = "en";
+    language = "English";
+    hash = "sha256-uftx4a/MHXLCABlv+kNFEtII+ikg4geHhDP1BOWK6dc=";
+    installer = "Mathematica_12.0.0_LINUX.sh";
+  }
+]


### PR DESCRIPTION
Say I want to build Wolfram 14.2.0 (AKA Mathematica 14.2.0).  Since the installer is proprietary, it has to be added to Nix Store manually by the user, and then the nix expression for the package will find it using `requireFile`. But for that it needs hash. Most of those are added to `versions.nix`, but #376395 hasn't been merged yet, so I cannot just override `version` and call it a day, I will also need to provide the hash somehow. Okay, let's override `source`! I do it, but the thing still fails, because it still tries to find a matching entry in `versions.nix` and get `version`, `lang`, and some other stuff from there. Even though I have provided everything manually. That's dumb.

I *can* hack around this, and tell it to use `version = "14.1.0"`, while providing source for 14.2.0 instead, but then the version string in the path will be wrong and the benefits of using Nix over just running the installer yourself barely outweigh the pain at that point.

So this PR adds a new optional argument to the expression: `versionInfo`. It is structured the same way as all the entries in `versions.nix`, and if the user provides it, we use that. If not, then we fallback to finding a known entry using the provided `version`, `lang`, & `webdoc`, just like before. So this is fully backwards-compatible.

In both cases, the source will default to `requireFile`, but the user can still override it with `source`.

As a bonus: this does not seem to conflict with #347648 (fundamentally; there might be some trivially resolvable git conflicts though).

To summarize:
- Before this pr:
    1. Find a fitting entry in `versions.nix` based on `version`, `lang`, and `webdoc`.
    2. Build the package using either the provided `source`, if any, or `requireFile` for the installer based on the found entry.
- After this pr:
   1. Use the provided `verionInfo`, if any.
   2. If none, find it from `versions.nix` based on `version`, `lang`, and `webdoc`.
   3. Build the package using either the provided `source`, if any, or `requireFile` for the installer based on the provided or found `versionInfo`.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
