### PR TITLE
torzu: use system libs and unbreak aarch64-linux

### DIFF
--- a/pkgs/by-name/si/simpleini/package.nix
+++ b/pkgs/by-name/si/simpleini/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   gtest,
   nix-update-script,
@@ -30,6 +31,14 @@ stdenv.mkDerivation (finalAttrs: {
   strictDeps = true;
 
   cmakeFlags = [ (lib.cmakeBool "SIMPLEINI_USE_SYSTEM_GTEST" true) ];
+
+  patches = [
+    # Fixes for cmake export from master, can be removed after the next release
+    (fetchpatch {
+      url = "https://github.com/brofield/simpleini/commit/aeacf861a8ad8add5f4974792a88ffea393e41db.patch";
+      hash = "sha256-lpoQHff8JwfljMUxL6Y2MqsGDZtDPjnOIKSIJ1rqrAI=";
+    })
+  ];
 
   passthru.updateScript = nix-update-script { };
 

--- a/pkgs/by-name/to/torzu/fix-aarch64-linux-build.patch
+++ b/pkgs/by-name/to/torzu/fix-aarch64-linux-build.patch
@@ -1,0 +1,14 @@
+diff --git a/src/video_core/host1x/vic.cpp b/src/video_core/host1x/vic.cpp
+index 3ad56bb80..57e6adbf8 100644
+--- a/src/video_core/host1x/vic.cpp
++++ b/src/video_core/host1x/vic.cpp
+@@ -13,7 +13,8 @@
+ #endif
+ #elif defined(ARCHITECTURE_arm64)
+ #pragma GCC diagnostic push
+-#pragma GCC diagnostic ignored "-Wimplicit-int-conversion"
++#pragma GCC diagnostic ignored "-Wconversion"
++#pragma GCC diagnostic ignored "-Wshadow"
+ #include <sse2neon.h>
+ #pragma GCC diagnostic pop
+ #endif

--- a/pkgs/by-name/to/torzu/package.nix
+++ b/pkgs/by-name/to/torzu/package.nix
@@ -27,6 +27,9 @@
   nv-codec-headers-12,
   pkg-config,
   qt6,
+  spirv-tools,
+  spirv-headers,
+  vulkan-utility-libraries,
   vulkan-headers,
   vulkan-loader,
   yasm,
@@ -147,7 +150,10 @@ stdenv.mkDerivation (finalAttrs: {
     # intentionally omitted: renderdoc - heavy, developer only
     SDL2
     # intentionally omitted: stb - header only libraries, vendor uses git snapshot
+    spirv-tools
+    spirv-headers
     vulkan-memory-allocator
+    vulkan-utility-libraries
     # intentionally omitted: xbyak - prefer vendored version for compatibility
     zlib
     zstd
@@ -167,10 +173,11 @@ stdenv.mkDerivation (finalAttrs: {
 
     # use system libraries
     # NB: "external" here means "from the externals/ directory in the source",
-    # so "off" means "use system"
+    # so "false" means "use system"
     (lib.cmakeBool "YUZU_USE_EXTERNAL_SDL2" false)
-    (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_HEADERS" true)
-    "-DVulkan_INCLUDE_DIRS=${vulkan-headers}/include"
+    (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_HEADERS" false)
+    (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_UTILITY_LIBRARIES" false)
+    (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_SPIRV_TOOLS" false)
 
     # # don't use system ffmpeg, suyu uses internal APIs
     # (lib.cmakeBool "YUZU_USE_BUNDLED_FFMPEG" true)

--- a/pkgs/by-name/to/torzu/package.nix
+++ b/pkgs/by-name/to/torzu/package.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   SDL2,
-  autoconf,
   boost,
   catch2_3,
   cmake,
@@ -18,13 +17,11 @@
   glslang,
   libopus,
   libusb1,
-  libva,
   lz4,
   python3,
   unzip,
   nix-update-script,
   nlohmann_json,
-  nv-codec-headers-12,
   pkg-config,
   qt6,
   spirv-tools,
@@ -32,7 +29,6 @@
   vulkan-utility-libraries,
   vulkan-headers,
   vulkan-loader,
-  yasm,
   simpleini,
   zlib,
   vulkan-memory-allocator,
@@ -126,15 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
     # intentionally omitted: dynarmic - prefer vendored version for compatibility
     enet
 
-    # ffmpeg deps (also includes vendored)
-    # we do not use internal ffmpeg because cuda errors
-    autoconf
-    yasm
-    libva # for accelerated video decode on non-nvidia
-    nv-codec-headers-12 # for accelerated video decode on nvidia
     ffmpeg-headless
-    # end ffmpeg deps
-
     fmt
     # intentionally omitted: gamemode - loaded dynamically at runtime
     # intentionally omitted: httplib - upstream requires an older version than what we have
@@ -178,9 +166,6 @@ stdenv.mkDerivation (finalAttrs: {
     (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_HEADERS" false)
     (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_UTILITY_LIBRARIES" false)
     (lib.cmakeBool "YUZU_USE_EXTERNAL_VULKAN_SPIRV_TOOLS" false)
-
-    # # don't use system ffmpeg, suyu uses internal APIs
-    # (lib.cmakeBool "YUZU_USE_BUNDLED_FFMPEG" true)
 
     # don't check for missing submodules
     (lib.cmakeBool "YUZU_CHECK_SUBMODULES" false)

--- a/pkgs/by-name/to/torzu/package.nix
+++ b/pkgs/by-name/to/torzu/package.nix
@@ -138,6 +138,7 @@ stdenv.mkDerivation (finalAttrs: {
     # intentionally omitted: renderdoc - heavy, developer only
     SDL2
     # intentionally omitted: stb - header only libraries, vendor uses git snapshot
+    simpleini
     spirv-tools
     spirv-headers
     vulkan-memory-allocator

--- a/pkgs/by-name/to/torzu/package.nix
+++ b/pkgs/by-name/to/torzu/package.nix
@@ -98,6 +98,8 @@ stdenv.mkDerivation (finalAttrs: {
     ./fix-udp-protocol.patch
     # Use specific boost::asio includes and update to modern io_context
     ./fix-udp-client.patch
+    # Updates suppressed diagnostics
+    ./fix-aarch64-linux-build.patch
   ];
 
   nativeBuildInputs = [
@@ -215,10 +217,6 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://notabug.org/litucks/torzu";
     mainProgram = "yuzu";
     platforms = lib.platforms.linux;
-    badPlatforms = [
-      # Several conversion errors, probably caused by the update to GCC 14
-      "aarch64-linux"
-    ];
     maintainers = with lib.maintainers; [ liberodark ];
     license = with lib.licenses; [
       gpl3Plus


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This patch removes some old code that is no longer needed and uses more dependencies from nixpkgs.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
