### PR TITLE
remotegamepad: init at 0-unstable-2025-03-27

### DIFF
--- a/pkgs/by-name/re/remotegamepad/package.nix
+++ b/pkgs/by-name/re/remotegamepad/package.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeDesktopItem,
+  copyDesktopItems,
+  wrapGAppsHook3,
+  cairo,
+  libxcrypt-legacy,
+}:
+
+stdenv.mkDerivation {
+  pname = "remotegamepad";
+  version = "0-unstable-2025-03-27";
+  src = fetchurl {
+    url = "https://archive.org/download/remotegamepad_amd64.tar_20250327/remotegamepad_amd64.tar.gz";
+    hash = "sha256-nZ/oStf/vsw2lD1rDscvZTDDi1ID4QqZUEpZRVpnnjU=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    wrapGAppsHook3
+    copyDesktopItems
+  ];
+
+  buildInputs = [
+    cairo
+    libxcrypt-legacy
+  ];
+
+  sourceRoot = ".";
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "Remote Gamepad";
+      exec = "remotegamepad";
+      icon = "remotegamepad";
+      desktopName = "Remote Gamepad";
+      genericName = "Remote Gamepad";
+      categories = [ "Game" ];
+      terminal = false;
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -m 755 -D remotegamepad $out/bin/remotegamepad
+    install -m 644 -D 60-remotegamepad.rules $out/lib/udev/rules.d/60-remotegamepad.rules
+    install -m 644 -D icon.png $out/share/icons/hicolor/256x256/apps/remotegamepad.png
+
+    cp -r notices $out/bin
+    cp -r icon.png $out/bin
+
+    runHook postInstal
+  '';
+
+  meta = {
+    description = "Use your phone as a gamepad for your PC";
+    homepage = "https://remotegamepad.com/";
+    license = lib.licenses.unfree;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ astronaut0212 ];
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    mainProgram = "remotegamepad";
+  };
+}


### PR DESCRIPTION
Remote gamepad PC for turning android and iOS phone to remote gamepad.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
