### PR TITLE
nixos/geth: add sepolia, remove obsolete networks, fix license

### DIFF
--- a/nixos/modules/services/blockchain/ethereum/geth.nix
+++ b/nixos/modules/services/blockchain/ethereum/geth.nix
@@ -126,12 +126,8 @@ let
         network = lib.mkOption {
           type = lib.types.nullOr (
             lib.types.enum [
-              "goerli"
               "holesky"
-              "rinkeby"
-              "ropsten"
               "sepolia"
-              "yolov2"
             ]
           );
           default = null;

--- a/nixos/modules/services/blockchain/ethereum/geth.nix
+++ b/nixos/modules/services/blockchain/ethereum/geth.nix
@@ -129,8 +129,9 @@ let
               "goerli"
               "holesky"
               "rinkeby"
-              "yolov2"
               "ropsten"
+              "sepolia"
+              "yolov2"
             ]
           );
           default = null;

--- a/nixos/tests/geth.nix
+++ b/nixos/tests/geth.nix
@@ -15,7 +15,8 @@ import ./make-test-python.nix (
             enable = true;
           };
         };
-        services.geth."testnet" = {
+
+        services.geth."holesky" = {
           enable = true;
           port = 30304;
           network = "holesky";
@@ -28,15 +29,31 @@ import ./make-test-python.nix (
             port = 18551;
           };
         };
+
+        services.geth."sepolia" = {
+          enable = true;
+          port = 30305;
+          network = "sepolia";
+          http = {
+            enable = true;
+            port = 28545;
+          };
+          authrpc = {
+            enable = true;
+            port = 28551;
+          };
+        };
       };
 
     testScript = ''
       start_all()
 
       machine.wait_for_unit("geth-mainnet.service")
-      machine.wait_for_unit("geth-testnet.service")
+      machine.wait_for_unit("geth-holesky.service")
+      machine.wait_for_unit("geth-sepolia.service")
       machine.wait_for_open_port(8545)
       machine.wait_for_open_port(18545)
+      machine.wait_for_open_port(28545)
 
       machine.succeed(
           'geth attach --exec "eth.blockNumber" http://localhost:8545 | grep \'^0$\' '
@@ -44,6 +61,10 @@ import ./make-test-python.nix (
 
       machine.succeed(
           'geth attach --exec "eth.blockNumber" http://localhost:18545 | grep \'^0$\' '
+      )
+
+      machine.succeed(
+          'geth attach --exec "eth.blockNumber" http://localhost:28545 | grep \'^0$\' '
       )
     '';
   }

--- a/pkgs/by-name/go/go-ethereum/package.nix
+++ b/pkgs/by-name/go/go-ethereum/package.nix
@@ -72,8 +72,8 @@ buildGoModule rec {
     homepage = "https://geth.ethereum.org/";
     description = "Official golang implementation of the Ethereum protocol";
     license = with licenses; [
-      lgpl3Plus
-      gpl3Plus
+      lgpl3Only
+      gpl3Only
     ];
     maintainers = with maintainers; [ RaghavSood ];
     mainProgram = "geth";


### PR DESCRIPTION
The removed networks are not exposed as flags anymore, so choosing them would've broken the service at runtime.
Sepolia is a current testnet network, and exposed as `--sepolia`.

Also, upstream dual licenses under GPLv3 and LGPLv3 only, not later versions (see https://github.com/ethereum/go-ethereum/blob/master/README.md#license).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
