### PR TITLE
nixos/snapserver: add extraConfig option

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -421,6 +421,8 @@
 - The paperless module now has an option for regular automatic export of
   documents data using the integrated document exporter.
 
+- The `services.snapserver` module now accepts [extraArgs](options.html.#opt-services.snapserver.extraArgs) allowing users to pass additional arguments to the commandline.
+
 - New options for the declarative configuration of the user space part of ALSA have been introduced under [hardware.alsa](options.html#opt-hardware.alsa.enable), including setting the default capture and playback device, defining sound card aliases and volume controls.
   Note: these are intended for users not running a sound server like PulseAudio or PipeWire, but having ALSA as their only sound system.
 

--- a/nixos/modules/services/audio/snapserver.nix
+++ b/nixos/modules/services/audio/snapserver.nix
@@ -71,6 +71,7 @@ let
       "--http.port=${toString cfg.http.port}"
     ]
     ++ lib.optional (cfg.http.docRoot != null) "--http.doc_root=\"${toString cfg.http.docRoot}\""
+    ++ cfg.extraArgs
   );
 
 in
@@ -208,6 +209,15 @@ in
         defaultText = lib.literalExpression "pkgs.snapweb";
         description = ''
           Path to serve from the HTTP servers root.
+        '';
+      };
+
+      extraArgs = lib.mkOption {
+        type = with lib.types; listOf str;
+        default = [ ];
+        example = [ "--logging.filter debug" ];
+        description = ''
+          Set extra config options or cli flags, that are not covered by other module options
         '';
       };
 


### PR DESCRIPTION
The snapserver module passes the config as cli arguments to the service, but there was no option to provide cli arguments that are not covered by other module options, like to increase logging for debugging.

Instead of a debugging option, this is a free text field, to cover all possible config options that might not be covered by the module




## Things done


- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) ([25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).