### PR TITLE
Use fetchCargoVendor for wasm-bindgen-cli

### DIFF
--- a/pkgs/applications/misc/pagefind/default.nix
+++ b/pkgs/applications/misc/pagefind/default.nix
@@ -12,19 +12,13 @@
   npmHooks,
   python3,
   rustc,
-  wasm-bindgen-cli,
+  wasm-bindgen-cli_0_2_92,
   wasm-pack,
 }:
 
 # TODO: package python bindings
 
 let
-
-  wasm-bindgen-92 = wasm-bindgen-cli.override {
-    version = "0.2.92";
-    hash = "sha256-1VwY8vQy7soKEgbki4LD+v259751kKxSxmo/gqE6yV0=";
-    cargoHash = "sha256-aACJ+lYNEU8FFBs158G1/JG8sc6Rq080PeKCMnwdpH0=";
-  };
 
   # the lindera-unidic v0.32.2 crate uses [1] an outdated unidic-mecab fork [2] and builds it in pure rust
   # [1] https://github.com/lindera/lindera/blob/v0.32.2/lindera-unidic/build.rs#L5-L11
@@ -121,7 +115,7 @@ rustPlatform.buildRustPackage rec {
       nodejs
       rustc
       rustc.llvmPackages.lld
-      wasm-bindgen-92
+      wasm-bindgen-cli_0_2_92
       wasm-pack
       httplz
     ]

--- a/pkgs/build-support/rust/fetchcrate.nix
+++ b/pkgs/build-support/rust/fetchcrate.nix
@@ -21,6 +21,8 @@ assert pname == null || pname == crateName;
   {
     name = "${crateName}-${version}.tar.gz";
     url = "${registryDl}/${crateName}/${version}/download";
+
+    passthru = { inherit pname version; };
   }
   // lib.optionalAttrs unpack {
     extension = "tar.gz";

--- a/pkgs/build-support/wasm-bindgen-cli/default.nix
+++ b/pkgs/build-support/wasm-bindgen-cli/default.nix
@@ -9,16 +9,18 @@
   stdenv,
   curl,
   darwin,
-  version ? "0.2.100",
-  hash ? "sha256-3RJzK7mkYFrs7C/WkhW9Rr4LdP5ofb2FdYGz1P7Uxog=",
-  cargoHash ? "sha256-tD0OY2PounRqsRiFh8Js5nyknQ809ZcHMvCOLrvYHRE=",
+}:
+
+{
+  version ? src.version,
+  src,
+  cargoDeps,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "wasm-bindgen-cli";
-  inherit version hash cargoHash;
 
-  src = fetchCrate { inherit pname version hash; };
+  inherit version src cargoDeps;
 
   nativeBuildInputs = [ pkg-config ];
 

--- a/pkgs/by-name/ll/lldap/package.nix
+++ b/pkgs/by-name/ll/lldap/package.nix
@@ -5,18 +5,12 @@
 , nixosTests
 , rustPlatform
 , rustc
-, wasm-bindgen-cli
+, wasm-bindgen-cli_0_2_95
 , wasm-pack
 , which
 }:
 
 let
-
-  wasm-bindgen-95 = wasm-bindgen-cli.override {
-    version = "0.2.95";
-    hash = "sha256-prMIreQeAcbJ8/g3+pMp1Wp9H5u+xLqxRxL+34hICss=";
-    cargoHash = "sha256-6iMebkD7FQvixlmghGGIvpdGwFNLfnUcFke/Rg8nPK4=";
-  };
 
   commonDerivationAttrs = rec {
     pname = "lldap";
@@ -44,7 +38,7 @@ let
     pname = commonDerivationAttrs.pname + "-frontend";
 
     nativeBuildInputs = [
-      wasm-pack wasm-bindgen-95 binaryen which rustc rustc.llvmPackages.lld
+      wasm-pack wasm-bindgen-cli_0_2_95 binaryen which rustc rustc.llvmPackages.lld
     ];
 
     buildPhase = ''

--- a/pkgs/by-name/st/stalwart-mail/webadmin.nix
+++ b/pkgs/by-name/st/stalwart-mail/webadmin.nix
@@ -9,7 +9,7 @@
   nodejs,
   npmHooks,
   llvmPackages,
-  wasm-bindgen-cli,
+  wasm-bindgen-cli_0_2_93,
   binaryen,
   zip,
 }:
@@ -46,11 +46,8 @@ rustPlatform.buildRustPackage rec {
     tailwindcss
     trunk
     # needs to match with wasm-bindgen version in upstreams Cargo.lock
-    (wasm-bindgen-cli.override {
-      version = "0.2.93";
-      hash = "sha256-DDdu5mM3gneraM85pAepBXWn3TMofarVR4NbjMdz3r0=";
-      cargoHash = "sha256-birrg+XABBHHKJxfTKAMSlmTVYLmnmqMDfRnmG6g/YQ=";
-    })
+    wasm-bindgen-cli_0_2_93
+
     zip
   ];
 

--- a/pkgs/by-name/tp/tpsecore/package.nix
+++ b/pkgs/by-name/tp/tpsecore/package.nix
@@ -4,18 +4,12 @@
   rustPlatform,
   rustc,
   wasm-pack,
-  wasm-bindgen-cli,
+  wasm-bindgen-cli_0_2_95,
   binaryen,
 }:
 
 let
   version = "0.1.1";
-
-  wasm-bindgen-cli-95 = wasm-bindgen-cli.override {
-    version = "0.2.95";
-    hash = "sha256-prMIreQeAcbJ8/g3+pMp1Wp9H5u+xLqxRxL+34hICss=";
-    cargoHash = "sha256-6iMebkD7FQvixlmghGGIvpdGwFNLfnUcFke/Rg8nPK4=";
-  };
 in
 rustPlatform.buildRustPackage {
   pname = "tpsecore";
@@ -32,7 +26,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [
     wasm-pack
-    wasm-bindgen-cli-95
+    wasm-bindgen-cli_0_2_95
     binaryen
     rustc.llvmPackages.lld
   ];

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_100/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_100/package.nix
@@ -11,9 +11,9 @@ buildWasmBindgenCli rec {
     hash = "sha256-3RJzK7mkYFrs7C/WkhW9Rr4LdP5ofb2FdYGz1P7Uxog=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     inherit (src) pname version;
-    hash = "sha256-tD0OY2PounRqsRiFh8Js5nyknQ809ZcHMvCOLrvYHRE=";
+    hash = "sha256-qsO12332HSjWCVKtf1cUePWWb9IdYUmT+8OPj/XP2WE=";
   };
 }

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_100/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_100/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.100";
+    hash = "sha256-3RJzK7mkYFrs7C/WkhW9Rr4LdP5ofb2FdYGz1P7Uxog=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-tD0OY2PounRqsRiFh8Js5nyknQ809ZcHMvCOLrvYHRE=";
+  };
+}

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_92/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_92/package.nix
@@ -11,9 +11,9 @@ buildWasmBindgenCli rec {
     hash = "sha256-1VwY8vQy7soKEgbki4LD+v259751kKxSxmo/gqE6yV0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     inherit (src) pname version;
-    hash = "sha256-aACJ+lYNEU8FFBs158G1/JG8sc6Rq080PeKCMnwdpH0=";
+    hash = "sha256-81vQkKubMWaX0M3KAwpYgMA1zUQuImFGvh5yTW+rIAs=";
   };
 }

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_92/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_92/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.92";
+    hash = "sha256-1VwY8vQy7soKEgbki4LD+v259751kKxSxmo/gqE6yV0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-aACJ+lYNEU8FFBs158G1/JG8sc6Rq080PeKCMnwdpH0=";
+  };
+}

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_93/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_93/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.93";
+    hash = "sha256-DDdu5mM3gneraM85pAepBXWn3TMofarVR4NbjMdz3r0=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-birrg+XABBHHKJxfTKAMSlmTVYLmnmqMDfRnmG6g/YQ=";
+  };
+}

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_93/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_93/package.nix
@@ -11,9 +11,9 @@ buildWasmBindgenCli rec {
     hash = "sha256-DDdu5mM3gneraM85pAepBXWn3TMofarVR4NbjMdz3r0=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     inherit (src) pname version;
-    hash = "sha256-birrg+XABBHHKJxfTKAMSlmTVYLmnmqMDfRnmG6g/YQ=";
+    hash = "sha256-s8srI+lu+DgQ+5BbaEXC4Ja/BL+K22LIl5Gd1PwNZZk=";
   };
 }

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_95/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_95/package.nix
@@ -1,0 +1,19 @@
+{
+  buildWasmBindgenCli,
+  fetchCrate,
+  rustPlatform,
+}:
+
+buildWasmBindgenCli rec {
+  src = fetchCrate {
+    pname = "wasm-bindgen-cli";
+    version = "0.2.95";
+    hash = "sha256-prMIreQeAcbJ8/g3+pMp1Wp9H5u+xLqxRxL+34hICss=";
+  };
+
+  cargoDeps = rustPlatform.fetchCargoTarball {
+    inherit src;
+    inherit (src) pname version;
+    hash = "sha256-6iMebkD7FQvixlmghGGIvpdGwFNLfnUcFke/Rg8nPK4=";
+  };
+}

--- a/pkgs/by-name/wa/wasm-bindgen-cli_0_2_95/package.nix
+++ b/pkgs/by-name/wa/wasm-bindgen-cli_0_2_95/package.nix
@@ -11,9 +11,9 @@ buildWasmBindgenCli rec {
     hash = "sha256-prMIreQeAcbJ8/g3+pMp1Wp9H5u+xLqxRxL+34hICss=";
   };
 
-  cargoDeps = rustPlatform.fetchCargoTarball {
+  cargoDeps = rustPlatform.fetchCargoVendor {
     inherit src;
     inherit (src) pname version;
-    hash = "sha256-6iMebkD7FQvixlmghGGIvpdGwFNLfnUcFke/Rg8nPK4=";
+    hash = "sha256-+h87/onAdpG0Jmeuy0Wd2djLFOAyaE52cAfxDVVcgP8=";
   };
 }

--- a/pkgs/servers/teleport/15/default.nix
+++ b/pkgs/servers/teleport/15/default.nix
@@ -1,4 +1,4 @@
-{ wasm-bindgen-cli, ... }@args:
+args:
 import ../generic.nix (
   args
   // {
@@ -13,13 +13,6 @@ import ../generic.nix (
         "ironrdp-async-0.1.0" = "sha256-nE5O/wRJ3vJqJG5zdYmpVkhx6JC6Yb92pR4EKSWSdkA=";
         "sspi-0.10.1" = "sha256-fkclC/plTh2d8zcmqthYmr5yXqbPTeFxI1VuaPX5vxk=";
       };
-    };
-
-    # wasm-bindgen-cli version must match the version of wasm-bindgen in Cargo.lock
-    wasm-bindgen-cli = wasm-bindgen-cli.override {
-      version = "0.2.92";
-      hash = "sha256-1VwY8vQy7soKEgbki4LD+v259751kKxSxmo/gqE6yV0=";
-      cargoHash = "sha256-aACJ+lYNEU8FFBs158G1/JG8sc6Rq080PeKCMnwdpH0=";
     };
   }
 )

--- a/pkgs/servers/teleport/16/default.nix
+++ b/pkgs/servers/teleport/16/default.nix
@@ -1,4 +1,4 @@
-{ wasm-bindgen-cli, ... }@args:
+args:
 import ../generic.nix (
   args
   // {
@@ -12,13 +12,6 @@ import ../generic.nix (
         "boring-4.7.0" = "sha256-ACzw4Bfo6OUrwvi3h21tvx5CpdQaWCEIDkslzjzy9o8=";
         "ironrdp-async-0.1.0" = "sha256-DOwDHavDaEda+JK9M6kbvseoXe2LxJg3MLTY/Nu+PN0=";
       };
-    };
-
-    # wasm-bindgen-cli version must match the version of wasm-bindgen in Cargo.lock
-    wasm-bindgen-cli = wasm-bindgen-cli.override {
-      version = "0.2.93";
-      hash = "sha256-DDdu5mM3gneraM85pAepBXWn3TMofarVR4NbjMdz3r0=";
-      cargoHash = "sha256-birrg+XABBHHKJxfTKAMSlmTVYLmnmqMDfRnmG6g/YQ=";
     };
   }
 )

--- a/pkgs/servers/teleport/default.nix
+++ b/pkgs/servers/teleport/default.nix
@@ -1,11 +1,34 @@
-{ callPackages, lib, ... }@args:
+{
+  callPackages,
+  lib,
+  wasm-bindgen-cli_0_2_92,
+  wasm-bindgen-cli_0_2_93,
+  ...
+}@args:
 let
   f = args: rec {
-    teleport_15 = import ./15 args;
-    teleport_16 = import ./16 args;
+    # wasm-bindgen-cli version must match the version of wasm-bindgen in Cargo.lock
+    teleport_15 = import ./15 (
+      args
+      // {
+        wasm-bindgen-cli = wasm-bindgen-cli_0_2_92;
+      }
+    );
+    teleport_16 = import ./16 (
+      args
+      // {
+        wasm-bindgen-cli = wasm-bindgen-cli_0_2_93;
+      }
+    );
     teleport = teleport_16;
   };
   # Ensure the following callPackages invocation includes everything 'generic' needs.
   f' = lib.setFunctionArgs f (builtins.functionArgs (import ./generic.nix));
 in
-callPackages f' (builtins.removeAttrs args [ "callPackages" ])
+callPackages f' (
+  builtins.removeAttrs args [
+    "callPackages"
+    "wasm-bindgen-cli_0_2_92"
+    "wasm-bindgen-cli_0_2_93"
+  ]
+)

--- a/pkgs/top-level/aliases.nix
+++ b/pkgs/top-level/aliases.nix
@@ -1478,6 +1478,7 @@ mapAliases {
   wakatime = wakatime-cli; # 2024-05-30
   wal_e = throw "wal_e was removed as it is unmaintained upstream and depends on the removed boto package; upstream recommends using wal-g or pgbackrest"; # Added 2024-09-22
   wapp = tclPackages.wapp; # Added 2024-10-02
+  wasm-bindgen-cli = wasm-bindgen-cli_0_2_100;
   wayfireApplications-unwrapped = throw ''
     'wayfireApplications-unwrapped.wayfire' has been renamed to/replaced by 'wayfire'
     'wayfireApplications-unwrapped.wayfirePlugins' has been renamed to/replaced by 'wayfirePlugins'

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5353,6 +5353,9 @@ with pkgs;
 
   webassemblyjs-cli = nodePackages."@webassemblyjs/cli-1.11.1";
   webassemblyjs-repl = nodePackages."@webassemblyjs/repl-1.11.1";
+
+  buildWasmBindgenCli = callPackage ../build-support/wasm-bindgen-cli { };
+
   wasm-strip = nodePackages."@webassemblyjs/wasm-strip";
   wasm-text-gen = nodePackages."@webassemblyjs/wasm-text-gen-1.11.1";
   wast-refmt = nodePackages."@webassemblyjs/wast-refmt-1.11.1";


### PR DESCRIPTION
Exposing an overridable cargoHash parameter is problematic because it
will produce silently broken FODs if we change the hashing scheme,
which we are currently doing across the tree because Cargo 1.84.0 has
changed the output of fetchCargoTarball, meaning all hashes have been
invalidated.  To avoid this happening in future, we are changing to
the fetchCargoVendor mechanism, which does not depend on
implementation details of Cargo.

The future-proof way to override a package with Cargo dependencies is
to pass a cargoDeps object.  This is more verbose, and requires the
caller to have access to the src object for the package.  To
compensate for this, I've introduced a buildWasmBindgenCli function
that is nicer to use than wasm-bindgen-cli.overrideAttrs, and I've
also introduced versioned attributes for wasm-bindgen-cli versions
currently in use in Nixpkgs, so that each package that wants to use a
particular version doesn't have to duplicate the src and cargoDeps
definitions for that version.

This is a bit urgent, because we need the transition to be completed by the end of the current staging-next cycle to avoid exposing broken FODs to users.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
