### PR TITLE
epson-workforce-635-nx625-series: fix GCC 14 build

### DIFF
--- a/pkgs/by-name/ep/epson-workforce-635-nx625-series/eps_raster_print-cast.patch
+++ b/pkgs/by-name/ep/epson-workforce-635-nx625-series/eps_raster_print-cast.patch
@@ -1,0 +1,21 @@
+diff --git a/src/raster_to_epson.c b/src/raster_to_epson.c
+index 6e621c8..a5ca797 100644
+--- a/src/raster_to_epson.c
++++ b/src/raster_to_epson.c
+@@ -438,14 +438,14 @@ static int print_page (void)
+ 					break;
+ 				}
+ 
+-				if (eps_raster_print(raster_h, image_raw, pageRegion.bytesPerLine, pageRegion.width, &nraster)) {
++				if (eps_raster_print(raster_h, image_raw, pageRegion.bytesPerLine, pageRegion.width, (int *) &nraster)) {
+ 					error  = 1;
+ 					break;
+ 				}
+ 			}
+ 
+ 			// flushing page
+-			eps_raster_print(raster_h, NULL, 0, 0, &nraster);
++			eps_raster_print(raster_h, NULL, 0, 0, (int *) &nraster);
+ 
+ 			bAbort = (error) ? TRUE : FALSE;
+ 			if (epcgEndPage (bAbort)) {

--- a/pkgs/by-name/ep/epson-workforce-635-nx625-series/include-raster-helper.patch
+++ b/pkgs/by-name/ep/epson-workforce-635-nx625-series/include-raster-helper.patch
@@ -1,0 +1,24 @@
+diff --git a/src/pagemanager/pagemanager.c b/src/pagemanager/pagemanager.c
+index 029e6d3..2881585 100644
+--- a/src/pagemanager/pagemanager.c
++++ b/src/pagemanager/pagemanager.c
+@@ -23,6 +23,7 @@
+ #include "debuglog.h"
+ #include "memory.h"
+ #include "raster.h"
++#include "raster-helper.h"
+ #include "pagemanager.h"
+ 
+ extern int JobCanceled;
+diff --git a/src/raster_to_epson.c b/src/raster_to_epson.c
+index 6e621c8..6eea77c 100644
+--- a/src/raster_to_epson.c
++++ b/src/raster_to_epson.c
+@@ -36,6 +36,7 @@
+ #include "raster.h"
+ #include "memory.h"
+ #include "raster_to_epson.h"
++#include "raster-helper.h"
+ #include "pagemanager.h"
+ #include "filter_option.h"
+ 

--- a/pkgs/by-name/ep/epson-workforce-635-nx625-series/package.nix
+++ b/pkgs/by-name/ep/epson-workforce-635-nx625-series/package.nix
@@ -44,6 +44,11 @@ stdenv.mkDerivation rec {
     done
   '';
 
+  patches = [
+    ./eps_raster_print-cast.patch
+    ./include-raster-helper.patch
+  ];
+
   preConfigure = ''
     chmod u+x configure
   '';


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
Due to the upgrade to GCC 14, the build for the epson-workforce-635-nx625-series fails with the following error message:
```
error: builder for '/nix/store/bchxz5kldkqij9cq5jwxiqii8phppx0c-epson-inkjet-printer-workforce-635-nx625-series-1.0.1.drv' failed with exit code 2;
       last 25 log lines:
       > make[3]: Entering directory '/build/epson-inkjet-printer-filter-1.0.0/src/pagemanager'
       > /nix/store/4fvc5fm8bszmkydng1ivrvr5cbvr1g60-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I../.. -I.. -I../../include -I../memory -I../filteropt -I../raster   -fsigned-char -O2 -c -o subpage.lo subpage.c
       > libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -I.. -I../../include -I../memory -I../filteropt -I../raster -fsigned-char -O2 -c subpage.c  -fPIC -DPIC -o .libs/subpage.o
       > /nix/store/4fvc5fm8bszmkydng1ivrvr5cbvr1g60-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I../.. -I.. -I../../include -I../memory -I../filteropt -I../raster   -fsigned-char -O2 -c -o subpagemanager.lo subpagemanager.c
       > libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -I.. -I../../include -I../memory -I../filteropt -I../raster -fsigned-char -O2 -c subpagemanager.c  -fPIC -DPIC -o .libs/subpagemanager.o
       > /nix/store/4fvc5fm8bszmkydng1ivrvr5cbvr1g60-bash-5.2p37/bin/bash ../../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I. -I../.. -I.. -I../../include -I../memory -I../filteropt -I../raster   -fsigned-char -O2 -c -o pagemanager.lo pagemanager.c
       > libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -I.. -I../../include -I../memory -I../filteropt -I../raster -fsigned-char -O2 -c pagemanager.c  -fPIC -DPIC -o .libs/pagemanager.o
       > pagemanager.c: In function 'pageManagerCreate':
       > pagemanager.c:155:63: error: implicit declaration of function 'raster_helper_create_pipeline' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
       >   155 |                 privateData->pipeline = (EpsRasterPipeline *) raster_helper_create_pipeline(&page, EPS_RASTER_PROCESS_MODE_FETCHING);
       >       |                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > pagemanager.c:155:41: warning: cast to pointer from integer of different size [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wint-to-pointer-cast-Wint-to-pointer-cast8;;]
       >   155 |                 privateData->pipeline = (EpsRasterPipeline *) raster_helper_create_pipeline(&page, EPS_RASTER_PROCESS_MODE_FETCHING);
       >       |                                         ^
       > pagemanager.c: In function 'pageManagerDestroy':
       > pagemanager.c:188:25: error: implicit declaration of function 'raster_helper_destroy_pipeline' [8;;https://gcc.gnu.org/onlinedocs/gcc-14.2.0/gcc/Warning-Options.html#index-Wimplicit-function-declaration-Wimplicit-function-declaration8;;]
       >   188 |                         raster_helper_destroy_pipeline(privateData->pipeline);
       >       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > make[3]: *** [Makefile:411: pagemanager.lo] Error 1
       > make[3]: Leaving directory '/build/epson-inkjet-printer-filter-1.0.0/src/pagemanager'
       > make[2]: *** [Makefile:511: all-recursive] Error 1
       > make[2]: Leaving directory '/build/epson-inkjet-printer-filter-1.0.0/src'
       > make[1]: *** [Makefile:462: all-recursive] Error 1
       > make[1]: Leaving directory '/build/epson-inkjet-printer-filter-1.0.0'
       > make: *** [Makefile:373: all] Error 2
       For full logs, run 'nix-store -l /nix/store/bchxz5kldkqij9cq5jwxiqii8phppx0c-epson-inkjet-printer-workforce-635-nx625-series-1.0.1.drv'.
```

This PR patches the sources to fix not only this error but also other errors that show up afterwards.

I tested its compilation with `NIXPKGS_ALLOW_UNFREE=1 nix build .#epson-workforce-635-nx625-series --impure`. Also, I tried testing compilation via `nix run nixpkgs#nixpkgs-review -- rev HEAD`, yet it built a way too large amount of and unrelated derivations, so I canceled it. I would be happy if someone could point out my error!

cc @jorsn 

ref. #356812

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
