### PR TITLE
ocamlPackages.mustache: 3.1.0 -> 3.3.0, ocamlPackages.mustache-cli: i…

### DIFF
--- a/pkgs/by-name/mu/mustache-ocaml/package.nix
+++ b/pkgs/by-name/mu/mustache-ocaml/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  ocamlPackages,
+  fetchFromGitHub,
+}:
+
+let
+  mustache = import ../../../development/ocaml-modules/mustache/base.nix {
+    inherit
+      fetchFromGitHub
+      ;
+    buildDunePackage = ocamlPackages.buildDunePackage;
+    menhirLib = ocamlPackages.menhirLib;
+    ezjsonm = ocamlPackages.ezjsonm;
+    ounit = ocamlPackages.ounit;
+    doCheck = false; # tests need to mustache-cli, but it's recursive
+    nativeBuildInputs = [
+      ocamlPackages.menhir
+    ];
+  };
+in
+ocamlPackages.buildDunePackage rec {
+  pname = "mustache-cli";
+  inherit (mustache) version src;
+
+  propagatedBuildInputs = with ocamlPackages; [
+    cmdliner
+    jsonm
+    mustache
+  ];
+
+  doCheck = true;
+  checkInputs = with ocamlPackages; [
+    ezjsonm
+    ounit2
+  ];
+
+  meta = {
+    description = "CLI for Mustache logic-less templates";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ momeemt ];
+    inherit (src.meta) homepage;
+    mainProgram = "mustache-ocaml";
+  };
+}

--- a/pkgs/development/ocaml-modules/mustache/base.nix
+++ b/pkgs/development/ocaml-modules/mustache/base.nix
@@ -1,0 +1,26 @@
+{
+  buildDunePackage,
+  fetchFromGitHub,
+  menhirLib,
+  ezjsonm,
+  ounit,
+  doCheck ? true,
+  nativeBuildInputs ? [ ],
+}:
+buildDunePackage rec {
+  pname = "mustache";
+  version = "3.3.0";
+  src = fetchFromGitHub {
+    owner = "rgrinberg";
+    repo = "ocaml-mustache";
+    tag = "v${version}";
+    hash = "sha256-7rdp7nrjc25/Nuj/cf78qxS3Qy4ufaNcKjSnYh4Ri8U=";
+  };
+
+  inherit nativeBuildInputs;
+  buildInputs = [ ezjsonm ];
+  propagatedBuildInputs = [ menhirLib ];
+
+  inherit doCheck;
+  checkInputs = [ ounit ];
+}

--- a/pkgs/development/ocaml-modules/mustache/default.nix
+++ b/pkgs/development/ocaml-modules/mustache/default.nix
@@ -2,34 +2,34 @@
   lib,
   buildDunePackage,
   fetchFromGitHub,
-  ezjsonm,
   menhir,
   menhirLib,
   ounit,
+  ezjsonm,
+  mustache-cli,
 }:
-
-buildDunePackage rec {
-  pname = "mustache";
-  version = "3.1.0";
-  duneVersion = "3";
-  src = fetchFromGitHub {
-    owner = "rgrinberg";
-    repo = "ocaml-mustache";
-    rev = "v${version}";
-    sha256 = "19v8rk8d8lkfm2rmhdawfgadji6wa267ir5dprh4w9l1sfj8a1py";
-  };
-
-  nativeBuildInputs = [ menhir ];
-  buildInputs = [ ezjsonm ];
-  propagatedBuildInputs = [ menhirLib ];
-
+import ./base.nix {
+  inherit
+    buildDunePackage
+    fetchFromGitHub
+    menhirLib
+    ezjsonm
+    ounit
+    ;
   doCheck = true;
-  checkInputs = [ ounit ];
-
+  nativeBuildInputs = [
+    menhir
+    mustache-cli
+  ];
+}
+// {
   meta = {
     description = "Mustache logic-less templates in OCaml";
     license = lib.licenses.mit;
-    maintainers = [ lib.maintainers.vbgl ];
-    inherit (src.meta) homepage;
+    maintainers = with lib.maintainers; [
+      vbgl
+      momeemt
+    ];
+    homepage = "https://github.com/rgrinberg/ocaml-mustache";
   };
 }


### PR DESCRIPTION
…nit at 3.3.0

Changelog: https://github.com/rgrinberg/ocaml-mustache/releases/tag/v3.3.0
Diff: https://github.com/rgrinberg/ocaml-mustache/compare/v3.1.0...v3.3.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
