### PR TITLE
[staging-next] python312Packages.types-lxml: fix tests

### DIFF
--- a/pkgs/development/python-modules/types-lxml/default.nix
+++ b/pkgs/development/python-modules/types-lxml/default.nix
@@ -55,7 +55,8 @@ buildPythonPackage rec {
     rm -r tests/static
     mv tests/runtime/* tests/
     rmdir tests/runtime
-    substituteInPlace tests/conftest.py --replace-fail '"pytest-revealtype-injector",' "" \
+    substituteInPlace tests/conftest.py \
+      --replace-fail '"pytest-revealtype-injector",' "" \
       --replace-fail 'runtime.register_strategy' 'tests.register_strategy'
   '';
 

--- a/pkgs/development/python-modules/types-lxml/default.nix
+++ b/pkgs/development/python-modules/types-lxml/default.nix
@@ -13,6 +13,7 @@
   typeguard,
   types-beautifulsoup4,
   typing-extensions,
+  hypothesis,
 }:
 
 buildPythonPackage rec {
@@ -40,6 +41,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     beautifulsoup4
     html5lib
+    hypothesis
     lxml
     pyright
     pytestCheckHook
@@ -48,16 +50,18 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "lxml-stubs" ];
 
+  # there may only be one conftest.py
+  preCheck = ''
+    rm -r tests/static
+    mv tests/runtime/* tests/
+    rmdir tests/runtime
+    substituteInPlace tests/conftest.py --replace-fail '"pytest-revealtype-injector",' "" \
+      --replace-fail 'runtime.register_strategy' 'tests.register_strategy'
+  '';
+
   disabledTests = [
-    # AttributeError: 'bytes' object has no attribute 'find_class'
-    # https://github.com/abelcheung/types-lxml/issues/34
-    "test_bad_methodfunc"
-    "test_find_class"
-    "test_find_rel_links"
-    "test_iterlinks"
-    "test_make_links_absolute"
-    "test_resolve_base_href"
-    "test_rewrite_links"
+    "test_single_ns_all_tag_2"
+    "test_default_ns"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Broken since #375144

Two tests had to be disabled. Since upstream is planning to rework their tests anyhow (https://github.com/abelcheung/types-lxml/issues/75) I did not investigate further.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).