### PR TITLE
python313Packages.sectxt: init at 0.9.6

### DIFF
--- a/pkgs/development/python-modules/pgpy-dtc/default.nix
+++ b/pkgs/development/python-modules/pgpy-dtc/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  pythonOlder,
+  fetchFromGitHub,
+  buildPythonPackage,
+  setuptools,
+  pyasn1,
+  cryptography,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pgpy-dtc";
+  version = "0.1.1";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "DigitalTrustCenter";
+    repo = "PGPy_dtc";
+    tag = version;
+    hash = "sha256-0zv2gtgp/iGDQescaDpng1gqbgjv7iXFvtwEt3YIPy4=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    pyasn1
+    cryptography
+  ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "pgpy_dtc" ];
+
+  meta = {
+    homepage = "https://github.com/DigitalTrustCenter/PGPy_dtc";
+    changelog = "https://github.com/DigitalTrustCenter/PGPy_dtc/releases/tag/${src.tag}";
+    description = "Pretty Good Privacy for Python";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ networkexception ];
+  };
+}

--- a/pkgs/development/python-modules/sectxt/default.nix
+++ b/pkgs/development/python-modules/sectxt/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  setuptools,
+  pythonOlder,
+  requests,
+  python-dateutil,
+  langcodes,
+  pgpy-dtc,
+  validators,
+  requests-mock,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "sectxt";
+  version = "0.9.6";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "DigitalTrustCenter";
+    repo = "sectxt";
+    tag = version;
+    hash = "sha256-49YxhcOpi1wofKMRuNxt8esBtfaSoBrGu+yBCRFWZYY=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    requests
+    python-dateutil
+    langcodes
+    pgpy-dtc
+    validators
+  ];
+
+  pythonRelaxDeps = [
+    "requests"
+    "langcodes"
+    "pgpy-dtc"
+    "validators"
+  ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+    requests-mock
+  ];
+
+  pythonImportsCheck = [ "sectxt" ];
+
+  meta = {
+    homepage = "https://github.com/DigitalTrustCenter/sectxt";
+    changelog = "https://github.com/DigitalTrustCenter/sectxt/releases/tag/${src.tag}";
+    description = "security.txt parser and validator";
+    license = lib.licenses.eupl12;
+    maintainers = with lib.maintainers; [ networkexception ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10277,6 +10277,8 @@ self: super: with self; {
 
   pgpy = callPackage ../development/python-modules/pgpy { };
 
+  pgpy-dtc = callPackage ../development/python-modules/pgpy-dtc { };
+
   pgsanity = callPackage ../development/python-modules/pgsanity { };
 
   pgspecial = callPackage ../development/python-modules/pgspecial { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14650,6 +14650,8 @@ self: super: with self; {
 
   sectools = callPackage ../development/python-modules/sectools { };
 
+  sectxt = callPackage ../development/python-modules/sectxt { };
+
   seedir = callPackage ../development/python-modules/seedir { };
 
   seekpath = callPackage ../development/python-modules/seekpath { };


### PR DESCRIPTION
This pull requests adds the `sectxt` and `pgpy-dtc` python libraries, the latter being a dependency of `sectxt`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
