### PR TITLE
backport [24.11]: microsoft-identity-broker: fix hash mismatch

### DIFF
--- a/pkgs/by-name/mi/microsoft-identity-broker/package.nix
+++ b/pkgs/by-name/mi/microsoft-identity-broker/package.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = "https://packages.microsoft.com/ubuntu/22.04/prod/pool/main/m/microsoft-identity-broker/microsoft-identity-broker_${version}_amd64.deb";
-    hash = "sha256-I4Q6ucT6ps8/QGiQTNbMXcKxq6UMcuwJ0Prcqvov56M=";
+    hash = "sha256-v/FxtdvRaUHYqvFSkJIZyicIdcyxQ8lPpY5rb9smnqA=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
The automatic backport pull request for https://github.com/NixOS/nixpkgs/pull/360248 didn't go through, so after suggestion of @NobbZ I created this manual backport pull request. 

I followed the steps in https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#how-to-backport-pull-requests. 

It's my first contribution, so I hope it's alright. 