### PR TITLE
haskellPackages.bsb-http-chunked: fix test suite

### DIFF
--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -3024,6 +3024,29 @@ self: super: {
       sha256 = "sha256-IxtyHFKygbrUK7JTAytWBZVHh+M1xQTv2IPCG3mjTGE=";
       stripLen = 1;
     }) super.yesod-core;
+
+  bsb-http-chunked = lib.pipe super.bsb-http-chunked [
+    (lib.warnIf
+      (lib.versionOlder "0.0.0.4" super.bsb-http-chunked.version)
+      "override for haskellPackages.bsb-http-chunked may no longer be needed"
+    )
+    # Last released in 2018
+    # https://github.com/sjakobi/bsb-http-chunked/issues/38
+    # https://github.com/sjakobi/bsb-http-chunked/issues/45
+    (overrideSrc {
+      src = pkgs.fetchFromGitHub {
+        owner = "sjakobi";
+        repo = "bsb-http-chunked";
+        rev = "c0ecd72fe2beb1cf7de9340cc8b4a31045460532";
+        hash = "sha256-+UDxfywXPjxPuFupcB8veyMYWVQCKha64me9HADtFGg=";
+      };
+    })
+    # https://github.com/sjakobi/bsb-http-chunked/pull/49
+    (appendPatch (fetchpatch {
+      url = "https://github.com/sjakobi/bsb-http-chunked/commit/689bf9ce12b8301d0e13a68e4a515c2779b62947.patch";
+      sha256 = "sha256-ZdCXMhni+RGisRODiElObW5c4hKy2giWQmWnatqeRJo=";
+    }))
+  ];
 } // import ./configuration-tensorflow.nix {inherit pkgs haskellLib;} self super
 
 # Gogol Packages

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -100,7 +100,6 @@ self: super: {
   #
   call-stack = dontCheck super.call-stack; # https://github.com/sol/call-stack/issues/19
   primitive-unlifted = dontCheck super.primitive-unlifted; # doesn't compile with primitive ==0.9.*
-  bsb-http-chunked = pkgs.haskell.lib.dontCheck super.bsb-http-chunked; # https://github.com/sjakobi/bsb-http-chunked/issues/45
   hinotify = pkgs.haskell.lib.dontCheck super.hinotify; # https://github.com/kolmodin/hinotify/issues/38
 
   haskell-language-server = disableCabalFlag "retrie" (disableCabalFlag "hlint" (disableCabalFlag "stylishhaskel" (super.haskell-language-server.override {stylish-haskell = null;retrie = null;apply-refact=null;hlint = null;})));

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -113,9 +113,6 @@ self: super: {
   # 0.2.2.3 requires Cabal >= 3.8
   shake-cabal = doDistribute self.shake-cabal_0_2_2_2;
 
-  # https://github.com/sjakobi/bsb-http-chunked/issues/38
-  bsb-http-chunked = dontCheck super.bsb-http-chunked;
-
   # https://github.com/NixOS/cabal2nix/issues/554
   # https://github.com/clash-lang/clash-compiler/blob/f0f6275e19b8c672f042026c478484c5fd45191d/README.md#ghc-compatibility
   clash-prelude = dontDistribute (markBroken super.clash-prelude);

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -89,9 +89,6 @@ in
     ] ++ drv.testFlags or [ ];
   }) (doJailbreak super.hpack);
 
-  # https://github.com/sjakobi/bsb-http-chunked/issues/38
-  bsb-http-chunked = dontCheck super.bsb-http-chunked;
-
   # 2022-08-01: Tests are broken on ghc 9.2.4: https://github.com/wz1000/HieDb/issues/46
   hiedb = dontCheck super.hiedb;
 

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -126,9 +126,6 @@ self: super:
   #   A factor of 100 is insufficent, 200 seems seems to work.
   hip = appendConfigureFlag "--ghc-options=-fsimpl-tick-factor=200" super.hip;
 
-  # Doctest comments have bogus imports.
-  bsb-http-chunked = dontCheck super.bsb-http-chunked;
-
   # This can be removed once https://github.com/typeclasses/ascii-predicates/pull/1
   # is merged and in a release that's being tracked.
   ascii-predicates = appendPatch (pkgs.fetchpatch {

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -95,7 +95,6 @@ self: super: {
   # Test suite issues
   #
   unordered-containers = dontCheck super.unordered-containers; # ChasingBottoms doesn't support base 4.20
-  bsb-http-chunked = dontCheck super.bsb-http-chunked; # umaintained, test suite doesn't compile anymore
   pcre-heavy = dontCheck super.pcre-heavy; # GHC warnings cause the tests to fail
 
   #


### PR DESCRIPTION
```
$ nix-build -A haskell.packages.ghc810.bsb-http-chunked
/nix/store/4d9j96w1d1s6dcqm7jgg2ql2s1v24z0j-bsb-http-chunked-0.0.0.4

$ nix-build -A haskell.packages.ghc98.bsb-http-chunked
/nix/store/phcmc6v5s3ja46br49zxxbj0hr4f50y2-bsb-http-chunked-0.0.0.4

$ nix-build -A pkgsCross.ghcjs.haskell.packages.ghc912.bsb-http-chunked
/nix/store/cnzw92pv8xv97lcc2i3a1kpf1s6qmr7n-bsb-http-chunked-0.0.0.4
```

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
