### PR TITLE
dovecot-fts-flatcurve: init at 1.0.5

### DIFF
--- a/pkgs/by-name/do/dovecot-fts-flatcurve/package.nix
+++ b/pkgs/by-name/do/dovecot-fts-flatcurve/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  dovecot,
+  xapian,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "dovecot-fts-flatcurve";
+  version = "1.0.5";
+
+  src = fetchFromGitHub {
+    owner = "slusarz";
+    repo = "dovecot-fts-flatcurve";
+    rev = "refs/tags/v${version}";
+    hash = "sha256-96sR/pl0G0sSjh/YrXdgVgASJPhrL32xHCbBGrDxzoU=";
+  };
+
+  buildInputs = [
+    xapian
+  ];
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkg-config
+  ];
+
+  configureFlags = [
+    "--with-dovecot=${dovecot}/lib/dovecot"
+    "--with-moduledir=$(out)/lib/dovecot"
+  ];
+
+  meta = with lib; {
+    homepage = "https://slusarz.github.io/dovecot-fts-flatcurve/";
+    description = "Dovecot FTS Flatcurve plugin (Xapian)";
+    license = licenses.lgpl21Only;
+    maintainers = with maintainers; [ euxane ];
+    platforms = platforms.unix;
+  };
+}

--- a/pkgs/servers/mail/dovecot/default.nix
+++ b/pkgs/servers/mail/dovecot/default.nix
@@ -15,6 +15,7 @@
   coreutils,
   clucene_core_2,
   icu,
+  libexttextcat,
   openldap,
   libsodium,
   libstemmer,
@@ -48,6 +49,7 @@ stdenv.mkDerivation rec {
       lz4
       clucene_core_2
       icu
+      libexttextcat
       openldap
       libsodium
       libstemmer
@@ -131,6 +133,7 @@ stdenv.mkDerivation rec {
       "--with-ldap"
       "--with-lucene"
       "--with-icu"
+      "--with-textcat"
     ]
     ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
       "i_cv_epoll_works=${if stdenv.hostPlatform.isLinux then "yes" else "no"}"


### PR DESCRIPTION
Upstreaming nixpgks patches by euxane submitted via https://lists.sr.ht/~andir/nixpkgs-dev/patches/57069 and https://lists.sr.ht/~andir/nixpkgs-dev/patches/57070.

See the individual commit messages and discussion at https://gitlab.com/simple-nixos-mailserver/nixos-mailserver/-/issues/239

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
