### PR TITLE
[staging-next] python312Packages.javaproperties: fix build, misc. cleanup

### DIFF
--- a/pkgs/development/python-modules/javaproperties/default.nix
+++ b/pkgs/development/python-modules/javaproperties/default.nix
@@ -2,27 +2,27 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
-  setuptools,
-  six,
+  hatchling,
   pytestCheckHook,
   python-dateutil,
+  pythonOlder,
 }:
 
 buildPythonPackage rec {
   version = "0.8.2";
   pname = "javaproperties";
-  format = "pyproject";
+  pyproject = true;
+
+  disabled = pythonOlder "3.8";
 
   src = fetchFromGitHub {
     owner = "jwodder";
-    repo = pname;
+    repo = "javaproperties";
     tag = "v${version}";
     sha256 = "sha256-8Deo6icInp7QpTqa+Ou6l36/23skxKOYRef2GbumDqo=";
   };
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [ six ];
+  build-system = [ hatchling ];
 
   nativeCheckInputs = [
     python-dateutil
@@ -33,10 +33,10 @@ buildPythonPackage rec {
 
   disabledTestPaths = [ "test/test_propclass.py" ];
 
-  meta = with lib; {
-    description = "Microsoft Azure API Management Client Library for Python";
-    homepage = "https://github.com/Azure/azure-sdk-for-python";
-    license = licenses.mit;
+  meta = {
+    description = "Python library for reading and writing Java .properties files";
+    homepage = "https://github.com/jwodder/javaproperties";
+    license = lib.licenses.mit;
     maintainers = [ ];
   };
 }


### PR DESCRIPTION
Migrated to hatchling as build tool. Removed seemingly unused `six` dependency.

Fixed meta values and added disabled condition.

Broken since #375144

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).