### PR TITLE
kdePackages: fetchCargoTarball -> fetchCargoVendor

### DIFF
--- a/pkgs/kde/gear/akonadi-search/default.nix
+++ b/pkgs/kde/gear/akonadi-search/default.nix
@@ -6,8 +6,6 @@
   rustPlatform,
   cargo,
   rustc,
-  # provided as callPackage input to enable easier overrides through overlays
-  cargoHash ? "sha256-ePvYL1ps2w7qscYNIgvjn6t/ir0izbS+MlP/jow4VrE=",
 }:
 mkKdeDerivation rec {
   pname = "akonadi-search";
@@ -15,12 +13,12 @@ mkKdeDerivation rec {
 
   cargoRoot = "agent/rs/htmlparser";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     # include version in the name so we invalidate the FOD
     name = "${pname}-${version}";
     src = sources.${pname};
     sourceRoot = "${pname}-${version}/${cargoRoot}";
-    hash = cargoHash;
+    hash = "sha256-fx8q7b0KGEevn0DlMAGgAvQMXqZmBF8aINDwpaGyq7I=";
   };
 
   extraNativeBuildInputs = [

--- a/pkgs/kde/gear/angelfish/default.nix
+++ b/pkgs/kde/gear/angelfish/default.nix
@@ -7,8 +7,6 @@
   rustPlatform,
   cargo,
   rustc,
-  # provided as callPackage input to enable easier overrides through overlays
-  cargoHash ? "sha256-Q8cKnW4IpcpNrECXtgkPX8TdYqC5Fo4oXm1lB8RULRo=",
   qcoro,
 }:
 mkKdeDerivation rec {
@@ -19,7 +17,7 @@ mkKdeDerivation rec {
     # include version in the name so we invalidate the FOD
     name = "${pname}-${version}";
     src = sources.${pname};
-    hash = cargoHash;
+    hash = "sha256-offD53HaPG0GQk+aPjRzhhc8d8wfHYmdaJ0X8NtluMU=";
   };
 
   extraNativeBuildInputs = [

--- a/pkgs/kde/gear/kdepim-addons/default.nix
+++ b/pkgs/kde/gear/kdepim-addons/default.nix
@@ -7,8 +7,6 @@
   discount,
   corrosion,
   alpaka,
-  # provided as callPackage input to enable easier overrides through overlays
-  cargoHash ? "sha256-LVPdcuKNPgT1kw9zOS04nd+5wuejDLyyhrK8EQfgY6A=",
 }:
 mkKdeDerivation rec {
   pname = "kdepim-addons";
@@ -17,12 +15,12 @@ mkKdeDerivation rec {
 
   cargoRoot = "plugins/webengineurlinterceptor/adblock";
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     # include version in the name so we invalidate the FOD
     name = "${pname}-${version}";
     src = sources.${pname};
     sourceRoot = "${pname}-${version}/${cargoRoot}";
-    hash = cargoHash;
+    hash = "sha256-v1TJ8xu4zXXig+ESYT0ZL6l1gOTbqyVA1P/6T/YnW0k=";
   };
 
   extraNativeBuildInputs = [


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor
again, once again invalidating fetchCargoTarball FOD hashes.  It's
time to fix this once and for all, switching across the board to
fetchCargoVendor, which is not dependent on cargo vendor's output
format.

Taking a cargoHash parameter isn't a good idea, because it will
produce a silently broken FOD if we change the hashing scheme, like
we're doing here.  Overlays should provide a full cargoDeps object,
which wouldn't have that problem, because the overlay would be
responsible for the whole FOD.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
