### PR TITLE
python312Packages.pypdfium2: pin to git revision

### DIFF
--- a/pkgs/by-name/pd/pdfium-binaries/package.nix
+++ b/pkgs/by-name/pd/pdfium-binaries/package.nix
@@ -5,6 +5,7 @@
   python3Packages,
 }:
 let
+  # also update rev of headers in python3Packages.pypdfium2
   version = "6968";
   src =
     let

--- a/pkgs/by-name/pd/pdfium-binaries/package.nix
+++ b/pkgs/by-name/pd/pdfium-binaries/package.nix
@@ -2,6 +2,7 @@
   lib,
   fetchzip,
   stdenv,
+  python3Packages,
 }:
 let
   version = "6968";
@@ -41,7 +42,12 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
-  passthru.updateScript = ./update.sh;
+  passthru = {
+    updateScript = ./update.sh;
+    tests = {
+      inherit (python3Packages) pypdfium2;
+    };
+  };
 
   meta = {
     description = "Binary distribution of PDFium";

--- a/pkgs/development/python-modules/pypdfium2/default.nix
+++ b/pkgs/development/python-modules/pypdfium2/default.nix
@@ -3,21 +3,25 @@
   pkgs,
   buildPythonPackage,
   fetchFromGitHub,
-  fetchurl,
+  fetchgit,
   setuptools-scm,
   pdfium-binaries,
   numpy,
   pillow,
   pytestCheckHook,
-  python,
 }:
 
 let
   pdfiumVersion = "${pdfium-binaries.version}";
 
-  headers = fetchurl {
-    url = "https://pdfium.googlesource.com/pdfium/+archive/refs/heads/chromium/${pdfiumVersion}/public.tar.gz";
-    hash = "sha256-vKfs4Jd8LEtA3aTI+DcJMS0VOErq1IR1eThnMlxiER0=";
+  headers = fetchgit {
+    url = "https://pdfium.googlesource.com/pdfium";
+    # The latest revision on the chromium/${pdfiumVersion} branch
+    rev = "f6da7d235728aeaff6586d2190badfb4290a9979";
+    hash = "sha256-xUylu//APbwpI+k6cQ7OrPCwDXp9qw0ZVaCba/d5zVg=";
+    sparseCheckout = [
+      "public"
+    ];
   };
 
   # They demand their own fork of ctypesgen
@@ -84,8 +88,8 @@ buildPythonPackage rec {
     in
     ''
       # Preseed the headers and version file
-      mkdir -p ${headersDir}
-      tar -xf ${headers} -C ${headersDir}
+      mkdir -p ${bindingsDir}
+      cp -r ${headers}/public ${headersDir}
       install -m 644 ${inputVersionFile} ${versionFile}
 
       # Make generated bindings consider pdfium derivation path when loading dynamic libraries


### PR DESCRIPTION
Previously, we were fetching headers from a branch, not a fixed
revision, so a new patch in the branch broke the build because hashes
changed.

Closes #378154

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
