### PR TITLE
various: fix some substituteAll / replace with replaceVars

### DIFF
--- a/pkgs/by-name/oh/oh-my-fish/package.nix
+++ b/pkgs/by-name/oh/oh-my-fish/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   fish,
   runtimeShell,
-  substituteAll,
+  replaceVars,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -38,13 +38,15 @@ stdenv.mkDerivation (finalAttrs: {
     cp -vr * $out/share/oh-my-fish
 
     cp -v ${
-      substituteAll {
-        name = "omf-install";
-        src = ./omf-install;
-        omf = placeholder "out";
+      replaceVars ./omf-install {
         inherit fish runtimeShell;
+        # replaced below
+        omf = null;
       }
     } $out/bin/omf-install
+
+    substituteInPlace $out/bin/omf-install \
+      --replace-fail '@omf@' "$out"
 
     chmod +x $out/bin/omf-install
     cat $out/bin/omf-install

--- a/pkgs/development/python-modules/mat2/default.nix
+++ b/pkgs/development/python-modules/mat2/default.nix
@@ -5,7 +5,7 @@
   pytestCheckHook,
   pythonOlder,
   fetchFromGitLab,
-  substituteAll,
+  replaceVars,
   bubblewrap,
   exiftool,
   ffmpeg,
@@ -40,22 +40,21 @@ buildPythonPackage rec {
   patches =
     [
       # hardcode paths to some binaries
-      (substituteAll (
-        {
-          src = ./paths.patch;
-          exiftool = "${exiftool}/bin/exiftool";
-          ffmpeg = "${ffmpeg}/bin/ffmpeg";
-        }
-        // lib.optionalAttrs dolphinIntegration { kdialog = "${plasma5Packages.kdialog}/bin/kdialog"; }
-      ))
+      (replaceVars ./paths.patch {
+        exiftool = "${exiftool}/bin/exiftool";
+        ffmpeg = "${ffmpeg}/bin/ffmpeg";
+        kdialog = if dolphinIntegration then "${plasma5Packages.kdialog}/bin/kdialog" else null;
+        # replaced in postPatch
+        mat2 = null;
+        mat2svg = null;
+      })
       # the executable shouldn't be called .mat2-wrapped
       ./executable-name.patch
       # hardcode path to mat2 executable
       ./tests.patch
     ]
     ++ lib.optionals (stdenv.hostPlatform.isLinux) [
-      (substituteAll {
-        src = ./bubblewrap-path.patch;
+      (replaceVars ./bubblewrap-path.patch {
         bwrap = "${bubblewrap}/bin/bwrap";
       })
     ];

--- a/pkgs/development/tools/build-managers/gradle/default.nix
+++ b/pkgs/development/tools/build-managers/gradle/default.nix
@@ -244,7 +244,7 @@ rec {
       lib,
       callPackage,
       mitm-cache,
-      substituteAll,
+      replaceVars,
       symlinkJoin,
       concatTextFile,
       makeSetupHook,
@@ -264,11 +264,10 @@ rec {
             name = "setup-hook.sh";
             files = [
               (mitm-cache.setupHook)
-              (substituteAll {
-                src = ./setup-hook.sh;
+              (replaceVars ./setup-hook.sh {
                 # jdk used for keytool
                 inherit (gradle) jdk;
-                init_script = ./init-build.gradle;
+                init_script = "${./init-build.gradle}";
               })
             ];
           }))

--- a/pkgs/development/tools/flatpak-builder/default.nix
+++ b/pkgs/development/tools/flatpak-builder/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  substituteAll,
+  replaceVars,
   nixosTests,
 
   docbook_xml_dtd_45,
@@ -65,8 +65,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./respect-xml-catalog-files-var.patch
 
     # Hardcode paths
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       brz = "${breezy}/bin/brz";
       cp = "${coreutils}/bin/cp";
       patch = "${patch}/bin/patch";
@@ -81,8 +80,7 @@ stdenv.mkDerivation (finalAttrs: {
       euelfcompress = "${elfutils}/bin/eu-elfcompress";
     })
 
-    (substituteAll {
-      src = ./fix-test-paths.patch;
+    (replaceVars ./fix-test-paths.patch {
       inherit glibcLocales;
     })
     ./fix-test-prefix.patch

--- a/pkgs/development/tools/flatpak-builder/fix-test-paths.patch
+++ b/pkgs/development/tools/flatpak-builder/fix-test-paths.patch
@@ -5,7 +5,7 @@
  
  skip_without_python2 () {
 -    if ! test -f /usr/bin/python2 || ! /usr/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
-+    if ! test -f @python2@/bin/python2 || ! @python2@/bin/python2 -c "import sys; sys.exit(0 if sys.version_info >= (2, 7) else 1)" ; then
++    if true ; then
          echo "1..0 # SKIP this test requires /usr/bin/python2 (2.7) support"
          exit 0
      fi

--- a/pkgs/servers/http/openresty/default.nix
+++ b/pkgs/servers/http/openresty/default.nix
@@ -39,6 +39,10 @@ callPackage ../nginx/generic.nix args rec {
   buildInputs = [ postgresql ];
 
   postPatch = ''
+    substituteInPlace bundle/nginx-${nginxVersion}/src/http/ngx_http_core_module.c \
+      --replace-fail '@nixStoreDir@' "$NIX_STORE" \
+      --replace-fail '@nixStoreDirLen@' "''${#NIX_STORE}"
+
     patchShebangs configure bundle/
   '';
 

--- a/pkgs/servers/http/tengine/default.nix
+++ b/pkgs/servers/http/tengine/default.nix
@@ -8,7 +8,7 @@
   libxcrypt,
   libxml2,
   libxslt,
-  substituteAll,
+  replaceVars,
   gd,
   geoip,
   gperftools,
@@ -48,17 +48,17 @@ stdenv.mkDerivation rec {
     jemalloc
   ] ++ lib.concatMap (mod: mod.inputs or [ ]) modules;
 
-  patches =
-    lib.singleton (substituteAll {
-      src = ../nginx/nix-etag-1.15.4.patch;
-      preInstall = ''
-        export nixStoreDir="$NIX_STORE" nixStoreDirLen="''${#NIX_STORE}"
-      '';
-    })
-    ++ [
-      ./check-resolv-conf.patch
-      ../nginx/nix-skip-check-logs-path.patch
-    ];
+  patches = [
+    ../nginx/nix-etag-1.15.4.patch
+    ./check-resolv-conf.patch
+    ../nginx/nix-skip-check-logs-path.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace src/http/ngx_http_core_module.c \
+      --replace-fail '@nixStoreDir@' "$NIX_STORE" \
+      --replace-fail '@nixStoreDirLen@' "''${#NIX_STORE}"
+  '';
 
   configureFlags =
     [


### PR DESCRIPTION
Last step before the big PR to remove all remaining `substituteAll` for #237216.

Deals with some of the more interesting / less mechanical cases of replacing `substituteAll` and fixes some bugs in `oh-my-fish` and `lua-5` / `luajit`.

Regarding the lua-5/luajit change, I had more (confusing) thoughts here:
https://github.com/NixOS/nixpkgs/pull/319325#discussion_r1929565867

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
