### PR TITLE
libloot: useFetchCargoVendor

### DIFF
--- a/pkgs/by-name/li/libloot/package.nix
+++ b/pkgs/by-name/li/libloot/package.nix
@@ -150,7 +150,8 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-qJ7gC4BkrXJiVcyA1BqlJSRzgc/7VmNBHtDq0ouJoTU=";
       };
 
-      cargoHash = "sha256-x4LFO6dD3bBKv6gTrNUAo7Rdw5cP67gn44QP6Iwbv0I=";
+      useFetchCargoVendor = true;
+      cargoHash = "sha256-m3lyABr7tU0AeC6EZomBw1X722ezQg/cjSZh/ZhkiBw=";
 
       lang = "c++";
       header = "libloadorder.hpp";
@@ -167,7 +168,8 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-ygjSyixg+9HFFNV/G+w+TxGFTrjlWxlDt8phpCE8xyQ=";
       };
 
-      cargoHash = "sha256-39iod83yVU5PyIjwv7pLLuMeNw9fHiM0tXDauyGrbx8=";
+      useFetchCargoVendor = true;
+      cargoHash = "sha256-6sY2M7kjSYB3+6+zoMxPwdl+g7ARLHm9RdSODHQR8bE=";
 
       lang = "c++";
       header = "esplugin.hpp";
@@ -184,7 +186,8 @@ stdenv.mkDerivation (finalAttrs: {
         hash = "sha256-yXbe7ByYHvFpokRpV2pz2SX0986dpk5IpehwDUhoZKg=";
       };
 
-      cargoHash = "sha256-p+raWZkW16MrvfZhJigSPth8pZZ68twU1+0GL/Mo1Xw=";
+      useFetchCargoVendor = true;
+      cargoHash = "sha256-d3JBpYI4XMkDnufvdyZkgtp7H4amMzM0dBEO6t9efGE=";
 
       lang = "c";
       header = "loot_condition_interpreter.h";


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
