### PR TITLE
haskellPackages.lifted-base: patch instead of jailbreaking in newer GHC

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -265,7 +265,6 @@ self: super: {
   cabal-plan = doJailbreak super.cabal-plan;
 
   # support for transformers >= 0.6
-  fused-effects-readline = doJailbreak super.fused-effects-readline;
   lifted-base = appendPatch (fetchpatch {
     url = "https://github.com/basvandijk/lifted-base/commit/6b61483ec7fd0d5d5d56ccb967860d42740781e8.patch";
     sha256 = "sha256-b29AVDiEMcShceRJyKEauK/411UkOh3ME9AnKEYvcEs=";

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -266,6 +266,10 @@ self: super: {
 
   # support for transformers >= 0.6
   fused-effects-readline = doJailbreak super.fused-effects-readline;
+  lifted-base = appendPatch (fetchpatch {
+    url = "https://github.com/basvandijk/lifted-base/commit/6b61483ec7fd0d5d5d56ccb967860d42740781e8.patch";
+    sha256 = "sha256-b29AVDiEMcShceRJyKEauK/411UkOh3ME9AnKEYvcEs=";
+  }) super.lifted-base;
 
   leveldb-haskell = overrideCabal (drv: {
     version = "2024-05-05-unstable";

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -99,7 +99,6 @@ self: super: {
   # Test suite issues
   #
   call-stack = dontCheck super.call-stack; # https://github.com/sol/call-stack/issues/19
-  lifted-base = dontCheck super.lifted-base; # doesn't compile with transformers ==0.6.*
   primitive-unlifted = dontCheck super.primitive-unlifted; # doesn't compile with primitive ==0.9.*
   bsb-http-chunked = pkgs.haskell.lib.dontCheck super.bsb-http-chunked; # https://github.com/sjakobi/bsb-http-chunked/issues/45
   hinotify = pkgs.haskell.lib.dontCheck super.hinotify; # https://github.com/kolmodin/hinotify/issues/38

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -103,7 +103,6 @@ self: super:
   # Jailbreaks for servant <0.20
   servant-lucid = doJailbreak super.servant-lucid;
 
-  lifted-base = dontCheck super.lifted-base;
   hw-prim = dontCheck (doJailbreak super.hw-prim);
   stm-containers = dontCheck super.stm-containers;
   regex-tdfa = dontCheck super.regex-tdfa;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -95,7 +95,6 @@ self: super: {
   # Test suite issues
   #
   unordered-containers = dontCheck super.unordered-containers; # ChasingBottoms doesn't support base 4.20
-  lifted-base = dontCheck super.lifted-base; # doesn't compile with transformers == 0.6.*
   bsb-http-chunked = dontCheck super.bsb-http-chunked; # umaintained, test suite doesn't compile anymore
   pcre-heavy = dontCheck super.pcre-heavy; # GHC warnings cause the tests to fail
 


### PR DESCRIPTION
```
$ git rev-parse HEAD
60e8e7a399e0eabd09cdb1886187a5493ac08451

$ nix-build -A haskell.packages.ghc810.fused-effects-readline
/nix/store/jkc7n4xzj7ykb5hq2d9dksjx3rwr6syg-fused-effects-readline-0.2.0.0
$ nix-build -A haskell.packages.ghc98.fused-effects-readline
/nix/store/mwyp0x3vh6rp2jfprq3mdzbaakw5rfi8-fused-effects-readline-0.2.0.0
nix-build -A haskell.packages.ghc912.fused-effects-readline
/nix/store/5bp1c3pkfjvnlkfn3rq12ihwnlgw1c6j-fused-effects-readline-0.2.0.0
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
