### PR TITLE
various: fix replaceVars with placeholder

### DIFF
--- a/pkgs/by-name/ch/chawan/package.nix
+++ b/pkgs/by-name/ch/chawan/package.nix
@@ -26,12 +26,14 @@ stdenv.mkDerivation {
     fetchSubmodules = true;
   };
 
-  patches = [
-    # Include chawan's man pages in mancha's search path
-    (replaceVars ./mancha-augment-path.diff {
-      out = placeholder "out";
-    })
-  ];
+  patches = [ ./mancha-augment-path.diff ];
+
+  # Include chawan's man pages in mancha's search path
+  postPatch = ''
+    # As we need the $out reference, we can't use `replaceVars` here.
+    substituteInPlace adapter/protocol/man.nim \
+      --replace-fail '@out@' "$out"
+  '';
 
   env.NIX_CFLAGS_COMPILE = toString (
     lib.optional stdenv.cc.isClang "-Wno-error=implicit-function-declaration"

--- a/pkgs/by-name/gu/gui-for-clash/package.nix
+++ b/pkgs/by-name/gu/gui-for-clash/package.nix
@@ -68,11 +68,13 @@ in
 buildGoModule {
   inherit pname version src;
 
-  patches = [
-    (replaceVars ./bridge.patch {
-      basepath = placeholder "out";
-    })
-  ];
+  patches = [ ./bridge.patch ];
+
+  postPatch = ''
+    # As we need the $out reference, we can't use `replaceVars` here.
+    substituteInPlace bridge/bridge.go \
+      --replace-fail '@basepath@' "$out"
+  '';
 
   vendorHash = "sha256-OrysyJF+lUMf+0vWmOZHjxUdE6fQCKArmpV4alXxtYs=";
 

--- a/pkgs/by-name/gu/gui-for-singbox/package.nix
+++ b/pkgs/by-name/gu/gui-for-singbox/package.nix
@@ -68,11 +68,13 @@ in
 buildGoModule {
   inherit pname version src;
 
-  patches = [
-    (replaceVars ./bridge.patch {
-      basepath = placeholder "out";
-    })
-  ];
+  patches = [ ./bridge.patch ];
+
+  postPatch = ''
+    # As we need the $out reference, we can't use `replaceVars` here.
+    substituteInPlace bridge/bridge.go \
+      --replace-fail '@basepath@' "$out"
+  '';
 
   vendorHash = "sha256-OrysyJF+lUMf+0vWmOZHjxUdE6fQCKArmpV4alXxtYs=";
 


### PR DESCRIPTION
Using `replaceVars` with `placeholder "..."` will never work as expected. The placeholder will refer to the derivation created by `replaceVars`, not to the derivation that this is called from. This was the same with `substituteAll` previously.

Those were introduced in db10106dbc08ac5ffd4c314a7de08d71159844de, 45ab4bd68c8568a97b40a9356be0f460c536f9a6 and 1b125a40d6a28d377007586be725f10f53327216. @aucub @eclairevoyant 

Found those with my [new tools](https://github.com/technowledgy/refactor-tractor) around the [`replaceVars` refactor](https://github.com/NixOS/nixpkgs/issues/237216) based on [ast-grep](https://ast-grep.github.io/). @philiptaron 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] ~~x86_64-darwin~~
  - [ ] ~~aarch64-darwin~~
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
