### PR TITLE
libnfc: Use autotools to build, fix broken darwin support

### DIFF
--- a/pkgs/by-name/li/libnfc/package.nix
+++ b/pkgs/by-name/li/libnfc/package.nix
@@ -4,7 +4,7 @@
   fetchFromGitHub,
   libusb-compat-0_1,
   readline,
-  cmake,
+  autoreconfHook,
   pkg-config,
 }:
 
@@ -20,22 +20,29 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [
-    cmake
+    # Note: Use autotools instead of cmake to build for darwin.
+    # When built with cmake, the following error occurs on real device like PN532:
+    # ```
+    # $ LIBNFC_DEVICE=pn532_uart:/dev/tty.usbserial-110 nfc-list
+    # nfc-list uses libnfc 1.8.0
+    # error       libnfc.bus.uart Unable to set serial port speed to 115200 baud. Speed value must be one of those defined in termios(3).
+    # error       libnfc.driver.pn532_uart        pn53x_check_communication error
+    # nfc-list: ERROR: Unable to open NFC device: pn532_uart:/dev/tty.usbserial-110
+    # ```
+    autoreconfHook
     pkg-config
   ];
 
   buildInputs = [
-    libusb-compat-0_1
     readline
+  ];
+
+  propagatedBuildInputs = [
+    libusb-compat-0_1
   ];
 
   configureFlags = [
     "sysconfdir=/etc"
-  ];
-
-  cmakeFlags = lib.optionals stdenv.hostPlatform.isDarwin [
-    "-DLIBNFC_DRIVER_PN532_I2C=OFF"
-    "-DLIBNFC_DRIVER_PN532_SPI=OFF"
   ];
 
   meta = with lib; {


### PR DESCRIPTION
Without this the following error occurs on real device like PN532:

```
$ LIBNFC_DEVICE=pn532_uart:/dev/tty.usbserial-110 nfc-list
nfc-list uses libnfc 1.8.0
error	libnfc.bus.uart	Unable to set serial port speed to 115200 baud. Speed value must be one of those defined in termios(3).
error	libnfc.driver.pn532_uart	pn53x_check_communication error
nfc-list: ERROR: Unable to open NFC device: pn532_uart:/dev/tty.usbserial-110
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
