### PR TITLE
python312Packages.ansible-compat: 25.0.0 -> 25.1.1

### DIFF
--- a/pkgs/development/python-modules/ansible-compat/default.nix
+++ b/pkgs/development/python-modules/ansible-compat/default.nix
@@ -16,19 +16,20 @@
   ansible-core,
   flaky,
   pytest-mock,
+  pytest-instafail,
   pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "ansible-compat";
-  version = "25.0.0";
+  version = "25.1.1";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "ansible";
     repo = "ansible-compat";
     tag = "v${version}";
-    hash = "sha256-9ETe9LiisPOaRxfwqj3O5iXljoIABkku4DXVaIerlkA=";
+    hash = "sha256-uchju9ZxmoqZX3xlAC9lXc+DPpbG71xq1mIHwtaiB9c=";
   };
 
   build-system = [
@@ -51,11 +52,13 @@ buildPythonPackage rec {
     ansible-core
     flaky
     pytest-mock
+    pytest-instafail
     pytestCheckHook
   ];
 
   disabledTests = [
     # require network
+    "test_install_collection"
     "test_install_collection_from_disk"
     "test_install_collection_git"
     "test_load_plugins"
@@ -64,9 +67,13 @@ buildPythonPackage rec {
     "test_prerun_reqs_v2"
     "test_require_collection_install"
     "test_require_collection_no_cache_dir"
+    "test_require_collection_preexisting_broken"
+    "test_require_collection_not_isolated"
     "test_runtime_has_playbook"
     "test_runtime_plugins"
+    "test_runtime_example"
     "test_scan_sys_path"
+    "test_upgrade_collection"
   ];
 
   pythonImportsCheck = [ "ansible_compat" ];


### PR DESCRIPTION
This fixes a test failure that 25.0.0 introduced: https://hydra.nixos.org/build/287379792

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
