### PR TITLE
xwax: init at version 1.9

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -16991,6 +16991,12 @@
     github = "obsidian-systems-maintenance";
     githubId = 80847921;
   };
+  obsoleszenz = {
+    name = "obsoleszenz";
+    email = "obsoleszenz@riseup.net";
+    github = "obsoleszenz";
+    githubId = 94946669;
+  };
   ocfox = {
     email = "i@ocfox.me";
     github = "ocfox";

--- a/pkgs/by-name/xw/xwax/package.nix
+++ b/pkgs/by-name/xw/xwax/package.nix
@@ -1,0 +1,77 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  SDL,
+  SDL_ttf,
+  jack2,
+  libmpg123,
+  ffmpeg,
+  cdparanoia,
+  dejavu_fonts,
+  versionCheckHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "xwax";
+  version = "1.9";
+
+  src = fetchurl {
+    url = "https://xwax.org/releases/xwax-${finalAttrs.version}.tar.gz";
+    hash = "sha256-m+2PoUMYKBhlA2H0kld1W/iR8UMWEGaqp7yoxszp9jI=";
+  };
+
+  postPatch = ''
+    # When cross-compiling sdl-config will not be available in $PATH,
+    # so we must provide the full path.
+    substituteInPlace Makefile \
+      --replace-fail sdl-config "${lib.getExe' (lib.getDev SDL) "sdl-config"}"
+
+    # font loading in xwax is relying on a hardcoded list of paths,
+    # therefore we patch interface.c to also look up in the dejavu_fonts nix store path
+    substituteInPlace interface.c \
+      --replace-fail "/usr/X11R6/lib/X11/fonts/TTF" "${dejavu_fonts.outPath}/share/fonts/truetype/"
+  '';
+
+  buildInputs = [
+    # sdl
+    SDL
+    SDL_ttf
+
+    # audio server
+    jack2
+
+    # audio decoder
+    libmpg123
+    ffmpeg
+    cdparanoia
+
+    # fonts
+    dejavu_fonts
+  ];
+
+  configureFlags = [
+    "--enable-alsa"
+    "--enable-jack"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "-h";
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp xwax  $out/bin/xwax
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://xwax.org";
+    description = "Digital vinyl on Linux";
+    mainProgram = "xwax";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ obsoleszenz ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
DISCLAIMER: This is the first time i'm contributing to nixpkgs

Adds xwax v1.9 (latest)

xwax is an open-source [Digital Vinyl System](http://en.wikipedia.org/wiki/Digital_vinyl_system) (DVS) for Linux. It allows DJs and turntablists to playback digital audio files (MP3, [Ogg Vorbis](http://www.vorbis.com/), [FLAC](http://flac.sourceforge.net/), AAC and more), controlled using a normal pair of turntables via timecoded vinyls.

It's designed for both [beat mixing](http://vinylproject.com/dp/audio/chris-everest-snowy-death) and [scratch mixing](http://www.youtube.com/watch?v=C6pVZSTTXeY). Needle drops, pitch changes, scratching, spinbacks and rewinds are all supported, and feel just like the audio is pressed onto the vinyl itself.

The focus is on an accurate vinyl feel which is efficient, stable and fast.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
