### PR TITLE
nixosTests.mate-wayland: Check for more text

### DIFF
--- a/nixos/tests/mate-wayland.nix
+++ b/nixos/tests/mate-wayland.nix
@@ -42,10 +42,11 @@ import ./make-test-python.nix (
             machine.wait_for_file("/run/user/${toString user.uid}/wayland-1")
 
         with subtest("Check if MATE session components actually start"):
-            for i in ["wayfire", "mate-panel", "mate-wayland.sh", "mate-wayland-components.sh"]:
-                machine.wait_until_succeeds(f"pgrep -f {i}")
-            # It is expected that this applet doesn't work in Wayland
-            machine.wait_for_text('WorkspaceSwitcherApplet')
+            for i in ["wayfire", "mate-panel", "mate-wayland.sh"]:
+                machine.wait_until_succeeds(f"pgrep {i}")
+            machine.wait_until_succeeds("pgrep -f mate-wayland-components.sh")
+            # It is expected that WorkspaceSwitcherApplet doesn't work in Wayland
+            machine.wait_for_text('(panel|Factory|Workspace|Switcher|Applet|configuration)')
 
         with subtest("Check if various environment variables are set"):
             cmd = "xargs --null --max-args=1 echo < /proc/$(pgrep -xf mate-panel)/environ"


### PR DESCRIPTION
As long as the dialog shows everything is fine, make the test less flaky.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

