### PR TITLE
cups-brother-dcp1610wlpr: init at 3.0.1-1

### DIFF
--- a/pkgs/by-name/cu/cups-brother-dcp1610wlpr/package.nix
+++ b/pkgs/by-name/cu/cups-brother-dcp1610wlpr/package.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  stdenvNoCC,
+  pkgsi686Linux,
+  fetchurl,
+  cups,
+  dpkg,
+  gnused,
+  makeWrapper,
+  ghostscript,
+  file,
+  a2ps,
+  coreutils,
+  gawk,
+}:
+
+let
+  version = "3.0.1-1";
+  cupsdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101532/dcp1610wcupswrapper-${version}.i386.deb";
+    hash = "sha256-ZgE2o/xU11+MzSnBYakXZE5m+Qa85/KIo31wKWAmsGY=";
+  };
+  lprdeb = fetchurl {
+    url = "https://download.brother.com/welcome/dlf101533/dcp1610wlpr-${version}.i386.deb";
+    hash = "sha256-hi0b23DgSXVT/fNA+Y2aJOdopt7SwjUyYyev81boGlg=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "cups-brother-dcp1610wlpr";
+  inherit version;
+
+  srcs = [
+    cupsdeb
+    lprdeb
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  buildInputs = [
+    cups
+    ghostscript
+    dpkg
+    a2ps
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    dpkg-deb -x ${lprdeb} $out
+    dpkg-deb -x ${cupsdeb} $out
+
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/cups/filter $out/share/cups/model
+    ln -s $out/opt/brother/Printers/DCP1610W/cupswrapper/brother_lpdwrapper_DCP1610W $out/lib/cups/filter/brother_lpdwrapper_DCP1610W
+    ln -s $out/opt/brother/Printers/DCP1610W/cupswrapper/brother-DCP1610W-cups-en.ppd $out/share/cups/model/
+    ln -s $out/opt/brother/Printers/DCP1610W/cupswrapper/brcupsconfig4 $out/lib/cups/filter/brcupsconfig4
+
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    substituteInPlace $out/opt/brother/Printers/DCP1610W/lpd/filter_DCP1610W \
+      --replace-fail /opt "$out/opt"
+
+    sed -i '/GHOST_SCRIPT=/c\GHOST_SCRIPT=gs' $out/opt/brother/Printers/DCP1610W/lpd/psconvert2
+
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/DCP1610W/lpd/brprintconflsr3
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/DCP1610W/lpd/rawtobr3
+    patchelf --set-interpreter ${pkgsi686Linux.glibc.out}/lib/ld-linux.so.2 $out/opt/brother/Printers/DCP1610W/inf/braddprinter
+
+    wrapProgram $out/opt/brother/Printers/DCP1610W/lpd/psconvert2 \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          gnused
+          coreutils
+          gawk
+        ]
+      }
+
+    wrapProgram $out/opt/brother/Printers/DCP1610W/lpd/filter_DCP1610W \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          ghostscript
+          a2ps
+          file
+          gnused
+          coreutils
+        ]
+      }
+
+    substituteInPlace $out/opt/brother/Printers/DCP1610W/cupswrapper/brother_lpdwrapper_DCP1610W \
+      --replace-fail /opt "$out/opt"
+
+    wrapProgram $out/opt/brother/Printers/DCP1610W/cupswrapper/brother_lpdwrapper_DCP1610W \
+      --prefix PATH ":" ${
+        lib.makeBinPath [
+          gnused
+          coreutils
+          gawk
+        ]
+      }
+  '';
+
+  meta = {
+    homepage = "http://www.brother.com/";
+    description = "Brother DCP-1610W printer driver";
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    license = lib.licenses.unfreeRedistributable;
+    platforms = [
+      "x86_64-linux"
+      "i686-linux"
+    ];
+    downloadPage = "https://support.brother.com/g/b/downloadlist.aspx?c=nz&lang=en&prod=dcp1610w_eu_as&os=128";
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
