### PR TITLE
fum: 0.6.4 -> 0.9.17

### DIFF
--- a/pkgs/by-name/fu/fum/package.nix
+++ b/pkgs/by-name/fu/fum/package.nix
@@ -3,25 +3,25 @@
   rustPlatform,
   fetchFromGitHub,
   autoPatchelfHook,
-  stdenv,
   openssl,
   dbus,
   pkg-config,
   libgcc,
+  nix-update-script,
 }:
 rustPlatform.buildRustPackage rec {
   pname = "fum";
-  version = "0.6.4";
+  version = "0.9.17";
 
   src = fetchFromGitHub {
     owner = "qxb3";
     repo = "fum";
     tag = "v${version}";
-    hash = "sha256-vBn76s2ewLVVYhyXviQUmq+AzH6FSVdJaTEJQ2EPlM0=";
+    hash = "sha256-E9Z8bs5bdNcXHRJIkzcISIz8R1wnZu8sO6tXQp+5bpQ=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-7h/KIAIxldXPXUo0lzuBqs6Uf5S5p39yV+kTfLe/LBo=";
+  cargoHash = "sha256-yrDukkbbXqS2iAdtY4WZS6VkqSbyeBXWkn2Od4+mWLw=";
 
   nativeBuildInputs = [
     autoPatchelfHook
@@ -36,9 +36,12 @@ rustPlatform.buildRustPackage rec {
 
   doCheck = false;
 
+  passthru.updateScript = nix-update-script { };
+
   meta = {
     description = "Fully ricable tui-based music client";
     homepage = "https://github.com/qxb3/fum";
+    changelog = "https://github.com/qxb3/fum/releases/tag/v${version}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ linuxmobile ];
     platforms = lib.platforms.linux;


### PR DESCRIPTION
Version and hash updates:

* Updated the `version` from "0.6.4" to "0.9.17".
* Enabled `useFetchCargoVendor` and updated the `cargoHash` value.

Additions:

* Added `nix-update-script` to the list of dependencies. 
* Included a new `passthru.updateScript` attribute.
* Added a `changelog` URL to the `meta` section.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
