### PR TITLE
code-cursor: 0.44.11->0.45.4

### DIFF
--- a/pkgs/by-name/co/code-cursor/package.nix
+++ b/pkgs/by-name/co/code-cursor/package.nix
@@ -8,16 +8,16 @@
 }:
 let
   pname = "cursor";
-  version = "0.44.11";
+  version = "0.45.4";
 
   sources = {
     x86_64-linux = fetchurl {
-      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.11-build-250103fqxdt5u9z-x86_64.AppImage";
-      hash = "sha256-eOZuofnpED9F6wic0S9m933Tb7Gq7cb/v0kRDltvFVg=";
+      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.45.4-build-250126vgr3vztvj-x86_64.AppImage";
+      hash = "sha256-b1HQrhqusIOjYcvHqySKUH6EVdLwG4iP6UOp9eCUD1M=";
     };
     aarch64-linux = fetchurl {
-      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.44.11-build-250103fqxdt5u9z-arm64.AppImage";
-      hash = "sha256-mxq7tQJfDccE0QsZDZbaFUKO0Xc141N00ntX3oEYRcc=";
+      url = "https://download.todesktop.com/230313mzl4w4u92/cursor-0.45.4-build-250126vgr3vztvj-arm64.AppImage";
+      hash = "sha256-0byKEm2BTXr4HEqj6suUDVF10YLxnBz5i1xOToFGkYM=";
     };
   };
 


### PR DESCRIPTION
Bump 0.44.11->0.45.4

Changelog:
```md
.cursor/rules, Better Codebase Understanding, New Tab ModelRolling

.cursor/rules: Users can write several repository-level rules to disk in the .cursor/rules directory. The Agent will automatically choose which rule to follow.
Summarize Previous Composers: When conversations grow too long, you can start a new conversation while referencing the previous one.
Agent sees recent changes: The agent can use a tool to see your recent changes. It also sees changes made between user messages.
Better Codebase Understanding: We've trained a new model for Codebase Understanding. We'll be rolling it out to all users on 0.45 in the coming week.
Fusion Model: We've trained a new Tab Model that is substantially better at jumps and long context. We'll also be rolling this out to users shortly.
Optional Long Context: When tagging long files, users have the option to request a larger context window with premium models. This will use more fast requests.
UPDATE (0.45.1-0.45.4): Fixes issue with older agent conversations, indexing stability, downloading incorrect extension versions, missing package on windows, and crash on opening long composer sessions. 
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
