### PR TITLE
[staging-next] python312Packages.conda: fix hash and patch

### DIFF
--- a/pkgs/development/python-modules/conda/0001-conda_exe.patch
+++ b/pkgs/development/python-modules/conda/0001-conda_exe.patch
@@ -9,7 +9,7 @@
 
      @property
      @deprecated(
-@@ -787,28 +787,17 @@
+@@ -787,27 +787,17 @@
          The vars can refer to each other if necessary since the dict is ordered.
          None means unset it.
          """
@@ -25,12 +25,11 @@
 -                "CONDA_PYTHON_EXE": sys.executable,
 -            }
 -        else:
--            bin_dir = "Scripts" if on_win else "bin"
 -            exe = "conda.exe" if on_win else "conda"
 -            # I was going to use None to indicate a variable to unset, but that gets tricky with
 -            # error-on-undefined.
 -            return {
--                "CONDA_EXE": os.path.join(sys.prefix, bin_dir, exe),
+-                "CONDA_EXE": os.path.join(sys.prefix, BIN_DIRECTORY, exe),
 -                "_CE_M": "",
 -                "_CE_CONDA": "",
 -                "CONDA_PYTHON_EXE": sys.executable,

--- a/pkgs/development/python-modules/conda/default.nix
+++ b/pkgs/development/python-modules/conda/default.nix
@@ -36,7 +36,7 @@ buildPythonPackage rec {
     owner = "conda";
     repo = "conda";
     tag = version;
-    hash = "sha256-JyAdGVddxUaFWWgReQxMeGI//mvKJUdxEFv6G0A9z3U=";
+    hash = "sha256-dFj9ob9RRmeaaVDJeDOVLe06fBkCGEWhavLFKytJ8Mo=";
   };
 
   build-system = [


### PR DESCRIPTION
No clue why the hash changed after the initial update a while ago.

Also update the patch to work again.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).