### PR TITLE
grafana-agent: 0.43.3 -> 0.44.2

### DIFF
--- a/pkgs/by-name/gr/grafana-agent/package.nix
+++ b/pkgs/by-name/gr/grafana-agent/package.nix
@@ -17,28 +17,28 @@
 # FIXME: unpin when fixed upstream
 buildGo122Module rec {
   pname = "grafana-agent";
-  version = "0.43.4";
+  version = "0.44.2";
 
   src = fetchFromGitHub {
     owner = "grafana";
     repo = "agent";
-    rev = "v${version}";
-    hash = "sha256-VmGxe2bwp7It1Po+6kLia952PcT2MIg60qp3V/uRvUM=";
+    tag = "v${version}";
+    hash = "sha256-dAfiTJ0DlChriYOl/bPCEHj/UpbZ2a8BZBCQ82H+O9I=";
   };
 
-  vendorHash = "sha256-aFGxRw0l56tO3NxpzAKKj8fl4Uj4tSVWqCK3YcZjjMc=";
+  vendorHash = "sha256-6nXUeRpaezzfRykqMCtwP0FQZchRdxLmtupVAMNAjmY=";
   proxyVendor = true; # darwin/linux hash mismatch
 
   frontendYarnOfflineCache = fetchYarnDeps {
     yarnLock = src + "/internal/web/ui/yarn.lock";
-    hash = "sha256-kThqcjQ7qdSSs6bItSfLSW1WXpEYEA9BSLmyRfeCLyw=";
+    hash = "sha256-uqKOGSEnR9CU4vlahldrLxDb3z7Yt1DebyRB91NQMRc=";
   };
 
   ldflags = let
     prefix = "github.com/grafana/agent/internal/build";
   in [
     "-s" "-w"
-    # https://github.com/grafana/agent/blob/v0.41.0/Makefile#L132-L137
+    # https://github.com/grafana/agent/blob/v0.44.2/Makefile#L132-L137
     "-X ${prefix}.Version=${version}"
     "-X ${prefix}.Branch=v${version}"
     "-X ${prefix}.Revision=v${version}"


### PR DESCRIPTION
0.44.0 and 0.44.1 have tags but aren't "proper" releases due to some CI and human errors (https://github.com/grafana/agent/pull/7105).

0.44.2 is the first "official" release after 0.43.3.

https://github.com/grafana/agent/releases/tag/v0.44.2

diff: https://github.com/grafana/agent/compare/v0.43.4...v0.44.2

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
