### PR TITLE
parted: backport upstream C23 fix

### DIFF
--- a/pkgs/by-name/pa/parted/package.nix
+++ b/pkgs/by-name/pa/parted/package.nix
@@ -56,6 +56,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional (lvm2 == null) "--disable-device-mapper"
     ++ lib.optional enableStatic "--enable-static";
 
+  enableParallelBuilding = true;
+
   # Tests were previously failing due to Hydra running builds as uid 0.
   # That should hopefully be fixed now.
   doCheck = !stdenv.hostPlatform.isMusl; # translation test

--- a/pkgs/by-name/pa/parted/package.nix
+++ b/pkgs/by-name/pa/parted/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchurl,
+  fetchpatch,
   lvm2,
   libuuid,
   gettext,
@@ -23,6 +24,15 @@ stdenv.mkDerivation rec {
     url = "mirror://gnu/parted/parted-${version}.tar.xz";
     sha256 = "sha256-O0Pb4zzKD5oYYB66tWt4UrEo7Bo986mzDM3l5zNZ5hI=";
   };
+
+  patches = [
+    # Fix the build against C23 compilers (like gcc-15):
+    (fetchpatch {
+      name = "c23.patch";
+      url = "https://git.savannah.gnu.org/gitweb/?p=parted.git;a=patch;h=16343bda6ce0d41edf43f8dac368db3bbb63d271";
+      hash = "sha256-8FgnwMrzMHPZNU+b/mRHCSu8sn6H7GhVLIhMUel40Hk=";
+    })
+  ];
 
   outputs = [
     "out"


### PR DESCRIPTION
Without the change the build against c23 compiler (like `gcc-15`) fails as:

    parted> parted.c: In function '_init_commands':
    parted> parted.c:2469:9: error: passing argument 2 of 'command_create' from incompatible pointer type []
    parted>  2469 |         do_version,
    parted>       |         ^~~~~~~~~~
    parted>       |         |
    parted>       |         int (*)(void)


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
