### PR TITLE
boost: fix cross build if enablePython

### DIFF
--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -282,7 +282,7 @@ stdenv.mkDerivation {
     # b2 needs to be explicitly told how to find Python when cross-compiling
     + lib.optionalString enablePython ''
       cat << EOF >> user-config.jam
-      using python : : ${python.interpreter}
+      using python : : ${python.pythonOnBuildForHost.interpreter}
         : ${python}/include/python${python.pythonVersion}
         : ${python}/lib
         ;


### PR DESCRIPTION
A working Python interpreter is required to detect the Python version. Otherwise the build output for cross would be `boost_python.so`, while native builds contain `boost_python312.so` or similar.

This is required for cross builds of `python312Packages.pycuda` and certainly more packages.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).