### PR TITLE
git-unroll: init at 0-unstable-2024-11-04

### DIFF
--- a/pkgs/by-name/gi/git-unroll/package.nix
+++ b/pkgs/by-name/gi/git-unroll/package.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitea,
+  makeWrapper,
+  bash,
+
+  git,
+  nix-prefetch-git,
+  rWrapper,
+  rPackages,
+
+  unstableGitUpdater,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "git-unroll";
+  version = "0-unstable-2024-11-04";
+
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "gm6k";
+    repo = "git-unroll";
+    rev = "9243bb8a6a9f6875e21a5c64320b66f7fdaf9b3f";
+    hash = "sha256-1MjbB1EVgmU0HlUibrKOkjmxQ8wseocSJENiAqyHcjU=";
+  };
+
+  postPatch = ''
+    substituteInPlace unroll \
+      --replace-fail "#! /usr/bin/env nix-shell" "#!/usr/bin/env bash" \
+      --replace-fail \
+        "#! nix-shell -i bash -p git nix rWrapper rPackages.jsonlite rPackages.processx rPackages.dplyr rPackages.plyr rPackages.stringr -I nixpkgs=." \
+        "" \
+      --replace-fail '"$PWD/pkgs/build-support/fetchgit/nix-prefetch-git",' '"nix-prefetch-git"'
+  '';
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    bash
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 unroll $out/bin/unroll
+    wrapProgram $out/bin/unroll \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          git
+          nix-prefetch-git
+          (rWrapper.override {
+            packages = with rPackages; [
+              jsonlite
+              processx
+              dplyr
+              plyr
+              stringr
+            ];
+          })
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = unstableGitUpdater { };
+  };
+
+  meta = {
+    description = "Convert Git repositories with submodules to a Nix expression based on non-recursive Git sources";
+    homepage = "https://codeberg.org/gm6k/git-unroll";
+    license = lib.licenses.gpl3Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "unroll";
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/development/python-modules/torch/default.nix
+++ b/pkgs/development/python-modules/torch/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitHub,
   fetchFromGitLab,
-  fetchFromGitea,
+  git-unroll,
   buildPythonPackage,
   python,
   runCommand,
@@ -228,14 +228,6 @@ let
       rocmSupport;
   };
 
-  git-unroll = fetchFromGitea {
-    domain = "codeberg.org";
-    owner = "gm6k";
-    repo = "git-unroll";
-    rev = "9243bb8a6a9f6875e21a5c64320b66f7fdaf9b3f";
-    hash = "sha256-1MjbB1EVgmU0HlUibrKOkjmxQ8wseocSJENiAqyHcjU=";
-  };
-
   unroll-src = writeShellScript "unroll-src" ''
     echo "{
       version,
@@ -244,7 +236,7 @@ let
       runCommand,
     }:
     assert version == "'"'$1'"'";"
-    ${git-unroll}/unroll https://github.com/pytorch/pytorch v$1
+    ${lib.getExe git-unroll} https://github.com/pytorch/pytorch v$1
     echo
     echo "# Update using: unroll-src [version]"
   '';


### PR DESCRIPTION
## Things done

Add [git-unroll](https://codeberg.org/gm6k/git-unroll), a script to convert Git repositories with submodules to a Nix expression based on non-recursive Git sources.

It is already used by the `python3Packages.torch` derivation.

cc @zeuner 

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
