### PR TITLE
php84Extensions.decimal: init at 1.5.0

### DIFF
--- a/pkgs/development/php-packages/decimal/default.nix
+++ b/pkgs/development/php-packages/decimal/default.nix
@@ -11,9 +11,8 @@ buildPecl {
   pname = "decimal";
 
   version = version;
-  sha256 = "it8w8hOLYwtCZoDYhaP5k5TD/pQLtj37K2lSESF80ok=";
+  hash = "sha256-it8w8hOLYwtCZoDYhaP5k5TD/pQLtj37K2lSESF80ok=";
 
-  internalDeps = lib.optional (lib.versionOlder php.version "8.0") php.extensions.json;
   buildInputs = [ mpdecimal ];
   configureFlags = [ "--with-libmpdec-path=${mpdecimal}" ];
 
@@ -22,7 +21,6 @@ buildPecl {
     homepage = "https://php-decimal.github.io";
     changelog = "https://pecl.php.net/package-changelog.php?package=decimal&release=${version}";
     license = lib.licenses.mit;
-    broken = lib.versionOlder php.version "7.0";
     maintainers = lib.teams.php.members;
   };
 }

--- a/pkgs/development/php-packages/decimal/default.nix
+++ b/pkgs/development/php-packages/decimal/default.nix
@@ -1,0 +1,28 @@
+{
+  buildPecl,
+  lib,
+  mpdecimal,
+  php,
+}:
+let
+  version = "1.5.0";
+in
+buildPecl {
+  pname = "decimal";
+
+  version = version;
+  sha256 = "it8w8hOLYwtCZoDYhaP5k5TD/pQLtj37K2lSESF80ok=";
+
+  internalDeps = lib.optional (lib.versionOlder php.version "8.0") php.extensions.json;
+  buildInputs = [ mpdecimal ];
+  configureFlags = [ "--with-libmpdec-path=${mpdecimal}" ];
+
+  meta = {
+    description = "Arbitrary-precision decimal arithmetic for PHP";
+    homepage = "https://php-decimal.github.io";
+    changelog = "https://pecl.php.net/package-changelog.php?package=decimal&release=${version}";
+    license = lib.licenses.mit;
+    broken = lib.versionOlder php.version "7.0";
+    maintainers = lib.teams.php.members;
+  };
+}

--- a/pkgs/top-level/php-packages.nix
+++ b/pkgs/top-level/php-packages.nix
@@ -292,6 +292,8 @@ lib.makeScope pkgs.newScope (
           inherit (pkgs) darwin;
         };
 
+        decimal = callPackage ../development/php-packages/decimal { };
+
         ds = callPackage ../development/php-packages/ds { };
 
         event = callPackage ../development/php-packages/event { };


### PR DESCRIPTION
Hi, folks. This is my first Nixpkgs PR, so please be gentle! This was instigated by @jtojnar [over at the Discourse](https://discourse.nixos.org/t/building-decimal-php-extension-pecl/59487/4). Hopefully I did stuff right?

This is a PHP extension that offers “Arbitrary-precision decimal arithmetic”. Here's an example of its use in PHP code:

```php
<?php
use Decimal\Decimal;
print_r((new Decimal("3"))->div("2.1")->toString());
//-> 1.428571428571428571428571429
```

The repo for this extension is not well tagged nor does it have a changelog, so I didn't add links to it, but here it is: https://github.com/php-decimal/php-decimal

Depends on the JSON extension, which was included in PHP starting from version 8, so it's added if building for an older PHP. See: https://www.php.net/manual/en/json.installation.php

Below is a readymade flake shell to try out a version of PHP with this extension integrated. It can be used to run the above code, if it was in a file called `test.php`, as follows: `nix develop --command bash -c 'php test.php'`.

```nix
{
  inputs = {
    nixpkgs.url = "github:agj/nixpkgs/add-pecl-decimal";
    flake-utils.url = "github:numtide/flake-utils";
  };

  outputs = {self, nixpkgs, flake-utils}:
    flake-utils.lib.eachDefaultSystem (
      system: let
        pkgs = import nixpkgs {system = system;};
      in {
        devShell = pkgs.mkShell {
          buildInputs = [
            (pkgs.php.buildEnv {
              extensions = {all, enabled}: enabled ++ [all.decimal];
            })
          ];
        };
      }
    );
}
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
