### PR TITLE
podman-bootc: init at 0.1.2

### DIFF
--- a/pkgs/by-name/po/podman-bootc/package.nix
+++ b/pkgs/by-name/po/podman-bootc/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildGoModule,
+  buildPackages,
+  fetchFromGitHub,
+  installShellFiles,
+  libisoburn,
+  libvirt,
+  pkg-config,
+  stdenv,
+}:
+
+buildGoModule rec {
+  pname = "podman-bootc";
+  version = "0.1.2";
+
+  src = fetchFromGitHub {
+    owner = "containers";
+    repo = "podman-bootc";
+    tag = "v${version}";
+    hash = "sha256-Hxg2QSedPAWYZpuesUEFol9bpTppjB0/MpCcB+txMDc=";
+  };
+
+  patches = [ ./respect-home-env.patch ];
+
+  vendorHash = "sha256-8QP4NziLwEo0M4NW5UgSEMAVgBDxmnE+PLbpyclK9RQ=";
+
+  tags = [
+    "exclude_graphdriver_btrfs"
+    "btrfs_noversion"
+    "exclude_graphdriver_devicemapper"
+    "containers_image_openpgp"
+    "remote"
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+    installShellFiles
+  ];
+  buildInputs = [
+    libvirt
+    libisoburn
+  ];
+
+  # All tests depend on booting virtual machines, which is infeasible here.
+  doCheck = false;
+
+  postInstall =
+    let
+      podman-bootc = "${stdenv.hostPlatform.emulator buildPackages} $out/bin/podman-bootc";
+    in
+    lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) ''
+      # podman-bootc always tries to touch cache and run dirs, no matter the command
+      export HOME=$TMPDIR
+      export XDG_RUNTIME_DIR=$TMPDIR
+
+      installShellCompletion --cmd podman-bootc \
+        --bash <(${podman-bootc} completion bash) \
+        --fish <(${podman-bootc} completion fish) \
+        --zsh <(${podman-bootc} completion zsh)
+    '';
+
+  meta = {
+    description = "Streamlining podman+bootc interactions";
+    homepage = "https://github.com/containers/podman-bootc";
+    changelog = "https://github.com/containers/podman-bootc/releases/tag/${src.tag}";
+    maintainers = with lib.maintainers; [ evan-goode ];
+    license = lib.licenses.asl20;
+    # x86_64-darwin does not seem to be supported at this time:
+    # https://github.com/containers/podman-bootc/issues/46
+    platforms = [
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "podman-bootc";
+  };
+}

--- a/pkgs/by-name/po/podman-bootc/respect-home-env.patch
+++ b/pkgs/by-name/po/podman-bootc/respect-home-env.patch
@@ -1,0 +1,14 @@
+diff --git a/pkg/user/user.go b/pkg/user/user.go
+index 1f8dbcf..713a6a7 100644
+--- a/pkg/user/user.go
++++ b/pkg/user/user.go
+@@ -38,6 +38,9 @@ func NewUser() (u User, err error) {
+ }
+ 
+ func (u *User) HomeDir() string {
++	if envHome := os.Getenv("HOME"); envHome != "" {
++		return envHome
++	}
+ 	return u.OSUser.HomeDir
+ }
+ 


### PR DESCRIPTION
[podman-bootc](https://github.com/containers/podman-bootc) offers an ergonomic "edit-compile-debug" cycle for [bootable containers](https://containers.github.io/bootc/). The core command is:

```
podman-bootc run <imagename>
```

This command creates a new virtual machine, backed by a persistent disk image from a "self install" of the container image, and makes a SSH connection to it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
