### PR TITLE
vimPlugins.sonarlint-nvim: init at 0-unstable-2025-04-18

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -22455,6 +22455,12 @@
     github = "sinanmohd";
     githubId = 69694713;
   };
+  sinics = {
+    name = "Zhifan";
+    email = "nonno.felice69uwu@gmail.com";
+    matrix = "@c3n21:matrix.org";
+    githubId = 37077738;
+  };
   sioodmy = {
     name = "Antoni Sokołowski";
     github = "sioodmy";

--- a/pkgs/applications/editors/vim/plugins/non-generated/sonarlint-nvim/default.nix
+++ b/pkgs/applications/editors/vim/plugins/non-generated/sonarlint-nvim/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  vimUtils,
+  fetchFromGitLab,
+  nix-update-script,
+}:
+vimUtils.buildVimPlugin {
+  pname = "sonarlint.nvim";
+  version = "0-unstable-2025-04-18";
+
+  src = fetchFromGitLab {
+    owner = "schrieveslaach";
+    repo = "sonarlint.nvim";
+    rev = "0b78f1db800f9ba76f81de773ba09ce2222bdcc2";
+    hash = "sha256-EUwuIFFe4tmw8u6RqEvOLL0Yi8J5cLBQx7ICxnmkT4k=";
+  };
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    homepage = "https://gitlab.com/schrieveslaach/sonarlint.nvim";
+    description = "Extensions for the built-in Language Server Protocol support in Neovim for sonarlint-language-server";
+    license = lib.licenses.gpl3;
+    maintainers = [ lib.maintainers.sinics ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
This PR aims to add [sonarlint.nvim](https://gitlab.com/schrieveslaach/sonarlint.nvim) to official repos.

Still testing because it doesn't work on my machine yet, I just managed to make it launch but I'm not receiving any linting for TypeScript


## Things done

```sh
nix run .#vimPluginsUpdater -- add "https://gitlab.com/schrieveslaach/sonarlint.nvim"
```

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
