### PR TITLE
haskellPackages: cleanup after latest hackage/stackage bump

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -819,7 +819,6 @@ self: super: {
   translatable-intset = dontCheck super.translatable-intset;
   ua-parser = dontCheck super.ua-parser;
   unagi-chan = dontCheck super.unagi-chan;
-  universe-some = dontCheck super.universe-some;
   wai-logger = dontCheck super.wai-logger;
   WebBits = dontCheck super.WebBits;                    # http://hydra.cryp.to/build/499604/log/raw
   webdriver = dontCheck super.webdriver;
@@ -2019,9 +2018,6 @@ self: super: {
   # https://github.com/faylang/fay/pull/474
   fay = doJailbreak super.fay;
 
-  # Need https://github.com/obsidiansystems/cli-extras/pull/12 and more
-  cli-extras = doJailbreak super.cli-extras;
-
   cli-git = addBuildTool pkgs.git super.cli-git;
 
   # Need https://github.com/obsidiansystems/cli-nix/pull/5 and more
@@ -2030,21 +2026,10 @@ self: super: {
     pkgs.nix-prefetch-git
   ] super.cli-nix;
 
-  nix-thunk = doJailbreak super.nix-thunk;
-
   # list `modbus` in librarySystemDepends, correct to `libmodbus`
   libmodbus = doJailbreak (addExtraLibrary pkgs.libmodbus super.libmodbus);
 
   ginger = doJailbreak super.ginger;
-
-  # 2024-05-05 syntax changes: https://github.com/obsidiansystems/haveibeenpwned/pull/9
-  haveibeenpwned = appendPatch
-    (fetchpatch {
-      url = "https://github.com/obsidiansystems/haveibeenpwned/pull/9/commits/14c134eec7de12f755b2d4667727762a8a1a6476.patch";
-      sha256 = "sha256-fau5+b6tufJ+MscrLgbYvvBsekPe8R6QAy/4H31dcQ4";
-    })
-    (doJailbreak super.haveibeenpwned);
-
 
   # Too strict version bounds on ghc-events
   # https://github.com/mpickering/hs-speedscope/issues/16

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/broken.yaml
@@ -5037,7 +5037,6 @@ broken-packages:
   - reflex-dom-retractable # failure in job https://hydra.nixos.org/build/233198362 at 2023-09-02
   - reflex-dom-svg # failure in job https://hydra.nixos.org/build/233193544 at 2023-09-02
   - reflex-external-ref # failure in job https://hydra.nixos.org/build/233215834 at 2023-09-02
-  - reflex-gadt-api # failure in job https://hydra.nixos.org/build/260124380 at 2024-05-19
   - reflex-jsx # failure in job https://hydra.nixos.org/build/233207137 at 2023-09-02
   - reflex-orphans # failure in job https://hydra.nixos.org/build/233249128 at 2023-09-02
   - reflex-test-host # failure in job https://hydra.nixos.org/build/233220665 at 2023-09-02
@@ -6489,7 +6488,6 @@ broken-packages:
   - verify # failure in job https://hydra.nixos.org/build/233239874 at 2023-09-02
   - verilog # failure in job https://hydra.nixos.org/build/233211999 at 2023-09-02
   - versioning # failure in job https://hydra.nixos.org/build/233205892 at 2023-09-02
-  - vessel # failure in job https://hydra.nixos.org/build/260124469 at 2024-05-19
   - vformat # failure in job https://hydra.nixos.org/build/233222840 at 2023-09-02
   - vgrep # failure in job https://hydra.nixos.org/build/233210982 at 2023-09-02
   - vhd # failure in job https://hydra.nixos.org/build/233230229 at 2023-09-02


### PR DESCRIPTION
These are now in good shape on hackage. Built with 9.8 & 9.10.



