### PR TITLE
nixos/fish: add functions setting

### DIFF
--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -381,35 +381,33 @@ in
       {
         etc = lib.mapAttrs' (name: def: {
           name = "fish/functions/${name}.fish";
-          value = {
-            source =
-              let
-                modifierStr = n: v: lib.optional (v != null) ''--${n}="${toString v}"'';
-                modifierStrs = n: v: lib.optional (v != null) "--${n}=${toString v}";
-                modifierBool = n: v: lib.optional (v != null && v) "--${n}";
+          value.source =
+            let
+              modifierStr = n: v: lib.optional (v != null) ''--${n}="${toString v}"'';
+              modifierStrs = n: v: lib.optional (v != null) "--${n}=${toString v}";
+              modifierBool = n: v: lib.optional (v != null && v) "--${n}";
 
-                mods =
-                  with def;
-                  modifierStr "description" description
-                  ++ modifierStr "wraps" wraps
-                  ++ modifierStr "on-event" onEvent
-                  ++ modifierStr "on-variable" onVariable
-                  ++ modifierStr "on-job-exit" onJobExit
-                  ++ modifierStr "on-process-exit" onProcessExit
-                  ++ modifierStr "on-signal" onSignal
-                  ++ modifierBool "no-scope-shadowing" noScopeShadowing
-                  ++ modifierStr "inherit-variable" inheritVariable
-                  ++ modifierStrs "argument-names" argumentNames;
+              mods =
+                with def;
+                modifierStr "description" description
+                ++ modifierStr "wraps" wraps
+                ++ modifierStr "on-event" onEvent
+                ++ modifierStr "on-variable" onVariable
+                ++ modifierStr "on-job-exit" onJobExit
+                ++ modifierStr "on-process-exit" onProcessExit
+                ++ modifierStr "on-signal" onSignal
+                ++ modifierBool "no-scope-shadowing" noScopeShadowing
+                ++ modifierStr "inherit-variable" inheritVariable
+                ++ modifierStrs "argument-names" argumentNames;
 
-                modifiers = if lib.isAttrs def then " ${toString mods}" else "";
-                body = if lib.isAttrs def then def.body else def;
-              in
-              fishIndent "${name}.fish" ''
-                function ${name}${modifiers}
-                  ${lib.strings.removeSuffix "\n" body}
-                end
-              '';
-          };
+              modifiers = if lib.isAttrs def then " ${toString mods}" else "";
+              body = if lib.isAttrs def then def.body else def;
+            in
+            fishIndent "${name}.fish" ''
+              function ${name}${modifiers}
+                ${lib.strings.removeSuffix "\n" body}
+              end
+            '';
         }) cfg.functions;
       }
 

--- a/nixos/modules/programs/fish.nix
+++ b/nixos/modules/programs/fish.nix
@@ -38,6 +38,127 @@ let
       nativeBuildInputs = [ pkgs.babelfish ];
     } "babelfish < ${path} > $out;";
 
+  fishIndent =
+    name: text:
+    pkgs.runCommand name {
+      nativeBuildInputs = [ cfg.package ];
+      inherit text;
+      passAsFile = [ "text" ];
+    } "env HOME=$(mktemp -d) fish_indent < $textPath > $out";
+
+  functionModule = lib.types.submodule {
+    options = {
+      body = lib.mkOption {
+        type = lib.types.lines;
+        description = ''
+          The function body.
+        '';
+      };
+
+      argumentNames = lib.mkOption {
+        type = with lib.types; nullOr (either str (listOf str));
+        default = null;
+        description = ''
+          Assigns the value of successive command line arguments to the names
+          given.
+        '';
+      };
+
+      description = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          A description of what the function does, suitable as a completion
+          description.
+        '';
+      };
+
+      wraps = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          Causes the function to inherit completions from the given wrapped
+          command.
+        '';
+      };
+
+      onEvent = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          Tells fish to run this function when the specified named event is
+          emitted. Fish internally generates named events e.g. when showing the
+          prompt.
+        '';
+      };
+
+      onVariable = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          Tells fish to run this function when the specified variable changes
+          value.
+        '';
+      };
+
+      onJobExit = lib.mkOption {
+        type = with lib.types; nullOr (either str int);
+        default = null;
+        description = ''
+          Tells fish to run this function when the job with the specified group
+          ID exits. Instead of a PID, the stringer `caller` can
+          be specified. This is only legal when in a command substitution, and
+          will result in the handler being triggered by the exit of the job
+          which created this command substitution.
+        '';
+      };
+
+      onProcessExit = lib.mkOption {
+        type = with lib.types; nullOr (either str int);
+        default = null;
+        example = "$fish_pid";
+        description = ''
+          Tells fish to run this function when the fish child process with the
+          specified process ID exits. Instead of a PID, for backwards
+          compatibility, `%self` can be specified as an alias
+          for `$fish_pid`, and the function will be run when
+          the current fish instance exits.
+        '';
+      };
+
+      onSignal = lib.mkOption {
+        type = with lib.types; nullOr (either str int);
+        default = null;
+        example = [
+          "SIGHUP"
+          "HUP"
+          1
+        ];
+        description = ''
+          Tells fish to run this function when the specified signal is
+          delievered. The signal can be a signal number or signal name.
+        '';
+      };
+
+      noScopeShadowing = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Allows the function to access the variables of calling functions.
+        '';
+      };
+
+      inheritVariable = lib.mkOption {
+        type = with lib.types; nullOr str;
+        default = null;
+        description = ''
+          Snapshots the value of the specified variable and defines a local
+          variable with that same name and value when the function is defined.
+        '';
+      };
+    };
+  };
+
 in
 
 {
@@ -142,6 +263,24 @@ in
         type = lib.types.lines;
       };
 
+      functions = lib.mkOption {
+        type = with lib.types; attrsOf (either lines functionModule);
+        default = { };
+        example = ''
+          {
+            __fish_command_not_found_handler = {
+              body = "__fish_default_command_not_found_handler $argv[1]";
+              onEvent = "fish_command_not_found";
+            };
+
+            gitignore = "curl -sL https://www.gitignore.io/api/$argv";
+          }
+        '';
+        description = ''
+          Basic functions to add to fish. For more information see
+          <https://fishshell.com/docs/current/cmds/function.html>.
+        '';
+      };
     };
 
   };
@@ -237,6 +376,41 @@ in
           set -g __fish_nixos_interactive_config_sourced 1
         end
       '';
+      }
+
+      {
+        etc = lib.mapAttrs' (name: def: {
+          name = "fish/functions/${name}.fish";
+          value = {
+            source =
+              let
+                modifierStr = n: v: lib.optional (v != null) ''--${n}="${toString v}"'';
+                modifierStrs = n: v: lib.optional (v != null) "--${n}=${toString v}";
+                modifierBool = n: v: lib.optional (v != null && v) "--${n}";
+
+                mods =
+                  with def;
+                  modifierStr "description" description
+                  ++ modifierStr "wraps" wraps
+                  ++ modifierStr "on-event" onEvent
+                  ++ modifierStr "on-variable" onVariable
+                  ++ modifierStr "on-job-exit" onJobExit
+                  ++ modifierStr "on-process-exit" onProcessExit
+                  ++ modifierStr "on-signal" onSignal
+                  ++ modifierBool "no-scope-shadowing" noScopeShadowing
+                  ++ modifierStr "inherit-variable" inheritVariable
+                  ++ modifierStrs "argument-names" argumentNames;
+
+                modifiers = if lib.isAttrs def then " ${toString mods}" else "";
+                body = if lib.isAttrs def then def.body else def;
+              in
+              fishIndent "${name}.fish" ''
+                function ${name}${modifiers}
+                  ${lib.strings.removeSuffix "\n" body}
+                end
+              '';
+          };
+        }) cfg.functions;
       }
 
       {


### PR DESCRIPTION
Notice: This PR is currently blocked by #377948.

This adds an option `programs.fish.functions`, to specify user-defined functions that should be available in the system-wide configuration. The code is taken from home-manager, but would also be useful for nixpkgs.

This is my first time contributing to nixpkgs, and still relatively new to Nix stuff. Feedback and guidance would be welcome!

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested basic functionality
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Module updates) Added a release notes entry if the change is significant
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
