### PR TITLE
vimPlugins.lze: 0.4.5 -> 0.5.0

### DIFF
--- a/pkgs/development/lua-modules/generated-packages.nix
+++ b/pkgs/development/lua-modules/generated-packages.nix
@@ -2565,14 +2565,14 @@ buildLuarocksPackage {
 lze = callPackage({ buildLuarocksPackage, fetchurl, fetchzip, luaOlder }:
 buildLuarocksPackage {
   pname = "lze";
-  version = "0.4.5-1";
+  version = "0.5.1-1";
   knownRockspec = (fetchurl {
-    url    = "mirror://luarocks/lze-0.4.5-1.rockspec";
-    sha256 = "1r029y9d8dvl5ynwspxq6168x0bg3qyf5m1x9yrqvb52mk0dyhbq";
+    url    = "mirror://luarocks/lze-0.5.1-1.rockspec";
+    sha256 = "0mh47481lyzam57lg1zqk1xkbz6549hyxgc3pbq495s5yxy5bpbr";
   }).outPath;
   src = fetchzip {
-    url    = "https://github.com/BirdeeHub/lze/archive/v0.4.5.zip";
-    sha256 = "0lsy7ikwqnpis8mwha4sl5i0v6x51xxravnsdjvy6fvcr6jbp51r";
+    url    = "https://github.com/BirdeeHub/lze/archive/v0.5.1.zip";
+    sha256 = "0xpdw2j8lvrhblfjdkpk6xg12qsy0r718j5c48pnxcph4sq44n5c";
   };
 
   disabled = luaOlder "5.1";


### PR DESCRIPTION
fixed slight mutability bug in beforeAll hook with startup plugins

Allowed handlers to accept false as a value and work properly

slight performance refactor

added lze.x by default rather than requiring setup step for them

This is a pure nvim lua plugin with no filesystem checks or outside dependencies