### PR TITLE
clog-cli: 0.9.3 -> 0.10.0; useFetchCargoVendor

### DIFF
--- a/pkgs/by-name/cl/clog-cli/package.nix
+++ b/pkgs/by-name/cl/clog-cli/package.nix
@@ -6,16 +6,18 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "clog-cli";
-  version = "0.9.3";
+  version = "0.10.0";
 
   src = fetchFromGitHub {
     owner = "clog-tool";
     repo = "clog-cli";
-    rev = "v${version}";
-    sha256 = "1wxglc4n1dar5qphhj5pab7ps34cjr7jy611fwn72lz0f6c7jp3z";
+    # Tag seems to be missing:
+    # https://github.com/clog-tool/clog-cli/issues/128
+    rev = "7066cba2bcbaea0f62ea22c320d48dac20f36a38";
+    sha256 = "sha256-d1csT7iHf48kLkn6/cGhoIoEN/kiYc6vlUwHDNmbnMI=";
   };
 
-  cargoHash = "sha256-yjBgccrkG2D8ZW3Uju4XUhz9Kar50jkJZ75MWhn9j3U=";
+  cargoHash = "sha256-DS9lpjR9BCgo6VJG1XD0qzVr/8fw9NR2L2UWaE6gqtw=";
 
   meta = {
     description = "Generate changelogs from local git metadata";
@@ -24,7 +26,5 @@ rustPlatform.buildRustPackage rec {
     platforms = lib.platforms.unix;
     maintainers = [ lib.maintainers.nthorne ];
     mainProgram = "clog";
-    # error: could not compile `rustc-serialize`
-    broken = true; # Added 2024-03-16
   };
 }

--- a/pkgs/by-name/cl/clog-cli/package.nix
+++ b/pkgs/by-name/cl/clog-cli/package.nix
@@ -17,7 +17,8 @@ rustPlatform.buildRustPackage rec {
     sha256 = "sha256-d1csT7iHf48kLkn6/cGhoIoEN/kiYc6vlUwHDNmbnMI=";
   };
 
-  cargoHash = "sha256-DS9lpjR9BCgo6VJG1XD0qzVr/8fw9NR2L2UWaE6gqtw=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-b8/n3y6fTqP5+rZySEDEb8Z5DPHQ2jUasp5SvaJJlGo=";
 
   meta = {
     description = "Generate changelogs from local git metadata";


### PR DESCRIPTION
Untested but at least it builds now.

Cargo 1.84.0 seems to have changed the output format of cargo vendor
again, once again invalidating fetchCargoTarball FOD hashes.  It's
time to fix this once and for all, switching across the board to
fetchCargoVendor, which is not dependent on cargo vendor's output
format.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
