### PR TITLE
python312Packages.connected-components-3d: init at 3.22.0

### DIFF
--- a/pkgs/development/python-modules/connected-components-3d/default.nix
+++ b/pkgs/development/python-modules/connected-components-3d/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  cython,
+  numpy,
+  pbr,
+  fastremap,
+  pytestCheckHook,
+  scipy,
+}:
+
+buildPythonPackage rec {
+  pname = "connected-components-3d";
+  version = "3.22.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "seung-lab";
+    repo = "connected-components-3d";
+    tag = version;
+    hash = "sha256-txgQY9k96hFKLrKVLE6ldPdNbSnKOk2FIMrHkRQXlPk=";
+  };
+
+  build-system = [
+    cython
+    numpy
+    pbr
+    setuptools
+  ];
+
+  dependencies = [ numpy ];
+
+  optional-dependencies = {
+    stack = [
+      # crackle-codec # not in nixpkgs
+      fastremap
+    ];
+  };
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    scipy
+  ] ++ optional-dependencies.stack;
+
+  disabledTests = [
+    # requires optional dependency crackle-codec (not in nixpkgs)
+    "test_connected_components_stack"
+  ];
+
+  pythonImportsCheck = [ "cc3d" ];
+
+  meta = {
+    description = "Connected components on discrete and continuous multilabel 3D & 2D images";
+    homepage = "https://github.com/seung-lab/connected-components-3d";
+    changelog = "https://github.com/seung-lab/connected-components-3d/releases/tag/${version}";
+    license = lib.licenses.lgpl3Plus;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/development/python-modules/fastremap/default.nix
+++ b/pkgs/development/python-modules/fastremap/default.nix
@@ -1,0 +1,52 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  cython,
+  numpy,
+  pbr,
+  setuptools,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "fastremap";
+  version = "1.15.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "seung-lab";
+    repo = "fastremap";
+    tag = version;
+    hash = "sha256-naDagGD0VNRjoJ1+gkgLm3QbrnE9hD85ULz91xAfKa4=";
+  };
+
+  build-system = [
+    cython
+    numpy
+    pbr
+    setuptools
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  env.PBR_VERSION = version;
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  pythonImportsCheck = [
+    "fastremap"
+  ];
+
+  meta = {
+    description = "Remap, mask, renumber, unique, and in-place transposition of 3D labeled images and point clouds";
+    homepage = "https://github.com/seung-lab/fastremap";
+    changelog = "https://github.com/seung-lab/fastremap/releases/tag/${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ bcdarwin ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4768,6 +4768,8 @@ self: super: with self; {
 
   fastprogress = callPackage ../development/python-modules/fastprogress { };
 
+  fastremap = callPackage ../development/python-modules/fastremap { };
+
   fastrlock = callPackage ../development/python-modules/fastrlock { };
 
   fasttext = callPackage ../development/python-modules/fasttext { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2763,6 +2763,8 @@ self: super: with self; {
 
   connect-box = callPackage ../development/python-modules/connect-box { };
 
+  connected-components-3d = callPackage ../development/python-modules/connected-components-3d { };
+
   connection-pool = callPackage ../development/python-modules/connection-pool { };
 
   connexion = callPackage ../development/python-modules/connexion { };


### PR DESCRIPTION
python312Packages.fastremap: init at 1.15.1

Init `python3Packages.connected-components-3d`, a [package for fast computation of connected components](https://github.com/seung-lab/connected-components-3d) in 2d and 3d images, including multilabel images, and handling various notions of connectedness and periodic boundary conditions, and its optional/test dependency `python3Packages.fastremap`, a [package](https://github.com/seung-lab/fastremap) for fast label remapping in multidimensional arrays.

## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
