### PR TITLE
phoc: 0.44.0 -> 0.44.1

### DIFF
--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -29,7 +29,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "phoc";
-  version = "0.44.0";
+  version = "0.44.1";
 
   src = fetchFromGitLab {
     domain = "gitlab.gnome.org";
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
     owner = "Phosh";
     repo = "phoc";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-KaCQtORMJUM7/BLD+Jnbunhd/9/3NYWYx/XMYMo27hI=";
+    hash = "sha256-Whke7wTRp5NaRauiiQZLjs0pSD1uAyr0aAhlK5e1+Hw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -1,29 +1,30 @@
-{ lib
-, stdenv
-, stdenvNoCC
-, fetchFromGitLab
-, meson
-, ninja
-, pkg-config
-, python3
-, wayland-scanner
-, wrapGAppsHook3
-, libinput
-, gobject-introspection
-, mutter
-, gnome-desktop
-, glib
-, gtk3
-, json-glib
-, wayland
-, libdrm
-, libxkbcommon
-, wlroots_0_17
-, xorg
-, directoryListingUpdater
-, nixosTests
-, testers
-, gmobile
+{
+  lib,
+  stdenv,
+  stdenvNoCC,
+  fetchFromGitLab,
+  meson,
+  ninja,
+  pkg-config,
+  python3,
+  wayland-scanner,
+  wrapGAppsHook3,
+  libinput,
+  gobject-introspection,
+  mutter,
+  gnome-desktop,
+  glib,
+  gtk3,
+  json-glib,
+  wayland,
+  libdrm,
+  libxkbcommon,
+  wlroots_0_17,
+  xorg,
+  directoryListingUpdater,
+  nixosTests,
+  testers,
+  gmobile,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -65,12 +66,12 @@ stdenv.mkDerivation (finalAttrs: {
     gmobile
   ];
 
-  mesonFlags = ["-Dembed-wlroots=disabled"];
+  mesonFlags = [ "-Dembed-wlroots=disabled" ];
 
   # Patch wlroots to remove a check which crashes Phosh.
   # This patch can be found within the phoc source tree.
   wlroots = wlroots_0_17.overrideAttrs (old: {
-    patches = (old.patches or []) ++ [
+    patches = (old.patches or [ ]) ++ [
       (stdenvNoCC.mkDerivation {
         name = "0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";
         inherit (finalAttrs) src;
@@ -94,7 +95,10 @@ stdenv.mkDerivation (finalAttrs: {
     mainProgram = "phoc";
     homepage = "https://gitlab.gnome.org/World/Phosh/phoc";
     license = licenses.gpl3Plus;
-    maintainers = with maintainers; [ masipcat zhaofengli ];
+    maintainers = with maintainers; [
+      masipcat
+      zhaofengli
+    ];
     platforms = platforms.linux;
   };
 })

--- a/pkgs/by-name/ph/phoc/package.nix
+++ b/pkgs/by-name/ph/phoc/package.nix
@@ -18,7 +18,7 @@
 , wayland
 , libdrm
 , libxkbcommon
-, wlroots
+, wlroots_0_17
 , xorg
 , directoryListingUpdater
 , nixosTests
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Patch wlroots to remove a check which crashes Phosh.
   # This patch can be found within the phoc source tree.
-  wlroots = wlroots.overrideAttrs (old: {
+  wlroots = wlroots_0_17.overrideAttrs (old: {
     patches = (old.patches or []) ++ [
       (stdenvNoCC.mkDerivation {
         name = "0001-Revert-layer-shell-error-on-0-dimension-without-anch.patch";

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4669,10 +4669,6 @@ with pkgs;
 
   pfstools = libsForQt5.callPackage ../tools/graphics/pfstools { };
 
-  phoc = callPackage ../applications/misc/phoc {
-    wlroots = wlroots_0_17;
-  };
-
   piper-train = callPackage ../tools/audio/piper/train.nix { };
   piper-tts = callPackage ../tools/audio/piper { };
 


### PR DESCRIPTION
Continuation of https://github.com/NixOS/nixpkgs/pull/376138

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
