### PR TITLE
[24.11] vst2-sdk: init at 2018-06-11

### DIFF
--- a/pkgs/applications/audio/airwave/default.nix
+++ b/pkgs/applications/audio/airwave/default.nix
@@ -12,6 +12,7 @@
   file,
   libX11,
   qt5,
+  vst2-sdk,
 }:
 
 let
@@ -22,18 +23,6 @@ let
     repo = "airwave";
     rev = version;
     sha256 = "1ban59skw422mak3cp57lj27hgq5d3a4f6y79ysjnamf8rpz9x4s";
-  };
-
-  vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk369_01_03_2018_build_132";
-    src = requireFile {
-      name = "${name}.zip";
-      url = "http://www.steinberg.net/en/company/developers.html";
-      sha256 = "0r29fv6yhm2m5yznn8m4my7fq01w1lpphax4sshagy6b1dgjlv3w";
-    };
-    nativeBuildInputs = [ unzip ];
-    installPhase = "cp -r . $out";
-    meta.license = lib.licenses.unfree;
   };
 
   wine-wow64 = wine.override {
@@ -84,7 +73,7 @@ multiStdenv.mkDerivation {
   # Cf. https://github.com/phantom-code/airwave/issues/57
   hardeningDisable = [ "format" ];
 
-  cmakeFlags = [ "-DVSTSDK_PATH=${vst-sdk}/VST2_SDK" ];
+  cmakeFlags = [ "-DVSTSDK_PATH=${vst2-sdk}" ];
 
   postInstall = ''
     mv $out/bin $out/libexec

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -20,6 +20,7 @@
   libXScrnSaver,
   libGL,
   libxcb,
+  vst2-sdk,
   xcbutil,
   libxkbcommon,
   xcbutilkeysyms,
@@ -44,20 +45,6 @@
   enableVST2 ? false,
 }:
 
-let
-  # equal to vst-sdk in ../oxefmsynth/default.nix
-  vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk3610_11_06_2018_build_37";
-    src = fetchzip {
-      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/${name}.zip";
-      sha256 = "0da16iwac590wphz2sm5afrfj42jrsnkr1bxcy93lj7a369ildkj";
-    };
-    installPhase = ''
-      cp -r . $out
-    '';
-  };
-
-in
 stdenv.mkDerivation rec {
   pname = "bespokesynth";
   version = "1.2.1";
@@ -72,7 +59,7 @@ stdenv.mkDerivation rec {
 
   cmakeBuildType = "Release";
 
-  cmakeFlags = lib.optionals enableVST2 [ "-DBESPOKE_VST2_SDK_LOCATION=${vst-sdk}/VST2_SDK" ];
+  cmakeFlags = lib.optionals enableVST2 [ "-DBESPOKE_VST2_SDK_LOCATION=${vst2-sdk}" ];
 
   nativeBuildInputs = [
     python3
@@ -160,22 +147,17 @@ stdenv.mkDerivation rec {
   }";
   dontPatchELF = true; # needed or nix will try to optimize the binary by removing "useless" rpath
 
-  meta = with lib; {
+  meta = {
     description = "Software modular synth with controllers support, scripting and VST";
     homepage = "https://www.bespokesynth.com/";
-    license =
-      with licenses;
-      [
-        gpl3Plus
-      ]
-      ++ lib.optional enableVST2 unfree;
-    maintainers = with maintainers; [
+    license = [ lib.licenses.gpl3Plus ];
+    maintainers = with lib.maintainers; [
       astro
       tobiasBora
       OPNA2608
       PowerUser64
     ];
     mainProgram = "BespokeSynth";
-    platforms = platforms.all;
+    platforms = lib.platforms.all;
   };
 }

--- a/pkgs/by-name/ja/jackass/package.nix
+++ b/pkgs/by-name/ja/jackass/package.nix
@@ -4,26 +4,11 @@
   fetchFromGitHub,
   fetchzip,
   pkg-config,
+  vst2-sdk,
   wine64,
   enableJackAssWine64 ? false,
 }:
 
-let
-  # equal to vst-sdk in ../oxefmsynth/default.nix
-  vst-sdk = stdenv.mkDerivation (finalAttrs: {
-    name = "vstsdk3610_11_06_2018_build_37";
-    src = fetchzip {
-      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/${finalAttrs.name}.zip";
-      hash = "sha256-cjYakxnqSDqSZ32FPK3OUhDpslOlavHh5SAVpng0QTU=";
-    };
-    installPhase = ''
-      runHook preInstall
-      cp -r . $out
-      runHook postInstall
-    '';
-  });
-
-in
 stdenv.mkDerivation (finalAttrs: {
   pname = "jackass";
   version = "1.1";
@@ -36,7 +21,7 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   postPatch = ''
-    cp -r ${vst-sdk}/VST2_SDK/{public.sdk,pluginterfaces} vstsdk2.4
+    cp -r ${vst2-sdk}/{public.sdk,pluginterfaces} vstsdk2.4
   '';
 
   nativeBuildInputs = [ pkg-config ] ++ lib.optionals enableJackAssWine64 [ wine64 ];
@@ -59,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "JackAss is a VST plugin that provides JACK-MIDI support for VST hosts";
     longDescription = ''
       Simply load the plugin in your favourite host to get a JACK-MIDI port.
@@ -67,11 +52,8 @@ stdenv.mkDerivation (finalAttrs: {
       applications. Set enableJackAssWine64 to true to enable this output.
     '';
     homepage = "https://github.com/falkTX/JackAss";
-    maintainers = with maintainers; [ PowerUser64 ];
-    license = with licenses; [
-      mit
-      unfree
-    ];
-    platforms = platforms.linux;
+    maintainers = with lib.maintainers; [ PowerUser64 ];
+    license = [ lib.licenses.mit ];
+    platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/by-name/ox/oxefmsynth/package.nix
+++ b/pkgs/by-name/ox/oxefmsynth/package.nix
@@ -4,20 +4,8 @@
   fetchFromGitHub,
   fetchzip,
   libX11,
+  vst2-sdk,
 }:
-
-let
-
-  vst-sdk = stdenv.mkDerivation rec {
-    name = "vstsdk3610_11_06_2018_build_37";
-    src = fetchzip {
-      url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/${name}.zip";
-      sha256 = "0da16iwac590wphz2sm5afrfj42jrsnkr1bxcy93lj7a369ildkj";
-    };
-    installPhase = "cp -r . $out";
-  };
-
-in
 stdenv.mkDerivation rec {
   pname = "oxefmsynth";
   version = "1.3.5";
@@ -31,7 +19,7 @@ stdenv.mkDerivation rec {
 
   env.NIX_CFLAGS_COMPILE = toString [ "-Wno-narrowing" ];
 
-  buildFlags = [ "VSTSDK_PATH=${vst-sdk}/VST2_SDK" ];
+  buildFlags = [ "VSTSDK_PATH=${vst2-sdk}" ];
 
   buildInputs = [ libX11 ];
 
@@ -40,11 +28,11 @@ stdenv.mkDerivation rec {
     install -Dm644 oxevst64.so -t $out/lib/lxvst
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/oxesoft/oxefmsynth";
     description = "Open source VST 2.4 instrument plugin";
-    maintainers = [ maintainers.hirenashah ];
+    maintainers = [ lib.maintainers.hirenashah ];
     platforms = [ "x86_64-linux" ];
-    license = licenses.gpl3Only;
+    license = lib.licenses.gpl3Only;
   };
 }

--- a/pkgs/by-name/vs/vst2-sdk/package.nix
+++ b/pkgs/by-name/vs/vst2-sdk/package.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  fetchzip,
+}:
+fetchzip rec {
+  name = "vst2-sdk-${version}"; # cannot be `pname`, as `fetchzip` expects `name`
+  version = "2018-06-11";
+  url = "https://web.archive.org/web/20181016150224if_/https://download.steinberg.net/sdk_downloads/vstsdk3610_11_06_2018_build_37.zip";
+  hash = "sha256-TyPy8FsXWB8LRz0yr38t3d5xxAxGufAn0dsyrg1JXBA=";
+
+  # Only keep the VST2_SDK directory
+  stripRoot = false;
+  postFetch = ''
+    mv $out/VST_SDK/VST2_SDK/* $out/
+    rm -rf $out/VST_SDK
+  '';
+
+  meta = {
+    description = "The VST2 source development kit";
+    longDescription = ''
+      VST2 is proprietary, and deprecated by Steinberg.
+      As such, it should only be used for legacy reasons.
+    '';
+    license = [ lib.licenses.unfree ];
+  };
+}


### PR DESCRIPTION
Backport of #376433:
- `vst2-sdk`: init at 2018-06-11
- replace ad-hoc definitions of `vst2-sdk` in `airwave`, `bespokesynth`, `jackass`, `oxefmsynth`
- fix licensing issue in `oxefmsynth`

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
