### PR TITLE
voicevox-engine: fix with poetry-core >=2.0; voicevox: 0.22.3 -> 0.22.4

### DIFF
--- a/pkgs/by-name/vo/voicevox-engine/make-installable.patch
+++ b/pkgs/by-name/vo/voicevox-engine/make-installable.patch
@@ -2,7 +2,7 @@ diff --git a/pyproject.toml b/pyproject.toml
 index fa23446..6a7705c 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -40,7 +40,15 @@ use_parentheses = true
+@@ -40,7 +40,20 @@ use_parentheses = true
  datas = "datas" # PyInstaller's argument
  
  [tool.poetry]
@@ -12,7 +12,12 @@ index fa23446..6a7705c 100644
 +authors = []
 +description = ""
 +packages = [ { include = "voicevox_engine" } ]
-+include = [ "resources/**/*", "run.py", "engine_manifest.json", "presets.yaml"]
++include = [
++  { path = "resources/**/*", format = ["sdist", "wheel"] },
++  { path = "run.py", format = ["sdist", "wheel"] },
++  { path = "engine_manifest.json", format = ["sdist", "wheel"] },
++  { path = "presets.yaml", format = ["sdist", "wheel"] }
++]
 +
 +[tool.poetry.scripts]
 +voicevox-engine = "run:main"

--- a/pkgs/by-name/vo/voicevox/package.nix
+++ b/pkgs/by-name/vo/voicevox/package.nix
@@ -15,13 +15,13 @@
 
 buildNpmPackage rec {
   pname = "voicevox";
-  version = "0.22.3";
+  version = "0.22.4";
 
   src = fetchFromGitHub {
     owner = "VOICEVOX";
     repo = "voicevox";
     tag = version;
-    hash = "sha256-6z+A4bJIDfN/K8IjEdt2TqEa/EDt4uQpGh+zSWfP74I=";
+    hash = "sha256-IOs3wBcFYpO4AHiWFOQWd5hp6EmwyA7Rcc8wjHKvYNQ=";
   };
 
   patches = [


### PR DESCRIPTION
First commit fixes the silently broken voicevox-engine package, which suffered this breaking change of poetry 2.0:
https://python-poetry.org/blog/announcing-poetry-2.0.0#consistent-include-behavior

Second is a small hotfix version bump:
https://github.com/VOICEVOX/voicevox/releases/tag/0.22.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
