### PR TITLE
home-assistant-custom-components.versatile_thermostat: init at 7.1.5, home-assistant-custom-lovelace-modules.versatile-thermostat-ui-card: init at 1.1.2

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/versatile_thermostat/package.nix
@@ -1,0 +1,29 @@
+{
+  buildHomeAssistantComponent,
+  fetchFromGitHub,
+  lib,
+  gitUpdater,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "jmcollin78";
+  domain = "versatile_thermostat";
+  version = "7.1.5";
+
+  src = fetchFromGitHub {
+    inherit owner;
+    repo = domain;
+    rev = "refs/tags/${version}";
+    hash = "sha256-XCDWByw/2xUjub/fNGvpIGzDyn3rq+JMI7syI1oPus0=";
+  };
+
+  passthru.updateScript = gitUpdater { ignoredVersions = "(Alpha|Beta|alpha|beta).*"; };
+
+  meta = {
+    changelog = "https://github.com/jmcollin78/versatile_thermostat/releases/tag/${version}";
+    description = "A full-featured thermostat";
+    homepage = "https://github.com/jmcollin78/versatile_thermostat";
+    maintainers = with lib.maintainers; [ pwoelfel ];
+    license = lib.licenses.mit;
+  };
+}

--- a/pkgs/servers/home-assistant/custom-lovelace-modules/versatile-thermostat-ui-card/package.nix
+++ b/pkgs/servers/home-assistant/custom-lovelace-modules/versatile-thermostat-ui-card/package.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+}:
+
+buildNpmPackage rec {
+  pname = "versatile-thermostat-ui-card";
+  version = "1.1.2";
+
+  src = fetchFromGitHub {
+    owner = "jmcollin78";
+    repo = "versatile-thermostat-ui-card";
+    rev = "${version}";
+    hash = "sha256-JOm0jQysBtKHjAXtWnjbEn7UPSNLHd95TGfP13WH0Ww=";
+  };
+
+  npmFlags = [ "--legacy-peer-deps" ];
+  npmDepsHash = "sha256-TlJGO0kw3+8ukT1DERp/xDwmeSu0ofP5mqrmXmGcF2M=";
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    install -m0644 dist/versatile-thermostat-ui-card.js $out
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    changelog = "https://github.com/jmcollin78/versatile-thermostat-ui-card/releases/tag/${version}";
+    description = "Home Assistant card for the Versatile Thermostat integration.";
+    homepage = "https://github.com/jmcollin78/versatile-thermostat-ui-card";
+    license = licenses.mit;
+    maintainers = with maintainers; [ pwoelfel ];
+  };
+}


### PR DESCRIPTION
Adds the `versatile_thermostat` home-assistant component and the accompanying lovelace module `versatile-thermostat-ui-card`.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
