### PR TITLE
g3proxy: init at 1.10.4

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -133,6 +133,8 @@
 
 - [PowerStation](https://github.com/ShadowBlip/PowerStation/), an open source TDP control and performance daemon with DBus interface for Linux. Available as [services.powerstation](#opt-services.powerstation.enable).
 
+- [`g3proxy`](https://github.com/bytedance/g3), an open source enterprise forward proxy from ByteDance, similar to Squid or tinyproxy. Available as [services.g3proxy](#opt-services.g3proxy.enable).
+
 - [echoip](https://github.com/mpolden/echoip), a simple service for looking up your IP address. Available as [services.echoip](#opt-services.echoip.enable).
 
 - [Buffyboard](https://gitlab.postmarketos.org/postmarketOS/buffybox/-/tree/master/buffyboard), a framebuffer on-screen keyboard. Available as [services.buffyboard](option.html#opt-services.buffyboard).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1266,6 +1266,7 @@
   ./services/networking/spacecookie.nix
   ./services/networking/spiped.nix
   ./services/networking/squid.nix
+  ./services/networking/g3proxy.nix
   ./services/networking/ssh/sshd.nix
   ./services/networking/sslh.nix
   ./services/networking/strongswan-swanctl/module.nix

--- a/nixos/modules/services/networking/g3proxy.nix
+++ b/nixos/modules/services/networking/g3proxy.nix
@@ -1,0 +1,92 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.g3proxy;
+
+  inherit (lib)
+    mkPackageOption
+    mkEnableOption
+    mkOption
+    mkIf
+    literalExpression
+    ;
+
+  settingsFormat = pkgs.formats.yaml { };
+in
+{
+  options.services.g3proxy = {
+    enable = mkEnableOption "g3proxy, a generic purpose forward proxy";
+
+    package = mkPackageOption pkgs "g3proxy" { };
+
+    settings = mkOption {
+      type = settingsFormat.type;
+      default = { };
+      example = literalExpression ''
+        {
+          server = [{
+            name = "test";
+            escaper = "default";
+            type = "socks_proxy";
+            listen = {
+              address = "[::]:10086";
+            };
+          }];
+        }
+      '';
+      description = ''
+        Settings of g3proxy.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.g3proxy = {
+      description = "g3proxy server";
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart =
+          let
+            g3proxy-yaml = settingsFormat.generate "g3proxy.yaml" cfg.settings;
+          in
+          "${lib.getExe cfg.package} --config-file ${g3proxy-yaml}";
+
+        WorkingDirectory = "/var/lib/g3proxy";
+        StateDirectory = "g3proxy";
+        RuntimeDirectory = "g3proxy";
+        DynamicUser = true;
+
+        RuntimeDirectoryMode = "0755";
+        PrivateTmp = true;
+        DevicePolicy = "closed";
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        PrivateUsers = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        ProtectSystem = "strict";
+        ProcSubset = "pid";
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        RemoveIPC = true;
+        SystemCallArchitectures = "native";
+        UMask = "0077";
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictSUIDSGID = true;
+      };
+    };
+  };
+}

--- a/pkgs/by-name/g3/g3proxy/package.nix
+++ b/pkgs/by-name/g3/g3proxy/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  pkg-config,
+  stdenv,
+  darwin,
+  c-ares,
+  python3,
+  lua5_4,
+  capnproto,
+  cmake,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "g3";
+  version = "v1.10.4";
+
+  src = fetchFromGitHub {
+    owner = "bytedance";
+    repo = "g3";
+    tag = "g3proxy-${version}";
+    hash = "sha256-uafKYyzjGdtC+oMJG1wWOvgkSht/wTOzyODcPoTfOnU=";
+  };
+
+  cargoHash = "sha256-NbrJGGnpZkF7ZX3MqrMsZ03tWkN/nqWahh00O3IJGOw=";
+  useFetchCargoVendor = true;
+
+  # TODO: can we unvendor AWS LC somehow?
+  buildFeatures = [
+    "vendored-aws-lc"
+    "rustls-aws-lc"
+  ];
+
+  # aws-lc/crypto compilation will trigger `strictoverflow` errors.
+  hardeningDisable = [ "strictoverflow" ];
+
+  nativeBuildInputs = [
+    pkg-config
+    rustPlatform.bindgenHook
+    python3
+    capnproto
+    cmake
+  ];
+
+  buildInputs =
+    [
+      c-ares
+      lua5_4
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      darwin.apple_sdk.frameworks.Security
+    ];
+
+  meta = {
+    description = "Enterprise-oriented Generic Proxy Solutions";
+    homepage = "https://github.com/bytedance/g3";
+    changelog = "https://github.com/bytedance/g3/blob/${src.rev}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ raitobezarius ];
+    mainProgram = "g3proxy";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

g3proxy is an alternative forward proxy to squid or tinyproxy, written
in Rust, relying on modern cryptography stacks like partially verified
AWS LC and RustTLS.

AWS LC library is vendored because of how the Rust ecosystem is, but we
should look into unvendoring this like unvendoring OpenSSL is usually
done.

Change-Id: Id7f2d8b59307c5306e178a38a165c19f426ad8de
Signed-off-by: Raito Bezarius <masterancpp@gmail.com>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
