### PR TITLE
colorstorm: 2.0.0 -> 2.0.0-unstable-2025-01-17

### DIFF
--- a/pkgs/by-name/co/colorstorm/0001-fix-segfault.patch
+++ b/pkgs/by-name/co/colorstorm/0001-fix-segfault.patch
@@ -1,0 +1,12 @@
+diff --git a/src/templator.zig b/src/templator.zig
+index 5630a04..0dc8ca7 100644
+--- a/src/templator.zig
++++ b/src/templator.zig
+@@ -77,7 +77,6 @@ pub fn parse_themes(f: std.fs.File) ![]Theme {
+     }
+ 
+     const parsed = try std.json.parseFromSlice([]Theme, a, list.items, .{});
+-    defer parsed.deinit();
+     const themes = parsed.value;
+ 
+     return themes;

--- a/pkgs/by-name/co/colorstorm/package.nix
+++ b/pkgs/by-name/co/colorstorm/package.nix
@@ -2,22 +2,31 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  zig_0_9,
+  zig_0_13,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "colorstorm";
-  version = "2.0.0";
+  # last tagged release is three years old and requires outdated Zig 0.9
+  # new release requested in: https://github.com/benbusby/colorstorm/issues/16
+  version = "2.0.0-unstable-2025-01-17";
 
   src = fetchFromGitHub {
     owner = "benbusby";
     repo = "colorstorm";
-    rev = "v${finalAttrs.version}";
-    hash = "sha256-6+P+QQpP1jxsydqhVrZkjl1gaqNcx4kS2994hOBhtu8=";
+    rev = "e645c4293fb5f72968038dac99e0b8dab3db194f";
+    hash = "sha256-6D+aNcjJksv7E9RJB9fnzgzvGoUPXV4Shz5wLu5YHtg=";
   };
 
+  patches = [
+    # Fixes a use-after-free segfault.
+    # See https://github.com/benbusby/colorstorm/pull/15#discussion_r1930406581
+    # and upstream PR https://github.com/NixOS/nixpkgs/pull/377279
+    ./0001-fix-segfault.patch
+  ];
+
   nativeBuildInputs = [
-    zig_0_9.hook
+    zig_0_13.hook
   ];
 
   meta = {
@@ -25,7 +34,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://github.com/benbusby/colorstorm";
     license = lib.licenses.mit;
     maintainers = [ ];
-    inherit (zig_0_9.meta) platforms;
+    inherit (zig_0_13.meta) platforms;
     mainProgram = "colorstorm";
   };
 })


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelog: https://github.com/benbusby/colorstorm/compare/v2.0.0...e645c4293fb5f72968038dac99e0b8dab3db194f

All changes since 2.0 are are only build- or documentation-related.
colorstorm is the last package in nixpkgs depending on a Zig version older than 0.11 (precisely, 0.9 even). Bumping it to the recent but yet untagged commit making it compatible with the current Zig version 0.13.

A new tagged release has been requested in https://github.com/benbusby/colorstorm/issues/16

Moved out of #376540 as the update itself isn't blocked by the Zig refactoring.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
