### PR TITLE
[staging-next] bluez: do not link to removed test binary

### DIFF
--- a/pkgs/by-name/bl/bluez/package.nix
+++ b/pkgs/by-name/bl/bluez/package.nix
@@ -170,7 +170,6 @@ stdenv.mkDerivation (finalAttrs: {
               simple-agent \
               test-adapter \
               test-device \
-              test-thermometer \
               ; do
         ln -s ../test/$t $test/bin/bluez-$t
       done


### PR DESCRIPTION
Broken since #370750

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).