### PR TITLE
Improve compare performance

### DIFF
--- a/ci/eval/compare/default.nix
+++ b/ci/eval/compare/default.nix
@@ -69,7 +69,6 @@ let
     groupByPlatform
     extractPackageNames
     getLabels
-    uniqueStrings
     ;
 
   getAttrs = dir: builtins.fromJSON (builtins.readFile "${dir}/outpaths.json");
@@ -81,7 +80,7 @@ let
   # - values: lists of `packagePlatformPath`s
   diffAttrs = diff beforeAttrs afterAttrs;
 
-  rebuilds = uniqueStrings (diffAttrs.added ++ diffAttrs.changed);
+  rebuilds = diffAttrs.added ++ diffAttrs.changed;
   rebuildsPackagePlatformAttrs = convertToPackagePlatformAttrs rebuilds;
 
   changed-paths =
@@ -110,7 +109,7 @@ let
     );
 
   maintainers = import ./maintainers.nix {
-    changedattrs = lib.unique (map (a: a.packagePath) rebuildsPackagePlatformAttrs);
+    changedattrs = lib.attrNames (lib.groupBy (a: a.name) rebuildsPackagePlatformAttrs);
     changedpathsjson = touchedFilesJson;
   };
 in

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -45,14 +45,6 @@ let
     pkg: pkg // { maintainers = (pkg.package.meta or { }).maintainers or [ ]; }
   ) attrsWithPackages;
 
-  attrsWeCanPing = builtins.filter (
-    pkg:
-    if (builtins.length pkg.maintainers) > 0 then
-      true
-    else
-      builtins.trace "Package has no maintainers: ${pkg.name}" false
-  ) attrsWithMaintainers;
-
   relevantFilenames =
     drv:
     (lib.lists.unique (
@@ -109,12 +101,6 @@ let
     }
   ) { } listToPing;
 
-  textForPackages =
-    packages: lib.strings.concatStringsSep ", " (builtins.map (pkg: pkg.packageName) packages);
-
-  textPerMaintainer = lib.attrsets.mapAttrs (
-    maintainer: packages: "- @${maintainer} for ${textForPackages packages}"
-  ) byMaintainer;
 
   packagesPerMaintainer = lib.attrsets.mapAttrs (
     maintainer: packages: builtins.map (pkg: pkg.packageName) packages

--- a/ci/eval/compare/maintainers.nix
+++ b/ci/eval/compare/maintainers.nix
@@ -11,17 +11,13 @@ let
   changedpaths = builtins.fromJSON (builtins.readFile changedpathsjson);
 
   anyMatchingFile =
-    filename:
-    let
-      matching = builtins.filter (changed: lib.strings.hasSuffix changed filename) changedpaths;
-    in
-    (builtins.length matching) > 0;
+    filename: builtins.any (changed: lib.strings.hasSuffix changed filename) changedpaths;
 
-  anyMatchingFiles = files: (builtins.length (builtins.filter anyMatchingFile files)) > 0;
+  anyMatchingFiles = files: builtins.any anyMatchingFile files;
 
-  enrichedAttrs = builtins.map (path: {
-    path = path;
-    name = builtins.concatStringsSep "." path;
+  enrichedAttrs = builtins.map (name: {
+    path = lib.splitString "." name;
+    name = name;
   }) changedattrs;
 
   validPackageAttributes = builtins.filter (
@@ -80,27 +76,16 @@ let
 
   attrsWithModifiedFiles = builtins.filter (pkg: anyMatchingFiles pkg.filenames) attrsWithFilenames;
 
-  listToPing = lib.lists.flatten (
-    builtins.map (
-      pkg:
-      builtins.map (maintainer: {
-        id = maintainer.githubId;
-        packageName = pkg.name;
-        dueToFiles = pkg.filenames;
-      }) pkg.maintainers
-    ) attrsWithModifiedFiles
-  );
+  listToPing = lib.concatMap (
+    pkg:
+    builtins.map (maintainer: {
+      id = maintainer.githubId;
+      packageName = pkg.name;
+      dueToFiles = pkg.filenames;
+    }) pkg.maintainers
+  ) attrsWithModifiedFiles;
 
-  byMaintainer = lib.lists.foldr (
-    ping: collector:
-    collector
-    // {
-      "${toString ping.id}" = [
-        { inherit (ping) packageName dueToFiles; }
-      ] ++ (collector."${toString ping.id}" or [ ]);
-    }
-  ) { } listToPing;
-
+  byMaintainer = lib.groupBy (ping: toString ping.id) listToPing;
 
   packagesPerMaintainer = lib.attrsets.mapAttrs (
     maintainer: packages: builtins.map (pkg: pkg.packageName) packages


### PR DESCRIPTION
Various improvements such as:
1. Avoiding deduplications when there can't be any duplicates
2. Avoiding O(n^2) deduplications
3. Using builtins.any to avoid list allocations
4. Using builtins.concatMap instead of lib.flatten when it's known that there's only one level of nesting
5. Using builtins.groupBy instead of folding with an accumulator

In particular 5. should fix CI exceeding the stack size on staging: https://github.com/NixOS/nixpkgs/actions/runs/12989244871/job/36240781244?pr=377253

While 2. in particular should make CI a lot faster.

Thanks for the report, @mweinelt!

## Things done

- [x] Manually ran it with manually downloaded artifacts. Takes about 6 minutes for https://github.com/NixOS/nixpkgs/pull/377253

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
