### PR TITLE
nixos/acpid: add systemd service hardening

### DIFF
--- a/nixos/modules/services/hardware/acpid.nix
+++ b/nixos/modules/services/hardware/acpid.nix
@@ -148,6 +148,37 @@ in
           ]
           ++ lib.optional cfg.logEvents "--logevents"
         );
+
+        # hardening
+        CapabilityBoundingSet = [
+          ""
+        ];
+        RestrictNamespaces = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        MemoryDenyWriteExecute = true;
+        RestrictSUIDSGID = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service";
+        LockPersonality = true;
+        ProtectSystem = "strict";
+        PrivateUsers = true;
+        RestrictRealtime = true;
+        PrivateTmp = true;
+        ProtectHome = true;
+        ProtectProc = "invisible";
+        ProtectKernelLogs = true;
+        IPAddressAllow = [ ];
+
+        PrivateDevices = false; # acpi needs device access
+        PrivateNetwork = false; # required for netlink to work properly
+        NoNewPrivileges = false; # custom hooks might want to execute things at higher/different access
+        ProcSubset = "all"; # requires access to /proc/acpi
+        RestrictAddressFamilies = [
+          "AF_NETLINK"
+          "AF_UNIX"
+        ];
       };
       unitConfig = {
         ConditionVirtualization = "!systemd-nspawn";


### PR DESCRIPTION
Acpid is used to register hooks to run on specific hardware events. This implies the requirement for hardware access. The service will spawn child processes to handle the hooked events. These child processes can request higher privileges than the service itself due to NoNewPriviliges not being enforced.

**WARNING: DO NOT BLINDLY MERGE WITHOUT TESTING.** I have this deployed on my setup without any issues. The registered hooks are working, and journal log is clean. However: it might well be this is breaking some niche custom hook of some person somewhere out there. Ideally this'd get reviews of people using acpi hooks. The alternative is to plop this into nixos-unstable and wait for breakage reports after it hits channels, but i'd rather avoid this if possible.

Pinging @mweinelt who is somewhat active with systemd hardening.

Acpi does sadly not have any active maintainers.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
