### PR TITLE
python312Packages.jaxopt: disable flaky test

### DIFF
--- a/pkgs/development/python-modules/jaxopt/default.nix
+++ b/pkgs/development/python-modules/jaxopt/default.nix
@@ -89,11 +89,12 @@ buildPythonPackage rec {
     "test_binary_logit_log_likelihood"
 
     # AssertionError (flaky numerical tests)
-    "test_logreg_with_intercept_manual_loop3"
-    "test_inv_hessian_product_pytree3"
-    "test_multiclass_logreg6"
     "test_Rosenbrock2"
     "test_Rosenbrock5"
+    "test_gradient1"
+    "test_inv_hessian_product_pytree3"
+    "test_logreg_with_intercept_manual_loop3"
+    "test_multiclass_logreg6"
   ];
 
   meta = {


### PR DESCRIPTION
## Things done


```
      with np.errstate(invalid='ignore'):
        # TODO(phawkins): surprisingly, assert_allclose sometimes reports invalid
        # value errors. It should not do that.
>       np.testing.assert_allclose(a, b, **kw, err_msg=err_msg)
E       AssertionError:
E       Not equal to tolerance rtol=0.002, atol=0.002
E       VJP of JVP cotangent projection
E       Mismatched elements: 1 / 1 (100%)
E       Max absolute difference among violations: 0.00696719
E       Max relative difference among violations: 0.00398552
E        ACTUAL: array(-1.755092, dtype=float32)
E        DESIRED: array(-1.748125, dtype=float32)

/nix/store/blg85n8dsvkahyzm9r94dvsv97yy9zq5-python3.12-jax-0.5.0/lib/python3.12/site-packages/jax/_src/public_test_util.py:142: AssertionError
```

cc @bcdarwin

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
