### PR TITLE
vulkan packages: 1.3.296.0 -> 1.4.304.0

### DIFF
--- a/pkgs/by-name/vu/vulkan-extension-layer/package.nix
+++ b/pkgs/by-name/vu/vulkan-extension-layer/package.nix
@@ -16,13 +16,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-extension-layer";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ExtensionLayer";
     rev = "vulkan-sdk-${version}";
-    hash = "sha256-pBpHYxJq36FrHsvpaMJvX0IKTvAh0R86qR7/vn6EBCw=";
+    hash = "sha256-HdRbnXb9/YghxRJEg7Xx2q+YyiLAUBZ7lm0ibxVpbdA=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vu/vulkan-loader/package.nix
+++ b/pkgs/by-name/vu/vulkan-loader/package.nix
@@ -18,25 +18,17 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vulkan-loader";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Loader";
     rev = "vulkan-sdk-${finalAttrs.version}";
-    hash = "sha256-6GHZUiYL3gDWN61SaLiD/3xXSoQb1rx6U5eu1cl8ZwM=";
+    hash = "sha256-qPknv8BvfJoewFfORXsFZlUnae36czHfOPXmtGccrOk=";
   };
 
   patches =
-    [ ./fix-pkgconfig.patch ]
-    ++ lib.optionals stdenv.hostPlatform.is32bit [
-      # Backport patch to support 64-bit inodes on 32-bit systems
-      # FIXME: remove in next update
-      (fetchpatch {
-        url = "https://github.com/KhronosGroup/Vulkan-Loader/commit/ecd88b5c6b1e4c072c55c8652d76513d74c5ad4e.patch";
-        hash = "sha256-Ea+v+RfmVl8fRbkr2ETM3/7R4vp+jw7hvTq2hnw4V/0=";
-      })
-    ];
+    [ ./fix-pkgconfig.patch ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/vu/vulkan-loader/package.nix
+++ b/pkgs/by-name/vu/vulkan-loader/package.nix
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-qPknv8BvfJoewFfORXsFZlUnae36czHfOPXmtGccrOk=";
   };
 
-  patches =
-    [ ./fix-pkgconfig.patch ];
+  patches = [ ./fix-pkgconfig.patch ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/vu/vulkan-tools-lunarg/package.nix
+++ b/pkgs/by-name/vu/vulkan-tools-lunarg/package.nix
@@ -27,13 +27,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools-lunarg";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   src = fetchFromGitHub {
     owner = "LunarG";
     repo = "VulkanTools";
     rev = "vulkan-sdk-${version}";
-    hash = "sha256-RaL7sqy5Rc8syPoM3SedZ6UilV9JUAA96JZh5/gIfPU=";
+    hash = "sha256-u2M9TzDwjZ/CVKX/ARUa075clXdrQjF3E0KUGpX1n+U=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vu/vulkan-utility-libraries/package.nix
+++ b/pkgs/by-name/vu/vulkan-utility-libraries/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "vulkan-utility-libraries";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Utility-Libraries";
     rev = "vulkan-sdk-${finalAttrs.version}";
-    hash = "sha256-WDRDpUOZN/akUA6gsJMlC2GKolVt3g1NerKqe7aLhek=";
+    hash = "sha256-d20PRTCCNWezwhTD3axiQeWvY9lqD/8XLGBlOFgNzFE=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/vu/vulkan-validation-layers/package.nix
+++ b/pkgs/by-name/vu/vulkan-validation-layers/package.nix
@@ -25,13 +25,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "vulkan-validation-layers";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-ValidationLayers";
     rev = "vulkan-sdk-${version}";
-    hash = "sha256-H5AG+PXM3IdCfDqHMdaunRUWRm8QgdS6ZbZLMaOOALk=";
+    hash = "sha256-n7fbhi5NCQRsj/sAjLfaW6EBFBqGutN5Cnl/CtnnVPY=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/vu/vulkan-volk/package.nix
+++ b/pkgs/by-name/vu/vulkan-volk/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "volk";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   src = fetchFromGitHub {
     owner = "zeux";
     repo = "volk";
     rev = "vulkan-sdk-${finalAttrs.version}";
-    hash = "sha256-faLszfOeFo5eAzwvnrAUDVAPCVt/F9xRUFGxC9TA8E8=";
+    hash = "sha256-+SLGRvCUKFntz60/xL/NjoFjvvATWMImR4CGnCHUj2o=";
   };
 
   nativeBuildInputs = [ cmake ];

--- a/pkgs/development/libraries/vulkan-headers/default.nix
+++ b/pkgs/development/libraries/vulkan-headers/default.nix
@@ -7,7 +7,7 @@
 }:
 stdenv.mkDerivation rec {
   pname = "vulkan-headers";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   # Adding `ninja` here to enable Ninja backend. Otherwise on gcc-14 or
   # later the build fails as:
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "KhronosGroup";
     repo = "Vulkan-Headers";
     rev = "vulkan-sdk-${version}";
-    hash = "sha256-u/40rOQyYbQza0aYbechLdKhYM1DgoMKkxauW2zZ/w0=";
+    hash = "sha256-X6HqcZDZ4ZQGBG3PlSxi0mhmYyrjmJYwk/pJ/XBqEZU=";
   };
 
   passthru.updateScript = ./update.sh;

--- a/pkgs/tools/graphics/vulkan-tools/default.nix
+++ b/pkgs/tools/graphics/vulkan-tools/default.nix
@@ -26,13 +26,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vulkan-tools";
-  version = "1.3.296.0";
+  version = "1.4.304.0";
 
   src = fetchFromGitHub {
     owner = "KhronosGroup";
     repo = "Vulkan-Tools";
     rev = "vulkan-sdk-${version}";
-    hash = "sha256-+24IVmmcxuPaT/vYRYZ4yluHS/uKfWiVa7yIvzsdTuQ=";
+    hash = "sha256-PtxzLsywYwaL4vhbDiabryLaMUMcwJGcL14dt8dnzvs=";
   };
 
   nativeBuildInputs = [
@@ -70,6 +70,10 @@ stdenv.mkDerivation rec {
 
   dontPatchELF = true;
 
+  patches = lib.optionals stdenv.hostPlatform.isLinux [
+    ./fix-wayland-protocols-path.patch
+  ];
+
   env.PKG_CONFIG_WAYLAND_SCANNER_WAYLAND_SCANNER = lib.getExe buildPackages.wayland-scanner;
 
   cmakeFlags =
@@ -86,6 +90,9 @@ stdenv.mkDerivation rec {
       "-DMOLTENVK_REPO_ROOT=${moltenvk}/share/vulkan/icd.d"
       # Don’t build the cube demo because it requires `ibtool`, which is not available in nixpkgs.
       "-DBUILD_CUBE=OFF"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      "-DWAYLAND_CLIENT_PATH=${buildPackages.wayland-scanner}/share/wayland"
     ];
 
   meta = with lib; {

--- a/pkgs/tools/graphics/vulkan-tools/fix-wayland-protocols-path.patch
+++ b/pkgs/tools/graphics/vulkan-tools/fix-wayland-protocols-path.patch
@@ -1,0 +1,9 @@
+--- a/cube/CMakeLists.txt
++++ b/cube/CMakeLists.txt
+@@ -96,7 +96,6 @@
+         pkg_get_variable(WAYLAND_SCANNER_EXECUTABLE wayland-scanner wayland_scanner)
+         message(DEBUG "WAYLAND_SCANNER_EXECUTABLE = ${WAYLAND_SCANNER_EXECUTABLE}")
+
+-        pkg_get_variable(WAYLAND_CLIENT_PATH wayland-client pkgdatadir)
+         message(DEBUG "WAYLAND_CLIENT_PATH = ${WAYLAND_CLIENT_PATH}")
+         set(WAYLAND_CODE_PROTOCOL ${WAYLAND_CLIENT_PATH}/wayland.xml)


### PR DESCRIPTION
Update vulkan packages to last stable sdk release 1.4.304

- vulkan-extension-layer: simply updated the package version
- vulkan-loader: updated the package version and removed 32bit patch because vulkan loader now can be built on 32bit systems without patches according to https://github.com/KhronosGroup/Vulkan-Loader/commit/6a6878c614c8c6dbe81ee7a9f1176bdb52dc7dd7
- vulkan-tools-lunarg: simply updated the package version
- vulkan-utility-libraries: simply updated the package version
- vulkan-validation-layers: simply updated the package version
- volk: simply updated the package version
- vulkan-headers: simply updated the package version
- vulkan-tools: updated the package version and applied patch to allow it to fund wayland.xml. This patch is needed because CMakeLists overrides path for wayland.xml file and otherwise it's impossible to build it with nix https://github.com/KhronosGroup/Vulkan-Tools/blob/vulkan-sdk-1.4.304/cube/CMakeLists.txt#L99


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin (some packages are not available on darwin)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
