### PR TITLE
python3.pkgs.dataclass-wizard: 0.22.2 → 0.35.0

### DIFF
--- a/pkgs/development/python-modules/dataclass-wizard/default.nix
+++ b/pkgs/development/python-modules/dataclass-wizard/default.nix
@@ -1,6 +1,7 @@
 {
   lib,
   fetchFromGitHub,
+  gitUpdater,
   buildPythonPackage,
   pythonOlder,
   pythonAtLeast,
@@ -50,6 +51,8 @@ buildPythonPackage rec {
     ];
 
   pythonImportsCheck = [ "dataclass_wizard" ];
+
+  passthru.updateScript = gitUpdater { rev-prefix = "v"; };
 
   meta = with lib; {
     description = "Set of simple, yet elegant wizarding tools for interacting with the Python dataclasses module";

--- a/pkgs/development/python-modules/dataclass-wizard/default.nix
+++ b/pkgs/development/python-modules/dataclass-wizard/default.nix
@@ -6,15 +6,16 @@
   pythonAtLeast,
   pytimeparse,
   pyyaml,
+  setuptools,
+  typing-extensions,
   pytestCheckHook,
   pytest-mock,
-  typing-extensions,
 }:
 
 buildPythonPackage rec {
   pname = "dataclass-wizard";
   version = "0.22.2";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rnag";
@@ -23,20 +24,18 @@ buildPythonPackage rec {
     hash = "sha256-Ufi4lZc+UkM6NZr4bS2OibpOmMjyiBEoVKxmrqauW50=";
   };
 
-  propagatedBuildInputs = [ ] ++ lib.optionals (pythonOlder "3.9") [ typing-extensions ];
+  build-system = [ setuptools ];
+  dependencies = lib.optional (pythonOlder "3.9") typing-extensions;
 
   optional-dependencies = {
     timedelta = [ pytimeparse ];
     yaml = [ pyyaml ];
   };
 
-  nativeCheckInputs =
-    [
-      pytestCheckHook
-      pytest-mock
-    ]
-    ++ optional-dependencies.timedelta
-    ++ optional-dependencies.yaml;
+  nativeCheckInputs = [
+    pytestCheckHook
+    pytest-mock
+  ] ++ lib.concatLists (lib.attrValues optional-dependencies);
 
   disabledTests =
     [ ]

--- a/pkgs/development/python-modules/dataclass-wizard/default.nix
+++ b/pkgs/development/python-modules/dataclass-wizard/default.nix
@@ -5,9 +5,12 @@
   buildPythonPackage,
   pythonOlder,
   pythonAtLeast,
+  python-dotenv,
   pytimeparse,
   pyyaml,
   setuptools,
+  tomli,
+  tomli-w,
   typing-extensions,
   pytestCheckHook,
   pytest-mock,
@@ -15,21 +18,23 @@
 
 buildPythonPackage rec {
   pname = "dataclass-wizard";
-  version = "0.22.2";
+  version = "0.35.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "rnag";
     repo = "dataclass-wizard";
     rev = "v${version}";
-    hash = "sha256-Ufi4lZc+UkM6NZr4bS2OibpOmMjyiBEoVKxmrqauW50=";
+    hash = "sha256-Ed9/y2blOGYfNcmCCAe4TPWssKWUS0gxvRXKMf+cJh0=";
   };
 
   build-system = [ setuptools ];
-  dependencies = lib.optional (pythonOlder "3.9") typing-extensions;
+  dependencies = lib.optional (pythonOlder "3.13") typing-extensions;
 
   optional-dependencies = {
+    dotenv = [ python-dotenv ];
     timedelta = [ pytimeparse ];
+    toml = [ tomli tomli-w ];
     yaml = [ pyyaml ];
   };
 
@@ -38,17 +43,11 @@ buildPythonPackage rec {
     pytest-mock
   ] ++ lib.concatLists (lib.attrValues optional-dependencies);
 
-  disabledTests =
-    [ ]
-    ++ lib.optionals (pythonAtLeast "3.11") [
-      # Any/None internal changes, tests need adjusting upstream
-      "without_type_hinting"
-      "default_dict"
-      "test_frozenset"
-      "test_set"
-      "date_times_with_custom_pattern"
-      "from_dict_handles_identical_cased_json_keys"
-    ];
+  disabledTests = [
+    # TypeError: dumps() got an unexpected keyword argument 'indent'
+    "test_catch_all"  # overly broad, but we're limited by pytest's selector syntax
+    "test_toml_wizard_methods"
+  ];
 
   pythonImportsCheck = [ "dataclass_wizard" ];
 

--- a/pkgs/development/python-modules/dataclass-wizard/default.nix
+++ b/pkgs/development/python-modules/dataclass-wizard/default.nix
@@ -34,7 +34,10 @@ buildPythonPackage rec {
   optional-dependencies = {
     dotenv = [ python-dotenv ];
     timedelta = [ pytimeparse ];
-    toml = [ tomli tomli-w ];
+    toml = [
+      tomli
+      tomli-w
+    ];
     yaml = [ pyyaml ];
   };
 
@@ -45,7 +48,7 @@ buildPythonPackage rec {
 
   disabledTests = [
     # TypeError: dumps() got an unexpected keyword argument 'indent'
-    "test_catch_all"  # overly broad, but we're limited by pytest's selector syntax
+    "test_catch_all" # overly broad, but we're limited by pytest's selector syntax
     "test_toml_wizard_methods"
   ];
 


### PR DESCRIPTION
In `python3.pkgs.dataclass-wizard`:
- bring up to current Python packaging conventions, as `format = "setuptools"` etc. are deprecated ;
- refactor
- add `updateScript`
- 0.22.2 → 0.35.0

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
