### PR TITLE
nixos/crashdump: Add option to pass architecture options to crashdump

### DIFF
--- a/nixos/modules/misc/crashdump.nix
+++ b/nixos/modules/misc/crashdump.nix
@@ -6,8 +6,8 @@
 }:
 let
   crashdump = config.boot.crashDump;
-
   kernelParams = lib.concatStringsSep " " crashdump.kernelParams;
+  architectureOptions = lib.concatStringsSep " " crashdump.architectureOptions;
 
 in
 ###### interface
@@ -45,6 +45,16 @@ in
             Parameters that will be passed to the kernel kexec-ed on crash.
           '';
         };
+        architectureOptions = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [
+            "--reset-vga"
+            "--console-vga"
+          ];
+          description = ''
+            Architecture options that will be passed to kexec.
+          '';
+        };
       };
     };
   };
@@ -55,9 +65,10 @@ in
     boot = {
       postBootCommands = ''
         echo "loading crashdump kernel...";
-        ${pkgs.kexec-tools}/sbin/kexec -p /run/current-system/kernel \
+        ${pkgs.kexec-tools}/sbin/kexec \
+        --load-panic /run/current-system/kernel \
         --initrd=/run/current-system/initrd \
-        --reset-vga --console-vga \
+        ${architectureOptions} \
         --command-line="init=$(readlink -f /run/current-system/init) irqpoll maxcpus=1 reset_devices ${kernelParams}"
       '';
       kernelParams = [

--- a/nixos/modules/misc/crashdump.nix
+++ b/nixos/modules/misc/crashdump.nix
@@ -47,10 +47,7 @@ in
         };
         architectureOptions = lib.mkOption {
           type = lib.types.listOf lib.types.str;
-          default = [
-            "--reset-vga"
-            "--console-vga"
-          ];
+          default = [ ];
           description = ''
             Architecture options that will be passed to kexec.
           '';
@@ -62,6 +59,15 @@ in
   ###### implementation
 
   config = lib.mkIf crashdump.enable {
+    boot.crashDump.architectureOptions = lib.mkDefault (
+      if pkgs.stdenv.isx86_64 && pkgs.stdenv.isLinux then
+        [
+          "--reset-vga"
+          "--console-vga"
+        ]
+      else
+        [ ]
+    );
     boot = {
       postBootCommands = ''
         echo "loading crashdump kernel...";


### PR DESCRIPTION
Adding an option to pass architecture options to kexec.
I run into a problem using crashdump on my raspberry pi, see #376525

closes #376525 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
