### PR TITLE
postgresqlPackages: enable strictDeps

### DIFF
--- a/pkgs/servers/sql/postgresql/buildPostgresqlExtension.nix
+++ b/pkgs/servers/sql/postgresql/buildPostgresqlExtension.nix
@@ -84,7 +84,9 @@ let
             ));
         };
 
+      strictDeps = true;
       buildInputs = [ postgresql ] ++ prevAttrs.buildInputs or [ ];
+      nativeBuildInputs = [ postgresql ] ++ prevAttrs.nativeBuildInputs or [ ];
 
       installFlags = [
         "DESTDIR=${placeholder "out"}"

--- a/pkgs/servers/sql/postgresql/ext/anonymizer.nix
+++ b/pkgs/servers/sql/postgresql/ext/anonymizer.nix
@@ -15,9 +15,7 @@ buildPostgresqlExtension (finalAttrs: {
 
   inherit (pg-dump-anon) version src;
 
-  nativeBuildInputs = [ postgresql ] ++ lib.optional jitSupport llvm;
-
-  strictDeps = true;
+  nativeBuildInputs = lib.optional jitSupport llvm;
 
   # Needs to be after postInstall, where removeNestedNixStore runs
   preFixup = ''

--- a/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
+++ b/pkgs/servers/sql/postgresql/ext/apache_datasketches.nix
@@ -3,7 +3,7 @@
   lib,
   fetchFromGitHub,
   postgresql,
-  boost,
+  boost186,
   postgresqlTestExtension,
   buildPostgresqlExtension,
 }:
@@ -39,7 +39,8 @@ buildPostgresqlExtension (finalAttrs: {
 
   sourceRoot = main_src.name;
 
-  buildInputs = [ boost ];
+  # fails to build with boost 1.87
+  buildInputs = [ boost186 ];
 
   patchPhase = ''
     runHook prePatch

--- a/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
+++ b/pkgs/servers/sql/postgresql/ext/cstore_fdw.nix
@@ -11,6 +11,7 @@ buildPostgresqlExtension rec {
   pname = "cstore_fdw";
   version = "1.7.0-unstable-2021-03-08";
 
+  buildInputs = [ protobufc ];
   nativeBuildInputs = [ protobufc ];
 
   src = fetchFromGitHub {

--- a/pkgs/servers/sql/postgresql/ext/pg-gvm.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg-gvm.nix
@@ -23,12 +23,9 @@ buildPostgresqlExtension (finalAttrs: {
     hash = "sha256-Sa9ltW3KV/69OCxD3gRcp5owL0oW+z3fs4fRBHbSh30=";
   };
 
-  strictDeps = true;
-
   nativeBuildInputs = [
     cmake
     pkg-config
-    postgresql
   ];
 
   buildInputs = [

--- a/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
+++ b/pkgs/servers/sql/postgresql/ext/pg_ed25519.nix
@@ -9,6 +9,7 @@
 buildPostgresqlExtension rec {
   pname = "pg_ed25519";
   version = "0.2";
+
   src = fetchFromGitLab {
     owner = "dwagin";
     repo = "pg_ed25519";
@@ -22,7 +23,7 @@ buildPostgresqlExtension rec {
     maintainers = [ maintainers.renzo ];
     platforms = postgresql.meta.platforms;
     license = licenses.mit;
-    # Broken on darwin and linux (JIT) with no upstream fix available.
-    broken = lib.versionAtLeast postgresql.version "16" && stdenv.cc.isClang;
+    # Broken with no upstream fix available.
+    broken = lib.versionAtLeast postgresql.version "16";
   };
 }

--- a/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgsql-http.nix
@@ -19,6 +19,7 @@ buildPostgresqlExtension rec {
   };
 
   buildInputs = [ curl ];
+  nativeBuildInputs = [ curl ];
 
   meta = with lib; {
     description = "HTTP client for PostgreSQL, retrieve a web page from inside the database";

--- a/pkgs/servers/sql/postgresql/ext/pgtap.nix
+++ b/pkgs/servers/sql/postgresql/ext/pgtap.nix
@@ -22,7 +22,6 @@ buildPostgresqlExtension (finalAttrs: {
   };
 
   nativeBuildInputs = [
-    postgresql
     perl
     perlPackages.TAPParserSourceHandlerpgTAP
     which

--- a/pkgs/servers/sql/postgresql/ext/postgis.nix
+++ b/pkgs/servers/sql/postgresql/ext/postgis.nix
@@ -51,7 +51,6 @@ buildPostgresqlExtension (finalAttrs: {
 
   buildInputs =
     [
-      libxml2
       geos
       proj
       gdal
@@ -65,8 +64,10 @@ buildPostgresqlExtension (finalAttrs: {
     autoconf
     automake
     libtool
+    libxml2
     perl
     pkg-config
+    protobufc
     which
   ] ++ lib.optional jitSupport llvm;
   dontDisableStatic = true;

--- a/pkgs/servers/sql/postgresql/ext/smlar.nix
+++ b/pkgs/servers/sql/postgresql/ext/smlar.nix
@@ -24,7 +24,7 @@ buildPostgresqlExtension rec {
     platforms = postgresql.meta.platforms;
     license = licenses.bsd2;
     maintainers = [ ];
-    # Broken on darwin and linux (JIT) with no upstream fix available.
-    broken = lib.versionAtLeast postgresql.version "16" && stdenv.cc.isClang;
+    # Broken with no upstream fix available.
+    broken = lib.versionAtLeast postgresql.version "16";
   };
 }


### PR DESCRIPTION
As mentioned in https://github.com/NixOS/nixpkgs/pull/377938#discussion_r1937067066, we should just do this for all our extensions.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
