### PR TITLE
vanguards: init at 0.3.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -7799,6 +7799,12 @@
     githubId = 24463229;
     name = "Forden";
   };
+  ForgottenBeast = {
+    email = "forgottenbeast@riseup.net";
+    github = "ForgottenBeast";
+    githubId = 5754552;
+    name = "ForgottenBeast";
+  };
   forkk = {
     email = "forkk@forkk.net";
     github = "Forkk";

--- a/pkgs/by-name/va/vanguards/package.nix
+++ b/pkgs/by-name/va/vanguards/package.nix
@@ -1,0 +1,38 @@
+{
+  python312Packages,
+  fetchFromGitHub,
+  lib,
+}:
+python312Packages.buildPythonApplication rec {
+  pname = "vanguards";
+  version = "0.3.1-unstable-2023-10-31";
+
+  dependencies = [ python312Packages.stem ];
+  #tries to access the network during the tests, which fails
+  doCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "mikeperry-tor";
+    repo = "vanguards";
+    rev = "8132fa0e556fbcbb3538ff9b48a2180c0c5e8fbd";
+    sha256 = "sha256-XauSTgoH6zXv2DXyX2lQc6gy6Ysm41fKnyuWZ3hj7kI=";
+  };
+  patches = [ ./python-3.12.patch ];
+  postPatch = ''
+    # fix import cycle issue
+    substituteInPlace src/vanguards/main.py --replace-fail \
+      'import stem.response.events' 'import stem.socket; import stem.control; import stem.response.events'
+  '';
+
+  meta = {
+    maintainers = with lib.maintainers; [ ForgottenBeast ];
+    mainProgram = "vanguards";
+    license = lib.licenses.mit;
+    homepage = "https://github.com/mikeperry-tor/vanguards";
+    description = "Protects TOR hidden services against guard node attacks";
+    longDescription = ''
+      Runs alongside tor and interacts with its control port
+      in order to protect and alert against guard node attacks on hidden services
+    '';
+  };
+}

--- a/pkgs/by-name/va/vanguards/python-3.12.patch
+++ b/pkgs/by-name/va/vanguards/python-3.12.patch
@@ -1,0 +1,51 @@
+Origin: https://github.com/mikeperry-tor/vanguards/pull/105/commits/183d24775521feb3ed61b681088347279c3fc84c
+From: Dave Jones <dave@waveform.org.uk>
+Date: Wed, 28 Aug 2024 12:54:24 +0100
+Subject: [PATCH] Python 3.12 compatibility
+
+Python 3.12 removes the deprecated `SafeConfigParser` class. This patch
+switches the code to using ConfigParser and read_file from Python 3.x,
+and patches 2.7's SafeConfigParser to a compatible definition.
+---
+ src/vanguards/config.py | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/src/vanguards/config.py b/src/vanguards/config.py
+index 1c33391..b8e3f9c 100644
+--- a/src/vanguards/config.py
++++ b/src/vanguards/config.py
+@@ -16,9 +16,12 @@
+ from .logger import plog
+ 
+ try:
+-  from configparser import SafeConfigParser, Error
++  from configparser import ConfigParser, Error
+ except ImportError:
+   from ConfigParser import SafeConfigParser, Error
++  class ConfigParser(SafeConfigParser):
++      def read_file(self, f, source=None):
++          return self.readfp(f, source)
+ 
+ ################# Global options ##################
+ 
+@@ -209,7 +212,7 @@ def set_options_from_module(config, module, section):
+       config.set(section, param, str(val))
+ 
+ def generate_config():
+-  config = SafeConfigParser(allow_no_value=True)
++  config = ConfigParser(allow_no_value=True)
+   set_options_from_module(config, sys.modules[__name__], "Global")
+   set_options_from_module(config, vanguards, "Vanguards")
+   set_options_from_module(config, bandguards, "Bandguards")
+@@ -219,9 +222,9 @@ def generate_config():
+   return config
+ 
+ def apply_config(config_file):
+-  config = SafeConfigParser(allow_no_value=True)
++  config = ConfigParser(allow_no_value=True)
+ 
+-  config.readfp(open(config_file, "r"))
++  config.read_file(open(config_file, "r"))
+ 
+   get_options_for_module(config, sys.modules[__name__], "Global")
+   get_options_for_module(config, vanguards, "Vanguards")


### PR DESCRIPTION
add derivation for vanguards, a set of scripts that increase security for tor hidden services by protecting against guard discovery attacks

resources:
https://github.com/mikeperry-tor/vanguards
https://spec.torproject.org/vanguards-spec/index.html?highlight=vanguards


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
