### PR TITLE
libsForQt5.extra-cmake-modules: fix for strictDeps

### DIFF
--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/default.nix
@@ -2,6 +2,7 @@
   mkDerivation,
   lib,
   fetchpatch,
+  bash,
   cmake,
   pkg-config,
 }:
@@ -19,10 +20,21 @@ mkDerivation {
 
   outputs = [ "out" ]; # this package has no runtime components
 
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    bash
+  ];
+
+  # note: these will be propagated into the same list extra-cmake-modules is in
   propagatedBuildInputs = [
     cmake
     pkg-config
   ];
+
+  strictDeps = true;
 
   setupHook = ./setup-hook.sh;
 

--- a/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
+++ b/pkgs/development/libraries/kde-frameworks/extra-cmake-modules/setup-hook.sh
@@ -1,3 +1,9 @@
+ecmCMakeFlags() {
+    appendToVar cmakeFlags "-DECM_DIR=@out@/share/ECM/cmake"
+}
+
+preConfigureHooks+=(ecmCMakeFlags)
+
 ecmEnvHook() {
     addToSearchPath XDG_DATA_DIRS "$1/share"
     addToSearchPath XDG_CONFIG_DIRS "$1/etc/xdg"


### PR DESCRIPTION
To fix ECM use in strictDeps builds (#178468), some changes are required.

1. New preConfigure hook to inform CMake about the existence of the package

Since extra-cmake-modules is put in nativeBuildInputs, it is not picked up correctly if strictDeps is true. Pass `-DECM_DIR=@out@/share/ECM/cmake` to fix it.

2. Bash is added as runtime dependency for some scripts (`share/ECM/kde-modules/kde-git-commit-hooks/{clang-format.sh,pre-commit.in}`)

## Things done

- Built on platform(s)
  - [x] x86_64-linux. Cross build is not relevant since ECM always goes in native inputs.
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of ~all~ some packages that depend on this change, just my usual reviews and update work. I have this patched for about two months already.
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).