### PR TITLE
hyprlandPlugins: update remaining plugins to 0.47

### DIFF
--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hypr-dynamic-cursors.nix
@@ -8,13 +8,13 @@
 
 mkHyprlandPlugin hyprland {
   pluginName = "hypr-dynamic-cursors";
-  version = "0-unstable-2024-12-19";
+  version = "0-unstable-2025-01-27";
 
   src = fetchFromGitHub {
     owner = "VirtCode";
     repo = "hypr-dynamic-cursors";
-    rev = "111669a699f998b5eb5a0d5610b5fcb748aab038";
-    hash = "sha256-EeNVNDNxbz1dGWs/jJ/JQbZtWkN+i4qfU7SAiQOMwwY=";
+    rev = "4d1d88522bbeefd07a9113dd5449a0a288d11ba8";
+    hash = "sha256-BTYq6SDfUvhLH/Zjc0sGr19m5qnjB9Vn3OfIpxumsyk=";
   };
 
   dontUseCmakeConfigure = true;

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprfocus.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprfocus.nix
@@ -3,27 +3,19 @@
   mkHyprlandPlugin,
   hyprland,
   fetchFromGitHub,
-  fetchpatch2,
   nix-update-script,
 }:
 
 mkHyprlandPlugin hyprland {
   pluginName = "hyprfocus";
-  version = "0-unstable-2024-11-09";
+  version = "0-unstable-2025-01-04";
 
   src = fetchFromGitHub {
     owner = "pyt0xic";
     repo = "hyprfocus";
-    rev = "bead5b77d80f222c006d1a6c6f44ee8b02021d73";
-    hash = "sha256-qIl7opF7fA1ZmC91TGQ7D12tB7kHc6Sn9DrfUN6sbBY=";
+    rev = "de6eaf5846b970b697bdf0e20e731b9fbe08654d";
+    hash = "sha256-o8uDSynpHAgpQZMjXyDiyQbxi+QgxY62uZeB08PcL/A=";
   };
-
-  patches = [
-    (fetchpatch2 {
-      url = "https://github.com/pyt0xic/hyprfocus/commit/e7d9ee3c470b194fe16179ff2f16fc4233e928ef.patch";
-      hash = "sha256-iETrtvoIZfcaD3TcKIIwFL8Rua0dFEqboml9AgQ/RZ0=";
-    })
-  ];
 
   installPhase = ''
     runHook preInstall
@@ -41,5 +33,6 @@ mkHyprlandPlugin hyprland {
     license = lib.licenses.bsd3;
     maintainers = with lib.maintainers; [ donovanglover ];
     platforms = lib.platforms.linux;
+    broken = true; # Doesn't work on Hyprland v0.47.0+
   };
 }

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprgrass.nix
@@ -13,13 +13,13 @@
 
 mkHyprlandPlugin hyprland {
   pluginName = "hyprgrass";
-  version = "0.8.2-unstable-2024-12-13";
+  version = "0.8.2-unstable-2025-02-01";
 
   src = fetchFromGitHub {
     owner = "horriblename";
     repo = "hyprgrass";
-    rev = "dc19ccb209147312a4f60d76193b995c2634e756";
-    hash = "sha256-3ALmrImk37KT+UHt1EMi6PAHyj8WhL9Xw/Ar/ys4rtk=";
+    rev = "f7017c493e071c02f203c09a63ef7260dede0586";
+    hash = "sha256-F9Jnu36LXJnfDdc3mG4JYKACw/ygsPcwEbZsOdCreIQ=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprland-plugins.nix
@@ -14,13 +14,13 @@ let
             mkHyprlandPlugin,
           }:
           let
-            version = "0.46.0";
+            version = "0.47.0";
 
             hyprland-plugins-src = fetchFromGitHub {
               owner = "hyprwm";
               repo = "hyprland-plugins";
               rev = "refs/tags/v${version}";
-              hash = "sha256-Q9bXV9d6xqxr8V1UKmmmHdCgky3I4n2hk1TDxZ/pBto=";
+              hash = "sha256-zys4H2zSSIw54ecnYnBh2NUKZQraWD4B7qftuClrXho=";
             };
           in
           mkHyprlandPlugin hyprland {

--- a/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
+++ b/pkgs/applications/window-managers/hyprwm/hyprland-plugins/hyprspace.nix
@@ -8,13 +8,13 @@
 
 mkHyprlandPlugin hyprland {
   pluginName = "hyprspace";
-  version = "0-unstable-2024-12-08";
+  version = "0-unstable-2025-01-18";
 
   src = fetchFromGitHub {
     owner = "KZDKM";
     repo = "hyprspace";
-    rev = "e2d561c933cd085d68bf0b39c4f78870ad0abbc2";
-    hash = "sha256-YiLUDw14NaavML8y9rxXxO7q+j3b/ghQhBmIy0+/Zmk=";
+    rev = "1b5865f4ac9a04ba614df50de7acfaa40dcb852f";
+    hash = "sha256-YQgW4QifYIcNaFF4nMw0LpllXn0rhk/Yb6cwyH3PB9o=";
   };
 
   dontUseCmakeConfigure = true;
@@ -36,5 +36,6 @@ mkHyprlandPlugin hyprland {
     license = lib.licenses.gpl2Only;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ donovanglover ];
+    broken = true; # Doesn't work on Hyprland v0.47.0+
   };
 }


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

Update remaining plugins to 0.47.

- **hyprlandPlugins/hyprland-plugins: 0.46.0 -> 0.47.0**
- **hyprlandPlugins.hypr-dynamic-cursors: 0-unstable-2024-12-19 -> 0-unstable-2025-01-27**
- **hyprlandPlugins.hyprfocus: 0-unstable-2024-11-09 -> 0-unstable-2025-01-04**
- **hyprlandPlugins.hyprgrass: 0.8.2-unstable-2024-12-13 -> 0.8.2-unstable-2025-02-01**
- **hyprlandPlugins.hyprspace: 0-unstable-2024-12-08 -> 0-unstable-2025-01-18**

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
