### PR TITLE
[24.11] Backport broadcom_sta: add patch to compile on kernel 6.13

### DIFF
--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -68,7 +68,13 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  patches = map (patch: "${rpmFusionPatches}/${patch}") patchset;
+  patches = map (patch: "${rpmFusionPatches}/${patch}") patchset ++ [
+    # Fix for Kernel 6.13
+    (fetchpatch2 {
+      url = "https://gist.githubusercontent.com/joanbm/72189c81ff67b39d36a660cf00483ccb/raw/17cae74c8d3ebb90e5bfcb84dc176c32f2519078/broadcom-wl-fix-linux-6.13.patch";
+      hash = "sha256-b4XE3Dys0d7finPmNhTtvQqxXBSX1CXEj2Krq7qGHAw=";
+    })
+  ];
 
   makeFlags = [ "KBASE=${kernel.dev}/lib/modules/${kernel.modDirVersion}" ];
 

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -21,8 +21,8 @@ let
   rpmFusionPatches = fetchFromGitHub {
     owner = "rpmfusion";
     repo = "wl-kmod";
-    rev = "a04330284bfc38fd91eade6f8b28fa63cfcdc95e";
-    hash = "sha256-c72Pr/v+nxZPLEeNKbWnSpbH3gqYZaTgzMO9PlYQkf0=";
+    rev = "cb67598cbf5d8c5260b750d6f7e5c6a6599b7b85";
+    hash = "sha256-g/j/LIZHG2Jl6UwnDNAlZpsuvjCyVzv4Qweog/tviqE=";
   };
   patchset = [
     "wl-kmod-001_wext_workaround.patch"
@@ -52,6 +52,7 @@ let
     "wl-kmod-025_kernel_6.5_adaptation.patch"
     "wl-kmod-026_kernel_6.10_fix_empty_body_in_if_warning.patch"
     "wl-kmod-027_wpa_supplicant-2.11_add_max_scan_ie_len.patch"
+    "wl-kmod-028_kernel_6.12_adaptation.patch"
   ];
 in
 stdenv.mkDerivation {
@@ -67,13 +68,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = kernel.moduleBuildDependencies;
 
-  patches = map (patch: "${rpmFusionPatches}/${patch}") patchset ++ [
-    # Fix for Kernel 6.12 and later (5f60d5f6bbc1)
-    (fetchpatch2 {
-      url = "https://gist.githubusercontent.com/joanbm/20db669eed4d8367a457780747be8cb9/raw/5536ba1354b6b97013530e7345d3bf29e92225b1/broadcom-wl-fix-linux-6.12.patch";
-      hash = "sha256-Y5VgWp0m5tNp8lxDhIg7IodbqyUsJVHHiVIFgP9ioHE=";
-    })
-  ];
+  patches = map (patch: "${rpmFusionPatches}/${patch}") patchset;
 
   makeFlags = [ "KBASE=${kernel.dev}/lib/modules/${kernel.modDirVersion}" ];
 

--- a/pkgs/os-specific/linux/broadcom-sta/default.nix
+++ b/pkgs/os-specific/linux/broadcom-sta/default.nix
@@ -100,7 +100,7 @@ stdenv.mkDerivation {
     description = "Kernel module driver for some Broadcom's wireless cards";
     homepage = "http://www.broadcom.com/support/802.11/linux_sta.php";
     license = lib.licenses.unfreeRedistributable;
-    maintainers = [ ];
+    maintainers = [ lib.maintainers.j0hax ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
Backport of #375808

cc @fpletz 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
