### PR TITLE
doc: recommend fetchCargoVendor

### DIFF
--- a/doc/hooks/tauri.section.md
+++ b/doc/hooks/tauri.section.md
@@ -26,6 +26,7 @@ In Nixpkgs, `cargo-tauri.hook` overrides the default build and install phases.
 rustPlatform.buildRustPackage rec {
   # . . .
 
+  useFetchCargoVendor = true;
   cargoHash = "...";
 
   # Assuming our app's frontend uses `npm` as a package manager

--- a/doc/languages-frameworks/rust.section.md
+++ b/doc/languages-frameworks/rust.section.md
@@ -26,16 +26,17 @@ Rust applications are packaged by using the `buildRustPackage` helper from `rust
 
 rustPlatform.buildRustPackage rec {
   pname = "ripgrep";
-  version = "12.1.1";
+  version = "14.1.1";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = pname;
     rev = version;
-    hash = "sha256-+s5RBC3XSgb8omTbUNLywZnP6jSxZBKSS1BmXOjRF8M=";
+    hash = "sha256-gyWnahj1A+iXUQlQ1O1H1u7K5euYQOld9qWm99Vjaeg=";
   };
 
-  cargoHash = "sha256-jtBw4ahSl88L0iuCXxQgZVm1EcboWRJMNtjxLVTtzts=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-9atn5qyBDy4P6iUoHFhg+TV6Ur71fiah4oTJbBMeEy4=";
 
   meta = {
     description = "Fast line-oriented regex search tool, similar to ag and ack";
@@ -63,18 +64,7 @@ hash using `nix-hash --to-sri --type sha256 "<original sha256>"`.
 }
 ```
 
-Exception: If the application has cargo `git` dependencies, the `cargoHash`
-approach will not work by default. In this case, you can set `useFetchCargoVendor = true`
-to use an improved fetcher that supports handling `git` dependencies.
-
-```nix
-{
-  useFetchCargoVendor = true;
-  cargoHash = "sha256-RqPVFovDaD2rW31HyETJfQ0qVwFxoGEvqkIgag3H6KU=";
-}
-```
-
-If this method still does not work, you can resort to copying the `Cargo.lock` file into nixpkgs
+If this method does not work, you can resort to copying the `Cargo.lock` file into nixpkgs
 and importing it as described in the [next section](#importing-a-cargo.lock-file).
 
 Both types of hashes are permitted when contributing to nixpkgs. The
@@ -119,7 +109,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-aDQA4A5mScX9or3Lyiv/5GyAehidnpKKE0grhbP1Ctc=";
   };
 
-  cargoHash = "sha256-tbrTbutUs5aPSV+yE0IBUZAAytgmZV7Eqxia7g+9zRs=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-iDYh52rj1M5Uupvbx2WeDd/jvQZ+2A50V5rp5e2t7q4=";
   cargoDepsName = pname;
 
   # ...
@@ -443,14 +434,14 @@ hooks that can be used to integrate Cargo in non-Rust packages.
 
 Since network access is not allowed in sandboxed builds, Rust crate
 dependencies need to be retrieved using a fetcher. `rustPlatform`
-provides the `fetchCargoTarball` fetcher, which vendors all
+provides the `fetchCargoVendor` fetcher, which vendors all
 dependencies of a crate. For example, given a source path `src`
-containing `Cargo.toml` and `Cargo.lock`, `fetchCargoTarball`
+containing `Cargo.toml` and `Cargo.lock`, `fetchCargoVendor`
 can be used as follows:
 
 ```nix
 {
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     hash = "sha256-BoHIN/519Top1NUBjpB/oEMqi86Omt3zTQcXFWqrek0=";
   };
@@ -482,7 +473,7 @@ In case the lockfile contains cargo `git` dependencies, you can use
 ```
 
 If a `Cargo.lock` file is available, you can alternatively use the
-`importCargoLock` function. In contrast to `fetchCargoTarball`, this
+`importCargoLock` function. In contrast to `fetchCargoVendor`, this
 function does not require a hash (unless git dependencies are used)
 and fetches every dependency as a separate fixed-output derivation.
 `importCargoLock` can be used as follows:
@@ -521,12 +512,13 @@ you of the correct hash.
 `rustPlatform` provides the following hooks to automate Cargo builds:
 
 * `cargoSetupHook`: configure Cargo to use dependencies vendored
-  through `fetchCargoTarball`. This hook uses the `cargoDeps`
-  environment variable to find the vendored dependencies. If a project
-  already vendors its dependencies, the variable `cargoVendorDir` can
-  be used instead. When the `Cargo.toml`/`Cargo.lock` files are not in
-  `sourceRoot`, then the optional `cargoRoot` is used to specify the
-  Cargo root directory relative to `sourceRoot`.
+  through `fetchCargoVendor` or `importCargoLock`. This hook uses the
+  `cargoDeps` environment variable to find the vendored
+  dependencies. If a project already vendors its dependencies, the
+  variable `cargoVendorDir` can be used instead. When the
+  `Cargo.toml`/`Cargo.lock` files are not in `sourceRoot`, then the
+  optional `cargoRoot` is used to specify the Cargo root directory
+  relative to `sourceRoot`.
 * `cargoBuildHook`: use Cargo to build a crate. If the crate to be
   built is a crate in e.g. a Cargo workspace, the relative path to the
   crate to build can be set through the optional `buildAndTestSubdir`
@@ -557,7 +549,7 @@ you of the correct hash.
 #### Python package using `setuptools-rust` {#python-package-using-setuptools-rust}
 
 For Python packages using `setuptools-rust`, you can use
-`fetchCargoTarball` and `cargoSetupHook` to retrieve and set up Cargo
+`fetchCargoVendor` and `cargoSetupHook` to retrieve and set up Cargo
 dependencies. The build itself is then performed by
 `buildPythonPackage`.
 
@@ -586,9 +578,9 @@ buildPythonPackage rec {
     hash = "sha256-rQ2hRV52naEf6PvRsWVCTN7B1oXAQGmnpJw4iIdhamw=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src sourceRoot;
-    hash = "sha256-miW//pnOmww2i6SOGbkrAIdc/JMDT4FJLqdMFojZeoY=";
+    hash = "sha256-RO1m8wEd5Ic2M9q+zFHeCJWhCr4Sv3CEWd08mkxsBec=";
   };
 
   sourceRoot = "${src.name}/bindings/python";
@@ -609,7 +601,7 @@ directory.  In such cases, the `cargoRoot` attribute can be used to
 specify the crate's directory relative to `sourceRoot`. In the
 following example, the crate is in `src/rust`, as specified in the
 `cargoRoot` attribute. Note that we also need to specify the correct
-path for `fetchCargoTarball`.
+path for `fetchCargoVendor`.
 
 ```nix
 
@@ -629,10 +621,10 @@ buildPythonPackage rec {
     hash = "sha256-xGDilsjLOnls3MfVbGKnj80KCUCczZxlis5PmHzpNcQ=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
     sourceRoot = "${pname}-${version}/${cargoRoot}";
-    hash = "sha256-PS562W4L1NimqDV2H0jl5vYhL08H9est/pbIxSdYVfo=";
+    hash = "sha256-ctUt8maCjnGddKPf+Ii++wKsAXA1h+JM6zKQNXXwJqQ=";
   };
 
   cargoRoot = "src/rust";
@@ -644,9 +636,9 @@ buildPythonPackage rec {
 #### Python package using `maturin` {#python-package-using-maturin}
 
 Python packages that use [Maturin](https://github.com/PyO3/maturin)
-can be built with `fetchCargoTarball`, `cargoSetupHook`, and
+can be built with `fetchCargoVendor`, `cargoSetupHook`, and
 `maturinBuildHook`. For example, the following (partial) derivation
-builds the `retworkx` Python package. `fetchCargoTarball` and
+builds the `retworkx` Python package. `fetchCargoVendor` and
 `cargoSetupHook` are used to fetch and set up the crate dependencies.
 `maturinBuildHook` is used to perform the build.
 
@@ -669,9 +661,9 @@ buildPythonPackage rec {
     hash = "sha256-11n30ldg3y3y6qxg3hbj837pnbwjkqw3nxq6frds647mmmprrd20=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-heOBK8qi2nuc/Ib+I/vLzZ1fUUD/G/KTw9d7M4Hz5O0=";
+    hash = "sha256-QsPCQhNZKYCAogQriQX6pBYQUDAIUsEdRX/63dAqTzg=";
   };
 
   nativeBuildInputs = with rustPlatform; [ cargoSetupHook maturinBuildHook ];
@@ -682,7 +674,7 @@ buildPythonPackage rec {
 
 #### Rust package built with `meson` {#rust-package-built-with-meson}
 
-Some projects, especially GNOME applications, are built with the Meson Build System instead of calling Cargo directly. Using `rustPlatform.buildRustPackage` may successfully build the main program, but related files will be missing. Instead, you need to set up Cargo dependencies with `fetchCargoTarball` and `cargoSetupHook` and leave the rest to Meson. `rust` and `cargo` are still needed in `nativeBuildInputs` for Meson to use.
+Some projects, especially GNOME applications, are built with the Meson Build System instead of calling Cargo directly. Using `rustPlatform.buildRustPackage` may successfully build the main program, but related files will be missing. Instead, you need to set up Cargo dependencies with `fetchCargoVendor` and `cargoSetupHook` and leave the rest to Meson. `rust` and `cargo` are still needed in `nativeBuildInputs` for Meson to use.
 
 ```nix
 { lib
@@ -713,9 +705,9 @@ stdenv.mkDerivation rec {
     hash = "sha256-PrNPprSS98yN8b8yw2G6hzTSaoE65VbsM3q7FVB4mds=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit pname version src;
-    hash = "sha256-8fa3fa+sFi5H+49B5sr2vYPkp9C9s6CcE0zv4xB8gww=";
+    hash = "sha256-eR1ZGtTZQNhofFUEjI7IX16sMKPJmAl7aIFfPJukecg=";
   };
 
   nativeBuildInputs = [
@@ -998,16 +990,17 @@ in
 
 rustPlatform.buildRustPackage rec {
   pname = "ripgrep";
-  version = "12.1.1";
+  version = "14.1.1";
 
   src = fetchFromGitHub {
     owner = "BurntSushi";
     repo = "ripgrep";
     rev = version;
-    hash = "sha256-+s5RBC3XSgb8omTbUNLywZnP6jSxZBKSS1BmXOjRF8M=";
+    hash = "sha256-gyWnahj1A+iXUQlQ1O1H1u7K5euYQOld9qWm99Vjaeg=";
   };
 
-  cargoHash = "sha256-l1vL2ZdtDRxSGvP0X/l3nMw8+6WF67KPutJEzUROjg8=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-9atn5qyBDy4P6iUoHFhg+TV6Ur71fiah4oTJbBMeEy4=";
 
   doCheck = false;
 


### PR DESCRIPTION
Cargo 1.84.0 broke fetchCargoTarball hashes, so fetchCargoTarball is not long for this world.  Tell people to use fetchCargoVendor, which Nixpkgs is currently in the process of switching to across the tree.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
