### PR TITLE
python312Packages.twilio: 9.4.3 -> 9.4.4

### DIFF
--- a/pkgs/development/python-modules/twilio/default.nix
+++ b/pkgs/development/python-modules/twilio/default.nix
@@ -21,7 +21,7 @@
 
 buildPythonPackage rec {
   pname = "twilio";
-  version = "9.4.3";
+  version = "9.4.4";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -30,7 +30,7 @@ buildPythonPackage rec {
     owner = "twilio";
     repo = "twilio-python";
     tag = version;
-    hash = "sha256-HgV6GEhtwk2smtzdOypucZBX+kj9lfqsY2sZ9Yl7fbM=";
+    hash = "sha256-qkbxu2FembYCdGOEaBmAod6HYGaulhcakTLgCHJoZZY=";
   };
 
   build-system = [ setuptools ];
@@ -59,16 +59,11 @@ buildPythonPackage rec {
     "test_set_user_agent_extensions"
   ];
 
-  disabledTestPaths =
-    [
-      # Tests require API token
-      "tests/cluster/test_webhook.py"
-      "tests/cluster/test_cluster.py"
-    ]
-    ++ lib.optionals (pythonAtLeast "3.11") [
-      # aiounittest is not supported on Python 3.12
-      "tests/unit/http/test_async_http_client.py"
-    ];
+  disabledTestPaths = [
+    # Tests require API token
+    "tests/cluster/test_webhook.py"
+    "tests/cluster/test_cluster.py"
+  ];
 
   pythonImportsCheck = [ "twilio" ];
 


### PR DESCRIPTION
Previous version fails in staging-next as 
```
Checking runtime dependencies for twilio-9.4.3-py2.py3-none-any.whl
  - aiohttp-retry==2.8.3 not satisfied by version 2.9.0
```

Upstream proceeded to allow newer versions (https://github.com/twilio/twilio-python/pull/837) until eventually "pinning" 2.8.3 again (https://github.com/twilio/twilio-python/pull/822). The last pin is evidently without effect, as it now builds without patches against the newer aiohttp-retry.

Also re-enabled some tests that now work again.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).