### PR TITLE
sideband: init at 1.3.0

### DIFF
--- a/pkgs/by-name/si/sideband/package.nix
+++ b/pkgs/by-name/si/sideband/package.nix
@@ -1,0 +1,66 @@
+{
+  lib,
+  python3Packages,
+  fetchFromGitHub,
+  versionCheckHook,
+}:
+
+python3Packages.buildPythonApplication rec {
+  pname = "sideband";
+  version = "1.3.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "markqvist";
+    repo = "Sideband";
+    tag = version;
+    hash = "sha256-tTduoP6Gh/8uy1a/qp8ohGpdDmsS61sNyaAQjdvvvb8=";
+  };
+
+  build-system = with python3Packages; [
+    setuptools
+  ];
+
+  pythonRelaxDeps = [
+    "numpy"
+  ];
+
+  dependencies =
+    with python3Packages;
+    [
+      rns
+      lxmf
+      kivy
+      pillow
+      qrcode
+      materialyoucolor
+      ffpyplayer
+      sh
+      numpy
+      mistune
+      beautifulsoup4
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
+      pycodec2
+      pyaudio
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      pyobjus
+    ];
+
+  pythonImportsCheck = [ "sbapp" ];
+
+  nativeCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = [ "--version" ];
+
+  meta = {
+    description = "LXMF client allowing you to communicate with people or LXMF-compatible systems over Reticulum networks";
+    homepage = "https://github.com/markqvist/Sideband";
+    changelog = "https://github.com/markqvist/Sideband/releases/tag/${version}";
+    license = lib.licenses.cc-by-nc-sa-40;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+    mainProgram = "sideband";
+  };
+}

--- a/pkgs/development/python-modules/ffpyplayer/default.nix
+++ b/pkgs/development/python-modules/ffpyplayer/default.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  pkg-config,
+
+  # build-system
+  cython,
+  setuptools,
+
+  # buildInputs
+  SDL2,
+  # ffpyplayer is not compatible with ffmpeg 7
+  # https://github.com/matham/ffpyplayer/issues/166
+  ffmpeg_6,
+}:
+
+buildPythonPackage rec {
+  pname = "ffpyplayer";
+  version = "4.5.2";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "matham";
+    repo = "ffpyplayer";
+    tag = "v${version}";
+    hash = "sha256-8NBTVN+MPeJfDHuzF45qIK46q5VbiwxipAvjgqdiWrw=";
+  };
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    (lib.getDev SDL2)
+    (lib.getDev ffmpeg_6)
+  ];
+
+  env = {
+    NIX_CFLAGS_COMPILE = toString ([
+      "-Wno-error=implicit-function-declaration"
+      "-Wno-error=incompatible-pointer-types"
+    ]);
+  };
+
+  pythonImportsCheck = [ "ffpyplayer" ];
+
+  # No proper test suite
+  doCheck = false;
+
+  meta = {
+    description = "A cython implementation of an ffmpeg based player";
+    homepage = "https://github.com/matham/ffpyplayer";
+    changelog = "https://github.com/matham/ffpyplayer/releases/tag/v${version}";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pycodec2/default.nix
+++ b/pkgs/development/python-modules/pycodec2/default.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cython,
+  numpy,
+  setuptools,
+
+  # buildInputs
+  codec2,
+
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pycodec2";
+  version = "4.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "gregorias";
+    repo = "pycodec2";
+    tag = "v${version}";
+    hash = "sha256-5BEJ8q+Onh3eITSmEk2PoNrVViVISULZsiI2cCl24b0=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "numpy==2.1.*" "numpy"
+  '';
+
+  build-system = [
+    cython
+    numpy
+    setuptools
+  ];
+
+  buildInputs = [
+    codec2
+  ];
+
+  dependencies = [
+    numpy
+  ];
+
+  pythonImportsCheck = [ "pycodec2" ];
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    rm -rf pycodec2
+  '';
+
+  # The only test fails with a cryptic AssertionError
+  doCheck = false;
+
+  meta = {
+    description = "Python's interface to codec 2";
+    homepage = "https://github.com/gregorias/pycodec2";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/development/python-modules/pyobjus/default.nix
+++ b/pkgs/development/python-modules/pyobjus/default.nix
@@ -1,0 +1,53 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+
+  # build-system
+  cython,
+  setuptools,
+
+  # buildInputs
+  libffi,
+  pytestCheckHook,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjus";
+  version = "1.2.3";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "kivy";
+    repo = "pyobjus";
+    tag = "v${version}";
+    hash = "sha256-8abbxskM3uNNLVKP4Hp6xA9Z45pNNJQKShu+4lj1+4A=";
+  };
+
+  build-system = [
+    cython
+    setuptools
+  ];
+
+  buildInputs = [
+    libffi
+  ];
+
+  pythonImportsCheck = [ "pyobjus" ];
+
+  preCheck = ''
+    rm -rf pyobjus
+  '';
+
+  nativeCheckInputs = [
+    pytestCheckHook
+  ];
+
+  meta = {
+    description = "Access Objective-C classes from Python";
+    homepage = "https://github.com/kivy/pyobjus";
+    changelog = "https://github.com/kivy/pyobjus/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ GaetanLepage ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10706,6 +10706,8 @@ self: super: with self; {
 
   pynx584 = callPackage ../development/python-modules/pynx584 { };
 
+  pyobjus = callPackage ../development/python-modules/pyobjus { };
+
   pyogrio = callPackage ../development/python-modules/pyogrio { };
 
   pyorthanc = callPackage ../development/python-modules/pyorthanc { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10591,6 +10591,8 @@ self: super: with self; {
 
   pycketcasts = callPackage ../development/python-modules/pycketcasts { };
 
+  pycodec2 = callPackage ../development/python-modules/pycodec2 { };
+
   pycolorecho = callPackage ../development/python-modules/pycolorecho { };
 
   pycomm3 = callPackage ../development/python-modules/pycomm3 { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -4575,6 +4575,8 @@ self: super: with self; {
 
   ffmpy = callPackage ../development/python-modules/ffmpy { };
 
+  ffpyplayer = callPackage ../development/python-modules/ffpyplayer { };
+
   fhir-py = callPackage ../development/python-modules/fhir-py { };
 
   fiblary3-fork = callPackage ../development/python-modules/fiblary3-fork { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Add [sideband](https://github.com/markqvist/Sideband), an LXMF client allowing you to communicate with people or LXMF-compatible systems over Reticulum networks.

- **python312Packages.ffpyplayer: init at 4.5.2**
- **python312Packages.pycodec2: init at 4.0.0**
- **python312Packages.pyobjus: init at 1.2.3**
- **sideband: init at 1.3.0**

---

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
