### PR TITLE
Update Uhdm, Surelog, Synlig

### DIFF
--- a/pkgs/by-name/su/surelog/package.nix
+++ b/pkgs/by-name/su/surelog/package.nix
@@ -17,14 +17,14 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "surelog";
-  version = "1.84-unstable-2024-11-09";
+  version = "1.84-unstable-2024-12-06";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "surelog";
     # Once we're back on a stable tag, use "v$(finalAttrs.version}" below.
-    rev = "da88163a02dbc16f1af3514f281b93941d371ad9";
-    hash = "sha256-TIwXIMcDImZjCIiXwvT2MhukArgrWCgOf2AOvkG/55g=";
+    rev = "298a9cddc672cce7f25ec352f9f8f36f5b23aa4e";
+    hash = "sha256-Qv4dosj2dwakNCcvu483ZMuw+LlYs4fhZTULszERLSI=";
     fetchSubmodules = false; # we use all dependencies from nix
   };
 

--- a/pkgs/by-name/uh/uhdm/package.nix
+++ b/pkgs/by-name/uh/uhdm/package.nix
@@ -11,14 +11,14 @@
 stdenv.mkDerivation (finalAttrs: {
   pname = "UHDM";
   # When updating this package, also consider updating science/logic/surelog
-  version = "1.84-unstable-2024-10-06";
+  version = "1.84-unstable-2024-11-12";
 
   src = fetchFromGitHub {
     owner = "chipsalliance";
     repo = "UHDM";
     # After we're back on a stable tag, use v${finalAttrs.version}
-    rev = "857f68de3ce5b6f919f3a0f489c93072751b1578";
-    hash = "sha256-qHcRncsvMiSJji+JLOlfQ87+pfKg+zvlqMTXKpImvTM=";
+    rev = "7d90dd0e68759775d0c86885d991925096b5b496";
+    hash = "sha256-msdtBAlOXwYJd0HhWmVo8oMJ6h8OUmy0ILxV1MV52PE=";
     fetchSubmodules = false; # we use all dependencies from nix
   };
 

--- a/pkgs/development/compilers/yosys/plugins/synlig.nix
+++ b/pkgs/development/compilers/yosys/plugins/synlig.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation (finalAttrs: {
   plugin = "synlig";
 
   # The module has automatic regular releases, with date + short git hash
-  GIT_VERSION = "2024-11-29-10efd31";
+  GIT_VERSION = "2024-12-10-2d838ed";
 
   # Derive our package version from GIT_VERSION, remove hash, just keep date.
   version = builtins.concatStringsSep "-" (


### PR DESCRIPTION
Three separate commits to update  these somewhat version-locked libraries and tools

  * uhdm: 1.84-unstable-2024-10-06 -> 1.84-unstable-2024-11-12 ( 780495a579688723dcf5e9b8074bfc163a3c7df9 )
  * surelog: 1.84-unstable-2024-11-09 -> 1.84-unstable-2024-12-06  (063975120723d08af0ebf8e935a2e9b64b34f88b)
  * synlig: 2024-11-29 -> 2024-12-10 (13b7493c0a6a15a3952d967d8e01fb298325b59a)
 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
