### PR TITLE
local-ai: try to fix ARM build

### DIFF
--- a/pkgs/by-name/lo/local-ai/package.nix
+++ b/pkgs/by-name/lo/local-ai/package.nix
@@ -27,11 +27,11 @@
   # https://github.com/NixOS/rfcs/pull/169
 
   # CPU extensions
-  enable_avx ? true,
-  enable_avx2 ? true,
+  enable_avx ? stdenv.hostPlatform.avxSupport,
+  enable_avx2 ? stdenv.hostPlatform.avx2Support,
   enable_avx512 ? stdenv.hostPlatform.avx512Support,
-  enable_f16c ? true,
-  enable_fma ? true,
+  enable_f16c ? stdenv.hostPlatform.isx86_64, # TODO: figure out proper condition
+  enable_fma ? stdenv.hostPlatform.fmaSupport,
 
   with_openblas ? false,
   openblas,


### PR DESCRIPTION
Note: users now MUST provide a correct stdenv (or override the parameters) to get the optimizations for their CPU.

I have not yet tested whether this is enough to build on ARM

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).