### PR TITLE
command-injection-tester: init at dbcf85f

### DIFF
--- a/pkgs/by-name/co/command-injection-tester/package.nix
+++ b/pkgs/by-name/co/command-injection-tester/package.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+}:
+
+python3Packages.buildPythonApplication {
+  pname = "command-injection-tester";
+  version = "0.0.2-unstable-2024-04-28";
+
+  src = fetchFromGitHub {
+    owner = "Email-Analysis-Toolkit";
+    repo = "command-injection-tester";
+    rev = "dbcf85f7fdb173028a8af461e2c0f8bfcac42b73";
+    hash = "sha256-g7FyyzpY4rJ9DHDamqUPq4gIUJE3ZUXfxP1ydmm9y+E=";
+  };
+
+  build-system = [ python3Packages.setuptools ];
+
+  meta = {
+    description = "Test mail servers for STARTTLS command injection vulnerability";
+    homepage = "https://github.com/Email-Analysis-Toolkit/command-injection-tester";
+    license = with lib.licenses; [ mit ];
+    maintainers = with lib.maintainers; [ mib ];
+    mainProgram = "command-injection-tester";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Adds tool used to test if mail servers are vulnerable to some STARTTLS vulnerabilities, as outlined in [Why TLS is better without STARTTLS: A Security Analysis of STARTTLS in the Email Context](https://nostarttls.secvuln.info/).

I've tested on 64-bit NixOS, and it both builds and works fine.

Although the name 'command-injection-tester'  _is_ it's name, it might be better to package it as something else? I'm not sure what the policy is on that, I just think it's an overly general name for something actually very specialized. Would like to hear what others think!

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
