### PR TITLE
chntpw: consistently use Debian's patches

### DIFF
--- a/pkgs/by-name/ch/chntpw/package.nix
+++ b/pkgs/by-name/ch/chntpw/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchurl,
   unzip,
-  fetchpatch,
+  fetchDebianPatch,
 }:
 
 stdenv.mkDerivation rec {
@@ -18,51 +18,65 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ unzip ];
 
-  patches = [
-    ./00-chntpw-build-arch-autodetect.patch
-    ./01-chntpw-install-target.patch
-    # Import various bug fixes from debian
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/04_get_abs_path";
-      sha256 = "17h0gaczqd5b792481synr1ny72frwslb779lm417pyrz6kh9q8n";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/06_correct_test_open_syscall";
-      sha256 = "00lg83bimbki988n71w54mmhjp9529r0ngm40d7fdmnc2dlpj3hd";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/07_detect_failure_to_write_key";
-      sha256 = "0pk6xnprh2pqyx4n4lw3836z6fqsw3mclkzppl5rhjaahriwxw4l";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/08_no_deref_null";
-      sha256 = "1g7pfmjaj0c2sm64s3api2kglj7jbgddjjd3r4drw6phwdkah0zs";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/09_improve_robustness";
-      sha256 = "1nszkdy01ixnain7cwdmfbhjngphw1300ifagc1wgl9wvghzviaa";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/11_improve_documentation";
-      sha256 = "0yql6hj72q7cq69rrspsjkpiipdhcwb0b9w5j8nhq40cnx9mgqgg";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/12_readonly_filesystem";
-      sha256 = "1kxcy7f2pl6fqgmjg8bnl3pl5wgiw5xnbyx12arinmqkkggp4fa4";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/13_write_to_hive";
-      sha256 = "1638lcyxjkrkmbr3n28byixny0qrxvkciw1xd97x48mj6bnwqrkv";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/14_improve_description";
-      sha256 = "11y5kc4dh4zv24nkb0jw2zwlifx6nzsd4jbizn63l6dbpqgb25rs";
-    })
-    (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/17_hexdump-pointer-type.patch";
-      sha256 = "ir9LFl8FJq141OwF5SbyVMtjQ1kTMH1NXlHl0XZq7m8=";
-    })
-  ];
+  patches =
+    let
+      fetchChntpwDebianPatch =
+        { patch, hash }:
+        fetchDebianPatch {
+          inherit
+            hash
+            patch
+            pname
+            version
+            ;
+          debianRevision = "1.2";
+        };
+    in
+    [
+      ./00-chntpw-build-arch-autodetect.patch
+      ./01-chntpw-install-target.patch
+      # Import various bug fixes from debian
+      (fetchChntpwDebianPatch {
+        patch = "04_get_abs_path";
+        hash = "sha256-FuEEp/nZ3xNIpemcRTXPThxvQ7ZeB0REOqs0/Jl6AJ4=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "06_correct_test_open_syscall";
+        hash = "sha256-DQ55aRPM1uZOA6Q+C3ISJV0JayWFh2MRSnGuGtdAjwI=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "07_detect_failure_to_write_key";
+        hash = "sha256-lPDOY4ZKSZgLvfdPyurgGjvzzUCDU2JJ9/gKmK/tZl4=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "08_no_deref_null";
+        hash = "sha256-+gOoZuPwGp4byaNJ2dpb8kj6pohXDU1M1YIBqWR197w=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "09_improve_robustness";
+        hash = "sha256-SsX94ds80ccDe8pFAEbg8D4r4XK1cXZsVLbHAHybX9s=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "11_improve_documentation";
+        hash = "sha256-7+FXU7cMEAwtkoWnBRZnsN0Y75T66pyTwexgcSQ0FHs=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "12_readonly_filesystem";
+        hash = "sha256-RDly35sTVxuzEqH7ZXvh8fFC76B2oSfrw87QK9zxrM8=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "13_write_to_hive";
+        hash = "sha256-e2bM7TKyItJPaj3wyObuGQNve/QLCTvyqjNP2T2jaJg=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "14_improve_description";
+        hash = "sha256-OhexHr6rGTqM/XFJ0vS3prtI+RdcgjUtEfsT2AibxYc=";
+      })
+      (fetchChntpwDebianPatch {
+        patch = "17_hexdump-pointer-type.patch";
+        hash = "sha256-ir9LFl8FJq141OwF5SbyVMtjQ1kTMH1NXlHl0XZq7m8=";
+      })
+    ];
 
   installPhase = ''
     make install PREFIX=$out

--- a/pkgs/by-name/ch/chntpw/package.nix
+++ b/pkgs/by-name/ch/chntpw/package.nix
@@ -23,45 +23,44 @@ stdenv.mkDerivation rec {
     ./01-chntpw-install-target.patch
     # Import various bug fixes from debian
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/04_get_abs_path";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/04_get_abs_path";
       sha256 = "17h0gaczqd5b792481synr1ny72frwslb779lm417pyrz6kh9q8n";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/06_correct_test_open_syscall";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/06_correct_test_open_syscall";
       sha256 = "00lg83bimbki988n71w54mmhjp9529r0ngm40d7fdmnc2dlpj3hd";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/07_detect_failure_to_write_key";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/07_detect_failure_to_write_key";
       sha256 = "0pk6xnprh2pqyx4n4lw3836z6fqsw3mclkzppl5rhjaahriwxw4l";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/08_no_deref_null";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/08_no_deref_null";
       sha256 = "1g7pfmjaj0c2sm64s3api2kglj7jbgddjjd3r4drw6phwdkah0zs";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/09_improve_robustness";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/09_improve_robustness";
       sha256 = "1nszkdy01ixnain7cwdmfbhjngphw1300ifagc1wgl9wvghzviaa";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/11_improve_documentation";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/11_improve_documentation";
       sha256 = "0yql6hj72q7cq69rrspsjkpiipdhcwb0b9w5j8nhq40cnx9mgqgg";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/12_readonly_filesystem";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/12_readonly_filesystem";
       sha256 = "1kxcy7f2pl6fqgmjg8bnl3pl5wgiw5xnbyx12arinmqkkggp4fa4";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/13_write_to_hive";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/13_write_to_hive";
       sha256 = "1638lcyxjkrkmbr3n28byixny0qrxvkciw1xd97x48mj6bnwqrkv";
     })
     (fetchpatch {
-      url = "https://sources.debian.org/data/main/c/chntpw/140201-1/debian/patches/14_improve_description";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/14_improve_description";
       sha256 = "11y5kc4dh4zv24nkb0jw2zwlifx6nzsd4jbizn63l6dbpqgb25rs";
     })
     (fetchpatch {
-      name = "17_hexdump-pointer-type.patch";
-      url = "https://git.launchpad.net/ubuntu/+source/chntpw/plain/debian/patches/17_hexdump-pointer-type.patch?id=aed501c87499f403293e7b9f505277567c2f3b52";
-      sha256 = "sha256-ir9LFl8FJq141OwF5SbyVMtjQ1kTMH1NXlHl0XZq7m8=";
+      url = "https://sources.debian.org/data/main/c/chntpw/140201-1.2/debian/patches/17_hexdump-pointer-type.patch";
+      sha256 = "ir9LFl8FJq141OwF5SbyVMtjQ1kTMH1NXlHl0XZq7m8=";
     })
   ];
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
[In a recent PR](https://github.com/NixOS/nixpkgs/pull/370154), an Ubuntu patch was added. To be consistent with the other patches, this patch now refers to Debian's sources.

Additionally, I thought it might be worthwile to replace `fetchpatch` by a specialized variant of `fetchDebianPatch`. The advantage of this approach is that it is easy to centrally manage the Debian revision number.

I successfully built the derivation using `nix build .#chntpw`. Also, I tried testing compilation via `nix run nixpkgs#nixpkgs-review -- rev HEAD`, yet it built a way too large amount of and unrelated derivations, so I canceled it. I would be happy if someone could point out my error!

cc @deepfire 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [x] (Refactoring) No changes needed
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
