### PR TITLE
snarkvm: init at 1.2.1

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -1643,6 +1643,12 @@
     matrix = "@schuelermine:matrix.org";
     keys = [ { fingerprint = "CDBF ECA8 36FE E340 1CEB  58FF BA34 EE1A BA3A 0955"; } ];
   }; # currently on hiatus, please do not ping until this notice is removed (or if it’s been like two years)
+  anstylian = {
+    email = "agathangelos.stylianidis@gmail.com";
+    github = "anstylian";
+    githubId = 11269403;
+    name = "Angelos Stylinidis";
+  };
   anthonyroussel = {
     email = "anthony@roussel.dev";
     github = "anthonyroussel";

--- a/pkgs/by-name/sn/snarkvm/0001-remove-update-subcommand.patch
+++ b/pkgs/by-name/sn/snarkvm/0001-remove-update-subcommand.patch
@@ -1,0 +1,13 @@
+diff --git a/vm/cli/cli.rs b/vm/cli/cli.rs
+index 6597cf101..06c829f56 100644
+--- a/vm/cli/cli.rs
++++ b/vm/cli/cli.rs
+@@ -62,7 +62,7 @@ impl Command {
+             Self::Execute(command) => command.parse(),
+             Self::New(command) => command.parse(),
+             Self::Run(command) => command.parse(),
+-            Self::Update(command) => command.parse(),
++            Self::Update(_) => anyhow::bail!("Package must be updated via Nix."),
+         }
+     }
+ }

--- a/pkgs/by-name/sn/snarkvm/package.nix
+++ b/pkgs/by-name/sn/snarkvm/package.nix
@@ -1,0 +1,60 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  curl,
+}:
+rustPlatform.buildRustPackage {
+  pname = "snarkvm";
+  version = "1.2.1";
+
+  src = fetchFromGitHub {
+    owner = "ProvableHQ";
+    repo = "snarkVM";
+    rev = "59b109c42d9188b8f8f361fd1eca2f134f045196";
+    hash = "sha256-XpadXcWKa3Eev/BjmNCQLlQlYkniDgge5CxDUBBDSeU=";
+  };
+
+  patch = [
+    ./0001-remove-update-subcommand.patch
+  ];
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-Hehi2CCRkY4qnF9EitmmY3cSbLL4MKdLWQOS4kLyRr4=";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs =
+    [ openssl ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      curl
+    ];
+
+  # This test are skipped because they require a internet connection to download some files
+  checkFlags = [
+    "skip=package::tests::test_package_run_and_execute_match"
+    "skip=file::prover::tests::test_create_and_open"
+    "skip=file::verifier::tests::test_create_and_open"
+    "skip=package::is_build_required::tests::test_prebuilt_package_does_not_rebuild"
+    "skip=package::clean::tests::test_clean"
+    "skip=package::run::tests::test_run"
+    "skip=package::build::tests::test_build"
+    "skip=package::deploy::tests::test_deploy"
+    "skip=package::run::tests::test_run_with_nested_imports"
+    "skip=package::deploy::tests::test_deploy_with_import"
+    "skip=package::clean::tests::test_clean_with_import"
+    "skip=package::run::tests::test_run_with_import"
+    "skip=package::build::tests::test_build_with_import"
+  ];
+
+  meta = {
+    description = "Zero-knowledge virtual machine";
+    homepage = "https://github.com/ProvableHQ/snarkVM";
+    maintainers = with lib.maintainers; [ anstylian ];
+    license = [ lib.licenses.asl20 ];
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Add snarvm to nix packages
The skipped test needs the internet to download some files.  If you have any suggestions on how to handle this let me know.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
