### PR TITLE
Allow "package" key in Cargo.toml dependencies

### DIFF
--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -54,7 +54,7 @@ def replace_key(
                 final["optional"] = True
 
             if "package" in local_dep:
-                final["package"] = local_dep.pop("package)
+                final["package"] = local_dep.pop("package")
 
             if local_dep:
                 raise Exception(f"Unhandled keys in inherited dependency {key}: {local_dep}")

--- a/pkgs/build-support/rust/replace-workspace-values.py
+++ b/pkgs/build-support/rust/replace-workspace-values.py
@@ -53,6 +53,9 @@ def replace_key(
             if optional:
                 final["optional"] = True
 
+            if "package" in local_dep:
+                final["package"] = local_dep.pop("package)
+
             if local_dep:
                 raise Exception(f"Unhandled keys in inherited dependency {key}: {local_dep}")
 


### PR DESCRIPTION
Some dependencies in Cargo.toml have a "package" key, which serves as an alias:
```
foo = { package = "original-name" ... }
```

The change in this script allows for such key to be supported (no specific action to take except to copy the key to te final value)

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
