### PR TITLE
socalabs-papu: init at 1.2.0

### DIFF
--- a/pkgs/by-name/so/socalabs-papu/package.nix
+++ b/pkgs/by-name/so/socalabs-papu/package.nix
@@ -25,28 +25,19 @@
   ninja,
   writableTmpDirAsHomeHook,
   nix-update-script,
-  # Disable VST building by default, since NixOS doesn't have a VST license
+  # Disable VST building by default, since its unfree
   enableVST2 ? false,
 }:
-let
-  version = "1.2.0";
-in
-stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   pname = "socalabs-papu";
-  inherit version;
+  version = "1.2.0";
 
   src = fetchFromGitHub {
     owner = "FigBug";
     repo = "PAPU";
-    tag = "v${version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-psSwQJwfCvsSgF72/K0WZQRqt0CoasVITLH69V4XcUg=";
     fetchSubmodules = true;
-    preFetch = ''
-      # can't clone using ssh
-      export GIT_CONFIG_COUNT=1
-      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
-      export GIT_CONFIG_VALUE_0=git@github.com:
-    '';
   };
 
   desktopItems = [
@@ -120,7 +111,7 @@ stdenv.mkDerivation {
     cp -r PAPU_artefacts/Release/LV2/PAPU.lv2 $out/lib/lv2
     cp -r PAPU_artefacts/Release/VST3/PAPU.vst3 $out/lib/vst3
 
-    install -Dm755 PAPU_artefacts/Release/Standalone/PAPU $out/bin
+    install -Dm555 PAPU_artefacts/Release/Standalone/PAPU $out/bin
 
     install -Dm444 $src/plugin/Resources/icon.png $out/share/pixmaps/PAPU.png
 
@@ -150,4 +141,4 @@ stdenv.mkDerivation {
     license = [ lib.licenses.gpl2 ] ++ lib.optional enableVST2 lib.licenses.unfree;
     maintainers = [ lib.maintainers.l1npengtul ];
   };
-}
+})

--- a/pkgs/by-name/so/socalabs-papu/package.nix
+++ b/pkgs/by-name/so/socalabs-papu/package.nix
@@ -1,0 +1,153 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  copyDesktopItems,
+  makeDesktopItem,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  libXdmcp,
+  libXext,
+  xvfb,
+  freetype,
+  fontconfig,
+  expat,
+  libGL,
+  libjack2,
+  curl,
+  ninja,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  # Disable VST building by default, since NixOS doesn't have a VST license
+  enableVST2 ? false,
+}:
+let
+  version = "1.2.0";
+in
+stdenv.mkDerivation {
+  pname = "socalabs-papu";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "FigBug";
+    repo = "PAPU";
+    tag = "v${version}";
+    hash = "sha256-psSwQJwfCvsSgF72/K0WZQRqt0CoasVITLH69V4XcUg=";
+    fetchSubmodules = true;
+    preFetch = ''
+      # can't clone using ssh
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "socalabs-papu";
+      desktopName = "Socalabs PAPU";
+      comment = "Socalabs Nintendo Gameboy PAPU Emulation Plugin (Standalone)";
+      icon = "PAPU";
+      exec = "PAPU";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    cmake
+    pkg-config
+    copyDesktopItems
+    ninja
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libX11
+    libXcomposite
+    libXcursor
+    libXinerama
+    libXrandr
+    libXtst
+    libXdmcp
+    libXext
+    xvfb
+    libGL
+    libjack2
+    freetype
+    fontconfig
+    expat
+    curl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+    "--preset ninja-gcc"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+    --replace-fail 'FORMATS Standalone VST VST3 AU LV2' 'FORMATS Standalone ${lib.optionalString enableVST2 "VST"} VST3 LV2'
+  '';
+
+  strictDeps = true;
+
+  preBuild = ''
+    cd ../Builds/ninja-gcc
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2 $out/bin
+
+    ${lib.optionalString enableVST2 ''
+      mkdir -p $out/lib/vst
+      cp -r PAPU_artefacts/Release/VST/libPAPU.so $out/lib/vst
+    ''}
+
+    cp -r PAPU_artefacts/Release/LV2/PAPU.lv2 $out/lib/lv2
+    cp -r PAPU_artefacts/Release/VST3/PAPU.vst3 $out/lib/vst3
+
+    install -Dm755 PAPU_artefacts/Release/Standalone/PAPU $out/bin
+
+    install -Dm444 $src/plugin/Resources/icon.png $out/share/pixmaps/PAPU.png
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcomposite"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-lXtst"
+      "-lXdmcp"
+    ]
+  );
+
+  meta = {
+    description = "Socalabs Nintendo Gameboy PAPU Emulation Plugin";
+    homepage = "https://socalabs.com/synths/papu/";
+    mainProgram = "PAPU";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.gpl2 ] ++ lib.optional enableVST2 lib.licenses.unfree;
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+}


### PR DESCRIPTION
Adds PAPU plugin from Socalabs to nixpkgs. 

https://socalabs.com/synths/papu/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
