### PR TITLE
ci/eval: make eval for non-native platforms less incorrect

### DIFF
--- a/ci/eval/default.nix
+++ b/ci/eval/default.nix
@@ -89,6 +89,7 @@ let
         set +e
         command time -f "Chunk $myChunk on $system done [%MKB max resident, %Es elapsed] %C" \
           nix-env -f "${nixpkgs}/pkgs/top-level/release-attrpaths-parallel.nix" \
+          --eval-system "$system" \
           --option restrict-eval true \
           --option allow-import-from-derivation false \
           --query --available \


### PR DESCRIPTION
We commonly use platform-dependent conditional patterns like `lib.meta.availableOn stdenv.hostPlatform` and `stdenv.hostPlatform.isLinux` to enable different features in a given derivation or to evaluate completely different derivations based on the platform.

For example, source builds of a given derivation may only be available on linux but not on darwin. The use of such conditionals allow us to fall back to patched binaries on darwin instead.

In `chromedriver` (pkgs/development/tools/selenium/chromedriver/default.nix), we use

~~~nix
if lib.meta.availableOn stdenv.hostPlatform chromium then
  callPackage ./source.nix { }
else
  callPackage ./binary.nix { }
~~~

To provide some context, `chromedriver` source builds are based on `chromium.mkDerivation` and `chromium` is limited to `lib.platforms.linux`. Based on the same `chromium.mkDerivation`, we also do source builds for `electron` (pkgs/top-level/all-packages.nix):

~~~nix
electron_33 = if lib.meta.availableOn stdenv.hostPlatform electron-source.electron_33 then electron-source.electron_33 else electron_33-bin; electron_34 = electron_34-bin;
electron = electron_34;
~~~

And finally, the top-level `jdk` (Java) attribute has a lot of indirection, but eventually also boils down to `stdenv.hostPlatform.isLinux` for source builds and binaries for x86_64-darwin and aarch64-darwin.

A surprising amount of electron and jdk consumers use variations of `meta.platforms = electron.meta.platforms` in their own meta block. Due to internal implementation details, the conditionals in those top-level attributes like `chromedriver`, `electron` and `jdk` are evaluated based on the value from `builtins.currentSystem` and not the system passed to `import <nixpkgs> { }`.

This then causes `chromedriver`, `electron`, `jdk` and all dependents that inherit those `meta.platforms` to appear only available on linux despite also being available on darwin. Hydra is affected similarly, but it's a lot more nuanced and in practice not actually *that* bad.

The addition of `--eval-system` ensures that `builtins.currentSystem` matches the requested platform.

As a bonus, this also fixes the store paths of an impure test that should probably be made pure:

~~~diff
@@ -885069,13 +886119,13 @@
     "out": "/nix/store/lb2500hc69czy4sfga9mbh2k679cr1rp-test-compressDrv"
   },
   "tests.config.allowPkgsInPermittedInsecurePackages.aarch64-darwin": {
-    "out": "/nix/store/0l5h8svrpzwymq35mnpvx82gyc7nf8s4-hello-2.12.1"
+    "out": "/nix/store/v1zjb688mp4y2132b6chii43d5kkxnpa-hello-2.12.1"
   },
   "tests.config.allowPkgsInPermittedInsecurePackages.aarch64-linux": {
-    "out": "/nix/store/0l5h8svrpzwymq35mnpvx82gyc7nf8s4-hello-2.12.1"
+    "out": "/nix/store/hb21z2zdk03dwygsw5lvpa8zc3fbr500-hello-2.12.1"
   },
   "tests.config.allowPkgsInPermittedInsecurePackages.x86_64-darwin": {
-    "out": "/nix/store/0l5h8svrpzwymq35mnpvx82gyc7nf8s4-hello-2.12.1"
+    "out": "/nix/store/gljdqsf0mxv1j8zb04phx9ws09pp7z3l-hello-2.12.1"
   },
   "tests.config.allowPkgsInPermittedInsecurePackages.x86_64-linux": {
     "out": "/nix/store/0l5h8svrpzwymq35mnpvx82gyc7nf8s4-hello-2.12.1"
~~~

Diff stats between two full evals based on 75c8548d8118c31509b89ffd7df6c322b94017dd with and without this fix on x86_64-linux:

~~~bash
# git diff --no-index --stat /nix/store/659l3xp78255wx7abbahggsnrlj3a1la-combined-result/outpaths.json /nix/store/4fhlq4g5qa65cxbibskq9pma40zigrx7-combined-result/outpaths.json
 /nix/store/{659l3xp78255wx7abbahggsnrlj3a1la-combined-result => 4fhlq4g5qa65cxbibskq9pma40zigrx7-combined-result}/outpaths.json | 1416 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 1405 insertions(+), 11 deletions(-)
~~~

The full diff is available as a gist at <https://gist.github.com/emilylange/d40c50031fc332bbcca133ad56d224f6>.

When we added `electron_34` only as binary instead of the usual source on linux with binary fallback in #376770 (cfed9a19cbc98d12c0167f69238673f4ed89f798) and made the unversioned `electron` top-level point to the newly added `electron_34` instead of `electron_33`, the GitHub workflow suddenly reported 20 new packages. Of those 20 reported packages, 17 where false-positives caused by dropping the wrongly evaluated conditional.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
