### PR TITLE
precice: fix build

### DIFF
--- a/pkgs/by-name/pr/precice/package.nix
+++ b/pkgs/by-name/pr/precice/package.nix
@@ -34,10 +34,10 @@ stdenv.mkDerivation rec {
   ];
 
   cmakeFlags = [
-    "-DPRECICE_PETScMapping=OFF"
-    "-DBUILD_SHARED_LIBS=ON"
-    "-DPYTHON_LIBRARIES=${python3.libPrefix}"
-    "-DPYTHON_INCLUDE_DIR=${python3}/include/${python3.libPrefix}"
+    (lib.cmakeBool "PRECICE_PETScMapping" false)
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeFeature "PYTHON_LIBRARIES" python3.libPrefix)
+    (lib.cmakeFeature "PYTHON_INCLUDE_DIR" "${python3}/include/${python3.libPrefix}")
   ];
 
   env.NIX_CFLAGS_COMPILE = toString (

--- a/pkgs/by-name/pr/precice/package.nix
+++ b/pkgs/by-name/pr/precice/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   fetchFromGitHub,
+  fetchpatch,
   cmake,
   gcc,
   boost,
@@ -23,6 +24,14 @@ stdenv.mkDerivation rec {
     rev = "v${version}";
     hash = "sha256-KpmcQj8cv5V5OXCMhe2KLTsqUzKWtTeQyP+zg+Y+yd0=";
   };
+
+  patches = lib.optionals (!lib.versionOlder "3.1.2" version) [
+    (fetchpatch {
+      name = "boost-187-fixes.patch";
+      url = "https://github.com/precice/precice/commit/23788e9eeac49a2069e129a0cb1ac846e8cbeb9f.patch";
+      hash = "sha256-Z8qOGOkXoCui8Wy0H/OeE+NaTDvyRuPm2A+VJKtjH4s=";
+    })
+  ];
 
   cmakeFlags = [
     "-DPRECICE_PETScMapping=OFF"

--- a/pkgs/by-name/pr/precice/package.nix
+++ b/pkgs/by-name/pr/precice/package.nix
@@ -4,7 +4,6 @@
   fetchFromGitHub,
   fetchpatch,
   cmake,
-  gcc,
   boost,
   eigen,
   libxml2,
@@ -40,19 +39,13 @@ stdenv.mkDerivation rec {
     (lib.cmakeFeature "PYTHON_INCLUDE_DIR" "${python3}/include/${python3.libPrefix}")
   ];
 
-  env.NIX_CFLAGS_COMPILE = toString (
-    lib.optionals stdenv.hostPlatform.isDarwin [ "-D_GNU_SOURCE" ]
-    # libxml2-2.12 changed const qualifiers
-    ++ [ "-fpermissive" ]
-  );
-
   nativeBuildInputs = [
     cmake
-    gcc
     pkg-config
     python3
     python3.pkgs.numpy
   ];
+
   buildInputs = [
     boost
     eigen

--- a/pkgs/development/python-modules/pyprecice/default.nix
+++ b/pkgs/development/python-modules/pyprecice/default.nix
@@ -1,23 +1,24 @@
 {
   lib,
   buildPythonPackage,
-  setuptools,
-  pip,
-  cython,
   fetchFromGitHub,
+
+  # build-system
+  cython,
+  pip,
+  pkgconfig,
+  setuptools,
+
+  # dependencies
   mpi4py,
   numpy,
   precice,
-  pkgconfig,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "pyprecice";
   version = "3.1.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "precice";
@@ -26,14 +27,24 @@ buildPythonPackage rec {
     hash = "sha256-/atuMJVgvY4kgvrB+LuQZmJuSK4O8TJdguC7NCiRS2Y=";
   };
 
-  nativeBuildInputs = [
-    setuptools
-    pip
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail "setuptools>=61,<72" "setuptools" \
+      --replace-fail "numpy<2" "numpy"
+  '';
+
+  build-system = [
     cython
+    pip
     pkgconfig
+    setuptools
   ];
 
-  propagatedBuildInputs = [
+  pythonRelaxDeps = [
+    "numpy"
+  ];
+
+  dependencies = [
     numpy
     mpi4py
     precice
@@ -44,10 +55,11 @@ buildPythonPackage rec {
 
   # Do not use pythonImportsCheck because this will also initialize mpi which requires a network interface
 
-  meta = with lib; {
+  meta = {
     description = "Python language bindings for preCICE";
     homepage = "https://github.com/precice/python-bindings";
-    license = licenses.lgpl3Only;
-    maintainers = with maintainers; [ Scriptkiddi ];
+    changelog = "https://github.com/precice/python-bindings/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.lgpl3Only;
+    maintainers = with lib.maintainers; [ Scriptkiddi ];
   };
 }


### PR DESCRIPTION
## Things done

```
In file included from /build/source/src/com/SocketSendQueue.cpp:7:
/build/source/src/com/SocketSendQueue.hpp:27:47: error: 'boost::asio::const_buffers_1' has not been declared
   27 |   void dispatch(std::shared_ptr<Socket> sock, boost::asio::const_buffers_1 data, std::function<void()> callback);
      |                                               ^~~~~
/build/source/src/com/SocketSendQueue.hpp:38:18: error: 'const_buffers_1' in namespace 'boost::asio' does not name a type; did you mean 'const_buffer'?
   38 |     boost::asio::const_buffers_1 data;
      |                  ^~~~~~~~~~~~~~~
      |                  const_buffer
/build/source/src/com/SocketSendQueue.cpp:22:32: error: 'boost::asio::const_buffers_1' has not been declared
   22 |                                boost::asio::const_buffers_1 data,
      |                                ^~~~~
...
```

Full logs: https://paste.glepage.com/raw/bat-ant-panda

EDIT: using `boost186` fixes the issue.

cc @Scriptkiddi

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
