### PR TITLE
aseprite: 1.3.7 -> 1.3.13

### DIFF
--- a/pkgs/by-name/as/aseprite/package.nix
+++ b/pkgs/by-name/as/aseprite/package.nix
@@ -33,15 +33,35 @@
 
 clangStdenv.mkDerivation (finalAttrs: {
   pname = "aseprite";
-  version = "1.3.7";
+  version = "1.3.13";
 
-  src = fetchFromGitHub {
-    owner = "aseprite";
-    repo = "aseprite";
-    rev = "v" + finalAttrs.version;
-    fetchSubmodules = true;
-    hash = "sha256-75kYJXmyags0cW2D5Ksq1uUrFSCAkFOdmn7Ya/6jLXc=";
-  };
+  srcs = [
+    (fetchFromGitHub {
+      name = "aseprite-source";
+      owner = "aseprite";
+      repo = "aseprite";
+      tag = "v${finalAttrs.version}";
+      fetchSubmodules = true;
+      hash = "sha256-eeB/4fQp1lbNYQj9LpNhOn7DYxaTc+BcmyvY2vPzpxk=";
+    })
+
+    # Translation strings
+    (fetchFromGitHub {
+      name = "aseprite-strings";
+      owner = "aseprite";
+      repo = "strings";
+      rev = "7b0af61dec1d98242d7eb2e9cab835d442d21235";
+      hash = "sha256-8OwwHCFP55pwLjk5O+a36hDZf9uX3P7cNliJM5SZdAg=";
+    })
+  ];
+
+  # Sets the main build directory to "aseprite-source" since multiple sources are fetched.
+  sourceRoot = "aseprite-source";
+
+  # Translation files are copied without overwriting existing ones to preserve the potentially more up-to-date English file from the main source.
+  postUnpack = ''
+    cp --no-clobber $PWD/aseprite-strings/* ./aseprite-source/data/strings
+  '';
 
   nativeBuildInputs = [
     cmake
@@ -75,33 +95,15 @@ clangStdenv.mkDerivation (finalAttrs: {
   ];
 
   patches = [
-    # https://github.com/aseprite/aseprite/issues/4486
-    # FIXME: remove on next release.
-    (fetchpatch {
-      name = "ENABLE_UPDATER-fix.patch";
-      url = "https://github.com/aseprite/aseprite/commit/8fce589.patch";
-      hash = "sha256-DbL6kK//gQXbsXEn/t+KTuoM7E9ocPAsVqEO+lYrka4=";
-    })
     ./shared-fmt.patch
     ./shared-libwebp.patch
     ./shared-skia-deps.patch
   ];
 
-  postPatch =
-    let
-      # Translation strings
-      strings = fetchFromGitHub {
-        owner = "aseprite";
-        repo = "strings";
-        rev = "e18a09fefbb6cd904e506183d5fbe08558a52ed4";
-        hash = "sha256-GyCCxbhgf0vST20EH/+KkNLrF+U9Xzgpxlao8s925PQ=";
-      };
-    in
-    ''
-      sed -i src/ver/CMakeLists.txt -e "s-set(VERSION \".*\")-set(VERSION \"$version\")-"
-      rm -rf data/strings
-      cp -r ${strings} data/strings
-    '';
+  postPatch = ''
+    substituteInPlace src/ver/CMakeLists.txt \
+      --replace-fail '"1.x-dev"' '"${finalAttrs.version}"'
+  '';
 
   cmakeFlags = [
     "-DENABLE_DESKTOP_INTEGRATION=ON"
@@ -116,7 +118,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     "-DUSE_SHARED_LIBPNG=ON"
     "-DUSE_SHARED_LIBWEBP=ON"
     "-DUSE_SHARED_PIXMAN=ON"
-    "-DUSE_SHARED_TINYXML=ON"
+    "-DUSE_SHARED_TINYXML=OFF"
     "-DUSE_SHARED_WEBP=ON"
     "-DUSE_SHARED_ZLIB=ON"
     # Disable libarchive programs.
@@ -124,7 +126,7 @@ clangStdenv.mkDerivation (finalAttrs: {
     "-DENABLE_CPIO=OFF"
     "-DENABLE_TAR=OFF"
     # UI backend.
-    "-DLAF_OS_BACKEND=skia"
+    "-DLAF_BACKEND=skia"
     "-DLAF_WITH_EXAMPLES=OFF"
     "-DSKIA_DIR=${skia-aseprite}"
     "-DSKIA_LIBRARY_DIR=${skia-aseprite}/lib"

--- a/pkgs/by-name/as/aseprite/shared-fmt.patch
+++ b/pkgs/by-name/as/aseprite/shared-fmt.patch
@@ -1,6 +1,8 @@
---- a/CMakeLists.txt	2022-01-08 00:37:08.165330523 +0100
-+++ b/CMakeLists.txt	2022-01-08 00:52:41.163585173 +0100
-@@ -54,6 +54,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b1bd0189b..3fb7abffb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,6 +66,7 @@ enable_testing()
  
  option(USE_SHARED_CMARK   "Use your installed copy of cmark" off)
  option(USE_SHARED_CURL    "Use your installed copy of curl" off)
@@ -8,7 +10,7 @@
  option(USE_SHARED_GIFLIB  "Use your installed copy of giflib" off)
  option(USE_SHARED_JPEGLIB "Use your installed copy of jpeglib" off)
  option(USE_SHARED_ZLIB    "Use your installed copy of zlib" off)
-@@ -165,6 +165,7 @@
+@@ -185,6 +186,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_PROFILE "${CMAKE_BINARY_DIR}/bin")
  set(SOURCE_DATA_DIR     ${CMAKE_CURRENT_SOURCE_DIR}/data)
  set(CMARK_DIR           ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cmark)
  set(CURL_DIR            ${CMAKE_CURRENT_SOURCE_DIR}/third_party/curl)
@@ -16,10 +18,11 @@
  set(GIFLIB_DIR          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/giflib)
  set(LIBJPEG_DIR         ${CMAKE_CURRENT_SOURCE_DIR}/third_party/jpeg)
  set(LIBPNG_DIR          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/libpng)
-@@ -204,6 +205,15 @@
+@@ -225,6 +227,16 @@ if(NOT USE_SHARED_CURL)
    set(CURL_STATICLIB ON BOOL)
  endif()
  
++# fmt
 +if(USE_SHARED_FMT)
 +  find_package(FMT REQUIRED)
 +  set(FMT_LIBRARIES fmt::fmt)
@@ -32,10 +35,12 @@
  # zlib
  if(USE_SHARED_ZLIB)
    find_package(ZLIB REQUIRED)
---- a/src/app/CMakeLists.txt	2022-01-08 00:37:07.378671200 +0100
-+++ b/src/app/CMakeLists.txt	2022-01-08 00:53:13.669969512 +0100
-@@ -741,7 +741,7 @@ target_link_libraries(app-lib
-   ${HARFBUZZ_LIBRARIES}
+diff --git a/src/app/CMakeLists.txt b/src/app/CMakeLists.txt
+index 9c67c0268..b19a3e412 100644
+--- a/src/app/CMakeLists.txt
++++ b/src/app/CMakeLists.txt
+@@ -754,7 +754,7 @@ target_link_libraries(app-lib
+   ${ZLIB_LIBRARIES}
    json11
    archive_static
 -  fmt
@@ -43,10 +48,11 @@
    tinyexpr
    qoi)
  
- if(ENABLE_PSD)
---- a/src/dio/CMakeLists.txt	2022-01-08 00:41:50.712726972 +0100
-+++ b/src/dio/CMakeLists.txt	2022-01-08 00:53:39.936408022 +0100
-@@ -10,7 +10,7 @@
+diff --git a/src/dio/CMakeLists.txt b/src/dio/CMakeLists.txt
+index 55cb24de5..b253dca0b 100644
+--- a/src/dio/CMakeLists.txt
++++ b/src/dio/CMakeLists.txt
+@@ -16,7 +16,7 @@ endif()
  
  target_link_libraries(dio-lib
    ${ZLIB_LIBRARIES}
@@ -55,9 +61,11 @@
    flic-lib
    laf-base
    fixmath-lib
---- a/third_party/CMakeLists.txt	2022-01-08 00:37:08.165330523 +0100
-+++ b/third_party/CMakeLists.txt	2022-01-08 00:54:30.455969136 +0100
-@@ -106,7 +106,10 @@
+diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
+index 9d09a98c8..1973b134b 100644
+--- a/third_party/CMakeLists.txt
++++ b/third_party/CMakeLists.txt
+@@ -117,7 +117,10 @@ if(NOT USE_SHARED_HARFBUZZ AND NOT LAF_BACKEND STREQUAL "skia")
  endif()
  
  add_subdirectory(simpleini)

--- a/pkgs/by-name/as/aseprite/shared-libwebp.patch
+++ b/pkgs/by-name/as/aseprite/shared-libwebp.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index af077f6..fed17ff 100644
+index  87aed2f28f9c..498472ec2a60 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -58,6 +58,7 @@ option(USE_SHARED_TINYXML "Use your installed copy of tinyxml" off)
+@@ -76,6 +76,7 @@ option(USE_SHARED_TINYXML "Use your installed copy of tinyxml" off)
  option(USE_SHARED_PIXMAN  "Use your installed copy of pixman" off)
  option(USE_SHARED_FREETYPE "Use shared FreeType library" off)
  option(USE_SHARED_HARFBUZZ "Use shared HarfBuzz library" off)
@@ -10,7 +10,7 @@ index af077f6..fed17ff 100644
  option(ENABLE_ASEPRITE_EXE "Compile main Aseprite executable" on)
  option(ENABLE_MEMLEAK      "Enable memory-leaks detector (only for developers)" off)
  option(ENABLE_NEWS         "Enable the news in Home tab" on)
-@@ -328,14 +351,17 @@ add_subdirectory(laf)
+@@ -380,7 +381,20 @@ add_subdirectory(laf)
  # libwebp
  if(ENABLE_WEBP)
    # Use libwebp from Skia
@@ -21,27 +21,27 @@ index af077f6..fed17ff 100644
 +    find_library(WEBPMUX_LIBRARY NAMES webpmux)
 +    set(WEBP_LIBRARIES ${WEBP_LIBRARY} ${WEBPDEMUX_LIBRARY} ${WEBPMUX_LIBRARY})
 +    find_path(WEBP_INCLUDE_DIRS NAMES decode.h PATH_SUFFIXES webp)
-+  else()
++    find_path(WEBP_INCLUDE_DIRS NAMES decode.h PATH_SUFFIXES webp)
++    find_path(WEBP_INCLUDE_DIRS NAMES decode.h PATH_SUFFIXES webp)
++    if(WEBP_LIBRARIES)
++      set(WEBP_FOUND ON)
++    else()
++      set(WEBP_FOUND OFF)
++    endif()
++  elseif(LAF_BACKEND STREQUAL "skia")
      find_library(WEBP_LIBRARIES webp
        NAMES libwebp # required for Windows
        PATHS "${SKIA_LIBRARY_DIR}" NO_DEFAULT_PATH)
-     set(WEBP_INCLUDE_DIR "${SKIA_DIR}/third_party/externals/libwebp/src")
--  else()
--    set(WEBP_LIBRARIES webp webpdemux libwebpmux)
--    set(WEBP_INCLUDE_DIR ${LIBWEBP_DIR}/src)
-   endif()
-   include_directories(${WEBP_INCLUDE_DIR})
- endif()
 diff --git a/third_party/CMakeLists.txt b/third_party/CMakeLists.txt
-index 4839d4097c..e8c3e83cbc 100644
+index 1973b134b9f8..f15dba5a7968 100644
 --- a/third_party/CMakeLists.txt
 +++ b/third_party/CMakeLists.txt
-@@ -32,7 +32,7 @@ if(NOT USE_SHARED_GIFLIB)
+@@ -33,7 +33,7 @@ if(NOT USE_SHARED_GIFLIB)
    add_subdirectory(giflib)
  endif()
- 
+
 -if(ENABLE_WEBP AND NOT LAF_BACKEND STREQUAL "skia")
 +if(ENABLE_WEBP AND NOT LAF_BACKEND STREQUAL "skia" AND NOT USE_SHARED_WEBP)
    set(WEBP_BUILD_EXTRAS OFF CACHE BOOL "Build extras.")
-   add_subdirectory(libwebp)
- endif()
+   set(WEBP_BUILD_ANIM_UTILS OFF CACHE BOOL "Build animation utilities.")
+   set(WEBP_BUILD_CWEBP OFF CACHE BOOL "Build the cwebp command line tool.")


### PR DESCRIPTION
Diff : https://github.com/aseprite/aseprite/compare/v1.3.7...v1.3.13
Changelog : https://github.com/aseprite/aseprite/releases/tag/v1.3.13
Fix: https://github.com/NixOS/nixpkgs/issues/352484

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
