### PR TITLE
treewide: remove uses of now-removed nixUnstable

### DIFF
--- a/doc/using/configuration.chapter.md
+++ b/doc/using/configuration.chapter.md
@@ -193,7 +193,7 @@ source: ../config-options.json
 
 ### Build an environment {#sec-building-environment}
 
-Using `packageOverrides`, it is possible to manage packages declaratively. This means that we can list all of our desired packages within a declarative Nix expression. For example, to have `aspell`, `bc`, `ffmpeg`, `coreutils`, `gdb`, `nixUnstable`, `emscripten`, `jq`, `nox`, and `silver-searcher`, we could use the following in `~/.config/nixpkgs/config.nix`:
+Using `packageOverrides`, it is possible to manage packages declaratively. This means that we can list all of our desired packages within a declarative Nix expression. For example, to have `aspell`, `bc`, `ffmpeg`, `coreutils`, `gdb`, `nix`, `emscripten`, `jq`, `nox`, and `silver-searcher`, we could use the following in `~/.config/nixpkgs/config.nix`:
 
 ```nix
 {
@@ -206,7 +206,7 @@ Using `packageOverrides`, it is possible to manage packages declaratively. This 
         coreutils
         gdb
         ffmpeg
-        nixUnstable
+        nix
         emscripten
         jq
         nox
@@ -230,7 +230,7 @@ To install it into our environment, you can just run `nix-env -iA nixpkgs.myPack
         coreutils
         gdb
         ffmpeg
-        nixUnstable
+        nix
         emscripten
         jq
         nox
@@ -258,7 +258,7 @@ After building that new environment, look through `~/.nix-profile` to make sure 
         bc
         coreutils
         ffmpeg
-        nixUnstable
+        nix
         emscripten
         jq
         nox
@@ -292,7 +292,7 @@ This provides us with some useful documentation for using our packages.  However
         coreutils
         ffmpeg
         man
-        nixUnstable
+        nix
         emscripten
         jq
         nox
@@ -344,7 +344,7 @@ Configuring GNU info is a little bit trickier than man pages. To work correctly,
         coreutils
         ffmpeg
         man
-        nixUnstable
+        nix
         emscripten
         jq
         nox

--- a/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
+++ b/pkgs/build-support/build-fhsenv-bubblewrap/default.nix
@@ -93,7 +93,7 @@ let
       files = [
         # NixOS Compatibility
         "static"
-        "nix" # mainly for nixUnstable users, but also for access to nix/netrc
+        "nix" # mainly for nixVersions.git users, but also for access to nix/netrc
         # Shells
         "shells"
         "bashrc"

--- a/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
+++ b/pkgs/os-specific/linux/nixos-rebuild/nixos-rebuild.8
@@ -272,7 +272,7 @@ relevant configuration options.
 Normally,
 .Nm
 first builds the
-.Ql nixUnstable
+.Ql nix
 attribute in Nixpkgs, and uses the resulting instance of the Nix package manager
 to build the new system configuration. This is necessary if the NixOS modules
 use features not provided by the currently installed version of Nix. This option

--- a/pkgs/top-level/release-cross.nix
+++ b/pkgs/top-level/release-cross.nix
@@ -5,7 +5,7 @@
 
    e.g.
 
-   $ nix-build pkgs/top-level/release-cross.nix -A crossMingw32.nixUnstable --arg supportedSystems '[builtins.currentSystem]'
+   $ nix-build pkgs/top-level/release-cross.nix -A crossMingw32.nix --arg supportedSystems '[builtins.currentSystem]'
 
    To build all of the bootstrapFiles bundles on every enabled platform, use:
 
@@ -70,7 +70,7 @@ let
     gmp = nativePlatforms;
     libcCross = nativePlatforms;
     nix = nativePlatforms;
-    nixUnstable = nativePlatforms;
+    nixVersions.git = nativePlatforms;
     mesa = nativePlatforms;
     rustc = nativePlatforms;
     cargo = nativePlatforms;


### PR DESCRIPTION
nixUnstable was removed in 2b4e18f3d4a7b80af21b640c0970f83b34efceff but is still referred to from a variety of places, including Hydra's cross-trunk jobset:

https://hydra.nixos.org/jobset/nixpkgs/cross-trunk#tabs-errors

```
in job ‘armv7l-hf.nixUnstable.aarch64-linux’:
error:
       … while evaluating a branch condition
         at /nix/store/m549zq6lcl10d1jqcdgcdaxxj9xdhxfv-source/lib/customisation.nix:479:5:
          478|     in
          479|     if drv == null then null else deepSeq drv' drv';
             |     ^
          480|

       … in the left operand of the update (//) operator
         at /nix/store/m549zq6lcl10d1jqcdgcdaxxj9xdhxfv-source/lib/meta.nix:43:9:
           42|   addMetaAttrs = newAttrs: drv:
           43|     drv // { meta = (drv.meta or {}) // newAttrs; };
             |         ^
           44|

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: nixUnstable has been removed. For bleeding edge (Nix
       master, roughly weekly updated) use nixVersions.git, otherwise
       use nixVersions.latest.
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
