### PR TITLE
various: replace substituteAll with replaceVars (left-overs for staging)

### DIFF
--- a/pkgs/build-support/buildenv/builder.pl
+++ b/pkgs/build-support/buildenv/builder.pl
@@ -1,5 +1,3 @@
-#! @perl@ -w
-
 use strict;
 use feature 'signatures';
 use Cwd 'abs_path';

--- a/pkgs/build-support/buildenv/default.nix
+++ b/pkgs/build-support/buildenv/default.nix
@@ -5,13 +5,12 @@
   buildPackages,
   runCommand,
   lib,
-  substituteAll,
+  replaceVars,
   writeClosure,
 }:
 
 let
-  builder = substituteAll {
-    src = ./builder.pl;
+  builder = replaceVars ./builder.pl {
     inherit (builtins) storeDir;
   };
 in

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -7,7 +7,7 @@
   makeWrapper,
   self,
   packageOverrides ? (final: prev: { }),
-  substituteAll,
+  replaceVars,
   pkgsBuildBuild,
   pkgsBuildHost,
   pkgsBuildTarget,
@@ -149,8 +149,7 @@ stdenv.mkDerivation (
     postInstall = ''
       mkdir -p "$out/nix-support" "$out/share/doc/lua" "$out/lib/pkgconfig"
       cp ${
-        substituteAll {
-          src = ./utils.sh;
+        replaceVars ./utils.sh {
           luapathsearchpaths = lib.escapeShellArgs finalAttrs.LuaPathSearchPaths;
           luacpathsearchpaths = lib.escapeShellArgs finalAttrs.LuaCPathSearchPaths;
         }

--- a/pkgs/development/interpreters/lua-5/utils.sh
+++ b/pkgs/development/interpreters/lua-5/utils.sh
@@ -118,15 +118,10 @@ buildLuaPath() {
 
   echo "BUILD_LUA_PATH"
 
-#   # set -x
 #   # Create an empty table of paths (see doc on loadFromPropagatedInputs
-#   # for how this is used). Build up the program_PATH and program_LUA_PATH
-#   # variables.
-  # declare -gA luaPathsSeen=()
+#   # for how this is used). Build up the program_PATH variable.
 #   # shellcheck disable=SC2034
   program_PATH=
-  luaPathsSeen["@lua@"]=1
-#   addToSearchPath program_PATH @lua@/bin
   for path in $luaPath; do
     _addToLuaPath "$path"
   done

--- a/pkgs/development/interpreters/luajit/default.nix
+++ b/pkgs/development/interpreters/luajit/default.nix
@@ -4,7 +4,7 @@
   buildPackages,
   version,
   src,
-  substituteAll,
+  replaceVars,
   extraMeta ? { },
   self,
   packageOverrides ? (final: prev: { }),
@@ -102,8 +102,7 @@ stdenv.mkDerivation (finalAttrs: {
   postInstall = ''
     mkdir -p $out/nix-support
     cp ${
-      substituteAll {
-        src = ../lua-5/utils.sh;
+      replaceVars ../lua-5/utils.sh {
         luapathsearchpaths = lib.escapeShellArgs finalAttrs.LuaPathSearchPaths;
         luacpathsearchpaths = lib.escapeShellArgs finalAttrs.LuaCPathSearchPaths;
       }

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -5,7 +5,7 @@
   fetchFromGitHub,
   fetchurl,
   pythonOlder,
-  substituteAll,
+  replaceVars,
 
   # build
   libpq,
@@ -45,8 +45,7 @@ let
   };
 
   patches = [
-    (substituteAll {
-      src = ./ctypes.patch;
+    (replaceVars ./ctypes.patch {
       libpq = "${libpq}/lib/libpq${stdenv.hostPlatform.extensions.sharedLibrary}";
       libc = "${stdenv.cc.libc}/lib/libc.so.6";
     })

--- a/pkgs/development/python-modules/pypass/default.nix
+++ b/pkgs/development/python-modules/pypass/default.nix
@@ -13,7 +13,7 @@
   pythonAtLeast,
   pytestCheckHook,
   setuptools,
-  substituteAll,
+  replaceVars,
   tree,
   xclip,
 }:
@@ -32,8 +32,7 @@ buildPythonPackage rec {
 
   # Set absolute nix store paths to the executables that pypass uses
   patches = [
-    (substituteAll {
-      src = ./mark-executables.patch;
+    (replaceVars ./mark-executables.patch {
       git_exec = "${gitMinimal}/bin/git";
       grep_exec = "${gnugrep}/bin/grep";
       gpg_exec = "${gnupg}/bin/gpg2";

--- a/pkgs/servers/sql/postgresql/generic.nix
+++ b/pkgs/servers/sql/postgresql/generic.nix
@@ -7,7 +7,7 @@ let
       fetchpatch,
       fetchurl,
       lib,
-      substituteAll,
+      replaceVars,
       writeShellScriptBin,
 
       # source specification
@@ -304,8 +304,7 @@ let
             hash = "sha256-EQJkDR0eb7QWCjyMzXMn+Vbcwx3MMdC83oN7XSVJP0U=";
           })
 
-          (substituteAll {
-            src = ./patches/locale-binary-path.patch;
+          (replaceVars ./patches/locale-binary-path.patch {
             locale = "${
               if stdenv.hostPlatform.isDarwin then darwin.adv_cmds else lib.getBin stdenv.cc.libc
             }/bin/locale";


### PR DESCRIPTION
Takes the left-overs from #376792 and #376800 to avoid merge conflicts and rebuilds.

For rationale see those PRs.

Tracking: #237216

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux via the refactor-tractor (see #376800)
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
