### PR TITLE
open-english-wordnet: 2022 → 2024

### DIFF
--- a/pkgs/by-name/op/open-english-wordnet/package.nix
+++ b/pkgs/by-name/op/open-english-wordnet/package.nix
@@ -1,7 +1,6 @@
 {
   lib,
   fetchFromGitHub,
-  fetchpatch,
   gzip,
   python3,
   stdenvNoCC,
@@ -9,30 +8,14 @@
 
 stdenvNoCC.mkDerivation (self: {
   pname = "open-english-wordnet";
-  version = "2022";
+  version = "2024";
 
   src = fetchFromGitHub {
     owner = "globalwordnet";
     repo = "english-wordnet";
     rev = "${self.version}-edition";
-    hash = "sha256-a1fWIp39uuJZL1aFX/r+ttLB1+kwh/XPHwphgENTQ5M=";
+    hash = "sha256-9HGcVoI4xnkIkGw03oF6jT0a5xqv4pZz1s0l0gvqsyY=";
   };
-
-  patches =
-    lib.mapAttrsToList
-      (
-        rev: hash:
-        fetchpatch {
-          url = "https://github.com/globalwordnet/english-wordnet/commit/${rev}.patch";
-          inherit hash;
-        }
-      )
-      {
-        # Upstream commit bumping the version number, accidentally ommited from the tagged release
-        "bc07902f8995b62c70f01a282b23f40f30630540" = "sha256-1e4MG/k86g3OFUhiShCCbNXnvDKrYFr1KlGVsGl++KI=";
-        # PR #982, “merge.py: Make result independent of filesystem order”
-        "6da46a48dd76a48ad9ff563e6c807b8271fc83cd" = "sha256-QkkJH7NVGy/IbeSWkotU80IGF4esz0b8mIL9soHdQtQ=";
-      };
 
   # TODO(nicoo): make compression optional?
   nativeBuildInputs = [
@@ -45,13 +28,19 @@ stdenvNoCC.mkDerivation (self: {
     runHook preBuild
 
     echo Generating wn.xml
-    python scripts/from-yaml.py
-    python scripts/merge.py
+    python scripts/from_yaml.py
 
     echo Compressing
     gzip --best --no-name --stdout ./wn.xml > 'oewn:${self.version}.xml.gz'
 
     runHook postBuild
+  '';
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    python scripts/validate.py
+    runHook postCheck
   '';
 
   installPhase = ''


### PR DESCRIPTION
Update `open-english-wordnet` to the 2024 release, add tests

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
