### PR TITLE
workflows/eval: fail hard without target run

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -175,7 +175,7 @@ jobs:
             --jq '.workflow_runs | sort_by(.run_started_at) | .[-1]') \
             || [[ -z "$run" ]]; then
             echo "Could not find an eval.yml workflow run for $BASE_SHA, cannot make comparison"
-            exit 0
+            exit 1
           fi
           echo "Comparing against $(jq .html_url <<< "$run")"
           runId=$(jq .id <<< "$run")
@@ -189,7 +189,7 @@ jobs:
 
           if [[ "$conclusion" != "success" ]]; then
             echo "Workflow was not successful (conclusion: $conclusion), cannot make comparison"
-            exit 0
+            exit 1
           fi
 
           echo "targetRunId=$runId" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -171,10 +171,10 @@ jobs:
         run: |
           # Get the latest eval.yml workflow run for the PR's target commit
           if ! run=$(gh api --method GET /repos/"$REPOSITORY"/actions/workflows/eval.yml/runs \
-            -f head_sha="$BASE_SHA" -f event=push \
+            -f head_sha="$TARGET_SHA" -f event=push \
             --jq '.workflow_runs | sort_by(.run_started_at) | .[-1]') \
             || [[ -z "$run" ]]; then
-            echo "Could not find an eval.yml workflow run for $BASE_SHA, cannot make comparison"
+            echo "Could not find an eval.yml workflow run for $TARGET_SHA, cannot make comparison"
             exit 1
           fi
           echo "Comparing against $(jq .html_url <<< "$run")"
@@ -195,7 +195,7 @@ jobs:
           echo "targetRunId=$runId" >> "$GITHUB_OUTPUT"
         env:
           REPOSITORY: ${{ github.repository }}
-          BASE_SHA: ${{ needs.attrs.outputs.targetSha }}
+          TARGET_SHA: ${{ needs.attrs.outputs.targetSha }}
           GH_TOKEN: ${{ github.token }}
 
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Without a target run, we won't get any rebuild labels, rebuild counts or
maintainer pings. This might have been correct before https://github.com/NixOS/nixpkgs/pull/373935, but by
now we run eval on all commits on the target branch, so we should treat
it as a failure if we can't find the run.

As mentioned in https://github.com/NixOS/nixpkgs/issues/355847#issuecomment-2629517606.

Resolves #378595

## Things done

- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
