### PR TITLE
crowdsec: Set tag version as expected by upstream

### DIFF
--- a/pkgs/by-name/cr/crowdsec/package.nix
+++ b/pkgs/by-name/cr/crowdsec/package.nix
@@ -42,6 +42,10 @@ buildGoModule rec {
     mkdir -p $out/share/crowdsec
     cp -r ./config $out/share/crowdsec/
 
+    mkdir -p $out/lib/systemd/system
+    substitute ./config/crowdsec.service $out/lib/systemd/system/crowdsec.service \
+      --replace-fail /usr/local $out
+
     installShellCompletion --cmd cscli \
       --bash <($out/bin/cscli completion bash) \
       --fish <($out/bin/cscli completion fish) \

--- a/pkgs/by-name/cr/crowdsec/package.nix
+++ b/pkgs/by-name/cr/crowdsec/package.nix
@@ -30,7 +30,7 @@ buildGoModule rec {
     "-w"
     "-X github.com/crowdsecurity/go-cs-lib/version.Version=v${version}"
     "-X github.com/crowdsecurity/go-cs-lib/version.BuildDate=1970-01-01_00:00:00"
-    "-X github.com/crowdsecurity/go-cs-lib/version.Tag=${src.rev}"
+    "-X github.com/crowdsecurity/go-cs-lib/version.Tag=v${version}"
     "-X github.com/crowdsecurity/crowdsec/pkg/cwversion.Codename=alphaga"
     "-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultConfigDir=/etc/crowdsec"
     "-X github.com/crowdsecurity/crowdsec/pkg/csconfig.defaultDataDir=/var/lib/crowdsec/data"
@@ -53,8 +53,13 @@ buildGoModule rec {
   '';
 
   # It's important that the version is correctly set as it also determines feature capabilities
-  checkPhase = ''
-    $GOPATH/bin/cscli version 2>&1 | grep -q "version: v${version}"
+  preCheck = ''
+    version=$($GOPATH/bin/cscli version 2>&1 | sed -nE 's/^version: (.*)/\1/p')
+
+    if [ "$version" != "v${version}" ]; then
+        echo "Invalid version string: '$version'"
+        exit 1
+    fi
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Without setting the correct version here, the package is completely broken as the local API checks that any clients report the correct user agent, which includes this string.

This has been broken since switching to `refs/tags` in 326517a5290c34e0cc4da564825a7193a692f2b0.

I fixed some other small nits (the upstream systemd service wasn't in the right location, ~~and we were asking go to strip the binary *before* the `fixupPhase`~~ - ok, let me not do that, apparently that's [a can of worms](https://github.com/NixOS/nixpkgs/issues/346380)) while I was here (in separate commits), hope that doesn't cause additional review overhead.

At least the tag version commit should probably be backported, the package is currently unusable on stable as well.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
