### PR TITLE
[24.11] Backport Linux 6.13 module fixes, set `latest` back to 6.13

### DIFF
--- a/pkgs/applications/emulators/cdemu/vhba.nix
+++ b/pkgs/applications/emulators/cdemu/vhba.nix
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-zjTLriw2zvjX0Jxfa9QtaHG5tTC7cLTKEA+WSCP+Dpg=";
   };
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];

--- a/pkgs/os-specific/linux/acpi-call/default.nix
+++ b/pkgs/os-specific/linux/acpi-call/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/akvcam/default.nix
+++ b/pkgs/os-specific/linux/akvcam/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
   sourceRoot = "${src.name}/src";
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/amneziawg/default.nix
+++ b/pkgs/os-specific/linux/amneziawg/default.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   makeFlags =
-    kernel.makeFlags
+    kernel.moduleMakeFlags
     ++ [ "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ]
     ++ lib.optional (lib.versionAtLeast kernel.version "5.6") "KERNEL_SOURCE_DIR=${srcOnly kernel}";
 

--- a/pkgs/os-specific/linux/apfs/default.nix
+++ b/pkgs/os-specific/linux/apfs/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "pic" ];
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELRELEASE=${kernel.modDirVersion}"
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"

--- a/pkgs/os-specific/linux/batman-adv/default.nix
+++ b/pkgs/os-specific/linux/batman-adv/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELPATH=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/bbswitch/default.nix
+++ b/pkgs/os-specific/linux/bbswitch/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation {
       --replace "/lib/modules" "${kernel.dev}/lib/modules"
   '';
 
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   installPhase = ''
     mkdir -p $out/lib/modules/${kernel.modDirVersion}/misc

--- a/pkgs/os-specific/linux/can-isotp/default.nix
+++ b/pkgs/os-specific/linux/can-isotp/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     sha256 = "1laax93czalclg7cy9iq1r7hfh9jigh7igj06y9lski75ap2vhfq";
   };
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];

--- a/pkgs/os-specific/linux/cryptodev/default.nix
+++ b/pkgs/os-specific/linux/cryptodev/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = kernel.moduleBuildDependencies;
   hardeningDisable = [ "pic" ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
     "prefix=$(out)"

--- a/pkgs/os-specific/linux/ddcci/default.nix
+++ b/pkgs/os-specific/linux/ddcci/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation rec {
       --replace depmod \#
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "KVER=${kernel.modDirVersion}"
     "KERNEL_MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"

--- a/pkgs/os-specific/linux/digimend/default.nix
+++ b/pkgs/os-specific/linux/digimend/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
     rm -r $out/lib/udev
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KVERSION=${kernel.modDirVersion}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "DESTDIR=${placeholder "out"}"

--- a/pkgs/os-specific/linux/dpdk-kmods/default.nix
+++ b/pkgs/os-specific/linux/dpdk-kmods/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];
   KSRC = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";

--- a/pkgs/os-specific/linux/drbd/driver.nix
+++ b/pkgs/os-specific/linux/drbd/driver.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     python3
   ];
 
-  makeFlags = [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "SPAAS=false"
   ];

--- a/pkgs/os-specific/linux/ena/default.nix
+++ b/pkgs/os-specific/linux/ena/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   env.KERNEL_BUILD_DIR = "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build";
 

--- a/pkgs/os-specific/linux/evdi/default.nix
+++ b/pkgs/os-specific/linux/evdi/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
     python3WithLibs
   ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KVER=${kernel.modDirVersion}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/fanout/default.nix
+++ b/pkgs/os-specific/linux/fanout/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/framework-laptop-kmod/default.nix
+++ b/pkgs/os-specific/linux/framework-laptop-kmod/default.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/fwts/module.nix
+++ b/pkgs/os-specific/linux/fwts/module.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   hardeningDisable = [ "pic" ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];
 

--- a/pkgs/os-specific/linux/gasket/default.nix
+++ b/pkgs/os-specific/linux/gasket/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     cd src
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "-C"
     "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "M=$(PWD)"

--- a/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
+++ b/pkgs/os-specific/linux/gcadapter-oc-kmod/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNEL_SOURCE_DIR=${kernel.dev}/${kerneldir}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];

--- a/pkgs/os-specific/linux/hid-ite8291r3/default.nix
+++ b/pkgs/os-specific/linux/hid-ite8291r3/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "VERSION=${version}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/hid-t150/default.nix
+++ b/pkgs/os-specific/linux/hid-t150/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   sourceRoot = "${src.name}/hid-t150";
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];

--- a/pkgs/os-specific/linux/hid-tmff2/default.nix
+++ b/pkgs/os-specific/linux/hid-tmff2/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/ipu6-drivers/default.nix
+++ b/pkgs/os-specific/linux/ipu6-drivers/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELRELEASE=${kernel.modDirVersion}"
     "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/ithc/default.nix
+++ b/pkgs/os-specific/linux/ithc/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "VERSION=${version}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/ivsc-driver/default.nix
+++ b/pkgs/os-specific/linux/ivsc-driver/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELRELEASE=${kernel.modDirVersion}"
     "KERNEL_SRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/jool/default.nix
+++ b/pkgs/os-specific/linux/jool/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation {
     sed -e 's@/lib/modules/\$(.*)@${kernel.dev}/lib/modules/${kernel.modDirVersion}@' -i src/mod/*/Makefile
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "-C src/mod"
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];

--- a/pkgs/os-specific/linux/kernel/perf/default.nix
+++ b/pkgs/os-specific/linux/kernel/perf/default.nix
@@ -101,7 +101,7 @@ stdenv.mkDerivation {
       "WERROR=0"
       "ASCIIDOC8=1"
     ]
-    ++ kernel.makeFlags
+    ++ kernel.moduleMakeFlags
     ++ lib.optional (!withGtk) "NO_GTK2=1"
     ++ lib.optional (!withZstd) "NO_LIBZSTD=1"
     ++ lib.optional (!withLibcap) "NO_LIBCAP=1";

--- a/pkgs/os-specific/linux/lenovo-legion/default.nix
+++ b/pkgs/os-specific/linux/lenovo-legion/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     sed -i -e '/depmod/d' ./Makefile
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "SHELL=bash"
     "KERNELVERSION=${kernel.modDirVersion}"
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"

--- a/pkgs/os-specific/linux/lkrg/default.nix
+++ b/pkgs/os-specific/linux/lkrg/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNEL=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/lttng-modules/default.nix
+++ b/pkgs/os-specific/linux/lttng-modules/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = "-Wno-error=implicit-function-declaration";
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=${placeholder "out"}"
   ];

--- a/pkgs/os-specific/linux/mba6x_bl/default.nix
+++ b/pkgs/os-specific/linux/mba6x_bl/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];

--- a/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
+++ b/pkgs/os-specific/linux/mbp-modules/mbp2018-bridge-drv/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   buildPhase = ''
     make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \

--- a/pkgs/os-specific/linux/msi-ec/default.nix
+++ b/pkgs/os-specific/linux/msi-ec/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation {
 
   hardeningDisable = [ "pic" ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"
   ];

--- a/pkgs/os-specific/linux/mstflint_access/default.nix
+++ b/pkgs/os-specific/linux/mstflint_access/default.nix
@@ -11,7 +11,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KVER=${kernel.modDirVersion}"
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/nct6687d/default.nix
+++ b/pkgs/os-specific/linux/nct6687d/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "-C"
     "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "M=$(sourceRoot)"

--- a/pkgs/os-specific/linux/netatop/default.nix
+++ b/pkgs/os-specific/linux/netatop/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation {
     kmod=${kmod} substituteAllInPlace netatop.service
   '';
 
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   preInstall = ''
     mkdir -p $out/lib/systemd/system $out/bin $out/sbin $out/share/man/man{4,8}

--- a/pkgs/os-specific/linux/nullfs/default.nix
+++ b/pkgs/os-specific/linux/nullfs/default.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/nvidia-x11/generic.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/generic.nix
@@ -195,12 +195,15 @@ let
     kernel = if libsOnly then null else kernel.dev;
     kernelVersion = if libsOnly then null else kernel.modDirVersion;
 
-    makeFlags = lib.optionals (!libsOnly) (kernel.makeFlags ++ [
-      "IGNORE_PREEMPT_RT_PRESENCE=1"
-      "NV_BUILD_SUPPORTS_HMM=1"
-      "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
-      "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-    ]);
+    makeFlags = lib.optionals (!libsOnly) (
+      kernel.moduleMakeFlags
+      ++ [
+        "IGNORE_PREEMPT_RT_PRESENCE=1"
+        "NV_BUILD_SUPPORTS_HMM=1"
+        "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
+        "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+      ]
+    );
 
     hardeningDisable = [ "pic" "format" ];
 

--- a/pkgs/os-specific/linux/nvidia-x11/open.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/open.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation ({
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
     "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"

--- a/pkgs/os-specific/linux/openrazer/driver.nix
+++ b/pkgs/os-specific/linux/openrazer/driver.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (
 
     nativeBuildInputs = kernel.moduleBuildDependencies;
 
-    makeFlags = kernel.makeFlags ++ [
+    makeFlags = kernel.moduleMakeFlags ++ [
       "KERNELDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     ];
 

--- a/pkgs/os-specific/linux/qc71_laptop/default.nix
+++ b/pkgs/os-specific/linux/qc71_laptop/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "VERSION=${version}"
     "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/r8168/default.nix
+++ b/pkgs/os-specific/linux/r8168/default.nix
@@ -27,7 +27,7 @@ in stdenv.mkDerivation rec {
   # avoid using the Makefile directly -- it doesn't understand
   # any kernel but the current.
   # based on the ArchLinux pkgbuild: https://git.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/r8168
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "-C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "M=$(PWD)/src"
     "modules"

--- a/pkgs/os-specific/linux/rtl8189es/default.nix
+++ b/pkgs/os-specific/linux/rtl8189es/default.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     substituteInPlace ./Makefile --replace '$(MODDESTDIR)' "$out/lib/modules/${kernel.modDirVersion}/kernel/net/wireless/"
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     (
       "CONFIG_PLATFORM_I386_PC="

--- a/pkgs/os-specific/linux/rtl8192eu/default.nix
+++ b/pkgs/os-specific/linux/rtl8192eu/default.nix
@@ -25,7 +25,9 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies ++ [ bc ];
 
-  makeFlags = kernel.makeFlags ++ [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
+  makeFlags = kernel.moduleMakeFlags ++ [
+    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/rtl8814au/default.nix
+++ b/pkgs/os-specific/linux/rtl8814au/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   hardeningDisable = [ "pic" ];
 

--- a/pkgs/os-specific/linux/rtl8821ce/default.nix
+++ b/pkgs/os-specific/linux/rtl8821ce/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation (finalAttrs: {
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   prePatch = ''
     substituteInPlace ./Makefile \

--- a/pkgs/os-specific/linux/rtl8821cu/default.nix
+++ b/pkgs/os-specific/linux/rtl8821cu/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   prePatch = ''
     substituteInPlace ./Makefile \

--- a/pkgs/os-specific/linux/rtl88x2bu/default.nix
+++ b/pkgs/os-specific/linux/rtl88x2bu/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   hardeningDisable = [ "pic" ];
 
   nativeBuildInputs = [ bc ] ++ kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags;
+  makeFlags = kernel.moduleMakeFlags;
 
   prePatch = ''
     substituteInPlace ./Makefile \

--- a/pkgs/os-specific/linux/rtw88/default.nix
+++ b/pkgs/os-specific/linux/rtw88/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags ++ [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
+  makeFlags = kernel.moduleMakeFlags ++ [
+    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/rtw89/default.nix
+++ b/pkgs/os-specific/linux/rtw89/default.nix
@@ -20,7 +20,9 @@ stdenv.mkDerivation {
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags ++ [ "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
+  makeFlags = kernel.moduleMakeFlags ++ [
+    "KSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
 
   enableParallelBuilding = true;
 

--- a/pkgs/os-specific/linux/rust-out-of-tree-module/default.nix
+++ b/pkgs/os-specific/linux/rust-out-of-tree-module/default.nix
@@ -17,7 +17,9 @@ kernel.stdenv.mkDerivation {
   };
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
-  makeFlags = kernel.makeFlags ++ [ "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build" ];
+  makeFlags = kernel.moduleMakeFlags ++ [
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+  ];
 
   installFlags = [ "INSTALL_MOD_PATH=${placeholder "out"}" ];
   installTargets = [ "modules_install" ];

--- a/pkgs/os-specific/linux/shufflecake/default.nix
+++ b/pkgs/os-specific/linux/shufflecake/default.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
     libgcrypt
     lvm2
   ];
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/tmon/default.nix
+++ b/pkgs/os-specific/linux/tmon/default.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation {
     cd tools/thermal/tmon
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "INSTALL_ROOT=\"$(out)\""
     "BINDIR=bin"
   ];

--- a/pkgs/os-specific/linux/trelay/default.nix
+++ b/pkgs/os-specific/linux/trelay/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation (finalAttrs: {
     cp '${./Makefile}' Makefile
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELRELEASE=${kernel.modDirVersion}"
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "INSTALL_MOD_PATH=$(out)"

--- a/pkgs/os-specific/linux/tuxedo-drivers/default.nix
+++ b/pkgs/os-specific/linux/tuxedo-drivers/default.nix
@@ -22,14 +22,11 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [ pahole ];
   nativeBuildInputs = [ kmod ] ++ kernel.moduleBuildDependencies;
 
-  # kernel makeFlags contain O=$$(buildRoot), that upstream passes through to make and causes build failure, so we filter it out here
-  makeFlags =
-    (lib.filter (flag: lib.head (lib.strings.splitString "=" flag) != "O") kernel.makeFlags)
-    ++ [
-      "KERNELRELEASE=${kernel.modDirVersion}"
-      "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
-      "INSTALL_MOD_PATH=${placeholder "out"}"
-    ];
+  makeFlags = kernel.moduleMakeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=${placeholder "out"}"
+  ];
 
   meta = {
     broken = stdenv.hostPlatform.isAarch64 || (lib.versionOlder kernel.version "5.5");

--- a/pkgs/os-specific/linux/v4l2loopback/default.nix
+++ b/pkgs/os-specific/linux/v4l2loopback/default.nix
@@ -28,7 +28,7 @@ in stdenv.mkDerivation {
 
   outputs = [ "out" "bin" ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "KERNELRELEASE=${kernel.modDirVersion}"
     "KERNEL_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];

--- a/pkgs/os-specific/linux/veikk-linux-driver/default.nix
+++ b/pkgs/os-specific/linux/veikk-linux-driver/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ kernel ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "BUILD_DIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
   ];
 

--- a/pkgs/os-specific/linux/virtio_vmmci/default.nix
+++ b/pkgs/os-specific/linux/virtio_vmmci/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
     CONFIG_RTC_HCTOSYS yes
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "DEPMOD=echo"
     "INSTALL_MOD_PATH=$(out)"
     "KERNELRELEASE=${kernel.modDirVersion}"

--- a/pkgs/os-specific/linux/vmm_clock/default.nix
+++ b/pkgs/os-specific/linux/vmm_clock/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     CONFIG_RTC_HCTOSYS yes
   '';
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "DEPMOD=echo"
     "INSTALL_MOD_PATH=$(out)"
     "KERNELRELEASE=${kernel.modDirVersion}"

--- a/pkgs/os-specific/linux/xpadneo/default.nix
+++ b/pkgs/os-specific/linux/xpadneo/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = kernel.moduleBuildDependencies;
   buildInputs = [ bluez ];
 
-  makeFlags = kernel.makeFlags ++ [
+  makeFlags = kernel.moduleMakeFlags ++ [
     "-C"
     "${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
     "M=$(sourceRoot)"

--- a/pkgs/os-specific/linux/zenergy/default.nix
+++ b/pkgs/os-specific/linux/zenergy/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation {
     "pic"
   ];
 
-  makeFlags = kernel.makeFlags ++ [ "KDIR=${kernelDirectory}" ];
+  makeFlags = kernel.moduleMakeFlags ++ [ "KDIR=${kernelDirectory}" ];
 
   installTargets = [ "modules_install" ];
 

--- a/pkgs/os-specific/linux/zfs/generic.nix
+++ b/pkgs/os-specific/linux/zfs/generic.nix
@@ -209,10 +209,10 @@ let
             "--with-linux=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
             "--with-linux-obj=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
           ]
-          ++ kernel.makeFlags
+          ++ kernel.moduleMakeFlags
         );
 
-      makeFlags = optionals buildKernel kernel.makeFlags;
+      makeFlags = optionals buildKernel kernel.moduleMakeFlags;
 
       enableParallelBuilding = true;
 

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -715,7 +715,7 @@ in {
   packageAliases = {
     linux_default = packages.linux_6_6;
     # Update this when adding the newest kernel major version!
-    linux_latest = packages.linux_6_12;
+    linux_latest = packages.linux_6_13;
     linux_mptcp = throw "'linux_mptcp' has been moved to https://github.com/teto/mptcp-flake";
     linux_rt_default = packages.linux_rt_5_15;
     linux_rt_latest = packages.linux_rt_6_6;


### PR DESCRIPTION
Backport of #376078.

cc @k900 @alyssais @fpletz

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
