### PR TITLE
blueberry: fix cross compilation

### DIFF
--- a/pkgs/by-name/bl/blueberry/package.nix
+++ b/pkgs/by-name/bl/blueberry/package.nix
@@ -13,9 +13,10 @@
   xapp,
 }:
 
-stdenv.mkDerivation rec {
+python3Packages.buildPythonApplication rec {
   pname = "blueberry";
   version = "1.4.8";
+  format = "other";
 
   src = fetchFromGitHub {
     owner = "linuxmint";
@@ -26,7 +27,6 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     gobject-introspection
-    python3Packages.wrapPython
     wrapGAppsHook3
   ];
 
@@ -34,7 +34,6 @@ stdenv.mkDerivation rec {
     bluez-tools
     gnome-bluetooth_1_0
     libnotify
-    python3Packages.python
     util-linux
     xapp
   ];

--- a/pkgs/by-name/bl/blueberry/package.nix
+++ b/pkgs/by-name/bl/blueberry/package.nix
@@ -53,28 +53,28 @@ stdenv.mkDerivation rec {
 
     # Fix paths
     substituteInPlace $out/bin/blueberry \
-      --replace /usr/lib/blueberry $out/lib/blueberry
+      --replace-fail /usr/lib/blueberry $out/lib/blueberry
     substituteInPlace $out/bin/blueberry-tray \
-      --replace /usr/lib/blueberry $out/lib/blueberry
+      --replace-fail /usr/lib/blueberry $out/lib/blueberry
     substituteInPlace $out/etc/xdg/autostart/blueberry-obex-agent.desktop \
-      --replace /usr/lib/blueberry $out/lib/blueberry
+      --replace-fail /usr/lib/blueberry $out/lib/blueberry
     substituteInPlace $out/etc/xdg/autostart/blueberry-tray.desktop \
-      --replace Exec=blueberry-tray Exec=$out/bin/blueberry-tray
+      --replace-fail Exec=blueberry-tray Exec=$out/bin/blueberry-tray
     substituteInPlace $out/lib/blueberry/blueberry-obex-agent.py \
-      --replace /usr/share $out/share
+      --replace-fail /usr/share $out/share
     substituteInPlace $out/lib/blueberry/blueberry-tray.py \
-      --replace /usr/share $out/share
+      --replace-fail /usr/share $out/share
     substituteInPlace $out/lib/blueberry/blueberry.py \
-      --replace '"bt-adapter"' '"${bluez-tools}/bin/bt-adapter"' \
-      --replace /usr/bin/pavucontrol ${pavucontrol}/bin/pavucontrol \
-      --replace /usr/lib/blueberry $out/lib/blueberry \
-      --replace /usr/share $out/share
+      --replace-fail '"bt-adapter"' '"${bluez-tools}/bin/bt-adapter"' \
+      --replace-fail /usr/bin/pavucontrol ${pavucontrol}/bin/pavucontrol \
+      --replace-fail /usr/lib/blueberry $out/lib/blueberry \
+      --replace-fail /usr/share $out/share
     substituteInPlace $out/lib/blueberry/rfkillMagic.py \
-      --replace /usr/bin/rfkill ${util-linux}/bin/rfkill \
-      --replace /usr/sbin/rfkill ${util-linux}/bin/rfkill \
-      --replace /usr/lib/blueberry $out/lib/blueberry
+      --replace-fail /usr/bin/rfkill ${util-linux}/bin/rfkill \
+      --replace-fail /usr/sbin/rfkill ${util-linux}/bin/rfkill \
+      --replace-fail /usr/lib/blueberry $out/lib/blueberry
     substituteInPlace $out/share/applications/blueberry.desktop \
-      --replace Exec=blueberry Exec=$out/bin/blueberry
+      --replace-fail Exec=blueberry Exec=$out/bin/blueberry
 
     glib-compile-schemas --strict $out/share/glib-2.0/schemas
 

--- a/pkgs/by-name/gn/gnome-bluetooth_1_0/package.nix
+++ b/pkgs/by-name/gn/gnome-bluetooth_1_0/package.nix
@@ -6,6 +6,7 @@
   gnome,
   adwaita-icon-theme,
   meson,
+  mesonEmulatorHook,
   ninja,
   pkg-config,
   gtk3,
@@ -51,20 +52,24 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  nativeBuildInputs = [
-    meson
-    ninja
-    gettext
-    itstool
-    pkg-config
-    libxml2
-    wrapGAppsHook3
-    gobject-introspection
-    gtk-doc
-    docbook-xsl-nons
-    docbook_xml_dtd_43
-    python3
-  ];
+  nativeBuildInputs =
+    [
+      meson
+      ninja
+      gettext
+      itstool
+      pkg-config
+      libxml2
+      wrapGAppsHook3
+      gobject-introspection
+      gtk-doc
+      docbook-xsl-nons
+      docbook_xml_dtd_43
+      python3
+    ]
+    ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
+      mesonEmulatorHook
+    ];
 
   buildInputs = [
     glib
@@ -85,6 +90,8 @@ stdenv.mkDerivation (finalAttrs: {
     chmod +x meson_post_install.py # patchShebangs requires executable file
     patchShebangs meson_post_install.py
   '';
+
+  strictDeps = true;
 
   passthru = {
     updateScript = gnome.updateScript {


### PR DESCRIPTION
- `nix-build -A pkgsCross.aarch64-multiplatform.blueberry`

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
