### PR TITLE
gg-jj: fetchCargoTarball -> fetchCargoVendor

### DIFF
--- a/pkgs/by-name/gg/gg-jj/native-tls.patch
+++ b/pkgs/by-name/gg/gg-jj/native-tls.patch
@@ -1,0 +1,351 @@
+diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
+index 37a1a2d..45640a1 100644
+--- a/src-tauri/Cargo.lock
++++ b/src-tauri/Cargo.lock
+@@ -778,9 +778,9 @@ dependencies = [
+  "bitflags 2.6.0",
+  "block",
+  "cocoa-foundation",
+- "core-foundation",
++ "core-foundation 0.10.0",
+  "core-graphics",
+- "foreign-types",
++ "foreign-types 0.5.0",
+  "libc",
+  "objc",
+ ]
+@@ -793,7 +793,7 @@ checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
+ dependencies = [
+  "bitflags 2.6.0",
+  "block",
+- "core-foundation",
++ "core-foundation 0.10.0",
+  "core-graphics-types",
+  "libc",
+  "objc",
+@@ -873,6 +873,16 @@ dependencies = [
+  "version_check",
+ ]
+ 
++[[package]]
++name = "core-foundation"
++version = "0.9.4"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
++dependencies = [
++ "core-foundation-sys",
++ "libc",
++]
++
+ [[package]]
+ name = "core-foundation"
+ version = "0.10.0"
+@@ -896,9 +906,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+ dependencies = [
+  "bitflags 2.6.0",
+- "core-foundation",
++ "core-foundation 0.10.0",
+  "core-graphics-types",
+- "foreign-types",
++ "foreign-types 0.5.0",
+  "libc",
+ ]
+ 
+@@ -909,7 +919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+ dependencies = [
+  "bitflags 2.6.0",
+- "core-foundation",
++ "core-foundation 0.10.0",
+  "libc",
+ ]
+ 
+@@ -1435,6 +1445,15 @@ version = "0.1.3"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+ 
++[[package]]
++name = "foreign-types"
++version = "0.3.2"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
++dependencies = [
++ "foreign-types-shared 0.1.1",
++]
++
+ [[package]]
+ name = "foreign-types"
+ version = "0.5.0"
+@@ -1442,7 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+ dependencies = [
+  "foreign-types-macros",
+- "foreign-types-shared",
++ "foreign-types-shared 0.3.1",
+ ]
+ 
+ [[package]]
+@@ -1456,6 +1475,12 @@ dependencies = [
+  "syn 2.0.87",
+ ]
+ 
++[[package]]
++name = "foreign-types-shared"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
++
+ [[package]]
+ name = "foreign-types-shared"
+ version = "0.3.1"
+@@ -2779,6 +2804,22 @@ dependencies = [
+  "want",
+ ]
+ 
++[[package]]
++name = "hyper-tls"
++version = "0.6.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
++dependencies = [
++ "bytes",
++ "http-body-util",
++ "hyper",
++ "hyper-util",
++ "native-tls",
++ "tokio",
++ "tokio-native-tls",
++ "tower-service",
++]
++
+ [[package]]
+ name = "hyper-util"
+ version = "0.1.10"
+@@ -3418,9 +3459,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.163"
++version = "0.2.164"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1fdaeca4cf44ed4ac623e86ef41f056e848dbeab7ec043ecb7326ba300b36fd0"
++checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+ 
+ [[package]]
+ name = "libgit2-sys"
+@@ -3453,7 +3494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+ dependencies = [
+  "cfg-if",
+- "windows-targets 0.52.6",
++ "windows-targets 0.48.5",
+ ]
+ 
+ [[package]]
+@@ -3688,6 +3729,23 @@ dependencies = [
+  "windows-sys 0.59.0",
+ ]
+ 
++[[package]]
++name = "native-tls"
++version = "0.2.13"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
++dependencies = [
++ "libc",
++ "log",
++ "openssl",
++ "openssl-probe",
++ "openssl-sys",
++ "schannel",
++ "security-framework",
++ "security-framework-sys",
++ "tempfile",
++]
++
+ [[package]]
+ name = "ndk"
+ version = "0.9.0"
+@@ -4065,6 +4123,32 @@ dependencies = [
+  "pathdiff",
+ ]
+ 
++[[package]]
++name = "openssl"
++version = "0.10.69"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
++dependencies = [
++ "bitflags 2.6.0",
++ "cfg-if",
++ "foreign-types 0.3.2",
++ "libc",
++ "once_cell",
++ "openssl-macros",
++ "openssl-sys",
++]
++
++[[package]]
++name = "openssl-macros"
++version = "0.1.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
++dependencies = [
++ "proc-macro2",
++ "quote",
++ "syn 2.0.87",
++]
++
+ [[package]]
+ name = "openssl-probe"
+ version = "0.1.5"
+@@ -4854,19 +4938,23 @@ dependencies = [
+  "http-body",
+  "http-body-util",
+  "hyper",
++ "hyper-tls",
+  "hyper-util",
+  "ipnet",
+  "js-sys",
+  "log",
+  "mime",
++ "native-tls",
+  "once_cell",
+  "percent-encoding",
+  "pin-project-lite",
++ "rustls-pemfile",
+  "serde",
+  "serde_json",
+  "serde_urlencoded",
+  "sync_wrapper",
+  "tokio",
++ "tokio-native-tls",
+  "tokio-util 0.7.12",
+  "tower-service",
+  "url",
+@@ -5000,6 +5088,21 @@ dependencies = [
+  "windows-sys 0.52.0",
+ ]
+ 
++[[package]]
++name = "rustls-pemfile"
++version = "2.2.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
++dependencies = [
++ "rustls-pki-types",
++]
++
++[[package]]
++name = "rustls-pki-types"
++version = "1.10.0"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
++
+ [[package]]
+ name = "rustversion"
+ version = "1.0.18"
+@@ -5027,6 +5130,15 @@ version = "0.1.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "088c5d71572124929ea7549a8ce98e1a6fd33d0a38367b09027b382e67c033db"
+ 
++[[package]]
++name = "schannel"
++version = "0.1.26"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
++dependencies = [
++ "windows-sys 0.59.0",
++]
++
+ [[package]]
+ name = "schemars"
+ version = "0.8.21"
+@@ -5089,6 +5201,29 @@ version = "4.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+ 
++[[package]]
++name = "security-framework"
++version = "2.11.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
++dependencies = [
++ "bitflags 2.6.0",
++ "core-foundation 0.9.4",
++ "core-foundation-sys",
++ "libc",
++ "security-framework-sys",
++]
++
++[[package]]
++name = "security-framework-sys"
++version = "2.12.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
++dependencies = [
++ "core-foundation-sys",
++ "libc",
++]
++
+ [[package]]
+ name = "selectors"
+ version = "0.22.0"
+@@ -5436,7 +5571,7 @@ dependencies = [
+  "bytemuck",
+  "cfg_aliases",
+  "core-graphics",
+- "foreign-types",
++ "foreign-types 0.5.0",
+  "js-sys",
+  "log",
+  "objc2",
+@@ -5631,7 +5766,7 @@ checksum = "6682a07cf5bab0b8a2bd20d0a542917ab928b5edb75ebd4eda6b05cbaab872da"
+ dependencies = [
+  "bitflags 2.6.0",
+  "cocoa",
+- "core-foundation",
++ "core-foundation 0.10.0",
+  "core-graphics",
+  "crossbeam-channel",
+  "dispatch",
+@@ -6208,6 +6343,16 @@ dependencies = [
+  "syn 2.0.87",
+ ]
+ 
++[[package]]
++name = "tokio-native-tls"
++version = "0.3.1"
++source = "registry+https://github.com/rust-lang/crates.io-index"
++checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
++dependencies = [
++ "native-tls",
++ "tokio",
++]
++
+ [[package]]
+ name = "tokio-util"
+ version = "0.6.10"
+@@ -7006,7 +7151,7 @@ version = "0.1.9"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+ dependencies = [
+- "windows-sys 0.59.0",
++ "windows-sys 0.48.0",
+ ]
+ 
+ [[package]]
+diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
+index 550b0cf..9b711a4 100644
+--- a/src-tauri/Cargo.toml
++++ b/src-tauri/Cargo.toml
+@@ -14,7 +14,7 @@ zip = "0.6"
+ assert_matches = "1.5"
+ 
+ [dependencies]
+-tauri = { version = "2.0.0", features = [] }
++tauri = { version = "2.0.0", features = ["native-tls"] }
+ tauri-codegen = "2.0.0"
+ tauri-macros = "2.0.0"
+ tauri-plugin = "2.0.0"

--- a/pkgs/by-name/gg/gg-jj/package.nix
+++ b/pkgs/by-name/gg/gg-jj/package.nix
@@ -37,13 +37,18 @@ stdenv.mkDerivation (finalAttrs: {
   buildAndTestSubdir = "src-tauri";
 
   # FIXME: Switch back to cargoHash when https://github.com/NixOS/nixpkgs/issues/356811 is fixed
-  cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) pname version src patches;
+  cargoDeps = rustPlatform.fetchCargoVendor {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      patches
+      ;
     # Tries to apply patches inside cargoRoot.
     prePatch = "pushd ..";
     postPatch = "popd";
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
-    hash = "sha256-inwETdMRKmJklkdjkcGuJuHaXwa5GyJEk7zo2r2li+M=";
+    hash = "sha256-zEYU5l57VxVKKhoGfa77kT05vwoLyAu9eyt7C9dhAGM=";
   };
 
   npmDeps = fetchNpmDeps {

--- a/pkgs/by-name/gg/gg-jj/package.nix
+++ b/pkgs/by-name/gg/gg-jj/package.nix
@@ -32,22 +32,18 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-iQxPJgMxBtyindkNdQkehwPf7ZgWCI09PToqs2y1Hfw=";
   };
 
+  patches = [ ./native-tls.patch ];
   cargoRoot = "src-tauri";
   buildAndTestSubdir = "src-tauri";
 
   # FIXME: Switch back to cargoHash when https://github.com/NixOS/nixpkgs/issues/356811 is fixed
   cargoDeps = rustPlatform.fetchCargoTarball {
-    inherit (finalAttrs) pname version src;
+    inherit (finalAttrs) pname version src patches;
+    # Tries to apply patches inside cargoRoot.
+    prePatch = "pushd ..";
+    postPatch = "popd";
     sourceRoot = "${finalAttrs.src.name}/${finalAttrs.cargoRoot}";
-    hash = "sha256-Lr/0GkWHvfDy/leRLxisuTzGPZYFo2beHq9UCl6XlDo=";
-
-    nativeBuildInputs = [ yq ];
-
-    # Work around https://github.com/rust-lang/cargo/issues/10801
-    # See https://discourse.nixos.org/t/rust-tauri-v2-error-no-matching-package-found/56751/4
-    preBuild = ''
-      tomlq -it '.dependencies.tauri.features += ["native-tls"]' Cargo.toml
-    '';
+    hash = "sha256-inwETdMRKmJklkdjkcGuJuHaXwa5GyJEk7zo2r2li+M=";
   };
 
   npmDeps = fetchNpmDeps {


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
