### PR TITLE
s3drive: init at 1.11.2

### DIFF
--- a/pkgs/by-name/s3/s3drive/package.nix
+++ b/pkgs/by-name/s3/s3drive/package.nix
@@ -1,0 +1,128 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  gtk3,
+  cairo,
+  pango,
+  harfbuzz,
+  atk,
+  at-spi2-atk,
+  gdk-pixbuf,
+  glib,
+  libsecret,
+  mpv,
+  libepoxy,
+  curl,
+  ayatana-ido,
+  libayatana-common,
+  libayatana-indicator,
+  libayatana-appindicator,
+  libdbusmenu-gtk3,
+  fontconfig,
+  wayland,
+  flutter,
+  sentry-native,
+  libsodium,
+  sqlite,
+  patchelf,
+}:
+
+let
+  libs = [
+    stdenv.cc.cc
+    flutter
+    gtk3
+    cairo
+    pango
+    harfbuzz
+    atk
+    at-spi2-atk
+    gdk-pixbuf
+    glib
+    libepoxy
+    curl
+    libdbusmenu-gtk3
+    fontconfig
+    wayland
+    mpv
+    sentry-native
+    libsodium
+    sqlite
+    libsecret
+    ayatana-ido
+    libayatana-common
+    libayatana-indicator
+    libayatana-appindicator
+  ];
+
+  libPath = lib.makeLibraryPath libs;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "s3drive";
+  version = "1.11.2";
+
+  src = fetchurl {
+    url = "https://github.com/s3drive/deb-app/releases/download/${finalAttrs.version}/s3drive_amd64.deb";
+    sha256 = "sZkpLAZLnkMTMV+7pbeuuUiIljUpxAXCZeBxg6KUGc4=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    patchelf
+  ];
+
+  buildInputs = libs;
+
+  unpackPhase = ''
+    dpkg-deb -x $src .
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/s3drive
+    cp -r usr/local/lib/s3drive/* $out/lib/s3drive/
+    chmod -R +w $out/lib/s3drive
+
+    mkdir -p $out/bin
+    ln -sf $out/lib/s3drive/kapsa $out/bin/s3drive
+
+    mkdir -p $out/lib/s3drive/lib
+    ln -sf ${mpv}/lib/libmpv.so $out/lib/s3drive/lib/libmpv.so.1
+
+    rpath="${libPath}:$out/lib/s3drive/lib"
+
+    patchelf --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" \
+             --set-rpath "$rpath" \
+             $out/lib/s3drive/kapsa
+
+    find $out/lib/s3drive/lib -name "*.so*" -type f -exec \
+      patchelf --set-rpath "$rpath" {} \;
+
+
+    mkdir -p $out/share/icons/
+    cp usr/share/icons/kapsa.svg $out/share/icons/${finalAttrs.pname}.svg
+
+    mkdir -p $out/share/applications
+    cp usr/share/applications/kapsa.desktop $out/share/applications/${finalAttrs.pname}.desktop
+    substituteInPlace $out/share/applications/${finalAttrs.pname}.desktop \
+      --replace-fail "/usr/local/lib/${finalAttrs.pname}/kapsa" ${finalAttrs.pname} \
+      --replace-fail "Exec=kapsa" "Exec=${finalAttrs.pname}" \
+      --replace-fail "Icon=io.kapsa.drive" "Icon=$out/share/icons/${finalAttrs.pname}.svg"
+
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Personal storage compatible with S3, WebDav and 70+ other Rclone back-ends";
+    homepage = "https://s3drive.app/";
+    license = licenses.unfree;
+    maintainers = with maintainers; [ abueide ];
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = finalAttrs.pname;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

s3drive is a remote storage client that allows interfacing via rclone and s3 to allow easy mounting, syncing and e2ee across many different storage providers. Provides a friendly client for linux, mac, windows, and android/ios.

https://s3drive.app/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
