### PR TITLE
astal: move source to a separate package

### DIFF
--- a/pkgs/development/libraries/astal/buildAstalModule.nix
+++ b/pkgs/development/libraries/astal/buildAstalModule.nix
@@ -1,7 +1,7 @@
 {
   lib,
   stdenv,
-  fetchFromGitHub,
+  source, # this is ./source.nix
 
   glib,
   wrapGAppsHook3,
@@ -39,17 +39,12 @@ let
       cleanArgs args
       // {
         pname = "astal-${name}";
-        version = "0-unstable-2025-03-21";
+        inherit (source) version;
 
         __structuredAttrs = true;
         strictDeps = true;
 
-        src = fetchFromGitHub {
-          owner = "Aylur";
-          repo = "astal";
-          rev = "dc0e5d37abe9424c53dcbd2506a4886ffee6296e";
-          hash = "sha256-5WgfJAeBpxiKbTR/gJvxrGYfqQRge5aUDcGKmU1YZ1Q=";
-        };
+        src = source;
 
         sourceRoot = "${finalAttrs.src.name}/${sourceRoot}";
 

--- a/pkgs/development/libraries/astal/default.nix
+++ b/pkgs/development/libraries/astal/default.nix
@@ -1,5 +1,6 @@
 { wireplumber }:
 self: {
+  source = self.callPackage ./source.nix { };
   buildAstalModule = self.callPackage ./buildAstalModule.nix { };
 
   apps = self.callPackage ./modules/apps.nix { };

--- a/pkgs/development/libraries/astal/modules/io.nix
+++ b/pkgs/development/libraries/astal/modules/io.nix
@@ -1,17 +1,6 @@
-{ buildAstalModule, nix-update-script }:
-(buildAstalModule {
+{ buildAstalModule }:
+buildAstalModule {
   name = "io";
   sourceRoot = "lib/astal/io";
-  meta = {
-    description = "Astal core library";
-    longDescription = ''
-      Astal is a collection of building blocks for creating custom desktop shells
-    '';
-    mainProgram = "astal";
-  };
-}).overrideAttrs
-  {
-    # add an update script only in one place,
-    # so r-ryantm won't run it multiple times
-    passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
-  }
+  meta.description = "Astal core library";
+}

--- a/pkgs/development/libraries/astal/source.nix
+++ b/pkgs/development/libraries/astal/source.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  nix-update-script,
+  fetchFromGitHub,
+}:
+(fetchFromGitHub {
+  owner = "Aylur";
+  repo = "astal";
+  rev = "dc0e5d37abe9424c53dcbd2506a4886ffee6296e";
+  hash = "sha256-5WgfJAeBpxiKbTR/gJvxrGYfqQRge5aUDcGKmU1YZ1Q=";
+}).overrideAttrs
+  (
+    final: prev: {
+      name = "${final.pname}-${final.version}"; # fetchFromGitHub already defines name
+      pname = "astal-source";
+      version = "0-unstable-2025-03-21";
+
+      meta = prev.meta // {
+        description = "Building blocks for creating custom desktop shells (source)";
+        longDescription = ''
+          Please don't use this package directly, use one of subpackages in
+          `astal` namespace. This package is just a `fetchFromGitHub`, which is
+          reused between all subpackages.
+        '';
+        maintainers = with lib.maintainers; [ perchun ];
+        platforms = lib.platforms.linux;
+      };
+
+      passthru = prev.passthru // {
+        updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+      };
+    }
+  )


### PR DESCRIPTION
It provides general description for all astal packages and r-ryantm will create properly named PRs.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
