### PR TITLE
androidenv: update to latest

### DIFF
--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -2,12 +2,12 @@
 , licenseAccepted ? false
 }:
 
-{ cmdLineToolsVersion ? "13.0"
+{ cmdLineToolsVersion ? "17.0"
 , toolsVersion ? "26.1.1"
 , platformToolsVersion ? "35.0.2"
-, buildToolsVersions ? [ "35.0.0" ]
+, buildToolsVersions ? [ "35.0.1" ]
 , includeEmulator ? false
-, emulatorVersion ? "35.3.10"
+, emulatorVersion ? "35.5.1"
 , platformVersions ? []
 , includeSources ? false
 , includeSystemImages ? false
@@ -15,7 +15,7 @@
 , abiVersions ? [ "x86" "x86_64" "armeabi-v7a" "arm64-v8a" ]
 , cmakeVersions ? [ ]
 , includeNDK ? false
-, ndkVersion ? "27.0.12077973"
+, ndkVersion ? "27.2.12479018"
 , ndkVersions ? [ndkVersion]
 , useGoogleAPIs ? false
 , useGoogleTVAddOns ? false

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -133,8 +133,8 @@ pkgs.mkShell rec {
           echo "installed_packages_section: ''${installed_packages_section}"
 
           packages=(
-            "build-tools;35.0.0" "cmdline-tools;13.0" \
-            "emulator" "platform-tools" "platforms;android-35" \
+            "build-tools;35.0.1" "cmdline-tools;13.0" \
+            "emulator" "patcher;v4" "platform-tools" "platforms;android-35" \
             "system-images;android-35;google_apis;x86_64"
           )
 

--- a/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
@@ -29,7 +29,7 @@ let
     versions = {
       cmdLineToolsVersion = "13.0";
       platformTools = "35.0.2";
-      buildTools = "35.0.0";
+      buildTools = "35.0.1";
     };
     platforms = [ "35" ];
   };

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -27,7 +27,7 @@ let
     versions = {
       cmdLineToolsVersion = "13.0";
       platformTools = "35.0.2";
-      buildTools = "35.0.0";
+      buildTools = "35.0.1";
       ndk = [
         "27.0.12077973"
       ];

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -11,7 +11,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -64,7 +64,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -110,7 +110,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -161,7 +161,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -198,7 +198,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -249,7 +249,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -286,7 +286,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -339,7 +339,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -399,7 +399,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -459,7 +459,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -519,7 +519,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -579,7 +579,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -639,7 +639,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -699,7 +699,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -759,7 +759,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -819,7 +819,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -879,7 +879,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -939,7 +939,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -985,7 +985,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1031,7 +1031,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1077,7 +1077,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1123,7 +1123,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1169,7 +1169,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1215,7 +1215,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1262,7 +1262,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1292,7 +1292,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1322,7 +1322,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1350,7 +1350,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -1390,7 +1390,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -1415,7 +1415,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -1442,15 +1442,8 @@
           "url": "https://dl.google.com/android/repository/google_play_services_v16_1_rc09.zip"
         }
       ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "patcher;v4"
-          }
-        }
-      },
       "displayName": "Google Play services",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -1478,7 +1471,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -1506,7 +1499,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -1535,15 +1528,8 @@
           "url": "https://dl.google.com/android/repository/google_m2repository_gms_v11_3_rc05_wear_2_0_5.zip"
         }
       ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "patcher;v4"
-          }
-        }
-      },
       "displayName": "Google Repository",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -1571,7 +1557,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -1599,7 +1585,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -1628,7 +1614,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -1656,7 +1642,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -1684,7 +1670,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20112,
+      "last-available-day": 20126,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -1701,636 +1687,6 @@
           "id:0": "google"
         }
       }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "b621b9d5adf273bb0725948589863e60e96eeaf1",
-          "size": 91207,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.0",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha4": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "2aa2aceecc6ba172742d0af0b43f11d03924eeb8",
-          "size": 95406,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0-alpha4.zip"
-        }
-      ],
-      "displayName": "com.android.support.constraint:constraint-layout-solver:1.0.0-alpha4",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-alpha4",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-alpha4",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha8": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "cd13d16a8f0198c1d6040ec8b1d0d4e5bb7feb6a",
-          "size": 97549,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0-alpha8.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.0-alpha8",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-alpha8",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-alpha8",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta1": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "042c25575e7650e96f0f5f5d1d3c54ed38eb821a",
-          "size": 104706,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0-beta1.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.0-beta1",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta1",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta1",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta2": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "28492fd42b20ae1586591ff906556d459cfdaae8",
-          "size": 107335,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0-beta2.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.0-beta2",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta2",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta2",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta3": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "268e763fa64bd217d8d830e59ce76be19aaba631",
-          "size": 107593,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0-beta3.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.0-beta3",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta3",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta3",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta4": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "2213bf37e7a2869db2635895b8e90ca6841e79d2",
-          "size": 109361,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0-beta4.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.0-beta4",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta4",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta4",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "3918cfef73e64048d0b3e048068e208b414e7e91",
-          "size": 92284,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.0-beta5.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.0-beta5",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.0-beta5",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.0-beta5",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.1": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "76f8823def9a6da8954a54737762a6820bc1d043",
-          "size": 91823,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.1.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.1",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.1",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.1",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "96d7ff669f0e808e9833b2c2e320702826ccc8be",
-          "size": 91961,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-solver-1.0.2.zip"
-        }
-      ],
-      "displayName": "Solver for ConstraintLayout 1.0.2",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-solver-1.0.2",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout-solver/1.0.2",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "70acf99689b933bc6735645d5c3d92b91954b6cb",
-          "size": 39153,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.0",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha4": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "645a9be1f0c1177301e71cd0ddccf1dd67c554fe",
-          "size": 15554,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-alpha4.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha4"
-          }
-        }
-      },
-      "displayName": "com.android.support.constraint:constraint-layout:1.0.0-alpha4",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-alpha4",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-alpha4",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-alpha8": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "7912ba03b04831f918f523648f118c4ee4da7604",
-          "size": 24797,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-alpha8.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-alpha8"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.0-alpha8",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-alpha8",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-alpha8",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta1": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "11f2f5cec4ff02986bad75435e5be77b704b4c64",
-          "size": 31750,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta1.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta1"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.0-beta1",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta1",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta1",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta2": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "623939865ede2e5c2c975dc55963e0d182bcce95",
-          "size": 31812,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta2.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta2"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.0-beta2",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta2",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta2",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta3": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "d78bb6a8ce92005fb1e4ed55d892a65b4258c60b",
-          "size": 32622,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta3.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta3"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.0-beta3",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta3",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta3",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta4": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "dc60844aab93a09a54a3c107685a77b18d7c1c39",
-          "size": 32687,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta4.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta4"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.0-beta4",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta4",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta4",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.0-beta5": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "4660f6c7a576ea1364f0c3225db71c29ca660d9a",
-          "size": 39266,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.0-beta5.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.0-beta5"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.0-beta5",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.0-beta5",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.0-beta5",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.1": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "342b0894b8651fff37586f80f383733e97aba9f9",
-          "size": 39547,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.1.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.1"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.1",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.1",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.1",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
-    },
-    "extras;m2repository;com;android;support;constraint;constraint-layout;1.0.2": {
-      "archives": [
-        {
-          "os": "all",
-          "sha1": "3d9688a50fe0ed7348275f85d1b02278f616d8a4",
-          "size": 39625,
-          "url": "https://dl.google.com/android/repository/com.android.support.constraint-constraint-layout-1.0.2.zip"
-        }
-      ],
-      "dependencies": {
-        "dependency:0": {
-          "element-attributes": {
-            "path": "extras;m2repository;com;android;support;constraint;constraint-layout-solver;1.0.2"
-          }
-        }
-      },
-      "displayName": "ConstraintLayout for Android 1.0.2",
-      "last-available-day": 19823,
-      "license": "android-sdk-license",
-      "name": "extras-m2repository-com-android-support-constraint-constraint-layout-1.0.2",
-      "path": "extras/m2repository/com/android/support/constraint/constraint-layout/1.0.2",
-      "revision": "1",
-      "revision-details": {
-        "major:0": "1"
-      },
-      "type-details": {
-        "element-attributes": {
-          "xsi:type": "ns8:mavenType"
-        },
-        "vendor:0": {
-          "display:1": "Android",
-          "id:0": "android"
-        }
-      }
     }
   },
   "images": {
@@ -2345,15 +1701,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-10_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -2383,15 +1732,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-10_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -2423,15 +1765,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-10_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -2464,15 +1799,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-10_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -2510,7 +1838,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -2544,15 +1872,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-15_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -2582,15 +1903,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-15_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -2622,15 +1936,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-15_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -2663,15 +1970,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-15_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -2708,15 +2008,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-16_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -2747,7 +2040,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -2777,15 +2070,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-16_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -2817,15 +2103,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-16_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -2858,15 +2137,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-16_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -2903,15 +2175,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-17_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -2942,7 +2207,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -2972,15 +2237,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-17_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3015,15 +2273,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-17_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3056,15 +2307,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-17_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3101,15 +2345,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-18_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3139,15 +2376,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-18_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -3179,15 +2409,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-18_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -3220,15 +2443,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-18_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -3265,15 +2481,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-19_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -3303,15 +2512,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-19_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -3343,15 +2545,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-19_r40.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -3384,15 +2579,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-19_r40.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -3430,7 +2618,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -3460,7 +2648,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -3492,7 +2680,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -3522,15 +2710,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-21_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -3560,15 +2741,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-21_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -3598,15 +2772,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-21_r05.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -3639,7 +2806,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -3672,15 +2839,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-21_r32.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -3713,15 +2873,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-21_r32.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -3754,15 +2907,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-21_r32.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -3800,7 +2946,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -3832,7 +2978,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -3862,15 +3008,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-22_r02.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -3900,15 +3039,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-22_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -3938,15 +3070,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-22_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -3979,7 +3104,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -4012,15 +3137,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-22_r26.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -4053,15 +3171,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-22_r26.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -4094,15 +3205,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-22_r26.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -4140,7 +3244,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -4169,15 +3273,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-23_r21.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -4209,7 +3306,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -4239,15 +3336,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-23_r06.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -4277,15 +3367,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-23_r10.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -4315,15 +3398,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-23_r10.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -4356,7 +3432,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -4389,15 +3465,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-23_r33.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -4430,15 +3499,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-23_r33.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -4471,15 +3533,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-23_r33.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -4516,15 +3571,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-24_r22.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -4556,7 +3604,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -4586,15 +3634,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/armeabi-v7a-24_r07.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -4624,15 +3665,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-24_r08.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -4662,15 +3696,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-24_r08.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -4702,15 +3729,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-24_r29.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -4743,15 +3763,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-24_r27.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -4784,15 +3797,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-24_r27.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -4827,15 +3833,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-24_r19.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -4872,15 +3871,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-25_r16.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -4911,15 +3903,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/armeabi-v7a-25_r03.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -4948,15 +3933,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-25_r03.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -4988,7 +3966,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -5018,15 +3996,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-25_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -5056,15 +4027,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-25_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -5097,7 +4061,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -5130,15 +4094,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/armeabi-v7a-25_r18.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -5171,15 +4128,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-25_r18.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -5212,15 +4162,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-25_r18.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -5255,15 +4198,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-25_r09.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -5310,20 +4246,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -5354,15 +4280,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-26_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -5406,7 +4325,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -5435,15 +4354,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-26_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -5472,15 +4384,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-26_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -5524,7 +4429,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -5567,20 +4472,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -5623,20 +4518,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -5681,20 +4566,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -5731,15 +4606,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-27_r09.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -5783,7 +4651,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -5812,15 +4680,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86-27_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -5849,15 +4710,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android/x86_64-27_r01.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -5901,7 +4755,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -5944,20 +4798,10 @@
                 "micro:2": "7",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "27",
-                "micro:2": "7",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -6002,20 +4846,10 @@
                 "micro:2": "3",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "26",
-                "micro:2": "3",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -6065,7 +4899,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -6100,15 +4934,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-tv/x86-28_r10.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -6139,15 +4966,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-28_r09.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -6191,7 +5011,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -6221,7 +5041,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -6251,7 +5071,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -6295,7 +5115,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -6338,20 +5158,10 @@
                 "micro:2": "12",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "29",
-                "micro:2": "12",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -6394,20 +5204,10 @@
                 "micro:2": "12",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "29",
-                "micro:2": "12",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -6455,7 +5255,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -6498,20 +5298,10 @@
                 "micro:2": "7",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "27",
-                "micro:2": "7",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -6554,20 +5344,10 @@
                 "micro:2": "7",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "27",
-                "micro:2": "7",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -6617,7 +5397,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -6662,20 +5442,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -6707,7 +5477,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -6761,7 +5531,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -6815,7 +5585,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -6859,7 +5629,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -6905,7 +5675,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -6951,7 +5721,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -7005,7 +5775,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -7060,20 +5830,10 @@
                 "micro:2": "9",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "9",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -7128,20 +5888,10 @@
                 "micro:2": "9",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "9",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -7191,7 +5941,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -7236,20 +5986,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -7280,15 +6020,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-30_r12.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear/arm64-v8a",
@@ -7317,15 +6050,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86-30_r12.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear/x86",
@@ -7357,7 +6083,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -7399,7 +6125,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -7443,7 +6169,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -7486,20 +6212,10 @@
                 "micro:2": "0",
                 "minor:1": "8"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "4",
-                "minor:1": "0"
-              }
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -7542,20 +6258,10 @@
                 "micro:2": "0",
                 "minor:1": "8"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "0",
-                "minor:1": "8"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -7609,7 +6315,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -7664,20 +6370,10 @@
                 "micro:2": "4",
                 "minor:1": "0"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "4",
-                "minor:1": "0"
-              }
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -7732,20 +6428,10 @@
                 "micro:2": "4",
                 "minor:1": "0"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "4",
-                "minor:1": "0"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -7792,20 +6478,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -7844,20 +6520,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -7901,7 +6567,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -7943,7 +6609,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -7984,20 +6650,10 @@
                 "micro:2": "7",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "31",
-                "micro:2": "7",
-                "minor:1": "2"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -8040,20 +6696,10 @@
                 "micro:2": "7",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "31",
-                "micro:2": "7",
-                "minor:1": "2"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -8104,20 +6750,10 @@
                 "micro:2": "7",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "31",
-                "micro:2": "7",
-                "minor:1": "2"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -8160,20 +6796,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -8223,7 +6849,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -8269,7 +6895,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -8317,7 +6943,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -8359,7 +6985,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -8400,20 +7026,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -8456,20 +7072,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -8520,20 +7126,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -8588,20 +7184,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -8651,7 +7237,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -8697,7 +7283,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -8742,20 +7328,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -8794,20 +7370,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -8838,15 +7404,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-33_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -8875,15 +7434,8 @@
               "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86_64-33_r04.zip"
             }
           ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            }
-          },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -8927,7 +7479,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -8969,7 +7521,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -9010,20 +7562,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -9066,20 +7608,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -9136,20 +7668,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -9192,20 +7714,10 @@
                 "micro:2": "3",
                 "minor:1": "7"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -9255,7 +7767,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -9301,7 +7813,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -9346,20 +7858,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -9398,20 +7900,10 @@
                 "micro:2": "6",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "6",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -9443,7 +7935,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -9473,7 +7965,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -9517,7 +8009,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -9559,7 +8051,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -9600,20 +8092,10 @@
                 "micro:2": "16",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -9656,20 +8138,10 @@
                 "micro:2": "16",
                 "minor:1": "2"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -9726,20 +8198,10 @@
                 "micro:2": "8",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -9748,7 +8210,6 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "arm64-v8a",
             "abi:3": "arm64-v8a",
             "api-level:0": "34",
             "element-attributes": {
@@ -9783,20 +8244,10 @@
                 "micro:2": "8",
                 "minor:1": "1"
               }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -9805,7 +8256,6 @@
             "major:0": "1"
           },
           "type-details": {
-            "abi:2": "x86_64",
             "abi:3": "x86_64",
             "api-level:0": "34",
             "element-attributes": {
@@ -9835,7 +8285,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -9865,7 +8315,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -9909,7 +8359,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -9951,7 +8401,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -9977,9 +8427,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "50b337d09eff0540022d24e5097f6df29407e7c1",
-              "size": 1776920399,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-35_r08.zip"
+              "sha1": "16f5bceca236b2737008977c4aaf826e46a8de7d",
+              "size": 1778933980,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-35_r09.zip"
             }
           ],
           "dependencies": {
@@ -9995,13 +8445,13 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
           "revision": "35-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "9"
           },
           "type-details": {
             "abi:3": "arm64-v8a",
@@ -10023,9 +8473,9 @@
           "archives": [
             {
               "os": "all",
-              "sha1": "d79169884cabc6680cb29d32c2112ad46c858c1b",
-              "size": 1736662833,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-35_r08.zip"
+              "sha1": "0103e6dab21290c4b9d16550a3ce99476f884eef",
+              "size": 1738815903,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-35_r09.zip"
             }
           ],
           "dependencies": {
@@ -10041,13 +8491,13 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
           "revision": "35-google_apis-x86_64",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "9"
           },
           "type-details": {
             "abi:3": "x86_64",
@@ -10089,7 +8539,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext14/google_apis_playstore/arm64-v8a",
@@ -10135,7 +8585,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext14/google_apis_playstore/x86_64",
@@ -10183,7 +8633,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-page_size_16kb-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
@@ -10229,7 +8679,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-35-page_size_16kb-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
@@ -10279,7 +8729,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis/arm64-v8a",
@@ -10326,7 +8776,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis-x86_64",
           "path": "system-images/android-Baklava/google_apis/x86_64",
@@ -10375,7 +8825,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore/arm64-v8a",
@@ -10422,7 +8872,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis_playstore-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore/x86_64",
@@ -10471,7 +8921,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/arm64-v8a",
@@ -10518,7 +8968,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM Intel x86_64 Atom System Image",
-          "last-available-day": 20112,
+          "last-available-day": 20126,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-page_size_16kb-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/x86_64",
@@ -10530,792 +8980,6 @@
             "abi:4": "x86_64",
             "api-level:0": "35",
             "codename:1": "Baklava",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
-    },
-    "TiramisuPrivacySandbox": {
-      "google_apis": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "fc34553283bcd0a52966e503d2a20f7de33a2600",
-              "size": 1630843209,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-TiramisuPrivacySandbox_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis-arm64-v8a",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis/arm64-v8a",
-          "revision": "TiramisuPrivacySandbox-google_apis-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "47c1b56d4974e4fbe22e36580cf6cfdc6aa1de85",
-              "size": 1521841948,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-TiramisuPrivacySandbox_r01.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis-x86_64",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis/x86_64",
-          "revision": "TiramisuPrivacySandbox-google_apis-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "macosx",
-              "sha1": "d4cb5f1b985cb9f6ee093a00a910c5afc1bb0912",
-              "size": 1592946784,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r09-darwin.zip"
-            },
-            {
-              "os": "linux",
-              "sha1": "d4cb5f1b985cb9f6ee093a00a910c5afc1bb0912",
-              "size": 1592946784,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-TiramisuPrivacySandbox_r09-linux.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/arm64-v8a",
-          "revision": "TiramisuPrivacySandbox-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "9"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "4893f6e62413e97e2bad5f183319d65d3947a375",
-              "size": 1492912127,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-TiramisuPrivacySandbox_r09.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "30",
-                "micro:2": "3",
-                "minor:1": "7"
-              }
-            }
-          },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-preview-license",
-          "name": "system-image-TiramisuPrivacySandbox-google_apis_playstore-x86_64",
-          "path": "system-images/android-TiramisuPrivacySandbox/google_apis_playstore/x86_64",
-          "revision": "TiramisuPrivacySandbox-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "9"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "33",
-            "codename:1": "TiramisuPrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
-    },
-    "UpsideDownCake": {
-      "google_apis": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "2335c0cf2c76cb1883a6d6ee38e6fff99989596f",
-              "size": 1549237055,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-UpsideDownCake_r04.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 19489,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-UpsideDownCake-google_apis-arm64-v8a",
-          "path": "system-images/android-UpsideDownCake/google_apis/arm64-v8a",
-          "revision": "UpsideDownCake-google_apis-arm64-v8a",
-          "revision-details": {
-            "major:0": "4"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "33",
-            "codename:1": "UpsideDownCake",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "15a514144f57865a84abbd6df8e6897c80bb8b88",
-              "size": 1491492723,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-UpsideDownCake_r04.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 19489,
-          "license": "android-sdk-preview-license",
-          "name": "system-image-UpsideDownCake-google_apis-x86_64",
-          "path": "system-images/android-UpsideDownCake/google_apis/x86_64",
-          "revision": "UpsideDownCake-google_apis-x86_64",
-          "revision-details": {
-            "major:0": "4"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "33",
-            "codename:1": "UpsideDownCake",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "macosx",
-              "sha1": "b9f7a7d25450e2385a8334af688ab862fc723dba",
-              "size": 1513459071,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCake_r04-darwin.zip"
-            },
-            {
-              "os": "linux",
-              "sha1": "b9f7a7d25450e2385a8334af688ab862fc723dba",
-              "size": 1513459071,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCake_r04-linux.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 19489,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-UpsideDownCake-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-UpsideDownCake/google_apis_playstore/arm64-v8a",
-          "revision": "UpsideDownCake-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "4"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "33",
-            "codename:1": "UpsideDownCake",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "4647cbb1877cca1394b1a4fff52c644e6220d07a",
-              "size": 1464098477,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-UpsideDownCake_r04.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "patcher;v4"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 19489,
-          "license": "android-sdk-preview-license",
-          "name": "system-image-UpsideDownCake-google_apis_playstore-x86_64",
-          "path": "system-images/android-UpsideDownCake/google_apis_playstore/x86_64",
-          "revision": "UpsideDownCake-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "4"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "33",
-            "codename:1": "UpsideDownCake",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
-    },
-    "UpsideDownCakePrivacySandbox": {
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "macosx",
-              "sha1": "90ccfc150180d529bc96ddc7d4a32249303ebd7f",
-              "size": 1548724067,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCakePrivacySandbox_r03-darwin.zip"
-            },
-            {
-              "os": "linux",
-              "sha1": "90ccfc150180d529bc96ddc7d4a32249303ebd7f",
-              "size": 1548724067,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-UpsideDownCakePrivacySandbox_r03-linux.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-UpsideDownCakePrivacySandbox-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-UpsideDownCakePrivacySandbox/google_apis_playstore/arm64-v8a",
-          "revision": "UpsideDownCakePrivacySandbox-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "3"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "UpsideDownCakePrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "f9b885d496787374be0c8be23eb7b69594c751a5",
-              "size": 1510877347,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-UpsideDownCakePrivacySandbox_r03.zip"
-            }
-          ],
-          "dependencies": {
-            "dependency:0": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            },
-            "dependency:1": {
-              "element-attributes": {
-                "path": "emulator"
-              },
-              "min-revision:0": {
-                "major:0": "32",
-                "micro:2": "8",
-                "minor:1": "1"
-              }
-            }
-          },
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-preview-license",
-          "name": "system-image-UpsideDownCakePrivacySandbox-google_apis_playstore-x86_64",
-          "path": "system-images/android-UpsideDownCakePrivacySandbox/google_apis_playstore/x86_64",
-          "revision": "UpsideDownCakePrivacySandbox-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "3"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "UpsideDownCakePrivacySandbox",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      }
-    },
-    "VanillaIceCream": {
-      "google_apis": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "896dec0aaae40954e2da30527f0763f292511217",
-              "size": 1737853248,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-VanillaIceCream-google_apis-arm64-v8a",
-          "path": "system-images/android-VanillaIceCream/google_apis/arm64-v8a",
-          "revision": "VanillaIceCream-google_apis-arm64-v8a",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "arm64-v8a",
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "2efa686b5a420f3b9cb30e45a1e0e78a10a5fba8",
-              "size": 1682110854,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-VanillaIceCream-google_apis-x86_64",
-          "path": "system-images/android-VanillaIceCream/google_apis/x86_64",
-          "revision": "VanillaIceCream-google_apis-x86_64",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "x86_64",
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google APIs",
-              "id:0": "google_apis"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "google_apis_playstore": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "41c8b6df52b60c76881fa5f819363678f9ef096c",
-              "size": 1745670932,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-VanillaIceCream-google_apis_playstore-arm64-v8a",
-          "path": "system-images/android-VanillaIceCream/google_apis_playstore/arm64-v8a",
-          "revision": "VanillaIceCream-google_apis_playstore-arm64-v8a",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "arm64-v8a",
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "0d4c047003eaa8c78698f9aea0708e71b0895248",
-              "size": 1704139494,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-VanillaIceCream_r05.zip"
-            }
-          ],
-          "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-VanillaIceCream-google_apis_playstore-x86_64",
-          "path": "system-images/android-VanillaIceCream/google_apis_playstore/x86_64",
-          "revision": "VanillaIceCream-google_apis_playstore-x86_64",
-          "revision-details": {
-            "major:0": "5"
-          },
-          "type-details": {
-            "abi:3": "x86_64",
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "Google Play",
-              "id:0": "google_apis_playstore"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        }
-      },
-      "page_size_16kb": {
-        "arm64-v8a": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "167fc0f1baae778d3382a7ec4a463a1bfbc3253c",
-              "size": 1392391828,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-ps16k-VanillaIceCream_r01.zip"
-            }
-          ],
-          "displayName": "Pre-Release 16 KB Page Size Google APIs ARM 64 v8a System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-arm-dbt-license",
-          "name": "system-image-VanillaIceCream-page_size_16kb-arm64-v8a",
-          "path": "system-images/android-VanillaIceCream/google_apis_ps16k/arm64-v8a",
-          "revision": "VanillaIceCream-page_size_16kb-arm64-v8a",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "arm64-v8a",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
-            "element-attributes": {
-              "xsi:type": "ns12:sysImgDetailsType"
-            },
-            "tag:2": {
-              "display:1": "16 KB Page Size",
-              "id:0": "page_size_16kb"
-            },
-            "vendor:3": {
-              "display:1": "Google Inc.",
-              "id:0": "google"
-            }
-          }
-        },
-        "x86_64": {
-          "archives": [
-            {
-              "os": "all",
-              "sha1": "4a48eab34ea526f9a4cd60948ed7e6698b3e5cfd",
-              "size": 1332306731,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-ps16k-VanillaIceCream_r01.zip"
-            }
-          ],
-          "displayName": "Pre-Release 16 KB Page Size Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 19954,
-          "license": "android-sdk-license",
-          "name": "system-image-VanillaIceCream-page_size_16kb-x86_64",
-          "path": "system-images/android-VanillaIceCream/google_apis_ps16k/x86_64",
-          "revision": "VanillaIceCream-page_size_16kb-x86_64",
-          "revision-details": {
-            "major:0": "1"
-          },
-          "type-details": {
-            "abi:4": "x86_64",
-            "api-level:0": "34",
-            "codename:1": "VanillaIceCream",
             "element-attributes": {
               "xsi:type": "ns12:sysImgDetailsType"
             },
@@ -11384,15 +9048,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r17-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11430,15 +9087,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11476,15 +9126,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11522,15 +9165,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r18.1.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11568,15 +9204,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11614,15 +9243,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11660,15 +9282,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11706,15 +9321,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11752,15 +9360,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r19.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -11797,15 +9398,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r20-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -11842,15 +9436,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11888,15 +9475,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11934,15 +9514,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -11980,15 +9553,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -12026,15 +9592,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -12072,15 +9631,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r21.1.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -12117,15 +9669,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r22-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -12163,15 +9708,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r22.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -12208,15 +9746,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -12254,15 +9785,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -12299,15 +9823,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -12344,15 +9861,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r23.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -12389,15 +9899,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -12434,15 +9937,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -12479,15 +9975,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -12524,15 +10013,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r24.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -12569,15 +10051,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -12614,15 +10089,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -12659,15 +10127,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -12704,15 +10165,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r25.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -12749,15 +10203,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -12794,15 +10241,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -12839,15 +10279,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -12884,15 +10317,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r26.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -12929,15 +10355,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -12974,15 +10393,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -13019,15 +10431,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -13064,15 +10469,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r27.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -13109,15 +10507,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -13154,15 +10545,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-rc1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -13201,15 +10585,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28-rc2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -13248,15 +10625,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -13293,15 +10663,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -13338,15 +10701,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r28.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -13383,15 +10739,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -13428,15 +10777,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -13475,15 +10817,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -13522,15 +10857,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29-rc3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -13569,15 +10897,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -13614,15 +10935,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -13659,15 +10973,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r29.0.3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -13704,15 +11011,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r30-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -13749,15 +11049,8 @@
             "url": "https://dl.google.com/android/repository/build-tools_r30.0.1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -13794,15 +11087,8 @@
             "url": "https://dl.google.com/android/repository/efbaa277338195608aa4e3dbd43927e97f60218c.build-tools_r30.0.2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -13839,15 +11125,8 @@
             "url": "https://dl.google.com/android/repository/f6d24b187cc6bd534c6c37604205171784ac5621.build-tools_r30.0.3-macosx.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "tools"
-            }
-          }
-        },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -13885,7 +11164,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -13923,7 +11202,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -13961,7 +11240,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -14000,7 +11279,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -14038,7 +11317,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -14076,7 +11355,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -14114,7 +11393,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -14152,7 +11431,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -14190,7 +11469,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -14229,7 +11508,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -14268,7 +11547,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -14278,45 +11557,6 @@
           "micro:2": "0",
           "minor:1": "0",
           "preview:3": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.0.0-rc4": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "61f7cfa64786bffbf6c6c9a3d74d025a07239928",
-            "size": 61206867,
-            "url": "https://dl.google.com/android/repository/build-tools_r34-rc4-linux.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "522431b33cd7fa1407914a8fa66a27bfe1755cbb",
-            "size": 76553187,
-            "url": "https://dl.google.com/android/repository/build-tools_r34-rc4-macosx.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "699f1cb99a8de88b1746ce12302d6c2ddce81186",
-            "size": 58219308,
-            "url": "https://dl.google.com/android/repository/build-tools_r34-rc4-windows.zip"
-          }
-        ],
-        "displayName": "Android SDK Build-Tools 34-rc4",
-        "last-available-day": 19489,
-        "license": "android-sdk-preview-license",
-        "name": "build-tools",
-        "path": "build-tools/34.0.0-rc4",
-        "revision": "34.0.0-rc4",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "0",
-          "minor:1": "0",
-          "preview:3": "4"
         },
         "type-details": {
           "element-attributes": {
@@ -14346,7 +11586,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -14384,7 +11624,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -14423,7 +11663,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -14462,7 +11702,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -14501,7 +11741,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -14540,7 +11780,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -14578,7 +11818,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -14617,7 +11857,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -14656,7 +11896,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -14697,7 +11937,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -14735,7 +11975,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -14773,7 +12013,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -14811,7 +12051,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -14849,7 +12089,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -14887,7 +12127,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -14925,7 +12165,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -14963,7 +12203,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -15001,7 +12241,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -15009,6 +12249,44 @@
         "revision-details": {
           "major:0": "3",
           "micro:2": "4",
+          "minor:1": "31"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "3.31.5": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "823156dfed8f1e4bf1a82bbc9c41a5415546b8ac",
+            "size": 30482790,
+            "url": "https://dl.google.com/android/repository/cmake-3.31.5-linux.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "4c28c635f08638494ce563ffa7d26d1c43a50190",
+            "size": 42792306,
+            "url": "https://dl.google.com/android/repository/cmake-3.31.5-darwin.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "6a51cf2d1f300edecbf04603087a31b07a0fcdec",
+            "size": 20465729,
+            "url": "https://dl.google.com/android/repository/cmake-3.31.5-windows.zip"
+          }
+        ],
+        "displayName": "CMake 3.31.5",
+        "last-available-day": 20126,
+        "license": "android-sdk-license",
+        "name": "cmake",
+        "path": "cmake/3.31.5",
+        "revision": "3.31.5",
+        "revision-details": {
+          "major:0": "3",
+          "micro:2": "5",
           "minor:1": "31"
         },
         "type-details": {
@@ -15039,7 +12317,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -15079,7 +12357,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -15116,7 +12394,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -15124,44 +12402,6 @@
         "revision-details": {
           "major:0": "10",
           "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "10.0-rc04": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "fe41906d2ce82df4cde74fe258e0ccdb283de60a",
-            "size": 138718717,
-            "url": "https://dl.google.com/android/repository/commandlinetools-linux-9645777_latest.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "021540982a843ae2c9b4e0a5c2034b29681b4f70",
-            "size": 138718701,
-            "url": "https://dl.google.com/android/repository/commandlinetools-mac-9645777_latest.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "9c3877a2926c1e73af981964b0f4381a6d68fb21",
-            "size": 138694572,
-            "url": "https://dl.google.com/android/repository/commandlinetools-win-9645777_latest.zip"
-          }
-        ],
-        "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 19489,
-        "license": "android-sdk-preview-license",
-        "name": "cmdline-tools",
-        "path": "cmdline-tools/10.0-beta04",
-        "revision": "10.0-rc04",
-        "revision-details": {
-          "major:0": "10",
-          "minor:1": "0",
-          "preview:2": "04"
         },
         "type-details": {
           "element-attributes": {
@@ -15191,7 +12431,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -15199,82 +12439,6 @@
         "revision-details": {
           "major:0": "11",
           "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "11.0-rc01": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "26048ffc9a0b0b6ef0fe491e3796486d2387f043",
-            "size": 148831286,
-            "url": "https://dl.google.com/android/repository/commandlinetools-linux-10320515_latest.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "8cf501a4efbcc3be6bc15a48ad17fcda8bf03116",
-            "size": 148831270,
-            "url": "https://dl.google.com/android/repository/commandlinetools-mac-10320515_latest.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "fe8694f50bf5b132c0c92f4a695f51aac71c8f27",
-            "size": 148807141,
-            "url": "https://dl.google.com/android/repository/commandlinetools-win-10320515_latest.zip"
-          }
-        ],
-        "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 19666,
-        "license": "android-sdk-preview-license",
-        "name": "cmdline-tools",
-        "path": "cmdline-tools/11.0-rc01",
-        "revision": "11.0-rc01",
-        "revision-details": {
-          "major:0": "11",
-          "minor:1": "0",
-          "preview:2": "01"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "11.0-rc07": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "c43e4fb8567c4625e8daf4cee0a5490f826a5442",
-            "size": 147822296,
-            "url": "https://dl.google.com/android/repository/commandlinetools-linux-9644228_latest.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "2c97234849128cb75b0691cf652ab098707c610c",
-            "size": 147822280,
-            "url": "https://dl.google.com/android/repository/commandlinetools-mac-9644228_latest.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "2bfc8fad022acce100a5b0583def1ca5bc56eff1",
-            "size": 147798151,
-            "url": "https://dl.google.com/android/repository/commandlinetools-win-9644228_latest.zip"
-          }
-        ],
-        "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 19489,
-        "license": "android-sdk-preview-license",
-        "name": "cmdline-tools",
-        "path": "cmdline-tools/11.0-alpha07",
-        "revision": "11.0-rc07",
-        "revision-details": {
-          "major:0": "11",
-          "minor:1": "0",
-          "preview:2": "07"
         },
         "type-details": {
           "element-attributes": {
@@ -15304,7 +12468,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -15312,44 +12476,6 @@
         "revision-details": {
           "major:0": "12",
           "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "12.0-rc15": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "9f67d98e686616bf92122b03051f02f695b11415",
-            "size": 153543827,
-            "url": "https://dl.google.com/android/repository/commandlinetools-linux-10572941_latest.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "feac1c4ad5e78e506cb55216181f3c5b58219e90",
-            "size": 153543811,
-            "url": "https://dl.google.com/android/repository/commandlinetools-mac-10572941_latest.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "4956c615fa087f5a716ffde76684085366c5a5bf",
-            "size": 153519682,
-            "url": "https://dl.google.com/android/repository/commandlinetools-win-10572941_latest.zip"
-          }
-        ],
-        "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 19666,
-        "license": "android-sdk-preview-license",
-        "name": "cmdline-tools",
-        "path": "cmdline-tools/12.0-alpha15",
-        "revision": "12.0-rc15",
-        "revision-details": {
-          "major:0": "12",
-          "minor:1": "0",
-          "preview:2": "15"
         },
         "type-details": {
           "element-attributes": {
@@ -15379,7 +12505,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -15416,7 +12542,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -15454,7 +12580,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -15492,7 +12618,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -15529,7 +12655,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -15567,7 +12693,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
@@ -15575,6 +12701,44 @@
         "revision-details": {
           "major:0": "17",
           "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "19.0-rc01": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "f25edbe00eccf74e940abb8d9872b7120c3942a3",
+            "size": 164759933,
+            "url": "https://dl.google.com/android/repository/commandlinetools-linux-12996373_latest.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "de2df8ad8705f3be6de366c953e4cb3e3a0b9f6c",
+            "size": 143250486,
+            "url": "https://dl.google.com/android/repository/commandlinetools-mac-12996373_latest.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "26805d62669b20af583074f67926e31600e43185",
+            "size": 143039915,
+            "url": "https://dl.google.com/android/repository/commandlinetools-win-12996373_latest.zip"
+          }
+        ],
+        "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 20126,
+        "license": "android-sdk-preview-license",
+        "name": "cmdline-tools",
+        "path": "cmdline-tools/19.0-alpha01",
+        "revision": "19.0-rc01",
+        "revision-details": {
+          "major:0": "19",
+          "minor:1": "0",
+          "preview:2": "01"
         },
         "type-details": {
           "element-attributes": {
@@ -15604,7 +12768,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -15642,7 +12806,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -15679,7 +12843,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -15716,7 +12880,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -15753,7 +12917,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -15790,7 +12954,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -15827,7 +12991,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -15864,7 +13028,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -15901,7 +13065,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -15918,912 +13082,6 @@
       }
     },
     "emulator": {
-      "31.3.10": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "4a35a2702f9138653cd1b67d04e01ffa65fb37bc",
-            "size": 347308456,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-8807927.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "43df6ed553b89e1553d588251526aae8f79da214",
-            "size": 293822881,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-8807927.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "52f8bfa4a09074e607d393302fe8a627846a18e9",
-            "size": 380246403,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-8807927.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19469,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "31.3.10",
-        "revision-details": {
-          "major:0": "31",
-          "micro:2": "10",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "31.3.14": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "b5ab96ebffc6ea6816a5b0e9474859463b21ab78",
-            "size": 293826836,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9322596.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "632eba430f67abeddcf15ceb0a872b25fdbb7e62",
-            "size": 381130167,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9322596.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "00e8685beffbe19f803cd5d698fbe6406b5ee6f3",
-            "size": 347313356,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9322596.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19469,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "31.3.14",
-        "revision-details": {
-          "major:0": "31",
-          "micro:2": "14",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "32.1.10": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "518eaa8575a2e5ae7bbb19847e0c25b7968a9e91",
-            "size": 309316195,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9475343.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "71ef457eeeee6b55382abf4a5aaab5de7426e383",
-            "size": 270160041,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9475343.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "a53b8e1026325b48cb722d91deeb128947971b8f",
-            "size": 333004087,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9475343.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "32.1.10",
-        "revision-details": {
-          "major:0": "32",
-          "micro:2": "10",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "32.1.12": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "556fb884d6e72b597bf5c1fa959f59744994fb68",
-            "size": 270165820,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9751036.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "0ee17dd9b4410d38dc2f6a6227e899d6910b2c55",
-            "size": 332999329,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9751036.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "d37d6e301f36d8f0797ca96a3fd6b8ee5f8d46ae",
-            "size": 307219070,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9751036.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19489,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "32.1.12",
-        "revision-details": {
-          "major:0": "32",
-          "micro:2": "12",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "32.1.14": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "04bab7711660fc9891fd5dec347a9f533a87af1a",
-            "size": 270178945,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10330179.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "f039bd816f82cda85ee4a2e14497bd00a1998867",
-            "size": 333010879,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10330179.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "3db11e3541bfced7dbaadc976a13045fd7e1bbcc",
-            "size": 309337702,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10330179.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "32.1.14",
-        "revision-details": {
-          "major:0": "32",
-          "micro:2": "14",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "32.1.15": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "b78f4d2c22d6aa5ca83d26ccb68cbf885a273888",
-            "size": 270191252,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10696886.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "90bd9f6de3473fe54c779cda87b67a4f381a1ed5",
-            "size": 333020049,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10696886.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "5e53ac67e346cc9b575e2d8cbeac836456218f96",
-            "size": 309355067,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10696886.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19666,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "32.1.15",
-        "revision-details": {
-          "major:0": "32",
-          "micro:2": "15",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "32.1.8": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "13cadd038b401fdfa04e4af153a7f696ccd422cc",
-            "size": 309314692,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9310560.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "7d82689a73aacdd56684d7134dc88cc3537fb911",
-            "size": 270158359,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9310560.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "8324aeb3bd74a214978252c51574b40cdb56b4ba",
-            "size": 333001267,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9310560.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19469,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "32.1.8",
-        "revision-details": {
-          "major:0": "32",
-          "micro:2": "8",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "33.1.10": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "f38b9ec7e9c9ff3b8c4022e7f9baa1d6622634a0",
-            "size": 325272345,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10078095.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "e97f77ce116ff8fb13bd8f89a2097cc4ab1dbc67",
-            "size": 180494623,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10078095.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "8738b20ee568c4e6a84b66b1fa848517db646c47",
-            "size": 354011689,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10078095.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19489,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "33.1.10",
-        "revision-details": {
-          "major:0": "33",
-          "micro:2": "10",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "33.1.17": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "cd989b0594ebe9382749b3a5dc026acb326e4de0",
-            "size": 341193257,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10594030.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "72c3fb1591755ee5f5d662114a394d08247efc13",
-            "size": 261440080,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10594030.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "cc302b5107e64348e957e4738530bcfbb58212a8",
-            "size": 363656447,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10594030.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19579,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "33.1.17",
-        "revision-details": {
-          "major:0": "33",
-          "micro:2": "17",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "33.1.20": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "8c42e2bbef2e05bc49b75c7db85ed64e760bf8bf",
-            "size": 323263766,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10871397.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "e3f5d94d29951964cbcdd09e2950d9a674664ac8",
-            "size": 252025229,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10871397.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "4be4223b1459a7f04a00abdc9e0532650f024210",
-            "size": 365300834,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10871397.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19666,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "33.1.20",
-        "revision-details": {
-          "major:0": "33",
-          "micro:2": "20",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "33.1.4": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "33be82356a352b79b742154f7c71f6f13455f27b",
-            "size": 345831055,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-9936625.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "cfa28a326b6328e2f3a068ac3030a075471d9df0",
-            "size": 260288819,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-9936625.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "0aab97a7b84853c8f8c7618191dc23416e2a7a4b",
-            "size": 373623936,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-9936625.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19469,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "33.1.4",
-        "revision-details": {
-          "major:0": "33",
-          "micro:2": "4",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "33.1.6": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "a31338f160fc5fa7973946d34a0d0ce1a2c0759a",
-            "size": 332134756,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-10047184.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "9f5c71277f52837d4fb43f72c80103bdf81c0569",
-            "size": 254562719,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-10047184.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "11ba13425c6fcd275f5e1aa95923f736dd2bcb64",
-            "size": 361497029,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-10047184.zip"
-          }
-        ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
-        "displayName": "Android Emulator",
-        "last-available-day": 19489,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "33.1.6",
-        "revision-details": {
-          "major:0": "33",
-          "micro:2": "6",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.1.19": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "d6cc94109b081c5f6042dcb71a453144f7e62ce7",
-            "size": 249458354,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11525734.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "cc0736b8af11d1e74e03ab13dfc214217d06626b",
-            "size": 324283427,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11525734.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "089de1942b9cc5d96c60c92fdad286434c340124",
-            "size": 363522255,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11525734.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19813,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "34.1.19",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "19",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.1.9": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "5d59f7b706d09c339f04dae6dc36f226c2b21381",
-            "size": 327266989,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11009885.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "ba6ffcefd507be5fc14d1319a60c92c5d80c0ea3",
-            "size": 253085442,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11009885.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "7ef53d77d429f77952b643062947c97dac8e2167",
-            "size": 367238620,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11009885.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19666,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "34.1.9",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "9",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.2.11": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "b1d6652408c1e5015ce2f590270aee7b0b19fb07",
-            "size": 298395480,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11592276.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "f363626bc90b00e2d7cf8ceef9dcb295d3f7f292",
-            "size": 394402351,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11592276.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "797a55cb5139c96eb17faca0b816b940eb006468",
-            "size": 418099397,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11592276.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19823,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "34.2.11",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "11",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.2.16": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "fe7a96bf6fbe7b026555dd7f76b713f22a07ec8b",
-            "size": 292750827,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12038310.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "8da9494f5a08c2a04f50aeef543fd32ca8424f12",
-            "size": 387388734,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12038310.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "76a5cbca04dc11bc04421e30392e78ab3b744d33",
-            "size": 412503831,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12038310.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "34.2.16",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "16",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.1.19": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "728fb67266a7648aee58c1f4eaadeb8781c646d8",
-            "size": 295185796,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12171648.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "a7c61d2f057186e54f41e0573f5cb5659daca9c4",
-            "size": 390781280,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12171648.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "a954a95bf3f49907ea8e3b4dbeda8f963394540c",
-            "size": 420058404,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12171648.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.1.19",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "19",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.1.2": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "c066c3d65b5a7454e039516ecc6a73b0ab754c17",
-            "size": 298454913,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11616444.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "bf5eaf896dbfdbb832fd38255bace1658e524534",
-            "size": 394769949,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11616444.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "dd37d4ab4e4655aea04b1ecc66fe4e4187b382e9",
-            "size": 423453316,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11616444.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19813,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.1.2",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "2",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.1.3": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "1fa0fe4bc06558a6bdbf622de1df6659c86fa832",
-            "size": 298471131,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11643238.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "8c082cc61fff70561e41df68de78081a86b24bc8",
-            "size": 394818583,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11643238.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "5128479f4d3eaef70f5412b665f6a706bbf2d898",
-            "size": 423494132,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11643238.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19823,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.1.3",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "3",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.1.4": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "28c76739fbca9f2c879eb51f960aeaffacfd2ecd",
-            "size": 349797729,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-11672324.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "27da156d86d02ca82f898ac8adb0bfd7147e3f08",
-            "size": 414289925,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-11672324.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "f8083528676b40f2592133cdb4eaf4809cdfa164",
-            "size": 463059783,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-11672324.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19823,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.1.4",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "4",
-          "minor:1": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.2.5": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "cc22b6fb2d6dbb17f436af29364929aba5f776ae",
-            "size": 301992613,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12205771.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "32e32d993b1af0c4c93a3aed775baeed881e0ce7",
-            "size": 399727915,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12205771.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "739dd017682373c745ec60189d2cb52be016181d",
-            "size": 426685873,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12205771.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 19954,
-        "license": "android-sdk-preview-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.2.5",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "5",
-          "minor:1": "2"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.3.10": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "1ee50867296f9b594ba2fa1a4f84a624cdd69e35",
-            "size": 303581032,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12721668.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "d1170e33688db3cce7e79804e6ed66037321469d",
-            "size": 400795998,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12721668.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "2e751a972fab5a96b2d82a7c8bb27fcfc65da031",
-            "size": 426363761,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12721668.zip"
-          }
-        ],
-        "displayName": "Android Emulator",
-        "last-available-day": 20112,
-        "license": "android-sdk-license",
-        "name": "emulator",
-        "path": "emulator",
-        "revision": "35.3.10",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "10",
-          "minor:1": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "35.3.11": {
         "archives": [
           {
@@ -16846,7 +13104,7 @@
           }
         ],
         "displayName": "Android Emulator",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
@@ -16862,37 +13120,75 @@
           }
         }
       },
-      "35.4.6": {
+      "35.4.8": {
         "archives": [
           {
             "os": "linux",
-            "sha1": "fb077c566b882aeaed465d91b7313cd739cfc35d",
-            "size": 303702485,
-            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12930357.zip"
+            "sha1": "9ed664edb9c2f59df8ba322e0703d3f5a87b8990",
+            "size": 298120058,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12990073.zip"
           },
           {
             "os": "macosx",
-            "sha1": "7f337706bdb6d3da3dca20be433c3af2bc944bd1",
-            "size": 401067221,
-            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12930357.zip"
+            "sha1": "40bd8f2332068eb11492640cbeb3267293585606",
+            "size": 393815670,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12990073.zip"
           },
           {
             "os": "windows",
-            "sha1": "0230221cb125140c7ce346525ca1a46e861881f9",
-            "size": 427996108,
-            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12930357.zip"
+            "sha1": "c8fc55380f321455a8cd515bfc6289b21fdfd5d5",
+            "size": 421986278,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12990073.zip"
           }
         ],
         "displayName": "Android Emulator",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "35.4.8",
+        "revision-details": {
+          "major:0": "35",
+          "micro:2": "8",
+          "minor:1": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "35.5.1": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "2606063af3b1610d93e01ff7b91e4ff150956f40",
+            "size": 303655749,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12973260.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "d1a543e56d2f035144f73be56a45ff3f5d9de3e8",
+            "size": 400948772,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12973260.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "063e558202ef357a6e096462359e5e941f56d5e2",
+            "size": 429039306,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12973260.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "emulator",
         "path": "emulator",
-        "revision": "35.4.6",
+        "revision": "35.5.1",
         "revision-details": {
           "major:0": "35",
-          "micro:2": "6",
-          "minor:1": "4"
+          "micro:2": "1",
+          "minor:1": "5"
         },
         "type-details": {
           "element-attributes": {
@@ -16923,15 +13219,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -16968,15 +13257,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -17013,15 +13295,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r18b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -17058,15 +13333,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -17104,15 +13372,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -17149,15 +13410,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -17196,15 +13450,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -17243,15 +13490,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -17288,15 +13528,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -17333,15 +13566,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -17379,15 +13605,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -17424,15 +13643,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -17470,15 +13682,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -17516,15 +13721,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -17561,15 +13759,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -17607,15 +13798,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -17652,15 +13836,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -17697,15 +13874,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -17742,15 +13912,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -17788,15 +13951,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -17833,15 +13989,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -17878,15 +14027,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -17924,15 +14066,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -17970,15 +14105,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -18016,15 +14144,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta4-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -18062,15 +14183,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta5-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -18108,15 +14222,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta6-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -18154,15 +14261,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -18199,15 +14299,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23b-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -18244,15 +14337,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23c-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -18289,15 +14375,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-beta1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -18335,15 +14414,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-beta2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -18381,15 +14453,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-rc1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -18427,15 +14492,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r24-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -18472,15 +14530,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -18518,15 +14569,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta2-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -18564,15 +14608,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta3-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -18610,15 +14647,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-beta4-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -18656,15 +14686,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -18701,15 +14724,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25b-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -18746,15 +14762,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r25c-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -18791,15 +14800,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r26-beta1-windows.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -18838,7 +14840,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -18877,7 +14879,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -18915,7 +14917,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -18953,7 +14955,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -18991,7 +14993,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -19029,7 +15031,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -19068,7 +15070,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -19107,7 +15109,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -19145,7 +15147,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -19183,7 +15185,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -19221,7 +15223,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -19260,7 +15262,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -19299,7 +15301,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -19309,6 +15311,44 @@
           "micro:2": "12916984",
           "minor:1": "0",
           "preview:3": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "28.0.13004108": {
+        "archives": [
+          {
+            "os": "linux",
+            "sha1": "894f469c5192a116d21f412de27966140a530ebc",
+            "size": 723148067,
+            "url": "https://dl.google.com/android/repository/android-ndk-r28-linux.zip"
+          },
+          {
+            "os": "macosx",
+            "sha1": "da6bbb3d007095658ae61d9d85da8fcc5c0dfb66",
+            "size": 950413046,
+            "url": "https://dl.google.com/android/repository/android-ndk-r28-darwin.zip"
+          },
+          {
+            "os": "windows",
+            "sha1": "f79a00c721dc5c15b2bf093d7bb2af96496a42b2",
+            "size": 748943210,
+            "url": "https://dl.google.com/android/repository/android-ndk-r28-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 28.0.13004108",
+        "last-available-day": 20126,
+        "license": "android-sdk-license",
+        "name": "ndk",
+        "path": "ndk/28.0.13004108",
+        "revision": "28.0.13004108",
+        "revision-details": {
+          "major:0": "28",
+          "micro:2": "13004108",
+          "minor:1": "0"
         },
         "type-details": {
           "element-attributes": {
@@ -19339,15 +15379,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r16b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19384,15 +15417,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r17c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19429,15 +15455,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r18b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19474,15 +15493,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -19520,15 +15532,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r19c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19565,15 +15570,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -19612,15 +15610,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -19659,15 +15650,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19704,15 +15688,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r20b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19749,15 +15726,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19795,15 +15765,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19840,15 +15803,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19886,15 +15842,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19932,15 +15881,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -19977,15 +15919,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21b-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20023,15 +15958,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21c-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20068,15 +15996,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21d-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20113,15 +16034,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r21e-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20158,15 +16072,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20204,15 +16111,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20249,15 +16149,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r22b-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20294,15 +16187,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta1-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20340,15 +16226,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta2-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20386,15 +16265,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta3-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20432,15 +16304,8 @@
             "url": "https://dl.google.com/android/repository/android-ndk-r23-beta4-windows-x86_64.zip"
           }
         ],
-        "dependencies": {
-          "dependency:0": {
-            "element-attributes": {
-              "path": "patcher;v4"
-            }
-          }
-        },
         "displayName": "NDK",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -20458,223 +16323,7 @@
         }
       }
     },
-    "patcher": {
-      "1": {
-        "archives": [
-          {
-            "os": "all",
-            "sha1": "046699c5e2716ae11d77e0bad814f7f33fab261e",
-            "size": 1827327,
-            "url": "https://dl.google.com/android/repository/3534162-studio.sdk-patcher.zip"
-          }
-        ],
-        "displayName": "SDK Patch Applier v4",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "patcher",
-        "path": "patcher/v4",
-        "revision": "1",
-        "revision-details": {
-          "major:0": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      }
-    },
     "platform-tools": {
-      "33.0.3": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "250da3216e4c93ccd2612dcec0b64c2668354b09",
-            "size": 12767128,
-            "url": "https://dl.google.com/android/repository/platform-tools_r33.0.3-darwin.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "deb43a0f9eaccd16a47937367ef3b53db3db8d10",
-            "size": 7505569,
-            "url": "https://dl.google.com/android/repository/platform-tools_r33.0.3-linux.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "6028a80149c0ccde2db22d69e7fe84a352d852a2",
-            "size": 5642796,
-            "url": "https://dl.google.com/android/repository/platform-tools_r33.0.3-windows.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 19469,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "33.0.3",
-        "revision-details": {
-          "major:0": "33",
-          "micro:2": "3",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.0.1": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "40f24dc4f2baf911ccb2a53c14bfb69fb8088c57",
-            "size": 11215880,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.1-darwin.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "7e8f205a0cfe574ffecb6ec41e6496f5328211fd",
-            "size": 6336109,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.1-linux.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "3806f15fddb6ffc5ce38efe78df1708be666a9f4",
-            "size": 6079357,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.1-windows.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 19489,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "34.0.1",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "1",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.0.4": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "ecc476b9801fcb6ea61605eedf60f85217964f09",
-            "size": 11208015,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.4-darwin.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "faaac1c05af0e3fa20baee6e8970d96fb53bfe58",
-            "size": 6325905,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.4-linux.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "d245eedc17259b15e799c312e9014f78aea3da21",
-            "size": 5992467,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.4-windows.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 19579,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "34.0.4",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "4",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "34.0.5": {
-        "archives": [
-          {
-            "os": "macosx",
-            "sha1": "2650ee512964f189f6a4838cf50a62f398349bbf",
-            "size": 11194858,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.5-darwin.zip"
-          },
-          {
-            "os": "linux",
-            "sha1": "96097475cf7b279fdd8f218f5d043ffe94104ec3",
-            "size": 6333075,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.5-linux.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "a390d5e377a985476612038335ed5ac6d27c12e4",
-            "size": 5909544,
-            "url": "https://dl.google.com/android/repository/platform-tools_r34.0.5-windows.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 19666,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "34.0.5",
-        "revision-details": {
-          "major:0": "34",
-          "micro:2": "5",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "35.0.1": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "959bf20c19ab1c82861ae4a7e7fdb293f4f1fe75",
-            "size": 7035310,
-            "url": "https://dl.google.com/android/repository/platform-tools_r35.0.1-linux.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "a54ebb00559f3e4582d8e06fc04bab7ce0a2a6c2",
-            "size": 12476293,
-            "url": "https://dl.google.com/android/repository/platform-tools_r35.0.1-darwin.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "bef587e13dda79457631574b5ee93c0c596b592f",
-            "size": 6551888,
-            "url": "https://dl.google.com/android/repository/platform-tools_r35.0.1-win.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 19823,
-        "license": "android-sdk-license",
-        "name": "platform-tools",
-        "path": "platform-tools",
-        "revision": "35.0.1",
-        "revision-details": {
-          "major:0": "35",
-          "micro:2": "1",
-          "minor:1": "0"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "35.0.2": {
         "archives": [
           {
@@ -20697,7 +16346,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -20725,7 +16374,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -20757,7 +16406,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -20789,7 +16438,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -20821,7 +16470,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -20853,7 +16502,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -20885,7 +16534,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -20917,7 +16566,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -20949,7 +16598,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -20981,7 +16630,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -21013,7 +16662,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -21057,7 +16706,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -21090,7 +16739,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -21122,7 +16771,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -21154,7 +16803,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -21186,7 +16835,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -21218,7 +16867,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -21250,7 +16899,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -21282,7 +16931,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -21314,7 +16963,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -21346,7 +16995,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -21378,7 +17027,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -21422,7 +17071,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -21455,7 +17104,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -21487,7 +17136,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -21519,7 +17168,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -21551,7 +17200,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -21583,7 +17232,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -21594,17 +17243,10 @@
         },
         "type-details": {
           "api-level:0": "34",
-          "codename:1": {
-          },
           "element-attributes": {
             "xsi:type": "ns11:platformDetailsType"
           },
           "layoutlib:1": {
-            "element-attributes": {
-              "api": "15"
-            }
-          },
-          "layoutlib:2": {
             "element-attributes": {
               "api": "15"
             }
@@ -21615,13 +17257,13 @@
         "archives": [
           {
             "os": "all",
-            "sha1": "2a0b06a1c89b52a3d70ce5d40554b094c1c1d0ac",
-            "size": 64281656,
+            "sha1": "0bb560a90a7a2cbd0dd8348224d518b638fe7949",
+            "size": 64273788,
             "url": "https://dl.google.com/android/repository/platform-35_r02.zip"
           }
         ],
         "displayName": "Android SDK Platform 35-ext14",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -21663,7 +17305,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -21708,7 +17350,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -21753,7 +17395,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -21786,7 +17428,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -21818,7 +17460,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -21850,7 +17492,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -21882,7 +17524,7 @@
           }
         ],
         "displayName": "Android SDK Platform Baklava",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-Baklava",
@@ -21903,37 +17545,6 @@
           }
         }
       },
-      "TiramisuPrivacySandbox": {
-        "archives": [
-          {
-            "os": "all",
-            "sha1": "6bc5e85cd2ea54df4dae036ff20fb0e889a6835e",
-            "size": 67663071,
-            "url": "https://dl.google.com/android/repository/platform-TiramisuPrivacySandbox_r09.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform TiramisuPrivacySandbox",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "platforms",
-        "path": "platforms/android-TiramisuPrivacySandbox",
-        "revision": "TiramisuPrivacySandbox",
-        "revision-details": {
-          "major:0": "9"
-        },
-        "type-details": {
-          "api-level:0": "33",
-          "codename:1": "TiramisuPrivacySandbox",
-          "element-attributes": {
-            "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
-          }
-        }
-      },
       "UpsideDownCake": {
         "archives": [
           {
@@ -21944,7 +17555,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -21965,107 +17576,9 @@
             }
           }
         }
-      },
-      "UpsideDownCakePrivacySandbox": {
-        "archives": [
-          {
-            "os": "all",
-            "sha1": "693beff31fe890c670efe34498c761ebe425ac8f",
-            "size": 64049813,
-            "url": "https://dl.google.com/android/repository/platform-UpsideDownCakePrivacySandbox_r03.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform UpsideDownCakePrivacySandbox",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "platforms",
-        "path": "platforms/android-UpsideDownCakePrivacySandbox",
-        "revision": "UpsideDownCakePrivacySandbox",
-        "revision-details": {
-          "major:0": "3"
-        },
-        "type-details": {
-          "api-level:0": "34",
-          "codename:1": "UpsideDownCakePrivacySandbox",
-          "element-attributes": {
-            "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
-          }
-        }
-      },
-      "VanillaIceCream": {
-        "archives": [
-          {
-            "os": "all",
-            "sha1": "593df928592daf8e8b904a1680f54be715b32e98",
-            "size": 64462100,
-            "url": "https://dl.google.com/android/repository/platform-VanillaIceCream_r04.zip"
-          }
-        ],
-        "displayName": "Android SDK Platform VanillaIceCream",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "platforms",
-        "path": "platforms/android-VanillaIceCream",
-        "revision": "VanillaIceCream",
-        "revision-details": {
-          "major:0": "4"
-        },
-        "type-details": {
-          "api-level:0": "34",
-          "codename:1": "VanillaIceCream",
-          "element-attributes": {
-            "xsi:type": "ns11:platformDetailsType"
-          },
-          "layoutlib:2": {
-            "element-attributes": {
-              "api": "15"
-            }
-          }
-        }
       }
     },
     "skiaparser": {
-      "1": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "72be6f7630b28e02449a8bbadff7589688f3c3d6",
-            "size": 7014665,
-            "url": "https://dl.google.com/android/repository/skiaparser-8339467-linux.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "53c688b0d2458bcead273791745fb27efa3b58ce",
-            "size": 17231541,
-            "url": "https://dl.google.com/android/repository/skiaparser-8339467-mac.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "8d08dc7c56531092f1704a24b3457bd0455a4be1",
-            "size": 10174177,
-            "url": "https://dl.google.com/android/repository/skiaparser-8339467-win.zip"
-          }
-        ],
-        "displayName": "Layout Inspector image server for API 31 and T",
-        "last-available-day": 19469,
-        "license": "android-sdk-license",
-        "name": "skiaparser",
-        "path": "skiaparser/3",
-        "revision": "1",
-        "revision-details": {
-          "major:0": "1"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
       "3": {
         "archives": [
           {
@@ -22088,49 +17601,13 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
         "revision": "3",
         "revision-details": {
           "major:0": "3"
-        },
-        "type-details": {
-          "element-attributes": {
-            "xsi:type": "ns5:genericDetailsType"
-          }
-        }
-      },
-      "4": {
-        "archives": [
-          {
-            "os": "linux",
-            "sha1": "caafe27824ceb1c69691766984ab287354104b50",
-            "size": 6433967,
-            "url": "https://dl.google.com/android/repository/skiaparser-11591181-linux-x64.zip"
-          },
-          {
-            "os": "macosx",
-            "sha1": "8043d8f669fec8a3785f95c3e22a7b753cc70c3d",
-            "size": 2933536,
-            "url": "https://dl.google.com/android/repository/skiaparser-11591181-darwin-x64.zip"
-          },
-          {
-            "os": "windows",
-            "sha1": "b1b2ca27aa2f2783dda3a7d73bb4f039513a9500",
-            "size": 2920006,
-            "url": "https://dl.google.com/android/repository/skiaparser-11591181-win-x64.zip"
-          }
-        ],
-        "displayName": "Layout Inspector image server for API 31-35",
-        "last-available-day": 19954,
-        "license": "android-sdk-license",
-        "name": "skiaparser",
-        "path": "skiaparser/3",
-        "revision": "4",
-        "revision-details": {
-          "major:0": "4"
         },
         "type-details": {
           "element-attributes": {
@@ -22160,7 +17637,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 31-36",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/3",
@@ -22196,7 +17673,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
@@ -22222,7 +17699,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -22250,7 +17727,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -22277,7 +17754,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -22304,7 +17781,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -22331,7 +17808,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -22358,7 +17835,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -22385,7 +17862,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -22412,7 +17889,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -22439,7 +17916,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -22466,7 +17943,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -22493,7 +17970,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -22520,7 +17997,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -22547,7 +18024,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -22574,7 +18051,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -22601,7 +18078,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -22628,7 +18105,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -22655,7 +18132,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -22682,7 +18159,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -22709,7 +18186,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -22736,7 +18213,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -22763,7 +18240,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -22790,7 +18267,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -22835,26 +18312,10 @@
             "element-attributes": {
               "path": "emulator"
             }
-          },
-          "dependency:1": {
-            "element-attributes": {
-              "path": "platform-tools"
-            },
-            "min-revision:0": {
-              "major:0": "20"
-            }
-          },
-          "dependency:2": {
-            "element-attributes": {
-              "path": "platform-tools"
-            },
-            "min-revision:0": {
-              "major:0": "20"
-            }
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20112,
+        "last-available-day": 20126,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",


### PR DESCRIPTION
Updated android resources.

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

I manually checked:
* run new version of emulator
* run inteliji and intelijj said that is nothing to download more from Google.

PS. This is my first PR here...

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
