### PR TITLE
trilium-next-{desktop,server}: 0.90.12 -> 0.91.5

### DIFF
--- a/pkgs/by-name/tr/trilium-next-desktop/package.nix
+++ b/pkgs/by-name/tr/trilium-next-desktop/package.nix
@@ -6,7 +6,7 @@
   fetchzip,
   makeBinaryWrapper,
   # use specific electron since it has to load a compiled module
-  electron_31,
+  electron_34,
   autoPatchelfHook,
   makeDesktopItem,
   copyDesktopItems,
@@ -16,13 +16,13 @@
 
 let
   pname = "trilium-next-desktop";
-  version = "0.90.12";
+  version = "0.91.5";
 
   linuxSource.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-linux-x64.zip";
-  linuxSource.sha256 = "0ji28l60wyzhjbi6g5845dnm763bvg7535zfgzcmfgwjs6zr6nfq";
+  linuxSource.sha256 = "10icng86y0idp7sjm7gzbcldd3gzc4z882d99hq959xiqd5lkcfi";
 
   darwinSource.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-macos-x64.zip";
-  darwinSource.sha256 = "0jv80k7dk6gpyfj36iin6y7fk7qan4bya72f14jcgfla95wvk6ls";
+  darwinSource.sha256 = "0377d12a43q2dmwb8zm22354w7crydj5q8n0g7i60gcyqsqpph8w";
 
   meta = {
     description = "Hierarchical note taking application with focus on building large personal knowledge bases";
@@ -99,7 +99,7 @@ let
       asar pack $tmp/ $out/share/trilium/resources/app.asar
       rm -rf $tmp
 
-      makeWrapper ${lib.getExe electron_31} $out/bin/trilium \
+      makeWrapper ${lib.getExe electron_34} $out/bin/trilium \
         "''${gappsWrapperArgs[@]}" \
         --set-default ELECTRON_IS_DEV 0 \
         --add-flags $out/share/trilium/resources/app.asar

--- a/pkgs/by-name/tr/trilium-next-desktop/update.sh
+++ b/pkgs/by-name/tr/trilium-next-desktop/update.sh
@@ -18,6 +18,8 @@ setKV ./package.nix linuxSource.sha256 $sha256_linux64
 setKV ./package.nix darwinSource.sha256 $sha256_darwin64
 
 # Update server
-sha256_linux64_server=$(nix-prefetch-url --quiet https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-server-linux-x64.tar.xz)
+sha256_linux64_server=$(nix-prefetch-url --quiet https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-linux-x64-v${version}.tar.xz)
+sha256_linux64_server_arm=$(nix-prefetch-url --quiet https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-linux-arm64-v${version}.tar.xz)
 setKV ../trilium-next-server/package.nix version $version
-setKV ../trilium-next-server/package.nix serverSource.sha256 $sha256_linux64_server
+setKV ../trilium-next-server/package.nix serverSource_x64.sha256 $sha256_linux64_server
+setKV ../trilium-next-server/package.nix serverSource_arm64.sha256 $sha256_linux64_server_arm

--- a/pkgs/by-name/tr/trilium-next-server/0001-Use-console-logger-instead-of-rolling-files.patch
+++ b/pkgs/by-name/tr/trilium-next-server/0001-Use-console-logger-instead-of-rolling-files.patch
@@ -2,78 +2,29 @@ diff --git a/src/services/log.js b/src/services/log.js
 index 2840c185a..7fb16dd08 100644
 --- a/src/services/log.js
 +++ b/src/services/log.js
-@@ -1,45 +1,12 @@
- "use strict";
--import fs from "fs";
--import dataDir from "./data_dir.js";
+@@ -3,9 +3,6 @@ import fs from "fs";
+ import dataDir from "./data_dir.js";
  import cls from "./cls.js";
+ import { isWindows } from "./utils.js";
 -if (!fs.existsSync(dataDir.LOG_DIR)) {
 -    fs.mkdirSync(dataDir.LOG_DIR, 0o700);
 -}
--let logFile;
+ let logFile;
  const SECOND = 1000;
  const MINUTE = 60 * SECOND;
--const HOUR = 60 * MINUTE;
--const DAY = 24 * HOUR;
--const NEW_LINE = process.platform === "win32" ? '\r\n' : '\n';
--let todaysMidnight;
--initLogFile();
--function getTodaysMidnight() {
--    const now = new Date();
--    return new Date(now.getFullYear(), now.getMonth(), now.getDate());
--}
--function initLogFile() {
--    todaysMidnight = getTodaysMidnight();
--    const path = `${dataDir.LOG_DIR}/trilium-${formatDate()}.log`;
--    if (logFile) {
--        logFile.end();
--    }
--    logFile = fs.createWriteStream(path, { flags: 'a' });
--}
--function checkDate(millisSinceMidnight) {
--    if (millisSinceMidnight >= DAY) {
--        initLogFile();
--        millisSinceMidnight -= DAY;
--    }
--    return millisSinceMidnight;
--}
- function log(str) {
-     const bundleNoteId = cls.get("bundleNoteId");
-     if (bundleNoteId) {
-         str = `[Script ${bundleNoteId}] ${str}`;
--    }
--    let millisSinceMidnight = Date.now() - todaysMidnight.getTime();
--    millisSinceMidnight = checkDate(millisSinceMidnight);
+@@ -24,7 +21,6 @@ function initLogFile() {
+     if (logFile) {
+         logFile.end();
+     }
+-    logFile = fs.createWriteStream(path, { flags: "a" });
+ }
+ function checkDate(millisSinceMidnight) {
+     if (millisSinceMidnight >= DAY) {
+@@ -40,7 +36,6 @@ function log(str) {
+     }
+     let millisSinceMidnight = Date.now() - todaysMidnight.getTime();
+     millisSinceMidnight = checkDate(millisSinceMidnight);
 -    logFile.write(`${formatTime(millisSinceMidnight)} ${str}${NEW_LINE}`);
-+    }    
      console.log(str);
  }
  function info(message) {
-@@ -61,27 +28,6 @@ function request(req, res, timeMs, responseLength = "?") {
-     info((timeMs >= 10 ? "Slow " : "") +
-         `${res.statusCode} ${req.method} ${req.url} with ${responseLength} bytes took ${timeMs}ms`);
- }
--function pad(num) {
--    num = Math.floor(num);
--    return num < 10 ? (`0${num}`) : num.toString();
--}
--function padMilli(num) {
--    if (num < 10) {
--        return `00${num}`;
--    }
--    else if (num < 100) {
--        return `0${num}`;
--    }
--    else {
--        return num.toString();
--    }
--}
--function formatTime(millisSinceMidnight) {
--    return `${pad(millisSinceMidnight / HOUR)}:${pad((millisSinceMidnight % HOUR) / MINUTE)}:${pad((millisSinceMidnight % MINUTE) / SECOND)}.${padMilli(millisSinceMidnight % SECOND)}`;
--}
--function formatDate() {
--    return `${pad(todaysMidnight.getFullYear())}-${pad(todaysMidnight.getMonth() + 1)}-${pad(todaysMidnight.getDate())}`;
--}
- export default {
-     info,
-     error,

--- a/pkgs/by-name/tr/trilium-next-server/package.nix
+++ b/pkgs/by-name/tr/trilium-next-server/package.nix
@@ -7,10 +7,20 @@
 }:
 
 let
-  version = "0.90.12";
+  version = "0.91.5";
 
-  serverSource.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-v${version}-server-linux-x64.tar.xz";
-  serverSource.sha256 = "0gvb01cj334n805rs230xwwcv4rf2z2giikpagw8wqrs54gy3b35";
+  serverSource_x64.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-linux-x64-v${version}.tar.xz";
+  serverSource_x64.sha256 = "sha256-zLq3Dfgdz01Ds3eNqd5MrgQ5Jy7Ioj3UwnaR+Mt1IjE=";
+  serverSource_arm64.url = "https://github.com/TriliumNext/Notes/releases/download/v${version}/TriliumNextNotes-linux-arm64-v${version}.tar.xz";
+  serverSource_arm64.sha256 = "0bih1v3lfmrjdvsdrlfayq23b3dnb2gpszxlvchgx4vq98nqdc8f";
+
+  serverSource =
+    if stdenv.hostPlatform.isx86_64 then
+      serverSource_x64
+    else if stdenv.hostPlatform.isAarch64 then
+      serverSource_arm64
+    else
+      throw "${stdenv.hostPlatform.config} not supported by trilium-next-server";
 in
 stdenv.mkDerivation {
   pname = "trilium-next-server";
@@ -45,6 +55,10 @@ stdenv.mkDerivation {
       --chdir "$out/share/trilium-server" \
       --add-flags "src/main"
 
+    # Clean up broken symlinks and build tools.
+    rm "$out"/share/trilium-server/node/bin/{npm,npx}
+    rm -r "$out"/share/trilium-server/node_modules/{@npmcli,@rollup,@babel}
+
     runHook postInstall
   '';
 
@@ -53,7 +67,10 @@ stdenv.mkDerivation {
     homepage = "https://github.com/TriliumNext/Notes";
     license = lib.licenses.agpl3Plus;
     sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
-    platforms = [ "x86_64-linux" ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
     maintainers = with lib.maintainers; [
       eliandoran
       fliegendewurst


### PR DESCRIPTION
Simple update to new stable version.

https://github.com/TriliumNext/Notes/releases/tag/v0.91.5

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux: needs testing of the new ARM server build
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).