### PR TITLE
firefox, thunderbird: enable wrapped derivations for darwin

### DIFF
--- a/pkgs/applications/networking/browsers/firefox-bin/default.nix
+++ b/pkgs/applications/networking/browsers/firefox-bin/default.nix
@@ -20,6 +20,7 @@
 , runtimeShell
 , systemLocale ? config.i18n.defaultLocale or "en_US"
 , patchelfUnstable  # have to use patchelfUnstable to support --no-clobber-old-sections
+, applicationName? "Firefox"
 }:
 
 let
@@ -97,7 +98,7 @@ stdenv.mkDerivation {
     '';
 
   passthru = {
-    inherit binaryName;
+    inherit applicationName binaryName;
     libName = "firefox-bin-${version}";
     ffmpegSupport = true;
     gssSupport = true;

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-beta.nix
@@ -11,7 +11,7 @@ buildMozillaMach rec {
   pname = "firefox-beta";
   binaryName = pname;
   version = "135.0b9";
-  applicationName = "Mozilla Firefox Beta";
+  applicationName = "Firefox Beta";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
     sha512 = "3007c2a8743e4444226e66f0c11f53f01255c09702deda7de83bbe134a19c324b8b49de78d3211b20bb82c7b2040127145d2e39ed8aa81c653ac4397c46476f6";

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-devedition.nix
@@ -11,7 +11,7 @@ buildMozillaMach rec {
   pname = "firefox-devedition";
   binaryName = pname;
   version = "135.0b9";
-  applicationName = "Mozilla Firefox Developer Edition";
+  applicationName = "Firefox Developer Edition";
   requireSigning = false;
   branding = "browser/branding/aurora";
   src = fetchurl {

--- a/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
+++ b/pkgs/applications/networking/browsers/firefox/packages/firefox-esr-128.nix
@@ -10,6 +10,7 @@
 buildMozillaMach rec {
   pname = "firefox";
   version = "128.7.0esr";
+  applicationName = "Firefox ESR";
   src = fetchurl {
     url = "mirror://mozilla/firefox/releases/${version}/source/firefox-${version}.source.tar.xz";
     sha512 = "26f9661b395b85a44b42bd72ef1ad976c614216c68f6c2dd834d0ac8b84b9c9f398b8ac550a47396995d96e6bb5fa9a50064d7f2f526bddd45aed5039ef131b8";

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -25,7 +25,7 @@ browser:
 let
   isDarwin = stdenv.hostPlatform.isDarwin;
   wrapper =
-    { applicationName ? browser.binaryName or (lib.getName browser) # Note: this is actually *binary* name and is different from browser.passthru.applicationName, which is *app* name!
+    { applicationName ? browser.binaryName or (lib.getName browser) # Note: this is actually *binary* name and is different from browser.applicationName, which is *app* name!
     , pname ? applicationName
     , version ? lib.getVersion browser
     , nameSuffix ? ""
@@ -164,7 +164,7 @@ let
         name = launcherName;
         exec = "${launcherName} --name ${wmClass} %U";
         inherit icon;
-        desktopName = browser.passthru.applicationName;
+        desktopName = browser.applicationName;
         startupNotify = true;
         startupWMClass = wmClass;
         terminal = false;
@@ -280,7 +280,7 @@ let
       ]) allNativeMessagingHosts);
 
       buildCommand = let
-        appPath = "Applications/${browser.passthru.applicationName}.app";
+        appPath = "Applications/${browser.applicationName}.app";
         executablePrefix = if isDarwin then "${appPath}/Contents/MacOS" else "bin";
         executablePath="${executablePrefix}/${applicationName}";
         finalBinaryPath = "${executablePath}" + lib.optionalString (!isDarwin) "${nameSuffix}";

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -323,14 +323,22 @@ let
         cd "$out"
 
       '' + lib.optionalString isDarwin ''
+        cd "${appPath}"
+
         # These files have to be copied and not symlinked, otherwise tabs crash.
         # Maybe related to how omni.ja file is mmapped into memory. See:
         # https://github.com/mozilla/gecko-dev/blob/b1662b447f306e6554647914090d4b73ac8e1664/modules/libjar/nsZipArchive.cpp#L204
-        cd "${appPath}"
         for file in $(find . -type l -name "omni.ja"); do
           rm "$file"
           cp "${browser}/${appPath}/$file" "$file"
         done
+
+        # Copy any embedded .app directories; plugin-container fails to start otherwise.
+        for dir in $(find . -type d -name '*.app'); do
+          rm -r "$dir"
+          cp -r "${browser}/${appPath}/$dir" "$dir"
+        done
+
         cd ..
 
       '' + ''

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, makeDesktopItem, makeWrapper, lndir, config
+{ stdenv, lib, makeDesktopItem, makeBinaryWrapper, lndir, config
 , buildPackages
 , jq, xdg-utils, writeText
 
@@ -24,11 +24,9 @@ browser:
 
 let
   wrapper =
-    { applicationName ? browser.binaryName or (lib.getName browser)
+    { applicationName ? browser.binaryName or (lib.getName browser) # Note: this is actually *binary* name and is different from browser.passthru.applicationName, which is *app* name!
     , pname ? applicationName
     , version ? lib.getVersion browser
-    , desktopName ? # applicationName with first letter capitalized
-      (lib.toUpper (lib.substring 0 1 applicationName) + lib.substring 1 (-1) applicationName)
     , nameSuffix ? ""
     , icon ? applicationName
     , wmClass ? applicationName
@@ -82,7 +80,8 @@ let
             ++ gtk_modules;
       gtk_modules = [ libcanberra-gtk3 ];
 
-      launcherName = "${applicationName}${nameSuffix}";
+      # Darwin does not rename bundled binaries
+      launcherName = "${applicationName}${lib.optionalString (!stdenv.hostPlatform.isDarwin) nameSuffix}";
 
       #########################
       #                       #
@@ -164,7 +163,7 @@ let
         name = launcherName;
         exec = "${launcherName} --name ${wmClass} %U";
         inherit icon;
-        inherit desktopName;
+        desktopName = browser.passthru.applicationName;
         startupNotify = true;
         startupWMClass = wmClass;
         terminal = false;
@@ -219,7 +218,7 @@ let
               };
             }));
 
-      nativeBuildInputs = [ makeWrapper lndir jq ];
+      nativeBuildInputs = [ makeBinaryWrapper lndir jq ];
       buildInputs = [ browser.gtk3 ];
 
       makeWrapperArgs = [
@@ -279,10 +278,18 @@ let
         ''ln -sfLt ''${MOZ_HOME:-~/.mozilla}/native-messaging-hosts ${ext}/lib/mozilla/native-messaging-hosts/*''
       ]) allNativeMessagingHosts);
 
-      buildCommand = ''
-        if [ ! -x "${browser}/bin/${applicationName}" ]
+      buildCommand = lib.optionalString stdenv.hostPlatform.isDarwin ''
+        appPath="Applications/${browser.passthru.applicationName}.app"
+        executablePrefix="$appPath/Contents/MacOS"
+      '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+        executablePrefix=bin
+      '' + ''
+        executablePath="$executablePrefix/${applicationName}"
+
+        sourceBinary="${browser}/$executablePath"
+        if [ ! -x "$sourceBinary" ]
         then
-            echo "cannot find executable file \`${browser}/bin/${applicationName}'"
+            echo "cannot find executable file \`$sourceBinary'"
             exit 1
         fi
 
@@ -312,12 +319,22 @@ let
           ln -sfT "$target" "$out/$l"
         done
 
+      '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        # These files have to be copied and not symlinked, otherwise tabs crash.
+        # Maybe related to how omni.ja file is mmapped into memory. See:
+        # https://github.com/mozilla/gecko-dev/blob/b1662b447f306e6554647914090d4b73ac8e1664/modules/libjar/nsZipArchive.cpp#L204
+        for path in "" "browser"; do
+          omniPath="$appPath/Contents/Resources/$path/"
+          rm "$out/$omniPath/omni.ja"
+          cp "${browser}/$omniPath/omni.ja" "$out/$omniPath/"
+        done
+      '' + ''
         cd "$out"
 
         # create the wrapper
 
-        executablePrefix="$out/bin"
-        executablePath="$executablePrefix/${applicationName}"
+        executablePrefix="$out/$executablePrefix"
+        executablePath="$out/$executablePath"
         oldWrapperArgs=()
 
         if [[ -L $executablePath ]]; then
@@ -348,13 +365,20 @@ let
 
         appendToVar makeWrapperArgs --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH"
         concatTo makeWrapperArgs oldWrapperArgs
-        makeWrapper "$oldExe" "''${executablePath}${nameSuffix}" "''${makeWrapperArgs[@]}"
+
+      '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        finalBinaryPath="$executablePath"
+      '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+        finalBinaryPath="''${executablePath}${nameSuffix}"
+      '' + ''
+        makeWrapper "$oldExe" "$finalBinaryPath" "''${makeWrapperArgs[@]}"
+
         #############################
         #                           #
         #   END EXTRA PREF CHANGES  #
         #                           #
         #############################
-
+      '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
         if [ -e "${browser}/share/icons" ]; then
             mkdir -p "$out/share"
             ln -s "${browser}/share/icons" "$out/share/icons"
@@ -389,12 +413,16 @@ let
         #                       #
         #########################
         # user customization
-        mkdir -p $out/lib/${libName}
 
+      '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+        libDir="$out/lib/${libName}"
+      '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        libDir="$out/$appPath/Contents/Resources"
+      '' + ''
         # creating policies.json
-        mkdir -p "$out/lib/${libName}/distribution"
+        mkdir -p "$libDir/distribution"
 
-        POL_PATH="$out/lib/${libName}/distribution/policies.json"
+        POL_PATH="$libDir/distribution/policies.json"
         rm -f "$POL_PATH"
         cat ${policiesJson} >> "$POL_PATH"
 
@@ -405,25 +433,30 @@ let
         done
 
         # preparing for autoconfig
-        mkdir -p "$out/lib/${libName}/defaults/pref"
+      '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+        prefsDir="$libDir/defaults/pref"
+      '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
+        prefsDir="$libDir/browser/defaults/preferences"
+      '' + ''
+        mkdir -p "$prefsDir"
 
-        echo 'pref("general.config.filename", "mozilla.cfg");' > "$out/lib/${libName}/defaults/pref/autoconfig.js"
-        echo 'pref("general.config.obscure_value", 0);' >> "$out/lib/${libName}/defaults/pref/autoconfig.js"
+        echo 'pref("general.config.filename", "mozilla.cfg");' > "$prefsDir/autoconfig.js"
+        echo 'pref("general.config.obscure_value", 0);' >> "$prefsDir/autoconfig.js"
 
-        cat > "$out/lib/${libName}/mozilla.cfg" << EOF
+        cat > "$libDir/mozilla.cfg" << EOF
         ${mozillaCfg}
         EOF
 
         extraPrefsFiles=(${builtins.toString extraPrefsFiles})
         for extraPrefsFile in "''${extraPrefsFiles[@]}"; do
-          cat "$extraPrefsFile" >> "$out/lib/${libName}/mozilla.cfg"
+          cat "$extraPrefsFile" >> "$libDir/mozilla.cfg"
         done
 
-        cat >> "$out/lib/${libName}/mozilla.cfg" << EOF
+        cat >> "$libDir/mozilla.cfg" << EOF
         ${extraPrefs}
         EOF
 
-        mkdir -p $out/lib/${libName}/distribution/extensions
+        mkdir -p "$libDir/distribution/extensions"
 
         #############################
         #                           #

--- a/pkgs/applications/networking/browsers/firefox/wrapper.nix
+++ b/pkgs/applications/networking/browsers/firefox/wrapper.nix
@@ -320,18 +320,20 @@ let
           ln -sfT "$target" "$out/$l"
         done
 
+        cd "$out"
+
       '' + lib.optionalString isDarwin ''
         # These files have to be copied and not symlinked, otherwise tabs crash.
         # Maybe related to how omni.ja file is mmapped into memory. See:
         # https://github.com/mozilla/gecko-dev/blob/b1662b447f306e6554647914090d4b73ac8e1664/modules/libjar/nsZipArchive.cpp#L204
-        for path in "" "browser"; do
-          omniPath="${appPath}/Contents/Resources/$path/"
-          rm "$out/$omniPath/omni.ja"
-          cp "${browser}/$omniPath/omni.ja" "$out/$omniPath/"
+        cd "${appPath}"
+        for file in $(find . -type l -name "omni.ja"); do
+          rm "$file"
+          cp "${browser}/${appPath}/$file" "$file"
         done
+        cd ..
 
       '' + ''
-        cd "$out"
 
         # create the wrapper
 

--- a/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird-bin/default.nix
@@ -24,6 +24,7 @@
   systemLocale ? config.i18n.defaultLocale or "en_US",
   patchelfUnstable, # have to use patchelfUnstable to support --no-clobber-old-sections
   generated,
+  applicationName ? "Thunderbird",
 }:
 
 let
@@ -120,6 +121,7 @@ stdenv.mkDerivation {
   };
 
   passthru = {
+    inherit applicationName;
     binaryName = "thunderbird";
     gssSupport = true;
     gtk3 = gtk3;

--- a/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/packages.nix
@@ -28,12 +28,12 @@ let
       version,
       sha512,
       updateScript,
+      applicationName ? "Thunderbird",
     }:
     (buildMozillaMach rec {
       pname = "thunderbird";
-      inherit version updateScript;
+      inherit version updateScript applicationName;
       application = "comm/mail";
-      applicationName = "Mozilla Thunderbird";
       binaryName = pname;
       src = fetchurl {
         url = "mirror://mozilla/thunderbird/releases/${version}/source/thunderbird-${version}.source.tar.xz";
@@ -98,6 +98,8 @@ rec {
   thunderbird-esr = thunderbird-128;
 
   thunderbird-128 = common {
+    applicationName = "Thunderbird ESR";
+
     version = "128.7.1esr";
     sha512 = "3f84e1f1a83379da1f154b66dbb5f941d04548ad017aab32aa9520f4315edb524e3754ac1fe9a7ae27f7aa33e2881c6783f11ccc53cda713f107760b7d880667";
 

--- a/pkgs/applications/networking/mailreaders/thunderbird/wrapper.nix
+++ b/pkgs/applications/networking/mailreaders/thunderbird/wrapper.nix
@@ -26,7 +26,7 @@ browser: args:
     buildCommand =
       old.buildCommand
       + ''
-        wrapProgram $out/bin/${browser.binaryName} \
+        wrapProgram "$executablePath" \
           --prefix LD_LIBRARY_PATH ':' "${lib.makeLibraryPath [ gpgme ]}" \
           --prefix PATH ':' "${lib.makeBinPath [ gnupg ]}"
       '';

--- a/pkgs/by-name/fi/firefoxpwa/package.nix
+++ b/pkgs/by-name/fi/firefoxpwa/package.nix
@@ -151,7 +151,7 @@ rustPlatform.buildRustPackage rec {
     homepage = "https://pwasforfirefox.filips.si/";
     changelog = "https://github.com/filips123/PWAsForFirefox/releases/tag/v${version}";
     license = lib.licenses.mpl20;
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [
       camillemndn
       pasqui23

--- a/pkgs/by-name/mi/midori-unwrapped/package.nix
+++ b/pkgs/by-name/mi/midori-unwrapped/package.nix
@@ -65,5 +65,7 @@ stdenv.mkDerivation rec {
       raskin
       ramkromberg
     ];
+    # https://github.com/NixOS/nixpkgs/issues/374354
+    broken = true;
   };
 }

--- a/pkgs/by-name/mi/midori-unwrapped/package.nix
+++ b/pkgs/by-name/mi/midori-unwrapped/package.nix
@@ -53,6 +53,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit gtk3;
+    applicationName = "Midori";
   };
 
   meta = with lib; {

--- a/pkgs/by-name/vi/vimb-unwrapped/package.nix
+++ b/pkgs/by-name/vi/vimb-unwrapped/package.nix
@@ -36,6 +36,7 @@ stdenv.mkDerivation rec {
 
   passthru = {
     inherit gtk3;
+    applicationName = "Vimb";
   };
 
   makeFlags = [ "PREFIX=${placeholder "out"}" ];

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -13406,24 +13406,20 @@ with pkgs;
   firefox-esr-unwrapped = firefox-esr-128-unwrapped;
 
   firefox = wrapFirefox firefox-unwrapped { };
-  firefox-beta = wrapFirefox firefox-beta-unwrapped {
-    desktopName = "Firefox Beta";
-  };
-  firefox-devedition = wrapFirefox firefox-devedition-unwrapped {
-    desktopName = "Firefox Developer Edition";
-  };
+  firefox-beta = wrapFirefox firefox-beta-unwrapped { };
+  firefox-devedition = wrapFirefox firefox-devedition-unwrapped { };
 
   firefox-mobile = callPackage ../applications/networking/browsers/firefox/mobile-config.nix { };
 
   firefox-esr-128 = wrapFirefox firefox-esr-128-unwrapped {
     nameSuffix = "-esr";
-    desktopName = "Firefox ESR";
     wmClass = "firefox-esr";
     icon = "firefox-esr";
   };
   firefox-esr = firefox-esr-128;
 
   firefox-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
+    inherit (firefox-unwrapped.passthru) applicationName;
     channel = "release";
     generated = import ../applications/networking/browsers/firefox-bin/release_sources.nix;
   };
@@ -13433,23 +13429,23 @@ with pkgs;
   };
 
   firefox-beta-bin-unwrapped = firefox-bin-unwrapped.override {
+    inherit (firefox-beta-unwrapped.passthru) applicationName;
     channel = "beta";
     generated = import ../applications/networking/browsers/firefox-bin/beta_sources.nix;
   };
 
   firefox-beta-bin = res.wrapFirefox firefox-beta-bin-unwrapped {
     pname = "firefox-beta-bin";
-    desktopName = "Firefox Beta";
   };
 
   firefox-devedition-bin-unwrapped = callPackage ../applications/networking/browsers/firefox-bin {
+    inherit (firefox-devedition-unwrapped.passthru) applicationName;
     channel = "developer-edition";
     generated = import ../applications/networking/browsers/firefox-bin/developer-edition_sources.nix;
   };
 
   firefox-devedition-bin = res.wrapFirefox firefox-devedition-bin-unwrapped {
     pname = "firefox-devedition-bin";
-    desktopName = "Firefox DevEdition";
     wmClass = "firefox-aurora";
   };
 
@@ -15241,9 +15237,7 @@ with pkgs;
   thunderbird-128 = wrapThunderbird thunderbirdPackages.thunderbird-128 { };
 
   thunderbird-bin = wrapThunderbird thunderbird-bin-unwrapped {
-    applicationName = "thunderbird";
     pname = "thunderbird-bin";
-    desktopName = "Thunderbird";
   };
   thunderbird-bin-unwrapped = callPackage ../applications/networking/mailreaders/thunderbird-bin {
     generated = import ../applications/networking/mailreaders/thunderbird-bin/release_sources.nix;


### PR DESCRIPTION
It also aligns application names for wrapped and unwrapped flavors of
the same derivations; and uses unique application names for each flavor,
so it's now possible to install multiple versions on the same Darwin
machine.

One visible change now is that `About Firefox` window now shows:

`Firefox for NixOS` instead of `Mozilla Firefox for NixOS`

...in the `distribution` field. I think it's fine and doesn't infringe
on any trademarks because this field is not required to mention Mozilla at
all, as per: https://wiki.mozilla.org/Distribution_INI_File

While at it, also changed the branding for Darwin builds to list:

`Firefox for Nix on MacOS` instead of `Firefox for NixOS`

The telemetry and distribution ids (`nixos`) are left intact.

Note: it's still not possible to install both source-based and -bin
Darwin derivations in the same profile. It would require renaming
applicationNames for these two different types to use unique names (e.g.
`Firefox (Official)` or `Firefox (Binary)`, which doesn't seem optimal.

Closes: https://github.com/NixOS/nixpkgs/issues/378433
Closes: https://github.com/NixOS/nixpkgs/issues/366581

---

In addition, the PR includes a patch to mark midori as broken because it is; and to mark firefoxpwa as linux only, because it's not currently implemented for Darwin.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
