### PR TITLE
netbird: disable shell completion generation when cross compiling

### DIFF
--- a/pkgs/tools/networking/netbird/default.nix
+++ b/pkgs/tools/networking/netbird/default.nix
@@ -91,7 +91,7 @@ buildGoModule rec {
         ''
           mv $out/bin/${lib.last (lib.splitString "/" module)} $out/bin/${binary}
         ''
-        + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform && !ui) ''
+        + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform && !ui) ''
           installShellCompletion --cmd ${binary} \
             --bash <($out/bin/${binary} completion bash) \
             --fish <($out/bin/${binary} completion fish) \

--- a/pkgs/tools/networking/netbird/default.nix
+++ b/pkgs/tools/networking/netbird/default.nix
@@ -91,7 +91,7 @@ buildGoModule rec {
         ''
           mv $out/bin/${lib.last (lib.splitString "/" module)} $out/bin/${binary}
         ''
-        + lib.optionalString (!ui) ''
+        + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform && !ui) ''
           installShellCompletion --cmd ${binary} \
             --bash <($out/bin/${binary} completion bash) \
             --fish <($out/bin/${binary} completion fish) \


### PR DESCRIPTION
Skip shell completion generation through execution of built binary when cross compiling, to prevent error:
```
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
/nix/store/gi58xbi7md9sb5gshvnjdkv9n0b3znrw-stdenv-linux/setup: line 228: /nix/store/rpmnk1a3n9ks4d5fj0sr5fkp9nfzdcca-netbird-riscv64-unknown-linux-gnu-0.35.2/bin/netbird: cannot execute binary file: Exec format error
/nix/store/gi58xbi7md9sb5gshvnjdkv9n0b3znrw-stdenv-linux/setup: line 228: /nix/store/rpmnk1a3n9ks4d5fj0sr5fkp9nfzdcca-netbird-riscv64-unknown-linux-gnu-0.35.2/bin/netbird: cannot execute binary file: Exec format error
/nix/store/gi58xbi7md9sb5gshvnjdkv9n0b3znrw-stdenv-linux/setup: line 228: /nix/store/rpmnk1a3n9ks4d5fj0sr5fkp9nfzdcca-netbird-riscv64-unknown-linux-gnu-0.35.2/bin/netbird: cannot execute binary file: Exec format error
installShellCompletion: installed shell completion file `/nix/store/rpmnk1a3n9ks4d5fj0sr5fkp9nfzdcca-netbird-riscv64-unknown-linux-gnu-0.35.2/share/bash-completion/completions/netbird.bash' does not exist or has zero size
```

When building for [Milk-V Duo S](https://github.com/NickCao/nixos-riscv/blob/master/duos.nix) with:
```nix
  nixpkgs = {
    localSystem.config = "x86_64-unknown-linux-gnu";
    crossSystem.config = "riscv64-unknown-linux-gnu";
  };
```

Inspired by https://github.com/NixOS/nixpkgs/pull/186436.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
