### PR TITLE
lixVersions: use fetchCargoVendor

### DIFF
--- a/pkgs/tools/package-management/lix/common.nix
+++ b/pkgs/tools/package-management/lix/common.nix
@@ -1,21 +1,13 @@
 {
   lib,
   fetchFromGitHub,
-  version,
   suffix ? "",
-  hash ? null,
-  src ? fetchFromGitHub {
-    owner = "lix-project";
-    repo = "lix";
-    rev = version;
-    inherit hash;
-  },
-  docCargoHash ? null,
-  docCargoLock ? null,
+  version,
+  src,
+  docCargoDeps,
   patches ? [ ],
   maintainers ? lib.teams.lix.members,
 }@args:
-assert (hash == null) -> (src != null);
 {
   stdenv,
   meson,
@@ -60,8 +52,7 @@ assert (hash == null) -> (src != null);
   lix-doc ? callPackage ./doc {
     inherit src;
     version = "${version}${suffix}";
-    cargoHash = docCargoHash;
-    cargoLock = docCargoLock;
+    cargoDeps = docCargoDeps;
   },
 
   enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
@@ -76,8 +67,6 @@ assert (hash == null) -> (src != null);
   stateDir,
   storeDir,
 }:
-assert lib.assertMsg (docCargoHash != null || docCargoLock != null)
-  "Either `lix-doc`'s cargoHash using `docCargoHash` or `lix-doc`'s `cargoLock.lockFile` using `docCargoLock` must be set!";
 let
   isLegacyParser = lib.versionOlder version "2.91";
 in

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -5,6 +5,7 @@
   callPackage,
   fetchFromGitHub,
   fetchpatch,
+  rustPlatform,
   Security,
 
   storeDir ? "/nix/store",
@@ -54,18 +55,42 @@ lib.makeExtensible (self: {
   buildLix = common;
 
   lix_2_90 = (
-    common {
+    common rec {
       version = "2.90.0";
-      hash = "sha256-f8k+BezKdJfmE+k7zgBJiohtS3VkkriycdXYsKOm3sc=";
-      docCargoHash = "sha256-vSf9MyD2XzofZlbzsmh6NP69G+LiX72GX4Um9UJp3dc=";
+
+      src = fetchFromGitHub {
+        owner = "lix-project";
+        repo = "lix";
+        rev = version;
+        hash = "sha256-f8k+BezKdJfmE+k7zgBJiohtS3VkkriycdXYsKOm3sc=";
+      };
+
+      docCargoDeps = rustPlatform.fetchCargoVendor {
+        name = "lix-doc-${version}";
+        inherit src;
+        sourceRoot = "${src.name or src}/lix-doc";
+        hash = "sha256-VPcrf78gfLlkTRrcbLkPgLOk0o6lsOJBm6HYLvavpNU=";
+      };
     }
   );
 
   lix_2_91 = (
-    common {
+    common rec {
       version = "2.91.1";
-      hash = "sha256-hiGtfzxFkDc9TSYsb96Whg0vnqBVV7CUxyscZNhed0U=";
-      docCargoHash = "sha256-F6Ld0HfRvW9r5zn8eMTP6djnV/jvwjYQet4Ghp2T90k=";
+
+      src = fetchFromGitHub {
+        owner = "lix-project";
+        repo = "lix";
+        rev = version;
+        hash = "sha256-hiGtfzxFkDc9TSYsb96Whg0vnqBVV7CUxyscZNhed0U=";
+      };
+
+      docCargoDeps = rustPlatform.fetchCargoVendor {
+        name = "lix-doc-${version}";
+        inherit src;
+        sourceRoot = "${src.name or src}/lix-doc";
+        hash = "sha256-U820gvcbQIBaFr2OWPidfFIDXycDFGgXX1NpWDDqENs=";
+      };
     }
   );
 

--- a/pkgs/tools/package-management/lix/doc/default.nix
+++ b/pkgs/tools/package-management/lix/doc/default.nix
@@ -2,8 +2,7 @@
   src,
   rustPlatform,
   version,
-  cargoHash ? null,
-  cargoLock ? null,
+  cargoDeps,
 }:
 
 rustPlatform.buildRustPackage {
@@ -12,7 +11,6 @@ rustPlatform.buildRustPackage {
   inherit
     version
     src
-    cargoHash
-    cargoLock
+    cargoDeps
     ;
 }


### PR DESCRIPTION
Cargo 1.84.0 seems to have changed the output format of cargo vendor again, once again invalidating fetchCargoTarball FOD hashes.  It's time to fix this once and for all, switching across the board to fetchCargoVendor, which is not dependent on cargo vendor's output format.

I've unified the cargoHash and cargoLock parameters into a single cargoDeps parameter, which is what cargoHash and cargoLock end up being shorthand for.  Taking a cargoHash parameter for a package builder isn't generally a good idea, because it will produce a silently broken FOD if we change the hashing scheme, like we're doing here.  For Lix this wouldn't be too bad currently because lix-doc isn't exposed and so can't be overridden, but I think this is still cleaner than having two mutually exclusive parameters passed through multiple layers of functions.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
