### PR TITLE
nautilus-python: fix cross build

### DIFF
--- a/pkgs/by-name/na/nautilus-python/package.nix
+++ b/pkgs/by-name/na/nautilus-python/package.nix
@@ -47,6 +47,7 @@ stdenv.mkDerivation (finalAttrs: {
     gtk-doc
     docbook-xsl-nons
     docbook_xml_dtd_412
+    python3.pythonOnBuildForHost
   ];
 
   buildInputs = [


### PR DESCRIPTION
Also fixes regular strictDeps build, ref. #178468

## Things done

- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).