### PR TITLE
alertmanager-gotify-bridge: init at 2.3.2

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -11596,6 +11596,14 @@
     githubId = 79042825;
     name = "Jan Kremer";
   };
+  juli0604 = {
+    name = "Julian Kuhn";
+    email = "juliankuhn06@gmail.com";
+    matrix = "@julian:matrix.epiccraft-mc.de";
+    github = "juli0604";
+    githubId = 62934740;
+    keys = [ { fingerprint = "E9C6 44C7 F6AA A865 4CB9  2723 22C8 B0CE B9AC 4AFF"; } ];
+  };
   JulianFP = {
     name = "Julian Partanen";
     github = "JulianFP";

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -951,6 +951,7 @@
   ./services/monitoring/opentelemetry-collector.nix
   ./services/monitoring/osquery.nix
   ./services/monitoring/parsedmarc.nix
+  ./services/monitoring/prometheus/alertmanager-gotify-bridge.nix
   ./services/monitoring/prometheus/alertmanager-irc-relay.nix
   ./services/monitoring/prometheus/alertmanager-webhook-logger.nix
   ./services/monitoring/prometheus/alertmanager.nix

--- a/nixos/modules/services/monitoring/prometheus/alertmanager-gotify-bridge.nix
+++ b/nixos/modules/services/monitoring/prometheus/alertmanager-gotify-bridge.nix
@@ -1,0 +1,194 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.prometheus.alertmanagerGotify;
+  pkg = cfg.package;
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    types
+    mkIf
+    mkPackageOption
+    optionalString
+    ;
+in
+{
+  meta.maintainers = with lib.maintainers; [ juli0604 ];
+  options.services.prometheus.alertmanagerGotify = {
+    enable = mkEnableOption "alertmagager-gotify";
+    package = mkPackageOption pkgs "alertmanager-gotify-bridge" { };
+    bindAddress = mkOption {
+      type = types.str;
+      default = "0.0.0.0";
+      description = "The address the server will listen on (bind address).";
+    };
+    defaultPriority = mkOption {
+      type = types.int;
+      default = 5;
+      description = "The default priority for messages sent to gotify.";
+    };
+    debug = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enables extended logs for debugging purposes. Should be disabled in productive mode.";
+    };
+    dispatchErrors = mkOption {
+      type = types.bool;
+      default = false;
+      description = "When enabled, alerts will be tried to dispatch with an error message regarding faulty templating or missing fields to help debugging.";
+    };
+    extendedDetails = mkOption {
+      type = types.bool;
+      default = false;
+      description = "When enabled, alerts are presented in HTML format and include colorized status (FIR|RES), alert start time, and a link to the generator of the alert.";
+    };
+    messageAnnotation = mkOption {
+      type = types.str;
+      description = "Annotation holding the alert message.";
+    };
+    openFirewall = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Opens the bridge port in the firewall.";
+    };
+    port = mkOption {
+      type = types.port;
+      default = 8080;
+      description = "The local port the bridge is listening on.";
+    };
+    priorityAnnotation = mkOption {
+      type = types.str;
+      default = "priority";
+      description = "Annotation holding the priority of the alert.";
+    };
+    timeout = mkOption {
+      type = types.ints.positive;
+      default = 5;
+      description = "The time between sending a message and the timeout.";
+    };
+    titleAnnotation = mkOption {
+      type = types.str;
+      default = "summary";
+      description = "Annotation holding the title of the alert";
+    };
+    webhookPath = mkOption {
+      type = types.str;
+      default = "/gotify_webhook";
+      description = "The URL path to handle requests on.";
+    };
+    environmentFile = mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      description = ''
+        File containing additional config environment variables for alertmanager-gotify-bridge.
+        This is especially for secrets like GOTIFY_TOKEN and AUTH_PASSWORD.
+      '';
+    };
+    gotifyEndpoint = {
+      host = mkOption {
+        type = types.str;
+        default = "127.0.0.1";
+        description = "The hostname or ip your gotify endpoint is running.";
+      };
+      port = mkOption {
+        type = types.port;
+        default = 443;
+        description = "The port your gotify endpoint is running.";
+      };
+      tls = mkOption {
+        type = types.bool;
+        default = true;
+        description = "If your gotify endpoint uses https, leave this option set to default";
+      };
+    };
+    metrics = {
+      username = mkOption {
+        type = types.str;
+        description = "The username used to access your metrics.";
+      };
+      namespace = mkOption {
+        type = types.str;
+        default = "alertmanager-gotify-bridge";
+        description = "The namescape of the metrics.";
+      };
+      path = mkOption {
+        type = types.str;
+        default = "/metrics";
+        description = "The path under which the metrics will be exposed.";
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      groups.alertmanager-gotify = { };
+      users.alertmanager-gotify = {
+        group = "alertmanager-gotify";
+        isSystemUser = true;
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    systemd.services.alertmanager-gotify-bridge = {
+      description = "A bridge between Prometheus AlertManager and a Gotify server";
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        ExecStart = "${lib.getExe pkg} ${optionalString cfg.debug "--debug"}";
+        EnvironmentFile = lib.mkIf (cfg.environmentFile != null) [ cfg.environmentFile ];
+        User = "alertmanager-gotify";
+        Group = "alertmanager-gotify";
+
+        #hardening
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        PrivateIPC = true;
+        DevicePolicy = "closed";
+        ProtectSystem = "strict";
+        ProtectHome = "read-only";
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        ProtectKernelTunables = true;
+        ProtectHostname = true;
+        ProtectProc = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+        MemoryDenyWriteExecute = true;
+        LockPersonality = true;
+        ProcSubset = "pid";
+        SystemCallArchitectures = "native";
+        RemoveIPC = true;
+
+      };
+      environment = {
+        BIND_ADDRESS = cfg.bindAddress;
+        DEFAULT_PRIORITY = toString cfg.defaultPriority;
+        DISPATCH_ERRORS = toString cfg.dispatchErrors;
+        EXTENDED_DETAILS = toString cfg.extendedDetails;
+        MESSAGE_ANNOTATION = cfg.messageAnnotation;
+        PORT = toString cfg.port;
+        PRIORITY_ANNOTATION = cfg.priorityAnnotation;
+        TIMEOUT = "${toString cfg.timeout}s";
+        TITLE_ANNOTATION = cfg.titleAnnotation;
+        WEBHOOK_PATH = cfg.webhookPath;
+        GOTIFY_ENDPOINT = "${
+          if cfg.gotifyEndpoint.tls then "https://" else "http://"
+        }${toString cfg.gotifyEndpoint.host}:${toString cfg.gotifyEndpoint.port}/message";
+        AUTH_USERNAME = cfg.metrics.username;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/al/alertmanager-gotify-bridge/package.nix
+++ b/pkgs/by-name/al/alertmanager-gotify-bridge/package.nix
@@ -1,0 +1,42 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  versionCheckHook,
+  nix-update-script,
+}:
+buildGoModule rec {
+  pname = "alertmanager-gotify-bridge";
+  version = "2.3.2";
+
+  src = fetchFromGitHub {
+    owner = "DRuggeri";
+    repo = "alertmanager_gotify_bridge";
+    tag = "v${version}";
+    hash = "sha256-jG4SC+go6ZxdV1RtLJjZdL4I8jLayY5JKK8mlMDD2pE=";
+  };
+
+  vendorHash = "sha256-EjsfY8Ys0Fd99sx7OsZ2jcstdVloqDQQj5xfoIVSX9E=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.Version=${version}"
+  ];
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgram = "${placeholder "out"}/bin/alertmanager_gotify_bridge";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Bridge between Prometheus AlertManager and a Gotify server";
+    homepage = "https://github.com/DRuggeri/alertmanager_gotify_bridge";
+    changelog = "https://github.com/DRuggeri/alertmanager_gotify_bridge/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ juli0604 ];
+    mainProgram = "alertmanager_gotify_bridge";
+  };
+}


### PR DESCRIPTION
See https://github.com/DRuggeri/alertmanager_gotify_bridge/pull/37

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
