### PR TITLE
simple-completion-language-server: init at 0-unstable-2025-01-28

### DIFF
--- a/pkgs/by-name/si/simple-completion-language-server/3c098ca0715c0f037240e97cf3a77bef788a36cc.patch
+++ b/pkgs/by-name/si/simple-completion-language-server/3c098ca0715c0f037240e97cf3a77bef788a36cc.patch
@@ -1,0 +1,57 @@
+From 3c098ca0715c0f037240e97cf3a77bef788a36cc Mon Sep 17 00:00:00 2001
+From: Piotr Osiewicz <24362066+osiewicz@users.noreply.github.com>
+Date: Wed, 19 Jun 2024 11:34:08 +0200
+Subject: [PATCH] 0.1.1: Add SCLS_CONFIG_SUBDIRECTORY to override default
+ lookup dir
+
+---
+ src/main.rs  | 12 +++++++-----
+ 1 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/src/main.rs b/src/main.rs
+index 8a9d612..850732b 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,5 +1,5 @@
+ use etcetera::base_strategy::{choose_base_strategy, BaseStrategy};
+-use std::collections::HashMap;
++use std::{collections::HashMap, path::PathBuf};
+ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+ use xshell::{cmd, Shell};
+
+@@ -132,7 +132,9 @@ async fn main() {
+
+     let strategy = choose_base_strategy().expect("Unable to find the config directory!");
+     let mut config_dir = strategy.config_dir();
+-    config_dir.push("helix");
++    let config_subdirectory_name =
++        std::env::var("SCLS_CONFIG_SUBDIRECTORY").unwrap_or_else(|_| "helix".to_owned());
++    config_dir.push(config_subdirectory_name);
+
+     let start_options = StartOptions {
+         home_dir: etcetera::home_dir()
+@@ -141,21 +143,21 @@ async fn main() {
+             .expect("Unable to get home dir as string!")
+             .to_string(),
+         snippets_path: std::env::var("SNIPPETS_PATH")
+-            .map(std::path::PathBuf::from)
++            .map(PathBuf::from)
+             .unwrap_or_else(|_| {
+                 let mut filepath = config_dir.clone();
+                 filepath.push("snippets");
+                 filepath
+             }),
+         external_snippets_config_path: std::env::var("EXTERNAL_SNIPPETS_CONFIG")
+-            .map(std::path::PathBuf::from)
++            .map(PathBuf::from)
+             .unwrap_or_else(|_| {
+                 let mut filepath = config_dir.clone();
+                 filepath.push("external-snippets.toml");
+                 filepath
+             }),
+         unicode_input_path: std::env::var("UNICODE_INPUT_PATH")
+-            .map(std::path::PathBuf::from)
++            .map(PathBuf::from)
+             .unwrap_or_else(|_| {
+                 let mut filepath = config_dir.clone();
+                 filepath.push("unicode-input");

--- a/pkgs/by-name/si/simple-completion-language-server/package.nix
+++ b/pkgs/by-name/si/simple-completion-language-server/package.nix
@@ -1,0 +1,50 @@
+{
+  applyPatches,
+  fetchFromGitHub,
+  lib,
+  openssl,
+  pkg-config,
+  rustPlatform,
+}:
+rustPlatform.buildRustPackage {
+  pname = "simple-completion-language-server";
+  version = "0-unstable-2025-01-28";
+
+  # We need to use `applyPatches` here since our patch modifies the `Cargo.lock` file.
+  # `cargoHash` seems to use `src` directly without applying `patches`.
+  src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "estin";
+      repo = "simple-completion-language-server";
+      rev = "7bdf05bbf2c72d2b083c04c025de9c2af5bf1d78";
+      hash = "sha256-SNhn4J3EPFsyjh97OmXHJmq6FmDWZLXOWZDi8Sway+A=";
+    };
+    patches = [
+      # Ideally we would fetch this patch from GitHub directly, but I needed to
+      # modify it to only include the changes for src/main.rs.
+      #
+      # ref; https://github.com/zed-industries/simple-completion-language-server/commit/3c098ca0715c0f037240e97cf3a77bef788a36cc
+      ./3c098ca0715c0f037240e97cf3a77bef788a36cc.patch
+    ];
+  };
+
+  cargoHash = "sha256-ziVmO86modj1pQmwAp1HfFqnF4j2V+sJNwu2o3v/oZ8=";
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    openssl
+  ];
+
+  doCheck = false;
+
+  meta = {
+    mainProgram = "simple-completion-language-server";
+    description = "Language server to enable word completion and snippets";
+    homepage = "https://github.com/zed-industries/simple-completion-language-server/";
+    maintainers = with lib.maintainers; [ matthewpi ];
+    license = lib.licenses.mit;
+  };
+}


### PR DESCRIPTION
Adds <https://github.com/estin/simple-completion-language-server> with the patch from zed (<https://github.com/zed-industries/simple-completion-language-server/commit/3c098ca0715c0f037240e97cf3a77bef788a36cc>) to support changing the configuration directory.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
