### PR TITLE
tuicam: init at 0.0.2

### DIFF
--- a/pkgs/by-name/tu/tuicam/package.nix
+++ b/pkgs/by-name/tu/tuicam/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  autoPatchelfHook,
+  pkg-config,
+  udev,
+  opencv,
+  llvmPackages,
+  clang,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "tuicam";
+  version = "0.0.1";
+
+  src = fetchFromGitHub {
+    owner = "hlsxx";
+    repo = "tuicam";
+    tag = "v${version}";
+    hash = "sha256-IBSkMvLAUvY6v/0DxgpaA0L/mu2s/ahHQsYJjtLNmCY=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-b+hAKnLImbadjGcxlktoL0yJ8ZEa7EUlIE6h+/fFg0k=";
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    pkg-config
+    clang
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    udev
+    opencv
+  ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Terminal-based camera with switchable modes";
+    homepage = "https://github.com/hlsxx/tuicam";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ linuxmobile ];
+    platforms = lib.platforms.linux;
+    mainProgram = "tuicam";
+  };
+}


### PR DESCRIPTION
Init of a terminal-based ASCII camera

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
