### PR TITLE
sbcl: 2.5.0 -> 2.5.1

### DIFF
--- a/pkgs/development/compilers/sbcl/default.nix
+++ b/pkgs/development/compilers/sbcl/default.nix
@@ -20,11 +20,11 @@ let
     };
     # By unofficial and very loose convention we keep the latest version of
     # SBCL, and the previous one in case someone quickly needs to roll back.
-    "2.4.11" = {
-      sha256 = "sha256-TwPlhG81g0wQcAu+Iy2kG6S9v4G9zKyx1N4kKXZXpBU=";
-    };
     "2.5.0" = {
       sha256 = "sha256-Lhiv0Ijkot8ht3uuLhcM5XDRHabSdgcpImXxzGqKGbE=";
+    };
+    "2.5.1" = {
+      sha256 = "sha256-QTOzbNFtFNYzlpw3/VHCyJqOpdbhYRVSgZ2R9xshn4s=";
     };
   };
   # Collection of pre-built SBCL binaries for platforms that need them for

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -11073,17 +11073,17 @@ with pkgs;
     faslExt = "fasl";
     flags = [ "--dynamic-space-size" "3000" ];
   };
-  sbcl_2_4_11 = wrapLisp {
-    pkg = callPackage ../development/compilers/sbcl { version = "2.4.11"; };
-    faslExt = "fasl";
-    flags = [ "--dynamic-space-size" "3000" ];
-  };
   sbcl_2_5_0 = wrapLisp {
     pkg = callPackage ../development/compilers/sbcl { version = "2.5.0"; };
     faslExt = "fasl";
     flags = [ "--dynamic-space-size" "3000" ];
   };
-  sbcl = sbcl_2_5_0;
+  sbcl_2_5_1 = wrapLisp {
+    pkg = callPackage ../development/compilers/sbcl { version = "2.5.1"; };
+    faslExt = "fasl";
+    flags = [ "--dynamic-space-size" "3000" ];
+  };
+  sbcl = sbcl_2_5_1;
 
   sbclPackages = recurseIntoAttrs sbcl.pkgs;
 


### PR DESCRIPTION
https://sourceforge.net/p/sbcl/mailman/message/59124996/

>
> changes in sbcl-2.5.1 relative to sbcl-2.5.0:
>   * minor incompatible change: SBCL now reveals details of its COMPLEX
>     representations through UPGRADED-COMPLEX-PART-TYPE, rather than hiding
>     them.
>   * minor incompatible change: the compiler will warn on the use of a
>     SATISFIES type with an undefined function.  (lp#576608, reported by Roman
>     Marynchak)
>   * minor incompatible change: (room t) now counts the space taken by the
>     internals of hash-tables and CLOS instances.
>   * platform support
>     ** fixes to the included version of ASDF, and to sockets functions, for
>        the Haiku operating system.  (thanks to Alexandru Popa)
>     ** add support for CAS (compare-and-swap) on SAPs for arm64, x86-64 and
>        (partially) RISC-V.  (lp#1894057, reported by Yukari Hafner)
>     ** the system is now consistent with 64-bit time_t on 32-bit linux
>        platforms. (lp#2063340, reported by Peter van Eynde)
>     ** restore building on 32-bit ARM with newer gcc versions.  (lp#1839783,
>        reported by Sébastien Villemot)
>     ** fix large stack allocation on 64-bit Windows. 
>   * CL portability fixes to the definitions of certain compiler structures,
>     detected by CLISP.  (lp#2064301, lp#2064312, thanks to Robert Brown)
>   * bug fix: a misplaced assertion regarding weak hash tables would trigger
>     if a garbage collection hit at just the wrong time.  (lp#2096998)
>   * bug fix: structure BOA constructors with &REST arguments no longer cause
>     structure slots named NIL or T to be unconditionally initialized with the
>     values NIL and T respectively.
>   * bug fix: structure BOA constructors without values for some slots no
>     longer cause compilation errors for initforms that are not a single
>     variable.
>   * bug fix: sequence functions handle :TEST and :TEST-NOT both being given
>     uniformly.  (lp#309143)
>   * bug fix: the type system is better equipped to handle complicated unions
>     of numeric types.  (lp#308937, lp#1694839, lp#1734959, lp#2073544)
>   * bug fix: misoptimization of VALUES-LIST in the presence of intervening
>     stack operations.  (reported by haruhi.s)
>   * bug fix: apply the limit to inline expansions more selectively.
>     (lp#2092518, reported by Andrew Kravchuk)
>   * bug fix: compiler-detected type mismatches are reported even given the
>     presence of inlined functions.  (lp#2092613, reported by Vasily Postnicov)
>   * bug fix: improved type error detection for inlined array construction forms.
>     (lp#2092889, reported by Vasily Postnicov)
>   * bug fix: accesses to multidimensional arrays are now checked based on the
>     (internal) INSERT-ARRAY-BOUNDS-CHECKS declaration, as with one-dimensional
>     arrays.  (lp#2095155, thanks to Vasily Postnicov)
>   * bug fix: sb-bsd-sockets:socket-connect handles EINTR caused by GC signals.
>


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
