### PR TITLE
laurel: 0.6.4 -> 0.6.5

### DIFF
--- a/pkgs/servers/monitoring/laurel/default.nix
+++ b/pkgs/servers/monitoring/laurel/default.nix
@@ -3,20 +3,30 @@
   fetchFromGitHub,
   lib,
   rustPlatform,
+  fetchpatch2,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "laurel";
-  version = "0.6.4";
+  version = "0.6.5";
 
   src = fetchFromGitHub {
     owner = "threathunters-io";
     repo = "laurel";
     tag = "v${version}";
-    hash = "sha256-mp1XTFD6mvH3RzvzvnJ58iJ6/EjENKYSzOavC2rVixs=";
+    hash = "sha256-1UjIye+btsNtf9Klti/3frgO7M+D05WkC1iP+TPQkZk=";
   };
 
-  cargoHash = "sha256-F5yMNm1JaE9q0NQJ3PDmPlW4WdjfyJj/J9er18acsKw=";
+  cargoHash = "sha256-dQkT4AAbzvT8J8RocWOrdOaPCe8/Sn/5ZelRDPMGLIU=";
+
+  patches = [
+    # https://github.com/threathunters-io/laurel/commit/d2fc51c83e78aecd5c4ce922582df649c2600e1e
+    # Unbreaks the userdb::test::userdb test. Will be part of the next release (likely v0.6.6).
+    (fetchpatch2 {
+      url = "https://github.com/threathunters-io/laurel/commit/d2fc51c83e78aecd5c4ce922582df649c2600e1e.patch?full_index=1";
+      hash = "sha256-OId5ZCF71ikoCSggyy3u4USR71onFJpirp53k4M17Vo=";
+    })
+  ];
 
   postPatch = ''
     # Upstream started to redirect aarch64-unknown-linux-gnu to aarch64-linux-gnu-gcc
@@ -31,7 +41,7 @@ rustPlatform.buildRustPackage rec {
   meta = with lib; {
     description = "Transform Linux Audit logs for SIEM usage";
     homepage = "https://github.com/threathunters-io/laurel";
-    changelog = "https://github.com/threathunters-io/laurel/releases/tag/v${version}";
+    changelog = "https://github.com/threathunters-io/laurel/releases/tag/${src.tag}";
     license = licenses.gpl3Plus;
     maintainers = with maintainers; [ emilylange ];
     platforms = platforms.linux;


### PR DESCRIPTION
https://github.com/threathunters-io/laurel/releases/tag/v0.6.5

diff: https://github.com/threathunters-io/laurel/compare/v0.6.4...v0.6.5

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).