### PR TITLE
libuv: disable thread_affinity test

### DIFF
--- a/pkgs/development/libraries/libuv/default.nix
+++ b/pkgs/development/libraries/libuv/default.nix
@@ -52,6 +52,7 @@ stdenv.mkDerivation (finalAttrs: {
           "getaddrinfo_fail"
           "getaddrinfo_fail_sync"
           "tcp_connect6_link_local"
+          "thread_affinity" # else "test must be run with cpu 0 affinity" when affinity is set
           "threadpool_multiple_event_loops" # times out on slow machines
           "get_passwd" # passed on NixOS but failed on other Linuxes
           "tcp_writealot"


### PR DESCRIPTION
fixes NixOS/nixpkgs#378438

libuv includes a test which specifically requires thread-affinity to be unset, or else you get an error:
`# Assertion failed in test/test-thread-affinity.c on line 73: cpumask[0] && "test must be run with cpu 0 affinity"`

I assume that packages should be able to be built regardless of affinity, so this test should not be run.

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
