### PR TITLE
epick: update source commit and hash

### DIFF
--- a/pkgs/applications/graphics/epick/default.nix
+++ b/pkgs/applications/graphics/epick/default.nix
@@ -19,8 +19,9 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "vv9k";
     repo = pname;
-    rev = version;
-    sha256 = "sha256-k0WQu1n1sAHVor58jr060vD5/2rDrt1k5zzJlrK9WrU=";
+    # Upstream has rewritten tags on multiple occasions.
+    rev = "14ee92e049780406fffdc1e4a83bf1433775663f";
+    sha256 = "sha256-gjqAQrGJ9KFdzn2a3fOgu0VJ9zrX5stsbzriOGJaD/4=";
   };
 
   cargoHash = "sha256-OQZPOiMTpoWabxHa3TJG8L3zq8WxMeFttw8xggSXsMA=";


### PR DESCRIPTION
No activity upstream for three years, so not much point asking upstream about it.  Diff seems to be to things that we don't care about:

```diff
diff --git 1/nix/store/rlnw9ja3fs6kk52gwxxl80m75m0091dm-source/.github/workflows/release.yml 2/nix/store/n2wa70xwa4varqwj7xzavbl88cba5yi6-source/.github/workflows/release.yml index c08d9a4..af96564 100644
--- 1/nix/store/rlnw9ja3fs6kk52gwxxl80m75m0091dm-source/.github/workflows/release.yml +++ 2/nix/store/n2wa70xwa4varqwj7xzavbl88cba5yi6-source/.github/workflows/release.yml @@ -1,5 +1,3 @@
-#name: release
-
 on:
   push:
     branches:
@@ -40,7 +38,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [linux, windows-msvc]
         include:
         - build: linux
           os: ubuntu-latest
@@ -56,14 +53,18 @@ jobs:
       - name: Set up Rust
         uses: hecrj/setup-rust-action@v1
       - uses: actions/checkout@v3
-      - name: Set version
+      - name: Set version Unix
+        run: echo "EPICK_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        run: echo "EPICK_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-      - name: Set version
+      - name: Set archive name Unix
+        run: echo "EPICK_ARCHIVE=epick-${{ env.EPICK_VERSION }}-${{ matrix.target }}" >> $GITHUB_ENV
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      - name: Set version Windows
+        run: echo "EPICK_VERSION=$env:GITHUB_REF_NAME" >> $env:GITHUB_ENV
+        if: matrix.os == 'windows-latest'
+      - name: Set archive name Windows
+        run: echo "EPICK_ARCHIVE=epick-$env:EPICK_VERSION-${{ matrix.target }}" >> $env:GITHUB_ENV
         if: matrix.os == 'windows-latest'
-        run: echo "EPICK_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-      - name: Set archive name
-        run: echo "EPICK_ARCHIVE=epick-${{ env.EPICK_VERSION}}-${{ matrix.target}}" >> $GITHUB_ENV
       - name: Install dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
@@ -125,11 +126,16 @@ jobs:
       - name: Install pkger
         if: matrix.os == 'ubuntu-latest'
         run: |
-          curl -LO https://github.com/vv9k/pkger/releases/download/0.8.0/pkger-0.8.0-0.amd64.deb
-          sudo dpkg -i pkger-0.8.0-0.amd64.deb
+          curl -LO https://github.com/vv9k/pkger/releases/download/0.10.0/pkger-0.10.0-0.amd64.deb
+          sudo dpkg -i pkger-0.10.0-0.amd64.deb
           /usr/bin/pkger init
           mkdir -p $HOME/.config/pkger/recipes/epick
           cp pkger.yml $HOME/.config/pkger/recipes/epick/recipe.yaml
+      - name: Copy prebuilt archive
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cp ${{ env.EPICK_ARCHIVE }}.tar.gz $HOME/.config/pkger/recipes/epick/
+          tar zcvf $HOME/.config/pkger/recipes/epick/assets.tar.gz assets
       - name: Build RPM and DEB
         if: matrix.os == 'ubuntu-latest'
         run: /usr/bin/pkger build -s deb -s rpm -- epick
diff --git 1/nix/store/rlnw9ja3fs6kk52gwxxl80m75m0091dm-source/pkger.yml 2/nix/store/n2wa70xwa4varqwj7xzavbl88cba5yi6-source/pkger.yml
index 83d4d53..4fdf5e6 100644
--- 1/nix/store/rlnw9ja3fs6kk52gwxxl80m75m0091dm-source/pkger.yml
+++ 2/nix/store/n2wa70xwa4varqwj7xzavbl88cba5yi6-source/pkger.yml
@@ -5,23 +5,12 @@ metadata:
   version: 0.9.0
   description: Color picker for creating harmonic color palettes
   license: GPL-3.0
-  source: https://github.com/vv9k/$RECIPE/archive/refs/tags/$RECIPE_VERSION.tar.gz
-  build_depends:
-    pkger-deb: ['libxcb-render0-dev', 'libxcb-shape0-dev', 'libxcb-xfixes0-dev', 'libxkbcommon-dev']
-    pkger-rpm: ['libxcb-devel', 'libxkbcommon-devel', 'libxcb']
-    all:
-      - curl
-      - gcc
-      - pkg-config
-      - python3
-configure:
-  steps:
-    - cmd: curl -o /tmp/install_rust.sh https://sh.rustup.rs
-    - cmd: sh /tmp/install_rust.sh -y --default-toolchain stable
+  all_images: true
+  source:
+    - epick-0.9.0-x86_64-unknown-linux.tar.gz
+    - assets.tar.gz
 build:
-  working_dir: $PKGER_BLD_DIR/${RECIPE}-$RECIPE_VERSION
-  steps:
-    - cmd: $HOME/.cargo/bin/cargo build --release
+  steps: []
 install:
   steps:
     - cmd: >-
@@ -32,9 +21,9 @@ install:
           usr/share/icons/hicolor/48x48/apps \
           usr/share/icons/hicolor/scalable/apps \
           usr/share/applications
-    - cmd: install -m755 $PKGER_BLD_DIR/$RECIPE-$RECIPE_VERSION/target/release/$RECIPE usr/bin/
-    - cmd: install -m644 $PKGER_BLD_DIR/$RECIPE-$RECIPE_VERSION/LICENSE usr/share/licenses/$RECIPE/LICENSE
-    - cmd: install -m644 $PKGER_BLD_DIR/$RECIPE-$RECIPE_VERSION/README.md usr/share/doc/$RECIPE/README.md
-    - cmd: install -m644 $PKGER_BLD_DIR/$RECIPE-$RECIPE_VERSION/assets/icon.png usr/share/icons/hicolor/48x48/apps/$RECIPE.png
-    - cmd: install -m644 $PKGER_BLD_DIR/$RECIPE-$RECIPE_VERSION/assets/icon.svg usr/share/icons/hicolor/scalable/apps/$RECIPE.svg
-    - cmd: install -m644 $PKGER_BLD_DIR/$RECIPE-$RECIPE_VERSION/assets/$RECIPE.desktop usr/share/applications/$RECIPE.desktop
+    - cmd: install -m755 $PKGER_BLD_DIR/$RECIPE/$RECIPE usr/bin/
+    - cmd: install -m644 $PKGER_BLD_DIR/$RECIPE/LICENSE usr/share/licenses/$RECIPE/LICENSE
+    - cmd: install -m644 $PKGER_BLD_DIR/$RECIPE/README.md usr/share/doc/$RECIPE/README.md
+    - cmd: install -m644 $PKGER_BLD_DIR/assets/icon.png usr/share/icons/hicolor/48x48/apps/$RECIPE.png
+    - cmd: install -m644 $PKGER_BLD_DIR/assets/icon.svg usr/share/icons/hicolor/scalable/apps/$RECIPE.svg
+    - cmd: install -m644 $PKGER_BLD_DIR/assets/$RECIPE.desktop usr/share/applications/$RECIPE.desktop
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
