### PR TITLE
treewide: replace substituteAll with replaceVars (the end)

### DIFF
--- a/nixos/maintainers/scripts/incus/incus-container-image.nix
+++ b/nixos/maintainers/scripts/incus/incus-container-image.nix
@@ -16,8 +16,7 @@
   # copy the config for nixos-rebuild
   system.activationScripts.config =
     let
-      config = pkgs.substituteAll {
-        src = ./incus-container-image-inner.nix;
+      config = pkgs.replaceVars ./incus-container-image-inner.nix {
         stateVersion = lib.trivial.release;
       };
     in

--- a/nixos/maintainers/scripts/incus/incus-virtual-machine-image.nix
+++ b/nixos/maintainers/scripts/incus/incus-virtual-machine-image.nix
@@ -16,8 +16,7 @@
   # copy the config for nixos-rebuild
   system.activationScripts.config =
     let
-      config = pkgs.substituteAll {
-        src = ./incus-virtual-machine-image-inner.nix;
+      config = pkgs.replaceVars ./incus-virtual-machine-image-inner.nix {
         stateVersion = lib.trivial.release;
       };
     in

--- a/nixos/maintainers/scripts/lxd/lxd-container-image.nix
+++ b/nixos/maintainers/scripts/lxd/lxd-container-image.nix
@@ -18,8 +18,7 @@
   # copy the config for nixos-rebuild
   system.activationScripts.config =
     let
-      config = pkgs.substituteAll {
-        src = ./lxd-container-image-inner.nix;
+      config = pkgs.replaceVars ./lxd-container-image-inner.nix {
         stateVersion = lib.trivial.release;
       };
     in

--- a/nixos/maintainers/scripts/lxd/lxd-virtual-machine-image.nix
+++ b/nixos/maintainers/scripts/lxd/lxd-virtual-machine-image.nix
@@ -18,8 +18,7 @@
   # copy the config for nixos-rebuild
   system.activationScripts.config =
     let
-      config = pkgs.substituteAll {
-        src = ./lxd-virtual-machine-image-inner.nix;
+      config = pkgs.replaceVars ./lxd-virtual-machine-image-inner.nix {
         stateVersion = lib.trivial.release;
       };
     in

--- a/nixos/modules/installer/cd-dvd/iso-image.nix
+++ b/nixos/modules/installer/cd-dvd/iso-image.nix
@@ -832,11 +832,7 @@ in
         { source = config.isoImage.splashImage;
           target = "/isolinux/background.png";
         }
-        { source = pkgs.substituteAll  {
-            name = "isolinux.cfg";
-            src = pkgs.writeText "isolinux.cfg-in" isolinuxCfg;
-            bootRoot = "/boot";
-          };
+        { source = isolinuxCfg;
           target = "/isolinux/isolinux.cfg";
         }
         { source = "${pkgs.syslinux}/share/syslinux";

--- a/nixos/modules/services/misc/taskserver/default.nix
+++ b/nixos/modules/services/misc/taskserver/default.nix
@@ -142,8 +142,7 @@ let
       src = pkgs.runCommand "nixos-taskserver-src" { preferLocalBuild = true; } ''
         mkdir -p "$out"
         cat "${
-          pkgs.substituteAll {
-            src = ./helper-tool.py;
+          pkgs.replaceVars ./helper-tool.py {
             inherit taskd certtool;
             inherit (cfg)
               dataDir

--- a/nixos/modules/system/boot/loader/grub/grub.nix
+++ b/nixos/modules/system/boot/loader/grub/grub.nix
@@ -727,11 +727,13 @@ in
 
       system.build.installBootLoader =
         let
-          install-grub-pl = pkgs.substituteAll {
-            src = ./install-grub.pl;
+          install-grub-pl = pkgs.replaceVars ./install-grub.pl {
             utillinux = pkgs.util-linux;
             btrfsprogs = pkgs.btrfs-progs;
             inherit (config.system.nixos) distroName;
+            # targets of a replacement in code
+            bootPath = null;
+            bootRoot = null;
           };
           perl = pkgs.perl.withPackages (p: with p; [
             FileSlurp FileCopyRecursive

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -185,7 +185,6 @@ mkDerivation (finalAttrs: {
             ./native-comp-driver-options-30.patch
         )
         {
-
           backendPath = (
             lib.concatStringsSep " " (
               builtins.map (x: ''"-B${x}"'') (

--- a/pkgs/applications/networking/dropbox/cli.nix
+++ b/pkgs/applications/networking/dropbox/cli.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   autoreconfHook,
   pkg-config,
   fetchurl,
@@ -34,9 +34,10 @@ stdenv.mkDerivation {
   strictDeps = true;
 
   patches = [
-    (substituteAll {
-      src = ./fix-cli-paths.patch;
+    (replaceVars ./fix-cli-paths.patch {
       inherit dropboxd;
+      # patch context
+      DESKTOP_FILE_DIR = null;
     })
   ];
 

--- a/pkgs/applications/science/logic/z3/default.nix
+++ b/pkgs/applications/science/logic/z3/default.nix
@@ -150,7 +150,7 @@ let
   };
 
   # replace @dir@ in the path of the given list of patches
-  fixupPatches = dir: map (patch: replaceVars patch { dir = dir; });
+  fixupPatches = dir: map (patch: replaceVars patch { inherit dir; });
 in
 {
   z3_4_13 = common {

--- a/pkgs/build-support/replace-vars/replace-vars-with.nix
+++ b/pkgs/build-support/replace-vars/replace-vars-with.nix
@@ -58,13 +58,11 @@
 
 let
   # We use `--replace-fail` instead of `--subst-var-by` so that if the thing isn't there, we fail.
-  subst-var-by =
-    name: value:
-    lib.optionals (value != null) [
-      "--replace-fail"
-      (lib.escapeShellArg "@${name}@")
-      (lib.escapeShellArg value)
-    ];
+  subst-var-by = name: value: [
+    "--replace-fail"
+    (lib.escapeShellArg "@${name}@")
+    (lib.escapeShellArg (lib.defaultTo "@${name}@" value))
+  ];
 
   substitutions = lib.concatLists (lib.mapAttrsToList subst-var-by replacements);
 

--- a/pkgs/by-name/ar/arma3-unix-launcher/package.nix
+++ b/pkgs/by-name/ar/arma3-unix-launcher/package.nix
@@ -11,7 +11,7 @@
   nlohmann_json,
   qt5,
   spdlog,
-  substituteAll,
+  replaceVars,
   buildDayZLauncher ? false,
 }:
 stdenv.mkDerivation (finalAttrs: {
@@ -27,8 +27,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # prevent CMake from trying to get libraries on the internet
-    (substituteAll {
-      src = ./dont_fetch_dependencies.patch;
+    (replaceVars ./dont_fetch_dependencies.patch {
       argparse_src = fetchFromGitHub {
         owner = "p-ranav";
         repo = "argparse";

--- a/pkgs/by-name/br/brillo/package.nix
+++ b/pkgs/by-name/br/brillo/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitLab,
   go-md2man,
   coreutils,
-  substituteAll,
+  replaceVars,
 }:
 
 stdenv.mkDerivation rec {
@@ -19,9 +19,10 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./udev-rule.patch;
+    (replaceVars ./udev-rule.patch {
       inherit coreutils;
+      # patch context
+      group = null;
     })
   ];
 

--- a/pkgs/by-name/bu/budgie-control-center/package.nix
+++ b/pkgs/by-name/bu/budgie-control-center/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   accountsservice,
   adwaita-icon-theme,
   budgie-desktop,
@@ -81,13 +81,11 @@ stdenv.mkDerivation (finalAttrs: {
   };
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       budgie_desktop = budgie-desktop;
       gcm = gnome-color-manager;
       inherit
         cups
-        glibc
         libgnomekbd
         shadow
         ;

--- a/pkgs/by-name/cb/cbmc/0001-Do-not-download-sources-in-cmake.patch
+++ b/pkgs/by-name/cb/cbmc/0001-Do-not-download-sources-in-cmake.patch
@@ -17,7 +17,7 @@ index 2c1289a..8128362 100644
      download_project(PROJ cudd
 -            URL https://sourceforge.net/projects/cudd-mirror/files/cudd-3.0.0.tar.gz/download
 -            URL_MD5 4fdafe4924b81648b908881c81fe6c30
-+            SOURCE_DIR @cudd.src@
++            SOURCE_DIR @cudd@
              )
  
      if(NOT EXISTS ${cudd_SOURCE_DIR}/Makefile)

--- a/pkgs/by-name/cb/cbmc/package.nix
+++ b/pkgs/by-name/cb/cbmc/package.nix
@@ -8,7 +8,7 @@
   flex,
   makeWrapper,
   perl,
-  substituteAll,
+  replaceVars,
   cudd,
   nix-update-script,
   fetchpatch,
@@ -47,9 +47,8 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./0001-Do-not-download-sources-in-cmake.patch;
-      inherit cudd;
+    (replaceVars ./0001-Do-not-download-sources-in-cmake.patch {
+      cudd = cudd.src;
     })
     ./0002-Do-not-download-sources-in-cmake.patch
     # Fixes build with libc++ >= 19 due to the removal of std::char_traits<unsigned>.

--- a/pkgs/by-name/fb/fbmenugen/package.nix
+++ b/pkgs/by-name/fb/fbmenugen/package.nix
@@ -5,7 +5,7 @@
   gnused,
   makeWrapper,
   perlPackages,
-  substituteAll,
+  replaceVars,
   xorg,
   wrapGAppsHook3,
   gitUpdater,
@@ -23,10 +23,11 @@ perlPackages.buildPerlPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./0001-Fix-paths.patch;
+    (replaceVars ./0001-Fix-paths.patch {
       xmessage = xorg.xmessage;
       inherit fluxbox gnused;
+      # replaced in postPatch
+      fbmenugen = null;
     })
   ];
 

--- a/pkgs/by-name/fr/freenet/package.nix
+++ b/pkgs/by-name/fr/freenet/package.nix
@@ -8,7 +8,7 @@
   gradle_8,
   bash,
   coreutils,
-  substituteAll,
+  replaceVars,
   nixosTests,
   writeText,
 }:
@@ -50,14 +50,15 @@ stdenv.mkDerivation rec {
     jdk
   ];
 
-  wrapper = substituteAll {
-    src = ./freenetWrapper;
+  wrapper = replaceVars ./freenetWrapper {
     inherit
       bash
       coreutils
       jre
       seednodes
       ;
+    # replaced in installPhase
+    CLASSPATH = null;
   };
 
   mitmCache = gradle.fetchDeps {

--- a/pkgs/by-name/in/iniparser/package.nix
+++ b/pkgs/by-name/in/iniparser/package.nix
@@ -27,7 +27,6 @@ stdenv.mkDerivation (finalAttrs: {
     (replaceVars ./remove-fetchcontent-usage.patch {
       # Do not let cmake's fetchContent download unity
       unitySrc = symlinkJoin {
-        name = "unity-with-iniparser-config";
         paths = [
           (fetchFromGitHub {
             owner = "throwtheswitch";

--- a/pkgs/by-name/me/meson/package.nix
+++ b/pkgs/by-name/me/meson/package.nix
@@ -12,7 +12,7 @@
   ninja,
   pkg-config,
   python3,
-  substituteAll,
+  replaceVars,
   zlib,
 }:
 
@@ -46,8 +46,7 @@ python3.pkgs.buildPythonApplication rec {
     # are not as predictable, therefore we need to keep them in the RPATH.
     # At the moment we are keeping the paths starting with /nix/store.
     # https://github.com/NixOS/nixpkgs/issues/31222#issuecomment-365811634
-    (substituteAll {
-      src = ./001-fix-rpath.patch;
+    (replaceVars ./001-fix-rpath.patch {
       inherit (builtins) storeDir;
     })
 

--- a/pkgs/by-name/nu/nuget-to-json/package.nix
+++ b/pkgs/by-name/nu/nuget-to-json/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   runtimeShell,
-  substituteAll,
+  replaceVarsWith,
   nix,
   coreutils,
   jq,
@@ -12,23 +12,25 @@
   cacert,
 }:
 
-substituteAll {
+replaceVarsWith {
   name = "nuget-to-json";
   dir = "bin";
 
   src = ./nuget-to-json.sh;
   isExecutable = true;
 
-  inherit runtimeShell cacert;
-  binPath = lib.makeBinPath [
-    nix
-    coreutils
-    jq
-    xmlstarlet
-    curl
-    gnugrep
-    gawk
-  ];
+  replacements = {
+    inherit runtimeShell cacert;
+    binPath = lib.makeBinPath [
+      nix
+      coreutils
+      jq
+      xmlstarlet
+      curl
+      gnugrep
+      gawk
+    ];
+  };
 
   meta = {
     description = "Convert a nuget packages directory to a lockfile for buildDotnetModule";

--- a/pkgs/by-name/nu/nuget-to-nix/package.nix
+++ b/pkgs/by-name/nu/nuget-to-nix/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   runtimeShell,
-  substituteAll,
+  replaceVarsWith,
   nix,
   coreutils,
   jq,
@@ -13,24 +13,26 @@
   cacert,
 }:
 
-substituteAll {
+replaceVarsWith {
   name = "nuget-to-nix";
   dir = "bin";
 
   src = ./nuget-to-nix.sh;
   isExecutable = true;
 
-  inherit runtimeShell cacert;
-  binPath = lib.makeBinPath [
-    nix
-    coreutils
-    jq
-    xmlstarlet
-    curl
-    gnugrep
-    gawk
-    nuget-to-json
-  ];
+  replacements = {
+    inherit runtimeShell cacert;
+    binPath = lib.makeBinPath [
+      nix
+      coreutils
+      jq
+      xmlstarlet
+      curl
+      gnugrep
+      gawk
+      nuget-to-json
+    ];
+  };
 
   meta = {
     description = "Convert a nuget packages directory to a lockfile for buildDotnetModule";

--- a/pkgs/by-name/sp/speechd/package.nix
+++ b/pkgs/by-name/sp/speechd/package.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  substituteAll,
+  replaceVars,
   pkg-config,
   fetchurl,
   python3Packages,
@@ -47,16 +47,16 @@ stdenv.mkDerivation rec {
 
   patches =
     [
-      (substituteAll {
-        src = ./fix-paths.patch;
+      (replaceVars ./fix-paths.patch {
         utillinux = util-linux;
+        # patch context
+        bindir = null;
       })
     ]
     ++ lib.optionals (withEspeak && espeak.mbrolaSupport) [
       # Replace FHS paths.
-      (substituteAll {
-        src = ./fix-mbrola-paths.patch;
-        inherit espeak mbrola;
+      (replaceVars ./fix-mbrola-paths.patch {
+        inherit mbrola;
       })
     ];
 

--- a/pkgs/by-name/us/usbutils/package.nix
+++ b/pkgs/by-name/us/usbutils/package.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  substituteAll,
+  replaceVars,
   fetchpatch,
   meson,
   ninja,
@@ -23,8 +23,7 @@ stdenv.mkDerivation rec {
 
   patches =
     [
-      (substituteAll {
-        src = ./fix-paths.patch;
+      (replaceVars ./fix-paths.patch {
         inherit hwdata;
       })
     ]

--- a/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
+++ b/pkgs/data/sgml+xml/stylesheets/xslt/docbook-xsl/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   fetchurl,
   fetchpatch,
   findXMLCatalogs,
@@ -50,8 +50,7 @@ let
             })
 
             # Add legacy sourceforge.net URIs to the catalog
-            (substituteAll {
-              src = ./catalog-legacy-uris.patch;
+            (replaceVars ./catalog-legacy-uris.patch {
               inherit legacySuffix suffix version;
             })
           ]

--- a/pkgs/desktops/gnome/extensions/extensionOverrides.nix
+++ b/pkgs/desktops/gnome/extensions/extensionOverrides.nix
@@ -21,7 +21,6 @@
 , smartmontools
 , replaceVars
 , stdenvNoCC
-, substituteAll
 , touchegg
 , util-linux
 , vte
@@ -136,8 +135,7 @@ super: lib.trivial.pipe super [
     });
   in {
     patches = [
-      (substituteAll {
-        src = ./extensionOverridesPatches/lunarcal_at_ailin.nemui.patch;
+      (replaceVars ./extensionOverridesPatches/lunarcal_at_ailin.nemui.patch {
         chinese_calendar_path = chinese-calendar;
       })
     ];

--- a/pkgs/desktops/gnome/extensions/gsconnect/default.nix
+++ b/pkgs/desktops/gnome/extensions/gsconnect/default.nix
@@ -1,7 +1,7 @@
 { stdenv
 , lib
 , fetchFromGitHub
-, substituteAll
+, replaceVars
 , openssl
 , gsound
 , meson
@@ -35,9 +35,10 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Make typelibs available in the extension
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       gapplication = "${glib.bin}/bin/gapplication";
+      # Replaced in postPatch
+      typelibPath = null;
     })
 
     # Allow installing installed tests to a separate output

--- a/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
+++ b/pkgs/desktops/gnome/extensions/taskwhisperer/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   fetchFromGitHub,
   taskwarrior2,
   gettext,
@@ -37,10 +37,8 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       task = "${taskwarrior2}/bin/task";
-      shell = runtimeShell;
     })
   ];
 

--- a/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
+++ b/pkgs/desktops/lomiri/qml/lomiri-ui-toolkit/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitLab,
   gitUpdater,
-  substituteAll,
+  replaceVars,
   testers,
   dbus-test-runner,
   dpkg,
@@ -63,9 +63,7 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     ./2001-Mark-problematic-tests.patch
 
-    (substituteAll {
-      src = ./2002-Nixpkgs-versioned-QML-path.patch.in;
-      name = "2002-Nixpkgs-versioned-QML-path.patch";
+    (replaceVars ./2002-Nixpkgs-versioned-QML-path.patch.in {
       qtVersion = lib.versions.major qtbase.version;
     })
   ];

--- a/pkgs/desktops/mate/caja-dropbox/default.nix
+++ b/pkgs/desktops/mate/caja-dropbox/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  substituteAll,
+  replaceVars,
   pkg-config,
   gobject-introspection,
   gdk-pixbuf,
@@ -26,9 +26,10 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-cli-paths.patch;
+    (replaceVars ./fix-cli-paths.patch {
       inherit dropboxd;
+      # patch context
+      DESKTOP_FILE_DIR = null;
     })
   ];
 

--- a/pkgs/development/compilers/crystal/default.nix
+++ b/pkgs/development/compilers/crystal/default.nix
@@ -4,7 +4,7 @@
 , fetchurl
 , fetchpatch
 , lib
-, substituteAll
+, replaceVars
   # Dependencies
 , boehmgc
 , coreutils
@@ -95,8 +95,7 @@ let
       };
 
       patches = [
-          (substituteAll {
-            src = ./tzdata.patch;
+          (replaceVars ./tzdata.patch {
             inherit tzdata;
           })
         ]

--- a/pkgs/development/compilers/dotnet/sign-apphost.nix
+++ b/pkgs/development/compilers/dotnet/sign-apphost.nix
@@ -1,12 +1,11 @@
 {
-  substituteAll,
+  replaceVars,
   callPackage,
 }:
 let
   sigtool = callPackage ./sigtool.nix { };
 
 in
-substituteAll {
-  src = ./sign-apphost.proj;
+replaceVars ./sign-apphost.proj {
   codesign = "${sigtool}/bin/codesign";
 }

--- a/pkgs/development/compilers/dotnet/wrapper.nix
+++ b/pkgs/development/compilers/dotnet/wrapper.nix
@@ -15,7 +15,7 @@
   darwin,
   icu,
   lndir,
-  substituteAll,
+  replaceVars,
   nugetPackageHook,
   xmlstarlet,
 }:
@@ -42,10 +42,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
     [
       ./dotnet-setup-hook.sh
     ]
-    ++ lib.optional (type == "sdk") (substituteAll {
-      src = ./dotnet-sdk-setup-hook.sh;
-      inherit lndir xmlstarlet;
-    });
+    ++ lib.optional (type == "sdk") (
+      replaceVars ./dotnet-sdk-setup-hook.sh {
+        inherit lndir xmlstarlet;
+      }
+    );
 
   propagatedSandboxProfile = toString unwrapped.__propagatedSandboxProfile;
 

--- a/pkgs/development/compilers/emscripten/default.nix
+++ b/pkgs/development/compilers/emscripten/default.nix
@@ -10,7 +10,7 @@
   llvmPackages,
   symlinkJoin,
   makeWrapper,
-  substituteAll,
+  replaceVars,
   buildNpmPackage,
   emscripten,
 }:
@@ -57,8 +57,7 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./0001-emulate-clang-sysroot-include-logic.patch;
+    (replaceVars ./0001-emulate-clang-sysroot-include-logic.patch {
       resourceDir = "${llvmEnv}/lib/clang/${lib.versions.major llvmPackages.llvm.version}/";
     })
   ];

--- a/pkgs/development/compilers/go/1.22.nix
+++ b/pkgs/development/compilers/go/1.22.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   tzdata,
-  substituteAll,
+  replaceVars,
   iana-etc,
   xcbuild,
   mailcap,
@@ -75,20 +75,17 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   patches = [
-    (substituteAll {
-      src = ./iana-etc-1.17.patch;
+    (replaceVars ./iana-etc-1.17.patch {
       iana = iana-etc;
     })
     # Patch the mimetype database location which is missing on NixOS.
     # but also allow static binaries built with NixOS to run outside nix
-    (substituteAll {
-      src = ./mailcap-1.17.patch;
+    (replaceVars ./mailcap-1.17.patch {
       inherit mailcap;
     })
     # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
     # that run outside a nix server
-    (substituteAll {
-      src = ./tzdata-1.19.patch;
+    (replaceVars ./tzdata-1.19.patch {
       inherit tzdata;
     })
     ./remove-tools-1.11.patch

--- a/pkgs/development/compilers/go/1.23.nix
+++ b/pkgs/development/compilers/go/1.23.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   tzdata,
-  substituteAll,
+  replaceVars,
   iana-etc,
   xcbuild,
   mailcap,
@@ -75,20 +75,17 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   patches = [
-    (substituteAll {
-      src = ./iana-etc-1.17.patch;
+    (replaceVars ./iana-etc-1.17.patch {
       iana = iana-etc;
     })
     # Patch the mimetype database location which is missing on NixOS.
     # but also allow static binaries built with NixOS to run outside nix
-    (substituteAll {
-      src = ./mailcap-1.17.patch;
+    (replaceVars ./mailcap-1.17.patch {
       inherit mailcap;
     })
     # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
     # that run outside a nix server
-    (substituteAll {
-      src = ./tzdata-1.19.patch;
+    (replaceVars ./tzdata-1.19.patch {
       inherit tzdata;
     })
     ./remove-tools-1.11.patch

--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   tzdata,
-  substituteAll,
+  replaceVars,
   iana-etc,
   xcbuild,
   mailcap,
@@ -75,20 +75,17 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   patches = [
-    (substituteAll {
-      src = ./iana-etc-1.17.patch;
+    (replaceVars ./iana-etc-1.17.patch {
       iana = iana-etc;
     })
     # Patch the mimetype database location which is missing on NixOS.
     # but also allow static binaries built with NixOS to run outside nix
-    (substituteAll {
-      src = ./mailcap-1.17.patch;
+    (replaceVars ./mailcap-1.17.patch {
       inherit mailcap;
     })
     # prepend the nix path to the zoneinfo files but also leave the original value for static binaries
     # that run outside a nix server
-    (substituteAll {
-      src = ./tzdata-1.19.patch;
+    (replaceVars ./tzdata-1.19.patch {
       inherit tzdata;
     })
     ./remove-tools-1.11.patch

--- a/pkgs/development/compilers/ponyc/default.nix
+++ b/pkgs/development/compilers/ponyc/default.nix
@@ -13,7 +13,7 @@
   python3,
   # Not really used for anything real, just at build time.
   git,
-  substituteAll,
+  replaceVars,
   which,
   z3,
   cctools,
@@ -67,8 +67,7 @@ stdenv.mkDerivation (rec {
       ./disable-networking-tests.patch
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
-      (substituteAll {
-        src = ./fix-darwin-build.patch;
+      (replaceVars ./fix-darwin-build.patch {
         libSystem = darwin.Libsystem;
       })
     ];

--- a/pkgs/development/compilers/swift/compiler/default.nix
+++ b/pkgs/development/compilers/swift/compiler/default.nix
@@ -28,7 +28,7 @@
 , glibc
 , libuuid
 # Darwin-specific
-, substituteAll
+, replaceVars
 , fixDarwinDylibNames
 , xcbuild
 , cctools # libtool
@@ -300,12 +300,10 @@ in stdenv.mkDerivation {
     patch -p1 -d swift -i ${./patches/swift-linux-fix-libc-paths.patch}
     patch -p1 -d swift -i ${./patches/swift-linux-fix-linking.patch}
     patch -p1 -d swift -i ${./patches/swift-darwin-libcxx-flags.patch}
-    patch -p1 -d swift -i ${substituteAll {
-      src = ./patches/swift-darwin-plistbuddy-workaround.patch;
+    patch -p1 -d swift -i ${replaceVars ./patches/swift-darwin-plistbuddy-workaround.patch {
       inherit swiftArch;
     }}
-    patch -p1 -d swift -i ${substituteAll {
-      src = ./patches/swift-prevent-sdk-dirs-warning.patch;
+    patch -p1 -d swift -i ${replaceVars ./patches/swift-prevent-sdk-dirs-warning.patch {
       inherit (builtins) storeDir;
     }}
 

--- a/pkgs/development/compilers/swift/swift-driver/default.nix
+++ b/pkgs/development/compilers/swift/swift-driver/default.nix
@@ -10,7 +10,7 @@
   XCTest,
   sqlite,
   ncurses,
-  substituteAll,
+  replaceVars,
 }:
 let
   sources = callPackage ../sources.nix { };
@@ -50,8 +50,7 @@ stdenv.mkDerivation {
       hash = "sha256-eVBaKN6uzj48ZnHtwGV0k5ChKjak1tDCyE+wTdyGq2c=";
     })
     # Prevent a warning about SDK directories we don't have.
-    (substituteAll {
-      src = ./patches/prevent-sdk-dirs-warnings.patch;
+    (replaceVars ./patches/prevent-sdk-dirs-warnings.patch {
       inherit (builtins) storeDir;
     })
   ];

--- a/pkgs/development/compilers/swift/swiftpm/default.nix
+++ b/pkgs/development/compilers/swift/swiftpm/default.nix
@@ -13,7 +13,7 @@
   pkg-config,
   sqlite,
   ncurses,
-  substituteAll,
+  replaceVars,
   runCommandLocal,
   makeWrapper,
   DarwinTools, # sw_vers
@@ -45,8 +45,7 @@ let
       ./patches/disable-xctest.patch
       ./patches/fix-clang-cxx.patch
       ./patches/nix-pkgconfig-vars.patch
-      (substituteAll {
-        src = ./patches/fix-stdlib-path.patch;
+      (replaceVars ./patches/fix-stdlib-path.patch {
         inherit (builtins) storeDir;
         swiftLib = swift.swift.lib;
       })
@@ -429,8 +428,7 @@ stdenv.mkDerivation (
         # Prevent a warning about SDK directories we don't have.
         swiftpmMakeMutable swift-driver
         patch -p1 -d .build/checkouts/swift-driver -i ${
-          substituteAll {
-            src = ../swift-driver/patches/prevent-sdk-dirs-warnings.patch;
+          replaceVars ../swift-driver/patches/prevent-sdk-dirs-warnings.patch {
             inherit (builtins) storeDir;
           }
         }

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -15,7 +15,7 @@
   libintl,
   libtool,
   expat,
-  substituteAll,
+  replaceVars,
   vala,
   gobject-introspection,
 }:
@@ -45,8 +45,7 @@ let
       pname = "vala";
       inherit version;
 
-      setupHook = substituteAll {
-        src = ./setup-hook.sh;
+      setupHook = replaceVars ./setup-hook.sh {
         apiVersion = lib.versions.majorMinor version;
       };
 

--- a/pkgs/development/embedded/platformio/core.nix
+++ b/pkgs/development/embedded/platformio/core.nix
@@ -6,7 +6,7 @@
   installShellFiles,
   git,
   spdx-license-list-data,
-  substituteAll,
+  replaceVars,
 }:
 
 with python3Packages;
@@ -29,12 +29,10 @@ buildPythonApplication rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./interpreter.patch;
+    (replaceVars ./interpreter.patch {
       interpreter = (python3Packages.python.withPackages (_: propagatedBuildInputs)).interpreter;
     })
-    (substituteAll {
-      src = ./use-local-spdx-license-list.patch;
+    (replaceVars ./use-local-spdx-license-list.patch {
       spdx_license_list_data = spdx-license-list-data.json;
     })
     ./missing-udev-rules-nixos.patch

--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1325,9 +1325,11 @@ self: super: builtins.intersectAttrs super {
   # whatever graphviz is in PATH.
   graphviz = overrideCabal (drv: {
     patches = [
-      (pkgs.substituteAll {
-        src = ./patches/graphviz-hardcode-graphviz-store-path.patch;
+      (pkgs.replaceVars ./patches/graphviz-hardcode-graphviz-store-path.patch {
         inherit (pkgs) graphviz;
+        # patch context
+        dot = null;
+        PATH = null;
       })
     ] ++ (drv.patches or []);
   }) super.graphviz;

--- a/pkgs/development/interpreters/acl2/default.nix
+++ b/pkgs/development/interpreters/acl2/default.nix
@@ -6,7 +6,7 @@
   fetchpatch,
   runCommandLocal,
   makeWrapper,
-  substituteAll,
+  replaceVars,
   sbcl,
   bash,
   which,
@@ -52,8 +52,7 @@ stdenv.mkDerivation rec {
   libipasir = callPackage ./libipasirglucose4 { };
 
   patches = [
-    (substituteAll {
-      src = ./0001-Fix-some-paths-for-Nix-build.patch;
+    (replaceVars ./0001-Fix-some-paths-for-Nix-build.patch {
       libipasir = "${libipasir}/lib/${libipasir.libname}";
       libssl = "${lib.getLib openssl}/lib/libssl${stdenv.hostPlatform.extensions.sharedLibrary}";
       libcrypto = "${lib.getLib openssl}/lib/libcrypto${stdenv.hostPlatform.extensions.sharedLibrary}";

--- a/pkgs/development/interpreters/python/pypy/default.nix
+++ b/pkgs/development/interpreters/python/pypy/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, substituteAll, fetchurl
+{ lib, stdenv, replaceVars, fetchurl
 , zlibSupport ? true, zlib
 , bzip2, pkg-config, libffi
 , sqlite, openssl, ncurses, python, expat, tcl, tk, tclPackages, libX11
@@ -76,8 +76,7 @@ in with passthru; stdenv.mkDerivation rec {
   patches = [
     ./dont_fetch_vendored_deps.patch
 
-    (substituteAll {
-      src = ./tk_tcl_paths.patch;
+    (replaceVars ./tk_tcl_paths.patch {
       inherit tk tcl;
       tk_dev = tk.dev;
       tcl_dev = tcl;
@@ -85,8 +84,7 @@ in with passthru; stdenv.mkDerivation rec {
       tcl_libprefix = tcl.libPrefix;
     })
 
-    (substituteAll {
-      src = ./sqlite_paths.patch;
+    (replaceVars ./sqlite_paths.patch {
       inherit (sqlite) out dev;
     })
   ];

--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, substituteAll
+, replaceVars
 , fetchFromGitHub
 , meson
 , mesonEmulatorHook
@@ -50,8 +50,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # Fix hardcoded paths
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       libstemmer_includedir = "${lib.getDev libstemmer}/include";
     })
 

--- a/pkgs/development/libraries/gssdp/tools.nix
+++ b/pkgs/development/libraries/gssdp/tools.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   pkg-config,
@@ -18,8 +18,7 @@ stdenv.mkDerivation rec {
   patches = [
     # Allow building tools separately from the library.
     # This is needed to break the depenency cycle.
-    (substituteAll {
-      src = ./standalone-tools.patch;
+    (replaceVars ./standalone-tools.patch {
       inherit version;
     })
   ];

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -2,7 +2,7 @@
 , stdenv
 , fetchurl
 , fetchpatch
-, substituteAll
+, replaceVars
 , meson
 , ninja
 , gettext
@@ -127,8 +127,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Add fallback paths for nvidia userspace libraries
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit (addDriverRunpath) driverLink;
     })
     # Add support for newer AJA SDK from next GStreamer release

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -1,6 +1,6 @@
 { lib, stdenv
 , fetchurl
-, substituteAll
+, replaceVars
 , meson
 , nasm
 , ninja
@@ -71,8 +71,7 @@ stdenv.mkDerivation rec {
     # Reenable dynamic loading of libsoup on Darwin and use a different approach to do it.
     ./souploader-darwin.diff
     # dlopen libsoup_3 with an absolute path
-    (substituteAll {
-      src = ./souploader.diff;
+    (replaceVars ./souploader.diff {
       nixLibSoup3Path = "${lib.getLib libsoup_3}/lib";
     })
   ];

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -22,7 +22,7 @@
   pango,
   perl,
   pkg-config,
-  substituteAll,
+  replaceVars,
   testers,
   AppKit,
   Cocoa,
@@ -32,8 +32,7 @@
 }:
 
 let
-  gtkCleanImmodulesCache = substituteAll {
-    src = ./hooks/clean-immodules-cache.sh;
+  gtkCleanImmodulesCache = replaceVars ./hooks/clean-immodules-cache.sh {
     gtk_module_path = "gtk-2.0";
     gtk_binary_version = "2.10.0";
   };

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -1,6 +1,6 @@
 { lib
 , stdenv
-, substituteAll
+, replaceVars
 , fetchurl
 , pkg-config
 , gettext
@@ -53,8 +53,7 @@
 
 let
 
-  gtkCleanImmodulesCache = substituteAll {
-    src = ./hooks/clean-immodules-cache.sh;
+  gtkCleanImmodulesCache = replaceVars ./hooks/clean-immodules-cache.sh {
     gtk_module_path = "gtk-3.0";
     gtk_binary_version = "3.0.0";
   };

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , buildPackages
-, substituteAll
+, replaceVars
 , fetchurl
 , pkg-config
 , docutils
@@ -58,8 +58,7 @@
 
 let
 
-  gtkCleanImmodulesCache = substituteAll {
-    src = ./hooks/clean-immodules-cache.sh;
+  gtkCleanImmodulesCache = replaceVars ./hooks/clean-immodules-cache.sh {
     gtk_module_path = "gtk-4.0";
     gtk_binary_version = "4.0.0";
   };

--- a/pkgs/development/libraries/libextractor/default.nix
+++ b/pkgs/development/libraries/libextractor/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   fetchpatch2,
-  substituteAll,
+  replaceVars,
   libtool,
   gettext,
   zlib,
@@ -60,8 +60,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals gstreamerSupport [
 
       # Libraries cannot be wrapped so we need to hardcode the plug-in paths.
-      (substituteAll {
-        src = ./gst-hardcode-plugins.patch;
+      (replaceVars ./gst-hardcode-plugins.patch {
         load_gst_plugins = lib.concatMapStrings (
           plugin: ''gst_registry_scan_path(gst_registry_get(), "${lib.getLib plugin}/lib/gstreamer-1.0");''
         ) (gstPlugins gst_all_1);

--- a/pkgs/development/libraries/libpeas/2.x.nix
+++ b/pkgs/development/libraries/libpeas/2.x.nix
@@ -3,7 +3,7 @@
 , buildPackages
 , fetchurl
 , pkgsCross
-, substituteAll
+, replaceVars
 , pkg-config
 , gi-docgen
 , gobject-introspection
@@ -34,8 +34,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Make PyGObject’s gi library available.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       pythonPaths = lib.concatMapStringsSep ", " (pkg: "'${pkg}/${python3.sitePackages}'") [
         python3.pkgs.pygobject3
       ];

--- a/pkgs/development/libraries/libpeas/default.nix
+++ b/pkgs/development/libraries/libpeas/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchurl,
-  substituteAll,
+  replaceVars,
   meson,
   ninja,
   pkg-config,
@@ -34,8 +34,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Make PyGObject’s gi library available.
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       pythonPaths = lib.concatMapStringsSep ", " (pkg: "'${pkg}/${python3.sitePackages}'") [
         python3.pkgs.pygobject3
       ];

--- a/pkgs/development/libraries/libproxy/default.nix
+++ b/pkgs/development/libraries/libproxy/default.nix
@@ -15,7 +15,7 @@
   ninja,
   pkg-config,
   stdenv,
-  substituteAll,
+  replaceVars,
   vala,
 }:
 
@@ -46,8 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
 
       # Hardcode path to Settings schemas for GNOME & related desktops.
       # Otherwise every app using libproxy would need to be wrapped individually.
-      (substituteAll {
-        src = ./hardcode-gsettings.patch;
+      (replaceVars ./hardcode-gsettings.patch {
         gds = glib.getSchemaPath gsettings-desktop-schemas;
       })
     ];

--- a/pkgs/development/libraries/libqofono/default.nix
+++ b/pkgs/development/libraries/libqofono/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  substituteAll,
+  replaceVars,
   mkDerivation,
   fetchFromGitHub,
   gitUpdater,
@@ -22,8 +22,7 @@ mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./0001-NixOS-provide-mobile-broadband-provider-info-path.patch;
+    (replaceVars ./0001-NixOS-provide-mobile-broadband-provider-info-path.patch {
       mobileBroadbandProviderInfo = mobile-broadband-provider-info;
     })
     ./0001-NixOS-Skip-tests-they-re-shock-full-of-hardcoded-FHS.patch

--- a/pkgs/development/libraries/libsbsms/common.nix
+++ b/pkgs/development/libraries/libsbsms/common.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchurl,
-  substituteAll,
+  replaceVars,
   pname,
   version,
   url,
@@ -19,8 +19,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Fix buidling on platforms other than x86
-    (substituteAll {
-      src = ./configure.patch;
+    (replaceVars ./configure.patch {
       msse = lib.optionalString stdenv.hostPlatform.isx86_64 "-msse";
     })
   ];

--- a/pkgs/development/libraries/libvirt/default.nix
+++ b/pkgs/development/libraries/libvirt/default.nix
@@ -32,7 +32,7 @@
 , readline
 , rpcsvc-proto
 , stdenv
-, substituteAll
+, replaceVars
 , xhtml1
 , json_c
 , writeScript
@@ -127,8 +127,7 @@ stdenv.mkDerivation rec {
   patches = [
     ./0001-meson-patch-in-an-install-prefix-for-building-on-nix.patch
   ] ++ lib.optionals enableZfs [
-    (substituteAll {
-      src = ./0002-substitute-zfs-and-zpool-commands.patch;
+    (replaceVars ./0002-substitute-zfs-and-zpool-commands.patch {
       zfs = "${zfs}/bin/zfs";
       zpool = "${zfs}/bin/zpool";
     })

--- a/pkgs/development/libraries/qgnomeplatform/default.nix
+++ b/pkgs/development/libraries/qgnomeplatform/default.nix
@@ -11,7 +11,7 @@
   gtk3,
   qtbase,
   qtwayland,
-  substituteAll,
+  replaceVars,
   gsettings-desktop-schemas,
   useQt6 ? false,
 }:
@@ -29,8 +29,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     # Hardcode GSettings schema path to avoid crashes from missing schemas
-    (substituteAll {
-      src = ./hardcode-gsettings.patch;
+    (replaceVars ./hardcode-gsettings.patch {
       gds_gsettings_path = glib.getSchemaPath gsettings-desktop-schemas;
     })
 

--- a/pkgs/development/libraries/qt-5/modules/qttools.nix
+++ b/pkgs/development/libraries/qt-5/modules/qttools.nix
@@ -4,7 +4,7 @@
   lib,
   qtbase,
   qtdeclarative,
-  substituteAll,
+  replaceVars,
   llvmPackages,
 }:
 
@@ -29,13 +29,11 @@ qtModule {
 
   patches = [
     # fixQtBuiltinPaths overwrites builtin paths we should keep
-    (substituteAll {
-      src = ./qttools-QT_HOST_DATA-refs.patch;
+    (replaceVars ./qttools-QT_HOST_DATA-refs.patch {
       qtbaseDev = lib.getDev qtbase;
     })
 
-    (substituteAll {
-      src = ./qttools-libclang-main-header.patch;
+    (replaceVars ./qttools-libclang-main-header.patch {
       libclangDev = lib.getDev llvmPackages.libclang;
     })
   ];

--- a/pkgs/development/libraries/science/math/or-tools/default.nix
+++ b/pkgs/development/libraries/science/math/or-tools/default.nix
@@ -7,7 +7,7 @@
   eigen,
   ensureNewerSourcesForZipFilesHook,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   glpk,
   lib,
   pkg-config,
@@ -40,8 +40,7 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./offline.patch;
+    (replaceVars ./offline.patch {
       pybind11_protobuf = "../../pybind11_protobuf";
     })
   ];

--- a/pkgs/development/libraries/wayqt/default.nix
+++ b/pkgs/development/libraries/wayqt/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   fetchFromGitLab,
-  substituteAll,
+  replaceVars,
   meson,
   pkg-config,
   qttools,
@@ -25,8 +25,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     # qmake get qtbase's path, but wayqt need qtwayland
-    (substituteAll {
-      src = ./fix-qtwayland-header-path.diff;
+    (replaceVars ./fix-qtwayland-header-path.diff {
       qtWaylandPath = "${qtwayland}/include";
     })
   ];

--- a/pkgs/development/libraries/webkitgtk/default.nix
+++ b/pkgs/development/libraries/webkitgtk/default.nix
@@ -65,7 +65,7 @@
   libbacktrace,
   systemd,
   xdg-dbus-proxy,
-  substituteAll,
+  replaceVars,
   glib,
   unifdef,
   addDriverRunpath,
@@ -103,8 +103,7 @@ clangStdenv.mkDerivation (finalAttrs: {
   };
 
   patches = lib.optionals clangStdenv.hostPlatform.isLinux [
-    (substituteAll {
-      src = ./fix-bubblewrap-paths.patch;
+    (replaceVars ./fix-bubblewrap-paths.patch {
       inherit (builtins) storeDir;
       inherit (addDriverRunpath) driverLink;
     })

--- a/pkgs/development/lisp-modules/nix-cl.nix
+++ b/pkgs/development/lisp-modules/nix-cl.nix
@@ -59,7 +59,7 @@ let
     ;
 
   inherit (pkgs)
-    substituteAll
+    replaceVars
     ;
 
   # Stolen from python-packages.nix
@@ -209,8 +209,7 @@ let
               ;
           };
 
-          buildScript = substituteAll {
-            src = ./builder.lisp;
+          buildScript = replaceVars ./builder.lisp {
             asdf = "${asdfFasl}/asdf.${faslExt}";
           };
 

--- a/pkgs/development/lua-modules/nfd/default.nix
+++ b/pkgs/development/lua-modules/nfd/default.nix
@@ -5,7 +5,7 @@
   lua,
   pkg-config,
   lib,
-  substituteAll,
+  replaceVars,
   zenity,
   AppKit,
 }:
@@ -24,8 +24,7 @@ buildLuarocksPackage {
 
   # use zenity because default gtk impl just crashes
   patches = [
-    (substituteAll {
-      src = ./zenity.patch;
+    (replaceVars ./zenity.patch {
       inherit zenity;
     })
   ];

--- a/pkgs/development/ocaml-modules/carton/default.nix
+++ b/pkgs/development/ocaml-modules/carton/default.nix
@@ -27,7 +27,7 @@
   cmdliner,
   hxd,
   getconf,
-  substituteAll,
+  replaceVars,
 }:
 
 buildDunePackage rec {
@@ -42,8 +42,7 @@ buildDunePackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./carton-find-getconf.patch;
+    (replaceVars ./carton-find-getconf.patch {
       getconf = "${getconf}";
     })
   ];

--- a/pkgs/development/ocaml-modules/menhir/default.nix
+++ b/pkgs/development/ocaml-modules/menhir/default.nix
@@ -1,6 +1,6 @@
 {
   buildDunePackage,
-  substituteAll,
+  replaceVars,
   ocaml,
   menhirLib,
   menhirSdk,
@@ -19,8 +19,7 @@ buildDunePackage rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./menhir-suggest-menhirLib.patch;
+    (replaceVars ./menhir-suggest-menhirLib.patch {
       libdir = "${menhirLib}/lib/ocaml/${ocaml.version}/site-lib/menhirLib";
     })
   ];

--- a/pkgs/development/ocaml-modules/plotkicadsch/default.nix
+++ b/pkgs/development/ocaml-modules/plotkicadsch/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildDunePackage,
-  substituteAll,
+  replaceVars,
   base64,
   cmdliner,
   digestif,
@@ -24,8 +24,7 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.09";
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit coreutils imagemagick;
     })
   ];

--- a/pkgs/development/php-packages/couchbase/default.nix
+++ b/pkgs/development/php-packages/couchbase/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   libcouchbase,
   zlib,
-  substituteAll,
+  replaceVars,
   php,
 }:
 let
@@ -29,8 +29,7 @@ buildPecl {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./libcouchbase.patch;
+    (replaceVars ./libcouchbase.patch {
       inherit libcouchbase;
     })
   ];

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch2,
-  substituteAll,
+  replaceVars,
   isPy310,
   isPyPy,
 
@@ -57,8 +57,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./unvendor-llhttp.patch;
+    (replaceVars ./unvendor-llhttp.patch {
       llhttpDev = lib.getDev llhttp;
       llhttpLib = lib.getLib llhttp;
     })

--- a/pkgs/development/python-modules/anytree/default.nix
+++ b/pkgs/development/python-modules/anytree/default.nix
@@ -8,7 +8,7 @@
   pytest7CheckHook,
   pythonOlder,
   six,
-  substituteAll,
+  replaceVars,
   withGraphviz ? true,
 }:
 
@@ -27,8 +27,7 @@ buildPythonPackage rec {
   };
 
   patches = lib.optionals withGraphviz [
-    (substituteAll {
-      src = ./graphviz.patch;
+    (replaceVars ./graphviz.patch {
       inherit graphviz;
     })
   ];

--- a/pkgs/development/python-modules/attrs/default.nix
+++ b/pkgs/development/python-modules/attrs/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchPypi,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   hatchling,
 }:
 
@@ -20,9 +20,8 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
+    (replaceVars ./remove-hatch-plugins.patch {
       # hatch-vcs and hatch-fancy-pypi-readme depend on pytest, which depends on attrs
-      src = ./remove-hatch-plugins.patch;
       inherit version;
     })
   ];

--- a/pkgs/development/python-modules/bash-kernel/default.nix
+++ b/pkgs/development/python-modules/bash-kernel/default.nix
@@ -8,7 +8,7 @@
   python,
   pexpect,
   bashInteractive,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -23,8 +23,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./bash-path.patch;
+    (replaceVars ./bash-path.patch {
       bash = lib.getExe bashInteractive;
     })
   ];

--- a/pkgs/development/python-modules/bokeh/default.nix
+++ b/pkgs/development/python-modules/bokeh/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   fetchFromGitHub,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   colorama,
   contourpy,
   jinja2,
@@ -64,8 +64,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-nodejs-npmjs-paths.patch;
+    (replaceVars ./hardcode-nodejs-npmjs-paths.patch {
       node_bin = "${nodejs}/bin/node";
       npm_bin = "${nodejs}/bin/npm";
     })

--- a/pkgs/development/python-modules/cairocffi/default.nix
+++ b/pkgs/development/python-modules/cairocffi/default.nix
@@ -5,7 +5,7 @@
   pythonOlder,
   fetchPypi,
   lib,
-  substituteAll,
+  replaceVars,
   pikepdf,
   pytestCheckHook,
   cairo,
@@ -32,8 +32,7 @@ buildPythonPackage rec {
 
   patches = [
     # OSError: dlopen() failed to load a library: gdk-pixbuf-2.0 / gdk-pixbuf-2.0-0
-    (substituteAll {
-      src = ./dlopen-paths.patch;
+    (replaceVars ./dlopen-paths.patch {
       ext = stdenv.hostPlatform.extensions.sharedLibrary;
       cairo = cairo.out;
       glib = glib.out;

--- a/pkgs/development/python-modules/cmdstanpy/default.nix
+++ b/pkgs/development/python-modules/cmdstanpy/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   cmdstan,
   setuptools,
   pandas,
@@ -27,8 +27,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./use-nix-cmdstan-path.patch;
+    (replaceVars ./use-nix-cmdstan-path.patch {
       cmdstan = "${cmdstan}/opt/cmdstan";
     })
   ];

--- a/pkgs/development/python-modules/debugpy/default.nix
+++ b/pkgs/development/python-modules/debugpy/default.nix
@@ -5,7 +5,7 @@
   pythonOlder,
   pythonAtLeast,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   gdb,
   lldb,
   pytestCheckHook,
@@ -39,8 +39,7 @@ buildPythonPackage rec {
   patches =
     [
       # Use nixpkgs version instead of versioneer
-      (substituteAll {
-        src = ./hardcode-version.patch;
+      (replaceVars ./hardcode-version.patch {
         inherit version;
       })
 
@@ -62,15 +61,13 @@ buildPythonPackage rec {
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       # Hard code GDB path (used to attach to process)
-      (substituteAll {
-        src = ./hardcode-gdb.patch;
+      (replaceVars ./hardcode-gdb.patch {
         inherit gdb;
       })
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Hard code LLDB path (used to attach to process)
-      (substituteAll {
-        src = ./hardcode-lldb.patch;
+      (replaceVars ./hardcode-lldb.patch {
         inherit lldb;
       })
     ];

--- a/pkgs/development/python-modules/deltachat2/default.nix
+++ b/pkgs/development/python-modules/deltachat2/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   deltachat-rpc-server,
   setuptools-scm,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -20,8 +20,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       deltachatrpcserver = lib.getExe deltachat-rpc-server;
     })
   ];

--- a/pkgs/development/python-modules/django/3.nix
+++ b/pkgs/development/python-modules/django/3.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   geos_3_9,
   gdal,
   asgiref,
@@ -28,17 +28,17 @@ buildPythonPackage rec {
 
   patches =
     [
-      (substituteAll {
-        src = ./django_3_set_zoneinfo_dir.patch;
+      (replaceVars ./django_3_set_zoneinfo_dir.patch {
         zoneinfo = tzdata + "/share/zoneinfo";
       })
     ]
-    ++ lib.optional withGdal (substituteAll {
-      src = ./django_3_set_geos_gdal_lib.patch;
-      inherit geos_3_9;
-      inherit gdal;
-      extension = stdenv.hostPlatform.extensions.sharedLibrary;
-    });
+    ++ lib.optional withGdal (
+      replaceVars ./django_3_set_geos_gdal_lib.patch {
+        inherit geos_3_9;
+        inherit gdal;
+        extension = stdenv.hostPlatform.extensions.sharedLibrary;
+      }
+    );
 
   propagatedBuildInputs = [
     asgiref

--- a/pkgs/development/python-modules/django/4.nix
+++ b/pkgs/development/python-modules/django/4.nix
@@ -6,7 +6,7 @@
   fetchpatch,
   pythonAtLeast,
   pythonOlder,
-  substituteAll,
+  replaceVars,
 
   # build
   setuptools,
@@ -59,8 +59,7 @@ buildPythonPackage rec {
 
   patches =
     [
-      (substituteAll {
-        src = ./django_4_set_zoneinfo_dir.patch;
+      (replaceVars ./django_4_set_zoneinfo_dir.patch {
         zoneinfo = tzdata + "/share/zoneinfo";
       })
       # make sure the tests don't remove packages from our pythonpath
@@ -75,8 +74,7 @@ buildPythonPackage rec {
       })
     ]
     ++ lib.optionals withGdal [
-      (substituteAll {
-        src = ./django_4_set_geos_gdal_lib.patch;
+      (replaceVars ./django_4_set_geos_gdal_lib.patch {
         geos = geos;
         gdal = gdal;
         extension = stdenv.hostPlatform.extensions.sharedLibrary;

--- a/pkgs/development/python-modules/django/5.nix
+++ b/pkgs/development/python-modules/django/5.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchpatch,
   pythonOlder,
-  substituteAll,
+  replaceVars,
 
   # build-system
   setuptools,
@@ -58,8 +58,7 @@ buildPythonPackage rec {
 
   patches =
     [
-      (substituteAll {
-        src = ./django_5_set_zoneinfo_dir.patch;
+      (replaceVars ./django_5_set_zoneinfo_dir.patch {
         zoneinfo = tzdata + "/share/zoneinfo";
       })
       # prevent tests from messing with our pythonpath
@@ -75,8 +74,7 @@ buildPythonPackage rec {
       })
     ]
     ++ lib.optionals withGdal [
-      (substituteAll {
-        src = ./django_5_set_geos_gdal_lib.patch;
+      (replaceVars ./django_5_set_geos_gdal_lib.patch {
         geos = geos;
         gdal = gdal;
         extension = stdenv.hostPlatform.extensions.sharedLibrary;

--- a/pkgs/development/python-modules/dot2tex/default.nix
+++ b/pkgs/development/python-modules/dot2tex/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   pyparsing,
   graphviz,
   pytestCheckHook,
@@ -20,8 +20,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./path.patch;
+    (replaceVars ./path.patch {
       inherit graphviz;
     })
     ./test.patch # https://github.com/kjellmf/dot2tex/issues/5

--- a/pkgs/development/python-modules/espeak-phonemizer/default.nix
+++ b/pkgs/development/python-modules/espeak-phonemizer/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   espeak-ng,
   pytestCheckHook,
 }:
@@ -20,8 +20,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./cdll.patch;
+    (replaceVars ./cdll.patch {
       libespeak_ng = "${lib.getLib espeak-ng}/lib/libespeak-ng.so";
     })
   ];

--- a/pkgs/development/python-modules/flit-gettext/default.nix
+++ b/pkgs/development/python-modules/flit-gettext/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
 
   # build-system
   flit-scm,
@@ -30,8 +30,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./msgfmt-path.patch;
+    (replaceVars ./msgfmt-path.patch {
       msgfmt = lib.getExe' gettext "msgfmt";
     })
   ];

--- a/pkgs/development/python-modules/gattlib/default.nix
+++ b/pkgs/development/python-modules/gattlib/default.nix
@@ -3,7 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
-  substituteAll,
+  replaceVars,
+
+  # build
   pkg-config,
   glibc,
   python,
@@ -31,8 +33,7 @@ buildPythonPackage rec {
       url = "https://github.com/oscaracena/pygattlib/commit/73a73b71cfc139e1e0a08816fb976ff330c77ea5.patch";
       hash = "sha256-/Y/CZNdN/jcxWroqRfdCH2rPUxZUbug668MIAow0scs=";
     })
-    (substituteAll {
-      src = ./setup.patch;
+    (replaceVars ./setup.patch {
       boost_version =
         let
           pythonVersion = with lib.versions; "${major python.version}${minor python.version}";

--- a/pkgs/development/python-modules/git-annex-adapter/default.nix
+++ b/pkgs/development/python-modules/git-annex-adapter/default.nix
@@ -10,7 +10,7 @@
   pytestCheckHook,
   pythonOlder,
   setuptools,
-  substituteAll,
+  replaceVars,
   util-linux,
 }:
 
@@ -42,8 +42,7 @@ buildPythonPackage rec {
       url = "https://github.com/alpernebbi/git-annex-adapter/commit/d0d8905965a3659ce95cbd8f8b1e8598f0faf76b.patch";
       hash = "sha256-UcRTKzD3sbXGIuxj4JzZDnvjTYyWVkfeWgKiZ1rAlus=";
     })
-    (substituteAll {
-      src = ./git-annex-path.patch;
+    (replaceVars ./git-annex-path.patch {
       gitAnnex = "${git-annex}/bin/git-annex";
     })
   ];

--- a/pkgs/development/python-modules/glymur/default.nix
+++ b/pkgs/development/python-modules/glymur/default.nix
@@ -13,7 +13,7 @@
   pythonOlder,
   scikit-image,
   setuptools,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -37,8 +37,7 @@ buildPythonPackage rec {
       url = "https://github.com/quintusdias/glymur/commit/89b159299035ebb05776c3b90278f410ca6dba64.patch";
       hash = "sha256-C/Q5WZmW5YtN3U8fxKljfqwKHtFLfR2LQ69Tj8SuIWg=";
     })
-    (substituteAll {
-      src = ./set-lib-paths.patch;
+    (replaceVars ./set-lib-paths.patch {
       openjp2_lib = "${lib.getLib openjpeg}/lib/libopenjp2${stdenv.hostPlatform.extensions.sharedLibrary}";
       tiff_lib = "${lib.getLib libtiff}/lib/libtiff${stdenv.hostPlatform.extensions.sharedLibrary}";
     })

--- a/pkgs/development/python-modules/gpuctypes/default.nix
+++ b/pkgs/development/python-modules/gpuctypes/default.nix
@@ -3,7 +3,7 @@
   config,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   addDriverRunpath,
   cudaSupport ? config.cudaSupport,
   rocmSupport ? config.rocmSupport,
@@ -33,8 +33,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./0001-fix-dlopen-cuda.patch;
+    (replaceVars ./0001-fix-dlopen-cuda.patch {
       inherit (addDriverRunpath) driverLink;
       libnvrtc =
         if cudaSupport then

--- a/pkgs/development/python-modules/graphviz/default.nix
+++ b/pkgs/development/python-modules/graphviz/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   graphviz-nox,
   xdg-utils,
   makeFontsConf,
@@ -32,8 +32,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       graphviz = graphviz-nox;
       xdgutils = xdg-utils;
     })

--- a/pkgs/development/python-modules/hydra-core/default.nix
+++ b/pkgs/development/python-modules/hydra-core/default.nix
@@ -11,7 +11,7 @@
   packaging,
   pytestCheckHook,
   pythonOlder,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -29,8 +29,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./antlr4.patch;
+    (replaceVars ./antlr4.patch {
       antlr_jar = "${antlr4.out}/share/java/antlr-${antlr4.version}-complete.jar";
     })
     # https://github.com/facebookresearch/hydra/pull/2731

--- a/pkgs/development/python-modules/imageio-ffmpeg/default.nix
+++ b/pkgs/development/python-modules/imageio-ffmpeg/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   ffmpeg,
 
   # build-system
@@ -27,8 +27,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./ffmpeg-path.patch;
+    (replaceVars ./ffmpeg-path.patch {
       ffmpeg = lib.getExe ffmpeg;
     })
   ];

--- a/pkgs/development/python-modules/imageio/default.nix
+++ b/pkgs/development/python-modules/imageio/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   isPyPy,
-  substituteAll,
+  replaceVars,
 
   # build-system
   setuptools,
@@ -42,8 +42,7 @@ buildPythonPackage rec {
   };
 
   patches = lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    (substituteAll {
-      src = ./libgl-path.patch;
+    (replaceVars ./libgl-path.patch {
       libgl = "${libGL.out}/lib/libGL${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/img2pdf/default.nix
+++ b/pkgs/development/python-modules/img2pdf/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   isPy27,
   fetchFromGitea,
-  substituteAll,
+  replaceVars,
   fetchpatch,
   colord,
   setuptools,
@@ -38,8 +38,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./default-icc-profile.patch;
+    (replaceVars ./default-icc-profile.patch {
       srgbProfile =
         if stdenv.hostPlatform.isDarwin then
           "/System/Library/ColorSync/Profiles/sRGB Profile.icc"

--- a/pkgs/development/python-modules/iniconfig/default.nix
+++ b/pkgs/development/python-modules/iniconfig/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   buildPythonPackage,
-  substituteAll,
+  replaceVars,
   fetchPypi,
   hatchling,
 }:
@@ -20,8 +20,7 @@ buildPythonPackage rec {
 
   patches = [
     # Cannot use hatch-vcs, due to an inifinite recursion
-    (substituteAll {
-      src = ./version.patch;
+    (replaceVars ./version.patch {
       inherit version;
     })
   ];

--- a/pkgs/development/python-modules/isal/default.nix
+++ b/pkgs/development/python-modules/isal/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
 
   # build-system
   setuptools,
@@ -29,8 +29,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./version.patch;
+    (replaceVars ./version.patch {
       inherit version;
     })
   ];

--- a/pkgs/development/python-modules/k5test/default.nix
+++ b/pkgs/development/python-modules/k5test/default.nix
@@ -6,7 +6,7 @@
   krb5-c,
   pythonOlder,
   setuptools,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       inherit findutils;
       krb5 = krb5-c;
       # krb5-config is in dev output

--- a/pkgs/development/python-modules/kaldi-active-grammar/default.nix
+++ b/pkgs/development/python-modules/kaldi-active-grammar/default.nix
@@ -10,7 +10,7 @@
   numpy,
   cffi,
   openfst,
-  substituteAll,
+  replaceVars,
   callPackage,
 }:
 
@@ -43,8 +43,7 @@ buildPythonPackage rec {
     # Uses the dependencies' binaries from $PATH instead of a specific directory
     ./0002-exec-path.patch
     # Makes it dynamically link to the correct Kaldi library
-    (substituteAll {
-      src = ./0003-ffi-path.patch;
+    (replaceVars ./0003-ffi-path.patch {
       kaldiFork = "${kaldi}/lib";
     })
   ];

--- a/pkgs/development/python-modules/kornia-rs/default.nix
+++ b/pkgs/development/python-modules/kornia-rs/default.nix
@@ -6,7 +6,7 @@
   rustPlatform,
   cmake,
   nasm,
-  substituteAll,
+  replaceVars,
   libiconv,
 }:
 
@@ -36,8 +36,7 @@ buildPythonPackage rec {
 
   # The path dependency doesn't vendor the dependencies correctly, so get kornia-rs from crates instead.
   patches = [
-    (substituteAll {
-      src = ./kornia-rs-from-crates.patch;
+    (replaceVars ./kornia-rs-from-crates.patch {
       inherit version;
     })
   ];

--- a/pkgs/development/python-modules/libevdev/default.nix
+++ b/pkgs/development/python-modules/libevdev/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   isPy27,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   pkgs,
   pytestCheckHook,
 }:
@@ -20,8 +20,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       libevdev = lib.getLib pkgs.libevdev;
     })
   ];

--- a/pkgs/development/python-modules/libusb1/default.nix
+++ b/pkgs/development/python-modules/libusb1/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   setuptools,
   libusb1,
   pytestCheckHook,
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./ctypes.patch;
+    (replaceVars ./ctypes.patch {
       libusb = "${lib.getLib libusb1}/lib/libusb-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/mido/default.nix
+++ b/pkgs/development/python-modules/mido/default.nix
@@ -3,7 +3,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
 
   # build-system
   setuptools,
@@ -39,8 +39,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./libportmidi-cdll.patch;
+    (replaceVars ./libportmidi-cdll.patch {
       libportmidi = "${portmidi.out}/lib/libportmidi${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/mss/default.nix
+++ b/pkgs/development/python-modules/mss/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   pythonOlder,
   stdenv,
-  substituteAll,
+  replaceVars,
 
   # build-system
   hatchling,
@@ -34,8 +34,7 @@ buildPythonPackage rec {
   };
 
   patches = lib.optionals stdenv.hostPlatform.isLinux [
-    (substituteAll {
-      src = ./linux-paths.patch;
+    (replaceVars ./linux-paths.patch {
       x11 = "${xorg.libX11}/lib/libX11.so";
       xfixes = "${xorg.libXfixes}/lib/libXfixes.so";
       xrandr = "${xorg.libXrandr}/lib/libXrandr.so";

--- a/pkgs/development/python-modules/netmap/default.nix
+++ b/pkgs/development/python-modules/netmap/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   nmap,
   python,
 }:
@@ -20,8 +20,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./nmap-path.patch;
+    (replaceVars ./nmap-path.patch {
       nmap = "${lib.getBin nmap}/bin/nmap";
     })
   ];

--- a/pkgs/development/python-modules/nextcord/default.nix
+++ b/pkgs/development/python-modules/nextcord/default.nix
@@ -5,7 +5,7 @@
   pythonAtLeast,
   pythonOlder,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   ffmpeg,
   libopus,
   aiohttp,
@@ -34,8 +34,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       ffmpeg = "${ffmpeg}/bin/ffmpeg";
       libopus = "${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}";
     })

--- a/pkgs/development/python-modules/nocturne/default.nix
+++ b/pkgs/development/python-modules/nocturne/default.nix
@@ -9,7 +9,7 @@
   pybind11,
   pyvirtualdisplay,
   sfml,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -32,8 +32,7 @@ buildPythonPackage rec {
   '';
 
   patches = [
-    (substituteAll {
-      src = ./dependencies.patch;
+    (replaceVars ./dependencies.patch {
       gtest_src = gtest.src;
     })
   ];

--- a/pkgs/development/python-modules/notify-py/default.nix
+++ b/pkgs/development/python-modules/notify-py/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   alsa-utils,
   libnotify,
   which,
@@ -33,16 +33,14 @@ buildPythonPackage rec {
   patches =
     lib.optionals stdenv.hostPlatform.isLinux [
       # hardcode paths to aplay and notify-send
-      (substituteAll {
-        src = ./linux-paths.patch;
+      (replaceVars ./linux-paths.patch {
         aplay = "${alsa-utils}/bin/aplay";
         notifysend = "${libnotify}/bin/notify-send";
       })
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # hardcode path to which
-      (substituteAll {
-        src = ./darwin-paths.patch;
+      (replaceVars ./darwin-paths.patch {
         which = "${which}/bin/which";
       })
     ];

--- a/pkgs/development/python-modules/numba/default.nix
+++ b/pkgs/development/python-modules/numba/default.nix
@@ -11,7 +11,7 @@
   numpy_1,
   llvmlite,
   libcxx,
-  substituteAll,
+  replaceVars,
   writers,
   numba,
   pytestCheckHook,
@@ -96,8 +96,7 @@ buildPythonPackage rec {
   ];
 
   patches = lib.optionals cudaSupport [
-    (substituteAll {
-      src = ./cuda_path.patch;
+    (replaceVars ./cuda_path.patch {
       cuda_toolkit_path = cudatoolkit;
       cuda_toolkit_lib_path = lib.getLib cudatoolkit;
     })

--- a/pkgs/development/python-modules/nvidia-ml-py/default.nix
+++ b/pkgs/development/python-modules/nvidia-ml-py/default.nix
@@ -2,7 +2,7 @@
   lib,
   fetchPypi,
   buildPythonPackage,
-  substituteAll,
+  replaceVars,
   addDriverRunpath,
   setuptools,
   cudaPackages,
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch;
+    (replaceVars ./0001-locate-libnvidia-ml.so.1-on-NixOS.patch {
       inherit (addDriverRunpath) driverLink;
     })
   ];

--- a/pkgs/development/python-modules/objgraph/default.nix
+++ b/pkgs/development/python-modules/objgraph/default.nix
@@ -7,7 +7,7 @@
   isPyPy,
   python,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   setuptools,
 }:
 
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-graphviz-path.patch;
+    (replaceVars ./hardcode-graphviz-path.patch {
       graphviz = graphvizPkgs;
     })
   ];

--- a/pkgs/development/python-modules/ocrmypdf/default.nix
+++ b/pkgs/development/python-modules/ocrmypdf/default.nix
@@ -21,7 +21,7 @@
   pythonOlder,
   rich,
   reportlab,
-  substituteAll,
+  replaceVars,
   tesseract,
   unpaper,
   installShellFiles,
@@ -50,8 +50,7 @@ buildPythonPackage rec {
 
   patches = [
     ./use-pillow-heif.patch
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       gs = lib.getExe ghostscript_headless;
       jbig2 = lib.getExe jbig2enc;
       pngquant = lib.getExe pngquant;

--- a/pkgs/development/python-modules/omegaconf/default.nix
+++ b/pkgs/development/python-modules/omegaconf/default.nix
@@ -13,7 +13,7 @@
   pythonAtLeast,
   pythonOlder,
   pyyaml,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -31,8 +31,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./antlr4.patch;
+    (replaceVars ./antlr4.patch {
       antlr_jar = "${antlr4.out}/share/java/antlr-${antlr4.version}-complete.jar";
     })
 

--- a/pkgs/development/python-modules/openai-whisper/default.nix
+++ b/pkgs/development/python-modules/openai-whisper/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   buildPythonPackage,
-  substituteAll,
+  replaceVars,
 
   # build-system
   setuptools,
@@ -38,8 +38,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./ffmpeg-path.patch;
+    (replaceVars ./ffmpeg-path.patch {
       ffmpeg = ffmpeg-headless;
     })
   ];

--- a/pkgs/development/python-modules/opuslib/default.nix
+++ b/pkgs/development/python-modules/opuslib/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   setuptools,
 }:
 
@@ -38,8 +38,7 @@ buildPythonPackage rec {
       url = "https://github.com/orion-labs/opuslib/commit/87a214fc98c1dcae38035e99fe8e279a160c4a52.patch";
       hash = "sha256-UoOafyTFvWLY7ErtBhkXTZSgbMZFrg5DGxjbhqEI7wo=";
     })
-    (substituteAll {
-      src = ./opuslib-paths.patch;
+    (replaceVars ./opuslib-paths.patch {
       opusLibPath = "${libopus}/lib/libopus${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/ots-python/default.nix
+++ b/pkgs/development/python-modules/ots-python/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   opentype-sanitizer,
   setuptools-scm,
   pytestCheckHook,
@@ -23,8 +23,7 @@ buildPythonPackage rec {
     # Invoke ots-sanitize from the opentype-sanitizer package instead of
     # downloading precompiled binaries from the internet.
     # (nixpkgs-specific, not upstreamable)
-    (substituteAll {
-      src = ./0001-use-packaged-ots.patch;
+    (replaceVars ./0001-use-packaged-ots.patch {
       ots_sanitize = "${opentype-sanitizer}/bin/ots-sanitize";
     })
   ];

--- a/pkgs/development/python-modules/pdfminer-six/default.nix
+++ b/pkgs/development/python-modules/pdfminer-six/default.nix
@@ -8,7 +8,7 @@
   pythonOlder,
   pytestCheckHook,
   setuptools,
-  substituteAll,
+  replaceVars,
   ocrmypdf,
 }:
 
@@ -34,8 +34,7 @@ buildPythonPackage rec {
       excludes = [ "CHANGELOG.md" ];
       hash = "sha256-fsSXvN92MVtNFpAst0ctvGrbxVvoe4Nyz4wMZqJ1aw8=";
     })
-    (substituteAll {
-      src = ./disable-setuptools-git-versioning.patch;
+    (replaceVars ./disable-setuptools-git-versioning.patch {
       inherit version;
     })
   ];

--- a/pkgs/development/python-modules/phonemizer/default.nix
+++ b/pkgs/development/python-modules/phonemizer/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   buildPythonPackage,
   fetchPypi,
   joblib,
@@ -27,8 +27,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./backend-paths.patch;
+    (replaceVars ./backend-paths.patch {
       libespeak = "${lib.getLib espeak-ng}/lib/libespeak-ng${stdenv.hostPlatform.extensions.sharedLibrary}";
       # FIXME package festival
     })

--- a/pkgs/development/python-modules/pikepdf/default.nix
+++ b/pkgs/development/python-modules/pikepdf/default.nix
@@ -20,7 +20,7 @@
   python-xmp-toolkit,
   qpdf,
   setuptools,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -42,8 +42,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       jbig2dec = lib.getExe' jbig2dec "jbig2dec";
       mutool = lib.getExe' mupdf-headless "mutool";
     })

--- a/pkgs/development/python-modules/protobuf/4.nix
+++ b/pkgs/development/python-modules/protobuf/4.nix
@@ -9,7 +9,7 @@
   protobuf,
   pytestCheckHook,
   pythonAtLeast,
-  substituteAll,
+  replaceVars,
   tzdata,
 }:
 
@@ -31,8 +31,7 @@ buildPythonPackage {
   patches =
     lib.optionals (lib.versionAtLeast protobuf.version "22") [
       # Replace the vendored abseil-cpp with nixpkgs'
-      (substituteAll {
-        src = ./use-nixpkgs-abseil-cpp.patch;
+      (replaceVars ./use-nixpkgs-abseil-cpp.patch {
         abseil_cpp_include_path = "${lib.getDev protobuf.abseil-cpp}/include";
       })
     ]

--- a/pkgs/development/python-modules/proton-client/default.nix
+++ b/pkgs/development/python-modules/proton-client/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   bcrypt,
   pyopenssl,
   python-gnupg,
@@ -37,8 +37,7 @@ buildPythonPackage rec {
 
   patches = [
     # Patches library by fixing the openssl path
-    (substituteAll {
-      src = ./0001-OpenSSL-path-fix.patch;
+    (replaceVars ./0001-OpenSSL-path-fix.patch {
       openssl = openssl.out;
       ext = stdenv.hostPlatform.extensions.sharedLibrary;
     })

--- a/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
+++ b/pkgs/development/python-modules/protonvpn-nm-lib/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   dbus-python,
   distro,
   jinja2,
@@ -48,8 +48,7 @@ buildPythonPackage rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./0001-Patching-GIRepository.patch;
+    (replaceVars ./0001-Patching-GIRepository.patch {
       networkmanager_path = "${networkmanager}/lib/girepository-1.0";
     })
   ];

--- a/pkgs/development/python-modules/pulsectl/default.nix
+++ b/pkgs/development/python-modules/pulsectl/default.nix
@@ -4,7 +4,7 @@
   fetchPypi,
   libpulseaudio,
   glibc,
-  substituteAll,
+  replaceVars,
   stdenv,
   pulseaudio,
   unittestCheckHook,
@@ -22,8 +22,7 @@ buildPythonPackage rec {
 
   patches = [
     # substitute library paths for libpulse and librt
-    (substituteAll {
-      src = ./library-paths.patch;
+    (replaceVars ./library-paths.patch {
       libpulse = "${libpulseaudio.out}/lib/libpulse${stdenv.hostPlatform.extensions.sharedLibrary}";
       librt = "${glibc.out}/lib/librt${stdenv.hostPlatform.extensions.sharedLibrary}";
     })

--- a/pkgs/development/python-modules/pydot/default.nix
+++ b/pkgs/development/python-modules/pydot/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   fetchPypi,
   setuptools,
-  substituteAll,
+  replaceVars,
   graphviz,
   pytestCheckHook,
   chardet,
@@ -37,8 +37,7 @@ buildPythonPackage rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-graphviz-path.patch;
+    (replaceVars ./hardcode-graphviz-path.patch {
       inherit graphviz;
     })
   ];

--- a/pkgs/development/python-modules/pygame-ce/default.nix
+++ b/pkgs/development/python-modules/pygame-ce/default.nix
@@ -1,7 +1,7 @@
 {
   stdenv,
   lib,
-  substituteAll,
+  replaceVars,
   fetchFromGitHub,
   buildPythonPackage,
   pythonOlder,
@@ -45,8 +45,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-dependency-finding.patch;
+    (replaceVars ./fix-dependency-finding.patch {
       buildinputs_include = builtins.toJSON (
         builtins.concatMap (dep: [
           "${lib.getDev dep}/"

--- a/pkgs/development/python-modules/pygame/default.nix
+++ b/pkgs/development/python-modules/pygame/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   fontconfig,
   python,
 
@@ -44,8 +44,7 @@ buildPythonPackage rec {
 
   patches = [
     # Patch pygame's dependency resolution to let it find build inputs
-    (substituteAll {
-      src = ./fix-dependency-finding.patch;
+    (replaceVars ./fix-dependency-finding.patch {
       buildinputs_include = builtins.toJSON (
         builtins.concatMap (dep: [
           "${lib.getDev dep}/"

--- a/pkgs/development/python-modules/pygraphviz/default.nix
+++ b/pkgs/development/python-modules/pygraphviz/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   graphviz,
   coreutils,
   pkg-config,
@@ -27,8 +27,7 @@ buildPythonPackage rec {
 
   patches = [
     # pygraphviz depends on graphviz executables and wc being in PATH
-    (substituteAll {
-      src = ./path.patch;
+    (replaceVars ./path.patch {
       path = lib.makeBinPath [
         graphviz
         coreutils

--- a/pkgs/development/python-modules/pylama/default.nix
+++ b/pkgs/development/python-modules/pylama/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   git,
   eradicate,
   mccabe,
@@ -32,8 +32,7 @@ let
     };
 
     patches = [
-      (substituteAll {
-        src = ./paths.patch;
+      (replaceVars ./paths.patch {
         git = "${lib.getBin git}/bin/git";
       })
     ];

--- a/pkgs/development/python-modules/pylddwrap/default.nix
+++ b/pkgs/development/python-modules/pylddwrap/default.nix
@@ -6,7 +6,7 @@
   icontract,
   pytestCheckHook,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   typing-extensions,
 }:
 
@@ -24,8 +24,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./replace_env_with_placeholder.patch;
+    (replaceVars ./replace_env_with_placeholder.patch {
       ldd_bin = "${stdenv.cc.bintools.libc_bin}/bin/ldd";
     })
   ];

--- a/pkgs/development/python-modules/pyocr/default.nix
+++ b/pkgs/development/python-modules/pyocr/default.nix
@@ -7,7 +7,7 @@
   tesseract,
   cuneiform,
   isPy3k,
-  substituteAll,
+  replaceVars,
   pytestCheckHook,
   setuptools,
   setuptools-scm,
@@ -33,15 +33,17 @@ buildPythonPackage rec {
 
   patches =
     [ ]
-    ++ (lib.optional withTesseractSupport (substituteAll {
-      src = ./paths-tesseract.patch;
-      inherit tesseract;
-      tesseractLibraryLocation = "${tesseract}/lib/libtesseract${stdenv.hostPlatform.extensions.sharedLibrary}";
-    }))
-    ++ (lib.optional stdenv.hostPlatform.isLinux (substituteAll {
-      src = ./paths-cuneiform.patch;
-      inherit cuneiform;
-    }));
+    ++ (lib.optional withTesseractSupport (
+      replaceVars ./paths-tesseract.patch {
+        inherit tesseract;
+        tesseractLibraryLocation = "${tesseract}/lib/libtesseract${stdenv.hostPlatform.extensions.sharedLibrary}";
+      }
+    ))
+    ++ (lib.optional stdenv.hostPlatform.isLinux (
+      replaceVars ./paths-cuneiform.patch {
+        inherit cuneiform;
+      }
+    ));
 
   propagatedBuildInputs = [ pillow ];
 

--- a/pkgs/development/python-modules/pyogg/default.nix
+++ b/pkgs/development/python-modules/pyogg/default.nix
@@ -8,7 +8,7 @@
   libogg,
   libopus,
   opusfile,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -45,8 +45,7 @@ buildPythonPackage rec {
     "--binary"
   ];
   patches = [
-    (substituteAll {
-      src = ./pyogg-paths.patch;
+    (replaceVars ./pyogg-paths.patch {
       flacLibPath = "${flac.out}/lib/libFLAC${stdenv.hostPlatform.extensions.sharedLibrary}";
       oggLibPath = "${libogg}/lib/libogg${stdenv.hostPlatform.extensions.sharedLibrary}";
       vorbisLibPath = "${libvorbis}/lib/libvorbis${stdenv.hostPlatform.extensions.sharedLibrary}";

--- a/pkgs/development/python-modules/pypandoc/default.nix
+++ b/pkgs/development/python-modules/pypandoc/default.nix
@@ -6,7 +6,7 @@
   pandocfilters,
   poetry-core,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   texliveSmall,
 }:
 
@@ -25,8 +25,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./static-pandoc-path.patch;
+    (replaceVars ./static-pandoc-path.patch {
       pandoc = "${lib.getBin pandoc}/bin/pandoc";
       pandocVersion = pandoc.version;
     })

--- a/pkgs/development/python-modules/pyproj/default.nix
+++ b/pkgs/development/python-modules/pyproj/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pytestCheckHook,
   pythonOlder,
-  substituteAll,
+  replaceVars,
 
   certifi,
   cython,
@@ -31,8 +31,7 @@ buildPythonPackage rec {
 
   # force pyproj to use ${proj}
   patches = [
-    (substituteAll {
-      src = ./001.proj.patch;
+    (replaceVars ./001.proj.patch {
       proj = proj;
       projdev = proj.dev;
     })

--- a/pkgs/development/python-modules/pysaml2/default.nix
+++ b/pkgs/development/python-modules/pysaml2/default.nix
@@ -17,7 +17,7 @@
   requests,
   responses,
   setuptools,
-  substituteAll,
+  replaceVars,
   xmlschema,
   xmlsec,
   zope-interface,
@@ -38,8 +38,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-xmlsec1-path.patch;
+    (replaceVars ./hardcode-xmlsec1-path.patch {
       inherit xmlsec;
     })
   ];

--- a/pkgs/development/python-modules/pytesseract/default.nix
+++ b/pkgs/development/python-modules/pytesseract/default.nix
@@ -5,7 +5,7 @@
   packaging,
   pillow,
   tesseract,
-  substituteAll,
+  replaceVars,
   pytestCheckHook,
   setuptools,
 }:
@@ -23,8 +23,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./tesseract-binary.patch;
+    (replaceVars ./tesseract-binary.patch {
       drv = tesseract;
     })
   ];

--- a/pkgs/development/python-modules/python-magic/default.nix
+++ b/pkgs/development/python-modules/python-magic/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch,
-  substituteAll,
+  replaceVars,
   file,
   pytestCheckHook,
 }:
@@ -22,8 +22,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./libmagic-path.patch;
+    (replaceVars ./libmagic-path.patch {
       libmagic = "${file}/lib/libmagic${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
     (fetchpatch {

--- a/pkgs/development/python-modules/python-mapnik/default.nix
+++ b/pkgs/development/python-modules/python-mapnik/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   isPyPy,
   python,
   setuptools,
@@ -43,8 +43,7 @@ buildPythonPackage rec {
   patches = [
     # python-mapnik seems to depend on having the mapnik src directory
     # structure available at build time. We just hardcode the paths.
-    (substituteAll {
-      src = ./find-libmapnik.patch;
+    (replaceVars ./find-libmapnik.patch {
       libmapnik = "${mapnik}/lib";
     })
     # Use `std::optional` rather than `boost::optional`

--- a/pkgs/development/python-modules/python-matter-server/default.nix
+++ b/pkgs/development/python-modules/python-matter-server/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   pythonOlder,
   stdenvNoCC,
-  substituteAll,
+  replaceVars,
 
   # build
   setuptools,
@@ -69,8 +69,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./link-paa-root-certs.patch;
+    (replaceVars ./link-paa-root-certs.patch {
       paacerts = paaCerts;
     })
   ];

--- a/pkgs/development/python-modules/python-rapidjson/default.nix
+++ b/pkgs/development/python-modules/python-rapidjson/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
   pytz,
   setuptools,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -25,8 +25,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./rapidjson-include-dir.patch;
+    (replaceVars ./rapidjson-include-dir.patch {
       rapidjson = lib.getDev rapidjson;
     })
   ];

--- a/pkgs/development/python-modules/python3-gnutls/default.nix
+++ b/pkgs/development/python-modules/python3-gnutls/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   buildPythonPackage,
   isPy3k,
   gnutls,
@@ -34,8 +34,7 @@ buildPythonPackage rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./libgnutls-path.patch;
+    (replaceVars ./libgnutls-path.patch {
       gnutlslib = "${lib.getLib gnutls}/lib";
     })
   ];

--- a/pkgs/development/python-modules/pythran/default.nix
+++ b/pkgs/development/python-modules/pythran/default.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   fetchpatch2,
-  substituteAll,
+  replaceVars,
 
   # build-system
   setuptools,
@@ -37,8 +37,7 @@ buildPythonPackage rec {
 
   patches = [
     # Hardcode path to mp library
-    (substituteAll {
-      src = ./0001-hardcode-path-to-libgomp.patch;
+    (replaceVars ./0001-hardcode-path-to-libgomp.patch {
       gomp = "${
         if stdenv.cc.isClang then openmp else (lib.getLib stdenv.cc.cc)
       }/lib/libgomp${stdenv.hostPlatform.extensions.sharedLibrary}";

--- a/pkgs/development/python-modules/pyturbojpeg/default.nix
+++ b/pkgs/development/python-modules/pyturbojpeg/default.nix
@@ -7,7 +7,7 @@
   setuptools,
   numpy,
   python,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -23,8 +23,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./lib-path.patch;
+    (replaceVars ./lib-path.patch {
       libturbojpeg = "${lib.getLib libjpeg_turbo}/lib/libturbojpeg${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/pyvirtualdisplay/default.nix
+++ b/pkgs/development/python-modules/pyvirtualdisplay/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   xorg,
 
   # build-system
@@ -32,8 +32,7 @@ buildPythonPackage rec {
   };
 
   patches = lib.optionals stdenv.hostPlatform.isLinux [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       xauth = lib.getExe xorg.xauth;
       xdpyinfo = lib.getExe xorg.xdpyinfo;
     })

--- a/pkgs/development/python-modules/slixmpp/default.nix
+++ b/pkgs/development/python-modules/slixmpp/default.nix
@@ -8,7 +8,7 @@
   pyasn1,
   pyasn1-modules,
   pytestCheckHook,
-  substituteAll,
+  replaceVars,
   pythonOlder,
 }:
 
@@ -34,8 +34,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [ pytestCheckHook ];
 
   patches = [
-    (substituteAll {
-      src = ./hardcode-gnupg-path.patch;
+    (replaceVars ./hardcode-gnupg-path.patch {
       inherit gnupg;
     })
   ];

--- a/pkgs/development/python-modules/sounddevice/default.nix
+++ b/pkgs/development/python-modules/sounddevice/default.nix
@@ -8,7 +8,7 @@
   cffi,
   numpy,
   portaudio,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -38,8 +38,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "sounddevice" ];
 
   patches = [
-    (substituteAll {
-      src = ./fix-portaudio-library-path.patch;
+    (replaceVars ./fix-portaudio-library-path.patch {
       portaudio = "${portaudio}/lib/libportaudio${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/streamdeck/default.nix
+++ b/pkgs/development/python-modules/streamdeck/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   pkgs,
 }:
 
@@ -19,8 +19,7 @@ buildPythonPackage rec {
 
   patches = [
     # substitute libusb path
-    (substituteAll {
-      src = ./hardcode-libusb.patch;
+    (replaceVars ./hardcode-libusb.patch {
       libusb = "${pkgs.hidapi}/lib/libhidapi-libusb${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/termplotlib/default.nix
+++ b/pkgs/development/python-modules/termplotlib/default.nix
@@ -1,6 +1,6 @@
 {
   lib,
-  substituteAll,
+  replaceVars,
   buildPythonPackage,
   fetchFromGitHub,
   pytestCheckHook,
@@ -33,8 +33,7 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ numpy ];
 
   patches = [
-    (substituteAll {
-      src = ./gnuplot-subprocess.patch;
+    (replaceVars ./gnuplot-subprocess.patch {
       gnuplot = "${gnuplot.out}/bin/gnuplot";
     })
   ];

--- a/pkgs/development/python-modules/tinygrad/default.nix
+++ b/pkgs/development/python-modules/tinygrad/default.nix
@@ -3,7 +3,7 @@
   config,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   addDriverRunpath,
   cudaSupport ? config.cudaSupport,
   rocmSupport ? config.rocmSupport,
@@ -56,8 +56,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-dlopen-cuda.patch;
+    (replaceVars ./fix-dlopen-cuda.patch {
       inherit (addDriverRunpath) driverLink;
       libnvrtc =
         if cudaSupport then

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   buildPythonPackage,
   fetchPypi,
   fetchpatch,
@@ -53,8 +53,7 @@ buildPythonPackage rec {
       # when cross-compiling is turned on.
       # This patch changes the call to pycparser.preprocess_file to provide the name
       # of the cross-compiling cpp
-      (substituteAll {
-        src = ./cross.patch;
+      (replaceVars ./cross.patch {
         crossPrefix = stdenv.hostPlatform.config;
       })
     ];

--- a/pkgs/development/python-modules/vispy/default.nix
+++ b/pkgs/development/python-modules/vispy/default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   buildPythonPackage,
-  substituteAll,
+  replaceVars,
   fetchPypi,
   cython,
   fontconfig,
@@ -32,8 +32,7 @@ buildPythonPackage rec {
   };
 
   patches = lib.optionals (!stdenv.hostPlatform.isDarwin) [
-    (substituteAll {
-      src = ./library-paths.patch;
+    (replaceVars ./library-paths.patch {
       fontconfig = "${fontconfig.lib}/lib/libfontconfig${stdenv.hostPlatform.extensions.sharedLibrary}";
       gl = "${libGL.out}/lib/libGL${stdenv.hostPlatform.extensions.sharedLibrary}";
     })

--- a/pkgs/development/python-modules/wallet-py3k/default.nix
+++ b/pkgs/development/python-modules/wallet-py3k/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   openssl,
   setuptools,
   six,
@@ -19,8 +19,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./openssl-path.patch;
+    (replaceVars ./openssl-path.patch {
       openssl = lib.getExe openssl;
     })
   ];

--- a/pkgs/development/python-modules/wandb/default.nix
+++ b/pkgs/development/python-modules/wandb/default.nix
@@ -13,7 +13,7 @@
 
   ## wandb
   buildPythonPackage,
-  substituteAll,
+  replaceVars,
 
   # build-system
   hatchling,
@@ -150,8 +150,7 @@ buildPythonPackage rec {
 
   patches = [
     # Replace git paths
-    (substituteAll {
-      src = ./hardcode-git-path.patch;
+    (replaceVars ./hardcode-git-path.patch {
       git = lib.getExe git;
     })
   ];

--- a/pkgs/development/python-modules/wavefile/default.nix
+++ b/pkgs/development/python-modules/wavefile/default.nix
@@ -7,7 +7,7 @@
   pyaudio,
   numpy,
   libsndfile,
-  substituteAll,
+  replaceVars,
 }:
 
 buildPythonPackage rec {
@@ -40,8 +40,7 @@ buildPythonPackage rec {
   patches = [
     # Fix check error
     # OSError: libsndfile.so.1: cannot open shared object file: No such file or directory
-    (substituteAll {
-      src = ./libsndfile.py.patch;
+    (replaceVars ./libsndfile.py.patch {
       libsndfile = "${lib.getLib libsndfile}/lib/libsndfile${stdenv.hostPlatform.extensions.sharedLibrary}";
     })
   ];

--- a/pkgs/development/python-modules/weasyprint/default.nix
+++ b/pkgs/development/python-modules/weasyprint/default.nix
@@ -18,7 +18,7 @@
   pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
-  substituteAll,
+  replaceVars,
   tinycss2,
   tinyhtml5,
 }:
@@ -37,13 +37,11 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./library-paths.patch;
+    (replaceVars ./library-paths.patch {
       fontconfig = "${fontconfig.lib}/lib/libfontconfig${stdenv.hostPlatform.extensions.sharedLibrary}";
       pangoft2 = "${pango.out}/lib/libpangoft2-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       gobject = "${glib.out}/lib/libgobject-2.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       pango = "${pango.out}/lib/libpango-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
-      pangocairo = "${pango.out}/lib/libpangocairo-1.0${stdenv.hostPlatform.extensions.sharedLibrary}";
       harfbuzz = "${harfbuzz.out}/lib/libharfbuzz${stdenv.hostPlatform.extensions.sharedLibrary}";
       harfbuzz_subset = "${harfbuzz.out}/lib/libharfbuzz-subset${stdenv.hostPlatform.extensions.sharedLibrary}";
     })

--- a/pkgs/development/python-modules/wxpython/4.2.nix
+++ b/pkgs/development/python-modules/wxpython/4.2.nix
@@ -4,7 +4,7 @@
   buildPythonPackage,
   setuptools,
   fetchPypi,
-  substituteAll,
+  replaceVars,
 
   # build
   autoPatchelfHook,
@@ -52,8 +52,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./4.2-ctypes.patch;
+    (replaceVars ./4.2-ctypes.patch {
       libgdk = "${gtk3.out}/lib/libgdk-3.so";
       libpangocairo = "${pango}/lib/libpangocairo-1.0.so";
       libcairo = "${cairo}/lib/libcairo.so";

--- a/pkgs/development/python-modules/xsdata/default.nix
+++ b/pkgs/development/python-modules/xsdata/default.nix
@@ -3,7 +3,7 @@
   buildPythonPackage,
   pythonOlder,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   ruff,
   click,
   click-default-group,
@@ -32,8 +32,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./paths.patch;
+    (replaceVars ./paths.patch {
       ruff = lib.getExe ruff;
     })
   ];

--- a/pkgs/development/python-modules/youseedee/default.nix
+++ b/pkgs/development/python-modules/youseedee/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  substituteAll,
+  replaceVars,
   setuptools,
   setuptools-scm,
   filelock,
@@ -23,8 +23,7 @@ buildPythonPackage rec {
   patches = [
     # Load data files from the unicode-character-database package instead of
     # downloading them from the internet. (nixpkgs-specific, not upstreamable)
-    (substituteAll {
-      src = ./0001-use-packaged-unicode-data.patch;
+    (replaceVars ./0001-use-packaged-unicode-data.patch {
       ucd_dir = "${unicode-character-database}/share/unicode";
     })
   ];

--- a/pkgs/development/python-modules/yq/default.nix
+++ b/pkgs/development/python-modules/yq/default.nix
@@ -7,7 +7,7 @@
   pytestCheckHook,
   pyyaml,
   setuptools-scm,
-  substituteAll,
+  replaceVars,
   tomlkit,
   xmltodict,
 }:
@@ -23,8 +23,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./jq-path.patch;
+    (replaceVars ./jq-path.patch {
       jq = "${lib.getBin jq}/bin/jq";
     })
   ];

--- a/pkgs/development/python-modules/zlib-ng/default.nix
+++ b/pkgs/development/python-modules/zlib-ng/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
 
   # build-system
   cmake,
@@ -29,8 +29,7 @@ buildPythonPackage rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./version.patch;
+    (replaceVars ./version.patch {
       inherit version;
     })
   ];

--- a/pkgs/development/rocm-modules/5/rocprofiler/default.nix
+++ b/pkgs/development/rocm-modules/5/rocprofiler/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   rocmUpdateScript,
   symlinkJoin,
-  substituteAll,
+  replaceVars,
   cmake,
   clang,
   clr,
@@ -62,8 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0000-dont-install-tests-hsaco.patch
 
     # Fix bad paths
-    (substituteAll {
-      src = ./0001-fix-shell-scripts.patch;
+    (replaceVars ./0001-fix-shell-scripts.patch {
       rocmtoolkit_merged = rocmtoolkit-merged;
     })
   ];

--- a/pkgs/development/rocm-modules/6/rocprofiler/default.nix
+++ b/pkgs/development/rocm-modules/6/rocprofiler/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   rocmUpdateScript,
   symlinkJoin,
-  substituteAll,
+  replaceVars,
   cmake,
   clang,
   clr,
@@ -62,8 +62,7 @@ stdenv.mkDerivation (finalAttrs: {
     ./0000-dont-install-tests-hsaco.patch
 
     # Fix bad paths
-    (substituteAll {
-      src = ./0001-fix-shell-scripts.patch;
+    (replaceVars ./0001-fix-shell-scripts.patch {
       rocmtoolkit_merged = rocmtoolkit-merged;
     })
 

--- a/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
+++ b/pkgs/development/tcl-modules/by-name/ex/expect/package.nix
@@ -7,7 +7,7 @@
   makeWrapper,
   autoreconfHook,
   fetchpatch,
-  substituteAll,
+  replaceVars,
 }:
 
 tcl.mkTclDerivation rec {
@@ -20,8 +20,7 @@ tcl.mkTclDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-build-time-run-tcl.patch;
+    (replaceVars ./fix-build-time-run-tcl.patch {
       tcl = "${buildPackages.tcl}/bin/tclsh";
     })
     # The following patches fix compilation with clang 15+

--- a/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_5/default.nix
@@ -38,7 +38,7 @@
   # Also, don't clean up environment variables (so that NIX_ environment variables are passed to compilers).
   enableNixHacks ? false,
   file,
-  substituteAll,
+  replaceVars,
   writeTextFile,
 }:
 
@@ -203,8 +203,7 @@ stdenv.mkDerivation rec {
     # This patch removes using the -fobjc-arc compiler option and makes the code
     # compile without automatic reference counting. Caveat: this leaks memory, but
     # we accept this fact because xcode_locator is only a short-lived process used during the build.
-    (substituteAll {
-      src = ./no-arc.patch;
+    (replaceVars ./no-arc.patch {
       multiBinPatch = if stdenv.hostPlatform.system == "aarch64-darwin" then "arm64" else "x86_64";
     })
 
@@ -214,20 +213,17 @@ stdenv.mkDerivation rec {
     # This is non hermetic on non-nixos systems. On NixOS, bazel cannot find the required binaries.
     # So we are replacing this bazel paths by defaultShellPath,
     # improving hermeticity and making it work in nixos.
-    (substituteAll {
-      src = ../strict_action_env.patch;
+    (replaceVars ../strict_action_env.patch {
       strictActionEnvPatch = defaultShellPath;
     })
 
-    (substituteAll {
-      src = ./actions_path.patch;
+    (replaceVars ./actions_path.patch {
       actionsPathPatch = defaultShellPath;
     })
 
     # bazel reads its system bazelrc in /etc
     # override this path to a builtin one
-    (substituteAll {
-      src = ../bazel_rc.patch;
+    (replaceVars ../bazel_rc.patch {
       bazelSystemBazelRCPath = bazelRC;
     })
 

--- a/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_6/default.nix
@@ -16,7 +16,7 @@
 # Also, don't clean up environment variables (so that NIX_ environment variables are passed to compilers).
 , enableNixHacks ? false
 , file
-, substituteAll
+, replaceVars
 , writeTextFile
 , writeShellApplication
 , makeBinaryWrapper
@@ -239,8 +239,7 @@ stdenv.mkDerivation rec {
     # This patch removes using the -fobjc-arc compiler option and makes the code
     # compile without automatic reference counting. Caveat: this leaks memory, but
     # we accept this fact because xcode_locator is only a short-lived process used during the build.
-    (substituteAll {
-      src = ./no-arc.patch;
+    (replaceVars ./no-arc.patch {
       multiBinPatch = if stdenv.hostPlatform.system == "aarch64-darwin" then "arm64" else "x86_64";
     })
 
@@ -250,20 +249,17 @@ stdenv.mkDerivation rec {
     # This is non hermetic on non-nixos systems. On NixOS, bazel cannot find the required binaries.
     # So we are replacing this bazel paths by defaultShellPath,
     # improving hermeticity and making it work in nixos.
-    (substituteAll {
-      src = ../strict_action_env.patch;
+    (replaceVars ../strict_action_env.patch {
       strictActionEnvPatch = defaultShellPath;
     })
 
-    (substituteAll {
-      src = ./actions_path.patch;
+    (replaceVars ./actions_path.patch {
       actionsPathPatch = defaultShellPath;
     })
 
     # bazel reads its system bazelrc in /etc
     # override this path to a builtin one
-    (substituteAll {
-      src = ../bazel_rc.patch;
+    (replaceVars ../bazel_rc.patch {
       bazelSystemBazelRCPath = bazelRC;
     })
   ] ++ lib.optional enableNixHacks ./nix-hacks.patch;

--- a/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix
+++ b/pkgs/development/tools/build-managers/bazel/bazel_7/default.nix
@@ -5,7 +5,7 @@
   fetchurl,
   makeWrapper,
   writeTextFile,
-  substituteAll,
+  replaceVars,
   writeShellApplication,
   makeBinaryWrapper,
   autoPatchelfHook,
@@ -377,15 +377,13 @@ stdenv.mkDerivation rec {
       # This is non hermetic on non-nixos systems. On NixOS, bazel cannot find the required binaries.
       # So we are replacing this bazel paths by defaultShellPath,
       # improving hermeticity and making it work in nixos.
-      (substituteAll {
-        src = ../strict_action_env.patch;
+      (replaceVars ../strict_action_env.patch {
         strictActionEnvPatch = defaultShellPath;
       })
 
       # bazel reads its system bazelrc in /etc
       # override this path to a builtin one
-      (substituteAll {
-        src = ../bazel_rc.patch;
+      (replaceVars ../bazel_rc.patch {
         bazelSystemBazelRCPath = bazelRC;
       })
     ]

--- a/pkgs/development/tools/ocaml/merlin/4.x.nix
+++ b/pkgs/development/tools/ocaml/merlin/4.x.nix
@@ -64,7 +64,6 @@ buildDunePackage {
     in
     [
       (replaceVars (if old-patch then ./fix-paths.patch else ./fix-paths2.patch) {
-
         dot-merlin-reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
         dune = "${dune_3}/bin/dune";
       })

--- a/pkgs/development/tools/ocaml/merlin/default.nix
+++ b/pkgs/development/tools/ocaml/merlin/default.nix
@@ -3,7 +3,7 @@
   fetchurl,
   fetchpatch,
   buildDunePackage,
-  substituteAll,
+  replaceVars,
   dot-merlin-reader,
   dune_2,
   yojson,
@@ -24,9 +24,8 @@ buildDunePackage rec {
   minimalOCamlVersion = "4.02.3";
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      dot_merlin_reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
+    (replaceVars ./fix-paths.patch {
+      dot-merlin-reader = "${dot-merlin-reader}/bin/dot-merlin-reader";
       dune = "${dune_2}/bin/dune";
     })
     # https://github.com/ocaml/merlin/pull/1798

--- a/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
+++ b/pkgs/games/dwarf-fortress/dwarf-therapist/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, dwarf-therapist, dwarf-fortress, substituteAll, coreutils, wrapQtAppsHook
+{ stdenv, dwarf-therapist, dwarf-fortress, replaceVars, coreutils, wrapQtAppsHook
 }:
 
 let
@@ -14,8 +14,7 @@ stdenv.mkDerivation {
   pname = "dwarf-therapist";
   inherit (dwarf-therapist) version meta;
 
-  wrapper = substituteAll {
-    src = ./dwarf-therapist.in;
+  wrapper = replaceVars ./dwarf-therapist.in {
     stdenv_shell = "${stdenv.shell}";
     rm = "${coreutils}/bin/rm";
     ln = "${coreutils}/bin/ln";
@@ -23,6 +22,8 @@ stdenv.mkDerivation {
     mkdir = "${coreutils}/bin/mkdir";
     dirname = "${coreutils}/bin/dirname";
     therapist = "${dwarf-therapist}";
+    # replaced in buildCommand
+    install = null;
   };
 
   paths = [ dwarf-therapist ];

--- a/pkgs/games/dwarf-fortress/wrapper/default.nix
+++ b/pkgs/games/dwarf-fortress/wrapper/default.nix
@@ -2,7 +2,7 @@
   stdenv,
   lib,
   buildEnv,
-  substituteAll,
+  replaceVars,
   makeWrapper,
   runCommand,
   coreutils,
@@ -185,11 +185,8 @@ lib.throwIf (enableTWBT' && !enableDFHack) "dwarf-fortress: TWBT requires DFHack
     pname = "dwarf-fortress";
     version = dwarf-fortress.dfVersion;
 
-    dfInit = substituteAll {
-      name = "dwarf-fortress-init";
-      src = ./dwarf-fortress-init.in;
+    dfInit = replaceVars ./dwarf-fortress-init.in {
       inherit env;
-      inherit (dwarf-fortress) exe;
       stdenv_shell = "${stdenv.shell}";
       cp = "${coreutils}/bin/cp";
       rm = "${coreutils}/bin/rm";

--- a/pkgs/kde/plasma/kinfocenter/default.nix
+++ b/pkgs/kde/plasma/kinfocenter/default.nix
@@ -10,7 +10,7 @@
   pciutils,
   pulseaudio,
   qttools,
-  substituteAll,
+  replaceVars,
   systemsettings,
   util-linux,
   vulkan-tools,
@@ -40,9 +40,10 @@ mkKdeDerivation {
 
   patches = [
     # fwupdmgr is provided through NixOS' module
-    (substituteAll (
+    (replaceVars ./0001-tool-paths.patch (
       {
-        src = ./0001-tool-paths.patch;
+        # @QtBinariesDir@ only appears in the *removed* lines of the diff
+        QtBinariesDir = null;
       }
       // tools
     ))

--- a/pkgs/kde/plasma/plasma-workspace/default.nix
+++ b/pkgs/kde/plasma/plasma-workspace/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   mkKdeDerivation,
-  substituteAll,
+  replaceVars,
   dbus,
   fontconfig,
   xorg,
@@ -22,8 +22,7 @@ mkKdeDerivation {
   pname = "plasma-workspace";
 
   patches = [
-    (substituteAll {
-      src = ./dependency-paths.patch;
+    (replaceVars ./dependency-paths.patch {
       dbusSend = lib.getExe' dbus "dbus-send";
       fcMatch = lib.getExe' fontconfig "fc-match";
       lsof = lib.getExe lsof;
@@ -31,6 +30,8 @@ mkKdeDerivation {
       xmessage = lib.getExe xorg.xmessage;
       xrdb = lib.getExe xorg.xrdb;
       xsetroot = lib.getExe xorg.xsetroot;
+      # @QtBinariesDir@ only appears in the *removed* lines of the diff
+      QtBinariesDir = null;
     })
   ];
 

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -2,7 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   pkg-config,
   gnused,
   autoreconfHook,
@@ -55,20 +55,15 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "devdoc";
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      bash = "${bash}/bin/bash";
+    (replaceVars ./fix-paths.patch {
       false = "${coreutils}/bin/false";
       mdadm = "${mdadm}/bin/mdadm";
-      mkswap = "${util-linux}/bin/mkswap";
       sed = "${gnused}/bin/sed";
       sh = "${bash}/bin/sh";
       sleep = "${coreutils}/bin/sleep";
-      swapon = "${util-linux}/bin/swapon";
       true = "${coreutils}/bin/true";
     })
-    (substituteAll {
-      src = ./force-path.patch;
+    (replaceVars ./force-path.patch {
       path = lib.makeBinPath [
         btrfs-progs
         coreutils

--- a/pkgs/servers/home-assistant/default.nix
+++ b/pkgs/servers/home-assistant/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchPypi,
   python313,
-  substituteAll,
+  replaceVars,
   ffmpeg-headless,
   inetutils,
   nixosTests,
@@ -440,8 +440,7 @@ python.pkgs.buildPythonApplication rec {
     ./patches/static-follow-symlinks.patch
 
     # Patch path to ffmpeg binary
-    (substituteAll {
-      src = ./patches/ffmpeg-path.patch;
+    (replaceVars ./patches/ffmpeg-path.patch {
       ffmpeg = "${lib.getExe ffmpeg-headless}";
     })
   ];

--- a/pkgs/stdenv/generic/setup.sh
+++ b/pkgs/stdenv/generic/setup.sh
@@ -1042,19 +1042,15 @@ substituteStream() {
                 pattern="$2"
                 replacement="$3"
                 shift 3
-                local savedvar
-                savedvar="${!var}"
-                eval "$var"'=${'"$var"'//"$pattern"/"$replacement"}'
-                if [ "$pattern" != "$replacement" ]; then
-                    if [ "${!var}" == "$savedvar" ]; then
-                        if [ "$replace_mode" == --replace-warn ]; then
-                            printf "substituteStream() in derivation $name: WARNING: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
-                        elif [ "$replace_mode" == --replace-fail ]; then
-                            printf "substituteStream() in derivation $name: ERROR: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
-                            return 1
-                        fi
+                if ! [[ "${!var}" == *"$pattern"* ]]; then
+                    if [ "$replace_mode" == --replace-warn ]; then
+                        printf "substituteStream() in derivation $name: WARNING: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
+                    elif [ "$replace_mode" == --replace-fail ]; then
+                        printf "substituteStream() in derivation $name: ERROR: pattern %q doesn't match anything in %s\n" "$pattern" "$description" >&2
+                        return 1
                     fi
                 fi
+                eval "$var"'=${'"$var"'//"$pattern"/"$replacement"}'
                 ;;
 
             --subst-var)

--- a/pkgs/test/replace-vars/default.nix
+++ b/pkgs/test/replace-vars/default.nix
@@ -121,6 +121,30 @@ let
 
             touch $out
           '';
+
+      fails-in-check-phase-with-bad-exemption =
+        runCommand "replaceVars-fails"
+          {
+            failed =
+              let
+                src = builtins.toFile "source.txt" ''
+                  @a@
+                  @b@
+                '';
+              in
+              testBuildFailure (
+                callReplaceVars src {
+                  a = "a";
+                  b = null;
+                  c = null;
+                }
+              );
+          }
+          ''
+            grep -e "ERROR: pattern @c@ doesn't match anything in file.*source.txt" $failed/testBuildFailure.log
+
+            touch $out
+          '';
     };
 in
 {

--- a/pkgs/tools/inputmethods/ibus/default.nix
+++ b/pkgs/tools/inputmethods/ibus/default.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  substituteAll,
+  replaceVars,
   fetchFromGitHub,
   autoreconfHook,
   gettext,
@@ -71,10 +71,15 @@ stdenv.mkDerivation rec {
   };
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
+    (replaceVars ./fix-paths.patch {
       pythonInterpreter = python3Runtime.interpreter;
       pythonSitePackages = python3.sitePackages;
+      # patch context
+      prefix = null;
+      datarootdir = null;
+      localedir = null;
+      # removed line only
+      PYTHON = null;
     })
     ./build-without-dbus-launch.patch
   ];

--- a/pkgs/tools/misc/ckb-next/default.nix
+++ b/pkgs/tools/misc/ckb-next/default.nix
@@ -2,7 +2,7 @@
   lib,
   wrapQtAppsHook,
   fetchFromGitHub,
-  substituteAll,
+  replaceVars,
   udev,
   stdenv,
   pkg-config,
@@ -57,9 +57,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./install-dirs.patch
-    (substituteAll {
-      name = "ckb-next-modprobe.patch";
-      src = ./modprobe.patch;
+    (replaceVars ./modprobe.patch {
       inherit kmod;
     })
   ];

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -1,7 +1,7 @@
 { lib
 , stdenv
 , fetchurl
-, substituteAll
+, replaceVars
 , gettext
 , pkg-config
 , dbus
@@ -122,10 +122,11 @@ stdenv.mkDerivation rec {
   ];
 
   patches = [
-    (substituteAll {
-      src = ./fix-paths.patch;
-      inherit iputils openconnect ethtool gnused systemd;
+    (replaceVars ./fix-paths.patch {
+      inherit iputils openconnect ethtool gnused;
       inherit runtimeShell;
+      # patch context
+      OUTPUT = null;
     })
 
     # Meson does not support using different directories during build and


### PR DESCRIPTION
This replaces all remaining uses of `substituteAll` (the nix function) with `replaceVars` and `replaceVarsWith` for #237216.

The commit was created by:
- Running my [ast-grep based replacer](https://github.com/technowledgy/refactor-tractor/blob/main/rules/no-substitute-all-nix.yml) for substituteAll -> replaceVars.
- Fix everything that couldn't be done automatically.

Tested with:
- [`lint-replace-vars`](https://github.com/technowledgy/refactor-tractor/blob/main/rules/no-broken-replace-vars.yml) and
- [`build-replace-vars`](https://github.com/technowledgy/refactor-tractor/blob/main/scripts/build-replace-vars.nu)

The idea behind this approach to testing is described in https://github.com/technowledgy/refactor-tractor?tab=readme-ov-file#build-replace-vars.

## How to review?

Hop on the [refactor tractor](https://github.com/technowledgy/refactor-tractor):
- checkout this branch locally
- clone the refactor-tractor repo and enter its devshell
- run `build-replace-vars <path-to-checked-out-nixpkgs>`
- run `lint-replace-vars <path-to-checked-out-nixpkgs>`

Right now, there will be two build failures for lua, which are being fixed in #376792 and IIRC three linter errors, which have been fixed in #376728, but haven't made their way into this PR, yet.

If you want to see what's happening for the build command, do `NU_LOG_LEVEL=debug build-replace-vars ...` instead and see the expressions we're building fly by.

Instead of reviewing all the changes made in this PR, you could also re-run the `no-substitute-all <nixpkgs-path>` command from that repo on the base commit of this branch - and then compare the result of that to the HEAD of this branch. This would show the manual changes I made on top, a lot less to look at. On the flip-side - you'd probably have to dig into the ast-grep rules a bit as well ;)

## Things done

- Built on platform(s)
  - [x] x86_64-linux (via tools mentioned above)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
