### PR TITLE
grafana-to-ntfy: init at 0-unstable-2025-01-25

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -929,6 +929,7 @@
   ./services/monitoring/grafana-agent.nix
   ./services/monitoring/grafana-image-renderer.nix
   ./services/monitoring/grafana-reporter.nix
+  ./services/monitoring/grafana-to-ntfy.nix
   ./services/monitoring/grafana.nix
   ./services/monitoring/graphite.nix
   ./services/monitoring/hdaps.nix

--- a/nixos/modules/services/monitoring/grafana-to-ntfy.nix
+++ b/nixos/modules/services/monitoring/grafana-to-ntfy.nix
@@ -1,0 +1,123 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.services.grafana-to-ntfy;
+in
+{
+  options = {
+    services.grafana-to-ntfy = {
+      enable = lib.mkEnableOption "Grafana-to-ntfy (ntfy.sh) alerts channel";
+
+      package = lib.mkPackageOption pkgs "grafana-to-ntfy" { };
+
+      settings = {
+        ntfyUrl = lib.mkOption {
+          type = lib.types.str;
+          description = "The URL to the ntfy-sh topic.";
+          example = "https://push.example.com/grafana";
+        };
+
+        ntfyBAuthUser = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          description = ''
+            The ntfy-sh user to use for authenticating with the ntfy-sh instance.
+            Setting this option is required when using a ntfy-sh instance with access control enabled.
+          '';
+          default = null;
+          example = "grafana";
+        };
+
+        ntfyBAuthPass = lib.mkOption {
+          type = lib.types.path;
+          description = ''
+            The path to the password for the specified ntfy-sh user.
+            Setting this option is required when using a ntfy-sh instance with access control enabled.
+          '';
+          default = null;
+        };
+
+        bauthUser = lib.mkOption {
+          type = lib.types.str;
+          description = ''
+            The user that you will authenticate with in the Grafana webhook settings.
+            You can set this to whatever you like, as this is not the same as the ntfy-sh user.
+          '';
+          default = "admin";
+        };
+
+        bauthPass = lib.mkOption {
+          type = lib.types.path;
+          description = "The path to the password you will use in the Grafana webhook settings.";
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.grafana-to-ntfy = {
+      wantedBy = [ "multi-user.target" ];
+
+      script = ''
+        export BAUTH_PASS=$(${lib.getExe' config.systemd.package "systemd-creds"} cat BAUTH_PASS_FILE)
+        ${lib.optionalString (cfg.settings.ntfyBAuthPass != null) ''
+          export NTFY_BAUTH_PASS=$(${lib.getExe' config.systemd.package "systemd-creds"} cat NTFY_BAUTH_PASS_FILE)
+        ''}
+        exec ${lib.getExe cfg.package}
+      '';
+
+      environment =
+        {
+          NTFY_URL = cfg.settings.ntfyUrl;
+          BAUTH_USER = cfg.settings.bauthUser;
+        }
+        // lib.optionalAttrs (cfg.settings.ntfyBAuthUser != null) {
+          NTFY_BAUTH_USER = cfg.settings.ntfyBAuthUser;
+        };
+
+      serviceConfig = {
+        LoadCredential =
+          [
+            "BAUTH_PASS_FILE:${cfg.settings.bauthPass}"
+          ]
+          ++ lib.optional (
+            cfg.settings.ntfyBAuthPass != null
+          ) "NTFY_BAUTH_PASS_FILE:${cfg.settings.ntfyBAuthPass}";
+
+        DynamicUser = true;
+        CapabilityBoundingSet = [ "" ];
+        DeviceAllow = "";
+        LockPersonality = true;
+        PrivateDevices = true;
+        PrivateUsers = true;
+        ProcSubset = "pid";
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectProc = "invisible";
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+        MemoryDenyWriteExecute = true;
+        SystemCallArchitectures = "native";
+        SystemCallFilter = [
+          "@system-service"
+          "~@privileged"
+        ];
+        UMask = "0077";
+      };
+    };
+  };
+}

--- a/pkgs/by-name/gr/grafana-to-ntfy/package.nix
+++ b/pkgs/by-name/gr/grafana-to-ntfy/package.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+rustPlatform.buildRustPackage {
+  pname = "grafana-to-ntfy";
+  version = "0-unstable-2025-01-25";
+
+  src = fetchFromGitHub {
+    owner = "kittyandrew";
+    repo = "grafana-to-ntfy";
+    rev = "64d11f553776bbf7695d9febd74da1bad659352d";
+    hash = "sha256-GO9VE9wymRk+QKGFyDpd0wS9GCY3pjpFUe37KIcnKxc=";
+  };
+
+  useFetchCargoVendor = true;
+
+  cargoHash = "sha256-w4HSxdihElPz0q05vWjajQ9arZjAzd82L0kEKk1Uk8s=";
+
+  meta = {
+    description = "Grafana-to-ntfy (ntfy.sh) alerts channel";
+    homepage = "https://github.com/kittyandrew/grafana-to-ntfy";
+    license = lib.licenses.agpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ kranzes ];
+    mainProgram = "grafana-to-ntfy";
+  };
+}


### PR DESCRIPTION
- **grafana-to-ntfy: init at 0-unstable-2025-01-25**
- **nixos/grafana-to-nfy: init**

supersedes: #346731 
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
