### PR TITLE
python3Packages.ixia: 1.3.2 → 2.0.0, oddsprout: 0.1.1 → 0.1.2

### DIFF
--- a/pkgs/by-name/od/oddsprout/package.nix
+++ b/pkgs/by-name/od/oddsprout/package.nix
@@ -1,0 +1,5 @@
+{
+  python3Packages,
+}:
+
+python3Packages.toPythonApplication python3Packages.oddsprout

--- a/pkgs/development/python-modules/ixia/default.nix
+++ b/pkgs/development/python-modules/ixia/default.nix
@@ -2,22 +2,25 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  poetry-core,
+  hatchling,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "ixia";
-  version = "1.3.2";
+  version = "2.0.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "trag1c";
     repo = "ixia";
     tag = version;
-    hash = "sha256-lsov5AIT5uRf9nmS8ZsFmInKUFAxUATTbpfhV1fabhA=";
+    hash = "sha256-8STtLL63V+XnDqDNZOx7X9mkjUu176SSyQOL55LXFz0=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
   pythonImportsCheck = [ "ixia" ];
 
   meta = {

--- a/pkgs/development/python-modules/oddsprout/default.nix
+++ b/pkgs/development/python-modules/oddsprout/default.nix
@@ -2,8 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchpatch2,
-  poetry-core,
+  hatchling,
   pytestCheckHook,
   pythonOlder,
   dahlia,
@@ -12,7 +11,7 @@
 
 buildPythonPackage rec {
   pname = "oddsprout";
-  version = "0.1.1";
+  version = "0.1.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -21,28 +20,16 @@ buildPythonPackage rec {
     owner = "trag1c";
     repo = "oddsprout";
     tag = "v${version}";
-    hash = "sha256-BOUYq4yny3ScgzCzx2cpeK4e7nxxwTj8mJ42nr59mFA=";
+    hash = "sha256-RfAU3/Je3aC8JjQ51DqRCSAIfW2tQmQPP6G0/bfa1ZE=";
   };
 
-  build-system = [ poetry-core ];
+  build-system = [ hatchling ];
 
   dependencies = [
     dahlia
     ixia
   ];
 
-  patches = [
-    # https://github.com/trag1c/oddsprout/pull/8
-    (fetchpatch2 {
-      name = "allow-periods-in-path.patch";
-      url = "https://github.com/trag1c/oddsprout/commit/59713a797e7748d48f59f92397981c93a81f2c28.patch";
-      hash = "sha256-GAIQQi5s4D6KbTSgmP2hlBizLATxtJ/hzpWqPX4O0U4=";
-    })
-  ];
-
-  # has one test `test_main_recursion_error`
-  # that has a very low (~1%) but nonzero chance to fail,
-  # this is known upstream (https://github.com/trag1c/oddsprout/issues/5)
   nativeCheckInputs = [ pytestCheckHook ];
 
   pythonImportsCheck = [ "oddsprout" ];
@@ -56,5 +43,6 @@ buildPythonPackage rec {
       itepastra
       sigmanificient
     ];
+    mainProgram = "oddsprout";
   };
 }


### PR DESCRIPTION
- ixia: https://github.com/trag1c/ixia/releases/tag/2.0.0. Also uses pytest during check.
- oddsprout: https://github.com/trag1c/oddsprout/releases/tag/v0.1.2. Also adds as an application.

Both are done together as oddsprout 0.1.1 doesn't build with ixia 2.0.0.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
