### PR TITLE
golink: 0-unstable-2024-01-26 -> 1.0.0

### DIFF
--- a/pkgs/by-name/go/golink/darwin-sandbox-fix.patch
+++ b/pkgs/by-name/go/golink/darwin-sandbox-fix.patch
@@ -1,0 +1,20 @@
+--- vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go
++++ vendor/modernc.org/libc/honnef.co/go/netdb/netdb.go
+@@ -696,7 +696,7 @@ func init() {
+ 	// Load protocols
+ 	data, err := ioutil.ReadFile("/etc/protocols")
+ 	if err != nil {
+-		if !os.IsNotExist(err) {
++		if !os.IsNotExist(err) && !os.IsPermission(err) {
+ 			panic(err)
+ 		}
+ 
+@@ -732,7 +732,7 @@ func init() {
+ 	// Load services
+ 	data, err = ioutil.ReadFile("/etc/services")
+ 	if err != nil {
+-		if !os.IsNotExist(err) {
++		if !os.IsNotExist(err) && !os.IsPermission(err) {
+ 			panic(err)
+ 		}
+ 

--- a/pkgs/by-name/go/golink/package.nix
+++ b/pkgs/by-name/go/golink/package.nix
@@ -1,4 +1,5 @@
 {
+  git,
   lib,
   buildGoModule,
   fetchFromGitHub,
@@ -6,17 +7,23 @@
 
 buildGoModule rec {
   pname = "golink";
-  version = "0-unstable-2024-01-26";
+  version = "1.0.0";
 
   src = fetchFromGitHub {
     owner = "tailscale";
     repo = "golink";
-    # https://github.com/tailscale/golink/issues/104
-    rev = "d9de913fb174ec2569a15b6e2dbe5cb6e4a0a853";
-    hash = "sha256-w6jRbajEQkOrBqxDnQreSmSB5DNL9flWjloShiIBM+M=";
+    tag = "v${version}";
+    hash = "sha256-cIml0ewF5j2cQySLHkMmV1rl7cVH8wuoPFeFDCARi1A=";
   };
 
-  vendorHash = "sha256-R/o3csZC/M9nm0k5STL7AhbG5J4LtdxqKaVjM/9ggW8=";
+  vendorHash = "sha256-QIAkmqXWH3X2dIoWyVcqFXVHBwzyv1dNPfdkzD5LuSE=";
+
+  overrideModAttrs = old: {
+    # netdb.go allows /etc/protocols and /etc/services to not exist and happily proceeds, but it panic()s if they exist but return permission denied.
+    postBuild = ''
+      patch -p0 < ${./darwin-sandbox-fix.patch}
+    '';
+  };
 
   ldflags = [
     "-s"


### PR DESCRIPTION
Updates version of tailscale's golink service to the first properly-tagged version in their repo.

Version 1.0.0 was tagged three weeks ago and is therefore approximately 11 months newer than the version in nixpkgs right now.  The biggest difference here is the version of the tailscale library being used is bumped from 1.57 to 1.79.

I am aware there are further commits on top of this, but it feels appropriate to move this onto the regular version train at this point instead of sustaining an unstable version.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
