### PR TITLE
iperf2: 2.1.4 -> 2.2.1

### DIFF
--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -6,11 +6,11 @@
 
 stdenv.mkDerivation rec {
   pname = "iperf";
-  version = "2.1.4";
+  version = "2.2.1";
 
   src = fetchurl {
     url = "mirror://sourceforge/iperf2/files/${pname}-${version}.tar.gz";
-    sha256 = "1yflnj2ni988nm0p158q8lnkiq2gn2chmvsglyn2gqmqhwp3jaq6";
+    sha256 = "1yyqzgz526xn6v2hrdiizviddx3xphjg93ihh7mdncw0wakv0jkm";
   };
 
   hardeningDisable = [ "format" ];

--- a/pkgs/tools/networking/iperf/2.nix
+++ b/pkgs/tools/networking/iperf/2.nix
@@ -4,19 +4,16 @@
   fetchurl,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "iperf";
   version = "2.2.1";
 
   src = fetchurl {
-    url = "mirror://sourceforge/iperf2/files/${pname}-${version}.tar.gz";
-    sha256 = "1yyqzgz526xn6v2hrdiizviddx3xphjg93ihh7mdncw0wakv0jkm";
+    url = "mirror://sourceforge/iperf2/files/iperf-${finalAttrs.version}.tar.gz";
+    hash = "sha256-dUqwp+KAM9vqgTCO9CS8ffTW4v4xtgzFNrYbUf772Ps=";
   };
 
-  hardeningDisable = [ "format" ];
   configureFlags = [ "--enable-fastsampling" ];
-
-  makeFlags = [ "AR:=$(AR)" ];
 
   postInstall = ''
     mv $out/bin/iperf $out/bin/iperf2
@@ -32,4 +29,4 @@ stdenv.mkDerivation rec {
     # prioritize iperf3
     priority = 10;
   };
-}
+})


### PR DESCRIPTION
Upgrade iperf2 to 2.2.1

## Things done

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
Tested on x86_64-linux

Used a overlay-unstable override as described here to pull in the iperf2 from the branch.
https://nixos.wiki/wiki/Flakes#Importing_packages_from_multiple_channels

The difference between the documentation and what I did, was that I used the URL to my branch/commit
    nixpkgs-unstable.url = "github:randomizedcoder/nixpkgs/8f146535307f0168d758fe6fee6f52663cb11695";

( I really should submit a PR for the documentation, cos it took a while to work out how to do this. Easy when you know how. )

```
[das@t:~/nixos/laptops/t]$ make
Hostnames match: t
sudo nixos-rebuild switch --flake .
[sudo] password for das:
warning: Git tree '/home/das/nixos' is dirty
warning: updating lock file '/home/das/nixos/laptops/t/flake.lock':
• Updated input 'nixpkgs':
    'github:randomizedcoder/nixpkgs/8f146535307f0168d758fe6fee6f52663cb11695?narHash=sha256-ixVjn/td%2BTUvsPyLAMZ/fbrwgdTXPZ7ZS4RBz9TUSK0%3D' (2025-01-31)
  → 'github:nixos/nixpkgs/59e618d90c065f55ae48446f307e8c09565d5ab0?narHash=sha256-B/7Y1v4y%2BmsFFBW1JAdFjNvVthvNdJKiN6EGRPnqfno%3D' (2025-01-29)
• Added input 'nixpkgs-unstable':
    'github:randomizedcoder/nixpkgs/8f146535307f0168d758fe6fee6f52663cb11695?narHash=sha256-ixVjn/td%2BTUvsPyLAMZ/fbrwgdTXPZ7ZS4RBz9TUSK0%3D' (2025-01-31)
warning: Git tree '/home/das/nixos' is dirty
building the system configuration...
warning: Git tree '/home/das/nixos' is dirty
evaluation warning: das profile: You have enabled hyprland.systemd.enable or listed plugins in hyprland.plugins but do not have any configuration in hyprland.settings or hyprland.extraConfig. This is almost certainly a mistake.
stopping the following units: accounts-daemon.service
NOT restarting the following changed units: display-manager.service
activating the configuration...
setting up /etc...
reloading user units for das...
restarting sysinit-reactivation.target
reloading the following units: dbus.service
restarting the following units: polkit.service
starting the following units: accounts-daemon.service
the following new units were started: libvirtd.service, run-credentials-systemd\x2dtmpfiles\x2dresetup.service.mount, sysinit-reactivation.target, systemd-tmpfiles-resetup.service

[das@t:~/nixos/laptops/t]$ iperf --version
iperf version 2.2.1 (4 Nov 2024) pthreads                         <---- woot woot it works
```

- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)

- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module

- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
