### PR TITLE
junicode: 2.209 -> 2.211

### DIFF
--- a/pkgs/by-name/ju/junicode/package.nix
+++ b/pkgs/by-name/ju/junicode/package.nix
@@ -8,11 +8,11 @@
 
 stdenvNoCC.mkDerivation rec {
   pname = "junicode";
-  version = "2.209";
+  version = "2.211";
 
   src = fetchzip {
     url = "https://github.com/psb1558/Junicode-font/releases/download/v${version}/Junicode_${version}.zip";
-    hash = "sha256-hdCDLwTiyE2ZpFgmYAX7YWCujUwozIozD+k/lCStJUg=";
+    hash = "sha256-ZFJqNIsuWVph3U73lbcXVKXgzt+5cPxetvcAAzt0jvg=";
   };
 
   outputs = [

--- a/pkgs/by-name/ju/junicode/tex-font-path.patch
+++ b/pkgs/by-name/ju/junicode/tex-font-path.patch
@@ -5,10 +5,10 @@ locations, which are later patched up to refer to the package outputs,
 thus ensuring the style always uses the fonts packaged with it.
 
 diff --git a/TeX/junicode.sty b/TeX/junicode.sty
-index 83bd45d..8fe671c 100644
+index 3f80068..af3e3ba 100644
 --- a/TeX/junicode.sty
 +++ b/TeX/junicode.sty
-@@ -208,7 +208,14 @@
+@@ -211,7 +211,14 @@
  
  \RequirePackage{fontspec}
  \defaultfontfeatures{Ligatures=TeX, Extension=.\junicode@fonttype}
@@ -24,7 +24,7 @@ index 83bd45d..8fe671c 100644
  
  \ifxetex
  \typeout{\junicode@regstylename}
-@@ -219,6 +226,7 @@
+@@ -222,6 +229,7 @@
     ItalicFont =        *-\junicode@italstylename,
     BoldFont =          *-\junicode@boldstylename,
     BoldItalicFont =    *-\junicode@boldstylename Italic,
@@ -32,7 +32,7 @@ index 83bd45d..8fe671c 100644
    ]{Junicode}
  \fi
  \ifluatex
-@@ -230,6 +238,7 @@
+@@ -233,6 +241,7 @@
     ItalicFont =        *-\junicode@italstylename,
     BoldFont =          *-\junicode@boldstylename,
     BoldItalicFont =    *-\junicode@boldstylename Italic,
@@ -40,7 +40,7 @@ index 83bd45d..8fe671c 100644
    ]{Junicode}
  \fi
  
-@@ -242,6 +251,7 @@
+@@ -245,6 +254,7 @@
          #3
          Numbers =           {\junicode@figurealign,\junicode@figurestyle},
          SmallCapsFeatures = {Letters=SmallCaps},
@@ -48,7 +48,7 @@ index 83bd45d..8fe671c 100644
      ]
  }
  \fi
-@@ -252,6 +262,7 @@
+@@ -255,6 +265,7 @@
          #3
          Numbers =           {\junicode@figurealign,\junicode@figurestyle},
          SmallCapsFeatures = {Letters=SmallCaps},
@@ -57,10 +57,10 @@ index 83bd45d..8fe671c 100644
  }
  \fi
 diff --git a/TeX/junicodevf.lua b/TeX/junicodevf.lua
-index 7148668..acebe82 100644
+index 9c58f79..6ddcb55 100644
 --- a/TeX/junicodevf.lua
 +++ b/TeX/junicodevf.lua
-@@ -148,7 +148,7 @@ function mkfontcommands()
+@@ -118,7 +118,7 @@ function mkfontcommands()
           romfontcmd = "jRegular"
           italfontcmd = "jItalic"
        end
@@ -70,12 +70,12 @@ index 7148668..acebe82 100644
     end
  end
 diff --git a/TeX/junicodevf.sty b/TeX/junicodevf.sty
-index c01ccaf..07a99ad 100644
+index da987d0..4475add 100644
 --- a/TeX/junicodevf.sty
 +++ b/TeX/junicodevf.sty
-@@ -168,11 +168,13 @@ mkwidthcommands(wdindex, adjustment)}}
- 
- % DECLARE THE FONTS
+@@ -132,10 +132,12 @@ mkmainfontcommand(style_idx, weight_option, weight_adjust, width_option, width_a
+ % Set the main font, then the alternate styles. It appears that
+ % the fonts aren't embedded in the PDF unless actually used.
  
 -\setmainfont{JunicodeVF}[
 -    ItalicFont =         {*-Italic},
@@ -85,35 +85,35 @@ index c01ccaf..07a99ad 100644
 +    ItalicFont =         {JunicodeVF-Italic},
 +    BoldFont =           {JunicodeVF-Roman},
 +    BoldItalicFont =     {JunicodeVF-Italic},
-     Renderer =           HarfBuzz,
 +    Extension =          .ttf,
 +    Path =               @@@truetype_path@@@,
+     Renderer =           {\junicodevf@renderer},
      Numbers =            {\junicodevf@figurealign,\junicodevf@figurestyle},
      \MainDef,
-     UprightFeatures =    {\MainRegDef
-@@ -188,6 +190,8 @@ mkwidthcommands(wdindex, adjustment)}}
+@@ -152,6 +154,8 @@ mkmainfontcommand(style_idx, weight_option, weight_adjust, width_option, width_a
  \newcommand*{\junicodevf@newfont}[4]{
      \setfontface#1{#2}[
-         Renderer =          HarfBuzz,
+         Renderer =          {\junicodevf@renderer},
 +        Extension =          .ttf,
 +        Path =               @@@truetype_path@@@,
          Numbers =           {\junicodevf@figurealign,\junicodevf@figurestyle},
          SmallCapsFont =     {*},
          SmallCapsFeatures = {Letters=SmallCaps},
-@@ -200,43 +204,59 @@ mkwidthcommands(wdindex, adjustment)}}
+@@ -164,43 +168,60 @@ mkmainfontcommand(style_idx, weight_option, weight_adjust, width_option, width_a
  
  % ENLARGED FACES
  
 -\setfontface\EnlargedOne{JunicodeVF}[
 +\setfontface\EnlargedOne{JunicodeVF-Roman}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLAOneSizeDef
  ]
  
  \setfontface\EnlargedOneItalic{JunicodeVF-Italic}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
++    Renderer = HarfBuzz,
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLAOneSizeDef
@@ -121,14 +121,14 @@ index c01ccaf..07a99ad 100644
  
 -\setfontface\EnlargedTwo{JunicodeVF}[
 +\setfontface\EnlargedTwo{JunicodeVF-Roman}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLATwoSizeDef
  ]
  
  \setfontface\EnlargedTwoItalic{JunicodeVF-Italic}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLATwoSizeDef
@@ -136,14 +136,14 @@ index c01ccaf..07a99ad 100644
  
 -\setfontface\EnlargedThree{JunicodeVF}[
 +\setfontface\EnlargedThree{JunicodeVF-Roman}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLAThreeSizeDef
  ]
  
  \setfontface\EnlargedThreeItalic{JunicodeVF-Italic}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLAThreeSizeDef
@@ -151,14 +151,14 @@ index c01ccaf..07a99ad 100644
  
 -\setfontface\EnlargedFour{JunicodeVF}[
 +\setfontface\EnlargedFour{JunicodeVF-Roman}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLAFourSizeDef
  ]
  
  \setfontface\EnlargedFourItalic{JunicodeVF-Italic}[
-     Renderer = HarfBuzz,
+     Renderer = {\junicodevf@renderer},
 +    Extension = .ttf,
 +    Path = @@@truetype_path@@@,
      \ENLAFourSizeDef


### PR DESCRIPTION
There is no version 2.210

Changelog:
https://github.com/psb1558/Junicode-font/releases/tag/v2.211


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
