### PR TITLE
gum: fix cross build

### DIFF
--- a/pkgs/by-name/gu/gum/package.nix
+++ b/pkgs/by-name/gu/gum/package.nix
@@ -29,17 +29,14 @@ buildGoModule rec {
     "-X=main.Version=${version}"
   ];
 
-  postInstall =
-    ''
-      $out/bin/gum man > gum.1
-      installManPage gum.1
-    ''
-    + lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
-      installShellCompletion --cmd gum \
-        --bash <($out/bin/gum completion bash) \
-        --fish <($out/bin/gum completion fish) \
-        --zsh <($out/bin/gum completion zsh)
-    '';
+  postInstall = lib.optionalString (stdenv.buildPlatform.canExecute stdenv.hostPlatform) ''
+    $out/bin/gum man > gum.1
+    installManPage gum.1
+    installShellCompletion --cmd gum \
+      --bash <($out/bin/gum completion bash) \
+      --fish <($out/bin/gum completion fish) \
+      --zsh <($out/bin/gum completion zsh)
+  '';
 
   meta = with lib; {
     description = "Tasty Bubble Gum for your shell";


### PR DESCRIPTION
Hi :wave: 

I submit a PR because I'm experiencing issue during cross compilation of the `gum` package, from x86_64-linux to aarch64-linux.

From what I understand of https://github.com/NixOS/nixpkgs/issues/308283, we cannot run the binary that we currently building, so I move the condition to avoid running the `postInstall` phase during cross compilation.


## Logs
```
error: builder for '/nix/store/26faz5v7z5xcrnw06vpacdgks3m50dly-gum-aarch64-unknown-linux-gnu-0.15.1.drv' failed with exit code 126;
       last 10 log lines:
       > Building subPackage ./log
       > Building subPackage ./man
       > Building subPackage ./pager
       > Building subPackage ./spin
       > Building subPackage ./style
       > Building subPackage ./table
       > Building subPackage ./version
       > Building subPackage ./write
       > Running phase: installPhase
       > /nix/store/iczl70kzlylwq2p5sx27046rvslcgx9x-stdenv-linux/setup: line 227: /nix/store/k7camhybpxa4y3rm3ckg5ff1vypgh9a7-gum-aarch64-unknown-linux-gnu-0.15.1/bin/gum: cannot execute binary file: Exec format error
       For full logs, run 'nix-store -l /nix/store/26faz5v7z5xcrnw06vpacdgks3m50dly-gum-aarch64-unknown-linux-gnu-0.15.1.drv'.
```

## Things done
- Built on platform(s)
  - [x] x86_64-linux: and cross to aarch64
  - [ ] aarch64-linux
  - [ ]  x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).