### PR TITLE
socalabs-voc: init at 1.1.0

### DIFF
--- a/pkgs/by-name/so/socalabs-voc/package.nix
+++ b/pkgs/by-name/so/socalabs-voc/package.nix
@@ -1,0 +1,156 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  lib,
+  cmake,
+  pkg-config,
+  alsa-lib,
+  copyDesktopItems,
+  makeDesktopItem,
+  libX11,
+  libXcomposite,
+  libXcursor,
+  libXinerama,
+  libXrandr,
+  libXtst,
+  libXdmcp,
+  libXext,
+  xvfb,
+  freetype,
+  fontconfig,
+  expat,
+  libGL,
+  libjack2,
+  curl,
+  ninja,
+  writableTmpDirAsHomeHook,
+  nix-update-script,
+  # Disable VST building by default, since its unfree
+  enableVST2 ? false,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "socalabs-voc";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "FigBug";
+    repo = "Voc";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-aGlazHjZrO5r8OhL7wkMEIDnOW4gXcSZgqzNS+iZ12M=";
+    fetchSubmodules = true;
+    preFetch = ''
+      # can't clone using ssh
+      export GIT_CONFIG_COUNT=1
+      export GIT_CONFIG_KEY_0=url.https://github.com/.insteadOf
+      export GIT_CONFIG_VALUE_0=git@github.com:
+    '';
+  };
+
+  desktopItems = [
+    (makeDesktopItem {
+      type = "Application";
+      name = "socalabs-voc";
+      desktopName = "Socalabs Voc";
+      comment = "Socalabs Wacky Vocal Synth Plugin (Standalone)";
+      icon = "Voc";
+      exec = "Voc";
+      categories = [
+        "Audio"
+        "AudioVideo"
+      ];
+    })
+  ];
+
+  nativeBuildInputs = [
+    writableTmpDirAsHomeHook
+    cmake
+    pkg-config
+    copyDesktopItems
+    ninja
+  ];
+
+  buildInputs = [
+    alsa-lib
+    libX11
+    libXcomposite
+    libXcursor
+    libXinerama
+    libXrandr
+    libXtst
+    libXdmcp
+    libXext
+    xvfb
+    libGL
+    libjack2
+    freetype
+    fontconfig
+    expat
+    curl
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "JUCE_COPY_PLUGIN_AFTER_BUILD" false)
+    "--preset ninja-gcc"
+  ];
+
+  # This is needed because otherwise g++ will complain about
+  # "FORTIFY_SOURCE" needing to be ran with optimizations
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-O2"
+  ];
+
+  postPatch = ''
+    substituteInPlace CMakeLists.txt \
+    --replace-fail 'FORMATS Standalone VST VST3 AU LV2' 'FORMATS Standalone ${lib.optionalString enableVST2 "VST"} VST3 LV2'
+  '';
+
+  strictDeps = true;
+
+  preBuild = ''
+    cd ../Builds/ninja-gcc
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/vst3 $out/lib/lv2 $out/bin
+
+    ${lib.optionalString enableVST2 ''
+      mkdir -p $out/lib/vst
+      cp -r Voc_artefacts/Release/VST/libVoc.so $out/lib/vst
+    ''}
+
+    cp -r Voc_artefacts/Release/LV2/Voc.lv2 $out/lib/lv2
+    cp -r Voc_artefacts/Release/VST3/Voc.vst3 $out/lib/vst3
+
+    install -Dm555 Voc_artefacts/Release/Standalone/Voc $out/bin
+
+    install -Dm444 $src/plugin/Resources/logo.png $out/share/pixmaps/Voc.png
+
+    runHook postInstall
+  '';
+
+  NIX_LDFLAGS = (
+    toString [
+      "-lX11"
+      "-lXext"
+      "-lXcomposite"
+      "-lXcursor"
+      "-lXinerama"
+      "-lXrandr"
+      "-lXtst"
+      "-lXdmcp"
+    ]
+  );
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Socalabs Wacky Vocal Synthesizer Plugin";
+    homepage = "https://socalabs.com/synths/voc-vocal-synth/";
+    mainProgram = "Voc";
+    platforms = lib.platforms.linux;
+    license = [ lib.licenses.lgpl21 ] ++ lib.optional enableVST2 lib.licenses.unfree;
+    maintainers = [ lib.maintainers.l1npengtul ];
+  };
+})


### PR DESCRIPTION
Adds Voc plugin from socalabs, a "wacky vocal emulation plugin".

https://socalabs.com/synths/voc-vocal-synth/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
