### PR TITLE
python313Packages.inform: fix tests

### DIFF
--- a/pkgs/development/python-modules/inform/default.nix
+++ b/pkgs/development/python-modules/inform/default.nix
@@ -9,6 +9,7 @@
   num2words,
   pytestCheckHook,
   pythonOlder,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
@@ -38,7 +39,12 @@ buildPythonPackage rec {
     hypothesis
   ];
 
-  disabledTests = [ "test_prostrate" ];
+  disabledTests =
+    [ "test_prostrate" ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      # doctest runs one more test than expected
+      "test_inform"
+    ];
 
   meta = with lib; {
     description = "Print and logging utilities";


### PR DESCRIPTION
https://hydra.nixos.org/build/285542101/nixlog/1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).