### PR TITLE
[Backport 377843 to release 24.11] warp-terminal: 0.2024.11.19.08.02.stable_03 -> 0.2025.01.22.08.02.stable_05

### DIFF
--- a/pkgs/by-name/wa/warp-terminal/package.nix
+++ b/pkgs/by-name/wa/warp-terminal/package.nix
@@ -6,6 +6,7 @@
   autoPatchelfHook,
   undmg,
   zstd,
+  alsa-lib,
   curl,
   fontconfig,
   libglvnd,
@@ -48,6 +49,7 @@ let
     ];
 
     buildInputs = [
+      alsa-lib # libasound.so.2
       curl
       fontconfig
       (lib.getLib stdenv.cc.cc) # libstdc++.so libgcc_s.so

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-N1CvHYWhwi75+eelp3UPrqnigRTg1LWKhmVDNXv96LA=",
-    "version": "0.2024.11.19.08.02.stable_03"
+    "hash": "sha256-utxgI+fpobY9z06TpbXHcSpR7d6o1XLbfP/OwkoYbZQ=",
+    "version": "0.2024.12.03.08.02.stable_04"
   },
   "linux_x86_64": {
-    "hash": "sha256-vxK9GFYYFZK3NIIejh6dAK3sKkpAR4cyOSC/t2Aodg8=",
-    "version": "0.2024.11.19.08.02.stable_03"
+    "hash": "sha256-MNwO08xL3MtrB/3I0ObTa9hIK5GgeeXFKb0PDUld1EA=",
+    "version": "0.2024.12.03.08.02.stable_04"
   },
   "linux_aarch64": {
-    "hash": "sha256-eADShsB0/kKNMzBP1/JZ0Kofh2iTQtsxFz2N1H+hxY0=",
-    "version": "0.2024.11.19.08.02.stable_03"
+    "hash": "sha256-gMfRNNI0aVQ6ePt5hOLu/DDkrHQJMePj7hRaJA5pTbU=",
+    "version": "0.2024.12.03.08.02.stable_04"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-utxgI+fpobY9z06TpbXHcSpR7d6o1XLbfP/OwkoYbZQ=",
-    "version": "0.2024.12.03.08.02.stable_04"
+    "hash": "sha256-+UIvrnsoHzGRKX+ULqr4/IC5N8WLtH4adsjf8axcppU=",
+    "version": "0.2024.12.10.15.55.stable_02"
   },
   "linux_x86_64": {
-    "hash": "sha256-MNwO08xL3MtrB/3I0ObTa9hIK5GgeeXFKb0PDUld1EA=",
-    "version": "0.2024.12.03.08.02.stable_04"
+    "hash": "sha256-7QMYkqjurb5vgoYfhprAExlgPhhpTrBCYyLCO4hdV8g=",
+    "version": "0.2024.12.10.15.55.stable_02"
   },
   "linux_aarch64": {
-    "hash": "sha256-gMfRNNI0aVQ6ePt5hOLu/DDkrHQJMePj7hRaJA5pTbU=",
-    "version": "0.2024.12.03.08.02.stable_04"
+    "hash": "sha256-WjyxQZGzf0dpwR/hpxhdd3q+rV8SS4m8GiQqtVd9MLE=",
+    "version": "0.2024.12.10.15.55.stable_02"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-Un5dqYt3kGh3ODZnP2nskfzhma7KkpZXJTqPfwcZ4Dw=",
-    "version": "0.2024.12.18.08.02.stable_05"
+    "hash": "sha256-S1gNm8joPS2VKsTF2zUG9zSttFkSPBBOs4bpcph+saE=",
+    "version": "0.2025.01.08.08.02.stable_04"
   },
   "linux_x86_64": {
-    "hash": "sha256-U14TFQg72vfizYu8qXjH+JafL5aWndz1sbMSF3TD/+E=",
-    "version": "0.2024.12.18.08.02.stable_05"
+    "hash": "sha256-HHQnH4Sqju68RCBZxUpmdlpN6xSMB+3al8wKgLuvPVs=",
+    "version": "0.2025.01.08.08.02.stable_04"
   },
   "linux_aarch64": {
-    "hash": "sha256-lbZawoh9VUhNlbs+pxUu5pdWsizq9B1UPBsaNxUSs20=",
-    "version": "0.2024.12.18.08.02.stable_05"
+    "hash": "sha256-N0qHBTE6pczK5ceHXvCxNxWR9O7qcCtkgiPkGFUgNNE=",
+    "version": "0.2025.01.08.08.02.stable_04"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-S1gNm8joPS2VKsTF2zUG9zSttFkSPBBOs4bpcph+saE=",
-    "version": "0.2025.01.08.08.02.stable_04"
+    "hash": "sha256-OxBFw18XHLbR7HoJHYxVQVwkO14HvJjpjrWt8nQ+FDQ=",
+    "version": "0.2025.01.22.08.02.stable_05"
   },
   "linux_x86_64": {
-    "hash": "sha256-HHQnH4Sqju68RCBZxUpmdlpN6xSMB+3al8wKgLuvPVs=",
-    "version": "0.2025.01.08.08.02.stable_04"
+    "hash": "sha256-5Ro7nLGzmAWQGG0e2797LvvBW5nkB+OHSiw5hXw75wM=",
+    "version": "0.2025.01.22.08.02.stable_05"
   },
   "linux_aarch64": {
-    "hash": "sha256-N0qHBTE6pczK5ceHXvCxNxWR9O7qcCtkgiPkGFUgNNE=",
-    "version": "0.2025.01.08.08.02.stable_04"
+    "hash": "sha256-C00/LQc4AmB+8UcNENrt1Qrk6nZmPwQtHHa7SEvQ+GY=",
+    "version": "0.2025.01.22.08.02.stable_05"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-CrRt7fLoZ9LR3fD7xXBzlRFf4CAjQjokU5UaHNJnVNA=",
-    "version": "0.2024.12.18.08.02.stable_03"
+    "hash": "sha256-Un5dqYt3kGh3ODZnP2nskfzhma7KkpZXJTqPfwcZ4Dw=",
+    "version": "0.2024.12.18.08.02.stable_05"
   },
   "linux_x86_64": {
-    "hash": "sha256-0A9EPkDp77tpfrRuXV2rVPaXMYbY7erbKBd6IT9CTFQ=",
-    "version": "0.2024.12.18.08.02.stable_03"
+    "hash": "sha256-U14TFQg72vfizYu8qXjH+JafL5aWndz1sbMSF3TD/+E=",
+    "version": "0.2024.12.18.08.02.stable_05"
   },
   "linux_aarch64": {
-    "hash": "sha256-IlqpK8IbtSMKGNspKj2Rq2Jzlyc7RYcfRaoYY9Akhdk=",
-    "version": "0.2024.12.18.08.02.stable_03"
+    "hash": "sha256-lbZawoh9VUhNlbs+pxUu5pdWsizq9B1UPBsaNxUSs20=",
+    "version": "0.2024.12.18.08.02.stable_05"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-NK9/YhnEWdoxF8fkGJvYVFCsNh0XPSheXbw89wNkaio=",
-    "version": "0.2024.12.10.15.55.stable_04"
+    "hash": "sha256-CrRt7fLoZ9LR3fD7xXBzlRFf4CAjQjokU5UaHNJnVNA=",
+    "version": "0.2024.12.18.08.02.stable_03"
   },
   "linux_x86_64": {
-    "hash": "sha256-wAzPAaigjaHl5JhuS92rkHXLZRAQtq7p8IB67sqPDlY=",
-    "version": "0.2024.12.10.15.55.stable_04"
+    "hash": "sha256-0A9EPkDp77tpfrRuXV2rVPaXMYbY7erbKBd6IT9CTFQ=",
+    "version": "0.2024.12.18.08.02.stable_03"
   },
   "linux_aarch64": {
-    "hash": "sha256-GbirEK2Jhfunj9ORWp5uW/QHUzSnJRQRh1ezApr1p00=",
-    "version": "0.2024.12.10.15.55.stable_04"
+    "hash": "sha256-IlqpK8IbtSMKGNspKj2Rq2Jzlyc7RYcfRaoYY9Akhdk=",
+    "version": "0.2024.12.18.08.02.stable_03"
   }
 }

--- a/pkgs/by-name/wa/warp-terminal/versions.json
+++ b/pkgs/by-name/wa/warp-terminal/versions.json
@@ -1,14 +1,14 @@
 {
   "darwin": {
-    "hash": "sha256-+UIvrnsoHzGRKX+ULqr4/IC5N8WLtH4adsjf8axcppU=",
-    "version": "0.2024.12.10.15.55.stable_02"
+    "hash": "sha256-NK9/YhnEWdoxF8fkGJvYVFCsNh0XPSheXbw89wNkaio=",
+    "version": "0.2024.12.10.15.55.stable_04"
   },
   "linux_x86_64": {
-    "hash": "sha256-7QMYkqjurb5vgoYfhprAExlgPhhpTrBCYyLCO4hdV8g=",
-    "version": "0.2024.12.10.15.55.stable_02"
+    "hash": "sha256-wAzPAaigjaHl5JhuS92rkHXLZRAQtq7p8IB67sqPDlY=",
+    "version": "0.2024.12.10.15.55.stable_04"
   },
   "linux_aarch64": {
-    "hash": "sha256-WjyxQZGzf0dpwR/hpxhdd3q+rV8SS4m8GiQqtVd9MLE=",
-    "version": "0.2024.12.10.15.55.stable_02"
+    "hash": "sha256-GbirEK2Jhfunj9ORWp5uW/QHUzSnJRQRh1ezApr1p00=",
+    "version": "0.2024.12.10.15.55.stable_04"
   }
 }


### PR DESCRIPTION
Backports:
https://github.com/NixOS/nixpkgs/pull/362298
https://github.com/NixOS/nixpkgs/pull/364374
https://github.com/NixOS/nixpkgs/pull/365821
https://github.com/NixOS/nixpkgs/pull/366843
https://github.com/NixOS/nixpkgs/pull/370514
https://github.com/NixOS/nixpkgs/pull/373038
https://github.com/NixOS/nixpkgs/pull/377843

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
