### PR TITLE
rocmPackages.tensile: bypass warning from cc-wrapper

### DIFF
--- a/pkgs/development/rocm-modules/5/llvm/stage-2/1000-libcxx-failing-tests.list
+++ b/pkgs/development/rocm-modules/5/llvm/stage-2/1000-libcxx-failing-tests.list
@@ -173,3 +173,4 @@
 ../libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.array/sized_delete_array14.pass.cpp
 ../libcxx/test/std/language.support/support.dynamic/new.delete/new.delete.single/sized_delete14.pass.cpp
 ../libcxx/test/libcxx/selftest/sh.cpp/empty.sh.cpp
+../libcxx/test/libcxx/transitive_includes.sh.cpp

--- a/pkgs/development/rocm-modules/5/tensile/default.nix
+++ b/pkgs/development/rocm-modules/5/tensile/default.nix
@@ -12,6 +12,7 @@
   joblib,
   filelock,
   rocminfo,
+  writeText,
 }:
 
 buildPythonPackage rec {
@@ -45,6 +46,12 @@ buildPythonPackage rec {
 
   preCheck = ''
     export ROCM_PATH=${rocminfo}
+  '';
+
+  # TODO: remove this workaround once https://github.com/NixOS/nixpkgs/pull/323869
+  # does not cause issues anymore, or at least replace it with a better workaround
+  setupHook = writeText "setup-hook" ''
+    export TENSILE_ROCM_ASSEMBLER_PATH="${stdenv.cc.cc}/bin/clang++";
   '';
 
   pythonImportsCheck = [ "Tensile" ];

--- a/pkgs/development/rocm-modules/6/tensile/default.nix
+++ b/pkgs/development/rocm-modules/6/tensile/default.nix
@@ -13,6 +13,7 @@
   joblib,
   filelock,
   rocminfo,
+  writeText,
 }:
 
 buildPythonPackage rec {
@@ -60,6 +61,12 @@ buildPythonPackage rec {
   env = {
     ROCM_PATH = rocminfo;
   };
+
+  # TODO: remove this workaround once https://github.com/NixOS/nixpkgs/pull/323869
+  # does not cause issues anymore, or at least replace it with a better workaround
+  setupHook = writeText "setup-hook" ''
+    export TENSILE_ROCM_ASSEMBLER_PATH="${stdenv.cc.cc}/bin/clang++";
+  '';
 
   pythonImportsCheck = [ "Tensile" ];
 


### PR DESCRIPTION
closes https://github.com/NixOS/nixpkgs/issues/376930

Not sure yet if this will work out. Right now I am still running `nixpkgs-review` on it.
I also plan to check if my Ollama service works with that change on my two RX 7600 XTs.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
