### PR TITLE
nixos/mattermost: disable telemetry by default

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -34,6 +34,8 @@
 - `nixos-option` has been rewritten to a Nix expression called by a simple bash script. This lowers our maintenance threshold, makes eval errors less verbose, adds support for flake-based configurations, descending into `attrsOf` and `listOf` submodule options, and `--show-trace`.
 
 - The Mattermost module ({option}`services.mattermost`) and packages (`mattermost` and `mmctl`) have been substantially updated:
+  - {option}`services.mattermost.preferNixConfig` now defaults to true if you advance {option}`system.stateVersion` to 25.05. This means that if you have {option}`services.mattermost.mutableConfig` set, NixOS will override your settings to those that you define in the module. It is recommended to leave this at the default, even if you used a mutable config before, because it will ensure that your Mattermost data directories are correct. If you moved your data directories, you may want to review the module changes before upgrading.
+  - Mattermost telemetry reporting is now disabled by default, though security update notifications are enabled. Look at {option}`services.mattermost.telemetry` for options to control this behavior.
   - `pkgs.mattermostLatest` is now an option to track the latest (non-prerelease) Mattermost release. We test upgrade migrations from ESR releases (`pkgs.mattermost`) to `pkgs.mattermostLatest`.
   - The Mattermost frontend is now built from source and can be overridden.
     - Note that the Mattermost derivation containing both the webapp and server is now wrapped to allow them to be built independently, so overrides to both webapp and server look like `mattermost.overrideAttrs (prev: { webapp = prev.webapp.override { ... }; server = prev.server.override { ... }; })` now.

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -462,7 +462,10 @@ in
 
       preferNixConfig = mkOption {
         type = types.bool;
-        default = false;
+        default = versionAtLeast config.system.stateVersion "25.05";
+        defaultText = ''
+          versionAtLeast config.system.stateVersion "25.05";
+        '';
         description = ''
           If both mutableConfig and this option are set, the Nix configuration
           will take precedence over any settings configured in the server

--- a/nixos/modules/services/web-apps/mattermost.nix
+++ b/nixos/modules/services/web-apps/mattermost.nix
@@ -202,6 +202,7 @@ let
       ListenAddress = "${cfg.host}:${toString cfg.port}";
       LocalModeSocketLocation = cfg.socket.path;
       EnableLocalMode = cfg.socket.enable;
+      EnableSecurityFixAlert = cfg.telemetry.enableSecurityAlerts;
     };
     TeamSettings.SiteName = cfg.siteName;
     SqlSettings.DriverName = cfg.database.driver;
@@ -233,7 +234,13 @@ let
     FileSettings.Directory = cfg.dataDir;
     PluginSettings.Directory = "${pluginDir}/server";
     PluginSettings.ClientDirectory = "${pluginDir}/client";
-    LogSettings.FileLocation = cfg.logDir;
+    LogSettings = {
+      FileLocation = cfg.logDir;
+
+      # Reaches out to Mattermost's servers for telemetry; disable it by default.
+      # https://docs.mattermost.com/configure/environment-configuration-settings.html#enable-diagnostics-and-error-reporting
+      EnableDiagnostics = cfg.telemetry.enableDiagnostics;
+    };
   } cfg.settings;
 
   mattermostConf = recursiveUpdate mattermostConfWithoutPlugins (
@@ -472,6 +479,26 @@ in
           This is a list of paths to .tar.gz files or derivations evaluating to
           .tar.gz files.
         '';
+      };
+
+      telemetry = {
+        enableSecurityAlerts = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            True if we should enable security update checking. This reaches out to Mattermost's servers:
+            https://docs.mattermost.com/manage/telemetry.html#security-update-check-feature
+          '';
+        };
+
+        enableDiagnostics = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            True if we should enable sending diagnostic data. This reaches out to Mattermost's servers:
+            https://docs.mattermost.com/manage/telemetry.html#error-and-diagnostics-reporting-feature
+          '';
+        };
       };
 
       environment = mkOption {

--- a/nixos/tests/mattermost/default.nix
+++ b/nixos/tests/mattermost/default.nix
@@ -94,6 +94,7 @@ import ../make-test-python.nix (
         makeMattermost
           {
             mutableConfig = true;
+            preferNixConfig = false;
             settings.SupportSettings.HelpLink = "https://search.nixos.org";
           }
           {
@@ -105,7 +106,6 @@ import ../make-test-python.nix (
           };
       postgresMostlyMutable = makeMattermost {
         mutableConfig = true;
-        preferNixConfig = true;
         plugins = with pkgs; [
           # Build the demo plugin.
           (mattermost.buildPlugin {

--- a/nixos/tests/mattermost/default.nix
+++ b/nixos/tests/mattermost/default.nix
@@ -48,6 +48,7 @@ import ../make-test-python.nix (
               database = {
                 peerAuth = lib.mkDefault true;
               };
+              telemetry.enableSecurityAlerts = false;
               settings = {
                 SupportSettings.AboutLink = "https://nixos.org";
                 PluginSettings.AutomaticPrepackagedPlugins = false;


### PR DESCRIPTION
We should disable telemetry but enable security update checks. Make both controlable in the module without digging into settings.

Disabling telemetry also makes NixOS tests faster because the server tries to send telemetry on first start.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
