### PR TITLE
nixos/activation: pass the action as an argument to the pre-switch-checks

### DIFF
--- a/nixos/modules/system/activation/pre-switch-check.nix
+++ b/nixos/modules/system/activation/pre-switch-check.nix
@@ -44,6 +44,9 @@ in
       A set of shell script fragments that are executed before the switch to a
       new NixOS system configuration. A failure in any of these fragments will
       cause the switch to fail and exit early.
+      The scripts receive the new configuration path and the action verb passed
+      to switch-to-configuration, as the first and second positional arguments
+      (meaning that you can access them using `$1` and `$2`, respectively).
     '';
 
     type = lib.types.attrsOf lib.types.str;

--- a/nixos/modules/system/activation/switch-to-configuration.pl
+++ b/nixos/modules/system/activation/switch-to-configuration.pl
@@ -103,7 +103,7 @@ if (($ENV{"NIXOS_NO_CHECK"} // "") ne "1") {
     chomp(my $pre_switch_checks = <<'EOFCHECKS');
 @preSwitchCheck@
 EOFCHECKS
-    system("$pre_switch_checks $out") == 0 or exit 1;
+    system("$pre_switch_checks $out $action") == 0 or exit 1;
     if ($action eq "check") {
         exit 0;
     }

--- a/nixos/tests/switch-test.nix
+++ b/nixos/tests/switch-test.nix
@@ -612,8 +612,10 @@ in {
       system.switch.enable = true;
       users.mutableUsers = true;
       system.preSwitchChecks.succeeds = ''
-        echo this will succeed
-        true
+        config="$1"
+        action="$2"
+        echo "this should succeed (config: $config, action: $action)"
+        [ "$action" == "check" ] || [ "$action" == "test" ]
       '';
       specialisation.failingCheck.configuration.system.preSwitchChecks.failEveryTime = ''
         echo this will fail

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -139,7 +139,7 @@ fn parse_os_release() -> Result<HashMap<String, String>> {
         }))
 }
 
-fn do_pre_switch_check(command: &str, toplevel: &Path) -> Result<()> {
+fn do_pre_switch_check(command: &str, toplevel: &Path, action: &Action) -> Result<()> {
     let mut cmd_split = command.split_whitespace();
     let Some(argv0) = cmd_split.next() else {
         bail!("missing first argument in install bootloader commands");
@@ -148,6 +148,7 @@ fn do_pre_switch_check(command: &str, toplevel: &Path) -> Result<()> {
     match std::process::Command::new(argv0)
         .args(cmd_split.collect::<Vec<&str>>())
         .arg(toplevel)
+        .arg::<&str>(action.into())
         .spawn()
         .map(|mut child| child.wait())
     {
@@ -1053,7 +1054,7 @@ fn do_system_switch(action: Action) -> anyhow::Result<()> {
         .unwrap_or_default()
         != "1"
     {
-        do_pre_switch_check(&pre_switch_check, &toplevel)?;
+        do_pre_switch_check(&pre_switch_check, &toplevel, action)?;
     }
 
     if *action == Action::Check {

--- a/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
+++ b/pkgs/by-name/sw/switch-to-configuration-ng/src/src/main.rs
@@ -887,10 +887,7 @@ impl std::fmt::Display for Job {
 
 fn new_dbus_proxies(
     conn: &LocalConnection,
-) -> (
-    Proxy<'_, &LocalConnection>,
-    Proxy<'_, &LocalConnection>,
-) {
+) -> (Proxy<'_, &LocalConnection>, Proxy<'_, &LocalConnection>) {
     (
         conn.with_proxy(
             "org.freedesktop.systemd1",
@@ -1221,16 +1218,16 @@ won't take effect until you reboot the system.
                     unit.as_str(),
                     "suspend.target" | "hibernate.target" | "hybrid-sleep.target"
                 ) || parse_systemd_bool(
-                        Some(&new_unit_info),
-                        "Unit",
-                        "RefuseManualStart",
-                        false,
-                    ) || parse_systemd_bool(
-                        Some(&new_unit_info),
-                        "Unit",
-                        "X-OnlyManualStart",
-                        false,
-                    )) {
+                    Some(&new_unit_info),
+                    "Unit",
+                    "RefuseManualStart",
+                    false,
+                ) || parse_systemd_bool(
+                    Some(&new_unit_info),
+                    "Unit",
+                    "X-OnlyManualStart",
+                    false,
+                )) {
                     units_to_start.insert(unit.to_string(), ());
                     record_unit(START_LIST_FILE, unit);
                     // Don't spam the user with target units that always get started.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

This allows for instance to reject switching into a configuration, while still allowing to reboot into that same configuration.

This can be useful for instance to reject switching to a configuration with a new systemd major version, but setting that same configuration as the new boot default with `switch-to-configuration boot` is fine.

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
