### PR TITLE
python3Packages.selenium: 4.27.1 -> 4.28.1

### DIFF
--- a/pkgs/development/python-modules/selenium/default.nix
+++ b/pkgs/development/python-modules/selenium/default.nix
@@ -20,17 +20,17 @@
 
 buildPythonPackage rec {
   pname = "selenium";
-  version = "4.27.1";
+  version = "4.28.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.7";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "SeleniumHQ";
     repo = "selenium";
     # check if there is a newer tag with or without -python suffix
     tag = "selenium-${version}-python";
-    hash = "sha256-XpTfZCERA2SmLOj6dcERVJ47K0gFhdXMTl9VCeE6eD8=";
+    hash = "sha256-1MmvngJO9l52qKJ7MTFe8mXabaGTjByR6k3xMVrDouA=";
   };
 
   patches = [ ./dont-build-the-selenium-manager.patch ];

--- a/pkgs/development/python-modules/selenium/dont-build-the-selenium-manager.patch
+++ b/pkgs/development/python-modules/selenium/dont-build-the-selenium-manager.patch
@@ -1,5 +1,5 @@
 diff --git a/py/pyproject.toml b/py/pyproject.toml
-index e99a03cd5d..1061adbdf5 100644
+index 2e5edb61d5..f95515810e 100644
 --- a/py/pyproject.toml
 +++ b/py/pyproject.toml
 @@ -1,5 +1,5 @@
@@ -9,47 +9,16 @@ index e99a03cd5d..1061adbdf5 100644
  build-backend = "setuptools.build_meta"
  
  [project]
-diff --git a/py/setup.py b/py/setup.py
-deleted file mode 100755
-index 0f93e33f0e..0000000000
---- a/py/setup.py
-+++ /dev/null
-@@ -1,38 +0,0 @@
--# Licensed to the Software Freedom Conservancy (SFC) under one
--# or more contributor license agreements.  See the NOTICE file
--# distributed with this work for additional information
--# regarding copyright ownership.  The SFC licenses this file
--# to you under the Apache License, Version 2.0 (the
--# "License"); you may not use this file except in compliance
--# with the License.  You may obtain a copy of the License at
--#
--#   http://www.apache.org/licenses/LICENSE-2.0
--#
--# Unless required by applicable law or agreed to in writing,
--# software distributed under the License is distributed on an
--# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
--# KIND, either express or implied.  See the License for the
--# specific language governing permissions and limitations
--# under the License.
+@@ -43,12 +43,6 @@ exclude = ["test*"]
+ namespaces = true
+ # include-package-data is `true` by default in pyproject.toml
+ 
+-[[tool.setuptools-rust.ext-modules]]
+-target = "selenium.webdriver.common.selenium-manager"
 -
--from distutils.command.install import INSTALL_SCHEMES
--from os.path import dirname, join, abspath
--from setuptools import setup
--from setuptools.command.install import install
--from setuptools_rust import Binding, RustExtension
+-[[tool.setuptools-rust.bins]]
+-target = "selenium.webdriver.common.selenium-manager"
 -
--
--for scheme in INSTALL_SCHEMES.values():
--    scheme['data'] = scheme['purelib']
--
--setup_args = {
--    'cmdclass': {'install': install},
--    'rust_extensions': [
--        RustExtension(
--            {"selenium-manager": "selenium.webdriver.common.selenium-manager"},
--            binding=Binding.Exec
--        )
--    ],
--}
--
--setup(**setup_args)
+ [project.urls]
+ Repository = "https://github.com/SeleniumHQ/selenium/"
+ BugTracker = "https://github.com/SeleniumHQ/selenium/issues"


### PR DESCRIPTION
Selenium 4.27.1 has a bug that breaks the branca package. Specifically, there is no __init__.py file in this directory: https://github.com/SeleniumHQ/selenium/tree/selenium-4.27.1-python/py/selenium/webdriver/common/fedcm

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
