### PR TITLE
lcov: fix and enable strictDeps

### DIFF
--- a/pkgs/by-name/lc/lcov/package.nix
+++ b/pkgs/by-name/lc/lcov/package.nix
@@ -30,16 +30,22 @@ stdenv.mkDerivation rec {
     hash = "sha256-cZdDlOf3IgPQrUNl+wu6Gwecaj+r2xu0eqmlz67TeAI=";
   };
 
-  nativeBuildInputs = [ makeWrapper ];
+  nativeBuildInputs = [
+    makeWrapper
+    perl
+  ];
 
   buildInputs = [
     perl
     python3
   ];
 
+  strictDeps = true;
+
   preBuild = ''
-    patchShebangs bin/
-    makeFlagsArray=(PREFIX=$out LCOV_PERL_PATH=$(command -v perl))
+    patchShebangs --build bin/{fix.pl,get_version.sh} tests/*/*
+    patchShebangs --host bin/{gen*,lcov,perl2lcov}
+    makeFlagsArray=(PREFIX=$out LCOV_PERL_PATH=${lib.getExe perl})
   '';
 
   postInstall = ''


### PR DESCRIPTION
Fixes regular strictDeps build, ref. #178468

Cross is broken due to dependencies.

## Things done

- Built on platform(s)
  - [x] x86_64-linux. `$out/bin/*` all have correct shebangs
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).