### PR TITLE
python3Packages.cppyy: init at 3.5.0

### DIFF
--- a/pkgs/development/python-modules/cppyy-backend/backend-setup.patch
+++ b/pkgs/development/python-modules/cppyy-backend/backend-setup.patch
@@ -1,17 +1,17 @@
 diff --git a/clingwrapper/setup.py b/clingwrapper/setup.py
-index f94d93a..1566b9e 100755
+index f94d93a..8135b26 100755
 --- a/clingwrapper/setup.py
 +++ b/clingwrapper/setup.py
 @@ -53,17 +53,10 @@ def _get_config_exec():
      return [sys.executable, '-m', 'cppyy_backend._cling_config']
-
+ 
  def get_include_path():
 -    config_exec_args = _get_config_exec()
 -    config_exec_args.append('--incdir')
 -    cli_arg = subprocess.check_output(config_exec_args)
 -    return cli_arg.decode("utf-8").strip()
 +    %includes_placeholder%
-
+ 
  def get_cflags():
 -    config_exec_args = _get_config_exec()
 -    config_exec_args.append('--auxcflags')
@@ -19,6 +19,26 @@ index f94d93a..1566b9e 100755
 -    return cli_arg.decode("utf-8").strip()
 -
 +    %cflags_placeholder%
-
+ 
  #
  # customized commands
+@@ -140,19 +133,6 @@ cmdclass = {
+         #'clean': my_clean,
+         'install': my_install }
+ 
+-if has_wheel:
+-    class my_bdist_wheel(_bdist_wheel):
+-        def finalize_options(self):
+-         # this is a universal, but platform-specific package; a combination
+-         # that wheel does not recognize, thus simply fool it
+-            from distutils.util import get_platform
+-            self.plat_name = get_platform()
+-            self.universal = True
+-            _bdist_wheel.finalize_options(self)
+-            self.root_is_pure = True
+-    cmdclass['bdist_wheel'] = my_bdist_wheel
+-
+-
+ setup(
+     name='cppyy-backend',
+     description='C/C++ wrapper for Cling',

--- a/pkgs/development/python-modules/cppyy-backend/backend-setup.patch
+++ b/pkgs/development/python-modules/cppyy-backend/backend-setup.patch
@@ -1,0 +1,24 @@
+diff --git a/clingwrapper/setup.py b/clingwrapper/setup.py
+index f94d93a..1566b9e 100755
+--- a/clingwrapper/setup.py
++++ b/clingwrapper/setup.py
+@@ -53,17 +53,10 @@ def _get_config_exec():
+     return [sys.executable, '-m', 'cppyy_backend._cling_config']
+
+ def get_include_path():
+-    config_exec_args = _get_config_exec()
+-    config_exec_args.append('--incdir')
+-    cli_arg = subprocess.check_output(config_exec_args)
+-    return cli_arg.decode("utf-8").strip()
++    %includes_placeholder%
+
+ def get_cflags():
+-    config_exec_args = _get_config_exec()
+-    config_exec_args.append('--auxcflags')
+-    cli_arg = subprocess.check_output(config_exec_args)
+-    return cli_arg.decode("utf-8").strip()
+-
++    %cflags_placeholder%
+
+ #
+ # customized commands

--- a/pkgs/development/python-modules/cppyy-backend/default.nix
+++ b/pkgs/development/python-modules/cppyy-backend/default.nix
@@ -53,10 +53,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "cppyy_backend" ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/wlav/cppyy-backend/blob/master/clingwrapper/";
     description = "C/C++ wrapper for Cling";
-    license = licenses.bsd3Lbnl;
-    maintainers = with maintainers; [ kittywitch ];
+    license = lib.licenses.bsd3Lbnl;
+    maintainers = with lib.maintainers; [ kittywitch ];
   };
 }

--- a/pkgs/development/python-modules/cppyy-backend/default.nix
+++ b/pkgs/development/python-modules/cppyy-backend/default.nix
@@ -35,14 +35,18 @@ buildPythonPackage rec {
   propagatedBuildInputs = [ cppyy-cling ];
 
   configurePhase = ''
+    runHook preConfigure
     cd clingwrapper
     sed -i "s|%includes_placeholder%|return '\${cppyy-cling}/${python.sitePackages}/cppyy_backend/include'|" setup.py
     sed -i "s|%cflags_placeholder%|return '${lib.optionalString stdenv.hostPlatform.isLinux "-pthread"} -std=c++2a'|" setup.py
+    runHook postConfigure
   '';
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out
     env PIP_PREFIX=$out pip install dist/*.whl --no-use-pep517 --no-deps
+    runHook postInstall
   '';
 
   dontUseCmakeConfigure = true;

--- a/pkgs/development/python-modules/cppyy-backend/default.nix
+++ b/pkgs/development/python-modules/cppyy-backend/default.nix
@@ -1,0 +1,58 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  cppyy-cling,
+  setuptools,
+  buildPythonPackage,
+  stdenv,
+  python,
+  pip,
+}:
+buildPythonPackage rec {
+  pname = "cppyy-backend";
+  version = "1.15.3";
+
+  src = fetchFromGitHub {
+    owner = "wlav";
+    repo = "cppyy-backend";
+    rev = "clingwrapper-${version}";
+    hash = "sha256-XTocvkAT5fKH49BnNjnv6ASWU7YGlotKqRMRZrN5HhA=";
+  };
+
+  patches = [
+    ./backend-setup.patch
+  ];
+
+  nativeBuildInputs = [
+    setuptools
+    cmake
+    cppyy-cling
+    pip
+  ];
+
+  propagatedBuildInputs = [ cppyy-cling ];
+
+  configurePhase = ''
+    cd clingwrapper
+    sed -i "s|%includes_placeholder%|return '\${cppyy-cling}/${python.sitePackages}/cppyy_backend/include'|" setup.py
+    sed -i "s|%cflags_placeholder%|return '${lib.optionalString stdenv.hostPlatform.isLinux "-pthread"} -std=c++2a'|" setup.py
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    env PIP_PREFIX=$out pip install dist/*.whl --no-use-pep517 --no-deps
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  pythonImportsCheck = [ "cppyy_backend" ];
+
+  meta = with lib; {
+    homepage = "https://github.com/wlav/cppyy-backend/blob/master/clingwrapper/";
+    description = "C/C++ wrapper for Cling";
+    license = licenses.bsd3Lbnl;
+    maintainers = with maintainers; [ kittywitch ];
+  };
+}

--- a/pkgs/development/python-modules/cppyy-backend/default.nix
+++ b/pkgs/development/python-modules/cppyy-backend/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "wlav";
     repo = "cppyy-backend";
-    rev = "clingwrapper-${version}";
+    tag = "clingwrapper-${version}";
     hash = "sha256-XTocvkAT5fKH49BnNjnv6ASWU7YGlotKqRMRZrN5HhA=";
   };
 

--- a/pkgs/development/python-modules/cppyy-cling/cling-setup.patch
+++ b/pkgs/development/python-modules/cppyy-cling/cling-setup.patch
@@ -1,0 +1,13 @@
+diff --git a/source/cling/setup.py b/source/cling/setup.py
+index d43f9b1..77c013e 100755
+--- a/source/cling/setup.py
++++ b/source/cling/setup.py
+@@ -149,7 +149,7 @@ class my_cmake_build(_build):
+ 
+         CMAKE_COMMAND = ['cmake', srcdir, '-Wno-dev',
+                 stdcxx, '-DLLVM_ENABLE_TERMINFO=0', '-DLLVM_ENABLE_ASSERTIONS=0',
+-                '-Dminimal=ON', '-Dbuiltin_cling=ON', '-Druntime_cxxmodules=OFF', '-Dbuiltin_zlib=ON']
++                '-Dminimal=ON', '-Dbuiltin_cling=ON', '-Druntime_cxxmodules=OFF', '-Dbuiltin_zlib=OFF']
+         if 'darwin' in sys.platform:
+             CMAKE_COMMAND.append('-Dlibcxx=ON')
+         CMAKE_COMMAND.append('-DCMAKE_BUILD_TYPE='+get_build_type())

--- a/pkgs/development/python-modules/cppyy-cling/default.nix
+++ b/pkgs/development/python-modules/cppyy-cling/default.nix
@@ -71,10 +71,10 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/wlav/cppyy-backend/blob/master/cling/";
     description = "Re-packaged Cling, as backend for cppyy";
-    license = licenses.bsd3Lbnl;
-    maintainers = with maintainers; [ kittywitch ];
+    license = lib.licenses.bsd3Lbnl;
+    maintainers = with lib.maintainers; [ kittywitch ];
   };
 }

--- a/pkgs/development/python-modules/cppyy-cling/default.nix
+++ b/pkgs/development/python-modules/cppyy-cling/default.nix
@@ -35,11 +35,13 @@ buildPythonPackage rec {
       cern-root
     ];
 
-  nativeBuildInputs = [
-    cmake
-  ] ++ (lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.DarwinTools
-  ]);
+  nativeBuildInputs =
+    [
+      cmake
+    ]
+    ++ (lib.optionals stdenv.hostPlatform.isDarwin [
+      darwin.DarwinTools
+    ]);
 
   propagatedBuildInputs = [
     setuptools

--- a/pkgs/development/python-modules/cppyy-cling/default.nix
+++ b/pkgs/development/python-modules/cppyy-cling/default.nix
@@ -2,9 +2,14 @@
   lib,
   fetchFromGitHub,
   fetchurl,
+  zlib,
   cmake,
+  pkg-config,
   setuptools,
+  darwin,
   buildPythonPackage,
+  clang-tools,
+  stdenv,
   rootVersion ? "6.32.08",
 }:
 buildPythonPackage rec {
@@ -38,7 +43,17 @@ buildPythonPackage rec {
     setuptools
   ];
 
-  patchPhase = ''
+  buildInputs = [
+    zlib
+  ] ++ (lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.DarwinTools
+  ]);
+
+  patches = [
+    ./cling-setup.patch
+  ];
+
+  postPatch = ''
     # facilitate generation of compiledata.h
     patchShebangs source/cling/src/build/unix/compiledata.sh
 

--- a/pkgs/development/python-modules/cppyy-cling/default.nix
+++ b/pkgs/development/python-modules/cppyy-cling/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  fetchFromGitHub,
+  fetchurl,
+  cmake,
+  setuptools,
+  buildPythonPackage,
+  rootVersion ? "6.32.08",
+}:
+buildPythonPackage rec {
+  pname = "cppyy-cling";
+  version = "6.32.8";
+
+  sourceRoot = ".";
+  srcs =
+    let
+      clingwrapper = fetchFromGitHub {
+        owner = "wlav";
+        repo = "cppyy-backend";
+        rev = "cppyy-cling-${version}";
+        hash = "sha256-XTocvkAT5fKH49BnNjnv6ASWU7YGlotKqRMRZrN5HhA=";
+      };
+      cern-root = fetchurl {
+        url = "https://root.cern/download/root_v${rootVersion}.source.tar.gz";
+        hash = "sha256-Ka1JRact/xoAnDJqZbb6XuJHhJiCMlHTzvhqLL63eyc=";
+      };
+    in
+    [
+      clingwrapper
+      cern-root
+    ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  propagatedBuildInputs = [
+    setuptools
+  ];
+
+  patchPhase = ''
+    # facilitate generation of compiledata.h
+    patchShebangs source/cling/src/build/unix/compiledata.sh
+
+    # https://github.com/wlav/cppyy-backend/blob/master/cling/create_src_directory.py#L39
+    # Give build process the CERN root tarball due to sandbox
+    mkdir -p source/cling/releases
+    tar czf root_v${rootVersion}.source.tar.gz root-${rootVersion}
+    cp root_v${rootVersion}.source.tar.gz source/cling/releases/
+    cd source/cling
+    python setup.py egg_info
+    python create_src_directory.py
+  '';
+
+  dontUseCmakeConfigure = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/wlav/cppyy-backend/blob/master/cling/";
+    description = "Re-packaged Cling, as backend for cppyy";
+    license = licenses.bsd3Lbnl;
+    maintainers = with maintainers; [ kittywitch ];
+  };
+}

--- a/pkgs/development/python-modules/cppyy-cling/default.nix
+++ b/pkgs/development/python-modules/cppyy-cling/default.nix
@@ -22,7 +22,7 @@ buildPythonPackage rec {
       clingwrapper = fetchFromGitHub {
         owner = "wlav";
         repo = "cppyy-backend";
-        rev = "cppyy-cling-${version}";
+        tag = "cppyy-cling-${version}";
         hash = "sha256-XTocvkAT5fKH49BnNjnv6ASWU7YGlotKqRMRZrN5HhA=";
       };
       cern-root = fetchurl {

--- a/pkgs/development/python-modules/cppyy-cling/default.nix
+++ b/pkgs/development/python-modules/cppyy-cling/default.nix
@@ -37,7 +37,9 @@ buildPythonPackage rec {
 
   nativeBuildInputs = [
     cmake
-  ];
+  ] ++ (lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.DarwinTools
+  ]);
 
   propagatedBuildInputs = [
     setuptools
@@ -45,9 +47,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     zlib
-  ] ++ (lib.optionals stdenv.hostPlatform.isDarwin [
-    darwin.DarwinTools
-  ]);
+  ];
 
   patches = [
     ./cling-setup.patch

--- a/pkgs/development/python-modules/cppyy/default.nix
+++ b/pkgs/development/python-modules/cppyy/default.nix
@@ -17,7 +17,7 @@ buildPythonPackage rec {
 
   src = fetchFromGitHub {
     owner = "wlav";
-    repo = pname;
+    repo = "cppyy";
     tag = "${pname}-${version}";
     hash = "sha256-Q40zV7t7iQBJKjqpsvhqcsVtwuYzJkfBRoT1iQxh6rc=";
   };
@@ -39,10 +39,10 @@ buildPythonPackage rec {
 
   dontUseCmakeConfigure = true;
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/wlav/cppyy";
     description = "Python C++ bindings interface based on Cling/LLVM";
-    license = licenses.bsd3Lbnl;
-    maintainers = with maintainers; [ kittywitch ];
+    license = lib.licenses.bsd3Lbnl;
+    maintainers = with lib.maintainers; [ kittywitch ];
   };
 }

--- a/pkgs/development/python-modules/cppyy/default.nix
+++ b/pkgs/development/python-modules/cppyy/default.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  buildPythonPackage,
+  setuptools,
+  wheel,
+  pip,
+  cppyy-cling,
+  cppyy-backend,
+  CPyCppyy,
+}:
+buildPythonPackage rec {
+  pname = "cppyy";
+  version = "3.5.0";
+
+  src = fetchFromGitHub {
+    owner = "wlav";
+    repo = pname;
+    rev = "${pname}-${version}";
+    hash = "sha256-Q40zV7t7iQBJKjqpsvhqcsVtwuYzJkfBRoT1iQxh6rc=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+    pip
+    cppyy-cling
+    cppyy-backend
+    CPyCppyy
+  ];
+
+  propagatedBuildInputs = [
+    cppyy-cling
+    cppyy-backend
+    CPyCppyy
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  meta = with lib; {
+    homepage = "https://github.com/wlav/cppyy";
+    description = "Python C++ bindings interface based on Cling/LLVM";
+    license = licenses.bsd3Lbnl;
+    maintainers = with maintainers; [ kittywitch ];
+  };
+}

--- a/pkgs/development/python-modules/cppyy/default.nix
+++ b/pkgs/development/python-modules/cppyy/default.nix
@@ -18,7 +18,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "wlav";
     repo = pname;
-    rev = "${pname}-${version}";
+    tag = "${pname}-${version}";
     hash = "sha256-Q40zV7t7iQBJKjqpsvhqcsVtwuYzJkfBRoT1iQxh6rc=";
   };
 

--- a/pkgs/development/python-modules/cpycppyy/cpycppy-setup.patch
+++ b/pkgs/development/python-modules/cpycppyy/cpycppy-setup.patch
@@ -1,0 +1,16 @@
+diff --git a/setup.py b/setup.py
+index 0bab79e..0548d03 100755
+--- a/setup.py
++++ b/setup.py
+@@ -40,10 +40,7 @@ def _get_config_exec():
+     return [sys.executable, '-m', 'cppyy_backend._cling_config']
+ 
+ def get_cflags():
+-    config_exec_args = _get_config_exec()
+-    config_exec_args.append('--auxcflags')
+-    cli_arg = subprocess.check_output(config_exec_args)
+-    return cli_arg.decode("utf-8").strip()
++    %cflags_placeholder%
+ 
+ 
+ #

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -55,9 +55,12 @@ buildPythonPackage rec {
     "--no-deps"
   ];
 
-  postInstall = ''
+  postBuild = ''
     cmake ./
     make
+  '';
+
+  postInstall = ''
     cp libcppyy.so $out/${python3.sitePackages}/
   '';
 

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -6,9 +6,9 @@
   cmake,
   buildPythonPackage,
   setuptools,
-  python3,
   wheel,
   pip,
+  python,
   stdenv,
 }:
 
@@ -61,7 +61,7 @@ buildPythonPackage rec {
   '';
 
   postInstall = ''
-    cp libcppyy.so $out/${python3.sitePackages}/
+    cp libcppyy.so $out/${python.sitePackages}/
   '';
 
   meta = {

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -20,6 +20,9 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "wlav";
     repo = pname;
+    # Uncomment and replace rev & hash lines when a new release occurs within CPyCppyy.
+    #tag = "CPyCppyy-${version}";
+    #hash = "sha256-9y0BHYMQyKUC3JTlozSv167rA2hN2IP2J0a1e/1en0o=";
     rev = "8bd9d9e10d658a33294a4ba9b2251bf1f9223469";
     hash = "sha256-IEwdJSXG6diz7j2N7WQys5na7+xj1CYu7J3FCkW9/AQ=";
   };
@@ -42,8 +45,6 @@ buildPythonPackage rec {
     ./cpycppy-setup.patch
   ];
 
-  dontUseCmakeConfigure = true;
-
   configurePhase = ''
     runHook preConfigure
     sed -i "s|%cflags_placeholder%|return '${lib.optionalString stdenv.hostPlatform.isLinux "-pthread"} -std=c++2a'|" setup.py
@@ -61,10 +62,10 @@ buildPythonPackage rec {
     cp libcppyy.so $out/${python3.sitePackages}/
   '';
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/wlav/CPyCppyy";
     description = "CPyCppyy: Python-C++ bindings interface based on Cling/LLVM";
-    license = licenses.bsd3Lbnl;
-    maintainers = with maintainers; [ kittywitch ];
+    license = lib.licenses.bsd3Lbnl;
+    maintainers = with lib.maintainers; [ kittywitch ];
   };
 }

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -22,7 +22,6 @@ buildPythonPackage rec {
     repo = pname;
     # Uncomment and replace rev & hash lines when a new release occurs within CPyCppyy.
     #tag = "CPyCppyy-${version}";
-    #hash = "sha256-9y0BHYMQyKUC3JTlozSv167rA2hN2IP2J0a1e/1en0o=";
     rev = "8bd9d9e10d658a33294a4ba9b2251bf1f9223469";
     hash = "sha256-IEwdJSXG6diz7j2N7WQys5na7+xj1CYu7J3FCkW9/AQ=";
   };

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -57,7 +57,7 @@ buildPythonPackage rec {
   postInstall = ''
     cmake ../${pname}-${version}
     make
-    cp libcppyy${stdenv.hostPlatform.extensions.sharedLibrary} $out/${python3.sitePackages}/
+    cp libcppyy.so $out/${python3.sitePackages}/
   '';
 
   meta = with lib; {

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -18,7 +18,6 @@ buildPythonPackage rec {
   pyproject = true;
 
   src = fetchFromGitHub {
-    inherit pname version;
     owner = "wlav";
     repo = pname;
     rev = "8bd9d9e10d658a33294a4ba9b2251bf1f9223469";
@@ -55,7 +54,7 @@ buildPythonPackage rec {
   ];
 
   postInstall = ''
-    cmake ../${pname}-${version}
+    cmake ./
     make
     cp libcppyy.so $out/${python3.sitePackages}/
   '';

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -45,7 +45,9 @@ buildPythonPackage rec {
   dontUseCmakeConfigure = true;
 
   configurePhase = ''
+    runHook preConfigure
     sed -i "s|%cflags_placeholder%|return '${lib.optionalString stdenv.hostPlatform.isLinux "-pthread"} -std=c++2a'|" setup.py
+    runHook postConfigure
   '';
 
   pipInstallFlags = [

--- a/pkgs/development/python-modules/cpycppyy/default.nix
+++ b/pkgs/development/python-modules/cpycppyy/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  fetchFromGitHub,
+  cppyy-cling,
+  cppyy-backend,
+  cmake,
+  buildPythonPackage,
+  setuptools,
+  python3,
+  wheel,
+  pip,
+  stdenv,
+}:
+
+buildPythonPackage rec {
+  pname = "CPyCppyy";
+  version = "1.13.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    inherit pname version;
+    owner = "wlav";
+    repo = pname;
+    rev = "8bd9d9e10d658a33294a4ba9b2251bf1f9223469";
+    hash = "sha256-IEwdJSXG6diz7j2N7WQys5na7+xj1CYu7J3FCkW9/AQ=";
+  };
+
+  nativeBuildInputs = [
+    setuptools
+    wheel
+    pip
+    cmake
+    cppyy-cling
+    cppyy-backend
+  ];
+
+  propagatedBuildInputs = [
+    cppyy-cling
+    cppyy-backend
+  ];
+
+  patches = [
+    ./cpycppy-setup.patch
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  configurePhase = ''
+    sed -i "s|%cflags_placeholder%|return '${lib.optionalString stdenv.hostPlatform.isLinux "-pthread"} -std=c++2a'|" setup.py
+  '';
+
+  pipInstallFlags = [
+    "--no-use-pep517"
+    "--no-deps"
+  ];
+
+  postInstall = ''
+    cmake ../${pname}-${version}
+    make
+    cp libcppyy${stdenv.hostPlatform.extensions.sharedLibrary} $out/${python3.sitePackages}/
+  '';
+
+  meta = with lib; {
+    homepage = "https://github.com/wlav/CPyCppyy";
+    description = "CPyCppyy: Python-C++ bindings interface based on Cling/LLVM";
+    license = licenses.bsd3Lbnl;
+    maintainers = with maintainers; [ kittywitch ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -2690,7 +2690,15 @@ self: super: with self; {
 
   cppy = callPackage ../development/python-modules/cppy { };
 
+  cppyy = callPackage ../development/python-modules/cppyy { };
+
+  cppyy-cling = callPackage ../development/python-modules/cppyy-cling { };
+
+  cppyy-backend = callPackage ../development/python-modules/cppyy-backend { };
+
   cpufeature = callPackage ../development/python-modules/cpufeature { };
+
+  CPyCppyy = callPackage ../development/python-modules/cpycppyy { };
 
   cpyparsing = callPackage ../development/python-modules/cpyparsing { };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR contains the packages:
* cppyy
* cppyy-backend
* cppyy-cling
* cpycppy

as far up to date as I am able to get them from their upstream.

I have tested the functionality of cppyy within a devShell containing python3.withPackages, using it to check the version of a library via its header.

I believe this attempt at packaging cppyy meets CONTRIBUTING.md, I have also run a formatter over the files, although I am happy to fix or resolve any stylistic incongruousness and so on. I hope this is of suitable quality.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
