### PR TITLE
rustPlatform.fetchCargoVendor: reuse http session across requests

### DIFF
--- a/pkgs/build-support/rust/fetch-cargo-vendor-util.py
+++ b/pkgs/build-support/rust/fetch-cargo-vendor-util.py
@@ -31,7 +31,7 @@ def get_lockfile_version(cargo_lock_toml: dict[str, Any]) -> int:
     return version
 
 
-def download_file_with_checksum(url: str, destination_path: Path) -> str:
+def create_http_session() -> requests.Session:
     retries = Retry(
         total=5,
         backoff_factor=0.5,
@@ -40,7 +40,10 @@ def download_file_with_checksum(url: str, destination_path: Path) -> str:
     session = requests.Session()
     session.mount('http://', HTTPAdapter(max_retries=retries))
     session.mount('https://', HTTPAdapter(max_retries=retries))
+    return session
 
+
+def download_file_with_checksum(session: requests.Session, url: str, destination_path: Path) -> str:
     sha256_hash = hashlib.sha256()
     with session.get(url, stream=True) as response:
         if not response.ok:
@@ -66,7 +69,7 @@ def get_download_url_for_tarball(pkg: dict[str, Any]) -> str:
     return f"https://crates.io/api/v1/crates/{pkg["name"]}/{pkg["version"]}/download"
 
 
-def download_tarball(pkg: dict[str, Any], out_dir: Path) -> None:
+def download_tarball(session: requests.Session, pkg: dict[str, Any], out_dir: Path) -> None:
 
     url = get_download_url_for_tarball(pkg)
     filename = f"{pkg["name"]}-{pkg["version"]}.tar.gz"
@@ -78,7 +81,7 @@ def download_tarball(pkg: dict[str, Any], out_dir: Path) -> None:
     tarball_out_dir = out_dir / "tarballs" / filename
     eprint(f"Fetching {url} -> tarballs/{filename}")
 
-    calculated_checksum = download_file_with_checksum(url, tarball_out_dir)
+    calculated_checksum = download_file_with_checksum(session, url, tarball_out_dir)
 
     if calculated_checksum != expected_checksum:
         raise Exception(f"Hash mismatch! File fetched from {url} had checksum {calculated_checksum}, expected {expected_checksum}.")
@@ -157,7 +160,8 @@ def create_vendor_staging(lockfile_path: Path, out_dir: Path) -> None:
     with mp.Pool(min(5, mp.cpu_count())) as pool:
         if len(registry_packages) != 0:
             (out_dir / "tarballs").mkdir()
-            tarball_args_gen = ((pkg, out_dir) for pkg in registry_packages)
+            session = create_http_session()
+            tarball_args_gen = ((session, pkg, out_dir) for pkg in registry_packages)
             pool.starmap(download_tarball, tarball_args_gen)
 
 


### PR DESCRIPTION
Previously, the `download_file_with_checksum` function in `fetch-cargo-vendor-util.py` created a new session and thus established a new connection for each crate that had to be fetched from the registry, which caused the build of the `vendor-staging` derivation to be [very slow](https://github.com/NixOS/nixpkgs/pull/376519#issuecomment-2613726129) in some cases.

This PR changes this to create a single `requests.Session` which is reused across all download requests, which allows connections to the same registry to be reused and thus should improve performance.

For example, before this change the build of `mdbook.cargoDeps.vendorStaging` would take more than 190 seconds for me and after this change only 9 seconds. Similarly, this change reduced the build time of `uiua.cargoDeps.vendorStaging` from eight minutes to only 25 seconds.

cc @TomaSajt @alyssais @cafkafk 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
