### PR TITLE
chromium,chromedriver: 132.0.6834.110 -> 132.0.6834.159

### DIFF
--- a/pkgs/applications/networking/browsers/chromium/info.json
+++ b/pkgs/applications/networking/browsers/chromium/info.json
@@ -1,9 +1,9 @@
 {
   "chromium": {
-    "version": "132.0.6834.110",
+    "version": "132.0.6834.159",
     "chromedriver": {
-      "hash_darwin": "sha256-TEy3go3cMHlv8+XRUWJhPVlLSgk+2DifW1LNStqh+nU=",
-      "hash_darwin_aarch64": "sha256-gpqA5zYbhrdVoaAH1m6xHmH0k7jiC7sGicqpKhVaytw="
+      "hash_darwin": "sha256-t1WACSAqvu8Lp5xJpEpALXfSjF92gPdN0mUHQzz71YA=",
+      "hash_darwin_aarch64": "sha256-T0fDfWegn9kjhdDtAAK/IAFbKZ0r5VmvO2VQXzuNmSg="
     },
     "deps": {
       "depot_tools": {
@@ -19,8 +19,8 @@
     "DEPS": {
       "src": {
         "url": "https://chromium.googlesource.com/chromium/src.git",
-        "rev": "df453a35f099772fdb954e33551388add2ca3cde",
-        "hash": "sha256-deLCukHvNv6mUp33hHHFgeKD45SQs517xoRfCfReLAA=",
+        "rev": "2d77d3fc4452661469b78f115e0aed4d71269739",
+        "hash": "sha256-LbLIxN13fx6zzU5xzGvkTpw7tKRQBel2PYhflHLbWE8=",
         "recompress": true
       },
       "src/third_party/clang-format/script": {
@@ -760,8 +760,8 @@
       },
       "src/v8": {
         "url": "https://chromium.googlesource.com/v8/v8.git",
-        "rev": "625e932f21c984db3f9fba8b56b9afa4e977994c",
-        "hash": "sha256-19uEppABiuh+zHjgwAj/BPee/ClB/FKfzHxLKrdNhOE="
+        "rev": "210ec27ca748c70580fe374f9811761667312b41",
+        "hash": "sha256-pfkztEU22T15H2amf+b5bpALQ6Er1YAxZoxbbfb2YU8="
       }
     }
   },


### PR DESCRIPTION
https://chromereleases.googleblog.com/2025/01/stable-channel-update-for-desktop_28.html

This update includes 2 security fixes.

CVEs:
CVE-2025-0762

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
