### PR TITLE
googleearth-pro: fix strictDeps build

### DIFF
--- a/pkgs/applications/misc/googleearth-pro/default.nix
+++ b/pkgs/applications/misc/googleearth-pro/default.nix
@@ -9,6 +9,8 @@
   libGLU,
   libSM,
 
+  libXcomposite,
+  libXi,
   libXrender,
   libX11,
 
@@ -63,6 +65,8 @@ mkDerivation rec {
     libGLU
     libSM
     libX11
+    libXcomposite
+    libXi
     libXrender
     libproxy
     libxcb


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

It seems these libraries were previously propagated from somewhere, which no longer applies if you set `strictDeps = true`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).