### PR TITLE
naps2: 7.4.3 -> 7.5.3 and use non-EOL dotnet

### DIFF
--- a/pkgs/by-name/na/naps2/deps.json
+++ b/pkgs/by-name/na/naps2/deps.json
@@ -2,876 +2,711 @@
   {
     "pname": "AtkSharp",
     "version": "3.24.24.95",
-    "sha256": "0x4nr8rx50h87n6ijv5a4vkavs2x61bsrkxvam27h178finmc1rn"
+    "hash": "sha256-NgdWbXToBHhEVbvPrFcwXeit5iaqbBmNPQiC0jPKlnQ="
   },
   {
     "pname": "Autofac",
     "version": "8.0.0",
-    "sha256": "0w3y76vik6rfr9am649v4w6dyyp5s25244q3il2x8si11xgl6y7d"
+    "hash": "sha256-7XhDXw8hatQFjQMTIorQ5XrfDCc7EVNVyi6bGbc5fnA="
   },
   {
     "pname": "Ben.Demystifier",
     "version": "0.4.1",
-    "sha256": "1szlrhvwpwkjhpgvjlrpjg714bz1yhyljs72pxni3li4mgnklk1f"
+    "hash": "sha256-Lkw67ask0hFtv+JoST304S8SzpM3U7nfhXLyyzfM9Os="
   },
   {
     "pname": "CairoSharp",
     "version": "3.24.24.95",
-    "sha256": "05fq8jdlxzrrw7gh0i3w272q34wzmb3bizcghjnf9mlh1jcn1iy9"
+    "hash": "sha256-ycdgmQyQ1uSshI/9uMaqn5OBxRF8RADf4Tn/TptE2BU="
   },
   {
     "pname": "CommandLineParser",
     "version": "2.9.1",
-    "sha256": "1sldkj8lakggn4hnyabjj1fppqh50fkdrr1k99d4gswpbk5kv582"
+    "hash": "sha256-ApU9y1yX60daSjPk3KYDBeJ7XZByKW8hse9NRZGcjeo="
   },
   {
     "pname": "EmbedIO",
     "version": "3.5.2",
-    "sha256": "13saxicm07nkppzfxb60cpm1501n4ixaqhkvvqqfaqgifma9z8bv"
+    "hash": "sha256-e6GfVHXxYeUw3ntCrHokNoAS6mXArO7+vdMeUFnsSo8="
   },
   {
     "pname": "Eto.Forms",
     "version": "2.8.3",
-    "sha256": "00v2ffi9sl8cjllrz8rw3a5s5cgm9bfh45852znwz18zp06rh5bg"
+    "hash": "sha256-bxWYDbgfhc/tFwUVAt1K9bGiixo8o58plQxRnaJzYgM="
   },
   {
     "pname": "Eto.Platform.Gtk",
     "version": "2.8.3",
-    "sha256": "0av22hyx6xf6cnm89a4jvpnm80h1p6a6301r4n2906ihai9k3gsk"
+    "hash": "sha256-U78xU1QwGpCEJTmAYZS5AQJU7d2SqISqZcZ10z0UYis="
   },
   {
     "pname": "GdkSharp",
     "version": "3.24.24.95",
-    "sha256": "1wp2kgng0pwg8q5bl1zz4lzzj603qcjljql61h83bxa60q7c121m"
+    "hash": "sha256-NYjADgZG9TUQDIZiSSXDAxj5PyX/B7oKRo9f8Oyb4vI="
   },
   {
     "pname": "GioSharp",
     "version": "3.24.24.95",
-    "sha256": "121xb98hg955vwxfv1r5idr5a2zv09xpcmqckm7hhgprlzhz2cg5"
+    "hash": "sha256-5THx4af5PghPnQxXdnsC+wtVcoslh+0636WkB1FaPYg="
   },
   {
     "pname": "GLibSharp",
     "version": "3.24.24.95",
-    "sha256": "1l5nbg0qwjp55wfj06vnk5q5r5cnq5h064qp4k5xf8qlma8d346n"
+    "hash": "sha256-1pDRkKoUI9fLJBcTA2DBlpVccJl2GyAdL+VKjsFbttA="
   },
   {
     "pname": "Google.Protobuf",
     "version": "3.25.1",
-    "sha256": "0zcw9vmv2bdai3zaip86s37lj3r5z4zvcs9mf5a9nih0hy4gzwsi"
+    "hash": "sha256-UfP/iIcARptUcTVptj/5JQ9Jz9AG3aj+iKotsetOnH0="
   },
   {
     "pname": "Grpc.Core.Api",
     "version": "2.59.0",
-    "sha256": "0pajrxg0dsfnyxwrd2li5nrabz0r3b3bql776l44hn5rg1s1287k"
+    "hash": "sha256-8yARdHi5WEgINedQvMYaGfylsi2RipZ599bpBl7PUl0="
   },
   {
     "pname": "Grpc.Tools",
-    "version": "2.62.0",
-    "sha256": "1x6ydsvjckxdpnrl07h307wql5gghlb4fasf591ppr16kv5igdfp"
+    "version": "2.65.0",
+    "hash": "sha256-Nzpq4DIBnhZ7kX+/bwqUSMDa5NJB52iKuXARYnM5yZw="
   },
   {
     "pname": "GrpcDotNetNamedPipes",
     "version": "3.0.0",
-    "sha256": "1sndscz12dldjfvifp04ml56fkbl1vwb9llzq0h58hwri35nnbv7"
+    "hash": "sha256-Zy9ry4iZQ1QgwJ/StPgOdE1nCq0EXBe3k402ET7Tzeo="
   },
   {
     "pname": "GtkSharp",
     "version": "3.24.24.95",
-    "sha256": "0y20zn8wv72dg2bc7f95l8iz8z51ap08q5gnv6f2xnhz8zjf86xh"
+    "hash": "sha256-sBvk5Ecf2i6c2fYVjMBVoXz0I6IlucOWeE2czZH9QHg="
   },
   {
     "pname": "IsExternalInit",
     "version": "1.0.3",
-    "sha256": "01flcxs8m7m916s5rx5iyvzh6fjdl1dvcyzl9cpzn0d17yp8dz2i"
+    "hash": "sha256-UfyGrj+hAfsvS/R7tlugTToD//ax9Fy0CameinRn1AU="
   },
   {
     "pname": "Makaretu.Dns",
     "version": "2.0.1",
-    "sha256": "1l6ajfdcvqpz078wl6nm44bnhd8h47nssb5qgp5al9zqic50mqnd"
-  },
-  {
-    "pname": "Microsoft.Bcl.AsyncInterfaces",
-    "version": "7.0.0",
-    "sha256": "1waiggh3g1cclc81gmjrqbh128kwfjky3z79ma4bd2ms9pa3gvfm"
+    "hash": "sha256-zeIKCov4J6rKfbgsre0hEDVoFyHVGsrRAf/izZqTytA="
   },
   {
     "pname": "Microsoft.Bcl.AsyncInterfaces",
     "version": "8.0.0",
-    "sha256": "0z4jq5prnxyb4p3163yxx35znpd2msjd8hw8ysmv4ah90f5sd9gm"
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration",
-    "version": "2.1.0",
-    "sha256": "04rjl38wlr1jjjpbzgf64jp0ql6sbzbil0brwq9mgr3hdgwd7vx2"
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Abstractions",
-    "version": "2.1.0",
-    "sha256": "03gzlr3z9j1xnr1k6y91zgxpz3pj27i3zsvjwj7i8jqnlqmk7pxd"
+    "hash": "sha256-9aWmiwMJKrKr9ohD1KSuol37y+jdDxPGJct3m2/Bknw="
   },
   {
     "pname": "Microsoft.Extensions.Configuration.Abstractions",
     "version": "8.0.0",
-    "sha256": "1jlpa4ggl1gr5fs7fdcw04li3y3iy05w3klr9lrrlc7v8w76kq71"
-  },
-  {
-    "pname": "Microsoft.Extensions.Configuration.Binder",
-    "version": "2.1.0",
-    "sha256": "0x1888w5ypavvszfmpja9krgc64527prs75vm8xbf9fv3rgsplql"
+    "hash": "sha256-4eBpDkf7MJozTZnOwQvwcfgRKQGcNXe0K/kF+h5Rl8o="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection",
     "version": "8.0.0",
-    "sha256": "0i7qziz0iqmbk8zzln7kx9vd0lbx1x3va0yi3j1bgkjir13h78ps"
-  },
-  {
-    "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
-    "version": "2.1.0",
-    "sha256": "0c0cx8r5xkjpxmcfp51959jnp55qjvq28d9vaslk08avvi1by12s"
+    "hash": "sha256-+qIDR8hRzreCHNEDtUcPfVHQdurzWPo/mqviCH78+EQ="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
     "version": "8.0.0",
-    "sha256": "1zw0bpp5742jzx03wvqc8csnvsbgdqi0ls9jfc5i2vd3cl8b74pg"
+    "hash": "sha256-75KzEGWjbRELczJpCiJub+ltNUMMbz5A/1KQU+5dgP8="
   },
   {
     "pname": "Microsoft.Extensions.DependencyInjection.Abstractions",
     "version": "8.0.1",
-    "sha256": "1wyhpamm1nqjfi3r463dhxljdlr6rm2ax4fvbgq2s0j3jhpdhd4p"
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging",
-    "version": "2.1.0",
-    "sha256": "0dii8i7s6libfnspz2xb96ayagb4rwqj2kmr162vndivr9rmbm06"
+    "hash": "sha256-lzTYLpRDAi3wW9uRrkTNJtMmaYdtGJJHdBLbUKu60PM="
   },
   {
     "pname": "Microsoft.Extensions.Logging",
     "version": "8.0.0",
-    "sha256": "0nppj34nmq25gnrg0wh1q22y4wdqbih4ax493f226azv8mkp9s1i"
-  },
-  {
-    "pname": "Microsoft.Extensions.Logging.Abstractions",
-    "version": "2.1.0",
-    "sha256": "1gvgif1wcx4k6pv7gc00qv1hid945jdywy1s50s33q0hfd91hbnj"
+    "hash": "sha256-Meh0Z0X7KyOEG4l0RWBcuHHihcABcvCyfUXgasmQ91o="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
     "version": "8.0.0",
-    "sha256": "1klcqhg3hk55hb6vmjiq2wgqidsl81aldw0li2z98lrwx26msrr6"
+    "hash": "sha256-Jmddjeg8U5S+iBTwRlVAVLeIHxc4yrrNgqVMOB7EjM4="
   },
   {
     "pname": "Microsoft.Extensions.Logging.Abstractions",
     "version": "8.0.1",
-    "sha256": "0i9pgmk60b8xlws3q9z890gim1xjq42dhyh6dj4xvbycmgg1x1sd"
-  },
-  {
-    "pname": "Microsoft.Extensions.Options",
-    "version": "2.1.0",
-    "sha256": "0w9644sryd1c6r3n4lq2cgd5pn6jl3k5m38a05m7vjffa4m2spd2"
+    "hash": "sha256-TYce3qvMr92JbAZ62ATBsocaH0joJzw0px0tYGZ9N0U="
   },
   {
     "pname": "Microsoft.Extensions.Options",
     "version": "8.0.0",
-    "sha256": "0p50qn6zhinzyhq9sy5svnmqqwhw2jajs2pbjh9sah504wjvhscz"
-  },
-  {
-    "pname": "Microsoft.Extensions.Primitives",
-    "version": "2.1.0",
-    "sha256": "1r9gzwdfmb8ysnc4nzmyz5cyar1lw0qmizsvrsh252nhlyg06nmb"
+    "hash": "sha256-n2m4JSegQKUTlOsKLZUUHHKMq926eJ0w9N9G+I3FoFw="
   },
   {
     "pname": "Microsoft.Extensions.Primitives",
     "version": "8.0.0",
-    "sha256": "0aldaz5aapngchgdr7dax9jw5wy7k7hmjgjpfgfv1wfif27jlkqm"
+    "hash": "sha256-FU8qj3DR8bDdc1c+WeGZx/PCZeqqndweZM9epcpXjSo="
   },
   {
     "pname": "Microsoft.NETCore.App",
     "version": "2.1.30",
-    "sha256": "10brwj7csacwa4ra37pjb2bqwg961lxi576330xlhhwqixkjkrqf"
+    "hash": "sha256-DucpZ4+YQ0g7GMOcEjsNJj2Ol1jynqEyUZwpzY7keYE="
   },
   {
     "pname": "Microsoft.NETCore.DotNetAppHost",
     "version": "2.1.30",
-    "sha256": "0rabvmid1n604pk9rndlq62zqhq77p7cznmq9bzr7hshvr2rszab"
+    "hash": "sha256-S32dRd5Qw5P/Srjaz849B0P8hcG02ZzmJcDY0GLdS2U="
   },
   {
     "pname": "Microsoft.NETCore.DotNetHostPolicy",
     "version": "2.1.30",
-    "sha256": "1zk6ajalssvpm2yv4ri3g6hbxjaj1ns0y4w3g98wss54k7v44vpw"
+    "hash": "sha256-/G5C9pmkaM1ReoMTD7QNUsm+oHkjZrK9qHdrTZVUZv4="
   },
   {
     "pname": "Microsoft.NETCore.DotNetHostResolver",
     "version": "2.1.30",
-    "sha256": "0k3k6ldi5lj9ab9bdnhzfiykr6ipwz17d9g952bcanhvmk57l376"
-  },
-  {
-    "pname": "Microsoft.NETCore.Platforms",
-    "version": "1.1.0",
-    "sha256": "08vh1r12g6ykjygq5d3vq09zylgb84l63k49jc4v8faw9g93iqqm"
+    "hash": "sha256-5gx6yqwbWsWWKOmldsLnN5o8fXQf2rbSUknSEhs1c0w="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
     "version": "1.1.1",
-    "sha256": "164wycgng4mi9zqi2pnsf1pq6gccbqvw6ib916mqizgjmd8f44pj"
+    "hash": "sha256-8hLiUKvy/YirCWlFwzdejD2Db3DaXhHxT7GSZx/znJg="
   },
   {
     "pname": "Microsoft.NETCore.Platforms",
     "version": "2.1.14",
-    "sha256": "0mbmcgsky65y0xai4xjfnhm07kn856y9kpn6hnm1b5m3mdsf8dkq"
-  },
-  {
-    "pname": "Microsoft.NETCore.Platforms",
-    "version": "5.0.0",
-    "sha256": "0mwpwdflidzgzfx2dlpkvvnkgkr2ayaf0s80737h4wa35gaj11rc"
+    "hash": "sha256-eDbkdKujlhWqhcbembwpyM4DKrROdhJVB74YP/VjdVU="
   },
   {
     "pname": "Microsoft.NETCore.Targets",
     "version": "1.1.0",
-    "sha256": "193xwf33fbm0ni3idxzbr5fdq3i2dlfgihsac9jj7whj0gd902nh"
+    "hash": "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ="
   },
   {
     "pname": "Microsoft.NETCore.Targets",
     "version": "2.0.0",
-    "sha256": "0nsrrhafvxqdx8gmlgsz612bmlll2w3l2qn2ygdzr92rp1nqyka2"
-  },
-  {
-    "pname": "Microsoft.NETFramework.ReferenceAssemblies",
-    "version": "1.0.3",
-    "sha256": "0hc4d4d4358g5192mf8faijwk0bpf9pjwcfd3h85sr67j0zhj6hl"
-  },
-  {
-    "pname": "Microsoft.NETFramework.ReferenceAssemblies.net462",
-    "version": "1.0.3",
-    "sha256": "08bfss2p262d8zj41xqndv0qgvz9lq636k2xhl80jl23ay22lsgf"
+    "hash": "sha256-Qk2PbbhZpPzb88JiQQcXlNK6RDBfP1of6g337RTMWVs="
   },
   {
     "pname": "Microsoft.Win32.Primitives",
     "version": "4.3.0",
-    "sha256": "0j0c1wj4ndj21zsgivsc24whiya605603kxrbiw6wkfdync464wq"
-  },
-  {
-    "pname": "Microsoft.Win32.Registry",
-    "version": "5.0.0",
-    "sha256": "102hvhq2gmlcbq8y2cb7hdr2dnmjzfp2k3asr1ycwrfacwyaak7n"
+    "hash": "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg="
   },
   {
     "pname": "MimeKitLite",
-    "version": "4.4.0",
-    "sha256": "1am381zbh89qa520pllsa92by92lg6wn0zxhqa26z7mlh6jwc8nz"
+    "version": "4.7.1",
+    "hash": "sha256-vxCSs9w+xQDsUM8OiyCg6VmBi2twmqsD2BTJ1ESHLo8="
   },
   {
     "pname": "NAPS2.Mdns",
     "version": "1.0.1",
-    "sha256": "0xi46brppcjm8mrabnffahkmkcakhw94cnq1w2yk8y2hyq9qb4ms"
+    "hash": "sha256-upKFE/ZQeDS94AFbRhKHU7FZJ1TO2aVyRVWye/MyJHY="
   },
   {
     "pname": "NAPS2.NTwain",
     "version": "1.0.0",
-    "sha256": "088dw31h7rlgr0s05snm382wz65wi46yaizjnjpd0wzw2mb58yld"
+    "hash": "sha256-jXpUVhX8c9CutPJH5Q2JvJjPBRrV6gI0yI/mA8PgDSE="
   },
   {
     "pname": "NAPS2.Pdfium.Binaries",
     "version": "1.1.0",
-    "sha256": "0rnqkk6y047p6a6li2dr2cygkhjn3d2a13yn3rck5gf854k3q3ws"
+    "hash": "sha256-mg88JinIvTJZHtaPoEQbVsL5PBO5iUiNMvcQ4M2c2GY="
   },
   {
     "pname": "NAPS2.PdfSharp",
     "version": "1.0.1",
-    "sha256": "0x51whjhlqd5r0f1s5hjx41zzwwcwcdl19q6iz6k7fwx81746w0w"
+    "hash": "sha256-HHBDTkCduzPNjwanQBvjjPP/A+kSFh0cyKVhCiXkoXQ="
   },
   {
     "pname": "NAPS2.Tesseract.Binaries",
     "version": "1.2.0",
-    "sha256": "0m1aksfjg4vfl2llvhd2in0a5i4wa72nmfw2h78y4wwxmjplbfz2"
+    "hash": "sha256-4rtFr6ydc+LRgYK7asVRnMSigI2iwU2poG6TJ52eKlQ="
   },
   {
     "pname": "NAPS2.Wia",
     "version": "2.0.3",
-    "sha256": "0xszkccb8fy2x60nkblpda78wx2d86fn8y49j94qmvz4rp2nw98i"
+    "hash": "sha256-ESVuxc3k74pJkol4ZJ1BTXSOjmqXrmmB6cI7tBibX3c="
   },
   {
     "pname": "NETStandard.Library",
     "version": "2.0.3",
-    "sha256": "1fn9fxppfcg4jgypp2pmrpr6awl3qz1xmnri0cygpkwvyx27df1y"
+    "hash": "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo="
   },
   {
     "pname": "Newtonsoft.Json",
     "version": "13.0.3",
-    "sha256": "0xrwysmrn4midrjal8g2hr1bbg38iyisl0svamb11arqws4w2bw7"
+    "hash": "sha256-hy/BieY4qxBWVVsDqqOPaLy1QobiIapkbrESm6v2PHc="
   },
   {
     "pname": "NLog",
-    "version": "5.2.8",
-    "sha256": "1z3h20m5rjnizm1jbf5j0vpdc1f373rzzkg6478p1lxv5j385c12"
+    "version": "5.3.2",
+    "hash": "sha256-b/y/IFUSe7qsSeJ8JVB0VFmJlkviFb8h934ktnn9Fgc="
   },
   {
     "pname": "NLog.Extensions.Logging",
-    "version": "5.3.8",
-    "sha256": "1qnz91099f51vk7f5g2ig0041maw5hcbyqllxvj5zj7zkp0qw9b8"
+    "version": "5.3.11",
+    "hash": "sha256-DP3R51h+9kk06N63U+1C4/JCZTFiADeYTROToAA2R0g="
   },
   {
     "pname": "PangoSharp",
     "version": "3.24.24.95",
-    "sha256": "0548jrkgzia899va9smhh7if49nk6avbswb68xmc52k37lins6b2"
+    "hash": "sha256-YhltIz1jisJqR2ZxvbYy0ybi4oGw6qR2SkjF/2aWiBQ="
   },
   {
     "pname": "Polyfill",
-    "version": "4.2.0",
-    "sha256": "0h25jszwrkmxlklcr6mjjmz71rn6q36pqb5jx36l94lrccy2k0a8"
+    "version": "4.9.0",
+    "hash": "sha256-oTnmSAwMbxPFhzqBBrcSej0Nd3BKSX1kh0iwih2Iquo="
   },
   {
     "pname": "runtime.any.System.Collections",
     "version": "4.3.0",
-    "sha256": "0bv5qgm6vr47ynxqbnkc7i797fdi8gbjjxii173syrx14nmrkwg0"
+    "hash": "sha256-4PGZqyWhZ6/HCTF2KddDsbmTTjxs2oW79YfkberDZS8="
   },
   {
     "pname": "runtime.any.System.Diagnostics.Tracing",
     "version": "4.3.0",
-    "sha256": "00j6nv2xgmd3bi347k00m7wr542wjlig53rmj28pmw7ddcn97jbn"
+    "hash": "sha256-dsmTLGvt8HqRkDWP8iKVXJCS+akAzENGXKPV18W2RgI="
   },
   {
     "pname": "runtime.any.System.Globalization",
     "version": "4.3.0",
-    "sha256": "1daqf33hssad94lamzg01y49xwndy2q97i2lrb7mgn28656qia1x"
+    "hash": "sha256-PaiITTFI2FfPylTEk7DwzfKeiA/g/aooSU1pDcdwWLU="
   },
   {
     "pname": "runtime.any.System.Globalization.Calendars",
     "version": "4.3.0",
-    "sha256": "1ghhhk5psqxcg6w88sxkqrc35bxcz27zbqm2y5p5298pv3v7g201"
+    "hash": "sha256-AYh39tgXJVFu8aLi9Y/4rK8yWMaza4S4eaxjfcuEEL4="
   },
   {
     "pname": "runtime.any.System.IO",
     "version": "4.3.0",
-    "sha256": "0l8xz8zn46w4d10bcn3l4yyn4vhb3lrj2zw8llvz7jk14k4zps5x"
+    "hash": "sha256-vej7ySRhyvM3pYh/ITMdC25ivSd0WLZAaIQbYj/6HVE="
   },
   {
     "pname": "runtime.any.System.Reflection",
     "version": "4.3.0",
-    "sha256": "02c9h3y35pylc0zfq3wcsvc5nqci95nrkq0mszifc0sjx7xrzkly"
+    "hash": "sha256-ns6f++lSA+bi1xXgmW1JkWFb2NaMD+w+YNTfMvyAiQk="
   },
   {
     "pname": "runtime.any.System.Reflection.Primitives",
     "version": "4.3.0",
-    "sha256": "0x1mm8c6iy8rlxm8w9vqw7gb7s1ljadrn049fmf70cyh42vdfhrf"
+    "hash": "sha256-LkPXtiDQM3BcdYkAm5uSNOiz3uF4J45qpxn5aBiqNXQ="
   },
   {
     "pname": "runtime.any.System.Resources.ResourceManager",
     "version": "4.3.0",
-    "sha256": "03kickal0iiby82wa5flar18kyv82s9s6d4xhk5h4bi5kfcyfjzl"
+    "hash": "sha256-9EvnmZslLgLLhJ00o5MWaPuJQlbUFcUF8itGQNVkcQ4="
   },
   {
     "pname": "runtime.any.System.Runtime",
     "version": "4.3.0",
-    "sha256": "1cqh1sv3h5j7ixyb7axxbdkqx6cxy00p4np4j91kpm492rf4s25b"
+    "hash": "sha256-qwhNXBaJ1DtDkuRacgHwnZmOZ1u9q7N8j0cWOLYOELM="
   },
   {
     "pname": "runtime.any.System.Runtime.Handles",
     "version": "4.3.0",
-    "sha256": "0bh5bi25nk9w9xi8z23ws45q5yia6k7dg3i4axhfqlnj145l011x"
+    "hash": "sha256-PQRACwnSUuxgVySO1840KvqCC9F8iI9iTzxNW0RcBS4="
   },
   {
     "pname": "runtime.any.System.Runtime.InteropServices",
     "version": "4.3.0",
-    "sha256": "0c3g3g3jmhlhw4klrc86ka9fjbl7i59ds1fadsb2l8nqf8z3kb19"
+    "hash": "sha256-Kaw5PnLYIiqWbsoF3VKJhy7pkpoGsUwn4ZDCKscbbzA="
   },
   {
     "pname": "runtime.any.System.Text.Encoding",
     "version": "4.3.0",
-    "sha256": "0aqqi1v4wx51h51mk956y783wzags13wa7mgqyclacmsmpv02ps3"
+    "hash": "sha256-Q18B9q26MkWZx68exUfQT30+0PGmpFlDgaF0TnaIGCs="
   },
   {
     "pname": "runtime.any.System.Text.Encoding.Extensions",
     "version": "4.3.0",
-    "sha256": "0lqhgqi0i8194ryqq6v2gqx0fb86db2gqknbm0aq31wb378j7ip8"
+    "hash": "sha256-6MYj0RmLh4EVqMtO/MRqBi0HOn5iG4x9JimgCCJ+EFM="
   },
   {
     "pname": "runtime.any.System.Threading.Tasks",
     "version": "4.3.0",
-    "sha256": "03mnvkhskbzxddz4hm113zsch1jyzh2cs450dk3rgfjp8crlw1va"
+    "hash": "sha256-agdOM0NXupfHbKAQzQT8XgbI9B8hVEh+a/2vqeHctg4="
   },
   {
     "pname": "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "0rwpqngkqiapqc5c2cpkj7idhngrgss5qpnqg0yh40mbyflcxf8i"
+    "hash": "sha256-EbnOqPOrAgI9eNheXLR++VnY4pHzMsEKw1dFPJ/Fl2c="
   },
   {
     "pname": "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "1n06gxwlinhs0w7s8a94r1q3lwqzvynxwd3mp10ws9bg6gck8n4r"
+    "hash": "sha256-mVg02TNvJc1BuHU03q3fH3M6cMgkKaQPBxraSHl/Btg="
   },
   {
     "pname": "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "0404wqrc7f2yc0wxv71y3nnybvqx8v4j9d47hlscxy759a525mc3"
+    "hash": "sha256-g9Uiikrl+M40hYe0JMlGHe/lrR0+nN05YF64wzLmBBA="
   },
   {
     "pname": "runtime.linux-arm64.Microsoft.NETCore.App",
     "version": "2.1.30",
-    "sha256": "039r4c42mz8fg8nqn8p3v0dxnjv681xlllhrc4l91rbbwv04li6j"
+    "hash": "sha256-0kRKwOZr5ZAoYRlSSntAZkvbG9jjIosteg79KggjOQ0="
   },
   {
     "pname": "runtime.linux-arm64.Microsoft.NETCore.DotNetAppHost",
     "version": "2.1.30",
-    "sha256": "00pm387jvv574jsdd1261mbvxd7lbjbsfx3wq0z0iqjhr31pgmw1"
+    "hash": "sha256-gdd3w8hQ4gg+wHx0p5dc9LS+Vw1GhNa0JKfsLQ8a9QI="
   },
   {
     "pname": "runtime.linux-arm64.Microsoft.NETCore.DotNetHostPolicy",
     "version": "2.1.30",
-    "sha256": "1gjjs4xvg9x48lg00ys6r5vc00s973aknpqp0ffa946s8m8xhlfw"
+    "hash": "sha256-3FHYUUXakKScAxdfO9U4SQPAdslGewAeRaSntzvRUr4="
   },
   {
     "pname": "runtime.linux-arm64.Microsoft.NETCore.DotNetHostResolver",
     "version": "2.1.30",
-    "sha256": "0jyzw9wr9sgllgj08vdf716p27s13ad46nah2q1qmfa05cgdbikb"
+    "hash": "sha256-a8bVHitAuYoDFlBZQ5oaQR9xTTiubQTko/TplHni30s="
   },
   {
     "pname": "runtime.linux-x64.Microsoft.NETCore.App",
     "version": "2.1.30",
-    "sha256": "1wy9kagwj6avvhpp4lrlxw5sqgh4zlmii9wvf474fx999szi5bqb"
+    "hash": "sha256-C68Sv04pdUcOcZunGCv9BD6sC+80U3Iv3FsZyZ+ayfM="
   },
   {
     "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetAppHost",
     "version": "2.1.30",
-    "sha256": "0mrlvhm6yb3x40pfm4smi67p6wm3hi71jdnawqkqy73g203rjmgx"
+    "hash": "sha256-/VWZBxBvHI8n5so2GU6Eo3Jzj4lVk+ouIH0sbyrcNFc="
   },
   {
     "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetHostPolicy",
     "version": "2.1.30",
-    "sha256": "1zv9i8wqpsdr2vx35i3qzad1yvz00l6i9f00fclw02v2p92jz9c1"
+    "hash": "sha256-gaUvRbpiC8ApcwC4FA0F4G8fmvp4xDL6FrnpizmKaf8="
   },
   {
     "pname": "runtime.linux-x64.Microsoft.NETCore.DotNetHostResolver",
     "version": "2.1.30",
-    "sha256": "1s6zx2hpg60pscvz8yfdkxpdg1lhs534x5mz3yryxa91nfzhxv95"
+    "hash": "sha256-Je0Ov7Mhqe6zH7+WTkbRkIbXbp/NefQ30xeYd6Ho3+g="
   },
   {
     "pname": "runtime.native.System",
     "version": "4.3.0",
-    "sha256": "15hgf6zaq9b8br2wi1i3x0zvmk410nlmsmva9p0bbg73v6hml5k4"
+    "hash": "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y="
   },
   {
     "pname": "runtime.native.System.Net.Http",
     "version": "4.3.0",
-    "sha256": "1n6rgz5132lcibbch1qlf0g9jk60r0kqv087hxc0lisy50zpm7kk"
+    "hash": "sha256-c556PyheRwpYhweBjSfIwEyZHnAUB8jWioyKEcp/2dg="
   },
   {
     "pname": "runtime.native.System.Security.Cryptography.Apple",
     "version": "4.3.0",
-    "sha256": "1b61p6gw1m02cc1ry996fl49liiwky6181dzr873g9ds92zl326q"
+    "hash": "sha256-2IhBv0i6pTcOyr8FFIyfPEaaCHUmJZ8DYwLUwJ+5waw="
   },
   {
     "pname": "runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "0zy5r25jppz48i2bkg8b9lfig24xixg6nm3xyr1379zdnqnpm8f6"
+    "hash": "sha256-xqF6LbbtpzNC9n1Ua16PnYgXHU0LvblEROTfK4vIxX8="
   },
   {
     "pname": "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "096ch4n4s8k82xga80lfmpimpzahd2ip1mgwdqgar0ywbbl6x438"
+    "hash": "sha256-aJBu6Frcg6webvzVcKNoUP1b462OAqReF2giTSyBzCQ="
   },
   {
     "pname": "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "1dm8fifl7rf1gy7lnwln78ch4rw54g0pl5g1c189vawavll7p6rj"
+    "hash": "sha256-Mpt7KN2Kq51QYOEVesEjhWcCGTqWckuPf8HlQ110qLY="
   },
   {
     "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple",
     "version": "4.3.0",
-    "sha256": "10yc8jdrwgcl44b4g93f1ds76b176bajd3zqi2faf5rvh1vy9smi"
+    "hash": "sha256-serkd4A7F6eciPiPJtUyJyxzdAtupEcWIZQ9nptEzIM="
   },
   {
     "pname": "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "1m9z1k9kzva9n9kwinqxl97x2vgl79qhqjlv17k9s2ymcyv2bwr6"
+    "hash": "sha256-JvMltmfVC53mCZtKDHE69G3RT6Id28hnskntP9MMP9U="
   },
   {
     "pname": "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "1cpx56mcfxz7cpn57wvj18sjisvzq8b5vd9rw16ihd2i6mcp3wa1"
+    "hash": "sha256-QfFxWTVRNBhN4Dm1XRbCf+soNQpy81PsZed3x6op/bI="
   },
   {
     "pname": "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "15gsm1a8jdmgmf8j5v1slfz8ks124nfdhk2vxs2rw3asrxalg8hi"
+    "hash": "sha256-EaJHVc9aDZ6F7ltM2JwlIuiJvqM67CKRq682iVSo+pU="
   },
   {
     "pname": "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "0q0n5q1r1wnqmr5i5idsrd9ywl33k0js4pngkwq9p368mbxp8x1w"
+    "hash": "sha256-PHR0+6rIjJswn89eoiWYY1DuU8u6xRJLrtjykAMuFmA="
   },
   {
     "pname": "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl",
     "version": "4.3.2",
-    "sha256": "1x0g58pbpjrmj2x2qw17rdwwnrcl0wvim2hdwz48lixvwvp22n9c"
+    "hash": "sha256-LFkh7ua7R4rI5w2KGjcHlGXLecsncCy6kDXLuy4qD/Q="
   },
   {
     "pname": "runtime.unix.Microsoft.Win32.Primitives",
     "version": "4.3.0",
-    "sha256": "0y61k9zbxhdi0glg154v30kkq7f8646nif8lnnxbvkjpakggd5id"
+    "hash": "sha256-LZb23lRXzr26tRS5aA0xyB08JxiblPDoA7HBvn6awXg="
   },
   {
     "pname": "runtime.unix.System.Diagnostics.Debug",
     "version": "4.3.0",
-    "sha256": "1lps7fbnw34bnh3lm31gs5c0g0dh7548wfmb8zz62v0zqz71msj5"
+    "hash": "sha256-ReoazscfbGH+R6s6jkg5sIEHWNEvjEoHtIsMbpc7+tI="
   },
   {
     "pname": "runtime.unix.System.IO.FileSystem",
     "version": "4.3.0",
-    "sha256": "14nbkhvs7sji5r1saj2x8daz82rnf9kx28d3v2qss34qbr32dzix"
+    "hash": "sha256-Pf4mRl6YDK2x2KMh0WdyNgv0VUNdSKVDLlHqozecy5I="
   },
   {
     "pname": "runtime.unix.System.Net.Primitives",
     "version": "4.3.0",
-    "sha256": "0bdnglg59pzx9394sy4ic66kmxhqp8q8bvmykdxcbs5mm0ipwwm4"
+    "hash": "sha256-pHJ+I6i16MV6m77uhTC6GPY6jWGReE3SSP3fVB59ti0="
   },
   {
     "pname": "runtime.unix.System.Private.Uri",
     "version": "4.3.0",
-    "sha256": "1jx02q6kiwlvfksq1q9qr17fj78y5v6mwsszav4qcz9z25d5g6vk"
+    "hash": "sha256-c5tXWhE/fYbJVl9rXs0uHh3pTsg44YD1dJvyOA0WoMs="
   },
   {
     "pname": "runtime.unix.System.Runtime.Extensions",
     "version": "4.3.0",
-    "sha256": "0pnxxmm8whx38dp6yvwgmh22smknxmqs5n513fc7m4wxvs1bvi4p"
+    "hash": "sha256-l8S9gt6dk3qYG6HYonHtdlYtBKyPb29uQ6NDjmrt3V4="
   },
   {
     "pname": "SharpZipLib",
     "version": "1.4.2",
-    "sha256": "0ijrzz2szxjmv2cipk7rpmg14dfaigdkg7xabjvb38ih56m9a27y"
+    "hash": "sha256-/giVqikworG2XKqfN9uLyjUSXr35zBuZ2FX2r8X/WUY="
   },
   {
     "pname": "SimpleBase",
     "version": "1.3.1",
-    "sha256": "0mjvqbn3b6ai7nhzs5mssy2imn9lw10z4sj8nhgiapyqy9qlim0n"
+    "hash": "sha256-FtRIcfLYXxUftEhq8kHgNNkahde6Fv2hPVGZNezCW1Y="
   },
   {
     "pname": "SixLabors.Fonts",
     "version": "1.0.1",
-    "sha256": "08ljgagwm8aha9p4plqdnf507gcisajd9frcbvaykikrsrzpm33y"
+    "hash": "sha256-fox6f9Z5xunVXiy71KTSkb0DirMN00tuUlChyp96kiI="
   },
   {
     "pname": "StandardSocketsHttpHandler",
     "version": "2.2.0.8",
-    "sha256": "18h3rzh9pp3b6mjx1m4jvwwhv5abjqsd1nnbibc0gbkvbcrb16ni"
+    "hash": "sha256-0ZqwMlt7rgfYisva0DSWS5UNOd+S1NBlNWvcm+DPA6I="
   },
   {
     "pname": "System.Buffers",
     "version": "4.3.0",
-    "sha256": "0fgns20ispwrfqll4q1zc1waqcmylb3zc50ys9x8zlwxh9pmd9jy"
-  },
-  {
-    "pname": "System.Buffers",
-    "version": "4.4.0",
-    "sha256": "183f8063w8zqn99pv0ni0nnwh7fgx46qzxamwnans55hhs2l0g19"
-  },
-  {
-    "pname": "System.Buffers",
-    "version": "4.5.1",
-    "sha256": "04kb1mdrlcixj9zh1xdi5as0k0qi8byr5mi3p3jcxx72qz93s2y3"
+    "hash": "sha256-XqZWb4Kd04960h4U9seivjKseGA/YEIpdplfHYHQ9jk="
   },
   {
     "pname": "System.Collections",
     "version": "4.3.0",
-    "sha256": "19r4y64dqyrq6k4706dnyhhw7fs24kpp3awak7whzss39dakpxk9"
+    "hash": "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc="
   },
   {
     "pname": "System.Collections.Concurrent",
     "version": "4.3.0",
-    "sha256": "0wi10md9aq33jrkh2c24wr2n9hrpyamsdhsxdcnf43b7y86kkii8"
-  },
-  {
-    "pname": "System.Collections.Immutable",
-    "version": "5.0.0",
-    "sha256": "1kvcllagxz2q92g81zkz81djkn2lid25ayjfgjalncyc68i15p0r"
+    "hash": "sha256-KMY5DfJnDeIsa13DpqvyN8NkReZEMAFnlmNglVoFIXI="
   },
   {
     "pname": "System.Collections.Immutable",
     "version": "8.0.0",
-    "sha256": "0z53a42zjd59zdkszcm7pvij4ri5xbb8jly9hzaad9khlf69bcqp"
-  },
-  {
-    "pname": "System.ComponentModel.Annotations",
-    "version": "5.0.0",
-    "sha256": "021h7x98lblq9avm1bgpa4i31c2kgsa7zn4sqhxf39g087ar756j"
+    "hash": "sha256-F7OVjKNwpqbUh8lTidbqJWYi476nsq9n+6k0+QVRo3w="
   },
   {
     "pname": "System.Diagnostics.Debug",
     "version": "4.3.0",
-    "sha256": "00yjlf19wjydyr6cfviaph3vsjzg3d5nvnya26i2fvfg53sknh3y"
+    "hash": "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM="
   },
   {
     "pname": "System.Diagnostics.DiagnosticSource",
     "version": "4.3.0",
-    "sha256": "0z6m3pbiy0qw6rn3n209rrzf9x1k4002zh90vwcrsym09ipm2liq"
+    "hash": "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw="
   },
   {
     "pname": "System.Diagnostics.DiagnosticSource",
     "version": "7.0.2",
-    "sha256": "1h97ikph775gya93qsjjaka87qcygbyh1064rh1hnfcnp5xv0ipi"
+    "hash": "sha256-8Uawe7mWOQsDzMSAAP16nuGD1FRSajyS8q+cA++MJ8E="
   },
   {
     "pname": "System.Diagnostics.Tracing",
     "version": "4.3.0",
-    "sha256": "1m3bx6c2s958qligl67q7grkwfz3w53hpy7nc97mh6f7j5k168c4"
+    "hash": "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q="
   },
   {
     "pname": "System.Globalization",
     "version": "4.3.0",
-    "sha256": "1cp68vv683n6ic2zqh2s1fn4c2sd87g5hpp6l4d4nj4536jz98ki"
+    "hash": "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI="
   },
   {
     "pname": "System.Globalization.Calendars",
     "version": "4.3.0",
-    "sha256": "1xwl230bkakzzkrggy1l1lxmm3xlhk4bq2pkv790j5lm8g887lxq"
+    "hash": "sha256-uNOD0EOVFgnS2fMKvMiEtI9aOw00+Pfy/H+qucAQlPc="
   },
   {
     "pname": "System.Globalization.Extensions",
     "version": "4.3.0",
-    "sha256": "02a5zfxavhv3jd437bsncbhd2fp1zv4gxzakp1an9l6kdq1mcqls"
+    "hash": "sha256-mmJWA27T0GRVuFP9/sj+4TrR4GJWrzNIk2PDrbr7RQk="
   },
   {
     "pname": "System.IO",
     "version": "4.3.0",
-    "sha256": "05l9qdrzhm4s5dixmx68kxwif4l99ll5gqmh7rqgw554fx0agv5f"
+    "hash": "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY="
   },
   {
     "pname": "System.IO.FileSystem",
     "version": "4.3.0",
-    "sha256": "0z2dfrbra9i6y16mm9v1v6k47f0fm617vlb7s5iybjjsz6g1ilmw"
+    "hash": "sha256-vNIYnvlayuVj0WfRfYKpDrhDptlhp1pN8CYmlVd2TXw="
   },
   {
     "pname": "System.IO.FileSystem.Primitives",
     "version": "4.3.0",
-    "sha256": "0j6ndgglcf4brg2lz4wzsh1av1gh8xrzdsn9f0yznskhqn1xzj9c"
+    "hash": "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg="
   },
   {
     "pname": "System.Linq",
     "version": "4.3.0",
-    "sha256": "1w0gmba695rbr80l1k2h4mrwzbzsyfl2z4klmpbsvsg5pm4a56s7"
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.0",
-    "sha256": "1layqpcx1q4l805fdnj2dfqp6ncx2z42ca06rgsr6ikq4jjgbv30"
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.1",
-    "sha256": "0f07d7hny38lq9w69wx4lxkn4wszrqf9m9js6fh9is645csm167c"
-  },
-  {
-    "pname": "System.Memory",
-    "version": "4.5.4",
-    "sha256": "14gbbs22mcxwggn0fcfs1b062521azb9fbb7c113x0mq6dzq9h6y"
+    "hash": "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A="
   },
   {
     "pname": "System.Memory",
     "version": "4.5.5",
-    "sha256": "08jsfwimcarfzrhlyvjjid61j02irx6xsklf32rv57x2aaikvx0h"
+    "hash": "sha256-EPQ9o1Kin7KzGI5O3U3PUQAZTItSbk9h/i4rViN3WiI="
   },
   {
     "pname": "System.Net.Http",
     "version": "4.3.4",
-    "sha256": "0kdp31b8819v88l719j6my0yas6myv9d1viql3qz5577mv819jhl"
+    "hash": "sha256-FMoU0K7nlPLxoDju0NL21Wjlga9GpnAoQjsFhFYYt00="
   },
   {
     "pname": "System.Net.Primitives",
     "version": "4.3.0",
-    "sha256": "0c87k50rmdgmxx7df2khd9qj7q35j9rzdmm2572cc55dygmdk3ii"
-  },
-  {
-    "pname": "System.Numerics.Vectors",
-    "version": "4.4.0",
-    "sha256": "0rdvma399070b0i46c4qq1h2yvjj3k013sqzkilz4bz5cwmx1rba"
-  },
-  {
-    "pname": "System.Numerics.Vectors",
-    "version": "4.5.0",
-    "sha256": "1kzrj37yzawf1b19jq0253rcs8hsq1l2q8g69d7ipnhzb0h97m59"
+    "hash": "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE="
   },
   {
     "pname": "System.Private.Uri",
     "version": "4.3.0",
-    "sha256": "04r1lkdnsznin0fj4ya1zikxiqr0h6r6a1ww2dsm60gqhdrf0mvx"
+    "hash": "sha256-fVfgcoP4AVN1E5wHZbKBIOPYZ/xBeSIdsNF+bdukIRM="
   },
   {
     "pname": "System.Reflection",
     "version": "4.3.0",
-    "sha256": "0xl55k0mw8cd8ra6dxzh974nxif58s3k1rjv1vbd7gjbjr39j11m"
+    "hash": "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY="
   },
   {
     "pname": "System.Reflection.Metadata",
     "version": "5.0.0",
-    "sha256": "17qsl5nanlqk9iz0l5wijdn6ka632fs1m1fvx18dfgswm258r3ss"
+    "hash": "sha256-Wo+MiqhcP9dQ6NuFGrQTw6hpbJORFwp+TBNTq2yhGp8="
   },
   {
     "pname": "System.Reflection.Primitives",
     "version": "4.3.0",
-    "sha256": "04xqa33bld78yv5r93a8n76shvc8wwcdgr1qvvjh959g3rc31276"
+    "hash": "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM="
   },
   {
     "pname": "System.Resources.Extensions",
     "version": "8.0.0",
-    "sha256": "0chqkw486pb5dg9nlj5352lsz1206xyf953nd98dglia3isxklg5"
+    "hash": "sha256-5dHZdRwq0tdQanaU5Hw3QISvqSijSGrTa2VdgwifGDI="
   },
   {
     "pname": "System.Resources.ResourceManager",
     "version": "4.3.0",
-    "sha256": "0sjqlzsryb0mg4y4xzf35xi523s4is4hz9q4qgdvlvgivl7qxn49"
+    "hash": "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo="
   },
   {
     "pname": "System.Runtime",
     "version": "4.3.0",
-    "sha256": "066ixvgbf2c929kgknshcxqj6539ax7b9m570cp8n179cpfkapz7"
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.5.0",
-    "sha256": "17labczwqk3jng3kkky73m0jhi8wc21vbl7cz5c0hj2p1dswin43"
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.5.2",
-    "sha256": "1vz4275fjij8inf31np78hw50al8nqkngk04p3xv5n4fcmf1grgi"
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.5.3",
-    "sha256": "1afi6s2r1mh1kygbjmfba6l4f87pi5sg13p4a48idqafli94qxln"
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "4.7.0",
-    "sha256": "16r6sn4czfjk8qhnz7bnqlyiaaszr0ihinb7mq9zzr1wba257r54"
-  },
-  {
-    "pname": "System.Runtime.CompilerServices.Unsafe",
-    "version": "6.0.0",
-    "sha256": "0qm741kh4rh57wky16sq4m0v05fxmkjjr87krycf5vp9f0zbahbc"
+    "hash": "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg="
   },
   {
     "pname": "System.Runtime.Extensions",
     "version": "4.3.0",
-    "sha256": "1ykp3dnhwvm48nap8q23893hagf665k0kn3cbgsqpwzbijdcgc60"
+    "hash": "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o="
   },
   {
     "pname": "System.Runtime.Handles",
     "version": "4.3.0",
-    "sha256": "0sw2gfj2xr7sw9qjn0j3l9yw07x73lcs97p8xfc9w1x9h5g5m7i8"
+    "hash": "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms="
   },
   {
     "pname": "System.Runtime.InteropServices",
     "version": "4.3.0",
-    "sha256": "00hywrn4g7hva1b2qri2s6rabzwgxnbpw9zfxmz28z09cpwwgh7j"
+    "hash": "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI="
   },
   {
     "pname": "System.Runtime.Numerics",
     "version": "4.3.0",
-    "sha256": "19rav39sr5dky7afygh309qamqqmi9kcwvz3i0c5700v0c5cg61z"
-  },
-  {
-    "pname": "System.Security.AccessControl",
-    "version": "5.0.0",
-    "sha256": "17n3lrrl6vahkqmhlpn3w20afgz09n7i6rv0r3qypngwi7wqdr5r"
+    "hash": "sha256-P5jHCgMbgFMYiONvzmaKFeOqcAIDPu/U8bOVrNPYKqc="
   },
   {
     "pname": "System.Security.Cryptography.Algorithms",
     "version": "4.3.0",
-    "sha256": "03sq183pfl5kp7gkvq77myv7kbpdnq3y0xj7vi4q1kaw54sny0ml"
+    "hash": "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8="
   },
   {
     "pname": "System.Security.Cryptography.Cng",
     "version": "4.3.0",
-    "sha256": "1k468aswafdgf56ab6yrn7649kfqx2wm9aslywjam1hdmk5yypmv"
+    "hash": "sha256-u17vy6wNhqok91SrVLno2M1EzLHZm6VMca85xbVChsw="
   },
   {
     "pname": "System.Security.Cryptography.Csp",
     "version": "4.3.0",
-    "sha256": "1x5wcrddf2s3hb8j78cry7yalca4lb5vfnkrysagbn6r9x6xvrx1"
+    "hash": "sha256-oefdTU/Z2PWU9nlat8uiRDGq/PGZoSPRgkML11pmvPQ="
   },
   {
     "pname": "System.Security.Cryptography.Encoding",
     "version": "4.3.0",
-    "sha256": "1jr6w70igqn07k5zs1ph6xja97hxnb3mqbspdrff6cvssgrixs32"
+    "hash": "sha256-Yuge89N6M+NcblcvXMeyHZ6kZDfwBv3LPMDiF8HhJss="
   },
   {
     "pname": "System.Security.Cryptography.OpenSsl",
     "version": "4.3.0",
-    "sha256": "0givpvvj8yc7gv4lhb6s1prq6p2c4147204a0wib89inqzd87gqc"
+    "hash": "sha256-DL+D2sc2JrQiB4oAcUggTFyD8w3aLEjJfod5JPe+Oz4="
   },
   {
     "pname": "System.Security.Cryptography.Primitives",
     "version": "4.3.0",
-    "sha256": "0pyzncsv48zwly3lw4f2dayqswcfvdwq2nz0dgwmi7fj3pn64wby"
+    "hash": "sha256-fnFi7B3SnVj5a+BbgXnbjnGNvWrCEU6Hp/wjsjWz318="
   },
   {
     "pname": "System.Security.Cryptography.ProtectedData",
     "version": "8.0.0",
-    "sha256": "1ysjx3b5ips41s32zacf4vs7ig41906mxrsbmykdzi0hvdmjkgbx"
+    "hash": "sha256-fb0pa9sQxN+mr0vnXg1Igbx49CaOqS+GDkTfWNboUvs="
   },
   {
     "pname": "System.Security.Cryptography.X509Certificates",
     "version": "4.3.0",
-    "sha256": "0valjcz5wksbvijylxijjxb1mp38mdhv03r533vnx1q3ikzdav9h"
-  },
-  {
-    "pname": "System.Security.Principal.Windows",
-    "version": "5.0.0",
-    "sha256": "1mpk7xj76lxgz97a5yg93wi8lj0l8p157a5d50mmjy3gbz1904q8"
+    "hash": "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0="
   },
   {
     "pname": "System.Text.Encoding",
     "version": "4.3.0",
-    "sha256": "1f04lkir4iladpp51sdgmis9dj4y8v08cka0mbmsy0frc9a4gjqr"
-  },
-  {
-    "pname": "System.Text.Encoding.CodePages",
-    "version": "8.0.0",
-    "sha256": "1lgdd78cik4qyvp2fggaa0kzxasw6kc9a6cjqw46siagrm0qnc3y"
+    "hash": "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg="
   },
   {
     "pname": "System.Text.Encoding.Extensions",
     "version": "4.3.0",
-    "sha256": "11q1y8hh5hrp5a3kw25cb6l00v5l5dvirkz8jr3sq00h1xgcgrxy"
+    "hash": "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc="
   },
   {
     "pname": "System.Threading",
     "version": "4.3.0",
-    "sha256": "0rw9wfamvhayp5zh3j7p1yfmx9b5khbf4q50d8k5rk993rskfd34"
+    "hash": "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc="
   },
   {
     "pname": "System.Threading.Tasks",
     "version": "4.3.0",
-    "sha256": "134z3v9abw3a6jsw17xl3f6hqjpak5l682k2vz39spj4kmydg6k7"
+    "hash": "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w="
   },
   {
     "pname": "System.Threading.Tasks.Dataflow",
-    "version": "8.0.0",
-    "sha256": "02mmqnbd7ybin1yiffrq3ph71rsbrnf6r6m01j98ynydqfscz9s3"
-  },
-  {
-    "pname": "System.Threading.Tasks.Extensions",
-    "version": "4.5.2",
-    "sha256": "1sh63dz0dymqcwmprp0nadm77b83vmm7lyllpv578c397bslb8hj"
-  },
-  {
-    "pname": "System.Threading.Tasks.Extensions",
-    "version": "4.5.4",
-    "sha256": "0y6ncasgfcgnjrhynaf0lwpkpkmv4a07sswwkwbwb5h7riisj153"
+    "version": "8.0.1",
+    "hash": "sha256-hgCfF91BDd/eOtLEd5jhjzgJdvwmVv4/b42fXRr3nvo="
   },
   {
     "pname": "System.ValueTuple",
     "version": "4.5.0",
-    "sha256": "00k8ja51d0f9wrq4vv5z2jhq8hy31kac2rg0rv06prylcybzl8cy"
+    "hash": "sha256-niH6l2fU52vAzuBlwdQMw0OEoRS/7E1w5smBFoqSaAI="
   },
   {
     "pname": "Unosquare.Swan.Lite",
     "version": "3.1.0",
-    "sha256": "0yjbchc2rhgssfvb1qxg3kq3lzyx089r3rngpcjgrkw85bf0vgrw"
+    "hash": "sha256-PL8N3CqIz/wku8/mkRMC3X868Byv47C20/rBLBhkS3o="
   },
   {
     "pname": "ZXing.Net",
     "version": "0.16.9",
-    "sha256": "0bpki21p2wjjjviayhza0gam7s9lm7qj6g8hdcp2csd0mv54l980"
+    "hash": "sha256-ACVKyq6gaSYuaxA9I/GpNOlT1QPqQ6/illJycYOI8y4="
   }
 ]

--- a/pkgs/by-name/na/naps2/package.nix
+++ b/pkgs/by-name/na/naps2/package.nix
@@ -4,6 +4,7 @@
   buildDotnetModule,
   dotnetCorePackages,
   fetchFromGitHub,
+  wrapGAppsHook3,
   gtk3,
   gdk-pixbuf,
   glib,
@@ -13,34 +14,35 @@
 
 buildDotnetModule rec {
   pname = "naps2";
-  version = "7.4.3";
+  version = "7.5.3";
 
   src = fetchFromGitHub {
     owner = "cyanfish";
     repo = "naps2";
-    rev = "v${version}";
-    hash = "sha256-/qSfxGHcCSoNp516LFYWgEL4csf8EKgtSffBt1C02uE=";
+    tag = "v${version}";
+    hash = "sha256-vX+ZyCQsYqJjgYaufWJRnzX8retiFK5QHSP40bbBaCc=";
   };
 
   projectFile = "NAPS2.App.Gtk/NAPS2.App.Gtk.csproj";
   nugetDeps = ./deps.json;
 
+  postPatch = ''
+    substituteInPlace NAPS2.Images.Gtk/NAPS2.Images.Gtk.csproj \
+      --replace-fail TargetFramework TargetFrameworks \
+  '';
+
+  dotnetFlags = [
+    "-p:TargetFrameworks=net8"
+    "-p:EnablePreviewFeatures=true"
+  ];
+
   executables = [ "naps2" ];
 
-  dotnet-sdk =
-    with dotnetCorePackages;
-    sdk_8_0
-    // {
-      inherit
-        (combinePackages [
-          sdk_8_0
-          sdk_6_0-bin
-        ])
-        packages
-        targetPackages
-        ;
-    };
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
   dotnet-runtime = dotnetCorePackages.runtime_8_0;
+
+  nativeBuildInputs = [ wrapGAppsHook3 ];
+
   selfContainedBuild = true;
   runtimeDeps = [
     gtk3
@@ -68,7 +70,6 @@ buildDotnetModule rec {
     maintainers = with lib.maintainers; [ eliandoran ];
     platforms = lib.platforms.linux;
     mainProgram = "naps2";
-    broken = stdenv.hostPlatform.isAarch64; # Google.Protobuf.Tools dependency fails to build.
   };
 
 }


### PR DESCRIPTION
This package now uses .NET 8 instead of the EOL version 6

also added wrapGAppsHook3, this should resolve #339293


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
