### PR TITLE
python312Packages.microsoft-kiota-*: update to 1.9.1

### DIFF
--- a/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-abstractions/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-core,
+  poetry-core,
   opentelemetry-api,
   opentelemetry-sdk,
   pytest-asyncio,
@@ -14,19 +14,21 @@
 
 buildPythonPackage rec {
   pname = "microsoft-kiota-abstractions";
-  version = "1.3.3";
+  version = "1.9.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "kiota-abstractions-python";
-    tag = "v${version}";
-    hash = "sha256-TgHj5Ga6Aw/sN2Hobn0OocFB/iGRHTKEeOa2j2aqnRY=";
+    repo = "kiota-python";
+    tag = "microsoft-kiota-abstractions-v${version}";
+    hash = "sha256-ESRnI8prXG1h5H5RVD4eOQ1sQYSEMMLVHSk8yhzFGVw=";
   };
 
-  build-system = [ flit-core ];
+  sourceRoot = "source/packages/abstractions/";
+
+  build-system = [ poetry-core ];
 
   dependencies = [
     opentelemetry-api
@@ -44,8 +46,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Abstractions library for Kiota generated Python clients";
-    homepage = "https://github.com/microsoft/kiota-abstractions-python";
-    changelog = "https://github.com/microsoft/kiota-abstractions-python/blob/${version}/CHANGELOG.md";
+    homepage = "https://github.com/microsoft/kiota-python/tree/main/packages/abstractions/";
+    changelog = "https://github.com/microsoft/kiota-python/releases/tag/microsoft-kiota-abstractions-v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-authentication-azure/default.nix
@@ -4,7 +4,7 @@
   azure-core,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-core,
+  poetry-core,
   microsoft-kiota-abstractions,
   opentelemetry-api,
   opentelemetry-sdk,
@@ -16,19 +16,21 @@
 
 buildPythonPackage rec {
   pname = "microsoft-kiota-authentication-azure";
-  version = "1.1.0";
+  version = "1.9.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "kiota-authentication-azure-python";
-    tag = "v${version}";
-    hash = "sha256-JoR7qjAPNqtcV35AGwbyjhIro6AnFUZXXLHLOj7InY8=";
+    repo = "kiota-python";
+    tag = "microsoft-kiota-authentication-azure-v${version}";
+    hash = "sha256-ESRnI8prXG1h5H5RVD4eOQ1sQYSEMMLVHSk8yhzFGVw=";
   };
 
-  build-system = [ flit-core ];
+  sourceRoot = "source/packages/authentication/azure/";
+
+  build-system = [ poetry-core ];
 
   dependencies = [
     aiohttp
@@ -48,8 +50,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Kiota Azure authentication provider";
-    homepage = "https://github.com/microsoft/kiota-authentication-azure-python";
-    changelog = "https://github.com/microsoft/kiota-authentication-azure-python/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/microsoft/kiota-python/tree/main/packages/authentication/azure";
+    changelog = "https://github.com/microsoft/kiota-python/releases/tag/microsoft-kiota-authentication-azure-v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/microsoft-kiota-http/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-http/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-core,
+  poetry-core,
   httpx,
   microsoft-kiota-abstractions,
   opentelemetry-api,
@@ -16,19 +16,21 @@
 
 buildPythonPackage rec {
   pname = "microsoft-kiota-http";
-  version = "1.3.4";
+  version = "1.9.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "kiota-http-python";
-    tag = "v${version}";
-    hash = "sha256-0hntB9GSDE05l/ghWTzMrX1MAPdWNHJVIQFpskraDV8=";
+    repo = "kiota-python";
+    tag = "microsoft-kiota-http-v${version}";
+    hash = "sha256-ESRnI8prXG1h5H5RVD4eOQ1sQYSEMMLVHSk8yhzFGVw=";
   };
 
-  build-system = [ flit-core ];
+  sourceRoot = "source/packages/http/httpx/";
+
+  build-system = [ poetry-core ];
 
   dependencies = [
     httpx
@@ -48,8 +50,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "HTTP request adapter implementation for Kiota clients for Python";
-    homepage = "https://github.com/microsoft/kiota-http-python";
-    changelog = "https://github.com/microsoft/kiota-http-python/blob/${version}/CHANGELOG.md";
+    homepage = "https://github.com/microsoft/kiota-python/tree/main/packages/http/httpx";
+    changelog = "https://github.com/microsoft/kiota-python/releases/tag/microsoft-kiota-http-v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-form/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-form/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-core,
+  poetry-core,
   microsoft-kiota-abstractions,
   pytest-asyncio,
   pendulum,
@@ -13,19 +13,21 @@
 
 buildPythonPackage rec {
   pname = "microsoft-kiota-serialization-form";
-  version = "0.1.1";
+  version = "1.9.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "kiota-serialization-form-python";
-    tag = "v${version}";
-    hash = "sha256-yOdrqj8QPz497VWS4427zDRRFc/S5654JeYkO1ZcUcQ=";
+    repo = "kiota-python";
+    tag = "microsoft-kiota-serialization-form-v${version}";
+    hash = "sha256-ESRnI8prXG1h5H5RVD4eOQ1sQYSEMMLVHSk8yhzFGVw=";
   };
 
-  build-system = [ flit-core ];
+  sourceRoot = "source/packages/serialization/form/";
+
+  build-system = [ poetry-core ];
 
   dependencies = [
     microsoft-kiota-abstractions
@@ -42,8 +44,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Form serialization implementation for Kiota clients in Python";
-    homepage = "https://github.com/microsoft/kiota-serialization-form-python";
-    changelog = "https://github.com/microsoft/kiota-serialization-form-python/blob/v${version}/CHANGELOG.md";
+    homepage = "https://github.com/microsoft/kiota-python/tree/main/packages/serialization/form";
+    changelog = "https://github.com/microsoft/kiota-python/releases/tag/microsoft-kiota-serialization-form-v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-json/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-core,
+  poetry-core,
   microsoft-kiota-abstractions,
   pendulum,
   pytest-asyncio,
@@ -13,19 +13,21 @@
 
 buildPythonPackage rec {
   pname = "microsoft-kiota-serialization-json";
-  version = "1.3.3";
+  version = "1.9.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "kiota-serialization-json-python";
-    tag = "v${version}";
-    hash = "sha256-J+wX2vF1LZHq88RDhda6NDeYioZzAz2BxovVFz2xxfw=";
+    repo = "kiota-python";
+    tag = "microsoft-kiota-serialization-json-v${version}";
+    hash = "sha256-ESRnI8prXG1h5H5RVD4eOQ1sQYSEMMLVHSk8yhzFGVw=";
   };
 
-  build-system = [ flit-core ];
+  sourceRoot = "source/packages/serialization/json/";
+
+  build-system = [ poetry-core ];
 
   dependencies = [
     microsoft-kiota-abstractions
@@ -40,15 +42,10 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "kiota_serialization_json" ];
 
-  disabledTests = [
-    # Test compare an output format
-    "test_parse_union_type_complex_property1"
-  ];
-
   meta = with lib; {
     description = "JSON serialization implementation for Kiota clients in Python";
-    homepage = "https://github.com/microsoft/kiota-serialization-json-python";
-    changelog = "https://github.com/microsoft/kiota-serialization-json-python/blob/${version}/CHANGELOG.md";
+    homepage = "https://github.com/microsoft/kiota-python/tree/main/packages/serialization/json";
+    changelog = "https://github.com/microsoft/kiota-python/releases/tag/microsoft-kiota-serialization-json-v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-multipart/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-multipart/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-core,
+  poetry-core,
   microsoft-kiota-abstractions,
   microsoft-kiota-serialization-json,
   pytest-asyncio,
@@ -13,19 +13,21 @@
 
 buildPythonPackage rec {
   pname = "microsoft-kiota-serialization-multipart";
-  version = "0.1.0";
+  version = "1.9.1";
   pyproject = true;
 
   disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "kiota-serialization-multipart-python";
-    tag = "v${version}";
-    hash = "sha256-OGX6vX02928F1uCP8bF/q1Z5aDrdj29iQNOITzF2LQI=";
+    repo = "kiota-python";
+    tag = "microsoft-kiota-serialization-multipart-v${version}";
+    hash = "sha256-ESRnI8prXG1h5H5RVD4eOQ1sQYSEMMLVHSk8yhzFGVw=";
   };
 
-  build-system = [ flit-core ];
+  sourceRoot = "source/packages/serialization/multipart/";
+
+  build-system = [ poetry-core ];
 
   dependencies = [ microsoft-kiota-abstractions ];
 
@@ -40,8 +42,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Multipart serialization implementation for Kiota clients in Python";
-    homepage = "https://github.com/microsoft/kiota-serialization-multipart-python";
-    changelog = "https://github.com/microsoft/kiota-serialization-multipart-python/blob/${version}/CHANGELOG.md";
+    homepage = "https://github.com/microsoft/kiota-python/tree/main/packages/serialization/multipart";
+    changelog = "https://github.com/microsoft/kiota-python/releases/tag/microsoft-kiota-serialization-multipart-v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };

--- a/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
+++ b/pkgs/development/python-modules/microsoft-kiota-serialization-text/default.nix
@@ -2,7 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  flit-core,
+  poetry-core,
   microsoft-kiota-abstractions,
   pytest-asyncio,
   pytest-mock,
@@ -13,19 +13,21 @@
 
 buildPythonPackage rec {
   pname = "microsoft-kiota-serialization-text";
-  version = "1.0.0";
+  version = "1.9.1";
   pyproject = true;
 
-  disabled = pythonOlder "3.8";
+  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "microsoft";
-    repo = "kiota-serialization-text-python";
-    tag = "v${version}";
-    hash = "sha256-jPuRfvqO4n5/PjSOS5NMCawaYRhXmrZtfg6LgYFCv7o=";
+    repo = "kiota-python";
+    tag = "microsoft-kiota-serialization-text-v${version}";
+    hash = "sha256-ESRnI8prXG1h5H5RVD4eOQ1sQYSEMMLVHSk8yhzFGVw=";
   };
 
-  build-system = [ flit-core ];
+  sourceRoot = "source/packages/serialization/text/";
+
+  build-system = [ poetry-core ];
 
   dependencies = [
     microsoft-kiota-abstractions
@@ -42,8 +44,8 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Text serialization implementation for Kiota generated clients in Python";
-    homepage = "https://github.com/microsoft/kiota-serialization-text-python";
-    changelog = "https://github.com/microsoft/kiota-serialization-text-python/blob/${version}/CHANGELOG.md";
+    homepage = "https://github.com/microsoft/kiota-python/tree/main/packages/serialization/text";
+    changelog = "https://github.com/microsoft/kiota-python/releases/tag/microsoft-kiota-serialization-text-v${version}";
     license = licenses.mit;
     maintainers = with maintainers; [ fab ];
   };


### PR DESCRIPTION
Closes #352671

Re-enabled a now working test in -json. Let me know if it should rather stay disabled for robustness.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).