### PR TITLE
[Backport release-24.11] epson-escpr2: 1.2.21 -> 1.2.25

### DIFF
--- a/pkgs/by-name/ep/epson-escpr2/package.nix
+++ b/pkgs/by-name/ep/epson-escpr2/package.nix
@@ -37,6 +37,15 @@ stdenv.mkDerivation rec {
     cpio
   ];
 
+  patches = [
+    # Fixes "implicit declaration of function" errors
+    # source of patch: https://aur.archlinux.org/packages/epson-inkjet-printer-escpr2
+    (fetchurl {
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/bug_x86_64.patch?h=epson-inkjet-printer-escpr2";
+      sha256 = "sha256-G6/3oj25FUT+xv9aJ7qP5PBZWLfy+V8MCHUYucDhtzM=";
+    })
+  ];
+
   configureFlags = [
     "--with-cupsfilterdir=${builtins.placeholder "out"}/lib/cups/filter"
     "--with-cupsppddir=${builtins.placeholder "out"}/share/cups/model"

--- a/pkgs/by-name/ep/epson-escpr2/package.nix
+++ b/pkgs/by-name/ep/epson-escpr2/package.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation rec {
   pname = "epson-inkjet-printer-escpr2";
-  version = "1.2.21";
+  version = "1.2.24";
 
   src = fetchurl {
     # To find the most recent version go to
     # https://support.epson.net/linux/Printer/LSB_distribution_pages/en/escpr2.php
     # and retreive the download link for source package for x86 CPU
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/16/37/15/74a363ac972fde613c55618c2518f67e2a295cc8/epson-inkjet-printer-escpr2-1.2.21-1.src.rpm";
-    sha256 = "sha256-GwGR+K4VoLffAnI6wuJKOUCLnTrKEBK9j6rAzqKbX7U=";
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/16/58/53/436aba09336f96ed31378f90848be6588a177439/epson-inkjet-printer-escpr2-1.2.24-1.src.rpm";
+    sha256 = "sha256-SI5vXdpxRu6/QdAMdgNpqgcTqyHntiS0zo38XPd4Xtg=";
   };
 
   unpackPhase = ''

--- a/pkgs/by-name/ep/epson-escpr2/package.nix
+++ b/pkgs/by-name/ep/epson-escpr2/package.nix
@@ -10,14 +10,14 @@
 
 stdenv.mkDerivation rec {
   pname = "epson-inkjet-printer-escpr2";
-  version = "1.2.24";
+  version = "1.2.25";
 
   src = fetchurl {
     # To find the most recent version go to
     # https://support.epson.net/linux/Printer/LSB_distribution_pages/en/escpr2.php
     # and retreive the download link for source package for x86 CPU
-    url = "https://download3.ebz.epson.net/dsc/f/03/00/16/58/53/436aba09336f96ed31378f90848be6588a177439/epson-inkjet-printer-escpr2-1.2.24-1.src.rpm";
-    sha256 = "sha256-SI5vXdpxRu6/QdAMdgNpqgcTqyHntiS0zo38XPd4Xtg=";
+    url = "https://download3.ebz.epson.net/dsc/f/03/00/16/60/34/8e2b40dc2a02ae67c82b2c55786159f07edf3f5a/epson-inkjet-printer-escpr2-1.2.25-1.src.rpm";
+    sha256 = "sha256-rhNv6Ak83KG5SmdVUyu/2UXTB0BTj4yDyKRO++9q8WY=";
   };
 
   unpackPhase = ''
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
     # Fixes "implicit declaration of function" errors
     # source of patch: https://aur.archlinux.org/packages/epson-inkjet-printer-escpr2
     (fetchurl {
-      url = "https://aur.archlinux.org/cgit/aur.git/plain/bug_x86_64.patch?h=epson-inkjet-printer-escpr2";
+      url = "https://aur.archlinux.org/cgit/aur.git/plain/bug_x86_64.patch?h=epson-inkjet-printer-escpr2&id=575d1b959063044f233cca099caceec8e6d5c02f";
       sha256 = "sha256-G6/3oj25FUT+xv9aJ7qP5PBZWLfy+V8MCHUYucDhtzM=";
     })
   ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Backports the following PRs:

https://github.com/NixOS/nixpkgs/pull/363259 (this was just targeting staging-next to fix the build on staging)
That one is fixed as an later version bump contains changes for the patch url.

https://github.com/NixOS/nixpkgs/pull/370991
https://github.com/NixOS/nixpkgs/pull/375377


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
