### PR TITLE
nixos/systemd: add lockdownByDefault option

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -378,6 +378,7 @@
   ./security/sudo.nix
   ./security/sudo-rs.nix
   ./security/systemd-confinement.nix
+  ./security/systemd-hardening.nix
   ./security/tpm2.nix
   ./security/wrappers/default.nix
   ./services/accessibility/orca.nix

--- a/nixos/modules/security/systemd-hardening.nix
+++ b/nixos/modules/security/systemd-hardening.nix
@@ -1,0 +1,150 @@
+{
+  lib,
+  ...
+}:
+
+let
+  inherit (lib) types mkDefault;
+in
+{
+  options.systemd.services = lib.mkOption {
+    type = types.attrsOf (
+      types.submodule (
+        { config, ... }:
+        {
+          options.lockdownByDefault = lib.mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              If set, all privileges a service may have are removed and need to explicitly be enabled in {option}`serviceConfig`.
+              See {manpage}`systemd.exec(5)` for more info about service environment configuration.
+            '';
+          };
+          config = lib.mkIf config.lockdownByDefault {
+            serviceConfig = {
+
+              # see systemd-analyze capability for a full list of capabilities
+              CapabilityBoundingSet = mkDefault [
+                "" # empty entry forces allow-list instead of deny-list
+              ];
+
+              # mounts entire filesystem read-only (except /dev, /proc, /sys)
+              # different options: "full", true, false
+              ProtectSystem = mkDefault "strict";
+
+              # makes /home/, /root and /run/user inaccessible
+              # different options: "read-only", "tmpfs", false
+              ProtectHome = mkDefault true;
+
+              # special directories for various purposes do exist, but defaulting them to something "more secure" is not universally possible.
+              # RuntimeDirectory=, StateDirectory=, CacheDirectory=, LogsDirectory=, ConfigurationDirectory=
+              # RuntimeDirectoryMode=, StateDirectoryMode=, CacheDirectoryMode=, LogsDirectoryMode=, ConfigurationDirectoryMode=
+
+              # It might make sense to default /nix/store to ReadOnly
+              # It might also make sense to default everything to NoExec except /run/wrappers/bin and /nix/store. However, doing so is quite radical.
+              # ReadWritePaths=, ReadOnlyPaths=, InaccessiblePaths=, ExecPaths=, NoExecPaths=
+
+              # create a private tmp directory for the process
+              # different options: "disconnected" (makes a tmpfs), false
+              # implies a writable tmp path
+              PrivateTmp = mkDefault true;
+
+              PrivateDevices = true; # block direct hardware access. Allows pseudo-devices like /dev/null and /dev/shm
+
+              # sets a new network namespace with only loopback device
+              # limits AF_UNIX and AF_NETLINK access to only services running in a joint namespace
+              # implies PrivateMounts
+              PrivateNetwork = mkDefault true;
+
+              # PrivateIPC exists, but has various complicated implications and implicit effects
+              # PrivateIPC=
+
+              # PrivatePIDs exists to define process namespacing. However, it does not work with service type `Forking` and should be used with care.
+              # implies MountAPIVFS=true
+              # mounts /proc in a way such that only processes in the same namespace are visible
+              PrivatePIDs = mkDefault true;
+
+              # Use user namespacing
+              # WARNING: this makes the CaCapabilityBoundingSet only affect the user namespace, the service runs completely unprivileged on the host. Use with care!
+              PrivateUsers = mkDefault true;
+
+              # protect the hostname from being changed.
+              # WARNING: even though nixos uses /etc/hostname to define and change hostname, this option also prevents services from simply detecting hostname changes.
+              ProtectHostname = mkDefault true;
+
+              # prevent modifications and state checks to the system clock.
+              # implies removal of CAP_SYS_TIME and CAP_WAKE_ALARM
+              # implies block clock set system calls
+              # implies DeviceAllow=char-rtc r
+              ProtectClock = mkDefault true;
+
+              # read-only: /proc/sys/, /sys/, /proc/sysrq-trigger, /proc/latency_stats, /proc/acpi, /proc/timer_stats, /proc/fs, /proc/irq
+              # inaccessible: /proc/kallsyms, /proc/kcore
+              # implies MountAPIVFS=true
+              # Does not prevent callbacks to other processes/services (e.g. via IPC) from setting kernel tunables
+              ProtectKernelTunables = mkDefault true;
+
+              # disable explicit kernel module loading
+              # implies removal of CAP_SYS_MODULE
+              # implies inaccessible /usr/lib/modules
+              ProtectKernelModules = mkDefault true;
+
+              # dines access to kernel log ring buffer
+              # implies removal of CAP_SYSLOG
+              # implies inaccessible /dev/kmsg and /proc/kmsg
+              ProtectKernelLogs = mkDefault true;
+
+              # true or strict disables write access to control group hierarchies
+              # strict or private makes the unit run in a cgroup namespace with private /sys/fs/cgroup/
+              # different options: "private", true, false
+              ProtectControlGroups = mkDefault "strict";
+
+              # disable specific access for socket system call
+              # different options: list of AF_UNIX, AF_INET AF_INET6, AF_NETLINK, AF_PACKET
+              RestrictAddressFamilies = mkDefault "none";
+
+              # restrict access to namespacing
+              # different options: false, [ "pid" "user" "net" "uts" "mnt" "cgroup" "ipc" ]
+              # see `man namespaces` for a full list
+              RestrictNamespaces = mkDefault true;
+
+              LockPersonality = mkDefault true; # prevent service from initiating changes to its execution domain
+
+              # prevent creating memory mappings that are writable and executable simultaneously
+              # WARNING: breaks with JIT execution engines
+              MemoryDenyWriteExecute = mkDefault true;
+
+              RestrictRealtime = mkDefault true; # prevent service from requesting realtime scheduling
+
+              RestrictSUIDSGID = mkDefault true; # prevent setting suid/guid bit on files. Does NOT prevent existing suid/sgid binaries from being executed!
+
+              # PrivateMounts can be used to set mount namespaces. However, debugging issues caused by this is quite complex.
+              # PrivateMounts= MountFlags=
+
+              SystemCallFilter = mkDefault [ "@system-service" ]; # sensible default, works for most services. Prevents e.g. "@clock", "@mount", "@swap", "@reboot"
+              SystemCallErrorNumber = mkDefault "EPERM"; # services violating the SystemSystemCallFilter are killed silently by default. This makes debugging easier.
+
+              SystemCallArchitectures = mkDefault "native"; # allow only native system calls for defined SystemCallFilters
+
+              # prevents access to /proc/<pid> of other processes
+              # options: "noaccess", "invisible", "ptraceable", "default"
+              ProtectProc = mkDefault "invisible";
+
+              # ProcSubset can be set to "pid" to prevent access to non-process files in /proc.
+              # However, this prevents a lot of linux kernel API calls and should not be default
+              # ProcSubset
+
+              NoNewPrivileges = mkDefault true; # prevents service process and children from gaining privileges via execve
+
+              # use a dynamic user for this service instead of running as root
+              # WARNING: breaks dbus
+              DynamicUser = mkDefault true;
+            };
+          };
+        }
+      )
+    );
+  };
+
+  meta.maintainers = with lib.maintainers; [ grimmauld ];
+}

--- a/nixos/modules/security/systemd-hardening.nix
+++ b/nixos/modules/security/systemd-hardening.nix
@@ -5,6 +5,125 @@
 
 let
   inherit (lib) types mkDefault;
+
+  hardeningConfigs.rev1 = {
+    # see systemd-analyze capability for a full list of capabilities
+    CapabilityBoundingSet = [
+      "" # empty entry forces allow-list instead of deny-list
+    ];
+
+    # mounts entire filesystem read-only (except /dev, /proc, /sys)
+    # different options: "full", true, false
+    ProtectSystem = "strict";
+
+    # makes /home/, /root and /run/user inaccessible
+    # different options: "read-only", "tmpfs", false
+    ProtectHome = true;
+
+    # special directories for various purposes do exist, but defaulting them to something "more secure" is not universally possible.
+    # RuntimeDirectory=, StateDirectory=, CacheDirectory=, LogsDirectory=, ConfigurationDirectory=
+    # RuntimeDirectoryMode=, StateDirectoryMode=, CacheDirectoryMode=, LogsDirectoryMode=, ConfigurationDirectoryMode=
+
+    # It might make sense to default /nix/store to ReadOnly
+    # It might also make sense to default everything to NoExec except /run/wrappers/bin and /nix/store. However, doing so is quite radical.
+    # ReadWritePaths=, ReadOnlyPaths=, InaccessiblePaths=, ExecPaths=, NoExecPaths=
+
+    # create a private tmp directory for the process
+    # different options: "disconnected" (makes a tmpfs), false
+    # implies a writable tmp path
+    PrivateTmp = true;
+
+    PrivateDevices = true; # block direct hardware access. Allows pseudo-devices like /dev/null and /dev/shm
+
+    # sets a new network namespace with only loopback device
+    # limits AF_UNIX and AF_NETLINK access to only services running in a joint namespace
+    # implies PrivateMounts
+    PrivateNetwork = true;
+
+    # PrivateIPC exists, but has various complicated implications and implicit effects
+    # PrivateIPC=
+
+    # PrivatePIDs exists to define process namespacing. However, it does not work with service type `Forking` and should be used with care.
+    # implies MountAPIVFS=true
+    # mounts /proc in a way such that only processes in the same namespace are visible
+    PrivatePIDs = true;
+
+    # Use user namespacing
+    # WARNING: this makes the CaCapabilityBoundingSet only affect the user namespace, the service runs completely unprivileged on the host. Use with care!
+    PrivateUsers = true;
+
+    # protect the hostname from being changed.
+    # WARNING: even though nixos uses /etc/hostname to define and change hostname, this option also prevents services from simply detecting hostname changes.
+    ProtectHostname = true;
+
+    # prevent modifications and state checks to the system clock.
+    # implies removal of CAP_SYS_TIME and CAP_WAKE_ALARM
+    # implies block clock set system calls
+    # implies DeviceAllow=char-rtc r
+    ProtectClock = true;
+
+    # read-only: /proc/sys/, /sys/, /proc/sysrq-trigger, /proc/latency_stats, /proc/acpi, /proc/timer_stats, /proc/fs, /proc/irq
+    # inaccessible: /proc/kallsyms, /proc/kcore
+    # implies MountAPIVFS=true
+    # Does not prevent callbacks to other processes/services (e.g. via IPC) from setting kernel tunables
+    ProtectKernelTunables = true;
+
+    # disable explicit kernel module loading
+    # implies removal of CAP_SYS_MODULE
+    # implies inaccessible /usr/lib/modules
+    ProtectKernelModules = true;
+
+    # dines access to kernel log ring buffer
+    # implies removal of CAP_SYSLOG
+    # implies inaccessible /dev/kmsg and /proc/kmsg
+    ProtectKernelLogs = true;
+
+    # true or strict disables write access to control group hierarchies
+    # strict or private makes the unit run in a cgroup namespace with private /sys/fs/cgroup/
+    # different options: "private", true, false
+    ProtectControlGroups = "strict";
+
+    # disable specific access for socket system call
+    # different options: list of AF_UNIX, AF_INET AF_INET6, AF_NETLINK, AF_PACKET
+    RestrictAddressFamilies = "none";
+
+    # restrict access to namespacing
+    # different options: false, [ "pid" "user" "net" "uts" "mnt" "cgroup" "ipc" ]
+    # see `man namespaces` for a full list
+    RestrictNamespaces = true;
+
+    LockPersonality = true; # prevent service from initiating changes to its execution domain
+
+    # prevent creating memory mappings that are writable and executable simultaneously
+    # WARNING: breaks with JIT execution engines
+    MemoryDenyWriteExecute = true;
+
+    RestrictRealtime = true; # prevent service from requesting realtime scheduling
+
+    RestrictSUIDSGID = true; # prevent setting suid/guid bit on files. Does NOT prevent existing suid/sgid binaries from being executed!
+
+    # PrivateMounts can be used to set mount namespaces. However, debugging issues caused by this is quite complex.
+    # PrivateMounts= MountFlags=
+
+    SystemCallFilter = [ "@system-service" ]; # sensible default, works for most services. Prevents e.g. "@clock", "@mount", "@swap", "@reboot"
+    SystemCallErrorNumber = "EPERM"; # services violating the SystemSystemCallFilter are killed silently by default. This makes debugging easier.
+
+    SystemCallArchitectures = "native"; # allow only native system calls for defined SystemCallFilters
+
+    # prevents access to /proc/<pid> of other processes
+    # options: "noaccess", "invisible", "ptraceable", "default"
+    ProtectProc = "invisible";
+
+    # ProcSubset can be set to "pid" to prevent access to non-process files in /proc.
+    # However, this prevents a lot of linux kernel API calls and should not be default
+    # ProcSubset
+
+    NoNewPrivileges = true; # prevents service process and children from gaining privileges via execve
+
+    # use a dynamic user for this service instead of running as root
+    # WARNING: breaks dbus
+    DynamicUser = true;
+  };
 in
 {
   options.systemd.services = lib.mkOption {
@@ -13,133 +132,15 @@ in
         { config, ... }:
         {
           options.lockdownByDefault = lib.mkOption {
-            type = types.bool;
-            default = false;
+            type = types.nullOr (types.enum (builtins.attrNames hardeningConfigs));
+            default = null;
             description = ''
               If set, all privileges a service may have are removed and need to explicitly be enabled in {option}`serviceConfig`.
               See {manpage}`systemd.exec(5)` for more info about service environment configuration.
             '';
           };
-          config = lib.mkIf config.lockdownByDefault {
-            serviceConfig = {
-
-              # see systemd-analyze capability for a full list of capabilities
-              CapabilityBoundingSet = mkDefault [
-                "" # empty entry forces allow-list instead of deny-list
-              ];
-
-              # mounts entire filesystem read-only (except /dev, /proc, /sys)
-              # different options: "full", true, false
-              ProtectSystem = mkDefault "strict";
-
-              # makes /home/, /root and /run/user inaccessible
-              # different options: "read-only", "tmpfs", false
-              ProtectHome = mkDefault true;
-
-              # special directories for various purposes do exist, but defaulting them to something "more secure" is not universally possible.
-              # RuntimeDirectory=, StateDirectory=, CacheDirectory=, LogsDirectory=, ConfigurationDirectory=
-              # RuntimeDirectoryMode=, StateDirectoryMode=, CacheDirectoryMode=, LogsDirectoryMode=, ConfigurationDirectoryMode=
-
-              # It might make sense to default /nix/store to ReadOnly
-              # It might also make sense to default everything to NoExec except /run/wrappers/bin and /nix/store. However, doing so is quite radical.
-              # ReadWritePaths=, ReadOnlyPaths=, InaccessiblePaths=, ExecPaths=, NoExecPaths=
-
-              # create a private tmp directory for the process
-              # different options: "disconnected" (makes a tmpfs), false
-              # implies a writable tmp path
-              PrivateTmp = mkDefault true;
-
-              PrivateDevices = true; # block direct hardware access. Allows pseudo-devices like /dev/null and /dev/shm
-
-              # sets a new network namespace with only loopback device
-              # limits AF_UNIX and AF_NETLINK access to only services running in a joint namespace
-              # implies PrivateMounts
-              PrivateNetwork = mkDefault true;
-
-              # PrivateIPC exists, but has various complicated implications and implicit effects
-              # PrivateIPC=
-
-              # PrivatePIDs exists to define process namespacing. However, it does not work with service type `Forking` and should be used with care.
-              # implies MountAPIVFS=true
-              # mounts /proc in a way such that only processes in the same namespace are visible
-              PrivatePIDs = mkDefault true;
-
-              # Use user namespacing
-              # WARNING: this makes the CaCapabilityBoundingSet only affect the user namespace, the service runs completely unprivileged on the host. Use with care!
-              PrivateUsers = mkDefault true;
-
-              # protect the hostname from being changed.
-              # WARNING: even though nixos uses /etc/hostname to define and change hostname, this option also prevents services from simply detecting hostname changes.
-              ProtectHostname = mkDefault true;
-
-              # prevent modifications and state checks to the system clock.
-              # implies removal of CAP_SYS_TIME and CAP_WAKE_ALARM
-              # implies block clock set system calls
-              # implies DeviceAllow=char-rtc r
-              ProtectClock = mkDefault true;
-
-              # read-only: /proc/sys/, /sys/, /proc/sysrq-trigger, /proc/latency_stats, /proc/acpi, /proc/timer_stats, /proc/fs, /proc/irq
-              # inaccessible: /proc/kallsyms, /proc/kcore
-              # implies MountAPIVFS=true
-              # Does not prevent callbacks to other processes/services (e.g. via IPC) from setting kernel tunables
-              ProtectKernelTunables = mkDefault true;
-
-              # disable explicit kernel module loading
-              # implies removal of CAP_SYS_MODULE
-              # implies inaccessible /usr/lib/modules
-              ProtectKernelModules = mkDefault true;
-
-              # dines access to kernel log ring buffer
-              # implies removal of CAP_SYSLOG
-              # implies inaccessible /dev/kmsg and /proc/kmsg
-              ProtectKernelLogs = mkDefault true;
-
-              # true or strict disables write access to control group hierarchies
-              # strict or private makes the unit run in a cgroup namespace with private /sys/fs/cgroup/
-              # different options: "private", true, false
-              ProtectControlGroups = mkDefault "strict";
-
-              # disable specific access for socket system call
-              # different options: list of AF_UNIX, AF_INET AF_INET6, AF_NETLINK, AF_PACKET
-              RestrictAddressFamilies = mkDefault "none";
-
-              # restrict access to namespacing
-              # different options: false, [ "pid" "user" "net" "uts" "mnt" "cgroup" "ipc" ]
-              # see `man namespaces` for a full list
-              RestrictNamespaces = mkDefault true;
-
-              LockPersonality = mkDefault true; # prevent service from initiating changes to its execution domain
-
-              # prevent creating memory mappings that are writable and executable simultaneously
-              # WARNING: breaks with JIT execution engines
-              MemoryDenyWriteExecute = mkDefault true;
-
-              RestrictRealtime = mkDefault true; # prevent service from requesting realtime scheduling
-
-              RestrictSUIDSGID = mkDefault true; # prevent setting suid/guid bit on files. Does NOT prevent existing suid/sgid binaries from being executed!
-
-              # PrivateMounts can be used to set mount namespaces. However, debugging issues caused by this is quite complex.
-              # PrivateMounts= MountFlags=
-
-              SystemCallFilter = mkDefault [ "@system-service" ]; # sensible default, works for most services. Prevents e.g. "@clock", "@mount", "@swap", "@reboot"
-              SystemCallErrorNumber = mkDefault "EPERM"; # services violating the SystemSystemCallFilter are killed silently by default. This makes debugging easier.
-
-              SystemCallArchitectures = mkDefault "native"; # allow only native system calls for defined SystemCallFilters
-
-              # prevents access to /proc/<pid> of other processes
-              # options: "noaccess", "invisible", "ptraceable", "default"
-              ProtectProc = mkDefault "invisible";
-
-              # ProcSubset can be set to "pid" to prevent access to non-process files in /proc.
-              # However, this prevents a lot of linux kernel API calls and should not be default
-              # ProcSubset
-
-              NoNewPrivileges = mkDefault true; # prevents service process and children from gaining privileges via execve
-
-              # use a dynamic user for this service instead of running as root
-              # WARNING: breaks dbus
-              DynamicUser = mkDefault true;
-            };
+          config = lib.mkIf (config.lockdownByDefault != null) {
+            serviceConfig = builtins.mapAttrs (n: v: mkDefault v) hardeningConfigs."${config.lockdownByDefault}";
           };
         }
       )

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -1028,6 +1028,7 @@ in {
   systemd-cryptenroll = handleTest ./systemd-cryptenroll.nix {};
   systemd-credentials-tpm2 = handleTest ./systemd-credentials-tpm2.nix {};
   systemd-escaping = handleTest ./systemd-escaping.nix {};
+  systemd-hardening = handleTest ./systemd-hardening.nix {};
   systemd-initrd-bridge = handleTest ./systemd-initrd-bridge.nix {};
   systemd-initrd-btrfs-raid = handleTest ./systemd-initrd-btrfs-raid.nix {};
   systemd-initrd-luks-fido2 = handleTest ./systemd-initrd-luks-fido2.nix {};

--- a/nixos/tests/systemd-hardening.nix
+++ b/nixos/tests/systemd-hardening.nix
@@ -9,7 +9,7 @@ import ./make-test-python.nix (
       {
 
         systemd.services.unprivileged_service = {
-          lockdownByDefault = true;
+          lockdownByDefault = "rev1";
           wantedBy = [ "multi-user.target" ];
           serviceConfig = {
             ExecStart = lib.getExe pkgs.hello;

--- a/nixos/tests/systemd-hardening.nix
+++ b/nixos/tests/systemd-hardening.nix
@@ -1,0 +1,32 @@
+import ./make-test-python.nix (
+  { pkgs, lib, ... }:
+
+  {
+    name = "systemd-misc";
+
+    nodes.machine =
+      { pkgs, lib, ... }:
+      {
+
+        systemd.services.unprivileged_service = {
+          lockdownByDefault = true;
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart = lib.getExe pkgs.hello;
+            Type = "oneshot";
+            RemainAfterExit = "yes";
+          };
+        };
+      };
+
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("unprivileged service executed successfully"):
+          machine.succeed("systemctl status unprivileged_service")
+
+      with subtest("unprivileged service analysis comes back with low exposure"):
+          machine.succeed("${lib.getExe' pkgs.diffutils "diff"} -u <((systemd-analyze security unprivileged_service.service --json pretty --no-pager | ${lib.getExe pkgs.jq} '[.[] | select(.exposure != null and .set == false ) | (.exposure | tonumber) ] | add - 1 < 3')) <(echo true)")
+    '';
+  }
+)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

While working on https://github.com/NixOS/nixpkgs/issues/377827, @niklaskorz stated interest in having a blanket-deny-all option from where privileges can be allow-listed. This would avoid duplicating the many systemd hardening features accross each module defining a service.

i am aware this needs release notes, for now i am looking for discussion and feedback on this draft. Especially because this has some overlap with ` systemd.services.<name>.confinement`, which aims to confine accessible paths (but no other systemd hardening features).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
