### PR TITLE
pngout: 20200115 -> 20230322

### DIFF
--- a/pkgs/by-name/pn/pngout/package.nix
+++ b/pkgs/by-name/pn/pngout/package.nix
@@ -7,6 +7,9 @@
 
 let
   platforms = {
+    aarch64-darwin = {
+      folder = ".";
+    };
     aarch64-linux = {
       folder = "aarch64";
       ld-linux = "ld-linux-aarch64.so.1";
@@ -33,22 +36,22 @@ let
   download =
     if stdenv.hostPlatform.isDarwin then
       {
-        extension = "macos.zip";
-        hash = "sha256-MnL6lH7q/BrACG4fFJNfnvoh0JClVeaJIlX+XIj2aG4=";
+        suffix = "20230322-mac.zip";
+        hash = "sha256-Lj63k0UgYECuOg0NDs/prQHZL+UAK4oWdqZWMqVoQOE=";
       }
     else
       {
-        extension = "linux.tar.gz";
+        suffix = "20200115-linux.tar.gz";
         hash = "sha256-rDi7pvDeKQM96GZTjDr6ZDQTGbaVu+OI77xf2egw6Sg=";
       };
 in
 stdenv.mkDerivation rec {
   pname = "pngout";
-  version = "20200115";
+  version = "20230322";
 
   src = fetchurl {
     inherit (download) hash;
-    url = "http://static.jonof.id.au/dl/kenutils/pngout-${version}-${download.extension}";
+    url = "https://www.jonof.id.au/files/kenutils/pngout-${download.suffix}";
   };
 
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isDarwin [ unzip ];


### PR DESCRIPTION
This bumps the nix `version` of the package to 20230322, although the linux binary remains unchanged. The 20230322 release just adds aarch64-darwin support to the mac binary.

(This is admittedly unusual... I guess the alternative is to have two distinct packages at different versions, but IMO the approach in this PR is the lesser of two evils. It seems safe to assume there won't be a new Linux release that would conflict with that version number - if they do put out a new release, presumably it would be for all Linux and Mac versions at, say, 20250130)

https://www.jonof.id.au/kenutils.html

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
