### PR TITLE
python312Packages.highdicom: 0.23.1 -> 0.24.0

### DIFF
--- a/pkgs/development/python-modules/highdicom/default.nix
+++ b/pkgs/development/python-modules/highdicom/default.nix
@@ -11,6 +11,7 @@
   pylibjpeg,
   pylibjpeg-libjpeg,
   setuptools,
+  typing-extensions,
 }:
 
 let
@@ -23,7 +24,7 @@ let
 in
 buildPythonPackage rec {
   pname = "highdicom";
-  version = "0.23.1";
+  version = "0.24.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -32,7 +33,7 @@ buildPythonPackage rec {
     owner = "MGHComputationalPathology";
     repo = "highdicom";
     tag = "v${version}";
-    hash = "sha256-LrsG85/bpqIEP++LgvyaVyw4tMsuUTtHNwWl7apuToM=";
+    hash = "sha256-1LRXJkltRLtPJ/NrFZVyjTusXfmcEVOTFEuq0gOI+yQ=";
   };
 
   build-system = [
@@ -44,6 +45,7 @@ buildPythonPackage rec {
     pillow
     pillow-jpls
     pydicom
+    typing-extensions
   ];
 
   optional-dependencies = {
@@ -77,6 +79,7 @@ buildPythonPackage rec {
     "test_rgb_jpegls"
     "test_construction_autotile"
     "test_pixel_types_fractional"
+    "test_pixel_types_labelmap"
   ];
 
   pythonImportsCheck = [


### PR DESCRIPTION
Routine update [changelog](https://github.com/ImagingDataCommons/highdicom/releases/tag/v0.24.0)

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
