### PR TITLE
nixos/pay-respects: fix environment config

### DIFF
--- a/nixos/modules/programs/pay-respects.nix
+++ b/nixos/modules/programs/pay-respects.nix
@@ -8,11 +8,11 @@ let
   inherit (lib)
     getExe
     isBool
+    listToAttrs
     literalExpression
     maintainers
     mkEnableOption
     mkIf
-    mkMerge
     mkOption
     mkPackageOption
     optionalString
@@ -169,16 +169,19 @@ in
           "url"
           "model"
         ];
-    environment = mkMerge (
-      [
-        {
-          systemPackages = [ finalPackage ];
-        }
-      ]
-      ++ map (rule: {
-        etc."xdg/pay-respects/rules/${rule.command}.toml".source = generate "${rule.command}.toml" rule;
-      }) cfg.runtimeRules
-    );
+
+    environment = {
+      etc = listToAttrs (
+        map (rule: {
+          name = "xdg/pay-respects/rules/${rule.command}.toml";
+          value = {
+            source = generate "${rule.command}.toml" rule;
+          };
+        }) cfg.runtimeRules
+      );
+
+      systemPackages = [ finalPackage ];
+    };
 
     programs = {
       bash.interactiveShellInit = initScript "bash";


### PR DESCRIPTION
Unable to build flake since this was introduced, seems it clobbers other configuration attributes causing evaluation to fail. Haven't validated it produces the desired output, yet... just tested getting my flake to evaluate again since I dont use this module and haven't been able to build since it made it to nixos-unstable.

Follow up to https://github.com/NixOS/nixpkgs/pull/357425

```bash
info  Switching system configuration to .#
error:
       … while calling the 'seq' builtin
         at /nix/store/0mvgypp6dk31wdwx7kf6k2g565mpvhjy-source/lib/modules.nix:334:18:
          333|         options = checked options;
          334|         config = checked (removeAttrs config [ "_module" ]);
             |                  ^
          335|         _module = checked (config._module);

       … while evaluating a branch condition
         at /nix/store/0mvgypp6dk31wdwx7kf6k2g565mpvhjy-source/lib/modules.nix:273:9:
          272|       checkUnmatched =
          273|         if config._module.check && config._module.freeformType == null && merged.unmatchedDefns != [] then
             |         ^
          274|           let

       … while evaluating the option `_module.check':

       … while evaluating definitions from `/nix/store/0mvgypp6dk31wdwx7kf6k2g565mpvhjy-source/nixos/modules/rename.nix':

       … while evaluating the module argument `pkgs' in "/nix/store/0mvgypp6dk31wdwx7kf6k2g565mpvhjy-source/nixos/modules/programs/pay-respects.nix":

       … while evaluating definitions from `/nix/store/0mvgypp6dk31wdwx7kf6k2g565mpvhjy-source/flake.nix':

       … while evaluating the option `_module.check':

       … while evaluating definitions from `/nix/store/0mvgypp6dk31wdwx7kf6k2g565mpvhjy-source/nixos/modules/rename.nix':

       … while evaluating the module argument `pkgs' in "/nix/store/0mvgypp6dk31wdwx7kf6k2g565mpvhjy-source/nixos/modules/programs/pay-respects.nix":

       … while evaluating the option `nixpkgs.localSystem':

       … while evaluating the option `nixpkgs.system':

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: Neither nixpkgs.hostPlatform nor the legacy option nixpkgs.system has been set.
       You can set nixpkgs.hostPlatform in hardware-configuration.nix by re-running
       a recent version of nixos-generate-config.
       The option nixpkgs.system is still fully supported for NixOS 22.05 interoperability,
       but will be deprecated in the future, so we recommend to set nixpkgs.hostPlatform.
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
