### PR TITLE
mdformat: Support more than 1 plugin at a time

### DIFF
--- a/pkgs/by-name/md/mdformat/package.nix
+++ b/pkgs/by-name/md/mdformat/package.nix
@@ -26,7 +26,7 @@ let
         };
       }
       ''
-        buildPythonPath $plugins
+        buildPythonPath "$plugins"
         makeWrapper ${lib.getExe python.pkgs.mdformat} $out/bin/mdformat \
           --suffix PYTHONPATH : "$program_PYTHONPATH"
       '';


### PR DESCRIPTION
There was a bug in mdformat's `withPlugins` which meant that only the first plugin was installed. With this change, the `$plugins` bash array is fully expanded and all plugins listed in `withPlugins` are installed.

## Things done

In the nix repl, I have evaluated and built `legacyPackages.aarch64-darwin.mdformat.withPlugins (ps: with ps; [mdformat-gfm mdformat-frontmatter])` before and after this change and prior to it "mdformat-frontmatter" does not appear in the generated `mdformat-wrapped` script, and it does correctly afterwards.

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
