### PR TITLE
python313Packages.pyhomee: init at 1.2.5

### DIFF
--- a/pkgs/development/python-modules/pyhomee/default.nix
+++ b/pkgs/development/python-modules/pyhomee/default.nix
@@ -1,0 +1,41 @@
+{
+  aiohttp,
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+  websockets,
+}:
+
+buildPythonPackage rec {
+  pname = "pyhomee";
+  version = "1.2.5";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "Taraman17";
+    repo = "pyHomee";
+    tag = "v${version}";
+    hash = "sha256-cwiV2GvoWeFQ4YrwwHW7ZHk2ZjvBKSAff4xY7+iUpAk=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    aiohttp
+    websockets
+  ];
+
+  pythonImportsCheck = [ "pyHomee" ];
+
+  # upstream has no tests
+  doCheck = false;
+
+  meta = {
+    changelog = "https://github.com/Taraman17/pyHomee/blob/${src.tag}/CHANGELOG.md";
+    description = "Python library to interact with homee";
+    homepage = "https://github.com/Taraman17/pyHomee";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ dotlambda ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -11941,6 +11941,8 @@ self: super: with self; {
 
   pyhocon = callPackage ../development/python-modules/pyhocon { };
 
+  pyhomee = callPackage ../development/python-modules/pyhomee { };
+
   pyhomematic = callPackage ../development/python-modules/pyhomematic { };
 
   pyhomepilot = callPackage ../development/python-modules/pyhomepilot { };


### PR DESCRIPTION
will become a Home Assistant dependency: https://github.com/home-assistant/core/pull/133738
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
