### PR TITLE
electron{-source,-bin,-chromedriver}: 32.2.8 -> 32.3.0, 33.3.1 -> 33.3.2

### DIFF
--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -78,13 +78,13 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "f5886daefc3ea8851a087eafd23826337f97e0e921256a70f887c8acc8128bca",
-            "aarch64-linux": "b428ecca13d4ffc05c28e28759a310f317e4e89b05e9a30ba07e0d58fbaedef5",
-            "armv7l-linux": "e9e74509304e87a889bc59fe86eb2efc901d3c43b02d18acd5a9ba07800334a5",
-            "headers": "054d8hkm8kvknwamcblpyvgzmfqwb954x6gxgi0ma9xym8dl2qks",
-            "x86_64-darwin": "2d6015ff12c8b712b7e928dd163c1fd0e4c988665ce626c441ceb97753d48e1d",
-            "x86_64-linux": "cdca6f9ec2f98708dcbcb8baba3d0521e15ed4e5aab68b2d1c6668f99faafc38"
+            "aarch64-darwin": "4c7ffa4927aec31912ae2047d8d6c33e801501e4b576c724947866da9346110c",
+            "aarch64-linux": "c55b6b66fe8018e0e05953cd794735782f05b7e3b2a117a86413eafcedfda7ef",
+            "armv7l-linux": "2e7f915c71b11e6cc1ec46aee8f87c28fdd029a0a90a9196117a8f0c7aa81aa8",
+            "headers": "07m9p2nz0rzl3asq466kqzdq1bdmlvxb5slrr24dj9awijlyrrb6",
+            "x86_64-darwin": "fa451db2991506cacebd2a836e84ca7eff73770ed987d5b958f9854637c12d3d",
+            "x86_64-linux": "13b99da4a78dae9bf0960309cd1e9476faf5f7260bbf930bd302189d490ff77c"
         },
-        "version": "33.3.1"
+        "version": "33.3.2"
     }
 }

--- a/pkgs/development/tools/electron/binary/info.json
+++ b/pkgs/development/tools/electron/binary/info.json
@@ -67,14 +67,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "39d5298563ec488b3b329c9ad6e4f40e941a7326e82683a588d2f103a6f7dd78",
-            "aarch64-linux": "67782c4208cb64347552c003ded53ae993af8de16fadd19fd43105d1b592971f",
-            "armv7l-linux": "e1ace6669dc5aa9696b6f37af0d1210125e96ebda4dbb82496896047191a1810",
-            "headers": "0qw1nfi0c53d346lchmya6dr0l3c94ssdbazbr547qih2njc7jbz",
-            "x86_64-darwin": "91cb09191798606e4666952f8bb01d4851eab68973874ba5e26d6c7d1287b3be",
-            "x86_64-linux": "b01f9f5fcef719f0d76dc2f61c3f5a5b411970e425639de65aa823804918ce22"
+            "aarch64-darwin": "7b0071f5162fe81cc020e76b3e71aa18e5e888edacca6a0c92f389199097534c",
+            "aarch64-linux": "292740690b445bf8e3b13c37c74ff2c9820e8d30f6d0ac8e03a62421746f189c",
+            "armv7l-linux": "efc6bfdbd92e76cde23bfa0967809593ae32e74ed1897765f1105e3761db9478",
+            "headers": "0pmgcns26pvvp7ihqkl9llpdr8l871p7m6r72scia93siwnyvrvv",
+            "x86_64-darwin": "a7070ea98e5a4c5d53b2184229428d29109682165be62b17faf0bcdd9547174f",
+            "x86_64-linux": "8fb72c1d19a51552438eb42fdaae915643c2e310fa3090d8d5293ad6fc94b8c5"
         },
-        "version": "32.2.8"
+        "version": "32.3.0"
     },
     "33": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -34,14 +34,14 @@
     },
     "32": {
         "hashes": {
-            "aarch64-darwin": "f7aef40a833edda014b50e5c3db52a8f966045f3e16b113bd410afc0fea24da0",
-            "aarch64-linux": "b81a9f916d49f1867d6326f34a1e2e5f4069c4ac445123a90dc2034a0a1bfd34",
-            "armv7l-linux": "e3573aa5940158aa953c8b58a6c709288466347675cca032adb71f6f7042fb06",
-            "headers": "0qw1nfi0c53d346lchmya6dr0l3c94ssdbazbr547qih2njc7jbz",
-            "x86_64-darwin": "7428bb4dc438596875138a8f06c67b18266850797988f7c862cb39ca86eb5269",
-            "x86_64-linux": "57fe434c5437e45c866789622dac20f7b33204d51a7b923ad1e8b7259789d498"
+            "aarch64-darwin": "679a286100f2121a3566f7d0988894611628e93920843c873de36d3e37f1b0e9",
+            "aarch64-linux": "6a297a8db6f64ac3c95ddc17d2a9f95bff3d2fddef2aae565ebf91bcca960f3a",
+            "armv7l-linux": "c76c9ec01fff88a9cda3aedfd8251880a835d326c349b108f09e02a419dd9a52",
+            "headers": "0pmgcns26pvvp7ihqkl9llpdr8l871p7m6r72scia93siwnyvrvv",
+            "x86_64-darwin": "495b3f0e0459badba8f6e3406edd4bcf7e688eb9d11d4b544426fb25d1e22f43",
+            "x86_64-linux": "af9e3a6aac492827e1ace64fc50744f82523f09842b2414ad00d9a97f06d7a85"
         },
-        "version": "32.2.8"
+        "version": "32.3.0"
     },
     "33": {
         "hashes": {

--- a/pkgs/development/tools/electron/chromedriver/info.json
+++ b/pkgs/development/tools/electron/chromedriver/info.json
@@ -45,13 +45,13 @@
     },
     "33": {
         "hashes": {
-            "aarch64-darwin": "c2b4a3bb8a609e5272db39321d567f900eed1c2284eda89d7a4c41557e5b9ba3",
-            "aarch64-linux": "4b08bd54413a72d1a991f427cc8d27c313def385431f7e045e5b3efbbc880e39",
-            "armv7l-linux": "f84e71d37358d574fee6519c8dc1335c52bb783d92c2fa92c2fb4a48f9661413",
-            "headers": "054d8hkm8kvknwamcblpyvgzmfqwb954x6gxgi0ma9xym8dl2qks",
-            "x86_64-darwin": "c3c0cb8eec909cad52eb9f6b2d9ff2bffc9d2246f37280eb44ffc45fdb6b4861",
-            "x86_64-linux": "6e288cf2be3ceba26bec0cb1f86504574326bacd933a5da208dabef111abde6d"
+            "aarch64-darwin": "96648a7aa64bff1b6fdce75da395451cca23aafdd06437c31544125962e25323",
+            "aarch64-linux": "a5bce192adbc7dfcb6134296c15409b8299a64b3ecc9c61d7d150a644a8187e6",
+            "armv7l-linux": "a921c696a7371712b14ed64e408a57ad874340fd8d61a447cbc83fcf79e599a3",
+            "headers": "07m9p2nz0rzl3asq466kqzdq1bdmlvxb5slrr24dj9awijlyrrb6",
+            "x86_64-darwin": "06ae393d176e8fdd67b1fb6a2b3f0771e3971de112e338d7d30d2ea1ffd0fe8c",
+            "x86_64-linux": "85e3d980a43f4792d1b6246a50dad745653c0e13b95dbc37adadc78078cfcc99"
         },
-        "version": "33.3.1"
+        "version": "33.3.2"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -941,7 +941,7 @@
         "version": "32.3.0"
     },
     "33": {
-        "chrome": "130.0.6723.170",
+        "chrome": "130.0.6723.191",
         "chromium": {
             "deps": {
                 "gn": {
@@ -951,15 +951,15 @@
                     "version": "2024-09-09"
                 }
             },
-            "version": "130.0.6723.170"
+            "version": "130.0.6723.191"
         },
         "chromium_npm_hash": "sha256-4w5m/bTMygidlb4TZHMx1Obp784DLxMwrfe1Uvyyfp8=",
         "deps": {
             "src": {
                 "fetcher": "fetchFromGitiles",
-                "hash": "sha256-zhEHb3Jjr6CAgIAqMV4uwzVE80lAkVnlxi4FYnpkzdw=",
+                "hash": "sha256-hJZWDT7D2YP75CQJwYNqnMTvLyMIF3wS2yJaRuUiOhY=",
                 "postFetch": "rm -r $out/third_party/blink/web_tests; rm -r $out/third_party/hunspell/tests; rm -r $out/content/test/data; rm -rf $out/courgette/testdata; rm -r $out/extensions/test/data; rm -r $out/media/test/data; ",
-                "rev": "130.0.6723.170",
+                "rev": "130.0.6723.191",
                 "url": "https://chromium.googlesource.com/chromium/src.git"
             },
             "src/chrome/test/data/perf/canvas_bench": {
@@ -988,10 +988,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-PaWXPOPPvxpZNDXF+bdouxZCJRYxVVbwDsVNsnf5oXo=",
+                "hash": "sha256-20ggSgks8zVYsFeMRHzqpnQFE9UazwOY2BVQYhVo/Vk=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v33.3.1"
+                "rev": "v33.3.2"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -1883,14 +1883,14 @@
             },
             "src/v8": {
                 "fetcher": "fetchFromGitiles",
-                "hash": "sha256-4DcSWkMhPwMh6ZvURj2piKaIPNe2Rur+nA3vAirgvcM=",
-                "rev": "932a8d7bb284242fd92234cf734921b8383ae4f6",
+                "hash": "sha256-9TZ8a0ufsG/gWM2nYAWDymWeDlDg23Dgy/G6ic67QBI=",
+                "rev": "3551594a5f6604c7e5070f408cc81d60d08ddbbf",
                 "url": "https://chromium.googlesource.com/v8/v8.git"
             }
         },
         "electron_yarn_hash": "0bzsswcg62b39xinq5vikk7qz7d15276s2vc15v1gcb5wvh05ff8",
         "modules": "130",
         "node": "20.18.1",
-        "version": "33.3.1"
+        "version": "33.3.2"
     }
 }

--- a/pkgs/development/tools/electron/info.json
+++ b/pkgs/development/tools/electron/info.json
@@ -47,10 +47,10 @@
             },
             "src/electron": {
                 "fetcher": "fetchFromGitHub",
-                "hash": "sha256-TLTgZMpIqmdCPh+b45YDmWVGWrl4LmB0xqRfv0bc3o4=",
+                "hash": "sha256-pOWNw6MLjy7ucMGtF/sVPNmlmje0ozqRhEwOPkfW1oM=",
                 "owner": "electron",
                 "repo": "electron",
-                "rev": "v32.2.8"
+                "rev": "v32.3.0"
             },
             "src/media/cdm/api": {
                 "fetcher": "fetchFromGitiles",
@@ -938,7 +938,7 @@
         "electron_yarn_hash": "122y1vnizwg0rwz8qf37mvpa0i78141y98wn4h11l6b9gyshrs65",
         "modules": "128",
         "node": "20.18.1",
-        "version": "32.2.8"
+        "version": "32.3.0"
     },
     "33": {
         "chrome": "130.0.6723.170",


### PR DESCRIPTION
https://github.com/electron/electron/releases/tag/v32.3.0
diff: https://github.com/electron/electron/compare/refs/tags/v32.2.8...v32.3.0
Fixes CVE-2024-12693 CVE-2024-12694 CVE-2024-12695 CVE-2025-0434 CVE-2025-0436 CVE-2025-0437

https://github.com/electron/electron/releases/tag/v33.3.2
diff: https://github.com/electron/electron/compare/refs/tags/v33.3.1...v33.3.2
Fixes CVE-2025-0434 CVE-2025-0436 CVE-2025-0437

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
