### PR TITLE
treewide: migrate to fetchCargoVendor, batch 5

### DIFF
--- a/pkgs/by-name/ai/airshipper/package.nix
+++ b/pkgs/by-name/ai/airshipper/package.nix
@@ -66,7 +66,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-MHwyXCAqdBzdJlYzSeUXr6bJdTVHcjJ/kGcuAsZCCW8=";
   };
 
-  cargoHash = "sha256-mdII6CcSQkKZRWLiTJFCrhhkiqJJ5aTQ6vuf9uYGj/I=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-TkeB939zV5VvqICFqJd/7uX+ydXyEQOJ3sYQbHbZhP0=";
 
   buildInputs = [
     fontconfig

--- a/pkgs/by-name/ar/ares-rs/package.nix
+++ b/pkgs/by-name/ar/ares-rs/package.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-J+q7KeBthF9Wd08MNv0aHyLHgLUKg3mzQ8ic6+ashto=";
   };
 
-  cargoHash = "sha256-iJ04WPViqtafINkjn3PD8cE55LVdJZQXodAl3KlxweA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-K4qAUEVdi7OqpKAxyEMnKkGTuxSjrdE+UQaYosnUo70=";
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];

--- a/pkgs/by-name/ca/cargo-hack/package.nix
+++ b/pkgs/by-name/ca/cargo-hack/package.nix
@@ -13,7 +13,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-FAcKzLr835FxgcnWmAe1JirzlRc3fvxGXMKxnSmgCzA=";
   };
 
-  cargoHash = "sha256-zWIXIoKgLVu7EZLe1IrR3Rl5szrN0zbyKJWK2BvD7kQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-3M+UK0+lvnRH7j1vbqMgpE7mnz8YnPO3MEjQWnPRy8c=";
 
   # some necessary files are absent in the crate version
   doCheck = false;

--- a/pkgs/by-name/ch/charasay/package.nix
+++ b/pkgs/by-name/ch/charasay/package.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-NB2GDDFH9IW/c0acMojYHuzPrx0J3tjlDqjQa6ZRbN4=";
   };
 
-  cargoHash = "sha256-K6roydkLHvs+xg2LjrSHw8IcYEyOFcrsh4u6Fz7yYKQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-i2CvwQXKKfYLdK0tKf/w4TepPyMo99v1I+kIr00PWcY=";
 
   nativeBuildInputs = [ installShellFiles ];
 

--- a/pkgs/by-name/de/deno/package.nix
+++ b/pkgs/by-name/de/deno/package.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-FSip1EY6DCgmIgpkhzEF6h3yV8tJqZKnBpqgBDg1TKQ=";
   };
 
-  cargoHash = "sha256-35XKqVBXlK6iPHec1ALhymYCD1GG1ZnCU2ET3PRGidk=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-uLGdrPTXAHwZrevGPgZGiNorxVNkYiHn6mPyxd8O8zw=";
 
   postPatch = ''
     # upstream uses lld on aarch64-darwin for faster builds

--- a/pkgs/by-name/ez/eza/package.nix
+++ b/pkgs/by-name/ez/eza/package.nix
@@ -24,7 +24,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-XJ8RYfBduTK5CkvFjVRF6yGkgBdojuewFUrEvRcTJsA=";
   };
 
-  cargoHash = "sha256-FUd2dtSwZEBJDCs5EbgrtHfO2oquZP/4wxhVreCaayg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-38RQsr7bYIf/6edIcDwjHtDEI2lnB3Mp+qaOu7Dh41A=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/fl/flake-checker/package.nix
+++ b/pkgs/by-name/fl/flake-checker/package.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-K5E1sarWIUl4QavHBoS8sPr5Cp8ZndWjLYDLm++d7v0=";
   };
 
-  cargoHash = "sha256-TPF4usEIhgkGUJ16pxq0OhQoJJHLzeRXNQvbP8isWM4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-FDfsA87VATJ4CpXoJ0eFoFl5z9Jtv6tPjkCf7kz6g00=";
 
   buildInputs = lib.optionals stdenv.hostPlatform.isDarwin (with darwin.apple_sdk.frameworks; [
     Security

--- a/pkgs/by-name/pa/pay-respects/package.nix
+++ b/pkgs/by-name/pa/pay-respects/package.nix
@@ -18,7 +18,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-4m8/sp6r2Xb2SsNcatMv0+mWHBx+XKD0LEzrEwuWIEA=";
   };
 
-  cargoHash = "sha256-obuMixkXqWUuZFqs3mJyMpHx4RY70ZpE3H9GzqFmt6k=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-uE3nS5XAn20iB7VQuYpFryIhQ7WMAEFGrD+KHJb1H5I=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/pi/pineflash/package.nix
+++ b/pkgs/by-name/pi/pineflash/package.nix
@@ -27,7 +27,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-4tcwEok36vuXbtlZNUkLNw1kHFQPBEJM/gWRhRWNLPg=";
   };
 
-  cargoHash = "sha256-l01It6mUflENlADW6PpOQvK1o4qOjbTsMLB6n+OIl0U=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-OgUWOtqgGCRNYCrdMa8IAfxbbYqv+1WwubvfYybuAQU=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/rb/rbw/package.nix
+++ b/pkgs/by-name/rb/rbw/package.nix
@@ -31,7 +31,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-ebLbdIF+BybK7ssNtZacGWmAEwdNZh8b94QYgvcwzmM=";
   };
 
-  cargoHash = "sha256-230jJr2EQua9iI4jz+LxrTZn4TtVAsmPYB8JMLAylzc=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-xDb4shDHCbd0yuTSAt80i1aqyuhpkfd/fYF98CfXdcM=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/re/release-plz/package.nix
+++ b/pkgs/by-name/re/release-plz/package.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-m33tBLNOU2+vjIICU0ggnNxLvD/fxJVSxT6bRih9e7U=";
   };
 
-  cargoHash = "sha256-d7CltWp1RfQ8cJ6eLXF8spaWXBBEtla46FiRrzG5EVg=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-XPe5lQMKTGWlt9E3JSsCT1g7VTFBo/aYrVSf0VNOpVk=";
 
   nativeBuildInputs = [
     installShellFiles

--- a/pkgs/by-name/sl/slint-lsp/package.nix
+++ b/pkgs/by-name/sl/slint-lsp/package.nix
@@ -44,7 +44,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-1yXyf/9St03B8mZPfw8GVUIFOX/nWbwwCs/8ON3uBDw=";
   };
 
-  cargoHash = "sha256-iuLTqrYq3mXjZ1bUQvEwWUNOxdg21Yn5NWmiQTAtdIA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-FFNMI6mGYAqHPpdVo8iA2i8R2JNz8F5oQFXh7rk6wdI=";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/te/tex-fmt/package.nix
+++ b/pkgs/by-name/te/tex-fmt/package.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-3kRtBfIT6QcdZ1+h2WwvxsAv/UJLtwSodF5zvCUDbHQ=";
   };
 
-  cargoHash = "sha256-A8bRimM8eHUM86HLzReo4WFzaz6P9hnKuyhg0h0db9I=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-4kx3co9doFYD9SjJhL17hgf6ll4niKnF57evv/eNeM0=";
 
   nativeBuildInputs = [ installShellFiles ];
 


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.

These are a few cases that could have been in batch 1, but weren't for whatever reason.  Maybe there were merge conflicts, or a transient network failure.

It should be possible to reproduce this diff.  To do so, get the list of files changed by this commit, e.g. with git diff --name-only, then run the following two commands, each with that list of files as their standard input:

	xargs sed -i 's/^\(. *\)\(cargoHash\)\b/\1useFetchCargoVendor = true;\n\1cargoHash/'
	cut -d / -f 4 | xargs -n 1 nix-update --version=skip


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
