### PR TITLE
ocamlPackages.curses: 1.0.8 → 1.0.11

### DIFF
--- a/pkgs/development/ocaml-modules/curses/default.nix
+++ b/pkgs/development/ocaml-modules/curses/default.nix
@@ -1,49 +1,35 @@
 {
   lib,
-  stdenv,
+  buildDunePackage,
   fetchFromGitHub,
-  ocaml,
-  findlib,
   ncurses,
+  dune-configurator,
+  pkg-config,
 }:
 
-stdenv.mkDerivation rec {
-  pname = "ocaml-curses";
-  version = "1.0.8";
+buildDunePackage rec {
+  pname = "curses";
+  version = "1.0.11";
+
+  minimalOCamlVersion = "4.06";
 
   src = fetchFromGitHub {
     owner = "mbacarella";
     repo = "curses";
     rev = version;
-    sha256 = "0yy3wf8i7jgvzdc40bni7mvpkvclq97cgb5fw265mrjj0iqpkqpd";
+    hash = "sha256-tjBOv7RARDzBShToNLL9LEaU/Syo95MfwZunFsyN4/Q=";
   };
 
-  strictDeps = true;
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ dune-configurator ];
 
   propagatedBuildInputs = [ ncurses ];
 
-  nativeBuildInputs = [
-    ocaml
-    findlib
-  ];
-
-  # Fix build for recent ncurses versions
-  env.NIX_CFLAGS_COMPILE = "-DNCURSES_INTERNALS=1";
-
-  createFindlibDestdir = true;
-
-  postPatch = ''
-    substituteInPlace curses.ml --replace "pp gcc" "pp $CC"
-  '';
-
-  buildPhase = "make all opt";
-
-  meta = with lib; {
+  meta = {
     description = "OCaml Bindings to curses/ncurses";
     homepage = "https://github.com/mbacarella/curses";
-    license = licenses.lgpl21Plus;
+    license = lib.licenses.lgpl21Plus;
     changelog = "https://github.com/mbacarella/curses/raw/${version}/CHANGES";
-    maintainers = [ ];
-    inherit (ocaml.meta) platforms;
+    maintainers = [ lib.maintainers.vbgl ];
   };
 }


### PR DESCRIPTION
Support for latest OCaml.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
