### PR TITLE
geogram: 1.8.6 -> 1.9.2

### DIFF
--- a/pkgs/by-name/ge/geogram/package.nix
+++ b/pkgs/by-name/ge/geogram/package.nix
@@ -1,30 +1,39 @@
 {
   lib,
   stdenv,
-  fetchurl,
   fetchFromGitHub,
-
   cmake,
   doxygen,
   zlib,
   python3Packages,
+  nix-update-script,
+  fetchpatch2,
 }:
 
 let
+  exploragram = fetchFromGitHub {
+    owner = "BrunoLevy";
+    repo = "exploragram";
+    rev = "3190f685653f8aa75b7c4604d008c59a999f1bb6";
+    hash = "sha256-9ePCOyQWSxu12PtHFSxfoDcvTtxvYR3T68sU3cAfZiE=";
+  };
   testdata = fetchFromGitHub {
     owner = "BrunoLevy";
     repo = "geogram.data";
-    rev = "43dd49054a78d9b3fb8ef729f48ab47a272c718c";
-    hash = "sha256-F2Lyt4nEOczVYLz6WLny+YrsxNwREBGPkProN8NHFN4=";
+    rev = "ceab6179189d23713b902b6f26ea2ff36aea1515";
+    hash = "sha256-zUmYI6+0IdDkglLzzWHS8ZKmc5O6aJ2X4IwRBouRIxI=";
   };
 in
 stdenv.mkDerivation rec {
   pname = "geogram";
-  version = "1.8.6";
+  version = "1.9.2";
 
-  src = fetchurl {
-    url = "https://github.com/BrunoLevy/geogram/releases/download/v${version}/geogram_${version}.tar.gz";
-    hash = "sha256-Xqha5HVqD2Ao0z++RKcQdMZUmtMb5eZ1DMJEVrfNUzE=";
+  src = fetchFromGitHub {
+    owner = "BrunoLevy";
+    repo = "geogram";
+    tag = "v${version}";
+    hash = "sha256-v7ChuE9F/z1MD5OUMiGXZWiGqjMauIka4sNXVDe/yYU=";
+    fetchSubmodules = true;
   };
 
   outputs = [
@@ -65,11 +74,22 @@ stdenv.mkDerivation rec {
     zlib
   ];
 
+  # exploragram library is not listed as submodule and must be copied manually
+  prePatch = ''
+    cp -r ${exploragram} ./src/lib/exploragram/ && chmod 755 ./src/lib/exploragram/
+  '';
+
   patches = [
     # This patch replaces the bundled (outdated) zlib with our zlib
     # Should be harmless, but if there are issues this patch can also be removed
     # Also check https://github.com/BrunoLevy/geogram/issues/49 for progress
     ./replace-bundled-zlib.patch
+
+    # fixes https://github.com/BrunoLevy/geogram/issues/203, remove when 1.9.3 is released
+    (fetchpatch2 {
+      url = "https://github.com/BrunoLevy/geogram/commit/2e1b6fba499ddc55b2150a1f610cf9f8d4934c39.patch";
+      hash = "sha256-t6Pocf3VT8HpKOSh1UKKa0QHpsZyFqlAng6ltiAfKA8=";
+    })
   ];
 
   postPatch = lib.optionalString stdenv.hostPlatform.isAarch64 ''
@@ -90,16 +110,12 @@ stdenv.mkDerivation rec {
   checkPhase =
     let
       skippedTests = [
-        # Failing tests as of version 1.8.3
-        "FileConvert"
-        "Reconstruct"
-        "Remesh"
-
         # Skip slow RVD test
         "RVD"
 
-        # Flaky as of 1.8.5 (SIGSEGV, possibly a use-after-free)
-        "Delaunay"
+        # Needs unfree library geogramplus with extended precision
+        # see https://github.com/BrunoLevy/geogram/wiki/GeogramPlus
+        "CSGplus"
       ];
     in
     ''
@@ -115,6 +131,8 @@ stdenv.mkDerivation rec {
       runHook postCheck
     '';
 
+  passthru.updateScript = nix-update-script { };
+
   meta = with lib; {
     description = "Programming Library with Geometric Algorithms";
     longDescription = ''
@@ -124,10 +142,6 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://github.com/BrunoLevy/geogram";
     license = licenses.bsd3;
-
-    # Broken on aarch64-linux as of version 1.8.3
-    # See https://github.com/BrunoLevy/geogram/issues/74
-    broken = stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64;
 
     platforms = [
       "x86_64-linux"


### PR DESCRIPTION
Upgrade geogram to new version, which should fix Aarch build. https://github.com/BrunoLevy/geogram

I cleaned-up the build a bit and switch to GitHub clone instead of downloading a tarball.

I am still struggling with the multi-output build. The CMake install only seems to copy two binaries out. I'd be glad if anyone can help.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
