### PR TITLE
scalene: 1.5.49 -> 1.5.51

### DIFF
--- a/pkgs/development/python-modules/scalene/default.nix
+++ b/pkgs/development/python-modules/scalene/default.nix
@@ -31,22 +31,22 @@ let
     owner = "mpaland";
     repo = "printf";
     name = "printf";
-    rev = "v4.0.0";
+    tag = "v4.0.0";
     sha256 = "sha256-tgLJNJw/dJGQMwCmfkWNBvHB76xZVyyfVVplq7aSJnI=";
   };
 in
 
 buildPythonPackage rec {
   pname = "scalene";
-  version = "1.5.49";
+  version = "1.5.51";
   pyproject = true;
   disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "plasma-umass";
     repo = "scalene";
-    rev = "v${version}";
-    hash = "sha256-Ivce90+W9NBMQjebj3zCB5eqDJydT8OTPYy4fjbybgI=";
+    tag = "v${version}";
+    hash = "sha256-507auU1uy3StmDWruwd/sgJDpV1WhbneSj/bTxUuAN0=";
   };
 
   patches = [
@@ -109,5 +109,15 @@ buildPythonPackage rec {
     mainProgram = "scalene";
     license = licenses.asl20;
     maintainers = with maintainers; [ sarahec ];
+    badPlatforms = [
+      # The scalene doesn't seem to account for arm64 linux
+      "aarch64-linux"
+
+      # On darwin, builds 1) assume aarch64 and 2) mistakenly compile one part as
+      # x86 and the other as arm64 then tries to link them into a single binary
+      # which fails.
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
   };
 }


### PR DESCRIPTION
## Changes

1. Bump version via update script
2. Limit platforms to x86_64-Linux as this isn't building correctly for other platforms. 

### Why this is justified 

Adding back the other platforms will require major changes to the derivation and some help from upstream. Since it's only been building for x86_64-Linux all along, we'll mark that as the only supported platform for now.

## Release update

### Improved GPU/Neuron profiling; fixed encoding issue [Latest](https://github.com/plasma-umass/scalene/releases/latest)

[ v1.5.50](https://github.com/plasma-umass/scalene/tree/v1.5.50)
https://github.com/plasma-umass/scalene/commit/2493277395fa81e161eda955a21d7a6a64efde54
What's Changed
Don't change JIT behavior on Neuron by @emeryberger in https://github.com/plasma-umass/scalene/pull/896
Optimized implementation to use IOKit directly by @emeryberger in https://github.com/plasma-umass/scalene/pull/897
Fix UTF-8 encoding issue, resolving https://github.com/plasma-umass/scalene/issues/899 by @emeryberger in https://github.com/plasma-umass/scalene/pull/900
Full Changelog: https://github.com/plasma-umass/scalene/compare/v1.5.49...v1.5.50

1.5.51 Adds Python 3.13 support

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux -- tried and failed
  - [ ] x86_64-darwin  -- tried and failed
  - [ ] aarch64-darwin  -- tried and failed
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
