### PR TITLE
lomiri.lomiri-indicator-network: Apply patch to hopefully fix Hydra failures

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/1001-test-secret-agent-Make-GetServerInformation-not-leak-into-tests.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/1001-test-secret-agent-Make-GetServerInformation-not-leak-into-tests.patch
@@ -1,0 +1,240 @@
+From 9c2a6a6349f705017e3c8a34daa4ba1805586498 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Thu, 30 Jan 2025 14:53:02 +0100
+Subject: [PATCH] tests/unit/secret-agent/test-secret-agent: Make sure signal
+ emitted on agent startup doesn't leak into tests
+
+---
+ tests/unit/secret-agent/test-secret-agent.cpp | 116 ++++++++++--------
+ 1 file changed, 67 insertions(+), 49 deletions(-)
+
+diff --git a/tests/unit/secret-agent/test-secret-agent.cpp b/tests/unit/secret-agent/test-secret-agent.cpp
+index 1f1cd7e9..9c72e251 100644
+--- a/tests/unit/secret-agent/test-secret-agent.cpp
++++ b/tests/unit/secret-agent/test-secret-agent.cpp
+@@ -29,6 +29,16 @@
+ #include <lomiri/gmenuharness/MatchUtils.h>
+ #include <lomiri/gmenuharness/MenuMatcher.h>
+ 
++#define WAIT_FOR_SIGNALS(signalSpy, signalsExpected)\
++{\
++	while (signalSpy.size() < signalsExpected)\
++	{\
++		ASSERT_TRUE(signalSpy.wait()) << "Waiting for " << signalsExpected << " signals, got " << signalSpy.size();\
++	}\
++	ASSERT_EQ(signalsExpected, signalSpy.size()) << "Waiting for " << signalsExpected << " signals, got " << signalSpy.size();\
++}
++
++
+ using namespace std;
+ using namespace testing;
+ using namespace QtDBusTest;
+@@ -49,21 +59,6 @@ protected:
+ 		dbusMock.registerTemplate(NM_DBUS_SERVICE, NETWORK_MANAGER_TEMPLATE_PATH, {}, QDBusConnection::SystemBus);
+ 		dbusTestRunner.startServices();
+ 
+-		QProcessEnvironment env(QProcessEnvironment::systemEnvironment());
+-		env.insert("SECRET_AGENT_DEBUG_PASSWORD", "1");
+-		secretAgent.setProcessEnvironment(env);
+-		secretAgent.setReadChannel(QProcess::StandardOutput);
+-		secretAgent.setProcessChannelMode(QProcess::ForwardedErrorChannel);
+-		secretAgent.start(SECRET_AGENT_BIN, QStringList() << "--print-address");
+-		secretAgent.waitForStarted();
+-		secretAgent.waitForReadyRead();
+-		agentBus = secretAgent.readAll().trimmed();
+-
+-		agentInterface.reset(
+-				new OrgFreedesktopNetworkManagerSecretAgentInterface(agentBus,
+-				NM_DBUS_PATH_SECRET_AGENT, dbusTestRunner.systemConnection()));
+-
+-
+ 		notificationsInterface.reset(
+ 				new OrgFreedesktopDBusMockInterface(
+ 						"org.freedesktop.Notifications",
+@@ -72,8 +67,11 @@ protected:
+ 	}
+ 
+ 	virtual ~TestSecretAgentCommon() {
+-		secretAgent.terminate();
+-		secretAgent.waitForFinished();
++		if (secretAgent.state() != QProcess::NotRunning)
++		{
++				secretAgent.terminate();
++				secretAgent.waitForFinished();
++		}
+ 	}
+ 
+ 	QVariantDictMap connection(const QString &keyManagement) {
+@@ -111,6 +109,32 @@ protected:
+ 		return connection;
+ 	}
+ 
++	void setupSecretAgent (void) {
++		QSignalSpy notificationSpy(notificationsInterface.data(),
++				SIGNAL(MethodCalled(const QString &, const QVariantList &)));
++
++		QProcessEnvironment env(QProcessEnvironment::systemEnvironment());
++		env.insert("SECRET_AGENT_DEBUG_PASSWORD", "1");
++		secretAgent.setProcessEnvironment(env);
++		secretAgent.setReadChannel(QProcess::StandardOutput);
++		secretAgent.setProcessChannelMode(QProcess::ForwardedErrorChannel);
++		secretAgent.start(SECRET_AGENT_BIN, QStringList() << "--print-address");
++		secretAgent.waitForStarted();
++		secretAgent.waitForReadyRead();
++
++		agentBus = secretAgent.readAll().trimmed();
++
++		agentInterface.reset(
++				new OrgFreedesktopNetworkManagerSecretAgentInterface(agentBus,
++				NM_DBUS_PATH_SECRET_AGENT, dbusTestRunner.systemConnection()));
++
++		WAIT_FOR_SIGNALS(notificationSpy, 1);
++		{
++				const QVariantList &call(notificationSpy.at(0));
++				EXPECT_EQ(call.at(0), "GetServerInformation");
++		}
++	}
++
+ 	DBusTestRunner dbusTestRunner;
+ 
+ 	DBusMock dbusMock;
+@@ -163,22 +187,21 @@ static void transform(QVariantList &list) {
+ }
+ 
+ TEST_P(TestSecretAgentGetSecrets, ProvidesPasswordForWpaPsk) {
++	setupSecretAgent();
++
++	QSignalSpy notificationSpy(notificationsInterface.data(),
++			SIGNAL(MethodCalled(const QString &, const QVariantList &)));
++
+ 	QDBusPendingReply<QVariantDictMap> reply(
+ 			agentInterface->GetSecrets(connection(GetParam().keyManagement),
+ 					QDBusObjectPath("/connection/foo"),
+ 					SecretAgent::NM_WIRELESS_SECURITY_SETTING_NAME, QStringList(),
+ 					5));
+ 
+-	QSignalSpy notificationSpy(notificationsInterface.data(),
+-	SIGNAL(MethodCalled(const QString &, const QVariantList &)));
+-	if (notificationSpy.empty())
+-	{
+-		ASSERT_TRUE(notificationSpy.wait());
+-	}
++	WAIT_FOR_SIGNALS(notificationSpy, 1);
+ 
+-	ASSERT_EQ(1, notificationSpy.size());
+ 	const QVariantList &call(notificationSpy.at(0));
+-	EXPECT_EQ("Notify", call.at(0).toString().toStdString());
++	EXPECT_EQ("Notify", call.at(0));
+ 
+ 	QVariantList args(call.at(1).toList());
+ 	transform(args);
+@@ -254,6 +277,7 @@ class TestSecretAgent: public TestSecretAgentCommon, public Test {
+ };
+ 
+ TEST_F(TestSecretAgent, GetSecretsWithNone) {
++	setupSecretAgent();
+ 
+ 	QDBusPendingReply<QVariantDictMap> reply(
+ 			agentInterface->GetSecrets(
+@@ -272,6 +296,8 @@ TEST_F(TestSecretAgent, GetSecretsWithNone) {
+ /* Tests that if we request secrets and then cancel the request
+    that we close the notification */
+ TEST_F(TestSecretAgent, CancelGetSecrets) {
++	setupSecretAgent();
++
+ 	QSignalSpy notificationSpy(notificationsInterface.data(), SIGNAL(MethodCalled(const QString &, const QVariantList &)));
+ 
+ 	agentInterface->GetSecrets(
+@@ -280,23 +306,19 @@ TEST_F(TestSecretAgent, CancelGetSecrets) {
+ 			SecretAgent::NM_WIRELESS_SECURITY_SETTING_NAME, QStringList(),
+ 			5);
+ 
+-	notificationSpy.wait();
+-
+-	ASSERT_EQ(1, notificationSpy.size());
+-	const QVariantList &call(notificationSpy.at(0));
+-	EXPECT_EQ("Notify", call.at(0).toString().toStdString());
++	WAIT_FOR_SIGNALS(notificationSpy, 1);
++	{
++		const QVariantList &call(notificationSpy.at(0));
++		EXPECT_EQ("Notify", call.at(0));
++	}
+ 
+ 	notificationSpy.clear();
+ 
+ 	agentInterface->CancelGetSecrets(QDBusObjectPath("/connection/foo"),
+ 			SecretAgent::NM_WIRELESS_SECURITY_SETTING_NAME);
+ 
+-	if (notificationSpy.empty())
+-	{
+-		ASSERT_TRUE(notificationSpy.wait());
+-	}
++	WAIT_FOR_SIGNALS(notificationSpy, 1);
+ 
+-	ASSERT_EQ(1, notificationSpy.size());
+ 	const QVariantList &closecall(notificationSpy.at(0));
+ 	EXPECT_EQ("CloseNotification", closecall.at(0).toString().toStdString());
+ }
+@@ -304,6 +326,8 @@ TEST_F(TestSecretAgent, CancelGetSecrets) {
+ /* Ensures that if we request secrets twice we close the notification
+    for the first request */
+ TEST_F(TestSecretAgent, MultiSecrets) {
++	setupSecretAgent();
++
+ 	QSignalSpy notificationSpy(notificationsInterface.data(), SIGNAL(MethodCalled(const QString &, const QVariantList &)));
+ 
+ 	agentInterface->GetSecrets(
+@@ -312,15 +336,12 @@ TEST_F(TestSecretAgent, MultiSecrets) {
+ 			SecretAgent::NM_WIRELESS_SECURITY_SETTING_NAME, QStringList(),
+ 			5);
+ 
+-	if (notificationSpy.empty())
++	WAIT_FOR_SIGNALS(notificationSpy, 1);
+ 	{
+-		ASSERT_TRUE(notificationSpy.wait());
++		const QVariantList &call(notificationSpy.at(0));
++		EXPECT_EQ("Notify", call.at(0));
+ 	}
+ 
+-	ASSERT_EQ(1, notificationSpy.size());
+-	const QVariantList &call(notificationSpy.at(0));
+-	EXPECT_EQ("Notify", call.at(0).toString().toStdString());
+-
+ 	notificationSpy.clear();
+ 
+ 	agentInterface->GetSecrets(
+@@ -329,14 +350,7 @@ TEST_F(TestSecretAgent, MultiSecrets) {
+ 			SecretAgent::NM_WIRELESS_SECURITY_SETTING_NAME, QStringList(),
+ 			5);
+ 
+-	if (notificationSpy.empty())
+-	{
+-		ASSERT_TRUE(notificationSpy.wait());
+-	}
+-	if (notificationSpy.size() == 1)
+-	{
+-		ASSERT_TRUE(notificationSpy.wait());
+-	}
++	WAIT_FOR_SIGNALS(notificationSpy, 2);
+ 
+ 	ASSERT_EQ(2, notificationSpy.size());
+ 	const QVariantList &closecall(notificationSpy.at(1));
+@@ -347,11 +361,15 @@ TEST_F(TestSecretAgent, MultiSecrets) {
+ }
+ 
+ TEST_F(TestSecretAgent, SaveSecrets) {
++	setupSecretAgent();
++
+ 	agentInterface->SaveSecrets(QVariantDictMap(),
+ 			QDBusObjectPath("/connection/foo")).waitForFinished();
+ }
+ 
+ TEST_F(TestSecretAgent, DeleteSecrets) {
++	setupSecretAgent();
++
+ 	agentInterface->DeleteSecrets(QVariantDictMap(),
+ 			QDBusObjectPath("/connection/foo")).waitForFinished();
+ }
+-- 
+2.47.1
+

--- a/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-indicator-network/default.nix
@@ -49,6 +49,10 @@ stdenv.mkDerivation (finalAttrs: {
     "doc"
   ];
 
+  patches = [
+    ./1001-test-secret-agent-Make-GetServerInformation-not-leak-into-tests.patch
+  ];
+
   postPatch = ''
     # Override original prefixes
     substituteInPlace data/CMakeLists.txt \


### PR DESCRIPTION
See https://gitlab.com/ubports/development/core/lomiri-indicator-network/-/merge_requests/132 for details.

Aarch64 Hydra has a different failure, which I'll tackle another time: https://hydra.nixos.org/build/287246370
```
/build/source/tests/integration/test-connectivity-api.cpp:195: Failure
Expected equality of these values:
  1
  flightModeSwitchSpy.size()
    Which is: 2

[  FAILED  ] TestConnectivityApi.FlightModeTalksToURfkill (1008 ms)
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
