### PR TITLE
haskellPackages: cleanup overrides on GHC 9.10+

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -83,18 +83,14 @@ self: super: {
   # Jailbreaks
   #
   base64 = doJailbreak super.base64; # base <4.20
-  commutative-semigroups = doJailbreak super.commutative-semigroups; # base <4.20
-  dejafu = doJailbreak super.dejafu; # containers <0.7
   floskell = doJailbreak super.floskell; # base <4.20
   lucid = doJailbreak super.lucid; # base <4.20
-  tar = doJailbreak super.tar; # base <4.20
   tasty-coverage = doJailbreak super.tasty-coverage; # base <4.20, filepath <1.5
   tree-diff = doJailbreak super.tree-diff; # base <4.20
   time-compat = doJailbreak super.time-compat; # base <4.20
 
   bitvec = doJailbreak super.bitvec; # primitive <0.9
 
-  hashable = doJailbreak super.hashable; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
   hashable_1_5_0_0 = doJailbreak super.hashable_1_5_0_0; # relax bounds for QuickCheck, tasty, and tasty-quickcheck
 
   broadcast-chan = doJailbreak super.broadcast-chan; # base <4.19  https://github.com/merijn/broadcast-chan/pull/19
@@ -104,7 +100,6 @@ self: super: {
   #
   call-stack = dontCheck super.call-stack; # https://github.com/sol/call-stack/issues/19
   lifted-base = dontCheck super.lifted-base; # doesn't compile with transformers ==0.6.*
-  resolv = dontCheck super.resolv; # doesn't compile with filepath ==1.5.*
   primitive-unlifted = dontCheck super.primitive-unlifted; # doesn't compile with primitive ==0.9.*
   bsb-http-chunked = pkgs.haskell.lib.dontCheck super.bsb-http-chunked; # https://github.com/sjakobi/bsb-http-chunked/issues/45
   hinotify = pkgs.haskell.lib.dontCheck super.hinotify; # https://github.com/kolmodin/hinotify/issues/38

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -84,7 +84,6 @@ self: super: {
   #
   base64 = doJailbreak super.base64; # base <4.20
   floskell = doJailbreak super.floskell; # base <4.20
-  lucid = doJailbreak super.lucid; # base <4.20
   tasty-coverage = doJailbreak super.tasty-coverage; # base <4.20, filepath <1.5
   tree-diff = doJailbreak super.tree-diff; # base <4.20
   time-compat = doJailbreak super.time-compat; # base <4.20

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -57,16 +57,6 @@ self: super: {
   unix = null;
   xhtml = null;
 
-  # Version upgrades
-  jailbreak-cabal = overrideCabal {
-    # Manually update jailbreak-cabal to 1.4.1 (which supports Cabal >= 3.14)
-    # since Hackage bump containing it is tied up in the update to Stackage LTS 23.
-    version = "1.4.1";
-    sha256 = "0q6l608m965s6932xabm7v2kav5cxrihb5qcbrwz0c4xiwrz4l5x";
-
-    revision = null;
-    editedCabalFile = null;
-  } super.jailbreak-cabal;
   htree = doDistribute self.htree_0_2_0_0;
   tagged = doDistribute self.tagged_0_8_9;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -70,6 +70,11 @@ self: super: {
   htree = doDistribute self.htree_0_2_0_0;
   tagged = doDistribute self.tagged_0_8_9;
 
+  #
+  # Jailbreaks
+  #
+  lucid = doJailbreak super.lucid; # base <4.21
+
   # Test suite issues
   call-stack = dontCheck super.call-stack; # https://github.com/sol/call-stack/issues/19
 }


### PR DESCRIPTION
Tested with
```nix
nix-build --keep-going --expr 'with (import ./. {}).haskell.packages.ghc910; [commutative-semigroups dejafu lucid jailbreak-cabal tar hashable resolv]'
```
```nix
nix-build --keep-going --expr 'with (import ./. {}).haskell.packages.ghc912; [commutative-semigroups dejafu lucid jailbreak-cabal tar hashable resolv]'
``` 


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
