### PR TITLE
mk-python-derivation: avoid conversion of disabledTestPaths list to string

### DIFF
--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -42,7 +42,6 @@ let
     optionals
     optionalAttrs
     hasSuffix
-    escapeShellArgs
     extendDerivation
     head
     splitString
@@ -433,12 +432,10 @@ let
         installCheckPhase = attrs.checkPhase;
       }
       // optionalAttrs (attrs.doCheck or true) (
-        optionalAttrs (disabledTestPaths != [ ]) {
-          disabledTestPaths = escapeShellArgs disabledTestPaths;
+        optionalAttrs (attrs ? disabledTestPaths) {
+          disabledTestPaths = attrs.disabledTestPaths;
         }
         // optionalAttrs (attrs ? disabledTests) {
-          # `escapeShellArgs` should be used as well as `disabledTestPaths`,
-          # but some packages rely on existing raw strings.
           disabledTests = attrs.disabledTests;
         }
         // optionalAttrs (attrs ? pytestFlagsArray) {


### PR DESCRIPTION
I just found a very confusing behaviour of Python's `disabledTestPaths` attribute, which is declared as a list ([example](https://github.com/NixOS/nixpkgs/blob/1c71253d6f989d01f3e70bd3abf00e1f445866a6/pkgs/development/python-modules/branca/default.nix#L42)) , but is automatically converted in to string. 

Try in repl:
```
nix repl

nix-repl> :l .

nix-repl> pkgs.python3.pkgs.branca.disabledTestPaths
"tests/test_utilities.py"
```

Even worse, it is inconsistent with `disabledTests` which is NOT converted (stays as a list):

```
nix-repl> pkgs.python3.pkgs.branca.disabledTests
[
  "test_rendering_utf8_iframe"
  "test_rendering_figure_notebook"
]
```

This is very confusing, especially when using `overrideAttrs` in your overlay, and should be avoided. For example, following overlay code will fail:

```
              python3 = prev.python3.override {
                packageOverrides = python-final: python-prev: {
                  branca = python-prev.branca.overrideAttrs (old: {
                      disabledTestPaths = old.disabledTestPaths ++ ["tests/xyz"];
                  });
                };
              };
```
```
error: expected a list but found a string: "tests/test_utilities.py"
```


If something like this is really needed [pytest-check-hook.sh](https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh) looks like a better place to do so.




<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
