### PR TITLE
seafile-server: fix cross build

### DIFF
--- a/pkgs/by-name/se/seafile-server/package.nix
+++ b/pkgs/by-name/se/seafile-server/package.nix
@@ -51,6 +51,10 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     autoreconfHook
     pkg-config
+    python3
+    libsearpc # searpc-codegen.py
+    vala # valac
+    which
   ];
 
   buildInputs = [
@@ -64,8 +68,6 @@ stdenv.mkDerivation {
     fuse
     libarchive
     libjwt
-    which
-    vala
     libevhtp
     oniguruma
   ];


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

Confirmed that none of the build dependencies accidentally end up in the cross output.

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).