### PR TITLE
r8126: init at 10.014.01

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -5274,6 +5274,11 @@
     githubId = 118536343;
     name = "David Hamelin";
   };
+  davidkna = {
+    name = "David Knaack";
+    github = "davidkna";
+    githubId = 835177;
+  };
   David-Kopczynski = {
     name = "David Elias Chris Kopczynski";
     email = "mail@davidkopczynski.com";

--- a/pkgs/os-specific/linux/r8126/default.nix
+++ b/pkgs/os-specific/linux/r8126/default.nix
@@ -1,0 +1,50 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  kernel,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "r8126";
+  # On update please verify (using `diff -r`) that the source matches the
+  # realtek version.
+  version = "10.014.01";
+
+  # This is a mirror. The original website[1] doesn't allow non-interactive
+  # downloads.
+  # [1] https://www.realtek.com/Download/List?cate_id=584
+  src = fetchFromGitHub {
+    owner = "openwrt";
+    repo = "rtl8126";
+    tag = finalAttrs.version;
+    hash = "sha256-NSi95L5PN+o9z7N3zFjcYk2nQjY03csUBp0saakaqlE=";
+  };
+
+  hardeningDisable = [ "pic" ];
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  preBuild = ''
+    substituteInPlace Makefile --replace-fail "BASEDIR :=" "BASEDIR ?="
+    substituteInPlace Makefile --replace-fail "modules_install" "INSTALL_MOD_PATH=$out modules_install"
+  '';
+
+  makeFlags = [
+    "BASEDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}"
+  ];
+
+  buildFlags = [ "modules" ];
+
+  meta = {
+    homepage = "https://github.com/openwrt/rtl8126";
+    downloadPage = "https://www.realtek.com/Download/List?cate_id=584";
+    description = "Realtek r8126 driver";
+    longDescription = ''
+      A kernel module for Realtek 8126 5G network cards.
+    '';
+    license = lib.licenses.gpl2Only;
+    platforms = lib.platforms.linux;
+    maintainers = [ lib.maintainers.davidkna ];
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -458,6 +458,8 @@ in {
 
     r8125 = callPackage ../os-specific/linux/r8125 { };
 
+    r8126 = callPackage ../os-specific/linux/r8126 { };
+
     r8168 = callPackage ../os-specific/linux/r8168 { };
 
     rtl8188eus-aircrack = callPackage ../os-specific/linux/rtl8188eus-aircrack { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR packages the r8126 module linux kernel module, which is required to use realtek 5gbe interfaces. The package definition is based on the r8125 package definition.

Officially only up to 6.8 is supported, but even 6.13 appears to work fine. Since this is a new package, and I wasn't on the maitainers list I added myself and set myself as the package maintainer.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Compiled, loaded module, and verified wired networking works.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
