### PR TITLE
lomiri.lomiri-ui-toolkit: Mark tst_slotslayout.13.qml borked

### DIFF
--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2001-Mark-problematic-tests.patch
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/2001-Mark-problematic-tests.patch
@@ -1,16 +1,19 @@
-From c1a69117793acec6841898f219935852cadc78d3 Mon Sep 17 00:00:00 2001
+From 6f7fa32c524b2ae7e86c13dd55760506b4cd547d Mon Sep 17 00:00:00 2001
 From: OPNA2608 <opna2608@protonmail.com>
-Date: Wed, 15 Jan 2025 18:45:02 +0100
+Date: Sat, 25 Jan 2025 08:08:42 +0100
 Subject: [PATCH] Mark problematic tests
 
+- test_defaultLabelsQmlContext in tst_slotslayout.13.qml seems not properly written,
+  fails consistently on aarch64-linux Hydra:
+  https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/45
 - tst_textinput_touch.SEGFAULT.11.qml is flaky:
   https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/43
 ---
- tests/checkresults.sh | 28 ++++++++++++++++++++++------
- 1 file changed, 22 insertions(+), 6 deletions(-)
+ tests/checkresults.sh | 29 +++++++++++++++++++++++------
+ 1 file changed, 23 insertions(+), 6 deletions(-)
 
 diff --git a/tests/checkresults.sh b/tests/checkresults.sh
-index fc498985e..ade361236 100755
+index fc498985e..86619937d 100755
 --- a/tests/checkresults.sh
 +++ b/tests/checkresults.sh
 @@ -22,6 +22,7 @@ ERRORS_PATTERN='<failure'
@@ -21,12 +24,13 @@ index fc498985e..ade361236 100755
  EXCEPTED=0
  for _XML in $*; do
      _TESTNAME=$(basename $_XML | sed -r 's@(.+)\.xml@\1@' -)
-@@ -31,7 +32,12 @@ for _XML in $*; do
+@@ -31,7 +32,13 @@ for _XML in $*; do
        exit 1
      fi
  
 -    EXCEPTIONS='components_benchmark \
 +    ERROR_EXCEPTIONS='\
++                tst_slotslayout.13.qml \
 +                tst_textinput_touch.SEGFAULT.11.qml \
 +                '
 +
@@ -35,7 +39,7 @@ index fc498985e..ade361236 100755
                  tst_tabbar.11.qml \
                  tst_datepicker.bug1567840.SEGFAULT.12.qml \
                  tst_datepicker.bug1567840.SEGFAULT.13.qml \
-@@ -54,17 +60,22 @@ for _XML in $*; do
+@@ -54,17 +61,22 @@ for _XML in $*; do
      WARNINGS=$(grep -c -P "$WARNINGS_PATTERN" $_XML)
      ERRORS=$(grep -c -P "$ERRORS_PATTERN" $_XML)
      if [ $ERRORS -ne 0 ]; then
@@ -62,7 +66,7 @@ index fc498985e..ade361236 100755
        WOOT_FILES="${WOOT_FILES}  ${_TESTNAME}\n"
      fi
  done
-@@ -82,6 +93,11 @@ if [ -n "$FATAL_WARNINGS_FILES" ]; then
+@@ -82,6 +94,11 @@ if [ -n "$FATAL_WARNINGS_FILES" ]; then
      echo -e "$FATAL_WARNINGS_FILES"
  fi
  
@@ -74,7 +78,7 @@ index fc498985e..ade361236 100755
  if [ -n "$EXCEPTED_FILES" ]; then
      echo The following tests issued $EXCEPTED expected warnings:
      echo -e "$EXCEPTED_FILES"
-@@ -89,7 +105,7 @@ fi
+@@ -89,7 +106,7 @@ fi
  
  if [ -n "$WOOT_FILES" ]; then
      echo Woot! Known problematic tests passed!
@@ -84,5 +88,5 @@ index fc498985e..ade361236 100755
  fi
  
 -- 
-2.47.0
+2.47.1
 


### PR DESCRIPTION
https://gitlab.com/ubports/development/core/lomiri-ui-toolkit/-/issues/45

Fails somewhat consistently on aarch64 Hydra, and sometimes on x86_64 Hydra.

![image](https://github.com/user-attachments/assets/802505f4-40e2-4518-b32d-d4130104f6d3)

Mark the test borked for now, so Lomiri stuff can be cached again.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
