### PR TITLE
sourcegit: 2025.01 -> 2025.03

### DIFF
--- a/pkgs/by-name/so/sourcegit/deps.json
+++ b/pkgs/by-name/so/sourcegit/deps.json
@@ -106,11 +106,6 @@
   },
   {
     "pname": "HarfBuzzSharp",
-    "version": "7.3.0.2",
-    "hash": "sha256-ibgoqzT1NV7Qo5e7X2W6Vt7989TKrkd2M2pu+lhSDg8="
-  },
-  {
-    "pname": "HarfBuzzSharp",
     "version": "7.3.0.3",
     "hash": "sha256-1vDIcG1aVwVABOfzV09eAAbZLFJqibip9LaIx5k+JxM="
   },
@@ -136,18 +131,18 @@
   },
   {
     "pname": "LiveChartsCore",
-    "version": "2.0.0-rc4.5",
-    "hash": "sha256-2Fgn9Bo1aM6dZHCU+OVykOhggTzpcEfFNfYtWc4yvHc="
+    "version": "2.0.0-rc5",
+    "hash": "sha256-NHgYbeIdAoZlrC6QgVb1oLo3dlo17R8yTbPgiHMmJZc="
   },
   {
     "pname": "LiveChartsCore.SkiaSharpView",
-    "version": "2.0.0-rc4.5",
-    "hash": "sha256-03RR14tA0DtYHiLdgmAI4Gp5/e2H6QPkNFOBeqiFaJU="
+    "version": "2.0.0-rc5",
+    "hash": "sha256-zppOFKHGn2HJMP8AAuk6mxJXqvgjfN7o8f0sInUWZGc="
   },
   {
     "pname": "LiveChartsCore.SkiaSharpView.Avalonia",
-    "version": "2.0.0-rc4.5",
-    "hash": "sha256-lzG/5e6WDpUiHZ8GvovOMvwXyYoVBeB1Ktuuw2Fx5No="
+    "version": "2.0.0-rc5",
+    "hash": "sha256-xyFEZWWkRlBi8GNCDpyOUzt6aEe+9sR1+VN2yY59mhg="
   },
   {
     "pname": "MicroCom.Runtime",
@@ -161,18 +156,13 @@
   },
   {
     "pname": "SkiaSharp",
-    "version": "2.88.8",
-    "hash": "sha256-rD5gc4SnlRTXwz367uHm8XG5eAIQpZloGqLRGnvNu0A="
-  },
-  {
-    "pname": "SkiaSharp",
     "version": "2.88.9",
     "hash": "sha256-jZ/4nVXYJtrz9SBf6sYc/s0FxS7ReIYM4kMkrhZS+24="
   },
   {
     "pname": "SkiaSharp.HarfBuzz",
-    "version": "2.88.8",
-    "hash": "sha256-W9jNuEo/8q+k2aHNC19FfKcBUIEWx2zDcGwM+jDZ1o8="
+    "version": "2.88.9",
+    "hash": "sha256-JH8Jr25eftPfq0BztamvxfDcAZtnx/jLRj5DGCS5/G8="
   },
   {
     "pname": "SkiaSharp.NativeAssets.Linux",

--- a/pkgs/by-name/so/sourcegit/fix-darwin-git-path.patch
+++ b/pkgs/by-name/so/sourcegit/fix-darwin-git-path.patch
@@ -15,15 +15,16 @@ diff --git a/src/Native/MacOS.cs b/src/Native/MacOS.cs
 index 5721fe8..bc2a57d 100644
 --- a/src/Native/MacOS.cs
 +++ b/src/Native/MacOS.cs
-@@ -25,12 +25,7 @@ namespace SourceGit.Native
+@@ -25,13 +25,7 @@ namespace SourceGit.Native
  
          public string FindGitExecutable()
          {
 -            var gitPathVariants = new List<string>() {
--                 "/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "/opt/homebrew/opt/git/bin/git" 
+-                 "/usr/bin/git", "/usr/local/bin/git", "/opt/homebrew/bin/git", "/opt/homebrew/opt/git/bin/git"
 -            };
 -            foreach (var path in gitPathVariants)
--                if (File.Exists(path)) return path;
+-                if (File.Exists(path))
+-                    return path;
 -            return string.Empty;
 +            return Linux.FindExecutable("git");
          }

--- a/pkgs/by-name/so/sourcegit/package.nix
+++ b/pkgs/by-name/so/sourcegit/package.nix
@@ -19,13 +19,13 @@
 
 buildDotnetModule (finalAttrs: {
   pname = "sourcegit";
-  version = "2025.01";
+  version = "2025.03";
 
   src = fetchFromGitHub {
     owner = "sourcegit-scm";
     repo = "sourcegit";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-6FO0WRUcWm7xnuw6Br97+cWZhvzIOesg/eANZzeyxZo=";
+    hash = "sha256-l1M3ix0HY87y2ES/iwT2Ju/Mwb8CCmnz95amHlYKFS4=";
   };
 
   patches = [ ./fix-darwin-git-path.patch ];


### PR DESCRIPTION

https://github.com/sourcegit-scm/sourcegit/releases
https://github.com/sourcegit-scm/sourcegit/compare/v2025.01...v2025.03

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
