### PR TITLE
libloragw-{2g4,sx1302}: fix cross build

### DIFF
--- a/pkgs/by-name/li/libloragw-2g4/package.nix
+++ b/pkgs/by-name/li/libloragw-2g4/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   preBuild = ''
-    make -C libtools
+    make -C libtools CROSS_COMPILE=${stdenv.cc.targetPrefix}
   '';
 
   installPhase = ''

--- a/pkgs/by-name/li/libloragw-sx1302/package.nix
+++ b/pkgs/by-name/li/libloragw-sx1302/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   preBuild = ''
-    make -C libtools
+    make -C libtools CROSS_COMPILE=${stdenv.cc.targetPrefix}
   '';
 
   installPhase = ''


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).