### PR TITLE
dbus-sharp{,-glib}-{1,2}_0: fix strictDeps build

### DIFF
--- a/pkgs/development/libraries/dbus-sharp-glib/dbus-sharp-glib-1.0.nix
+++ b/pkgs/development/libraries/dbus-sharp-glib/dbus-sharp-glib-1.0.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    mono # gmcs
   ];
   buildInputs = [
     mono

--- a/pkgs/development/libraries/dbus-sharp-glib/default.nix
+++ b/pkgs/development/libraries/dbus-sharp-glib/default.nix
@@ -23,6 +23,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    mono # gmcs
   ];
   buildInputs = [
     mono

--- a/pkgs/development/libraries/dbus-sharp/dbus-sharp-1.0.nix
+++ b/pkgs/development/libraries/dbus-sharp/dbus-sharp-1.0.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    mono # gmcs
   ];
   buildInputs = [ mono ];
 

--- a/pkgs/development/libraries/dbus-sharp/default.nix
+++ b/pkgs/development/libraries/dbus-sharp/default.nix
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     pkg-config
     autoreconfHook
+    mono4 # gmcs
   ];
 
   # Use msbuild when https://github.com/NixOS/nixpkgs/pull/43680 is merged


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

Cross is broken due to mono.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).