### PR TITLE
nixos/bluetooth: add systemd hardening

### DIFF
--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 let
@@ -16,7 +17,6 @@ let
     mkRenamedOptionModule
     mkRemovedOptionModule
     concatStringsSep
-    escapeShellArgs
     optional
     optionalAttrs
     recursiveUpdate
@@ -146,7 +146,7 @@ in
             serviceConfig = {
               ExecStart = [
                 ""
-                "${package}/libexec/bluetooth/bluetoothd ${escapeShellArgs args}"
+                "${package}/libexec/bluetooth/bluetoothd ${utils.escapeSystemdExecArgs args}"
               ];
               CapabilityBoundingSet = [
                 "CAP_NET_BIND_SERVICE" # sockets and tethering

--- a/nixos/modules/services/hardware/bluetooth.nix
+++ b/nixos/modules/services/hardware/bluetooth.nix
@@ -9,7 +9,6 @@ let
   package = cfg.package;
 
   inherit (lib)
-    mkDefault
     mkEnableOption
     mkIf
     mkOption
@@ -18,9 +17,7 @@ let
     mkRemovedOptionModule
     concatStringsSep
     escapeShellArgs
-    literalExpression
     optional
-    optionals
     optionalAttrs
     recursiveUpdate
     types
@@ -146,10 +143,34 @@ in
           {
             wantedBy = [ "bluetooth.target" ];
             aliases = [ "dbus-org.bluez.service" ];
-            serviceConfig.ExecStart = [
-              ""
-              "${package}/libexec/bluetooth/bluetoothd ${escapeShellArgs args}"
-            ];
+            serviceConfig = {
+              ExecStart = [
+                ""
+                "${package}/libexec/bluetooth/bluetoothd ${escapeShellArgs args}"
+              ];
+              CapabilityBoundingSet = [
+                "CAP_NET_BIND_SERVICE" # sockets and tethering
+              ];
+              NoNewPrivileges = true;
+              RestrictNamespaces = true;
+              ProtectControlGroups = true;
+              MemoryDenyWriteExecute = true;
+              RestrictSUIDSGID = true;
+              SystemCallArchitectures = "native";
+              SystemCallFilter = "@system-service";
+              LockPersonality = true;
+              RestrictRealtime = true;
+              ProtectProc = "invisible";
+              PrivateTmp = true;
+
+              PrivateUsers = false;
+
+              # loading hardware modules
+              ProtectKernelModules = false;
+              ProtectKernelTunables = false;
+
+              PrivateNetwork = false; # tethering
+            };
             # restarting can leave people without a mouse/keyboard
             unitConfig.X-RestartIfChanged = false;
           };


### PR DESCRIPTION
This PR adds systemd hardening to the bluetooth service.

Things tested:
- pairing
- connecting
- bluetooth tethering
- sound via bluetooth (phone using the laptop as speakers)
- sound via bluetooth (laptop using headphones as speakers)
- mpris via bluetooth

This should be a complete list, but i'd appreciate a second set of eyes here.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
