### PR TITLE
nps: init at 0.2.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17043,6 +17043,12 @@
     githubId = 72201;
     name = "Ole Jørgen Brønner";
   };
+  olemussmann = {
+    email = "nixpkgs-account@ole.mn";
+    github = "OleMussmann";
+    githubId = 14004859;
+    name = "Ole Mussmann";
+  };
   olifloof = {
     email = "benmoreosm@gmail.com";
     github = "olifloof";

--- a/pkgs/by-name/np/nps/package.nix
+++ b/pkgs/by-name/np/nps/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  nix,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "nps";
+  version = "0.2.9";
+
+  src = fetchFromGitHub {
+    owner = "OleMussmann";
+    repo = "nps";
+    tag = "v${version}";
+    hash = "sha256-q/PkigsNAI7MCmeDFBMGuZJFXVL95pQCNOVhNvBH9dc=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-MThyvhzZXRM4l0K8csLDldMVKiDxKZ5EIFATGVpGpVc=";
+
+  nativeCheckInputs = [ nix ];
+
+  meta = {
+    description = "Cache the nix package list, query and sort results by relevance";
+    longDescription = ''
+      Find SEARCH_TERM in available nix packages and sort results by relevance.
+
+      List up to three columns, the latter two being optional:
+      PACKAGE_NAME  <PACKAGE_VERSION>  <PACKAGE_DESCRIPTION>
+
+      Matches are sorted by type. Show 'indirect' matches first, then 'direct' matches, and finally 'exact' matches.
+
+        indirect  fooSEARCH_TERMbar (SEARCH_TERM appears in any column)
+        direct    SEARCH_TERMbar (PACKAGE_NAME starts with SEARCH_TERM)
+        exact     SEARCH_TERM (PACKAGE_NAME is exactly SEARCH_TERM)
+    '';
+    changelog = "https://github.com/OleMussmann/nps/releases/tag/v${version}";
+    homepage = "https://github.com/OleMussmann/nps";
+    license = lib.licenses.mit;
+    mainProgram = "nps";
+    maintainers = with lib.maintainers; [ olemussmann ];
+    platforms = lib.platforms.all;
+  };
+}


### PR DESCRIPTION
Adds the nps package at 0.2.9. Also adds @olemussmann as a maintainer of the package.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
