### PR TITLE
nixosTests.terminal-emulators.lomiri-terminal-app: Drop

### DIFF
--- a/nixos/tests/lomiri.nix
+++ b/nixos/tests/lomiri.nix
@@ -256,9 +256,6 @@ in
               machine.send_key("ctrl-alt-t")
               wait_for_text(r"(${user}|machine)")
               machine.screenshot("terminal_opens")
-
-              # lomiri-terminal-app has a separate VM test to test its basic functionality
-
               machine.send_key("alt-f4")
 
           # We want the ability to launch applications
@@ -448,8 +445,6 @@ in
               machine.send_key("ctrl-alt-t")
               wait_for_text(r"(${user}|machine)")
               machine.screenshot("terminal_opens")
-
-              # lomiri-terminal-app has a separate VM test to test its basic functionality
 
               # for the LSS lomiri-content-hub test to work reliably, we need to kick off peer collecting
               machine.send_chars("lomiri-content-hub-test-importer\n")

--- a/nixos/tests/terminal-emulators.nix
+++ b/nixos/tests/terminal-emulators.nix
@@ -65,11 +65,6 @@ let
 
     konsole.pkg = p: p.plasma5Packages.konsole;
 
-    lomiri-terminal-app.pkg = p: p.lomiri.lomiri-terminal-app;
-    # after recent Mesa change, borked software rendering config under x86_64 icewm?
-    # BGR colour display on x86_64, RGB on aarch64
-    lomiri-terminal-app.colourTest = false;
-
     lxterminal.pkg = p: p.lxterminal;
 
     mate-terminal.pkg = p: p.mate.mate-terminal;

--- a/pkgs/desktops/lomiri/applications/lomiri-terminal-app/default.nix
+++ b/pkgs/desktops/lomiri/applications/lomiri-terminal-app/default.nix
@@ -61,7 +61,12 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   passthru = {
-    tests.vm-test = nixosTests.terminal-emulators.lomiri-terminal-app;
+    tests = {
+      # The way the test works sometimes causes segfaults in qtfeedback
+      # https://gitlab.com/ubports/development/apps/lomiri-terminal-app/-/issues/117
+      # vm-test = nixosTests.terminal-emulators.lomiri-terminal-app;
+      inherit (nixosTests.lomiri) desktop-basics desktop-appinteractions;
+    };
     updateScript = gitUpdater {
       rev-prefix = "v";
     };


### PR DESCRIPTION
This test is flaky on Hydra:

![image](https://github.com/user-attachments/assets/51cc63e3-2028-4f21-adf1-97a38ada9133)
![image](https://github.com/user-attachments/assets/82a0862b-5cbc-4f37-afb4-aa0718b9246f)

…and the issue is that the way the test functions causes a crash in a Qt library, due to the app getting closed too quickly: https://gitlab.com/ubports/development/apps/lomiri-terminal-app/-/issues/117

I couldn't quickly figure out how to add a `sleep` to the `command` that will be run inside the terminal. There is nothing left about this test that works reliably, just drop it for now - `nixosTests.lomiri.desktop-{basics,appinteractions}` already test the functionality of the terminal to *some* degree, so it doesn't go completely untested.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
