### PR TITLE
aider-chat: 0.72.1 -> 0.72.3

### DIFF
--- a/pkgs/development/python-modules/aider-chat/default.nix
+++ b/pkgs/development/python-modules/aider-chat/default.nix
@@ -12,7 +12,7 @@ let
     self = python3;
     packageOverrides = _: super: { tree-sitter = super.tree-sitter_0_21; };
   };
-  version = "0.72.1";
+  version = "0.72.3";
   aider-chat = python3.pkgs.buildPythonPackage {
     pname = "aider-chat";
     inherit version;
@@ -22,7 +22,7 @@ let
       owner = "Aider-AI";
       repo = "aider";
       tag = "v${version}";
-      hash = "sha256-5dV1EW4qx2tXDlbzyS8CT3p0MXgdKVdIGVLDEQF/4Zc=";
+      hash = "sha256-aOdLaH/95i2/h86rH578Z9iAtQSf7rI0PvnZQEx4Yjs=";
     };
 
     pythonRelaxDeps = true;


### PR DESCRIPTION
aider-chat: 0.72.1 -> 0.72.3

**Version Update**
- Update to latest release [v0.72.3](https://github.com/Aider-AI/aider/releases/tag/v0.72.3)
- Update hash using `nix-prefetch-url --unpack` (sha256-aOdLaH/95i2/h86rH578Z9iAtQSf7rI0PvnZQEx4Yjs=)

**Changelog**
- See official release notes: https://aider.chat/HISTORY.html

**Verification**
- Basic CLI functionality confirmed (`aider --help` works)
- Runtime dependencies validated with test environment