### PR TITLE
krita-plugin-gmic: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/kr/krita-plugin-gmic/package.nix
+++ b/pkgs/by-name/kr/krita-plugin-gmic/package.nix
@@ -31,14 +31,16 @@ stdenv.mkDerivation (finalAttrs: {
   nativeBuildInputs = [
     cmake
     extra-cmake-modules
+    libsForQt5.qttools
   ];
 
   buildInputs = [
     fftw
     krita.unwrapped
     libsForQt5.kcoreaddons
-    libsForQt5.qttools
   ];
+
+  strictDeps = true;
 
   cmakeFlags = [
     (lib.cmakeFeature "GMIC_QT_HOST" "krita-plugin")


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468 (previously failed: https://paste.fliegendewurst.eu/KbTW+d.log)

Cross still broken due to Qt stuff.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).