### PR TITLE
 vscode-extensions.dendron.dendron: init at 0.124.0 

### DIFF
--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1314,6 +1314,8 @@ let
         };
       };
 
+      dendron.adjust-heading-level = callPackage ./dendron.adjust-heading-level { };
+
       dendron.dendron = callPackage ./dendron.dendron { };
 
       dendron.dendron-markdown-preview-enhanced =

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1316,6 +1316,10 @@ let
 
       dendron.dendron = callPackage ./dendron.dendron { };
 
+      dendron.dendron-markdown-preview-enhanced =
+        callPackage ./dendron.dendron-markdown-preview-enhanced
+          { };
+
       denoland.vscode-deno = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-deno";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1314,6 +1314,8 @@ let
         };
       };
 
+      dendron.dendron = callPackage ./dendron.dendron { };
+
       denoland.vscode-deno = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-deno";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1322,6 +1322,8 @@ let
 
       dendron.dendron-paste-image = callPackage ./dendron.dendron-paste-image { };
 
+      dendron.dendron-snippet-maker = callPackage ./dendron.dendron-snippet-maker { };
+
       denoland.vscode-deno = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-deno";

--- a/pkgs/applications/editors/vscode/extensions/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/default.nix
@@ -1320,6 +1320,8 @@ let
         callPackage ./dendron.dendron-markdown-preview-enhanced
           { };
 
+      dendron.dendron-paste-image = callPackage ./dendron.dendron-paste-image { };
+
       denoland.vscode-deno = buildVscodeMarketplaceExtension {
         mktplcRef = {
           name = "vscode-deno";

--- a/pkgs/applications/editors/vscode/extensions/dendron.adjust-heading-level/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/dendron.adjust-heading-level/default.nix
@@ -1,0 +1,17 @@
+{ lib, vscode-utils }:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "adjust-heading-level";
+    publisher = "dendron";
+    version = "0.1.0";
+    hash = "sha256-u50RJ7ETVFUC43mp94VJsR931b9REBaTyRhZE7muoLw=";
+  };
+  meta = {
+    description = "A VSCode extension to adjust the heading level of the selected text";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=dendron.adjust-heading-level";
+    homepage = "https://github.com/kevinslin/adjust-heading-level";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.ivyfanchiang ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/dendron.dendron-markdown-preview-enhanced/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/dendron.dendron-markdown-preview-enhanced/default.nix
@@ -1,0 +1,17 @@
+{ lib, vscode-utils }:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "dendron-markdown-preview-enhanced";
+    publisher = "dendron";
+    version = "0.10.57";
+    hash = "sha256-uJmdsC+nKCkAJVH+szNepPcyfHD4ZQ83on195jjqZig=";
+  };
+  meta = {
+    description = "A SUPER POWERFUL markdown extension for Visual Studio Code to bring you a wonderful markdown writing experience";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=dendron.dendron-markdown-preview-enhanced";
+    homepage = "https://github.com/dendronhq/markdown-preview-enhanced";
+    license = lib.licenses.ncsa;
+    maintainers = [ lib.maintainers.ivyfanchiang ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/dendron.dendron-paste-image/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/dendron.dendron-paste-image/default.nix
@@ -1,0 +1,17 @@
+{ lib, vscode-utils, ... }:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "dendron-paste-image";
+    publisher = "dendron";
+    version = "1.1.1";
+    hash = "sha256-SlW8MEWBgf8cJsdSzeegqPiAlEvlnrxuvrJJdhHwq2E=";
+  };
+  meta = {
+    description = "Paste images directly from your clipboard to markdown/asciidoc(or other file)!";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=dendron.dendron-paste-image";
+    homepage = "https://github.com/dendronhq/dendron-paste-image";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ivyfanchiang ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/dendron.dendron-snippet-maker/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/dendron.dendron-snippet-maker/default.nix
@@ -1,0 +1,17 @@
+{ lib, vscode-utils }:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "dendron-snippet-maker";
+    publisher = "dendron";
+    version = "0.1.6";
+    hash = "sha256-KOIbAt6EjqRGaqOlCV+HO9phR4tk2KV/+FMCefCKN+8=";
+  };
+  meta = {
+    description = "Easily create markdown snippets. Used in Dendron but can also be used standalone.";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=dendron.dendron-snippet-maker";
+    homepage = "https://github.com/dendronhq/easy-snippet-maker";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.ivyfanchiang ];
+  };
+}

--- a/pkgs/applications/editors/vscode/extensions/dendron.dendron/default.nix
+++ b/pkgs/applications/editors/vscode/extensions/dendron.dendron/default.nix
@@ -1,0 +1,18 @@
+{ lib, vscode-utils }:
+
+vscode-utils.buildVscodeMarketplaceExtension {
+  mktplcRef = {
+    name = "dendron";
+    publisher = "dendron";
+    version = "0.124.0";
+    hash = "sha256-/hxgmmiMUfBtPt5BcuNvtXs3LzDmPwDuUOyDf2udHws=";
+  };
+  meta = {
+    changelog = "https://github.com/dendronhq/dendron/blob/master/CHANGELOG.md";
+    description = "The personal knowledge management (PKM) tool that grows as you do!";
+    downloadPage = "https://marketplace.visualstudio.com/items?itemName=dendron.dendron";
+    homepage = "https://www.dendron.so/";
+    license = lib.licenses.asl20;
+    maintainers = [ lib.maintainers.ivyfanchiang ];
+  };
+}


### PR DESCRIPTION
Dendron is an open-source, local-first, markdown-based, note-taking tool within Visual Studio Code.

PR creates VSCode extension packages for Dendron and its dependency extensions:
- [x] [dendron.dendron: init at 0.124.0](https://github.com/NixOS/nixpkgs/commit/d3d9b5501ecc9c770e966c3a63f6809d0fc23f96)
- [x] [dendron-paste-image: init at 1.1.1](https://github.com/NixOS/nixpkgs/commit/589e026c1a9cbf86cc3a62d1d387229b2c1214b3)
- [x] [dendron-markdown-preview-enhanced: init at 0.10.57](https://github.com/NixOS/nixpkgs/commit/9881fd84b0b6a283c136c1be3305a66331cbe1bb)
- [x] dendron.dendron-snippet-maker
- [x] dendron.adjust-heading-level

closes #282907

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
