### PR TITLE
go 1.23.4 -> 1.23.5

### DIFF
--- a/pkgs/development/compilers/go/1.23.nix
+++ b/pkgs/development/compilers/go/1.23.nix
@@ -16,7 +16,7 @@
 }:
 
 let
-  goBootstrap = buildPackages.callPackage ./bootstrap121.nix { };
+  goBootstrap = buildPackages.callPackage ./bootstrap122.nix { };
 
   skopeoTest = skopeo.override { buildGoModule = buildGo123Module; };
 
@@ -49,11 +49,11 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";
-  version = "1.23.4";
+  version = "1.23.5";
 
   src = fetchurl {
     url = "https://go.dev/dl/go${finalAttrs.version}.src.tar.gz";
-    hash = "sha256-rTRaxCHpCBQpOpaZzKGd1SOCUcP2h5gLvK4oSVsmNTE=";
+    hash = "sha256-pvP0u9PmvdYm95tmjyEvu1ZJ2vdQhPt5tnigrk2XQjs=";
   };
 
   strictDeps = true;


### PR DESCRIPTION
## Things done

go 1.23.4 -> 1.23.5

go1.23.5 (released 2025-01-16) includes security fixes to the crypto/x509 and net/http packages, as well as bug fixes to the compiler, the runtime, and the net package. See the [Go 1.23.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.23.5+label%3ACherryPickApproved) on our issue tracker for details.

https://go.dev/doc/devel/release#go1.23.minor

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:

Tested this by using an overlay in by system flake to pull in the branch/commit
nixpkgs-unstable.url = "github:randomizedcoder/nixpkgs/c9580e24eb621d72eda63355d7c8dbfb1654d333";
https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#get-a-branch

```
[das@t:~/nixos/laptops/t]$ make
Hostnames match: t
sudo nixos-rebuild switch --flake .
[sudo] password for das:
warning: Git tree '/home/das/nixos' is dirty
warning: updating lock file '/home/das/nixos/laptops/t/flake.lock':
• Updated input 'nixpkgs-unstable':
    'github:randomizedcoder/nixpkgs/c20918449ffa3a0c31c0cb2b36b25f490669cffd?narHash=sha256-jlETjjcz%2BvI/ItoiXkUNb2HVNeVV/uIe4cbkvC7FI2o%3D' (2025-02-01)
  → 'github:randomizedcoder/nixpkgs/c9580e24eb621d72eda63355d7c8dbfb1654d333?narHash=sha256-xo3e%2BSFJfC69lqorgLc0DlRSFq2w59h4TTSGx1zbTrE%3D' (2025-02-01)
warning: Git tree '/home/das/nixos' is dirty
building the system configuration...
warning: Git tree '/home/das/nixos' is dirty
evaluation warning: das profile: You have enabled hyprland.systemd.enable or listed plugins in hyprland.plugins but do not have any configuration in hyprland.settings or hyprland.extraConfig. This is almost certainly a mistake.
activating the configuration...
setting up /etc...
reloading user units for das...
restarting sysinit-reactivation.target
the following new units were started: libvirtd.service

[das@t:~/nixos/laptops/t]$ go version
go version go1.23.5 linux/amd64
```

  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
