### PR TITLE
hyprland-qt-support: init at 0.1.0; hyprpolkitagent: add missing hyprland-qt-support dependency; hyprsysteminfo: init at 0.1.3

### DIFF
--- a/pkgs/by-name/hy/hyprland-qt-support/package.nix
+++ b/pkgs/by-name/hy/hyprland-qt-support/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  ninja,
+  qt6,
+  pkg-config,
+  hyprlang,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprland-qt-support";
+  version = "0.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprland-qt-support";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-+uZovj+X0a28172y0o0BvgGXyZLpKPbG03sVlCiSrWc=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    qt6.qtwayland
+    hyprlang
+  ];
+
+  cmakeFlags = [
+    (lib.cmakeFeature "INSTALL_QML_PREFIX" qt6.qtbase.qtQmlPrefix)
+  ];
+
+  meta = {
+    description = "A Qt6 QML provider for hypr* apps";
+    homepage = "https://github.com/hyprwm/hyprland-qt-support";
+    license = lib.licenses.bsd3;
+    platforms = lib.platforms.linux;
+    maintainers = lib.teams.hyprland.members;
+  };
+})

--- a/pkgs/by-name/hy/hyprpolkitagent/package.nix
+++ b/pkgs/by-name/hy/hyprpolkitagent/package.nix
@@ -4,6 +4,7 @@
   cmake,
   pkg-config,
   fetchFromGitHub,
+  hyprland-qt-support,
   hyprutils,
   kdePackages,
   polkit,
@@ -27,6 +28,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
+    hyprland-qt-support
     hyprutils
     kdePackages.kirigami-addons
     kdePackages.polkit-qt-1

--- a/pkgs/by-name/hy/hyprsysteminfo/package.nix
+++ b/pkgs/by-name/hy/hyprsysteminfo/package.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  cmake,
+  qt6,
+  pkg-config,
+  hyprutils,
+  pciutils,
+  hyprland-qt-support,
+}:
+let
+  inherit (lib.strings) makeBinPath;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hyprsysteminfo";
+  version = "0.1.3";
+
+  src = fetchFromGitHub {
+    owner = "hyprwm";
+    repo = "hyprsysteminfo";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-KDxT9B+1SATWiZdUBAQvZu17vk3xmyXcw2Zy56bdWbY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+    qt6.wrapQtAppsHook
+  ];
+
+  buildInputs = [
+    qt6.qtbase
+    qt6.qtdeclarative
+    qt6.qtsvg
+    qt6.qtwayland
+    hyprutils
+    hyprland-qt-support
+  ];
+
+  preFixup = ''
+    qtWrapperArgs+=(--prefix PATH : "${makeBinPath [ pciutils ]}")
+  '';
+
+  meta = {
+    description = "A tiny qt6/qml application to display information about the running system";
+    homepage = "https://github.com/hyprwm/hyprsysteminfo";
+    license = lib.licenses.bsd3;
+    maintainers = lib.teams.hyprland.members;
+    mainProgram = "hyprsysteminfo";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Was setting up hyprpolkitagent and saw runtime error because of missing dependency. 

Before:
```bash
 Adding new listener  PolkitQt1::Agent::Listener(0x33c564b0) for  0x33c56ea0
 Listener adapter polkit_qt_listener_initiate_authentication
 GSimpleAsyncResult: 0x341eb8d0
 polkit_qt_listener_initiate_authentication callback for  0x33c56ea0
 QQmlApplicationEngine failed to load component
 qrc:/qt/qml/hpa/qml/main.qml: module "org.hyprland.style" is not installed
 REQUEST
 cancelled_cb for  0x33c56ea0
 Listener adapter polkit_qt_listener_initiate_authentication_finish
 polkit_qt_listener_initiate_authentication_finish callback for  0x33c56ea0
```
After:
```bash
./result/libexec/hyprpolkitagent
New PolkitAgentListener  0x1ecaea0
Adding new listener  PolkitQt1::Agent::Listener(0x1eca4b0) for  0x1ecaea0
Listener adapter polkit_qt_listener_initiate_authentication
GSimpleAsyncResult: 0x246f0d0
polkit_qt_listener_initiate_authentication callback for  0x1ecaea0
> New authentication session
Spawning qml prompt
REQUEST
> PKS request: Password:  echo: false
Got result from qml: auth:**PASSWORD**
COMPLETED
> PKS completed: Auth successful
> finishAuth: Gained auth, cleaning up.
Listener adapter polkit_qt_listener_initiate_authentication_finish
polkit_qt_listener_initiate_authentication_finish callback for  0x1ecaea0
```
![image](https://github.com/user-attachments/assets/e986a5d1-f11a-4af7-bf01-40079dc8618e)

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
