### PR TITLE
nixosTests.lxqt: init

### DIFF
--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -570,6 +570,7 @@ in {
   lomiri-gallery-app = runTest ./lomiri-gallery-app.nix;
   lomiri-system-settings = handleTest ./lomiri-system-settings.nix {};
   lorri = handleTest ./lorri/default.nix {};
+  lxqt = handleTest ./lxqt.nix {};
   ly = handleTest ./ly.nix {};
   maddy = discoverTests (import ./maddy { inherit handleTest; });
   maestral = handleTest ./maestral.nix {};

--- a/nixos/tests/lxqt.nix
+++ b/nixos/tests/lxqt.nix
@@ -1,0 +1,80 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+
+  {
+    name = "lxqt";
+
+    meta.maintainers = lib.teams.lxqt.members ++ [ lib.maintainers.bobby285271 ];
+
+    nodes.machine =
+      { ... }:
+
+      {
+        imports = [ ./common/user-account.nix ];
+
+        services.xserver.enable = true;
+        services.xserver.desktopManager.lxqt.enable = true;
+
+        services.displayManager = {
+          sddm.enable = true;
+          defaultSession = "lxqt";
+          autoLogin = {
+            enable = true;
+            user = "alice";
+          };
+        };
+      };
+
+    enableOCR = true;
+
+    testScript =
+      { nodes, ... }:
+      let
+        user = nodes.machine.users.users.alice;
+      in
+      ''
+        machine.wait_for_unit("display-manager.service")
+
+        with subtest("Wait for login"):
+            machine.wait_for_x()
+            machine.wait_for_file("/tmp/xauth_*")
+            machine.succeed("xauth merge /tmp/xauth_*")
+            machine.succeed("su - ${user.name} -c 'xauth merge /tmp/xauth_*'")
+
+        with subtest("Check that logging in has given the user ownership of devices"):
+            machine.succeed("getfacl -p /dev/snd/timer | grep -q ${user.name}")
+
+        with subtest("Check if LXQt components actually start"):
+            for i in ["openbox", "lxqt-session", "pcmanfm-qt", "lxqt-panel", "lxqt-runner"]:
+                machine.wait_until_succeeds(f"pgrep {i}")
+            machine.wait_for_window("pcmanfm-desktop0")
+            machine.wait_for_window("lxqt-panel")
+            machine.wait_for_text("(Computer|Network|Trash)")
+
+        with subtest("Open QTerminal"):
+            machine.succeed("su - ${user.name} -c 'DISPLAY=:0 qterminal >&2 &'")
+            machine.wait_until_succeeds("pgrep qterminal")
+            machine.wait_for_window("${user.name}@machine: ~")
+
+        with subtest("Open PCManFM-Qt"):
+            machine.succeed("mkdir -p /tmp/test/test")
+            machine.succeed("su - ${user.name} -c 'DISPLAY=:0 QT_SCALE_FACTOR=2 pcmanfm-qt /tmp/test >&2 &'")
+            machine.wait_for_window("test")
+            machine.wait_for_text("(test|Bookmarks|Reload)")
+
+        with subtest("Check if various environment variables are set"):
+            cmd = "xargs --null --max-args=1 echo < /proc/$(pgrep -xf /run/current-system/sw/bin/lxqt-panel)/environ"
+            machine.succeed(f"{cmd} | grep 'XDG_CURRENT_DESKTOP=LXQt'")
+            machine.succeed(f"{cmd} | grep 'QT_PLATFORM_PLUGIN=lxqt'")
+            # From login shell.
+            machine.succeed(f"{cmd} | grep '__NIXOS_SET_ENVIRONMENT_DONE=1'")
+            # See the nixos/lxqt module.
+            machine.succeed(f"{cmd} | grep 'XDG_CONFIG_DIRS' | grep '${nodes.machine.system.path}'")
+
+        with subtest("Check if any coredumps are found"):
+            machine.succeed("(coredumpctl --json=short 2>&1 || true) | grep 'No coredumps found'")
+            machine.sleep(10)
+            machine.screenshot("screen")
+      '';
+  }
+)


### PR DESCRIPTION


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

cc @romildo