### PR TITLE
ieda: useFetchCargoVendor

### DIFF
--- a/pkgs/by-name/ie/ieda/rustpkgs.nix
+++ b/pkgs/by-name/ie/ieda/rustpkgs.nix
@@ -8,7 +8,8 @@ in
     version = "0.1.3";
     src = rootSrc;
     sourceRoot = "${src.name}/src/operation/iIR/source/iir-rust/iir";
-    cargoHash = "sha256-ka91IsmBGBYts4U9X4uZDUMeS9adPn3MKl2BY4ZKDCY=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-xyNaUTPvU21yOdkQq8vdnHCyLzcpDAFAje0R/gDqliU=";
 
     doCheck = false;
 
@@ -19,7 +20,8 @@ in
     version = "0.1.0";
     src = rootSrc;
     sourceRoot = "${src.name}/src/database/manager/parser/liberty/lib-rust/liberty-parser";
-    cargoHash = "sha256-7yUD8M3efisuVoH3/R+Pk2CP4mizSinrqeuy3uqkq2c=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-nRIOuSz5ImENvKeMAnthmBo+2/Jy5xbM66xkcfVCTMI=";
 
     doCheck = false;
 
@@ -30,7 +32,8 @@ in
     version = "0.1.0";
     src = rootSrc;
     sourceRoot = "${src.name}/src/database/manager/parser/sdf/sdf_parse";
-    cargoHash = "sha256-6uzufy3S21vHJYgx9sItxQyccG0g/Zz1r2xHsYoQPRM=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-PORA/9DDIax4lOn/pzmi7Y8mCCBUphMTzbBsb64sDl0=";
 
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
   };
@@ -39,7 +42,8 @@ in
     version = "0.2.4";
     src = rootSrc;
     sourceRoot = "${src.name}/src/database/manager/parser/spef/spef-parser";
-    cargoHash = "sha256-KTd3HVKV8hRCXf56FPksYGVJNDdlmMMIcSEk1MMGLsw=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-Qr/oXTqn2gaxyAyLsRjaXNniNzIYVzPGefXTdkULmYk=";
 
     nativeBuildInputs = [ rustPlatform.bindgenHook ];
   };
@@ -48,7 +52,8 @@ in
     version = "0.1.0";
     src = rootSrc;
     sourceRoot = "${src.name}/src/database/manager/parser/vcd/vcd_parser";
-    cargoHash = "sha256-1y1nPNfx23MyIJUV+E6mMuDOhdob0BDGuQwOl0Le/lE=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-xcfVzDrnW4w3fU7qo6xzSQeIH8sEbEyzPF92F5tDcAk=";
 
     doCheck = false;
 
@@ -59,7 +64,8 @@ in
     version = "0.1.0";
     src = rootSrc;
     sourceRoot = "${src.name}/src/database/manager/parser/verilog/verilog-rust/verilog-parser";
-    cargoHash = "sha256-Z/LXQzQ0m1lQdIPaWQ5rs2EAu/mbyi2JvrjGYVmKONs=";
+    useFetchCargoVendor = true;
+    cargoHash = "sha256-ooxY8Q8bfD+klBGfpTDD3YyWptEOGGHDoyamhjlSNTM=";
 
     doCheck = false;
 


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
