### PR TITLE
soupault: remove references to ocaml

### DIFF
--- a/pkgs/by-name/so/soupault/package.nix
+++ b/pkgs/by-name/so/soupault/package.nix
@@ -3,6 +3,8 @@
   darwin,
   fetchzip,
   ocamlPackages,
+  ocaml,
+  removeReferencesTo,
   soupault,
   stdenv,
   testers,
@@ -22,9 +24,11 @@ ocamlPackages.buildDunePackage rec {
     hash = "sha256-UABbrNNcNaN9NgtAjCs4HUoNXMaK4QvCuWERuEnMG6I=";
   };
 
-  nativeBuildInputs = lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
-    darwin.sigtool
-  ];
+  nativeBuildInputs =
+    [ removeReferencesTo ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
+      darwin.sigtool
+    ];
 
   buildInputs = with ocamlPackages; [
     base64
@@ -47,6 +51,10 @@ ocamlPackages.buildDunePackage rec {
     tsort
     yaml
   ];
+
+  postFixup = ''
+    find "$out" -type f -exec remove-references-to -t ${ocaml} '{}' +
+  '';
 
   passthru.tests.version = testers.testVersion {
     package = soupault;


### PR DESCRIPTION
When I was using `nix run nixpkgs#soupault` I recognized the ocaml compiler being downloaded, which should not be a runtime dependency.
Inspecting the closure I saw that several libraries were also depending on `ocaml`:
```
nix/store/y4aq1mix30jdgrjc8fqv5w474dvzsl3j-ocaml5.2.1-soupault-4.11.0
├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36
│   ├───/nix/store/ii1fdbyzymw9vj2ywxrmz34wbnlg4fb6-libidn2-2.3.7
│   │   ├───/nix/store/34ypj5kl3jgbdj22fc5299zk3kw51hzi-libunistring-1.3
│   │   │   └───/nix/store/34ypj5kl3jgbdj22fc5299zk3kw51hzi-libunistring-1.3 [...]
│   │   └───/nix/store/ii1fdbyzymw9vj2ywxrmz34wbnlg4fb6-libidn2-2.3.7 [...]
│   ├───/nix/store/jnjv6jf8k0qpnqk4bqqziaf89f4l0v0r-xgcc-14-20241116-libgcc
│   └───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1
│   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   ├───/nix/store/9bzm5g670567swmg6vd1l7l4q5spvc80-gcc-14-20241116-lib
│   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   ├───/nix/store/nmwhzmw3jxk5xx09jji890hqpx5vyvd4-gcc-14-20241116-libgcc
│   │   └───/nix/store/9bzm5g670567swmg6vd1l7l4q5spvc80-gcc-14-20241116-lib [...]
│   └───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
├───/nix/store/9ifm0cr5hgxrbq2yzwmfmsj5x0a4s0sf-ocaml5.2.1-camomile-2.0.0
│   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   ├───/nix/store/h6gwj8nj93xwhq3sq3a41a39jnn31898-ocaml5.2.1-camlp-streams-5.0.1
│   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   │   └───/nix/store/h6gwj8nj93xwhq3sq3a41a39jnn31898-ocaml5.2.1-camlp-streams-5.0.1 [...]
│   ├───/nix/store/jfmn4p9s543lzdpb9ziijiky3csrszzz-ocaml5.2.1-dune-private-libs-3.17.1
│   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   │   ├───/nix/store/a4jqij1ymxm5nsga0n9dsg17x70p46gx-ocaml5.2.1-stdune-3.17.1
│   │   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   │   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   │   │   ├───/nix/store/ajikpndhfwhapprn3sl45sy51k3nbh2f-ocaml5.2.1-ordering-3.17.1
│   │   │   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   │   │   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   │   │   │   └───/nix/store/ajikpndhfwhapprn3sl45sy51k3nbh2f-ocaml5.2.1-ordering-3.17.1 [...]
│   │   │   ├───/nix/store/0c6f5fc0gdbzplxvvyhkfhkn30546xmj-ocaml5.2.1-dyn-3.17.1
│   │   │   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   │   │   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   │   │   │   ├───/nix/store/ajikpndhfwhapprn3sl45sy51k3nbh2f-ocaml5.2.1-ordering-3.17.1 [...]
│   │   │   │   └───/nix/store/0c6f5fc0gdbzplxvvyhkfhkn30546xmj-ocaml5.2.1-dyn-3.17.1 [...]
│   │   │   ├───/nix/store/nhdhb7jxq26qylccznj5md2cgkzn54pz-ocaml5.2.1-csexp-1.5.2
│   │   │   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   │   │   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   │   │   │   └───/nix/store/nhdhb7jxq26qylccznj5md2cgkzn54pz-ocaml5.2.1-csexp-1.5.2 [...]
│   │   │   └───/nix/store/a4jqij1ymxm5nsga0n9dsg17x70p46gx-ocaml5.2.1-stdune-3.17.1 [...]
│   │   └───/nix/store/jfmn4p9s543lzdpb9ziijiky3csrszzz-ocaml5.2.1-dune-private-libs-3.17.1 [...]
│   ├───/nix/store/n3fr3zi2mlgdw2y1qgyi3yk5h91hggvz-ocaml5.2.1-dune-site-3.17.1
│   │   ├───/nix/store/h7zcxabfxa7v5xdna45y2hplj31ncf8a-glibc-2.40-36 [...]
│   │   ├───/nix/store/vxg8zng9m6cbgpwnv60iysdwpwm932am-ocaml-5.2.1 [...]
│   │   ├───/nix/store/jfmn4p9s543lzdpb9ziijiky3csrszzz-ocaml5.2.1-dune-private-libs-3.17.1 [...]
│   │   └───/nix/store/n3fr3zi2mlgdw2y1qgyi3yk5h91hggvz-ocaml5.2.1-dune-site-3.17.1 [...]
│   └───/nix/store/9ifm0cr5hgxrbq2yzwmfmsj5x0a4s0sf-ocaml5.2.1-camomile-2.0.0 [...]
└───/nix/store/y4aq1mix30jdgrjc8fqv5w474dvzsl3j-ocaml5.2.1-soupault-4.11.0 [...]
```

After removing the references to ocaml, the binary still works as expected and the closure looks like:
(I use a different nixpkgs checkout, therefore the different ocaml version prefixes)
```
/nix/store/wpwk66xdf38gxy11bkk29f87wqpz3l1q-ocaml4.14.1-soupault-4.4.0
├───/nix/store/1n2l5law9g3b77hcfyp50vrhhssbrj5g-glibc-2.37-8
│   ├───/nix/store/wv33zvn4m0j6qlipy5ybfrixgipnfnyj-xgcc-12.2.0-libgcc
│   ├───/nix/store/y382xj6bh8h4mmm22sw1a6q81rijrxl7-libidn2-2.3.4
│   │   ├───/nix/store/jrid72i6ii9wx2ia6fyr2b1plri2m07l-libunistring-1.1
│   │   │   └───/nix/store/jrid72i6ii9wx2ia6fyr2b1plri2m07l-libunistring-1.1 [...]
│   │   └───/nix/store/y382xj6bh8h4mmm22sw1a6q81rijrxl7-libidn2-2.3.4 [...]
│   └───/nix/store/1n2l5law9g3b77hcfyp50vrhhssbrj5g-glibc-2.37-8 [...]
└───/nix/store/wpwk66xdf38gxy11bkk29f87wqpz3l1q-ocaml4.14.1-soupault-4.4.0 [...]
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
