### PR TITLE
nixos/*: tag manpage references

### DIFF
--- a/nixos/modules/config/ldap.nix
+++ b/nixos/modules/config/ldap.nix
@@ -135,7 +135,7 @@ in
           type = types.lines;
           description = ''
             Extra configuration options that will be added verbatim at
-            the end of the nslcd configuration file (`nslcd.conf(5)`).
+            the end of the nslcd configuration file ({manpage}`nslcd.conf(5)`).
           '';
         };
 
@@ -219,7 +219,7 @@ in
         type = types.lines;
         description = ''
           Extra configuration options that will be added verbatim at
-          the end of the ldap configuration file (`ldap.conf(5)`).
+          the end of the ldap configuration file ({manpage}`ldap.conf(5)`).
           If {option}`users.ldap.daemon` is enabled, this
           configuration will not be used. In that case, use
           {option}`users.ldap.daemon.extraConfig` instead.

--- a/nixos/modules/config/mysql.nix
+++ b/nixos/modules/config/mysql.nix
@@ -111,7 +111,7 @@ in
                 - `0` (or `"plain"`):
                   No encryption. Passwords are stored in plaintext. HIGHLY DISCOURAGED.
                 - `1` (or `"Y"`):
-                  Use crypt(3) function.
+                  Use {manpage}`crypt(3)` function.
                 - `2` (or `"mysql"`):
                   Use the MySQL PASSWORD() function. It is possible that the encryption function used
                   by `pam_mysql` is different from that of the MySQL server, as

--- a/nixos/modules/config/swap.nix
+++ b/nixos/modules/config/swap.nix
@@ -46,7 +46,7 @@ let
           If not specified, the amount of data to read from `source` will be
           determined by cryptsetup.
 
-          See `cryptsetup-open(8)` for details.
+          See `{manpage}`cryptsetup-open(8)`` for details.
         '';
       };
 
@@ -60,7 +60,7 @@ let
           If not specified, the default sector size is determined from the
           underlying block device.
 
-          See `cryptsetup-open(8)` for details.
+          See `{manpage}`cryptsetup-open(8)`` for details.
         '';
       };
 
@@ -158,7 +158,7 @@ let
           whole swap space is discarded at swapon invocation. If "pages",
           asynchronous discard on freed pages is performed, before returning to
           the available pages pool. With "both", both policies are activated.
-          See swapon(8) for more information.
+          See {manpage}`swapon(8)` for more information.
         '';
       };
 

--- a/nixos/modules/config/users-groups.nix
+++ b/nixos/modules/config/users-groups.nix
@@ -204,7 +204,7 @@ let
       homeMode = mkOption {
         type = types.strMatching "[0-7]{1,5}";
         default = "700";
-        description = "The user's home directory mode in numeric format. See chmod(1). The mode is only applied if {option}`users.users.<name>.createHome` is true.";
+        description = "The user's home directory mode in numeric format. See {manpage}`chmod(1)`. The mode is only applied if {option}`users.users.<name>.createHome` is true.";
       };
 
       cryptHomeLuks = mkOption {

--- a/nixos/modules/config/xdg/portals/wlr.nix
+++ b/nixos/modules/config/xdg/portals/wlr.nix
@@ -28,7 +28,7 @@ in
       description = ''
         Configuration for `xdg-desktop-portal-wlr`.
 
-        See `xdg-desktop-portal-wlr(5)` for supported
+        See {manpage}`xdg-desktop-portal-wlr(5)` for supported
         values.
       '';
 

--- a/nixos/modules/programs/gamemode.nix
+++ b/nixos/modules/programs/gamemode.nix
@@ -26,7 +26,7 @@ in
         default = { };
         description = ''
           System-wide configuration for GameMode (/etc/gamemode.ini).
-          See gamemoded(8) man page for available settings.
+          See {manpage}`gamemoded(8)` man page for available settings.
         '';
         example = lib.literalExpression ''
           {

--- a/nixos/modules/programs/git.nix
+++ b/nixos/modules/programs/git.nix
@@ -47,7 +47,7 @@ in
           `config` to `[ { foo.x = 42; } { bar.y = 42; }]` will put the `foo`
           section before the `bar` section unlike the default alphabetical
           order, which can be helpful for sections such as `include` and
-          `includeIf`. See the CONFIGURATION FILE section of git-config(1) for
+          `includeIf`. See the CONFIGURATION FILE section of {manpage}`git-config(1)` for
           more information.
         '';
       };

--- a/nixos/modules/programs/msmtp.nix
+++ b/nixos/modules/programs/msmtp.nix
@@ -34,7 +34,7 @@ in
         };
         description = ''
           Default values applied to all accounts.
-          See msmtp(1) for the available options.
+          See {manpage}`msmtp(1)` for the available options.
         '';
       };
 
@@ -52,7 +52,7 @@ in
         description = ''
           Named accounts and their respective configurations.
           The special name "default" allows a default account to be defined.
-          See msmtp(1) for the available options.
+          See {manpage}`msmtp(1)` for the available options.
 
           Use `programs.msmtp.extraConfig` instead of this attribute set-based
           option if ordered account inheritance is needed.
@@ -68,7 +68,7 @@ in
         default = "";
         description = ''
           Extra lines to add to the msmtp configuration verbatim.
-          See msmtp(1) for the syntax and available options.
+          See {manpage}`msmtp(1)` for the syntax and available options.
         '';
       };
     };

--- a/nixos/modules/programs/shadow.nix
+++ b/nixos/modules/programs/shadow.nix
@@ -31,7 +31,7 @@ in
         description = ''
           Config options for the /etc/login.defs file, that defines
           the site-specific configuration for the shadow password suite.
-          See login.defs(5) man page for available options.
+          See {manpage}`login.defs(5)` man page for available options.
         '';
         type = lib.types.submodule {
           freeformType = (pkgs.formats.keyValue { }).type;

--- a/nixos/modules/security/pam.nix
+++ b/nixos/modules/security/pam.nix
@@ -1483,7 +1483,7 @@ in
           the YubiCloud.
 
           Use "challenge-response" for offline validation using YubiKeys with HMAC-SHA-1
-          Challenge-Response configurations. See the man-page ykpamcfg(1) for further
+          Challenge-Response configurations. See the man-page {manpage}`ykpamcfg(1)` for further
           details on how to configure offline Challenge-Response validation.
 
           More information can be found [here](https://developers.yubico.com/yubico-pam/Authentication_Using_Challenge-Response.html).

--- a/nixos/modules/security/wrappers/default.nix
+++ b/nixos/modules/security/wrappers/default.nix
@@ -214,7 +214,7 @@ in
       example = "10G";
       type = lib.types.str;
       description = ''
-        Size limit for the /run/wrappers tmpfs. Look at mount(8), tmpfs size option,
+        Size limit for the /run/wrappers tmpfs. Look at {manpage}`mount(8)`, tmpfs size option,
         for the accepted syntax. WARNING: don't set to less than 64MB.
       '';
     };

--- a/nixos/modules/services/backup/btrbk.nix
+++ b/nixos/modules/services/backup/btrbk.nix
@@ -163,7 +163,7 @@ in
         default = 10;
       };
       ioSchedulingClass = mkOption {
-        description = "IO scheduling class for btrbk (see ionice(1) for a quick description). Applies to local instances, and remote ones connecting by ssh if set to idle.";
+        description = "IO scheduling class for btrbk (see {manpage}`ionice(1)` for a quick description). Applies to local instances, and remote ones connecting by ssh if set to idle.";
         type = types.enum [
           "idle"
           "best-effort"
@@ -181,7 +181,7 @@ in
                 type = types.nullOr types.str;
                 default = "daily";
                 description = ''
-                  How often this btrbk instance is started. See systemd.time(7) for more information about the format.
+                  How often this btrbk instance is started. See {manpage}`systemd.time(7)` for more information about the format.
                   Setting it to null disables the timer, thus this instance can only be started manually.
                 '';
               };

--- a/nixos/modules/services/backup/restic.nix
+++ b/nixos/modules/services/backup/restic.nix
@@ -23,7 +23,7 @@ in
           default = null;
           description = ''
             file containing the credentials to access the repository, in the
-            format of an EnvironmentFile as described by systemd.exec(5)
+            format of an EnvironmentFile as described by {manpage}`systemd.exec(5)`
           '';
         };
 

--- a/nixos/modules/services/backup/tarsnap.nix
+++ b/nixos/modules/services/backup/tarsnap.nix
@@ -60,8 +60,8 @@ in
           `"/root/tarsnap.key"`.
 
           It's recommended for backups that you generate a key for every archive
-          using `tarsnap-keygen(1)`, and then generate a
-          write-only tarsnap key using `tarsnap-keymgmt(1)`,
+          using {manpage}`tarsnap-keygen(1)`, and then generate a
+          write-only tarsnap key using {manpage}`tarsnap-keymgmt(1)`,
           and keep your master key(s) for a particular machine off-site.
 
           The keyfile name should be given as a string and not a path, to
@@ -86,11 +86,11 @@ in
                     Use this option if you want to run multiple backups
                     concurrently - each archive must have a unique key. You can
                     generate a write-only key derived from your master key (which
-                    is recommended) using `tarsnap-keymgmt(1)`.
+                    is recommended) using {manpage}`tarsnap-keymgmt(1)`.
 
                     Note: every archive must have an individual master key. You
                     must generate multiple keys with
-                    `tarsnap-keygen(1)`, and then generate write
+                    {manpage}`tarsnap-keygen(1)`, and then generate write
                     only keys from those.
 
                     The keyfile name should be given as a string and not a path, to

--- a/nixos/modules/services/cluster/k3s/default.nix
+++ b/nixos/modules/services/cluster/k3s/default.nix
@@ -227,7 +227,7 @@ in
     environmentFile = lib.mkOption {
       type = lib.types.nullOr lib.types.path;
       description = ''
-        File path containing environment variables for configuring the k3s service in the format of an EnvironmentFile. See systemd.exec(5).
+        File path containing environment variables for configuring the k3s service in the format of an EnvironmentFile. See {manpage}`systemd.exec(5)`.
       '';
       default = null;
     };

--- a/nixos/modules/services/hardware/libinput.nix
+++ b/nixos/modules/services/hardware/libinput.nix
@@ -136,7 +136,7 @@ let
       default = null;
       example = "1 6 3 4 5 0 7";
       description = ''
-        Sets the logical button mapping for this device, see XSetPointerMapping(3). The string  must
+        Sets the logical button mapping for this device, see {manpage}`XSetPointerMapping(3)`. The string  must
         be  a  space-separated  list  of  button mappings in the order of the logical buttons on the
         device, starting with button 1.  The default mapping is "1 2 3 ... 32". A mapping of 0 deac‐
         tivates the button. Multiple buttons can have the same mapping.  Invalid mapping strings are

--- a/nixos/modules/services/hardware/thinkfan.nix
+++ b/nixos/modules/services/hardware/thinkfan.nix
@@ -249,7 +249,7 @@ in
         ];
         description = ''
           A list of extra command line arguments to pass to thinkfan.
-          Check the thinkfan(1) manpage for available arguments.
+          Check the {manpage}`thinkfan(1)` manpage for available arguments.
         '';
       };
 
@@ -259,7 +259,7 @@ in
         description = ''
           Thinkfan settings. Use this option to configure thinkfan
           settings not exposed in a NixOS option or to bypass one.
-          Before changing this, read the `thinkfan.conf(5)`
+          Before changing this, read the `{manpage}`thinkfan.conf(5)``
           manpage and take a look at the example config file at
           <https://github.com/vmatare/thinkfan/blob/master/examples/thinkfan.yaml>
         '';

--- a/nixos/modules/services/hardware/upower.nix
+++ b/nixos/modules/services/hardware/upower.nix
@@ -65,7 +65,7 @@ in
           on or off. We can't do much to fix these problems, but this is a way
           for users to make the laptop panel vanish, a state that might be used
           by a couple of user-space daemons. On Linux systems, see also
-          logind.conf(5).
+          {manpage}`logind.conf(5)`.
         '';
       };
 

--- a/nixos/modules/services/home-automation/esphome.nix
+++ b/nixos/modules/services/home-automation/esphome.nix
@@ -67,7 +67,7 @@ in
       ];
       description = ''
         A list of device nodes to which {command}`esphome` has access to.
-        Refer to DeviceAllow in systemd.resource-control(5) for more information.
+        Refer to DeviceAllow in {manpage}`systemd.resource-control(5)` for more information.
         Beware that if a device is referred to by an absolute path instead of a device category,
         it will only allow devices that already are plugged in when the service is started.
       '';

--- a/nixos/modules/services/logging/journalwatch.nix
+++ b/nixos/modules/services/logging/journalwatch.nix
@@ -135,7 +135,7 @@ in
                   this patternBlock's {option}`filters` are applied.
                   If `value` starts and ends with a slash, it is interpreted as
                   an extended python regular expression, if not, it's an exact match.
-                  The journal fields are explained in systemd.journal-fields(7).
+                  The journal fields are explained in {manpage}`systemd.journal-fields(7)`.
                 '';
               };
 
@@ -210,7 +210,7 @@ in
         description = ''
           How often to run journalwatch.
 
-          The format is described in systemd.time(7).
+          The format is described in {manpage}`systemd.time(7)`.
         '';
       };
       accuracy = lib.mkOption {
@@ -219,7 +219,7 @@ in
         description = ''
           The time window around the interval in which the journalwatch run will be scheduled.
 
-          The format is described in systemd.time(7).
+          The format is described in {manpage}`systemd.time(7)`.
         '';
       };
     };

--- a/nixos/modules/services/logging/syslogd.nix
+++ b/nixos/modules/services/logging/syslogd.nix
@@ -70,7 +70,7 @@ in
         type = lib.types.bool;
         default = false;
         description = ''
-          Accept logging through UDP. Option -r of syslogd(8).
+          Accept logging through UDP. Option -r of {manpage}`syslogd(8)`.
         '';
       };
 

--- a/nixos/modules/services/mail/clamsmtp.nix
+++ b/nixos/modules/services/mail/clamsmtp.nix
@@ -43,7 +43,7 @@ in
                 default = "";
                 example = "X-Virus-Scanned: ClamAV using ClamSMTP";
                 description = ''
-                  A header to add to scanned messages. See clamsmtpd.conf(5) for
+                  A header to add to scanned messages. See {manpage}`clamsmtpd.conf(5)` for
                   more details. Empty means no header.
                 '';
               };
@@ -65,7 +65,7 @@ in
                 example = "127.0.0.1:10025";
                 description = ''
                   Address to wait for incoming SMTP connections on. See
-                  clamsmtpd.conf(5) for more details.
+                  {manpage}`clamsmtpd.conf(5)` for more details.
                 '';
               };
 
@@ -118,7 +118,7 @@ in
                 default = null;
                 description = ''
                   Command to run when a virus is found. Please see VIRUS ACTION in
-                  clamsmtpd(8) for a discussion of this option and its safe use.
+                  {manpage}`clamsmtpd(8)` for a discussion of this option and its safe use.
                 '';
               };
 

--- a/nixos/modules/services/mail/cyrus-imap.nix
+++ b/nixos/modules/services/mail/cyrus-imap.nix
@@ -80,7 +80,7 @@ in
       type = int;
       default = 32;
       description = ''
-        Socket listen queue backlog size. See listen(2) for more information about a backlog.
+        Socket listen queue backlog size. See {manpage}`listen(2)` for more information about a backlog.
         Default is 32, which may be increased if you have a very high connection rate.
       '';
     };
@@ -194,7 +194,7 @@ in
           DAEMON = mkOption {
             default = { };
             description = ''
-              This section lists long running daemons to start before any SERVICES are spawned. master(8) will ensure that these processes are running, restarting any process which dies or forks. All listed processes will be shutdown when master(8) is exiting.
+              This section lists long running daemons to start before any SERVICES are spawned. {manpage}`master(8)` will ensure that these processes are running, restarting any process which dies or forks. All listed processes will be shutdown when {manpage}`master(8)` is exiting.
             '';
           };
         };
@@ -221,7 +221,7 @@ in
             type = path;
             default = "/run/cyrus/lmtp";
             description = ''
-              Unix socket that lmtpd listens on, used by deliver(8). This should match the path specified in cyrus.conf(5).
+              Unix socket that lmtpd listens on, used by {manpage}`deliver(8)`. This should match the path specified in {manpage}`cyrus.conf(5)`.
             '';
           };
           idlesocket = mkOption {

--- a/nixos/modules/services/mail/offlineimap.nix
+++ b/nixos/modules/services/mail/offlineimap.nix
@@ -37,13 +37,13 @@ in
     onCalendar = lib.mkOption {
       type = lib.types.str;
       default = "*:0/3"; # every 3 minutes
-      description = "How often is offlineimap started. Default is '*:0/3' meaning every 3 minutes. See systemd.time(7) for more information about the format.";
+      description = "How often is offlineimap started. Default is '*:0/3' meaning every 3 minutes. See {manpage}`systemd.time(7)` for more information about the format.";
     };
 
     timeoutStartSec = lib.mkOption {
       type = lib.types.str;
       default = "120sec"; # Kill if still alive after 2 minutes
-      description = "How long waiting for offlineimap before killing it. Default is '120sec' meaning every 2 minutes. See systemd.time(7) for more information about the format.";
+      description = "How long waiting for offlineimap before killing it. Default is '120sec' meaning every 2 minutes. See {manpage}`systemd.time(7)` for more information about the format.";
     };
   };
   config = lib.mkIf (cfg.enable || cfg.install) {

--- a/nixos/modules/services/mail/opendkim.nix
+++ b/nixos/modules/services/mail/opendkim.nix
@@ -65,7 +65,7 @@ in
         defaultText = lib.literalExpression ''"csl:''${config.networking.hostName}"'';
         example = "csl:example.com,mydomain.net";
         description = ''
-          Local domains set (see `opendkim(8)` for more information on datasets).
+          Local domains set (see {manpage}`opendkim(8)` for more information on datasets).
           Messages from them are signed, not verified.
         '';
       };

--- a/nixos/modules/services/mail/postfix.nix
+++ b/nixos/modules/services/mail/postfix.nix
@@ -546,7 +546,7 @@ in
         type = lib.types.lines;
         default = "";
         description = ''
-          Additional entries to put verbatim into aliases file, cf. man-page aliases(8).
+          Additional entries to put verbatim into aliases file, cf. man-page {manpage}`aliases(8)`.
         '';
       };
 
@@ -631,7 +631,7 @@ in
         type = lib.types.lines;
         default = "";
         description = ''
-          Entries for the virtual alias map, cf. man-page virtual(5).
+          Entries for the virtual alias map, cf. man-page {manpage}`virtual(5)`.
         '';
       };
 
@@ -654,7 +654,7 @@ in
           List of accepted local users. Specify a bare username, an
           `"@domain.tld"` wild-card, or a complete
           `"user@domain.tld"` address. If set, these names end
-          up in the local recipient map -- see the local(8) man-page -- and
+          up in the local recipient map -- see the {manpage}`local(8)` man-page -- and
           effectively replace the system user database lookup that's otherwise
           used by default.
         '';
@@ -664,7 +664,7 @@ in
         default = "";
         type = lib.types.lines;
         description = ''
-          Entries for the transport map, cf. man-page transport(8).
+          Entries for the transport map, cf. man-page {manpage}`transport(8)`.
         '';
       };
 

--- a/nixos/modules/services/mail/postgrey.nix
+++ b/nixos/modules/services/mail/postgrey.nix
@@ -119,7 +119,7 @@ in
       greylistAction = mkOption {
         type = str;
         default = "DEFER_IF_PERMIT";
-        description = "Response status for greylisted messages (see access(5))";
+        description = "Response status for greylisted messages (see {manpage}`access(5)`)";
       };
       greylistHeader = mkOption {
         type = str;
@@ -170,12 +170,12 @@ in
       whitelistClients = mkOption {
         type = listOf path;
         default = [ ];
-        description = "Client address whitelist files (see postgrey(8))";
+        description = "Client address whitelist files (see {manpage}`postgrey(8)`)";
       };
       whitelistRecipients = mkOption {
         type = listOf path;
         default = [ ];
-        description = "Recipient address whitelist files (see postgrey(8))";
+        description = "Recipient address whitelist files (see {manpage}`postgrey(8)`)";
       };
     };
   };

--- a/nixos/modules/services/misc/autofs.nix
+++ b/nixos/modules/services/misc/autofs.nix
@@ -49,7 +49,7 @@ in
           '''
         '';
         description = ''
-          Contents of `/etc/auto.master` file. See {command}`auto.master(5)` and {command}`autofs(5)`.
+          Contents of `/etc/auto.master` file. See {manpage}`auto.master(5)` and {manpage}`autofs(5)`.
         '';
       };
 

--- a/nixos/modules/services/misc/gpsd.nix
+++ b/nixos/modules/services/misc/gpsd.nix
@@ -105,7 +105,7 @@ in
         ];
         description = ''
           A list of extra command line arguments to pass to gpsd.
-          Check gpsd(8) mangpage for possible arguments.
+          Check {manpage}`gpsd(8)` mangpage for possible arguments.
         '';
       };
 

--- a/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
+++ b/nixos/modules/services/monitoring/prometheus/exporters/restic.nix
@@ -54,7 +54,7 @@ in
       default = null;
       description = ''
         File containing the credentials to access the repository, in the
-        format of an EnvironmentFile as described by systemd.exec(5)
+        format of an EnvironmentFile as described by {manpage}`systemd.exec(5)`
       '';
     };
 

--- a/nixos/modules/services/network-filesystems/cachefilesd.nix
+++ b/nixos/modules/services/network-filesystems/cachefilesd.nix
@@ -35,7 +35,7 @@ in
         type = lib.types.lines;
         default = "";
         example = "brun 10%";
-        description = "Additional configuration file entries. See cachefilesd.conf(5) for more information.";
+        description = "Additional configuration file entries. See {manpage}`cachefilesd.conf(5)` for more information.";
       };
 
     };

--- a/nixos/modules/services/network-filesystems/openafs/client.nix
+++ b/nixos/modules/services/network-filesystems/openafs/client.nix
@@ -73,7 +73,7 @@ in
           });
         description = ''
           This cell's database server records, added to the global
-          CellServDB. See CellServDB(5) man page for syntax. Ignored when
+          CellServDB. See {manpage}`CellServDB(5)` man page for syntax. Ignored when
           `afsdb` is set to `true`.
         '';
         example = [

--- a/nixos/modules/services/network-filesystems/openafs/server.nix
+++ b/nixos/modules/services/network-filesystems/openafs/server.nix
@@ -117,7 +117,7 @@ in
       advertisedAddresses = mkOption {
         type = types.listOf types.str;
         default = [ ];
-        description = "List of IP addresses this server is advertised under. See NetInfo(5)";
+        description = "List of IP addresses this server is advertised under. See {manpage}`NetInfo(5)`";
       };
 
       cellName = mkOption {

--- a/nixos/modules/services/networking/cgit.nix
+++ b/nixos/modules/services/networking/cgit.nix
@@ -146,7 +146,7 @@ in
               };
 
               repos = lib.mkOption {
-                description = "cgit repository settings, see cgitrc(5)";
+                description = "cgit repository settings, see {manpage}`cgitrc(5)`";
                 type = with lib.types; attrsOf (attrsOf settingType);
                 default = { };
                 example = {
@@ -165,7 +165,7 @@ in
               };
 
               settings = lib.mkOption {
-                description = "cgit configuration, see cgitrc(5)";
+                description = "cgit configuration, see {manpage}`cgitrc(5)`";
                 type = lib.types.attrsOf repeatedSettingType;
                 default = { };
                 example = lib.literalExpression ''

--- a/nixos/modules/services/networking/hylafax/options.nix
+++ b/nixos/modules/services/networking/hylafax/options.nix
@@ -194,7 +194,7 @@ in
         will be symlinked to the location given here.
         This file must exist and be
         readable only by the `uucp` user.
-        See hosts.hfaxd(5) for details.
+        See {manpage}`hosts.hfaxd(5)` for details.
         This configuration permits access for all users:
         ```
           environment.etc."hosts.hfaxd" = {
@@ -299,7 +299,7 @@ in
       description = ''
         purging old files from the spooling area with
         {file}`faxcron` with the given frequency
-        (see systemd.time(7))
+        (see {manpage}`systemd.time(7)`)
       '';
     };
     faxcron.infoDays = mkOption {
@@ -339,7 +339,7 @@ in
       description = ''
         Purge old files from the spooling area with
         {file}`faxcron` with the given frequency
-        (see systemd.time(7)).
+        (see {manpage}`systemd.time(7)`).
       '';
     };
     faxqclean.archiving = mkOption {
@@ -356,7 +356,7 @@ in
         `as-flagged` archives jobs that
         have been flagged for archiving by sendfax,
         `always` forces archiving of all jobs.
-        See also sendfax(1) and faxqclean(8).
+        See also {manpage}`sendfax(1)` and {manpage}`faxqclean(8)`.
       '';
     };
     faxqclean.doneqMinutes = mkOption {

--- a/nixos/modules/services/networking/minidlna.nix
+++ b/nixos/modules/services/networking/minidlna.nix
@@ -12,7 +12,7 @@ in {
 
   options.services.minidlna.settings = lib.mkOption {
     default = {};
-    description = "Configuration for `minidlna.conf(5)`.";
+    description = "Configuration for {manpage}`minidlna.conf(5)`.";
     type = lib.types.submodule {
       freeformType = format.type;
 

--- a/nixos/modules/services/networking/ngircd.nix
+++ b/nixos/modules/services/networking/ngircd.nix
@@ -29,7 +29,7 @@ in
       enable = mkEnableOption "the ngircd IRC server";
 
       config = mkOption {
-        description = "The ngircd configuration (see ngircd.conf(5)).";
+        description = "The ngircd configuration (see {manpage}`ngircd.conf(5)`).";
 
         type = types.lines;
       };

--- a/nixos/modules/services/networking/ntopng.nix
+++ b/nixos/modules/services/networking/ntopng.nix
@@ -58,7 +58,7 @@ in
           interfaces and displays its findings at http://localhost:''${toString
           config.${opt.http-port}}. Default username and password is admin/admin.
 
-          See the ntopng(8) manual page and http://www.ntop.org/products/ntop/
+          See the {manpage}`ntopng(8)` manual page and http://www.ntop.org/products/ntop/
           for more info.
 
           Note that enabling ntopng will also enable redis (key-value

--- a/nixos/modules/services/networking/pppd.nix
+++ b/nixos/modules/services/networking/pppd.nix
@@ -53,7 +53,7 @@ in
                 config = mkOption {
                   type = types.lines;
                   default = "";
-                  description = "pppd configuration for this peer, see the pppd(8) man page.";
+                  description = "pppd configuration for this peer, see the {manpage}`pppd(8)` man page.";
                 };
               };
             }

--- a/nixos/modules/services/networking/privoxy.nix
+++ b/nixos/modules/services/networking/privoxy.nix
@@ -114,7 +114,7 @@ in
         the disk usage, since Privoxy itself never deletes the certificates.
 
         ::: {.note}
-        The format is that of the `tmpfiles.d(5)`
+        The format is that of the {manpage}`tmpfiles.d(5)`
         Age parameter.
         :::
       '';

--- a/nixos/modules/services/networking/r53-ddns.nix
+++ b/nixos/modules/services/networking/r53-ddns.nix
@@ -45,7 +45,7 @@ in
         type = types.str;
         description = ''
           File containing the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-          in the format of an EnvironmentFile as described by systemd.exec(5)
+          in the format of an EnvironmentFile as described by {manpage}`systemd.exec(5)`
         '';
       };
 

--- a/nixos/modules/services/networking/robustirc-bridge.nix
+++ b/nixos/modules/services/networking/robustirc-bridge.nix
@@ -13,7 +13,7 @@ in
       extraFlags = mkOption {
         type = types.listOf types.str;
         default = [];
-        description = ''Extra flags passed to the {command}`robustirc-bridge` command. See [RobustIRC Documentation](https://robustirc.net/docs/adminguide.html#_bridge) or robustirc-bridge(1) for details.'';
+        description = ''Extra flags passed to the {command}`robustirc-bridge` command. See [RobustIRC Documentation](https://robustirc.net/docs/adminguide.html#_bridge) or {manpage}`robustirc-bridge(1)` for details.'';
         example = [
           "-network robustirc.net"
         ];

--- a/nixos/modules/services/networking/rpcbind.nix
+++ b/nixos/modules/services/networking/rpcbind.nix
@@ -16,7 +16,7 @@ with lib;
         description = ''
           Whether to enable `rpcbind`, an ONC RPC directory service
           notably used by NFS and NIS, and which can be queried
-          using the rpcinfo(1) command. `rpcbind` is a replacement for
+          using the {manpage}`rpcinfo(1)` command. `rpcbind` is a replacement for
           `portmap`.
         '';
       };

--- a/nixos/modules/services/networking/searx.nix
+++ b/nixos/modules/services/networking/searx.nix
@@ -56,7 +56,7 @@ in
         type = types.nullOr types.path;
         default = null;
         description = ''
-          Environment file (see `systemd.exec(5)`
+          Environment file (see {manpage}`systemd.exec(5)`
           "EnvironmentFile=" section for the syntax) to define variables for
           Searx. This option can be used to safely include secret keys into the
           Searx configuration.

--- a/nixos/modules/services/networking/spacecookie.nix
+++ b/nixos/modules/services/networking/spacecookie.nix
@@ -53,7 +53,7 @@ in {
         description = ''
           Address to listen on. Must be in the
           `ListenStream=` syntax of
-          [systemd.socket(5)](https://www.freedesktop.org/software/systemd/man/systemd.socket.html).
+          {manpage}`systemd.socket(5)`.
         '';
       };
 

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -357,7 +357,7 @@ in
               type = lib.types.nullOr (lib.types.enum [ "QUIET" "FATAL" "ERROR" "INFO" "VERBOSE" "DEBUG" "DEBUG1" "DEBUG2" "DEBUG3" ]);
               default = "INFO"; # upstream default
               description = ''
-                Gives the verbosity level that is used when logging messages from sshd(8). Logging with a DEBUG level
+                Gives the verbosity level that is used when logging messages from {manpage}`sshd(8)`. Logging with a DEBUG level
                 violates the privacy of users and is not recommended.
               '';
             };
@@ -369,7 +369,7 @@ in
               # apply if cfg.useDns then "yes" else "no"
               default = false;
               description = ''
-                Specifies whether sshd(8) should look up the remote host name, and to check that the resolved host name for
+                Specifies whether {manpage}`sshd(8)` should look up the remote host name, and to check that the resolved host name for
                 the remote IP address maps back to the very same IP address.
                 If this option is set to no (the default) then only addresses and not host names may be used in
                 ~/.ssh/authorized_keys from and sshd_config Match Host directives.

--- a/nixos/modules/services/networking/tinydns.nix
+++ b/nixos/modules/services/networking/tinydns.nix
@@ -16,7 +16,7 @@ with lib;
       data = mkOption {
         type = types.lines;
         default = "";
-        description = "The DNS data to serve, in the format described by tinydns-data(8)";
+        description = "The DNS data to serve, in the format described by {manpage}`tinydns-data(8)`";
       };
 
       ip = mkOption {

--- a/nixos/modules/services/security/clamav.nix
+++ b/nixos/modules/services/security/clamav.nix
@@ -53,7 +53,7 @@ in
           type = lib.types.str;
           default = "hourly";
           description = ''
-            How often freshclam is invoked. See systemd.time(7) for more
+            How often freshclam is invoked. See {manpage}`systemd.time(7)` for more
             information about the format.
           '';
         };
@@ -74,7 +74,7 @@ in
           type = lib.types.str;
           default = "hourly";
           description = ''
-            How often freshclam is invoked. See systemd.time(7) for more
+            How often freshclam is invoked. See {manpage}`systemd.time(7)` for more
             information about the format.
           '';
         };
@@ -105,7 +105,7 @@ in
           type = lib.types.str;
           default = "*-*-* 04:00:00";
           description = ''
-            How often clamdscan is invoked. See systemd.time(7) for more
+            How often clamdscan is invoked. See {manpage}`systemd.time(7)` for more
             information about the format.
             By default this runs using 10 cores at most, be sure to run it at a time of low traffic.
           '';

--- a/nixos/modules/services/torrent/transmission.nix
+++ b/nixos/modules/services/torrent/transmission.nix
@@ -181,7 +181,7 @@ in
               defaultText = literalExpression "if cfg.package == pkgs.transmission_3 then 18 else \"022\"";
               description = ''
                 Sets transmission's file mode creation mask.
-                See the umask(2) manpage for more information.
+                See the {manpage}`umask(2)` manpage for more information.
                 Users who want their saved torrents to be world-writable
                 may want to set this value to 0/`"000"`.
 

--- a/nixos/modules/services/web-apps/cloudlog.nix
+++ b/nixos/modules/services/web-apps/cloudlog.nix
@@ -173,7 +173,7 @@ in
         type = str;
         default = "daily";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the
           time at which the LoTW upload will occur.
         '';
       };
@@ -191,7 +191,7 @@ in
         type = str;
         default = "daily";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the time
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the time
           at which the Clublog upload will occur.
         '';
       };
@@ -210,7 +210,7 @@ in
         type = str;
         default = "weekly";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the
           time at which the LoTW user update will occur.
         '';
       };
@@ -228,7 +228,7 @@ in
         type = str;
         default = "monthly";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the
           time at which the DOK update will occur.
         '';
       };
@@ -247,7 +247,7 @@ in
         type = str;
         default = "monthly";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the time
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the time
           at which the Clublog SCP update will occur.
         '';
       };
@@ -266,7 +266,7 @@ in
         type = str;
         default = "monthly";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the time
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the time
           at which the WWFF update will occur.
         '';
       };
@@ -284,7 +284,7 @@ in
         type = str;
         default = "daily";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the
           time at which the QRZ upload will occur.
         '';
       };
@@ -302,7 +302,7 @@ in
         type = str;
         default = "monthly";
         description = ''
-          Specification (in the format described by systemd.time(7)) of the time
+          Specification (in the format described by {manpage}`systemd.time(7)`) of the time
           at which the SOTA update will occur.
         '';
       };

--- a/nixos/modules/services/web-apps/dex.nix
+++ b/nixos/modules/services/web-apps/dex.nix
@@ -51,7 +51,7 @@ in
       type = types.nullOr types.path;
       default = null;
       description = ''
-        Environment file (see `systemd.exec(5)`
+        Environment file (see {manpage}`systemd.exec(5)`
         "EnvironmentFile=" section for the syntax) to define variables for dex.
         This option can be used to safely include secret keys into the dex configuration.
       '';

--- a/nixos/modules/services/web-apps/gotosocial.nix
+++ b/nixos/modules/services/web-apps/gotosocial.nix
@@ -80,7 +80,7 @@ in
       type = lib.types.nullOr lib.types.path;
       description = ''
         File path containing environment variables for configuring the GoToSocial service
-        in the format of an EnvironmentFile as described by systemd.exec(5).
+        in the format of an EnvironmentFile as described by {manpage}`systemd.exec(5)`.
 
         This option could be used to pass sensitive configuration to the GoToSocial daemon.
 

--- a/nixos/modules/services/web-apps/miniflux.nix
+++ b/nixos/modules/services/web-apps/miniflux.nix
@@ -72,7 +72,7 @@ in
         description = ''
           File containing the ADMIN_USERNAME and
           ADMIN_PASSWORD (length >= 6) in the format of
-          an EnvironmentFile=, as described by systemd.exec(5).
+          an EnvironmentFile=, as described by {manpage}`systemd.exec(5)`.
         '';
         example = "/etc/nixos/miniflux-admin-credentials";
       };

--- a/nixos/modules/services/web-servers/merecat.nix
+++ b/nixos/modules/services/web-servers/merecat.nix
@@ -30,7 +30,7 @@ in
       inherit (format) type;
       default = { };
       description = ''
-        Merecat configuration. Refer to merecat(8) for details on supported values.
+        Merecat configuration. Refer to {manpage}`merecat(8)` for details on supported values.
       '';
       example = {
         hostname = "localhost";

--- a/nixos/modules/services/web-servers/minio.nix
+++ b/nixos/modules/services/web-servers/minio.nix
@@ -72,7 +72,7 @@ in
       description = ''
         File containing the MINIO_ROOT_USER, default is "minioadmin", and
         MINIO_ROOT_PASSWORD (length >= 8), default is "minioadmin"; in the format of
-        an EnvironmentFile=, as described by systemd.exec(5).
+        an EnvironmentFile=, as described by {manpage}`systemd.exec(5)`.
       '';
       example = "/etc/nixos/minio-root-credentials";
     };

--- a/nixos/modules/services/web-servers/pomerium.nix
+++ b/nixos/modules/services/web-servers/pomerium.nix
@@ -50,7 +50,7 @@ in
       default = null;
       description = ''
         Path to file containing secrets for Pomerium, in systemd
-        EnvironmentFile format. See the systemd.exec(5) man page.
+        EnvironmentFile format. See the {manpage}`systemd.exec(5)` man page.
       '';
     };
   };

--- a/nixos/modules/services/web-servers/uwsgi.nix
+++ b/nixos/modules/services/web-servers/uwsgi.nix
@@ -200,7 +200,7 @@ in
         '';
         description = ''
           Grant capabilities to the uWSGI instance. See the
-          `capabilities(7)` for available values.
+          {manpage}`capabilities(7)` for available values.
 
           ::: {.note}
           uWSGI runs as an unprivileged user (even as Emperor) with the minimal

--- a/nixos/modules/services/x11/display-managers/startx.nix
+++ b/nixos/modules/services/x11/display-managers/startx.nix
@@ -27,7 +27,7 @@ in
           which allows users to start X manually via the "startx" command
           from a vt shell. The X server runs under the user's id, not as root.
           The user must provide a ~/.xinitrc file containing session startup
-          commands, see startx(1). This is not automatically generated
+          commands, see {manpage}`startx(1)`. This is not automatically generated
           from the desktopManager and windowManager settings.
         '';
       };

--- a/nixos/modules/services/x11/display-managers/sx.nix
+++ b/nixos/modules/services/x11/display-managers/sx.nix
@@ -18,7 +18,7 @@ in
           to start manually via the "sx" command from a vt shell. The X server
           runs under the user's id, not as root. The user must provide a
           ~/.config/sx/sxrc file containing session startup commands, see
-          sx(1). This is not automatically generated from the desktopManager
+          {manpage}`sx(1)`. This is not automatically generated from the desktopManager
           and windowManager settings. sx doesn't have a way to directly set
           X server flags, but it can be done by overriding its xorgserver
           dependency.

--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -126,7 +126,7 @@ in
       ];
       description = ''
         List of conditions of windows that should not be faded.
-        See `picom(1)` man page for more examples.
+        See {manpage}`picom(1)` man page for more examples.
       '';
     };
 
@@ -172,7 +172,7 @@ in
       ];
       description = ''
         List of conditions of windows that should have no shadow.
-        See `picom(1)` man page for more examples.
+        See {manpage}`picom(1)` man page for more examples.
       '';
     };
 
@@ -326,7 +326,7 @@ in
         description = ''
           Picom settings. Use this option to configure Picom settings not exposed
           in a NixOS option or to bypass one.  For the available options see the
-          CONFIGURATION FILES section at `picom(1)`.
+          CONFIGURATION FILES section at {manpage}`picom(1)`.
         '';
       };
   };

--- a/nixos/modules/system/activation/activation-script.nix
+++ b/nixos/modules/system/activation/activation-script.nix
@@ -203,7 +203,7 @@ in
       type = types.nullOr types.path;
       visible = false;
       description = ''
-        The env(1) executable that is linked system-wide to
+        The {manpage}`env(1)` executable that is linked system-wide to
         `/usr/bin/env`.
       '';
     };

--- a/nixos/modules/system/boot/systemd/coredump.nix
+++ b/nixos/modules/system/boot/systemd/coredump.nix
@@ -29,7 +29,7 @@ in
       type = types.lines;
       example = "Storage=journal";
       description = ''
-        Extra config options for systemd-coredump. See coredump.conf(5) man page
+        Extra config options for systemd-coredump. See {manpage}`coredump.conf(5)` man page
         for available options.
       '';
     };

--- a/nixos/modules/system/boot/systemd/initrd.nix
+++ b/nixos/modules/system/boot/systemd/initrd.nix
@@ -163,7 +163,7 @@ in
       type = types.lines;
       example = "DefaultLimitCORE=infinity";
       description = ''
-        Extra config options for systemd. See systemd-system.conf(5) man page
+        Extra config options for systemd. See {manpage}`systemd-system.conf(5)` man page
         for available options.
       '';
     };

--- a/nixos/modules/system/boot/systemd/logind.nix
+++ b/nixos/modules/system/boot/systemd/logind.nix
@@ -29,7 +29,7 @@ in
       example = "IdleAction=lock";
       description = ''
         Extra config options for systemd-logind.
-        See [logind.conf(5)](https://www.freedesktop.org/software/systemd/man/logind.conf.html)
+        See {manpage}`logind.conf(5)`
         for available options.
       '';
     };

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -28,7 +28,7 @@ in
           `timesyncd.conf` file as opposed to setting this option to null which
           will remove `NTP=` entirely.
 
-          See man:{manpage}`timesyncd.conf(5)` for details.
+          See {manpage}`timesyncd.conf(5)` for details.
         '';
       };
       fallbackServers = mkOption {
@@ -42,7 +42,7 @@ in
           `timesyncd.conf` file as opposed to setting this option to null which
           will remove `FallbackNTP=` entirely.
 
-          See man:{manpage}`timesyncd.conf(5)` for details.
+          See {manpage}`timesyncd.conf(5)` for details.
         '';
       };
       extraConfig = mkOption {

--- a/nixos/modules/system/boot/timesyncd.nix
+++ b/nixos/modules/system/boot/timesyncd.nix
@@ -28,7 +28,7 @@ in
           `timesyncd.conf` file as opposed to setting this option to null which
           will remove `NTP=` entirely.
 
-          See man:timesyncd.conf(5) for details.
+          See man:{manpage}`timesyncd.conf(5)` for details.
         '';
       };
       fallbackServers = mkOption {
@@ -42,7 +42,7 @@ in
           `timesyncd.conf` file as opposed to setting this option to null which
           will remove `FallbackNTP=` entirely.
 
-          See man:timesyncd.conf(5) for details.
+          See man:{manpage}`timesyncd.conf(5)` for details.
         '';
       };
       extraConfig = mkOption {

--- a/nixos/modules/tasks/filesystems/nfs.nix
+++ b/nixos/modules/tasks/filesystems/nfs.nix
@@ -99,7 +99,7 @@ in
         default = { };
         description = ''
           General configuration for NFS daemons and tools.
-          See nfs.conf(5) and related man pages for details.
+          See {manpage}`nfs.conf(5)` and related man pages for details.
         '';
         example = lib.literalExpression ''
           {

--- a/nixos/modules/tasks/network-interfaces.nix
+++ b/nixos/modules/tasks/network-interfaces.nix
@@ -97,7 +97,7 @@ let
         default = null;
         description = ''
           Type of the route.  See the `Route types` section
-          in the `ip-route(8)` manual page for the details.
+          in the {manpage}`ip-route(8)` manual page for the details.
 
           Note that `prohibit`, `blackhole`,
           `unreachable`, and `throw` cannot
@@ -118,7 +118,7 @@ let
         example = { mtu = "1492"; window = "524288"; };
         description = ''
           Other route options. See the symbol `OPTIONS`
-          in the `ip-route(8)` manual page for the details.
+          in the {manpage}`ip-route(8)` manual page for the details.
           You may also specify `metric`,
           `src`, `protocol`,
           `scope`, `from`

--- a/nixos/modules/virtualisation/docker.nix
+++ b/nixos/modules/virtualisation/docker.nix
@@ -34,7 +34,7 @@ in
         default = ["/run/docker.sock"];
         description = ''
             A list of unix and tcp docker should listen to. The format follows
-            ListenStream as described in systemd.socket(5).
+            ListenStream as described in {manpage}`systemd.socket(5)`.
           '';
       };
 

--- a/nixos/modules/virtualisation/nixos-containers.nix
+++ b/nixos/modules/virtualisation/nixos-containers.nix
@@ -349,7 +349,7 @@ let
           Device node access modifier. Takes a combination
           `r` (read), `w` (write), and
           `m` (mknod). See the
-          `systemd.resource-control(5)` man page for more
+          {manpage}`systemd.resource-control(5)` man page for more
           information.'';
       };
     };
@@ -563,7 +563,7 @@ in
               example = [ "CAP_NET_ADMIN" "CAP_MKNOD" ];
               description = ''
                 Grant additional capabilities to the container.  See the
-                capabilities(7) and systemd-nspawn(1) man pages for more
+                {manpage}`capabilities(7)` and {manpage}`systemd-nspawn(1)` man pages for more
                 information.
               '';
             };
@@ -644,7 +644,7 @@ in
                 shall run in. The specified path should refer to a (possibly bind-mounted) network
                 namespace file, as exposed by the kernel below /proc/<PID>/ns/net. This makes the
                 container enter the given network namespace. One of the typical use cases is to give
-                a network namespace under /run/netns created by ip-netns(8).
+                a network namespace under /run/netns created by {manpage}`ip-netns(8)`.
                 Note that this option cannot be used together with other network-related options,
                 such as --private-network or --network-interface=.
               '';
@@ -737,7 +737,7 @@ in
                 Mounts a set of tmpfs file systems into the container.
                 Multiple paths can be specified.
                 Valid items must conform to the --tmpfs argument
-                of systemd-nspawn. See systemd-nspawn(1) for details.
+                of systemd-nspawn. See {manpage}`systemd-nspawn(1)` for details.
               '';
             };
 
@@ -747,7 +747,7 @@ in
               example = [ "--drop-capability=CAP_SYS_CHROOT" ];
               description = ''
                 Extra flags passed to the systemd-nspawn command.
-                See systemd-nspawn(1) for details.
+                See {manpage}`systemd-nspawn(1)` for details.
               '';
             };
 

--- a/nixos/modules/virtualisation/oci-containers.nix
+++ b/nixos/modules/virtualisation/oci-containers.nix
@@ -155,7 +155,7 @@ let
             [Docker engine documentation](https://docs.docker.com/engine/logging/configure/)
 
             For Podman:
-            Refer to the docker-run(1) man page.
+            Refer to the {manpage}`docker-run(1)` man page.
           '';
         };
 

--- a/nixos/modules/virtualisation/waagent.nix
+++ b/nixos/modules/virtualisation/waagent.nix
@@ -151,7 +151,7 @@ let
           ];
           description = ''
             This option specifies disk mount options to be passed to the `mount -o` command.
-            For more information, see the `mount(8)` manual page.
+            For more information, see the {manpage}`mount(8)` manual page.
           '';
         };
 


### PR DESCRIPTION
This is basically the second commit in https://github.com/NixOS/nixpkgs/pull/377170 on steroids, candidate for https://github.com/NixOS/nixpkgs/issues/346453

Candidates were made using

```shell
#!/usr/bin/env nix-shell
#!nix-shell --pure -i bash -p ripgrep sd jq git

git restore .

# convert foobar(1) manpage references to {manpage}`foobar(1)`
while read fname; do
    echo $fname

    # list all found manpage references
    # rg '[a-zA-Z.-]+\([0-9]+\)' "$fname" --json | jq '.data.submatches[]?.match.text' -r | sort -u

    (set -x
        sd ' `([a-zA-Z.-]+\([0-9]+\))`' ' {manpage}`$1`' "$fname"
        sd '\(`([a-zA-Z.-]+\([0-9]+\))`\)' '({manpage}`$1`)' "$fname"
        sd '\b([a-zA-Z.-]+\([0-9]+\))' '{manpage}`$1`' "$fname"
        # undo double manpage tagging
        sd '\{manpage\}`\{manpage\}`([a-zA-Z.-]+\([0-9]+\))``' '{manpage}`$1`' "$fname"
    )

done < <(rg '[a-zA-Z.-]+\([0-9]+\)' -tnix nixos/ -l)

git restore nixos/tests
```

and picked with `GIT_DIFF_OPTS='--unified=20' git add -p` for improved context.

The second commit was made using 

```
jq <doc/manpage-urls.json 'to_entries[] | "rg -F \"[\(.key)](\(.value))\" nixos/ -l | xe sd -F \"[\(.key)](\(.value))\" \"{manpage}`\(.key)`\""' -r  | tr \" \' | bash -x
```

The third commit and onward are manual cleanups and fixes

---

The next stage is to either (a) expand `doc/manpage-urls.json` with more urls or (b) add `https://linux.die.net/man/` as a fallback, or (c) both. (see https://github.com/NixOS/nixpkgs/pull/208762.)



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
