### PR TITLE
ovn: fix more missing ovs binaries

### DIFF
--- a/pkgs/by-name/ov/ovn/package.nix
+++ b/pkgs/by-name/ov/ovn/package.nix
@@ -47,14 +47,16 @@ stdenv.mkDerivation rec {
   preConfigure = ''
     pushd ovs
     ./boot.sh
-    ./configure
+    ./configure --with-dbdir=/var/lib/openvswitch
     make -j $NIX_BUILD_CORES
     popd
   '';
 
   configureFlags = [
     "--localstatedir=/var"
+    "--sharedstatedir=/var"
     "--with-dbdir=/var/lib/ovn"
+    "--sbindir=$(out)/bin"
     "--enable-ssl"
   ];
 
@@ -71,14 +73,20 @@ stdenv.mkDerivation rec {
   postInstall = ''
     mkdir -vp $out/share/openvswitch/scripts
     mkdir -vp $out/etc/ovn
-    cp ovs/ovsdb/ovsdb-client $out/share/openvswitch/scripts
-    cp ovs/ovsdb/ovsdb-server $out/share/openvswitch/scripts
-    cp ovs/ovsdb/ovsdb-tool $out/share/openvswitch/scripts
-    cp ovs/utilities/ovs-appctl $out/share/openvswitch/scripts
-    cp ovs/utilities/ovs-vsctl $out/share/openvswitch/scripts
+    cp ovs/ovsdb/ovsdb-client $out/bin
+    cp ovs/ovsdb/ovsdb-server $out/bin
+    cp ovs/ovsdb/ovsdb-tool $out/bin
+    cp ovs/vswitchd/ovs-vswitchd $out/bin
+    cp ovs/utilities/ovs-appctl $out/bin
+    cp ovs/utilities/ovs-vsctl $out/bin
+    cp ovs/utilities/ovs-ctl $out/share/openvswitch/scripts
     cp ovs/utilities/ovs-lib $out/share/openvswitch/scripts
-    sed -i "s#/usr/local/bin#$out/share/openvswitch/scripts#g" $out/share/openvswitch/scripts/ovs-lib
-    sed -i "s#/usr/local/sbin#$out/share/openvswitch/scripts#g" $out/share/openvswitch/scripts/ovs-lib
+    cp ovs/utilities/ovs-kmod-ctl $out/share/openvswitch/scripts
+    cp ovs/vswitchd/vswitch.ovsschema $out/share/openvswitch
+    sed -i "s#/usr/local/etc#/var/lib#g" $out/share/openvswitch/scripts/ovs-lib
+    sed -i "s#/usr/local/bin#$out/bin#g" $out/share/openvswitch/scripts/ovs-lib
+    sed -i "s#/usr/local/sbin#$out/bin#g" $out/share/openvswitch/scripts/ovs-lib
+    sed -i "s#/usr/local/share#$out/share#g" $out/share/openvswitch/scripts/ovs-lib
     sed -i '/chown -R $INSTALL_USER:$INSTALL_GROUP $ovn_etcdir/d' $out/share/ovn/scripts/ovn-ctl
   '';
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Hi @adamcstephens,

Here are some additional changes for the ovn package:
* Added `--with-dbdir=/var/lib/openvswitch` to configure OVS, as it is the traditional location for OVS DB. In the Open vSwitch module, it is set as `/var/db/openvswitch`. I guess that we can do the same for consistency, if you think it is better.
* Moved the OVS binaries to `$out/bin` to match the file tree of the Open vSwitch package. This also helps with running the `ovn-ctl` and `ovs-ctl` scripts.
* Added more OVS binaries needed by `ovs-ctl`.
* We have to keep the `system-id.conf` file between reboots and package upgrades, so I set the sysconfig directory to `var/lib` because it seems to me that nixpkgs should not create files in `/etc`.

These changes allowed me to successfully set up Incus with a standalone OVN network. I was able to create an OVN network, attach a container to it, and ping the internet. To do so, I used this Nix module that I wrote: [nixos-ovn-module](https://github.com/positiveEV/nixos-ovn-module). This module creates OVS services, as I unfortunately was not able to fix the OVS build in the OVN package to use the NixOS Open vSwitch module.
For reference the issue is the lack of git submodule awareness in nix-build, which does not seem to provide a way to set the variables we need to pass to the OVS autoconf. This results in multiple path issues in the OVS binaries that prevent me from using the Open vSwitch module with the OVN package

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
