### PR TITLE
mcpelauncher-client: fix hard-coded paths

### DIFF
--- a/pkgs/by-name/mc/mcpelauncher-client/package.nix
+++ b/pkgs/by-name/mc/mcpelauncher-client/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   clangStdenv,
+  stdenv,
   fetchFromGitHub,
   fetchpatch,
   cmake,
@@ -18,6 +19,8 @@
   withQtWebview ? true,
   withQtErrorWindow ? true,
   fetchzip,
+  zenity,
+  xdg-utils,
 }:
 
 # gcc doesn't support __has_feature
@@ -50,6 +53,16 @@ clangStdenv.mkDerivation (finalAttrs: {
       extraPrefix = "mcpelauncher-client/";
     })
   ];
+
+  # Path hard-coded paths.
+  postPatch = lib.optionalString stdenv.isLinux ''
+    substituteInPlace mcpelauncher-client/src/jni/main_activity.cpp \
+      --replace-fail /usr/bin/xdg-open ${xdg-utils}/bin/xdg-open \
+      --replace-fail /usr/bin/zenity ${zenity}/bin/zenity
+
+    substituteInPlace file-picker/src/file_picker_zenity.cpp \
+      --replace-fail /usr/bin/zenity ${zenity}/bin/zenity
+  '';
 
   # FORTIFY_SOURCE breaks libc_shim and the project will fail to compile
   hardeningDisable = [ "fortify" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Currently, attempting to open file pickers (namely when selecting a classic skin file) results in an error. Additionally, clicking on buttons that should open links doesn't do anything.

This patches some of the hard-coded paths pointing to [zenity](https://github.com/minecraft-linux/mcpelauncher-client/blob/da164f04c91a03062b9991d5c3afc320408c5d8c/src/jni/main_activity.cpp#L204) and [xdg-open](https://github.com/minecraft-linux/mcpelauncher-client/blob/da164f04c91a03062b9991d5c3afc320408c5d8c/src/jni/main_activity.cpp#L186) which resolves this.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
