### PR TITLE
nextcloudPackages.apps.collectives: init at 2.16.0

### DIFF
--- a/pkgs/servers/nextcloud/packages/28.json
+++ b/pkgs/servers/nextcloud/packages/28.json
@@ -19,6 +19,16 @@
       "agpl"
     ]
   },
+  "collectives": {
+    "hash": "sha256-IAnJZuaj6KW6kF4daIKxvCEDCViWu30gogm8q2/ooQs=",
+    "url": "https://github.com/nextcloud/collectives/releases/download/v2.16.0/collectives-2.16.0.tar.gz",
+    "version": "2.16.0",
+    "description": "Collectives is a Nextcloud App for activist and community projects to organize together.\nCome and gather in collectives to build shared knowledge.\n\n* 👥 **Collective and non-hierarchical workflow by heart**: Collectives are\n  tied to a [Nextcloud Team](https://github.com/nextcloud/circles) and\n  owned by the collective.\n* 📝 **Collaborative page editing** like known from Etherpad thanks to the\n  [Text app](https://github.com/nextcloud/text).\n* 🔤 **Well-known [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax**\n  for page formatting.\n\n## Installation\n\nIn your Nextcloud instance, simply navigate to **»Apps«**, find the\n**»Teams«** and **»Collectives«** apps and enable them.",
+    "homepage": "https://github.com/nextcloud/collectives",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "contacts": {
     "hash": "sha256-zxmgMiizzXGfReRS9XJ+fb6tJRLH/Z5NvuLpspYARFI=",
     "url": "https://github.com/nextcloud-releases/contacts/releases/download/v5.5.3/contacts-v5.5.3.tar.gz",

--- a/pkgs/servers/nextcloud/packages/29.json
+++ b/pkgs/servers/nextcloud/packages/29.json
@@ -19,6 +19,16 @@
       "agpl"
     ]
   },
+  "collectives": {
+    "hash": "sha256-IAnJZuaj6KW6kF4daIKxvCEDCViWu30gogm8q2/ooQs=",
+    "url": "https://github.com/nextcloud/collectives/releases/download/v2.16.0/collectives-2.16.0.tar.gz",
+    "version": "2.16.0",
+    "description": "Collectives is a Nextcloud App for activist and community projects to organize together.\nCome and gather in collectives to build shared knowledge.\n\n* 👥 **Collective and non-hierarchical workflow by heart**: Collectives are\n  tied to a [Nextcloud Team](https://github.com/nextcloud/circles) and\n  owned by the collective.\n* 📝 **Collaborative page editing** like known from Etherpad thanks to the\n  [Text app](https://github.com/nextcloud/text).\n* 🔤 **Well-known [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax**\n  for page formatting.\n\n## Installation\n\nIn your Nextcloud instance, simply navigate to **»Apps«**, find the\n**»Teams«** and **»Collectives«** apps and enable them.",
+    "homepage": "https://github.com/nextcloud/collectives",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "contacts": {
     "hash": "sha256-hqCDr7qEqsi8tZ9Woz9hsUm1HENK16FNz4pcQCto8S4=",
     "url": "https://github.com/nextcloud-releases/contacts/releases/download/v6.0.2/contacts-v6.0.2.tar.gz",

--- a/pkgs/servers/nextcloud/packages/30.json
+++ b/pkgs/servers/nextcloud/packages/30.json
@@ -19,6 +19,16 @@
       "agpl"
     ]
   },
+  "collectives": {
+    "hash": "sha256-IAnJZuaj6KW6kF4daIKxvCEDCViWu30gogm8q2/ooQs=",
+    "url": "https://github.com/nextcloud/collectives/releases/download/v2.16.0/collectives-2.16.0.tar.gz",
+    "version": "2.16.0",
+    "description": "Collectives is a Nextcloud App for activist and community projects to organize together.\nCome and gather in collectives to build shared knowledge.\n\n* 👥 **Collective and non-hierarchical workflow by heart**: Collectives are\n  tied to a [Nextcloud Team](https://github.com/nextcloud/circles) and\n  owned by the collective.\n* 📝 **Collaborative page editing** like known from Etherpad thanks to the\n  [Text app](https://github.com/nextcloud/text).\n* 🔤 **Well-known [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax**\n  for page formatting.\n\n## Installation\n\nIn your Nextcloud instance, simply navigate to **»Apps«**, find the\n**»Teams«** and **»Collectives«** apps and enable them.",
+    "homepage": "https://github.com/nextcloud/collectives",
+    "licenses": [
+      "agpl"
+    ]
+  },
   "contacts": {
     "hash": "sha256-5h94RmmJcM7P0Wjx/hHDbUA55x3H/klOjkmH3qxMbpQ=",
     "url": "https://github.com/nextcloud-releases/contacts/releases/download/v6.1.3/contacts-v6.1.3.tar.gz",

--- a/pkgs/servers/nextcloud/packages/nextcloud-apps.json
+++ b/pkgs/servers/nextcloud/packages/nextcloud-apps.json
@@ -1,6 +1,7 @@
 {
   "bookmarks": "agpl3Plus"
 , "calendar": "agpl3Plus"
+, "collectives": "agpl3Plus"
 , "contacts": "agpl3Plus"
 , "cookbook": "agpl3Plus"
 , "cospend": "agpl3Plus"


### PR DESCRIPTION
Adds the [Collectives](https://apps.nextcloud.com/apps/collectives) app:

> Collectives is a Nextcloud App for activist and community projects to organize together. Come and gather in collectives to build shared knowledge.

It is licensed as AGPL-3.0-or-later:
- https://github.com/nextcloud/collectives/blob/a3fc489a383060b6ccc66e6b8a66029a65aad53d/appinfo/info.xml#L30
- https://api.reuse.software/info/github.com/nextcloud/collectives

CC @schneefux @bachp @globin @Ma27 @britter

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
