### PR TITLE
runzip: fix build, drop unused libzip from buildInputs, enable tests

### DIFF
--- a/pkgs/by-name/ru/runzip/package.nix
+++ b/pkgs/by-name/ru/runzip/package.nix
@@ -2,8 +2,8 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  libzip,
   libiconv,
+  zlib,
   autoreconfHook,
 }:
 
@@ -14,7 +14,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
   buildInputs = [
     libiconv
-    libzip
+    zlib
   ];
 
   src = fetchFromGitHub {
@@ -23,6 +23,11 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     sha256 = "0l5zbb5hswxczigvyal877j0aiq3fc01j3gv88bvy7ikyvw3lc07";
   };
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-Wno-error=implicit-int"
+    "-Wno-error=incompatible-pointer-types"
+  ];
 
   meta = {
     description = "Tool to convert filename encoding inside a ZIP archive";

--- a/pkgs/by-name/ru/runzip/package.nix
+++ b/pkgs/by-name/ru/runzip/package.nix
@@ -24,10 +24,16 @@ stdenv.mkDerivation rec {
     sha256 = "0l5zbb5hswxczigvyal877j0aiq3fc01j3gv88bvy7ikyvw3lc07";
   };
 
+  postPatch = ''
+    patchShebangs tests/check-runzip.sh
+  '';
+
   env.NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=implicit-int"
     "-Wno-error=incompatible-pointer-types"
   ];
+
+  doCheck = true;
 
   meta = {
     description = "Tool to convert filename encoding inside a ZIP archive";


### PR DESCRIPTION
Configure script produces a cryptic message:

```
configure:4540: error: ZLIB version too old, please install at least v1.1.2
```

It's actually misleading and comes from the vendored libzip 0.7.1 configure check.
It fails due to do `-Wimplicit-int`:

```
conftest.c:16:16: error: type defaults to 'int' in declaration of 'unzOpen' [-Wimplicit-int]
   16 | extern ZEXPORT unzOpen (const char *path);
```

Vendored libzip is pretty heavily modified and unvendoring seems impossible.
Furthermore, libzip from nixpkgs in buildInputs is actually unused and can be dropped - only zlib is necessary.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
