### PR TITLE
kodiPackages.libretro-fbneo: init at 1.0.0.81

### DIFF
--- a/pkgs/applications/video/kodi/addons/libretro-fbneo/default.nix
+++ b/pkgs/applications/video/kodi/addons/libretro-fbneo/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  rel,
+  buildKodiBinaryAddon,
+  fetchFromGitHub,
+  libretro,
+  fbneo,
+}:
+
+buildKodiBinaryAddon rec {
+  pname = "libretro-fbneo";
+  namespace = "game.libretro.fbneo";
+  version = "1.0.0.81";
+
+  src = fetchFromGitHub {
+    owner = "kodi-game";
+    repo = "game.libretro.fbneo";
+    rev = "${version}-${rel}";
+    hash = "sha256-+stktDSoaz4fJGPIVuxlGuA2il/WC1cLhUPVvRM6CuU=";
+  };
+
+  extraCMakeFlags = [
+    "-DFBNEO_LIB=${fbneo}/lib/retroarch/cores/fbneo_libretro.so"
+  ];
+
+  extraBuildInputs = [ fbneo ];
+  propagatedBuildInputs = [ libretro ];
+
+  meta = with lib; {
+    homepage = "https://github.com/kodi-game/game.libretro.fbneo";
+    description = "FinalBurn Neo GameClient for Kodi (previously FinalBurn Alpha)";
+    platforms = platforms.all;
+    license = licenses.gpl2Only;
+    maintainers = teams.kodi.members;
+  };
+}

--- a/pkgs/top-level/kodi-packages.nix
+++ b/pkgs/top-level/kodi-packages.nix
@@ -9,7 +9,7 @@ let
     unique
     ;
 
-  inherit (libretro) fuse genesis-plus-gx gw mgba nestopia snes9x twenty-fortyeight;
+  inherit (libretro) fbneo fuse genesis-plus-gx gw mgba nestopia snes9x twenty-fortyeight;
 
   callPackage = newScope self;
 
@@ -70,6 +70,8 @@ let
     libretro = callPackage ../applications/video/kodi/addons/libretro { };
 
     libretro-2048 = callPackage ../applications/video/kodi/addons/libretro-2048 { inherit twenty-fortyeight; };
+
+    libretro-fbneo = callPackage ../applications/video/kodi/addons/libretro-fbneo { inherit fbneo; };
 
     libretro-fuse = callPackage ../applications/video/kodi/addons/libretro-fuse { inherit fuse; };
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

FinalBurn Neo GameClient for Kodi (previously FinalBurn Alpha)
Project page: https://github.com/kodi-game/game.libretro.fbneo

This is an emulator for arcade games and select consoles. IAGL plugin attempts to use it for ZX Spectrum emulation by default.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
