### PR TITLE
vscode-insiders: fix downloading correct artifacts

### DIFF
--- a/pkgs/applications/editors/vscode/update-vscode.sh
+++ b/pkgs/applications/editors/vscode/update-vscode.sh
@@ -10,44 +10,64 @@ set -eou pipefail
 
 ROOT="$(dirname "$(readlink -f "$0")")"
 if [ ! -f "$ROOT/vscode.nix" ]; then
-  echo "ERROR: cannot find vscode.nix in $ROOT"
-  exit 1
+    echo "ERROR: cannot find vscode.nix in $ROOT"
+    exit 1
 fi
 
 # VSCode
 
-VSCODE_VER=$(curl --fail --silent https://api.github.com/repos/Microsoft/vscode/releases/latest | jq --raw-output .tag_name)
-sed -i "s/version = \".*\"/version = \"${VSCODE_VER}\"/" "$ROOT/vscode.nix"
+VSCODE_VER=$(curl --fail --silent https://update.code.visualstudio.com/api/releases/stable | jq --raw-output .[0])
+VSCODE_INSIDER_VER=$(curl --fail --silent https://update.code.visualstudio.com/api/releases/insider | jq --raw-output .[0])
+sed -i "s/stableVersion = \".*\"/stableVersion = \"${VSCODE_VER}\"/" "$ROOT/vscode.nix"
+sed -i "s/insiderVersion = \".*\"/insiderVersion = \"${VSCODE_INSIDER_VER}\"/" "$ROOT/vscode.nix"
 
 TEMP_FOLDER=$(mktemp -d)
 
 VSCODE_X64_LINUX_URL="https://update.code.visualstudio.com/${VSCODE_VER}/linux-x64/stable"
 
 # Split output by newlines into Bash array
-readarray -t VSCODE_X64_LINUX <<< $(nix-prefetch-url --print-path ${VSCODE_X64_LINUX_URL})
+readarray -t VSCODE_X64_LINUX <<<"$(nix-prefetch-url --print-path "$VSCODE_X64_LINUX_URL")"
 
-sed -i "s/x86_64-linux = \".\{52\}\"/x86_64-linux = \"${VSCODE_X64_LINUX[0]}\"/" "$ROOT/vscode.nix"
-
-tar xf ${VSCODE_X64_LINUX[1]} -C $TEMP_FOLDER
-VSCODE_COMMIT=$(jq --raw-output .commit $TEMP_FOLDER/VSCode-linux-x64/resources/app/product.json)
+tar xf "${VSCODE_X64_LINUX[1]}" -C "$TEMP_FOLDER"
+VSCODE_COMMIT=$(jq --raw-output .commit "$TEMP_FOLDER"/VSCode-linux-x64/resources/app/product.json)
 sed -i "s/rev = \".\{40\}\"/rev = \"${VSCODE_COMMIT}\"/" "$ROOT/vscode.nix"
 
 SERVER_X64_LINUX_URL="https://update.code.visualstudio.com/commit:${VSCODE_COMMIT}/server-linux-x64/stable"
-SERVER_X64_LINUX_SHA256=$(nix-prefetch-url ${SERVER_X64_LINUX_URL})
+SERVER_X64_LINUX_SHA256=$(nix-prefetch-url "$SERVER_X64_LINUX_URL")
 sed -i "s/sha256 = \".\{51,52\}\"/sha256 = \"${SERVER_X64_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
 
-VSCODE_X64_DARWIN_URL="https://update.code.visualstudio.com/${VSCODE_VER}/darwin/stable"
-VSCODE_X64_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_X64_DARWIN_URL})
-sed -i "s/x86_64-darwin = \".\{52\}\"/x86_64-darwin = \"${VSCODE_X64_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"
+update_platform_hashes() {
+    local channel=$1
+    local version=$2
 
-VSCODE_AARCH64_LINUX_URL="https://update.code.visualstudio.com/${VSCODE_VER}/linux-arm64/stable"
-VSCODE_AARCH64_LINUX_SHA256=$(nix-prefetch-url ${VSCODE_AARCH64_LINUX_URL})
-sed -i "s/aarch64-linux = \".\{52\}\"/aarch64-linux = \"${VSCODE_AARCH64_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
+    # Linux x86
+    VSCODE_X86_LINUX_URL="https://update.code.visualstudio.com/${version}/linux-x64/${channel}"
+    VSCODE_X86_LINUX_SHA256=$(nix-prefetch-url "$VSCODE_X86_LINUX_URL")
+    sed -i "s/${channel}\.x86_64-linux = \".\{52\}\"/${channel}.x86_64-linux = \"${VSCODE_X86_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
 
-VSCODE_AARCH64_DARWIN_URL="https://update.code.visualstudio.com/${VSCODE_VER}/darwin-arm64/stable"
-VSCODE_AARCH64_DARWIN_SHA256=$(nix-prefetch-url ${VSCODE_AARCH64_DARWIN_URL})
-sed -i "s/aarch64-darwin = \".\{52\}\"/aarch64-darwin = \"${VSCODE_AARCH64_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"
+    # Darwin x64
+    VSCODE_X64_DARWIN_URL="https://update.code.visualstudio.com/${version}/darwin/${channel}"
+    VSCODE_X64_DARWIN_SHA256=$(nix-prefetch-url "$VSCODE_X64_DARWIN_URL")
+    sed -i "s/${channel}\.x86_64-darwin = \".\{52\}\"/${channel}.x86_64-darwin = \"${VSCODE_X64_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"
 
-VSCODE_ARMV7L_LINUX_URL="https://update.code.visualstudio.com/${VSCODE_VER}/linux-armhf/stable"
-VSCODE_ARMV7L_LINUX_SHA256=$(nix-prefetch-url ${VSCODE_ARMV7L_LINUX_URL})
-sed -i "s/armv7l-linux = \".\{52\}\"/armv7l-linux = \"${VSCODE_ARMV7L_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
+    # Linux ARM64
+    VSCODE_AARCH64_LINUX_URL="https://update.code.visualstudio.com/${version}/linux-arm64/${channel}"
+    VSCODE_AARCH64_LINUX_SHA256=$(nix-prefetch-url "$VSCODE_AARCH64_LINUX_URL")
+    sed -i "s/${channel}\.aarch64-linux = \".\{52\}\"/${channel}.aarch64-linux = \"${VSCODE_AARCH64_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
+
+    # Darwin ARM64
+    VSCODE_AARCH64_DARWIN_URL="https://update.code.visualstudio.com/${version}/darwin-arm64/${channel}"
+    VSCODE_AARCH64_DARWIN_SHA256=$(nix-prefetch-url "$VSCODE_AARCH64_DARWIN_URL")
+    sed -i "s/${channel}\.aarch64-darwin = \".\{52\}\"/${channel}.aarch64-darwin = \"${VSCODE_AARCH64_DARWIN_SHA256}\"/" "$ROOT/vscode.nix"
+
+    # Linux ARMHF
+    VSCODE_ARMV7L_LINUX_URL="https://update.code.visualstudio.com/${version}/linux-armhf/${channel}"
+    VSCODE_ARMV7L_LINUX_SHA256=$(nix-prefetch-url "$VSCODE_ARMV7L_LINUX_URL")
+    sed -i "s/${channel}\.armv7l-linux = \".\{52\}\"/${channel}.armv7l-linux = \"${VSCODE_ARMV7L_LINUX_SHA256}\"/" "$ROOT/vscode.nix"
+}
+
+# Update stable hashes
+update_platform_hashes "stable" "$VSCODE_VER"
+
+# Update insiders hashes
+update_platform_hashes "insider" "$VSCODE_INSIDER_VER"


### PR DESCRIPTION
Looks like they moved the download location for insiders and it has a different versioning system.

https://update.code.visualstudio.com/api/update/linux-x64/insider/latest
https://update.code.visualstudio.com/api/releases/insider

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Found while testing https://github.com/nix-community/home-manager/pull/6305
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
