### PR TITLE
kanidm_1_3,kanidm_1_4: useFetchCargoVendor

### DIFF
--- a/pkgs/by-name/ka/kanidm/1_3.nix
+++ b/pkgs/by-name/ka/kanidm/1_3.nix
@@ -1,7 +1,7 @@
 import ./generic.nix {
   version = "1.3.3";
   hash = "sha256-W5G7osV4du6w/BfyY9YrDzorcLNizRsoz70RMfO2AbY=";
-  cargoHash = "sha256-iziTHr0gvv319Rzgkze9J1H4UzPR7WxMmCkiGVsb33k=";
+  cargoHash = "sha256-QgEoeXjGm7fhPnJBbquWJYDYPg+Uv1IjZnaI5yUEYlQ=";
   patchDir = ./patches/1_3;
   extraMeta = {
     knownVulnerabilities = [

--- a/pkgs/by-name/ka/kanidm/1_4.nix
+++ b/pkgs/by-name/ka/kanidm/1_4.nix
@@ -1,6 +1,6 @@
 import ./generic.nix {
   version = "1.4.6";
   hash = "sha256-pjJyq52wO5p34LN2Jmt0npgWBDcWin8gIX4skZ7Ff8E=";
-  cargoHash = "sha256-XyyvXxZOvaxSzH8Jd23IxE4Wyd/6h5N3HRVEvdQ8RtY=";
+  cargoHash = "sha256-33HRoH/vWPe/wOZJtQLWV9eBocbj0iR/XUu4zMehu8M=";
   patchDir = ./patches/1_4;
 }

--- a/pkgs/by-name/ka/kanidm/generic.nix
+++ b/pkgs/by-name/ka/kanidm/generic.nix
@@ -38,6 +38,7 @@ in
 rustPlatform.buildRustPackage rec {
   pname = "kanidm" + (lib.optionalString enableSecretProvisioning "-with-secret-provisioning");
   inherit version cargoHash;
+  useFetchCargoVendor = true;
   cargoDepsName = "kanidm";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
