### PR TITLE
Revert "llvmPackages.tblgen: add missing lldb-tblgen"

### DIFF
--- a/pkgs/development/compilers/llvm/common/tblgen.nix
+++ b/pkgs/development/compilers/llvm/common/tblgen.nix
@@ -50,7 +50,6 @@ let
           cp -r ${monorepoSrc}/clang "$out"
           cp -r ${monorepoSrc}/clang-tools-extra "$out"
           cp -r ${monorepoSrc}/mlir "$out"
-          cp -r ${monorepoSrc}/lldb "$out"
         ''
       )
     else
@@ -87,7 +86,6 @@ let
             "llvm"
             "clang"
             "clang-tools-extra"
-            "lldb"
           ]
           ++ lib.optionals (lib.versionAtLeast release_version "16") [
             "mlir"
@@ -101,7 +99,6 @@ let
       [
         "clang-tblgen"
         "llvm-tblgen"
-        "lldb-tblgen"
       ]
       ++ lib.optionals (lib.versionAtLeast release_version "15") [
         "clang-tidy-confusable-chars-gen"
@@ -117,10 +114,6 @@ let
 
     installPhase = ''
       mkdir -p $out
-
-      # Remove useless files
-      rm -f bin/{lldb-dotest,lldb-repro,llvm-lit,update_core_linalg_named_ops.sh}
-
       cp -ar bin $out/bin
     '';
   });


### PR DESCRIPTION
Breaks Darwin bootstrap:

    CMake Error at /tmp/nix-build-llvm-tblgen-19.1.7.drv-0/llvm-tblgen-src-19.1.7/lldb/test/CMakeLists.txt:197 (message):
      LLDB test suite requires libc++, but it is currently disabled.  Please add
      `libcxx` to `LLVM_ENABLE_RUNTIMES` or disable tests via
      `LLDB_INCLUDE_TESTS=OFF`.

It’s probably not too hard to fix but I don’t really understand the details of this derivation and it’s blocking Darwin `stdenv` builds with a few days to go until the next cycle, so reverting for now.

This reverts commit d175d8a4c55ce11c61e70f6d0d0458e7801441c8.

cc @pwaller (not part of the org, can’t request for review)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
