### PR TITLE
linuxPackages.nvidia_x11.open: don't include date for reproducibility

### DIFF
--- a/pkgs/os-specific/linux/nvidia-x11/open.nix
+++ b/pkgs/os-specific/linux/nvidia-x11/open.nix
@@ -29,6 +29,7 @@ stdenv.mkDerivation (
       "SYSSRC=${kernel.dev}/lib/modules/${kernel.modDirVersion}/source"
       "SYSOUT=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "MODLIB=$(out)/lib/modules/${kernel.modDirVersion}"
+      "DATE="
       {
         aarch64-linux = "TARGET_ARCH=aarch64";
         x86_64-linux = "TARGET_ARCH=x86_64";


### PR DESCRIPTION
date string was included in debug info, making the build non-reproducible: https://github.com/NVIDIA/open-gpu-kernel-modules/blob/9d0b0414a5304c3679c5db9d44d2afba8e58cc1b/utils.mk#L552

```
│ │ │ │ │ │ │   --- /nix/store/y4lkv451s2dn0m0088i8kfrfvi7d2sfl-nvidia-open-6.12.11-550.142/lib/modules/6.12.11-gnu/kernel/drivers/video/nvidia.ko.xz
│ │ │ │ │ │ ├── +++ /nix/store/y4lkv451s2dn0m0088i8kfrfvi7d2sfl-nvidia-open-6.12.11-550.142.check/lib/modules/6.12.11-gnu/kernel/drivers/video/nvidia.ko.xz
│ │ │ │ │ │ │ ├── nvidia.ko
│ │ │ │ │ │ │ │┄ File has been modified after NT_GNU_BUILD_ID has been applied.
│ │ │ │ │ │ │ │ ├── readelf --wide --notes {}
│ │ │ │ │ │ │ │ │ @@ -1,13 +1,13 @@
│ │ │ │ │ │ │ │ │  
│ │ │ │ │ │ │ │ │  Displaying notes found in: .note.gnu.property
│ │ │ │ │ │ │ │ │    Owner                Data size     Description
│ │ │ │ │ │ │ │ │    GNU                  0x00000030    NT_GNU_PROPERTY_TYPE_0        Properties: x86 feature: IBT, x86 feature used: x86, x86 ISA used: x86-64-baseline
│ │ │ │ │ │ │ │ │  
│ │ │ │ │ │ │ │ │  Displaying notes found in: .note.gnu.build-id
│ │ │ │ │ │ │ │ │    Owner                Data size     Description
│ │ │ │ │ │ │ │ │ -  GNU                  0x00000014    NT_GNU_BUILD_ID (unique build ID bitstring)         Build ID: aa37d42114b89f7dfc33253d732d12291ca935eb
│ │ │ │ │ │ │ │ │ +  GNU                  0x00000014    NT_GNU_BUILD_ID (unique build ID bitstring)         Build ID: 6dea79d218f42675ec3d96a255285387d7597a6d
│ │ │ │ │ │ │ │ │  
│ │ │ │ │ │ │ │ │  Displaying notes found in: .note.Linux
│ │ │ │ │ │ │ │ │    Owner                Data size     Description
│ │ │ │ │ │ │ │ │    Linux                0x00000004    func       description data: 00 00 00 00 
│ │ │ │ │ │ │ │ │    Linux                0x00000001    OPEN       description data: 00
│ │ │ │ │ │ │ │ ├── strings --all --bytes=8 {}
│ │ │ │ │ │ │ │ │ @@ -24187,15 +24187,15 @@
│ │ │ │ │ │ │ │ │  **** Bad metadata.  Lost %lld entries from %s ****
│ │ │ │ │ │ │ │ │  Assertion failed: %s (0x%08X) returned from 
│ │ │ │ │ │ │ │ │  Check failed: %s (0x%08X) returned from 
│ │ │ │ │ │ │ │ │  ../common/uproc/os/libos-v3.1.0/lib/liblogdecode.c
│ │ │ │ │ │ │ │ │  (pLog->hNvLogNoWrap != 0) && (pNvLogBuffer != NULL)
│ │ │ │ │ │ │ │ │  (pLog->hNvLogWrap != 0) && (pNvLogBuffer != NULL)
│ │ │ │ │ │ │ │ │  0123456789ABCDEF
│ │ │ │ │ │ │ │ │ -nvidia id: NVIDIA UNIX Open Kernel Module for x86_64  550.142  Release Build  (nixbld@)  Sun Jan 26 00:46:12 UTC 2025
│ │ │ │ │ │ │ │ │ +nvidia id: NVIDIA UNIX Open Kernel Module for x86_64  550.142  Release Build  (nixbld@)  Mon Jan 27 14:42:33 UTC 2025
```

This patch sets an empty string as date instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
