### PR TITLE
postgresql: refactor `postgresqlVersions` attribute & tests

### DIFF
--- a/nixos/tests/postgresql/anonymizer.nix
+++ b/nixos/tests/postgresql/anonymizer.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -107,11 +108,7 @@ let
       '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs && !p.pkgs.anonymizer.meta.broken) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests {
+  inherit makeTestFor;
+  filter = _: p: !p.pkgs.anonymizer.meta.broken;
+}

--- a/nixos/tests/postgresql/default.nix
+++ b/nixos/tests/postgresql/default.nix
@@ -7,7 +7,25 @@
 with import ../../lib/testing-python.nix { inherit system pkgs; };
 
 let
-  importWithArgs = path: import path { inherit pkgs makeTest; };
+  inherit (pkgs.lib)
+    recurseIntoAttrs
+    filterAttrs
+    mapAttrs
+    const
+    ;
+  genTests =
+    {
+      makeTestFor,
+      filter ? (_: _: true),
+    }:
+    recurseIntoAttrs (
+      mapAttrs (const makeTestFor) (filterAttrs filter pkgs.postgresqlVersions)
+      // {
+        passthru.override = makeTestFor;
+      }
+    );
+
+  importWithArgs = path: import path { inherit pkgs makeTest genTests; };
 in
 {
   # postgresql

--- a/nixos/tests/postgresql/pgjwt.nix
+++ b/nixos/tests/postgresql/pgjwt.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -48,11 +49,7 @@ let
         '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs && !p.pkgs.pgjwt.meta.broken) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests {
+  inherit makeTestFor;
+  filter = _: p: !p.pkgs.pgjwt.meta.broken;
+}

--- a/nixos/tests/postgresql/pgvecto-rs.nix
+++ b/nixos/tests/postgresql/pgvecto-rs.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -72,11 +73,7 @@ let
         '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs && !p.pkgs.pgvecto-rs.meta.broken) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests {
+  inherit makeTestFor;
+  filter = _: p: !p.pkgs.pgvecto-rs.meta.broken;
+}

--- a/nixos/tests/postgresql/postgresql-jit.nix
+++ b/nixos/tests/postgresql/postgresql-jit.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -48,11 +49,7 @@ let
       '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (n: _: lib.hasSuffix "_jit" n) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests {
+  inherit makeTestFor;
+  filter = n: _: lib.hasSuffix "_jit" n;
+}

--- a/nixos/tests/postgresql/postgresql-tls-client-cert.nix
+++ b/nixos/tests/postgresql/postgresql-tls-client-cert.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -128,11 +129,4 @@ let
       '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests { inherit makeTestFor; }

--- a/nixos/tests/postgresql/postgresql-wal-receiver.nix
+++ b/nixos/tests/postgresql/postgresql-wal-receiver.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -108,11 +109,4 @@ let
       '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests { inherit makeTestFor; }

--- a/nixos/tests/postgresql/postgresql.nix
+++ b/nixos/tests/postgresql/postgresql.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -262,11 +263,4 @@ let
         '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests { inherit makeTestFor; }

--- a/nixos/tests/postgresql/timescaledb.nix
+++ b/nixos/tests/postgresql/timescaledb.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -91,11 +92,7 @@ in
 # Not run by default, because this requires allowUnfree.
 # To run these tests:
 #   NIXPKGS_ALLOW_UNFREE=1 nix-build -A nixosTests.postgresql.timescaledb
-lib.dontRecurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs && !p.pkgs.timescaledb.meta.broken) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+lib.dontRecurseIntoAttrs (genTests {
+  inherit makeTestFor;
+  filter = _: p: !p.pkgs.timescaledb.meta.broken;
+})

--- a/nixos/tests/postgresql/tsja.nix
+++ b/nixos/tests/postgresql/tsja.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -41,11 +42,7 @@ let
       '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs && !p.pkgs.tsja.meta.broken) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests {
+  inherit makeTestFor;
+  filter = _: p: !p.pkgs.tsja.meta.broken;
+}

--- a/nixos/tests/postgresql/wal2json.nix
+++ b/nixos/tests/postgresql/wal2json.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   makeTest,
+  genTests,
 }:
 
 let
@@ -43,11 +44,7 @@ let
       '';
     };
 in
-lib.recurseIntoAttrs (
-  lib.concatMapAttrs (n: p: { ${n} = makeTestFor p; }) (
-    lib.filterAttrs (_: p: p ? pkgs && !p.pkgs.wal2json.meta.broken) pkgs.postgresqlVersions
-  )
-  // {
-    passthru.override = p: makeTestFor p;
-  }
-)
+genTests {
+  inherit makeTestFor;
+  filter = _: p: !p.pkgs.wal2json.meta.broken;
+}

--- a/pkgs/servers/sql/postgresql/default.nix
+++ b/pkgs/servers/sql/postgresql/default.nix
@@ -33,5 +33,9 @@ let
   libpq = self.callPackage ./libpq.nix { };
 
 in
-# variations without and with JIT
-(mkAttributes false) // (mkAttributes true) // { inherit libpq; }
+{
+  # variations without and with JIT
+  postgresqlVersions = mkAttributes false // mkAttributes true;
+
+  inherit libpq;
+}

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11688,10 +11688,11 @@ with pkgs;
     asciidoc = asciidoc-full;
   };
 
-  postgresqlVersions = import ../servers/sql/postgresql pkgs;
-  inherit (postgresqlVersions)
-    libpq
+  inherit (import ../servers/sql/postgresql pkgs)
+    postgresqlVersions
+    libpq;
 
+  inherit (postgresqlVersions)
     postgresql_13
     postgresql_14
     postgresql_15


### PR DESCRIPTION
Every postgresql testcase essentially does the following things:

* Filter `postgresqlVersions` for server packages
* Filter postgresql server packages for suitable ones (i.e. extensions must support the given version)
* Generate an attribute-set of testcases

The first item became necessary in
7ab1e888334ddc2745b285e3df0b0efd5839d0f8 given that `postgresql/default.nix` now exposes JIT and non-JIT servers AND a `libpq` that is not suitable for the tests here.

This changes restructures this a little bit, i.e.:

* Having an attribute-set that contains a bunch of postgresql servers
  and a single client package seems odd (and the sole consumer of
  `postgresqlVersions` in nixpkgs, the test suite, has to take that into
  account). Hence, postgresql's default.nix now provides `libpq` (the client)
  and a `postgresqlVersions` attribute with all supported JIT and non-JIT
  variants of postgresql.
* Each test-case gets a third argument, a function called `genTests`: this function sets `recurseForDerivations = true;` and generates an attribute-set of tests for each postgresql version given a function that returns a testcase or multiple test-cases (`makeTestFor`). The argument to `makeTestFor` is a postgresql server package.

  This function also accepts a filter predicate that is passed against `filterAttrs` to remove postgresql server packages that are not suitable for the test (e.g. because the version isn't supported by the extension to test).

I checked by making sure that the `.drv` doesn't change on staging with this change on top for postgresq, postgresql-jit,
postgresql-wal-receiver, postgresql-tls-client-cert, anonymizer, pgjwt, pgvecto-rs, timescaledb, tsja and wal2json.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
