### PR TITLE
lib.types.submodule: deprecate the submodule family

### DIFF
--- a/lib/types.nix
+++ b/lib/types.nix
@@ -90,6 +90,9 @@ let
     '' payload.elemType;
   };
 
+  # Custom that doesn't abort if NIX_ABORT_ON_WARN is set.
+  # This is needed for deprecations that are to big to change at once
+  deprecated = msg: v: builtins.trace "[1;35mDeprecation warning:[0m ${msg}" v;
 
   outer_types =
 rec {

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -914,7 +914,8 @@ rec {
         in mergedOption.type;
     };
 
-    submoduleWith =
+    submoduleWith = deprecated "lib.types.submoduleWith is deprecated, use types.moduleWith instead." moduleWith;
+    moduleWith =
       { modules
       , specialArgs ? {}
       , shorthandOnlyDefinesConfig ? false

--- a/lib/types.nix
+++ b/lib/types.nix
@@ -850,8 +850,13 @@ rec {
     };
 
     # A submodule (like typed attribute set). See NixOS manual.
-    submodule = modules: submoduleWith {
+    submodule = deprecated "lib.types.submodule is deprecated, use lib.types.module instead" (modules: submoduleWith {
       shorthandOnlyDefinesConfig = true;
+      modules = toList modules;
+    });
+
+    # Shorthand of moduleWith { modules = ...; }
+    module = modules: moduleWith {
       modules = toList modules;
     };
 


### PR DESCRIPTION
This PR adds a graceful trace to `types.submoduie` and promotes migrating to the alternative lib.types.module that is introduced here as more well behaved.

Problem: as described in https://github.com/NixOS/nixpkgs/issues/377575
The following code behaves inconsistently.

```nix
options.foo = lib.mkOption {
  # With this type modules in `default` or via `config` can't declare any `imports`
  type = lib.types.submodule {
    options.bar = mkOption {
      type = types.str;
    };            
   };
   default = {
   # Error
    imports = [
      {
        bar = "bar";
       }
     ];
    };
};
config.foo = {
  # Same Error as above
  imports = [ ... ];
}
```

While using the exact same code `submoduleWith` resolves the `imports`. 

```nix
options.foo = lib.mkOption {
  # With this type the imports do work
   type = lib.types.submoduleWith {
      modules = [
          {
             options.bar = mkOption {
               type = types.str;
            };
         }
       ];
    };
    default = {
     # Works as expected
      imports = [
         {
           bar = "bar";
          }
        ];
    };
};
# Works as expected
config.foo = {
  imports = [ ... ];
}
```


Alternatives considered:

- Special casing `config.imports` 
   Problems:
   - it is unclear how many downstream usages already exist: https://github.com/search?q=lang%3Anix+%2F%5Csimports+%3D+lib.mkOption%2F&type=code found ~12-20 
   - It is unclear how to warn for the changed behavior in those cases.
   - For consistency that means therefore to special case `config.config` and `config.options` for the same reason. Which is again unclear how many usages it has and how to deprecate it.
   
Cons:   

- types `submodule` has about ~1050 occurrences in .nix files in nixpkgs.
- types `submoduleWith` has about  20 occurrences
- types `submodule` has potentially 21k occurrences in .nix files only on github (https://github.com/search?q=lang%3Anix+%2F%28%5C.%2B%7C%5Cs%2B%29submodule%5Cs%2F&type=code)
- `submodule` is well established in the community
    
Pros:

- Migration to `types.module` is graceful
- Migration is trivial with search and replace. (Excluding those who use `config.imports` and `config.options` via shorthand, must double check)
- The name is shorter
- The name more closely captures the actual type.
  Compare the type  `module` vs `submodule`. Why should the type of a `module` be different that the `submodule`? In fact all module are submodules. So why the name of the type suggests something else?
  `type Module :: { imports :: ListOf  Module; config :: ...; options :: ...;  }`
  and 
  `evalModules :: { module :: ListOf Module; } -> Configuration` (not sure about the result. but the point about the name should be clear)


I am also very divided on this topic. And seeking for advice how to actively improve the situation.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
