### PR TITLE
teamspeak-client: 5.0.0-beta77 -> 6.0.0-beta2

### DIFF
--- a/pkgs/applications/networking/instant-messengers/teamspeak/client6.nix
+++ b/pkgs/applications/networking/instant-messengers/teamspeak/client6.nix
@@ -21,19 +21,20 @@
   libpulseaudio,
   libxkbcommon,
   libgbm,
+  libGL,
   nss,
   udev,
   xorg,
 }:
 
 stdenv.mkDerivation rec {
-  pname = "teamspeak5-client";
-  version = "5.0.0-beta77";
+  pname = "teamspeak6-client";
+  version = "6.0.0-beta2";
 
   src = fetchurl {
     # check https://teamspeak.com/en/downloads/#ts5 for version and checksum
     url = "https://files.teamspeak-services.com/pre_releases/client/${version}/teamspeak-client.tar.gz";
-    sha256 = "6f3bf97b120d3c799cefc90c448e45836708a826d7caa07ad32b5c868eb9181b";
+    sha256 = "de334fbf7b90d91ced475a785d034b520e4856bbd6fdd71db6a5dd88624a552b";
   };
 
   sourceRoot = ".";
@@ -60,6 +61,7 @@ stdenv.mkDerivation rec {
     xorg.libXdamage
     xorg.libXfixes
     xorg.libxshmfence
+    xorg.libXtst
   ];
 
   nativeBuildInputs = [
@@ -96,7 +98,7 @@ stdenv.mkDerivation rec {
     cp logo-256.png $out/share/icons/hicolor/64x64/apps/${pname}.png
 
     makeWrapper $out/share/${pname}/TeamSpeak $out/bin/TeamSpeak \
-      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ udev ]}"
+      --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [ udev libGL ]}"
 
     runHook postInstall
   '';


### PR DESCRIPTION
Just making a cleaner and more adherent version of @TheRealRobin 's pull request.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
