### PR TITLE
socalabs-rp2a03: init at 1.1.0

### DIFF
--- a/pkgs/by-name/so/socalabs-rp2a03/package.nix
+++ b/pkgs/by-name/so/socalabs-rp2a03/package.nix
@@ -1,0 +1,141 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  copyDesktopItems,
+  makeDesktopItem,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  libXdmcp,
+  libXext,
+  xvfb,
+  freetype,
+  fontconfig,
+  expat,
+  libGL,
+  libjack2,
+  curl,
+  ninja,
+  writableTmpDirAsHomeHook,
+  # Disable VST building by default, since its unfree
+  enableVST2 ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "socalabs-rp2a03";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "FigBug";
+    repo = "RP2A03";
+    rev = "dd90863aed05afe110a5302b5eff4b5144f28d4c";
+    hash = "sha256-arEM6mq2oJATj87pyPZ+ZNlLd3kL//BNO5y2SFf+nSo=";
+    fetchSubmodules = true;
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "socalabs-rp2a03";
+      desktopName = "Socalabs RP2A03";
+      comment = "Socalabs NES Ricoh 2A03 Emulation Plugin (Standalone)";
+      icon = "RP2A03";
+      exec = "RP2A03";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    cmake
+    pkg-config
+    copyDesktopItems
+    ninja
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libX11
+    libXcomposite
+    libXcursor
+    libXinerama
+    libXrandr
+    libXtst
+    libXdmcp
+    libXext
+    xvfb
+    libGL
+    libjack2
+    freetype
+    fontconfig
+    expat
+    curl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+    "--preset ninja-gcc"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+    --replace-fail 'FORMATS Standalone VST VST3 AU LV2' 'FORMATS Standalone ${lib.optionalString enableVST2 "VST"} VST3 LV2'
+  '';
+
+  strictDeps = true;
+
+  preBuild = ''
+    cd ../Builds/ninja-gcc
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2 $out/bin
+
+    ${lib.optionalString enableVST2 ''
+      mkdir -p $out/lib/vst
+      cp -r RP2A03_artefacts/Release/VST/libRP2A03.so $out/lib/vst
+    ''}
+
+    cp -r RP2A03_artefacts/Release/LV2/RP2A03.lv2 $out/lib/lv2
+    cp -r RP2A03_artefacts/Release/VST3/RP2A03.vst3 $out/lib/vst3
+
+    install -Dm555 RP2A03_artefacts/Release/Standalone/RP2A03 $out/bin
+
+    install -Dm444 $src/plugin/Resources/logo.png $out/share/pixmaps/RP2A03.png
+
+    runHook postInstall
+  '';
+
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcomposite"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-lXtst"
+      "-lXdmcp"
+    ]
+  );
+
+  meta = {
+    description = "Socalabs NES Ricoh 2A03 Emulation Plugin";
+    homepage = "https://socalabs.com/synths/rp2a03/";
+    mainProgram = "RP2A03";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.lgpl21 ] ++ lib.optional enableVST2 lib.licenses.unfree;
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+})


### PR DESCRIPTION
Adds RP2A03 Emulation plugin by socalabs to nixpkgs.

https://socalabs.com/synths/rp2a03/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
