### PR TITLE
treewide: migrate to fetchCargoVendor, batch 6

### DIFF
--- a/pkgs/by-name/ca/cargo-espmonitor/package.nix
+++ b/pkgs/by-name/ca/cargo-espmonitor/package.nix
@@ -14,7 +14,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "hWFdim84L2FfG6p9sEf+G5Uq4yhp5kv1ZMdk4sMHa+4=";
   };
 
-  cargoHash = "sha256-d0tN6NZiAd+RkRy941fIaVEw/moz6tkpL0rN8TZew3g=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Fb/xJLhmInYOanJC6XGsxxsCJNCLvHDe04+wtvXMecE=";
 
   meta = with lib; {
     description = "Cargo tool for monitoring ESP32/ESP8266 execution";

--- a/pkgs/by-name/co/colorpanes/package.nix
+++ b/pkgs/by-name/co/colorpanes/package.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "qaOH+LXNDq+utwyI1yzHWNt25AvdAXCTAziGV9ElroU=";
   };
 
-  cargoHash = "sha256-eJne4OmV4xHxntTb8HE+2ghX1hZLE3WQ3QqsjVm9E4M=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-+ltcTuLksNwe7KIt8apYNZkMoA2w4EObG5dhJliRb6Y=";
 
   postInstall = ''
     ln -s $out/bin/colp $out/bin/colorpanes

--- a/pkgs/by-name/co/commit-formatter/package.nix
+++ b/pkgs/by-name/co/commit-formatter/package.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "EYzhb9jJ4MzHxIbaTb1MxeXUgoxTwcnq5JdxAv2uNcA=";
   };
 
-  cargoHash = "sha256-AeHQCoP1HOftlOt/Yala3AXocMlwwIXIO2i1AsFSvGQ=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-uW+mmArQZ5Pl2TlKIRd00dB6615Nn/Q8KtRE/ahl5V4=";
 
   meta = with lib; {
     description = "CLI tool to help you write git commit";

--- a/pkgs/by-name/dd/ddh/package.nix
+++ b/pkgs/by-name/dd/ddh/package.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "XFfTpX4c821pcTAJZFUjdqM940fRoBwkJC6KTknXtCw=";
   };
 
-  cargoHash = "sha256-6yPDkbag81TZ4k72rbmGT6HWKdGK4yfKxjGNFKEWXPI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-rl9+3JSFkqZwaIWCuZBDhDF0QBr+aB2I7kB1o9LWCEw=";
 
   meta = with lib; {
     description = "Fast duplicate file finder";

--- a/pkgs/by-name/di/didu/package.nix
+++ b/pkgs/by-name/di/didu/package.nix
@@ -16,7 +16,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "szYWRN1NZbfpshipwMMJSWJw/NG4w7I+aqwtmqpT0R0=";
   };
 
-  cargoHash = "sha256-O1kkfrwv7xiOh3wCV/ce6cqpkMPRRzcXOFESYMAhiKA=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NDri4VuTI/ZsY3ZvpWmu/2I5GpmldQaoUSzyjGlq9lE=";
 
   meta = with lib; {
     description = "Duration conversion between units";

--- a/pkgs/by-name/nu/nux/package.nix
+++ b/pkgs/by-name/nu/nux/package.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-k3HRaWN8/MTZRGWBxI8RRK0tcSYBbSLs3vHkUdLGTc8";
   };
 
-  cargoHash = "sha256-wfUr3dcdALMEgJ6CaXhK4Gqk6xflCnov9tELA63drV4=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-iemfLIiT2BOsf0Q4X8fmEHmgHMd0WQk1t2rmRUuF5pY=";
 
   nativeBuildInputs = [
     asciidoctor

--- a/pkgs/by-name/pe/peertube-viewer/package.nix
+++ b/pkgs/by-name/pe/peertube-viewer/package.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage {
     hash = "sha256-ZzeWk01migUrKR7GndtNo0kLYSCUXCg0H0eCXgrDXaM==";
   };
 
-  cargoHash = "sha256-5u5240PL5cKhnHsT7sRdccrbZBAbRN+fa+FhJP1gX/4==";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Pf8Jj8XGYbNOAyYEBdAysOK92S3S7bZHerQh/2UlrbQ=";
 
   meta = with lib; {
     description = "A simple CLI browser for the peertube federated video platform";

--- a/pkgs/by-name/pr/present-cli/package.nix
+++ b/pkgs/by-name/pr/present-cli/package.nix
@@ -15,7 +15,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "+kCHe84ikdCLd7j5YwP2j3xz+XTzzo/kLy+b9YUFDnI=";
   };
 
-  cargoHash = "sha256-VKY/FQUrFWtLxKoK6LP6qPMqNN4absZvnAbH9mha1fI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-NZUxgS4iCmXsQa2bOdFiw7EqAAT22bgJjYaDZjJgL6I=";
 
   # required for tests
   postPatch = ''

--- a/pkgs/by-name/pr/proton-vpn-local-agent/package.nix
+++ b/pkgs/by-name/pr/proton-vpn-local-agent/package.nix
@@ -9,7 +9,8 @@
 rustPlatform.buildRustPackage rec {
   pname = "proton-vpn-local-agent";
   version = "1.2.0";
-  cargoHash = "sha256-qxNbHM6KmBmLbruOhbFIp3klz6RuKWBLioVsBPDQiLI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-KD+cTEmezTiGL+OmMryS/Q1mRR0n9jx80o3hb5X3ZYM=";
 
   src = fetchFromGitHub {
     owner = "ProtonVPN";

--- a/pkgs/by-name/to/todo/package.nix
+++ b/pkgs/by-name/to/todo/package.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "oyRdXvVnCfdFM8lI1eCDHHYNWcJc0Qg0TKxQXUqNo40=";
   };
 
-  cargoHash = "sha256-B0tecuBx/FFQokhfI6+xpppyG5DD8WS2+MkmPaZfMhI=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-mRLTQYkKXxhcwI2Ra/HCkxejDl3nnraJw+VCqRgCUig=";
 
   nativeBuildInputs = [ pkg-config ];
 


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.

These cases could have been included in batch 1, except that nix-update also changes the formatting of source hash.  It should be possible to verify this in the same way as batch 1, except that the commands will additionally result in non-functional source hash changes that I didn't include here.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
