### PR TITLE
nixosTests.networking.networkd.bond: drop from channel blockers

### DIFF
--- a/nixos/release-combined.nix
+++ b/nixos/release-combined.nix
@@ -149,7 +149,8 @@ rec {
         (onFullSupported "nixos.tests.networking.scripted.static")
         (onFullSupported "nixos.tests.networking.scripted.virtual")
         (onFullSupported "nixos.tests.networking.scripted.vlan")
-        (onFullSupported "nixos.tests.networking.networkd.bond")
+        # Fails often on Hydra, no maintainers.
+        #(onFullSupported "nixos.tests.networking.networkd.bond")
         (onFullSupported "nixos.tests.networking.networkd.bridge")
         (onFullSupported "nixos.tests.networking.networkd.dhcpOneIf")
         (onFullSupported "nixos.tests.networking.networkd.dhcpSimple")


### PR DESCRIPTION
On Hydra it often gets stuck and needs multiple restarts, e.g.:
- https://hydra.nixos.org/build/287396829#tabs-buildsteps
- https://hydra.nixos.org/build/287252282#tabs-buildsteps

I looked at some and the machine didn't look overloaded or something.

Unfortunately this test has no `.meta.maintainers` either...
Of course, I'll be happy if someone fixes the flakiness instead (and adopts the test).

_The usual checklist doesn't really apply here._


<!--
List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
