### PR TITLE
hydra-check: 2.0.1 -> 2.0.3

### DIFF
--- a/pkgs/by-name/hy/hydra-check/package.nix
+++ b/pkgs/by-name/hy/hydra-check/package.nix
@@ -10,16 +10,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hydra-check";
-  version = "2.0.1";
+  version = "2.0.2";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "hydra-check";
-    rev = "v${version}";
-    hash = "sha256-QdCXToHNymOdlTyQjk9eo7LTznGKB+3pIOgjjaGoTXg=";
+    tag = "v${version}";
+    hash = "sha256-FfeT6oxhHORbd4uR4gRNhI6W9YOkG8ieiL0Co3GWzb4=";
   };
 
-  cargoHash = "sha256-iqFUMok36G1qSUbfY7WD6etY0dtfro3F7mLoOELzxbs=";
+  cargoHash = "sha256-35e+ACUyp5sQiHz9fgDXXz365XbxHMLcX2aTA41rJN0=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/hy/hydra-check/package.nix
+++ b/pkgs/by-name/hy/hydra-check/package.nix
@@ -20,7 +20,8 @@ rustPlatform.buildRustPackage rec {
     hash = "sha256-h8bs6oe8zkzEDCoC9F6IzTaTkNf4eAAjt663V0qn73I=";
   };
 
-  cargoHash = "sha256-AUIm8OLN+BgEtlYCFQkozEwkp0Iwfkj+l5ttSAoCz60=";
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-aV4URx9bGAOLWRh/kFDU67GiXk7RdCqfahG+fZPfdUo=";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/hy/hydra-check/package.nix
+++ b/pkgs/by-name/hy/hydra-check/package.nix
@@ -6,6 +6,7 @@
   openssl,
   stdenv,
   installShellFiles,
+  versionCheckHook,
 }:
 
 rustPlatform.buildRustPackage rec {
@@ -36,6 +37,12 @@ rustPlatform.buildRustPackage rec {
       --fish <($out/bin/hydra-check --shell-completion fish) \
       --zsh <($out/bin/hydra-check --shell-completion zsh)
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+
+  doInstallCheck = true;
 
   meta = {
     description = "Check hydra for the build status of a package";

--- a/pkgs/by-name/hy/hydra-check/package.nix
+++ b/pkgs/by-name/hy/hydra-check/package.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "hydra-check";
-  version = "2.0.2";
+  version = "2.0.3";
 
   src = fetchFromGitHub {
     owner = "nix-community";
     repo = "hydra-check";
     tag = "v${version}";
-    hash = "sha256-FfeT6oxhHORbd4uR4gRNhI6W9YOkG8ieiL0Co3GWzb4=";
+    hash = "sha256-h8bs6oe8zkzEDCoC9F6IzTaTkNf4eAAjt663V0qn73I=";
   };
 
-  cargoHash = "sha256-35e+ACUyp5sQiHz9fgDXXz365XbxHMLcX2aTA41rJN0=";
+  cargoHash = "sha256-AUIm8OLN+BgEtlYCFQkozEwkp0Iwfkj+l5ttSAoCz60=";
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
## Description of changes


## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
