### PR TITLE
nifskope: fix zlib build

### DIFF
--- a/pkgs/tools/graphics/nifskope/default.nix
+++ b/pkgs/tools/graphics/nifskope/default.nix
@@ -7,6 +7,7 @@
   qttools,
   replaceVars,
   libGLU,
+  zlib,
   wrapQtAppsHook,
   fetchpatch,
 }:
@@ -19,12 +20,13 @@ stdenv.mkDerivation {
     owner = "niftools";
     repo = "nifskope";
     rev = "47b788d26ae0fa12e60e8e7a4f0fa945a510c7b2"; # `v${version}` doesn't work with submodules
-    sha256 = "1wqpn53rkq28ws3apqghkzyrib4wis91x171ns64g8kp4q6mfczi";
+    hash = "sha256-8TNXDSZ3okeMtuGEHpKOnKyY/Z/w4auG5kjgmUexF/M=";
     fetchSubmodules = true;
   };
 
   patches = [
     ./external-lib-paths.patch
+    ./zlib.patch
     (replaceVars ./qttools-bins.patch {
       qttools = "${qttools.dev}/bin";
     })
@@ -39,6 +41,7 @@ stdenv.mkDerivation {
     qtbase
     qttools
     libGLU
+    zlib
   ];
   nativeBuildInputs = [
     qmake

--- a/pkgs/tools/graphics/nifskope/zlib.patch
+++ b/pkgs/tools/graphics/nifskope/zlib.patch
@@ -1,0 +1,39 @@
+diff --git a/NifSkope.pro b/NifSkope.pro
+index 89b8471f6410..8e136ddf44c6 100644
+--- a/NifSkope.pro
++++ b/NifSkope.pro
+@@ -17,7 +17,7 @@ contains(QT_VERSION, ^5\\.[0-6]\\..*) {
+ CONFIG += c++14
+
+ # Dependencies
+-CONFIG += nvtristrip qhull zlib lz4 fsengine gli
++CONFIG += nvtristrip qhull lz4 fsengine gli
+
+ # Debug/Release options
+ CONFIG(debug, debug|release) {
+@@ -345,14 +345,6 @@ gli {
+     HEADERS += $$files($$PWD/lib/gli/external/glm/*.inl, true)
+ }
+
+-zlib {
+-    !*msvc*:QMAKE_CFLAGS += -isystem ./lib/zlib
+-    !*msvc*:QMAKE_CXXFLAGS += -isystem ./lib/zlib
+-    else:INCLUDEPATH += lib/zlib
+-    HEADERS += $$files($$PWD/lib/zlib/*.h, false)
+-    SOURCES += $$files($$PWD/lib/zlib/*.c, false)
+-}
+-
+ lz4 {
+     DEFINES += LZ4_STATIC XXH_PRIVATE_API
+
+@@ -442,6 +434,10 @@ win32 {
+     LIBS += -lopengl32 -lglu32
+ }
+
++unix {
++  LIBS += -lz
++}
++
+ unix:!macx {
+ 	LIBS += -lGLU
+ }


### PR DESCRIPTION
Replace vendored zlib with a nixpkgs one. I tested the app with a sample NIF file and it somewhat works, but the graphics is very buggy on my Wayland setup, the 3D view does not refresh properly, but the camera movement still works.

Fixes #376015

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
