### PR TITLE
daggerfall-unity: Fix desktop shortcut issues

### DIFF
--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -73,9 +73,10 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir --parents "$out/bin" "$out/share/doc"
+    mkdir --parents "$out/bin" "$out/share/doc" "$out/share/pixmaps/"
     cp --recursive * "$out"
     ln --symbolic "../${finalAttrs.meta.mainProgram}" "$out/bin/"
+    ln --symbolic ../../DaggerfallUnity_Data/Resources/UnityPlayer.png "$out/share/pixmaps/"
 
     ${lib.strings.concatMapStringsSep "\n" (file: ''
       cp "${file}" "$out/share/doc/${file.name}"

--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -91,7 +91,7 @@ stdenv.mkDerivation (finalAttrs: {
       desktopName = "Daggerfall Unity";
       comment = finalAttrs.meta.description;
       icon = "UnityPlayer";
-      exec = "DaggerfallUnity.x86_64";
+      exec = finalAttrs.meta.mainProgram;
       categories = [ "Game" ];
     })
   ];

--- a/pkgs/by-name/da/daggerfall-unity/package.nix
+++ b/pkgs/by-name/da/daggerfall-unity/package.nix
@@ -73,8 +73,9 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir --parents "$out/share/doc/"
+    mkdir --parents "$out/bin" "$out/share/doc"
     cp --recursive * "$out"
+    ln --symbolic "../${finalAttrs.meta.mainProgram}" "$out/bin/"
 
     ${lib.strings.concatMapStringsSep "\n" (file: ''
       cp "${file}" "$out/share/doc/${file.name}"


### PR DESCRIPTION
Resolves #376877.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] `nix run .#daggerfall-unity`
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
