### PR TITLE
Fix Xf86videointel driver immediate crash on NixOS (Mesa Patch Backport)

### DIFF
--- a/nixos/doc/manual/configuration/x-windows.chapter.md
+++ b/nixos/doc/manual/configuration/x-windows.chapter.md
@@ -123,6 +123,24 @@ setting](https://en.wikipedia.org/wiki/Mode_setting) (KMS) mechanism, it
 supports Glamor (2D graphics acceleration via OpenGL) and is actively
 maintained, it may perform worse in some cases (like in old chipsets).
 
+There is a second driver, `intel` (provided by the xf86-video-intel package),
+specific to older Intel iGPUs from generation 2 to 9. It is not recommended by
+most distributions: it lacks several modern features (for example, it doesn't
+support Glamor) and the package hasn't been officially updated since 2015.
+
+Third generation and older iGPUs (15-20+ years old) are not supported by the
+`modesetting` driver (X will crash upon startup). Thus, the `intel` driver is
+required for these chipsets.
+Otherwise, the results vary depending on the hardware, so you may have to try
+both drivers. Use the option
+[](#opt-services.xserver.videoDrivers)
+to set one. The recommended configuration for modern systems is:
+
+```nix
+{
+  services.xserver.videoDrivers = [ "modesetting" ];
+}
+```
 ::: {.note}
 The `modesetting` driver doesn't currently provide a `TearFree` option (this
 will become available in an upcoming X.org release), So, without using a
@@ -130,19 +148,21 @@ compositor (for example, see [](#opt-services.picom.enable)) you will
 experience screen tearing.
 :::
 
-There also used to be a second driver, `intel` (provided by the
-xf86-video-intel package), specific to older Intel iGPUs from generation 2 to
-9.
-This driver hasn't been maintained in years and was removed in NixOS 24.11
-after it stopped working. If you chipset is too old to be supported by
-`modesetting` and have no other choice you may try an unsupported NixOS version
-(reportedly working up to NixOS 24.05) and set
+If you experience screen tearing no matter what, this configuration was
+reported to resolve the issue:
 
 ```nix
 {
   services.xserver.videoDrivers = [ "intel" ];
+  services.xserver.deviceSection = ''
+    Option "DRI" "2"
+    Option "TearFree" "true"
+  '';
 }
 ```
+
+Note that this will likely downgrade the performance compared to
+`modesetting` or `intel` with DRI 3 (default).
 
 ## Proprietary NVIDIA drivers {#sec-x11-graphics-cards-nvidia}
 

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -231,9 +231,6 @@
 
 - The NVIDIA driver no longer defaults to the proprietary kernel module with versions >= 560. You will need to manually set `hardware.nvidia.open` to select the proprietary or open modules.
 
-- The `intel` driver for the X server (`services.xserver.videoDrives = [ "intel" ]`) is no longer functional due to incompatibilities with the latest Mesa version.
-  All users are strongly encouraged to switch to the generic `modesetting` driver (the default one) whenever possible, for more information see the manual chapter on [Intel Graphics](#sec-x11--graphics-cards-intel) and issue [#342763](https://github.com/NixOS/nixpkgs/issues/342763).
-
 - The `(buildPythonPackage { ... }).override` and `(buildPythonPackage { ... }).overrideDerivation` attributes is now deprecated and removed in favour of `overridePythonAttrs` and `lib.overrideDerivation`.
   This change does not affect the override interface of most Python packages, as [`<pkg>.override`](https://nixos.org/manual/nixpkgs/unstable/#sec-pkg-override) provided by `callPackage` shadows such a locally-defined `override` attribute.
   The `<pkg>.overrideDerivation` attribute of Python packages called with `callPackage` will also remain available after this change.

--- a/nixos/doc/manual/release-notes/rl-2411.section.md
+++ b/nixos/doc/manual/release-notes/rl-2411.section.md
@@ -231,6 +231,9 @@
 
 - The NVIDIA driver no longer defaults to the proprietary kernel module with versions >= 560. You will need to manually set `hardware.nvidia.open` to select the proprietary or open modules.
 
+- The `intel` driver for the X server (`services.xserver.videoDrives = [ "intel" ]`) is no longer functional due to incompatibilities with the latest Mesa version.
+  All users are strongly encouraged to switch to the generic `modesetting` driver (the default one) whenever possible, for more information see the manual chapter on [Intel Graphics](#sec-x11--graphics-cards-intel) and issue [#342763](https://github.com/NixOS/nixpkgs/issues/342763).
+
 - The `(buildPythonPackage { ... }).override` and `(buildPythonPackage { ... }).overrideDerivation` attributes is now deprecated and removed in favour of `overridePythonAttrs` and `lib.overrideDerivation`.
   This change does not affect the override interface of most Python packages, as [`<pkg>.override`](https://nixos.org/manual/nixpkgs/unstable/#sec-pkg-override) provided by `callPackage` shadows such a locally-defined `override` attribute.
   The `<pkg>.overrideDerivation` attribute of Python packages called with `callPackage` will also remain available after this change.

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -47,6 +47,8 @@
   - A new `pkgs.mattermost.buildPlugin` function has been added, which allows plugins to be built from source, including webapp frontends with a supported package-lock.json. See the Mattermost NixOS test and [manual](https://nixos.org/manual/nixpkgs/unstable/#sec-mattermost-plugins-build) for an example.
   - Note that the Mattermost module will create an account _without_ a well-known UID if the username differs from the default (`mattermost`). If you used Mattermost with a nonstandard username, you may want to review the module changes before upgrading.
 
+- The `intel` video driver for X.org (from the xf86-video-intel package) which was previously removed because it was non-functional has been fixed and the driver has been re-introduced.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -6,6 +6,7 @@
 , expat
 , fetchCrate
 , fetchFromGitLab
+, fetchpatch
 , file
 , flex
 , glslang

--- a/pkgs/development/libraries/mesa/default.nix
+++ b/pkgs/development/libraries/mesa/default.nix
@@ -141,6 +141,13 @@ in stdenv.mkDerivation {
     # cherry-picked from https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/32719
     # safe to remove for versions > 24.3.2
     ./cross_clc.patch
+
+    # dril fix for xf86videointel
+    # FIXME: remove when backported upstream
+    (fetchpatch {
+      url = "https://gitlab.freedesktop.org/mesa/mesa/-/commit/4ecd183c563670c5c3ab371d6b5596ecabbe6fad.diff";
+      hash = "sha256-AXXp1MHXEsvua1SyzQUbQLVqaA4Iw1yziqvAce+UkxQ=";
+    })
   ];
 
   postPatch = ''

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -1017,10 +1017,26 @@ self: super:
     meta = attrs.meta // { mainProgram = "xinit"; };
   });
 
-  xf86videointel = throw ''
-    xf86videointel has been removed as the package is unmaintained and the driver is no longer functional.
-    Please remove "intel" from `services.xserver.videoDrivers` and switch to the "modesetting" driver.
-  ''; # Added 2024-12-16;
+  xf86videointel = super.xf86videointel.overrideAttrs (attrs: {
+    # the update script only works with released tarballs :-/
+    name = "xf86-video-intel-2024-05-06";
+    src = fetchFromGitLab {
+      domain = "gitlab.freedesktop.org";
+      group = "xorg";
+      owner = "driver";
+      repo = "xf86-video-intel";
+      rev = "ce811e78882d9f31636351dfe65351f4ded52c74";
+      sha256 = "sha256-PKCxFHMwxgbew0gkxNBKiezWuqlFG6bWLkmtUNyoF8Q=";
+    };
+    buildInputs = attrs.buildInputs ++ [ xorg.libXScrnSaver xorg.libXv xorg.pixman xorg.utilmacros ];
+    nativeBuildInputs = attrs.nativeBuildInputs ++ [autoreconfHook ];
+    configureFlags = [ "--with-default-dri=3" "--enable-tools" ];
+    patches = [ ./use_crocus_and_iris.patch ];
+
+    meta = attrs.meta // {
+      platforms = ["i686-linux" "x86_64-linux"];
+    };
+  });
 
   xf86videoopenchrome = super.xf86videoopenchrome.overrideAttrs (attrs: {
     buildInputs = attrs.buildInputs ++ [ xorg.libXv ];

--- a/pkgs/servers/x11/xorg/use_crocus_and_iris.patch
+++ b/pkgs/servers/x11/xorg/use_crocus_and_iris.patch
@@ -1,0 +1,28 @@
+--- a/src/uxa/intel_dri.c
++++ b/src/uxa/intel_dri.c
+@@ -1540,8 +1540,10 @@
+ 			return has_i830_dri() ? "i830" : "i915";
+ 		else if (INTEL_INFO(intel)->gen < 040)
+ 			return "i915";
++		else if (INTEL_INFO(intel)->gen < 0100)
++			return "crocus";
+ 		else
+-			return "i965";
++			return "iris";
+ 	}
+ 
+ 	return s;
+--- a/src/sna/sna_dri2.c
++++ b/src/sna/sna_dri2.c
+@@ -3707,8 +3707,10 @@
+ 			return has_i830_dri() ? "i830" : "i915";
+ 		else if (sna->kgem.gen < 040)
+ 			return "i915";
++		else if (sna->kgem.gen < 0100)
++			return "crocus";
+ 		else
+-			return "i965";
++			return "iris";
+ 	}
+ 
+ 	return s;


### PR DESCRIPTION
<!--
The 
-->

This PR adds a patch that fixes an upstream issue in Mesa which breaks the xf86videointel driver on NixOS. I am going to submit this patch to Mesa upstream as well, but it would be very nice to have this backported to 24.11 :)

The issue was introduced in Mesa 24.2.2 in [this patch](https://gitlab.freedesktop.org/mesa/mesa/-/commit/06d417af80bc1f171cadc338e63a7aa75c877754.diff). Not checking for an invalid config causes X to crash immediately when launching with the xf86videointel driver.

The xf86videointel driver is **required** on i915 gpus, the modesetting driver simply crashes on startup.

This also re-adds the xf86videointel driver to xorg's `overrides.conf`, and updates it to the latest version (2024-05-06). Currently it throws an error when used on 24.11 and unstable.

Please see [this thread](https://discourse.nixos.org/t/xinit-segfault-unw-get-proc-name-failed-no-unwind-info-found-10-intel-gma-i915-modesetting-does-not-work-have-to-use-xf86videointel/59060/11) on NixOS Discourse for additional context.

Thanks!

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
