### PR TITLE
firefox, thunderbird: disable wrapped derivations for Darwin

### DIFF
--- a/doc/packages/firefox.section.md
+++ b/doc/packages/firefox.section.md
@@ -2,6 +2,10 @@
 
 ## Build wrapped Firefox with extensions and policies {#build-wrapped-firefox-with-extensions-and-policies}
 
+:::{.note}
+The wrapper is not available on macOS.
+:::
+
 The `wrapFirefox` function allows to pass policies, preferences and extensions that are available to Firefox. With the help of `fetchFirefoxAddon` this allows to build a Firefox version that already comes with add-ons pre-installed:
 
 ```nix

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -469,6 +469,7 @@ let
         mainProgram = launcherName;
         hydraPlatforms = [];
         priority = (browser.meta.priority or lib.meta.defaultPriority) - 1; # prefer wrapper over the package
+        platforms = lib.lists.remove lib.platforms.darwin browser.meta.platforms;
       };
     });
 in lib.makeOverridable wrapper

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -26,8 +26,9 @@
 browser:
 
 let
+  appName = browser.binaryName or (lib.getName browser);
   wrapper =
-    { applicationName ? browser.binaryName or (lib.getName browser)
+    { applicationName ? appName
     , pname ? applicationName
     , version ? lib.getVersion browser
     , desktopName ? # applicationName with first letter capitalized
@@ -472,4 +473,8 @@ let
         platforms = lib.lists.remove lib.platforms.darwin browser.meta.platforms;
       };
     });
-in lib.makeOverridable wrapper
+in
+  if stdenv.isDarwin then
+    throw "Wrapped app is not supported on MacOS. Use ${appName}-unwrapped instead."
+  else
+    lib.makeOverridable wrapper


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

```
$ nix build --file . thunderbird
error:
       … while calling a functor (an attribute set with a '__functor' attribute)
         at /Users/ihrachys/src/nixpkgs/darwin-disable-wrapped-mozilla-apps/pkgs/applications/networking/mailreaders/thunderbird/wrapper.nix:10:2:
            9|
           10| (wrapFirefox browser (
             |  ^
           11|   {

       … while calling the 'throw' builtin
         at /Users/ihrachys/src/nixpkgs/darwin-disable-wrapped-mozilla-apps/pkgs/applications/networking/browsers/firefox/wrapper.nix:478:5:
          477|   if stdenv.isDarwin then
          478|     throw "Wrapped app is not supported on MacOS. Use ${applicationName}-unwrapped instead."
             |     ^
          479|   else

       error: Wrapped app is not supported on MacOS. Use thunderbird-unwrapped instead.
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
