### PR TITLE
nixos/network-interfaces-systemd: remove unused arg in genericDhcpNetworks

### DIFF
--- a/nixos/modules/tasks/network-interfaces-systemd.nix
+++ b/nixos/modules/tasks/network-interfaces-systemd.nix
@@ -53,28 +53,26 @@ let
     )
   );
 
-  genericDhcpNetworks =
-    initrd:
-    mkIf cfg.useDHCP {
-      networks."99-ethernet-default-dhcp" = {
-        matchConfig = {
-          Type = "ether";
-          Kind = "!*"; # physical interfaces have no kind
-        };
-        DHCP = "yes";
-        networkConfig.IPv6PrivacyExtensions = "kernel";
+  genericDhcpNetworks = mkIf cfg.useDHCP {
+    networks."99-ethernet-default-dhcp" = {
+      matchConfig = {
+        Type = "ether";
+        Kind = "!*"; # physical interfaces have no kind
       };
-      networks."99-wireless-client-dhcp" = {
-        matchConfig.WLANInterfaceType = "station";
-        DHCP = "yes";
-        networkConfig.IPv6PrivacyExtensions = "kernel";
-        # We also set the route metric to one more than the default
-        # of 1024, so that Ethernet is preferred if both are
-        # available.
-        dhcpV4Config.RouteMetric = 1025;
-        ipv6AcceptRAConfig.RouteMetric = 1025;
-      };
+      DHCP = "yes";
+      networkConfig.IPv6PrivacyExtensions = "kernel";
     };
+    networks."99-wireless-client-dhcp" = {
+      matchConfig.WLANInterfaceType = "station";
+      DHCP = "yes";
+      networkConfig.IPv6PrivacyExtensions = "kernel";
+      # We also set the route metric to one more than the default
+      # of 1024, so that Ethernet is preferred if both are
+      # available.
+      dhcpV4Config.RouteMetric = 1025;
+      ipv6AcceptRAConfig.RouteMetric = 1025;
+    };
+  };
 
   interfaceNetworks = mkMerge (
     forEach interfaces (i: {
@@ -220,7 +218,7 @@ in
       # former, the user retains full control over the configuration.
       boot.initrd.systemd.network = mkMerge [
         defaultGateways
-        (genericDhcpNetworks true)
+        genericDhcpNetworks
         interfaceNetworks
         bridgeNetworks
         vlanNetworks
@@ -271,7 +269,7 @@ in
           enable = true;
         }
         defaultGateways
-        (genericDhcpNetworks false)
+        genericDhcpNetworks
         interfaceNetworks
         bridgeNetworks
         (mkMerge (


### PR DESCRIPTION
The first argument is not used (anymore).


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
