### PR TITLE
socalabs-sn76489: init at 1.1.0

### DIFF
--- a/pkgs/by-name/so/socalabs-sn76489/package.nix
+++ b/pkgs/by-name/so/socalabs-sn76489/package.nix
@@ -1,0 +1,153 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  copyDesktopItems,
+  makeDesktopItem,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  libXdmcp,
+  libXext,
+  xvfb,
+  freetype,
+  fontconfig,
+  expat,
+  libGL,
+  libjack2,
+  curl,
+  ninja,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  # Disable VST building by default, since it is unfree
+  enableVST2 ? false,
+}:
+let
+  version = "1.1.0";
+in
+stdenv.mkDerivation {
+  pname = "socalabs-sn76489";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "FigBug";
+    repo = "SN76489";
+    tag = "v${version}";
+    hash = "sha256-m+bmS2ZTA4yH1+UTow+wMYugx/VloPCHEQJp1P6pxvc=";
+    fetchSubmodules = true;
+    preFetch = ''
+      # can't clone using ssh
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "socalabs-sn76489";
+      desktopName = "Socalabs SN76489";
+      comment = "Socalabs Texas Instruments SN76489 Emulation Plugin";
+      icon = "SN76489";
+      exec = "SN76489";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    cmake
+    pkg-config
+    copyDesktopItems
+    ninja
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libX11
+    libXcomposite
+    libXcursor
+    libXinerama
+    libXrandr
+    libXtst
+    libXdmcp
+    libXext
+    xvfb
+    libGL
+    libjack2
+    freetype
+    fontconfig
+    expat
+    curl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+    "--preset ninja-gcc"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+    --replace-fail 'FORMATS Standalone VST VST3 AU LV2' 'FORMATS Standalone ${lib.optionalString enableVST2 "VST"} VST3 LV2'
+  '';
+
+  strictDeps = true;
+
+  preBuild = ''
+    cd ../Builds/ninja-gcc
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2 $out/bin
+
+    ${lib.optionalString enableVST2 ''
+      mkdir -p $out/lib/vst
+      cp -r SN76489_artefacts/Release/VST/libSN76489.so $out/lib/vst
+    ''}
+
+    cp -r SN76489_artefacts/Release/LV2/SN76489.lv2 $out/lib/lv2
+    cp -r SN76489_artefacts/Release/VST3/SN76489.vst3 $out/lib/vst3
+
+    install -Dm555 SN76489_artefacts/Release/Standalone/SN76489 $out/bin
+
+    install -Dm444 $src/plugin/Resources/logo.png $out/share/pixmaps/SN76489.png
+
+    runHook postInstall
+  '';
+
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcomposite"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-lXtst"
+      "-lXdmcp"
+    ]
+  );
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Socalabs Texas Instruments SN76489 Emulation Plugin";
+    homepage = "https://socalabs.com/synths/sn76489/";
+    mainProgram = "SN76489";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.lgpl21 ] ++ lib.optional enableVST2 lib.licenses.unfree;
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+}


### PR DESCRIPTION
Adds SN76489 emulation plugin from socalabs to nixpkgs.

https://socalabs.com/synths/sn76489/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
