### PR TITLE
srsran: fix CPU option selection, split output

### DIFF
--- a/pkgs/by-name/sr/srsran/package.nix
+++ b/pkgs/by-name/sr/srsran/package.nix
@@ -31,6 +31,11 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-3cQMZ75I4cyHpik2d/eBuzw7M4OgbKqroCddycw4uW8=";
   };
 
+  outputs = [
+    "out"
+    "dev"
+  ];
+
   nativeBuildInputs = [
     cmake
     pkg-config
@@ -57,6 +62,9 @@ stdenv.mkDerivation rec {
     (lib.cmakeBool "ENABLE_AVX512" enableAvx512)
   ];
 
+  postInstall = lib.optionalString (!stdenv.hostPlatform.isStatic) ''
+    rm $out/lib/*.a
+  '';
 
   meta = with lib; {
     homepage = "https://www.srslte.com/";

--- a/pkgs/by-name/sr/srsran/package.nix
+++ b/pkgs/by-name/sr/srsran/package.nix
@@ -14,6 +14,10 @@
   soapysdr-with-plugins,
   libbladeRF,
   zeromq,
+  enableAvx ? stdenv.hostPlatform.avxSupport,
+  enableAvx2 ? stdenv.hostPlatform.avx2Support,
+  enableFma ? stdenv.hostPlatform.fmaSupport,
+  enableAvx512 ? stdenv.hostPlatform.avx512Support,
 }:
 
 stdenv.mkDerivation rec {
@@ -45,7 +49,14 @@ stdenv.mkDerivation rec {
     zeromq
   ];
 
-  cmakeFlags = [ "-DENABLE_WERROR=OFF" ];
+  cmakeFlags = [
+    "-DENABLE_WERROR=OFF"
+    (lib.cmakeBool "ENABLE_AVX" enableAvx)
+    (lib.cmakeBool "ENABLE_AVX2" enableAvx2)
+    (lib.cmakeBool "ENABLE_FMA" enableFma)
+    (lib.cmakeBool "ENABLE_AVX512" enableAvx512)
+  ];
+
 
   meta = with lib; {
     homepage = "https://www.srslte.com/";


### PR DESCRIPTION
srsran tries to autodetect CPU features such as AVX512 at build time. This leads to "illegal instruction" errors at run time when run on non-AVX512 CPU.
Explicitly enable/disable CPU flags based on stdenv capabilities instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
