### PR TITLE
.github/labeler-no-sync: fix backport labelling

### DIFF
--- a/.github/labeler-no-sync.yml
+++ b/.github/labeler-no-sync.yml
@@ -1,13 +1,12 @@
 # This file is used by .github/workflows/labels.yml
 # This version uses `sync-labels: false`, meaning that a non-match will NOT remove the label
 
-"backport: release-24.11":
+"backport release-24.11":
   - any:
     - changed-files:
       - any-glob-to-any-file:
         - .github/workflows/*
-        - ci/**/*
-        - "!ci/OWNERS"
+        - ci/**/*.*
 
 "6.topic: policy discussion":
   - any:


### PR DESCRIPTION
This broken in https://github.com/NixOS/nixpkgs/pull/374921#issuecomment-2628927702 - and results in labelling every incoming PR.

Moving the OWNERS file away seems to be the only way to get the desired behavior. GitHub should only react to `CODEOWNERS`, so we should be safe by putting it into `.github/OWNERS`, right?

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
