### PR TITLE
ssh-openpgp-auth,sshd-openpgp-auth: useFetchCargoVendor

### DIFF
--- a/pkgs/by-name/ss/ssh-openpgp-auth/daemon.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/daemon.nix
@@ -8,6 +8,6 @@ callPackage ./generic.nix {
   pname = "sshd-openpgp-auth";
   version = "0.3.0";
   srcHash = "sha256-IV0Nhdqyn12HDOp1jaKz3sKTI3ktFd5b6qybCLWt27I=";
-  cargoHash = "sha256-/+lZkVMeFUMRD7NQ/MHDU5f3rkKDx1kDv5tjA41RExc=";
+  cargoHash = "sha256-WyYzDzC83iL1c8gCj+mYDq3/gsFxmxEWKwLhWLEygkI=";
   metaDescription = "Command-line tool for creating and managing OpenPGP based trust anchors for SSH host keys";
 }

--- a/pkgs/by-name/ss/ssh-openpgp-auth/generic.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/generic.nix
@@ -34,6 +34,7 @@ rustPlatform.buildRustPackage {
     hash = srcHash;
   };
   buildAndTestSubdir = pname;
+  useFetchCargoVendor = true;
   inherit cargoHash;
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ss/ssh-openpgp-auth/package.nix
+++ b/pkgs/by-name/ss/ssh-openpgp-auth/package.nix
@@ -4,6 +4,6 @@ callPackage ./generic.nix {
   pname = "ssh-openpgp-auth";
   version = "0.2.2";
   srcHash = "sha256-5ew6jT6Zr54QYaWFQIGYXd8sqC3yHHZjPfoaCossm8o=";
-  cargoHash = "sha256-/k/XAp7PHIJaJWf4Oa1JC1mMSR5pyeM4SSPCcr77cAg=";
+  cargoHash = "sha256-PHJiyq7zovn7EA7jDLJQxjxu2ErPHqBMwAlJpb5UVQY=";
   metaDescription = "Command-line tool that provides client-side functionality to transparently verify the identity of remote SSH hosts";
 }


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
