### PR TITLE
python312Packages.django-registration: init at 5.1.0

### DIFF
--- a/pkgs/development/python-modules/django-registration/default.nix
+++ b/pkgs/development/python-modules/django-registration/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  buildPythonPackage,
+  confusable-homoglyphs,
+  coverage,
+  django,
+  fetchFromGitHub,
+  pdm-backend,
+  pythonAtLeast,
+  pythonOlder,
+}:
+
+buildPythonPackage rec {
+  pname = "django-registration";
+  version = "5.1.0";
+  pyproject = true;
+
+  disabled = pythonOlder "3.9" || pythonAtLeast "3.13";
+
+  src = fetchFromGitHub {
+    owner = "ubernostrum";
+    repo = "django-registration";
+    tag = version;
+    hash = "sha256-02kAZXxzTdLBvgff+WNUww2k/yGqxIG5gv8gXy9z7KE=";
+  };
+
+  build-system = [ pdm-backend ];
+
+  dependencies = [
+    confusable-homoglyphs
+  ];
+
+  nativeCheckInputs = [
+    coverage
+    django
+  ];
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    DJANGO_SETTINGS_MODULE=tests.settings python -m coverage run --source django_registration runtests.py
+
+    runHook postInstallCheck
+  '';
+
+  pythonImportsCheck = [ "django_registration" ];
+
+  meta = {
+    changelog = "https://github.com/ubernostrum/django-registration/blob/${version}/docs/changelog.rst";
+    description = "User registration app for Django";
+    homepage = "https://django-registration.readthedocs.io/en/${version}/";
+    downloadPage = "https://github.com/ubernostrum/django-registration";
+    license = lib.licenses.bsd3;
+    maintainers = [ lib.maintainers.l0b0 ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3619,6 +3619,8 @@ self: super: with self; {
 
   django-q2 = callPackage ../development/python-modules/django-q2 { };
 
+  django-registration = callPackage ../development/python-modules/django-registration { };
+
   django-scheduler = callPackage ../development/python-modules/django-scheduler { };
 
   django-scim2 = callPackage ../development/python-modules/django-scim2 { };


### PR DESCRIPTION
[User registration app for Django](https://github.com/ubernostrum/django-registration)

Split off of #341963 to simplify review.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
