### PR TITLE
riscv{32,64}-embedded: build multilib gcc by default

### DIFF
--- a/lib/systems/examples.nix
+++ b/lib/systems/examples.nix
@@ -127,11 +127,15 @@ rec {
   riscv64-embedded = {
     config = "riscv64-none-elf";
     libc = "newlib";
+    # embedded riscv has various architectural extensions in common use
+    gcc.enableMultilib = true;
   };
 
   riscv32-embedded = {
     config = "riscv32-none-elf";
     libc = "newlib";
+    # embedded riscv has various architectural extensions in common use
+    gcc.enableMultilib = true;
   };
 
   mips64-embedded = {

--- a/pkgs/development/compilers/gcc/default.nix
+++ b/pkgs/development/compilers/gcc/default.nix
@@ -20,7 +20,7 @@
 , zlib ? null
 , libucontext ? null
 , gnat-bootstrap ? null
-, enableMultilib ? false
+, enableMultilib ? !withoutTargetLibc && (stdenv.targetPlatform.gcc.enableMultilib or false) # only enable if with libc
 , enablePlugin ? stdenv.hostPlatform == stdenv.buildPlatform # Whether to support user-supplied plug-ins
 , name ? "gcc"
 , libcCross ? null


### PR DESCRIPTION
Furthermore, we only enableMultilib when building a libc, since it shouldn't matter then otherwise.

Most compiled riscv-none-elf toolchains have the multilib for soft/ hard float. Debian enables extra 'multilibs' on top of the default set: https://salsa.debian.org/debian/gcc-riscv64-unknown-elf/-/blob/20c71585bc7e5f9fa3f30eb7eb614bcebe745451/debian/patches/0002-Add-more-multi-lib-for-rv32-and-rv64.patch https://www.sifive.com/blog/all-aboard-part-5-risc-v-multilib

This has been tested with an embedded system, where previously compiling would produce soft-float libraries which would then fail to link against the hard-float libc. With this recompilation, it just works™.

For reference, `riscv64-none-elf-gcc --print-multi-lib` now prints:

```
.;
rv32i/ilp32;@march=rv32i@mabi=ilp32
rv32im/ilp32;@march=rv32im@mabi=ilp32
rv32iac/ilp32;@march=rv32iac@mabi=ilp32
rv32imac/ilp32;@march=rv32imac@mabi=ilp32
rv32imafc/ilp32f;@march=rv32imafc@mabi=ilp32f
rv64imac/lp64;@march=rv64imac@mabi=lp64
rv64imafdc/lp64d;@march=rv64imafdc@mabi=lp64d
```

Two other alternatives were considered:

- Changing the default riscv64-embedded target to be the soft float variant. This is recommended by the sifive blog above as the most common embedded case. It would entail likely adding an extra riscv64-embedded-hf target, like arm has. As this is a potentially breaking change, this was avoided. Furthermore, there are many architectural variations that it wouldn't exposed all possibilities. Also reference [a previous PR](https://github.com/NixOS/nixpkgs/pull/178140).

- Exposing a gccMultilib (precompiled in binary cache). This is possibly a nicer alternative, but requires extra effort to use. In contrast, most distro packages just use multilib, so nixpkgs would remain special by default.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
