### PR TITLE
hoppscotch-desktop: init at 2025.1.0

### DIFF
--- a/pkgs/by-name/ho/hoppscotch-desktop/base.nix
+++ b/pkgs/by-name/ho/hoppscotch-desktop/base.nix
@@ -1,0 +1,131 @@
+# Since hoppscotch is a mono-repo with multiple subprojects, I chose to split
+# the package into multiple derivations. By splitting the package, it will be
+# easier in the future to add additional hoppscotch applications if needed.
+#
+# The first is this file, it has the source of the repo and builds (almost) all
+# of the JavaScript code in the repository.
+#
+# The second is hoppscotch-desktop, which is a tauri app. That package builds
+# the desktop frontend (which depends on some of the JS packages we built here)
+# and the Rust code for Tauri.
+#
+# Hoppscotch also includes other apps like hoppscotch-agent which I would also
+# like to package but couldn't get to work.
+{
+  fetchFromGitHub,
+  gcc,
+  lib,
+  nodejs,
+  node-gyp,
+  node-pre-gyp,
+  python3,
+  pnpm_9,
+  prisma,
+  prisma-engines,
+  stdenv,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "hoppscotch";
+  version = "2025.1.0";
+
+  src = fetchFromGitHub {
+    owner = "hoppscotch";
+    repo = "hoppscotch";
+    tag = finalAttrs.version;
+    hash = "sha256-jift7Mw3VGF2T7LywPg0RPyYZ77Gx+N4lbJRxzpipOU=";
+  };
+
+  doCheck = false;
+
+  pnpmDeps = pnpm_9.fetchDeps {
+    inherit (finalAttrs) pname version src;
+    hash = "sha256-p2D4bRUlRS07jkW9SPAvFJxIq/nf0BUvEoH29XERu/k=";
+  };
+
+  nativeBuildInputs = [
+    gcc
+    nodejs
+    nodejs.pkgs.node-gyp-build
+    node-gyp
+    node-pre-gyp
+    python3
+    pnpm_9.configHook
+    prisma
+  ];
+
+  env = {
+    PRISMA_BINARY_PATH = lib.getExe' prisma "prisma";
+    PRISMA_SCHEMA_ENGINE_BINARY = "${prisma-engines}/bin/schema-engine";
+    PRISMA_QUERY_ENGINE_BINARY = "${prisma-engines}/bin/query-engine";
+    PRISMA_QUERY_ENGINE_LIBRARY = "${lib.getLib prisma-engines}/lib/libquery_engine.node";
+
+    CPPFLAGS = "-I${nodejs}/include/node";
+  };
+
+  preBuild = ''
+    # Link Node.js headers so `isolated-vm` can build within the Nix sandbox.
+    mkdir -p "$HOME"/.node-gyp/${nodejs.version}
+    echo 9 > "$HOME"/.node-gyp/${nodejs.version}/installVersion
+    ln -sfv ${nodejs}/include "$HOME"/.node-gyp/${nodejs.version}
+    export npm_config_nodedir=${nodejs}
+
+    pushd node_modules/.pnpm/argon2@0.41.1/node_modules/argon2
+    if [ -z "$npm_config_node_gyp" ]; then
+      export npm_config_node_gyp=${node-gyp}/lib/node_modules/node-gyp/bin/node-gyp.js
+    fi
+    "$npm_config_node_gyp" rebuild
+    popd
+
+    pushd node_modules/.pnpm/bcrypt@5.1.1/node_modules/bcrypt
+    node-pre-gyp install --prefer-offline --build-from-source --nodedir=${nodejs}/include/node
+    popd
+
+    pnpm rebuild --recursive --pending --use-stderr --stream
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    cp .env.example .env
+    cp .env.example .env.development
+
+    echo 'Generating prisma for hoppscotch-backend...'
+    (cd packages/hoppscotch-backend; prisma generate)
+    echo 'Prisma generated for hoppscotch-backend!'
+
+    echo 'Running graphql-codegen for hoppscotch-selfhost-desktop...'
+    (cd packages/hoppscotch-selfhost-desktop; pnpm graphql-codegen --config gql-codegen.yml)
+    echo 'graphql-codegen completed for hoppscotch-selfhost-desktop'
+
+    # Equivalent of `pnpm run generate` for this project. We do this so extra
+    # args can be added to `pnpm` to get the output to print properly in the
+    # event of a failure.
+    pnpm run --recursive --use-stderr --stream do-build-prod
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    cp --recursive "$(pwd)" "$out"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Open source API development ecosystem";
+    longDescription = ''
+      Hoppscotch is a lightweight, web-based API development suite. It was built
+      from the ground up with ease of use and accessibility in mind providing
+      all the functionality needed for API developers with minimalist,
+      unobtrusive UI.
+    '';
+    homepage = "https://hoppscotch.com";
+    downloadPage = "https://hoppscotch.com/downloads";
+    changelog = "https://hoppscotch.com/changelog";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ matthewpi ];
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+})

--- a/pkgs/by-name/ho/hoppscotch-desktop/package.nix
+++ b/pkgs/by-name/ho/hoppscotch-desktop/package.nix
@@ -1,0 +1,44 @@
+{
+  callPackage,
+  desktop-file-utils,
+  lib,
+  stdenv,
+  symlinkJoin,
+  wrapGAppsHook3,
+  xdg-utils,
+}:
+let
+  hoppscotch-desktop-unwrapped = callPackage ./unwrapped.nix { };
+in
+symlinkJoin rec {
+  name = "${pname}-${version}";
+  pname = "hoppscotch-desktop";
+  inherit (hoppscotch-desktop-unwrapped) version;
+
+  paths = [ hoppscotch-desktop-unwrapped ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook3
+  ];
+
+  postBuild = ''
+    gappsWrapperArgs+=(
+      ${lib.optionalString stdenv.hostPlatform.isLinux ''
+        --prefix PATH : ${
+          lib.makeBinPath [
+            desktop-file-utils
+            xdg-utils
+          ]
+        }
+      ''}
+    )
+
+    wrapGAppsHook
+  '';
+
+  passthru = {
+    unwrapped = hoppscotch-desktop-unwrapped;
+  };
+
+  inherit (hoppscotch-desktop-unwrapped) meta;
+}

--- a/pkgs/by-name/ho/hoppscotch-desktop/unwrapped.nix
+++ b/pkgs/by-name/ho/hoppscotch-desktop/unwrapped.nix
@@ -1,0 +1,119 @@
+{
+  callPackage,
+  cargo-tauri,
+  darwin,
+  desktop-file-utils,
+  glib-networking,
+  gtk3,
+  lib,
+  libayatana-appindicator,
+  libsoup_2_4,
+  nodejs,
+  openssl,
+  perl,
+  pkg-config,
+  pnpm_9,
+  rustPlatform,
+  stdenv,
+  webkitgtk_4_0,
+}:
+let
+  hoppscotch = callPackage ./base.nix { };
+in
+rustPlatform.buildRustPackage {
+  pname = "hoppscotch-desktop-unwrapped";
+  inherit (hoppscotch) version;
+
+  src = hoppscotch;
+
+  cargoRoot = "packages/hoppscotch-selfhost-desktop/src-tauri";
+  cargoHash = "sha256-N7Dm0pknmAJrgvlajTJ+KBsXmaJKylQ+qffuBTZ5U4w=";
+  useFetchCargoVendor = true;
+
+  # could not find `Cargo.toml` in `/build/source` or any parent directory.
+  doCheck = false;
+
+  nativeBuildInputs = [
+    cargo-tauri
+    desktop-file-utils
+    nodejs
+    perl
+    pkg-config
+    pnpm_9
+    stdenv.cc.cc
+  ];
+
+  buildInputs =
+    [
+      glib-networking
+      openssl
+      stdenv.cc.cc.lib
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      libayatana-appindicator
+      libsoup_2_4
+      gtk3
+      webkitgtk_4_0
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin (
+      with darwin.apple_sdk.frameworks;
+      [
+        AppKit
+        CoreServices
+        Security
+        WebKit
+      ]
+    );
+
+  env = {
+    tauriBundle =
+      {
+        Darwin = "app";
+        Linux = "deb";
+      }
+      .${stdenv.hostPlatform.uname.system}
+        or (throw "No tauri bundle available for ${stdenv.hostPlatform.uname.system}!");
+  };
+
+  buildPhase = ''
+    runHook preBuild
+
+    cd "$cargoRoot"
+
+    echo 'Building hoppscotch-selfhost-desktop Tauri...'
+    pnpm tauri build --bundles "$tauriBundle"
+    echo 'Built hoppscotch-selfhost-desktop Tauri'
+
+    runHook postBuild
+  '';
+
+  installPhase =
+    ''
+      runHook preInstall
+    ''
+    + lib.optionalString stdenv.isDarwin ''
+      mkdir -p "$out"/bin
+      cp -r target/release/bundle/macos "$out"/Applications
+      mv "$out"/Applications/Hoppscotch.app/Contents/MacOS/Hoppscotch "$out"/bin/hoppscotch
+      ln -s "$out"/bin/hoppscotch "$out"/Applications/Hoppscotch.app/Contents/MacOS/Hoppscotch
+    ''
+    + lib.optionalString stdenv.isLinux ''
+      cp -r target/release/bundle/"$tauriBundle"/*/data/usr "$out"
+      desktop-file-edit \
+        --set-comment 'Hoppscotch' \
+        --set-key='StartupNotify' --set-value='true' \
+        --set-key='Categories' --set-value='Development;' \
+        --set-key='Keywords' --set-value='api;rest;' \
+        --set-key='StartupWMClass' --set-value='io.hoppscotch.desktop' \
+        --add-mime-type='hoppscotch' \
+        --add-mime-type='io.hoppscotch.desktop' \
+        "$out"/share/applications/hoppscotch.desktop
+    ''
+    + ''
+      runHook postInstall
+    '';
+
+  meta = hoppscotch.meta // {
+    mainProgram = "hoppscotch";
+  };
+}


### PR DESCRIPTION
Adds <https://hoppscotch.io/>. While there is already a [`hoppscotch` package](https://github.com/NixOS/nixpkgs/blob/71b080a8e5175b175be0fc9f65e7d5c29919b521/pkgs/by-name/ho/hoppscotch/package.nix), it is not built from source and doesn't support Wayland (it will run using Xwayland no matter what flags I set).

For reviewers:

This package may seem weird, it is split into 3 files, base, unwrapped, and package. It's common to have wrapped and unwrapped variants of a package, so that's not out of the ordinary.  But the base is here to make it easier to package other applications from the hoppscotch repo, such as hoppscotch-agent without requiring multiple full builds of hoppscotch (which are a little resource intensive).  It also makes it easier to package this since `hoppscotch-desktop` is in a subdirectory but we still need to build almost all the JS packages for the entire repository.

NOTE: since this provides the same applications as the existing [`hoppscotch` package](https://github.com/NixOS/nixpkgs/blob/71b080a8e5175b175be0fc9f65e7d5c29919b521/pkgs/by-name/ho/hoppscotch/package.nix), do we want to alias it to this package or rename that package to `hoppscotch-bin`/`hoppscotch-desktop-bin`?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
