### PR TITLE
nixos/tests/userborn: fix setting hostPlatform

### DIFF
--- a/nixos/tests/userborn-immutable-etc.nix
+++ b/nixos/tests/userborn-immutable-etc.nix
@@ -20,7 +20,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -36,8 +36,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+          nixpkgs.hostPlatform = {
+            inherit (pkgs.stdenv.hostPlatform) system;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-immutable-users.nix
+++ b/nixos/tests/userborn-immutable-users.nix
@@ -16,7 +16,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -32,8 +32,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+          nixpkgs.hostPlatform = {
+            inherit (pkgs.stdenv.hostPlatform) system;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-mutable-etc.nix
+++ b/nixos/tests/userborn-mutable-etc.nix
@@ -20,7 +20,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -36,8 +36,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+          nixpkgs.hostPlatform = {
+            inherit (pkgs.stdenv.hostPlatform) system;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-mutable-users.nix
+++ b/nixos/tests/userborn-mutable-users.nix
@@ -16,7 +16,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { config, ... }:
+    { pkgs, ... }:
     {
       imports = [ common ];
 
@@ -33,8 +33,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs = {
-            inherit (config.nixpkgs) hostPlatform;
+          nixpkgs.hostPlatform = {
+            inherit (pkgs.stdenv.hostPlatform) system;
           };
           imports = [ common ];
 


### PR DESCRIPTION
Fix tests broken by https://github.com/NixOS/nixpkgs/pull/376988

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
