### PR TITLE
nixos-rebuild-ng: add --no-reexec flag, deprecate --fast

### DIFF
--- a/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/nixos-rebuild.8.scd
@@ -17,11 +17,12 @@ nixos-rebuild - reconfigure a NixOS machine
 
 # SYNOPSIS
 
+; document here only non-deprecated flags
 _nixos-rebuild_ \[--verbose] [--max-jobs MAX_JOBS] [--cores CORES] [--log-format LOG_FORMAT] [--keep-going] [--keep-failed] [--fallback] [--repair] [--option OPTION OPTION] [--builders BUILDERS]++
 	\[--include INCLUDE] [--quiet] [--print-build-logs] [--show-trace] [--accept-flake-config] [--refresh] [--impure] [--offline] [--no-net] [--recreate-lock-file]++
 	\[--no-update-lock-file] [--no-write-lock-file] [--no-registries] [--commit-lock-file] [--update-input UPDATE_INPUT] [--override-input OVERRIDE_INPUT OVERRIDE_INPUT]++
 	\[--no-build-output] [--use-substitutes] [--help] [--file FILE] [--attr ATTR] [--flake [FLAKE]] [--no-flake] [--install-bootloader] [--profile-name PROFILE_NAME]++
-	\[--specialisation SPECIALISATION] [--rollback] [--upgrade] [--upgrade-all] [--json] [--ask-sudo-password] [--sudo] [--fast]++
+	\[--specialisation SPECIALISATION] [--rollback] [--upgrade] [--upgrade-all] [--json] [--ask-sudo-password] [--sudo] [--no-reexec]++
 	\[--image-variant VARIANT]++
 	\[--build-host BUILD_HOST] [--target-host TARGET_HOST]++
 	\[{switch,boot,test,build,edit,repl,dry-build,dry-run,dry-activate,build-image,build-vm,build-vm-with-bootloader,list-generations}]
@@ -170,7 +171,7 @@ It must be one of the following:
 	Causes the boot loader to be (re)installed on the device specified by
 	the relevant configuration options.
 
-*--fast*
+*--no-reexec*
 	Normally, *nixos-rebuild* first finds and builds itself from the
 	_config.system.build.nixos-rebuild_ attribute from the current user
 	channel or flake and exec into it. This allows *nixos-rebuild* to run

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_main.py
@@ -144,7 +144,7 @@ def test_execute_nix_boot(mock_run: Any, tmp_path: Path) -> None:
 
     mock_run.side_effect = run_side_effect
 
-    nr.execute(["nixos-rebuild", "boot", "--no-flake", "-vvv", "--fast"])
+    nr.execute(["nixos-rebuild", "boot", "--no-flake", "-vvv", "--no-reexec"])
 
     assert mock_run.call_count == 6
     mock_run.assert_has_calls(
@@ -222,7 +222,7 @@ def test_execute_nix_build_vm(mock_run: Any, tmp_path: Path) -> None:
             "nixos-config=./configuration.nix",
             "-I",
             "nixpkgs=$HOME/.nix-defexpr/channels/pinned_nixpkgs",
-            "--fast",
+            "--no-reexec",
         ]
     )
 
@@ -340,7 +340,7 @@ def test_execute_nix_switch_flake(mock_run: Any, tmp_path: Path) -> None:
             "--install-bootloader",
             "--sudo",
             "--verbose",
-            "--fast",
+            "--no-reexec",
             # https://github.com/NixOS/nixpkgs/issues/374050
             "--option",
             "narinfo-cache-negative-ttl",
@@ -418,7 +418,7 @@ def test_execute_nix_switch_flake_target_host(
             "--use-remote-sudo",
             "--target-host",
             "user@localhost",
-            "--fast",
+            "--no-reexec",
         ]
     )
 
@@ -508,7 +508,7 @@ def test_execute_nix_switch_flake_build_host(
             "/path/to/config#hostname",
             "--build-host",
             "user@localhost",
-            "--fast",
+            "--no-reexec",
         ]
     )
 
@@ -587,7 +587,7 @@ def test_execute_switch_rollback(mock_run: Any, tmp_path: Path) -> None:
     nixpkgs_path.touch()
 
     nr.execute(
-        ["nixos-rebuild", "switch", "--rollback", "--install-bootloader", "--fast"]
+        ["nixos-rebuild", "switch", "--rollback", "--install-bootloader", "--no-reexec"]
     )
 
     assert mock_run.call_count >= 2
@@ -625,7 +625,7 @@ def test_execute_build(mock_run: Any, tmp_path: Path) -> None:
         CompletedProcess([], 0, str(config_path)),
     ]
 
-    nr.execute(["nixos-rebuild", "build", "--no-flake", "--fast"])
+    nr.execute(["nixos-rebuild", "build", "--no-flake", "--no-reexec"])
 
     assert mock_run.call_count == 1
     mock_run.assert_has_calls(
@@ -659,7 +659,7 @@ def test_execute_test_flake(mock_run: Any, tmp_path: Path) -> None:
     mock_run.side_effect = run_side_effect
 
     nr.execute(
-        ["nixos-rebuild", "test", "--flake", "github:user/repo#hostname", "--fast"]
+        ["nixos-rebuild", "test", "--flake", "github:user/repo#hostname", "--no-reexec"]
     )
 
     assert mock_run.call_count == 2
@@ -712,7 +712,7 @@ def test_execute_test_rollback(
     mock_run.side_effect = run_side_effect
 
     nr.execute(
-        ["nixos-rebuild", "test", "--rollback", "--profile-name", "foo", "--fast"]
+        ["nixos-rebuild", "test", "--rollback", "--profile-name", "foo", "--no-reexec"]
     )
 
     assert mock_run.call_count == 2

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -333,7 +333,7 @@ def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
         """,
     ),
 )
-def test_get_build_image_variants(mock_run: Any) -> None:
+def test_get_build_image_variants(mock_run: Any, tmp_path: Path) -> None:
     build_attr = m.BuildAttr("<nixpkgs/nixos>", None)
     assert n.get_build_image_variants(build_attr) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
@@ -357,7 +357,7 @@ def test_get_build_image_variants(mock_run: Any) -> None:
         stdout=PIPE,
     )
 
-    build_attr = m.BuildAttr(Path("/tmp"), "preAttr")
+    build_attr = m.BuildAttr(Path(tmp_path), "preAttr")
     assert n.get_build_image_variants(build_attr, {"inst_flag": True}) == {
         "azure": "nixos-image-azure-25.05.20250102.6df2492-x86_64-linux.vhd",
         "vmware": "nixos-image-vmware-25.05.20250102.6df2492-x86_64-linux.vmdk",
@@ -369,10 +369,10 @@ def test_get_build_image_variants(mock_run: Any) -> None:
             "--strict",
             "--json",
             "--expr",
-            textwrap.dedent("""
+            textwrap.dedent(f"""
             let
-              value = import "/tmp";
-              set = if builtins.isFunction value then value {} else value;
+              value = import "{tmp_path}";
+              set = if builtins.isFunction value then value {{}} else value;
             in
               builtins.mapAttrs (n: v: v.passthru.filePath) set.preAttr.config.system.build.images
             """),

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_nix.py
@@ -20,7 +20,7 @@ from .helpers import get_qualified_name
     autospec=True,
     return_value=CompletedProcess([], 0, stdout=" \n/path/to/file\n "),
 )
-def test_build(mock_run: Any, monkeypatch: Any) -> None:
+def test_build(mock_run: Any) -> None:
     assert n.build(
         "config.system.build.attr",
         m.BuildAttr("<nixpkgs/nixos>", None),
@@ -79,7 +79,7 @@ def test_build_flake(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> N
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
 @patch(get_qualified_name(n.uuid4, n), autospec=True)
-def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: Any) -> None:
+def test_build_remote(mock_uuid4: Any, mock_run: Any, monkeypatch: MonkeyPatch) -> None:
     build_host = m.Remote("user@host", [], None)
     monkeypatch.setenv("NIX_SSHOPTS", "--ssh opts")
 
@@ -226,7 +226,7 @@ def test_build_remote_flake(
     )
 
 
-def test_copy_closure(monkeypatch: Any) -> None:
+def test_copy_closure(monkeypatch: MonkeyPatch) -> None:
     closure = Path("/path/to/closure")
     with patch(get_qualified_name(n.run_wrapper, n), autospec=True) as mock_run:
         n.copy_closure(closure, None)
@@ -290,7 +290,7 @@ def test_copy_closure(monkeypatch: Any) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
+def test_edit(mock_run: Any, monkeypatch: MonkeyPatch, tmpdir: Path) -> None:
     # Flake
     flake = m.Flake.parse(f"{tmpdir}#attr")
     n.edit(flake, {"commit_lock_file": True})
@@ -309,8 +309,8 @@ def test_edit(mock_run: Any, monkeypatch: Any, tmpdir: Any) -> None:
 
     # Classic
     with monkeypatch.context() as mp:
-        default_nix = tmpdir.join("default.nix")
-        default_nix.write("{}")
+        default_nix = tmpdir / "default.nix"
+        default_nix.write_text("{}", encoding="utf-8")
 
         mp.setenv("NIXOS_CONFIG", str(tmpdir))
         mp.setenv("EDITOR", "editor")
@@ -687,7 +687,7 @@ def test_set_profile(mock_run: Any) -> None:
 
 
 @patch(get_qualified_name(n.run_wrapper, n), autospec=True)
-def test_switch_to_configuration(mock_run: Any, monkeypatch: Any) -> None:
+def test_switch_to_configuration(mock_run: Any, monkeypatch: MonkeyPatch) -> None:
     profile_path = Path("/path/to/profile")
     config_path = Path("/path/to/config")
 

--- a/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
+++ b/pkgs/by-name/ni/nixos-rebuild-ng/src/tests/test_process.py
@@ -1,6 +1,8 @@
 from typing import Any
 from unittest.mock import patch
 
+from pytest import MonkeyPatch
+
 import nixos_rebuild.models as m
 import nixos_rebuild.process as p
 
@@ -94,7 +96,7 @@ def test_run(mock_run: Any) -> None:
     )
 
 
-def test_remote_from_name(monkeypatch: Any) -> None:
+def test_remote_from_name(monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setenv("NIX_SSHOPTS", "")
     assert m.Remote.from_arg("user@localhost", None, False) == m.Remote(
         "user@localhost",


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

`--fast` from nixos-rebuild has an overloaded meaning that basically disables some eval operations pre-build.

However since it doesn't describe exactly what it does, it is also used in some context were it doesn't make sense, see this blog post for example:
https://www.haskellforall.com/2023/01/announcing-nixos-rebuild-new-deployment.html

One of the things that `--fast` does in nixos-rebuild doesn't make sense in nixos-rebuild-ng (skipping Nix build), and the other can be replaced with a new flag, that we will call `--no-reexec` and it is clear what it does.

Yes, the name may be non-descriptive if you don't know what re-exec is, but I think if this triggers someone to look at the manpage or at least Google it, it already does what it should.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
