### PR TITLE
VRCX: init at 2025-01-27T00.10-0ee8137

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -21233,6 +21233,12 @@
     github = "ein-shved";
     githubId = 3513222;
   };
+  ShyAssassin = {
+    name = "[Assassin]";
+    githubId = 49711232;
+    github = "ShyAssassin";
+    email = "ShyAssassin@assassin.dev";
+  };
   shyim = {
     email = "s.sayakci@gmail.com";
     github = "shyim";

--- a/pkgs/by-name/vr/vrcx/package.nix
+++ b/pkgs/by-name/vr/vrcx/package.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  fetchurl,
+  appimageTools,
+  dotnet-runtime,
+}:
+let
+  pname = "vrcx";
+  version = "2025-01-27T00.10-0ee8137";
+  src = fetchurl {
+    url = "https://github.com/Natsumi-sama/VRCX/releases/download/${version}/VRCX_${version}.AppImage";
+    hash = "sha256-kaQOME3jBLr7QJjc7rubNqFu3z+LmiP+UHe2EWYC7ek=";
+  };
+  appimageContents = appimageTools.extract {
+    inherit pname src version;
+  };
+in
+appimageTools.wrapType2 rec {
+  inherit pname version src;
+  extraPkgs = pkgs: [ dotnet-runtime ];
+  extraInstallCommands = ''
+    install -m 444 -D ${appimageContents}/vrcx.desktop $out/share/applications/vrcx.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/256x256/apps/vrcx.png \
+      $out/share/icons/hicolor/256x256/apps/vrcx.png
+    substituteInPlace $out/share/applications/vrcx.desktop \
+      --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+    # Fix icon path
+    substituteInPlace $out/share/applications/vrcx.desktop \
+      --replace-fail 'Icon=VRCX' "Icon=$out/share/icons/hicolor/256x256/apps/vrcx.png"
+  '';
+
+  meta = {
+    description = "Friendship management tool for VRChat";
+    longDescription = ''
+      VRCX is an assistant/companion application for VRChat that provides information about and helps you accomplish various things
+      related to VRChat in a more convenient fashion than relying on the plain VRChat client (desktop or VR), or website alone.
+    '';
+    license = lib.licenses.mit;
+    homepage = "https://github.com/vrcx-team/VRCX";
+    downloadPage = "https://github.com/vrcx-team/VRCX/releases";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    maintainers = with lib.maintainers; [ ShyAssassin ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Add a new package for VRCX, Closes #318576 
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
