### PR TITLE
swaylock,swaybg: fix svg support

### DIFF
--- a/nixos/tests/sway.nix
+++ b/nixos/tests/sway.nix
@@ -192,15 +192,15 @@ import ./make-test-python.nix (
         machine.screenshot("sway_exit")
 
         swaymsg("exec swaylock")
-        machine.wait_until_succeeds("pgrep -x swaylock")
+        machine.wait_until_succeeds("pgrep -xf swaylock")
         machine.sleep(3)
         machine.send_chars("${nodes.machine.config.users.users.alice.password}")
         machine.send_key("ret")
-        machine.wait_until_fails("pgrep -x swaylock")
+        machine.wait_until_fails("pgrep -xf swaylock")
 
         # Exit Sway and verify process exit status 0:
         swaymsg("exit", succeed=False)
-        machine.wait_until_fails("pgrep -x sway")
+        machine.wait_until_fails("pgrep -xf sway")
         machine.wait_for_file("/tmp/sway-exit-ok")
       '';
   }

--- a/nixos/tests/swayfx.nix
+++ b/nixos/tests/swayfx.nix
@@ -190,15 +190,15 @@ import ./make-test-python.nix (
         machine.screenshot("sway_exit")
 
         swaymsg("exec swaylock")
-        machine.wait_until_succeeds("pgrep -x swaylock")
+        machine.wait_until_succeeds("pgrep -xf swaylock")
         machine.sleep(3)
         machine.send_chars("${nodes.machine.users.users.alice.password}")
         machine.send_key("ret")
-        machine.wait_until_fails("pgrep -x swaylock")
+        machine.wait_until_fails("pgrep -xf swaylock")
 
         # Exit Sway and verify process exit status 0:
         swaymsg("exit", succeed=False)
-        machine.wait_until_fails("pgrep -x sway")
+        machine.wait_until_fails("pgrep -xf sway")
         machine.wait_for_file("/tmp/sway-exit-ok")
       '';
   }

--- a/pkgs/by-name/sw/swaybg/package.nix
+++ b/pkgs/by-name/sw/swaybg/package.nix
@@ -1,7 +1,16 @@
-{ lib, stdenv, fetchFromGitHub
-, meson, ninja, pkg-config, scdoc
-, wayland, wayland-protocols, cairo, gdk-pixbuf
-, wayland-scanner
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  scdoc,
+  wayland,
+  wayland-protocols,
+  cairo,
+  gdk-pixbuf,
+  wayland-scanner,
 }:
 
 stdenv.mkDerivation rec {
@@ -17,11 +26,23 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   depsBuildBuild = [ pkg-config ];
-  nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
-  buildInputs = [ wayland wayland-protocols cairo gdk-pixbuf ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+  ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    cairo
+    gdk-pixbuf
+  ];
 
   mesonFlags = [
-    "-Dgdk-pixbuf=enabled" "-Dman-pages=enabled"
+    "-Dgdk-pixbuf=enabled"
+    "-Dman-pages=enabled"
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/sw/swaybg/package.nix
+++ b/pkgs/by-name/sw/swaybg/package.nix
@@ -11,6 +11,8 @@
   cairo,
   gdk-pixbuf,
   wayland-scanner,
+  wrapGAppsNoGuiHook,
+  librsvg
 }:
 
 stdenv.mkDerivation rec {
@@ -20,7 +22,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "swaybg";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-IJcPSBJErf8Dy9YhYAc9eg/llgaaLZCQSB0Brof+kpg=";
   };
 
@@ -32,12 +34,15 @@ stdenv.mkDerivation rec {
     pkg-config
     scdoc
     wayland-scanner
+    wrapGAppsNoGuiHook
+    gdk-pixbuf
   ];
   buildInputs = [
     wayland
     wayland-protocols
     cairo
     gdk-pixbuf
+    librsvg
   ];
 
   mesonFlags = [

--- a/pkgs/by-name/sw/swaylock/package.nix
+++ b/pkgs/by-name/sw/swaylock/package.nix
@@ -1,6 +1,18 @@
-{ lib, stdenv, fetchFromGitHub
-, meson, ninja, pkg-config, scdoc, wayland-scanner
-, wayland, wayland-protocols, libxkbcommon, cairo, gdk-pixbuf, pam
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  pkg-config,
+  scdoc,
+  wayland-scanner,
+  wayland,
+  wayland-protocols,
+  libxkbcommon,
+  cairo,
+  gdk-pixbuf,
+  pam,
 }:
 
 stdenv.mkDerivation rec {
@@ -16,11 +28,26 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
   depsBuildBuild = [ pkg-config ];
-  nativeBuildInputs = [ meson ninja pkg-config scdoc wayland-scanner ];
-  buildInputs = [ wayland wayland-protocols libxkbcommon cairo gdk-pixbuf pam ];
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    scdoc
+    wayland-scanner
+  ];
+  buildInputs = [
+    wayland
+    wayland-protocols
+    libxkbcommon
+    cairo
+    gdk-pixbuf
+    pam
+  ];
 
   mesonFlags = [
-    "-Dpam=enabled" "-Dgdk-pixbuf=enabled" "-Dman-pages=enabled"
+    "-Dpam=enabled"
+    "-Dgdk-pixbuf=enabled"
+    "-Dman-pages=enabled"
   ];
 
   meta = with lib; {

--- a/pkgs/by-name/sw/swaylock/package.nix
+++ b/pkgs/by-name/sw/swaylock/package.nix
@@ -13,6 +13,8 @@
   cairo,
   gdk-pixbuf,
   pam,
+  wrapGAppsNoGuiHook,
+  librsvg
 }:
 
 stdenv.mkDerivation rec {
@@ -22,7 +24,7 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "swaywm";
     repo = "swaylock";
-    rev = "v${version}";
+    tag = "v${version}";
     hash = "sha256-1+AXxw1gH0SKAxUa0JIhSzMbSmsfmBPCBY5IKaYtldg=";
   };
 
@@ -34,6 +36,8 @@ stdenv.mkDerivation rec {
     pkg-config
     scdoc
     wayland-scanner
+    wrapGAppsNoGuiHook
+    gdk-pixbuf
   ];
   buildInputs = [
     wayland
@@ -42,6 +46,7 @@ stdenv.mkDerivation rec {
     cairo
     gdk-pixbuf
     pam
+    librsvg
   ];
 
   mesonFlags = [


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done
Support svg images for `swaylock` and `swaybg`.
Based on #355180

On my systems svg images already work if `swaylock` is started by `sway` (or indirectly with an `terminal`).
But they do not work when started by a systemd service like `swayidle`.
To test the program I used this command:
```bash
systemd-run --user --pty --property=Environment="WAYLAND_DISPLAY=wayland-1" result/bin/swaylock --config none --image=$(nix build nixpkgs#gnome-backgrounds --no-link --print-out-paths)/share/backgrounds/gnome/blobs-d.svg
``` 

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
