### PR TITLE
nixos/matrix-alertmanager: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -121,6 +121,8 @@
 
 - [vivid](https://github.com/sharkdp/vivid), a generator for LS_COLOR. Available as [programs.vivid](#opt-programs.vivid.enable).
 
+- [matrix-alertmanager](https://github.com/jaywink/matrix-alertmanager), a bot to receive Alertmanager webhook events and forward them to chosen Matrix rooms. Available as [services.matrix-alertmanager](options.html#opt-services.matrix-alertmanager.enable).
+
 - [waagent](https://github.com/Azure/WALinuxAgent), the Microsoft Azure Linux Agent (waagent) manages Linux provisioning and VM interaction with the Azure Fabric Controller. Available with [services.waagent](options.html#opt-services.waagent.enable).
 
 - [nfc-nci](https://github.com/StarGate01/ifdnfc-nci), an alternative NFC stack and PC/SC driver for the NXP PN54x chipset, commonly found in Lenovo systems as NXP1001 (NPC300). Available as [hardware.nfc-nci](#opt-hardware.nfc-nci.enable).

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -742,6 +742,7 @@
   ./services/matrix/dendrite.nix
   ./services/matrix/hebbot.nix
   ./services/matrix/hookshot.nix
+  ./services/matrix/matrix-alertmanager.nix
   ./services/matrix/maubot.nix
   ./services/matrix/mautrix-meta.nix
   ./services/matrix/mautrix-signal.nix

--- a/nixos/modules/services/matrix/matrix-alertmanager.nix
+++ b/nixos/modules/services/matrix/matrix-alertmanager.nix
@@ -1,0 +1,124 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.matrix-alertmanager;
+  rooms = room: lib.concatStringsSep "/" (room.receivers ++ [ room.roomId ]);
+  concatenatedRooms = lib.concatStringsSep "|" (map rooms cfg.matrixRooms);
+in
+{
+  meta.maintainers = [ lib.maintainers.erethon ];
+
+  options.services.matrix-alertmanager = {
+    enable = lib.mkEnableOption "matrix-alertmanager";
+    package = lib.mkPackageOption pkgs "matrix-alertmanager" { };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3000;
+      description = "Port that matrix-alertmanager listens on.";
+    };
+    homeserverUrl = lib.mkOption {
+      type = lib.types.str;
+      description = "URL of the Matrix homeserver to use.";
+      example = "https://matrix.example.com";
+    };
+    matrixUser = lib.mkOption {
+      type = lib.types.str;
+      description = "Matrix user to use for the bot.";
+      example = "@alertmanageruser:example.com";
+    };
+    matrixRooms = lib.mkOption {
+      type = lib.types.listOf (
+        lib.types.submodule {
+          options = {
+            receivers = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              description = "List of receivers for this room";
+            };
+            roomId = lib.mkOption {
+              type = lib.types.str;
+              description = "Matrix room ID";
+              apply =
+                x:
+                assert lib.assertMsg (lib.hasPrefix "!" x) "Matrix room ID must start with a '!'. Got: ${x}";
+                x;
+            };
+          };
+        }
+      );
+      description = ''
+        Combination of Alertmanager receiver(s) and rooms for the bot to join.
+        Each Alertmanager receiver can be mapped to post to a matrix room.
+
+        Note, you must use a room ID and not a room alias/name. Room IDs start
+        with a "!".
+      '';
+      example = [
+        {
+          receivers = [
+            "receiver1"
+            "receiver2"
+          ];
+          roomId = "!roomid@example.com";
+        }
+        {
+          receivers = [ "receiver3" ];
+          roomId = "!differentroomid@example.com";
+        }
+      ];
+    };
+    mention = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Makes the bot mention @room when posting an alert";
+    };
+    tokenFile = lib.mkOption {
+      type = lib.types.pathWith {
+        inStore = false;
+        absolute = true;
+      };
+      description = "File that contains a valid Matrix token for the Matrix user.";
+    };
+    secretFile = lib.mkOption {
+      type = lib.types.pathWith {
+        inStore = false;
+        absolute = true;
+      };
+      description = "File that contains a secret for the Alertmanager webhook.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.services.matrix-alertmanager = {
+      description = "A bot to receive Alertmanager webhook events and forward them to chosen rooms.";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        DynamicUser = true;
+        Restart = "always";
+        RestartSec = "10s";
+        LoadCredential = [
+          "token:${cfg.tokenFile}"
+          "secret:${cfg.secretFile}"
+        ];
+      };
+
+      environment = {
+        APP_PORT = toString cfg.port;
+        MATRIX_HOMESERVER_URL = cfg.homeserverUrl;
+        MATRIX_ROOMS = concatenatedRooms;
+        MATRIX_USER = cfg.matrixUser;
+        MENTION_ROOM = if cfg.mention then "1" else "0";
+      };
+
+      script = ''
+        export APP_ALERTMANAGER_SECRET=$(cat "''${CREDENTIALS_DIRECTORY}/secret")
+        export MATRIX_TOKEN=$(cat "''${CREDENTIALS_DIRECTORY}/token")
+        exec ${lib.getExe cfg.package}
+      '';
+    };
+  };
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -643,6 +643,7 @@ in {
   mate-wayland = handleTest ./mate-wayland.nix {};
   matter-server = handleTest ./matter-server.nix {};
   matomo = runTest ./matomo.nix;
+  matrix-alertmanager = runTest ./matrix/matrix-alertmanager.nix;
   matrix-appservice-irc = runTest ./matrix/appservice-irc.nix;
   matrix-conduit = handleTest ./matrix/conduit.nix {};
   matrix-synapse = handleTest ./matrix/synapse.nix {};

--- a/nixos/tests/matrix/matrix-alertmanager.nix
+++ b/nixos/tests/matrix/matrix-alertmanager.nix
@@ -1,0 +1,132 @@
+{ pkgs, ... }:
+let
+  secret-files = pkgs.runCommandLocal "secret-files" { } ''
+    mkdir -p $out
+    echo -n faketoken > $out/token.txt
+    echo -n wontbeused > $out/secret.txt
+  '';
+in
+{
+  name = "matrix-alertmanager";
+  meta.maintainers = with pkgs.lib.maintainers; [ erethon ];
+
+  nodes = {
+    homeserver =
+      { pkgs, ... }:
+      {
+        services.matrix-synapse = {
+          enable = true;
+          settings = {
+            database.name = "sqlite3";
+            tls_certificate_path = "../common/acme/server/acme.test.cert.pem";
+            tls_private_key_path = "../common/acme/server/acme.test.key.pem";
+            enable_registration = true;
+            enable_registration_without_verification = true;
+            registration_shared_secret = "supersecret-registration";
+            listeners = [
+              {
+                # The default but tls=false
+                bind_addresses = [
+                  "0.0.0.0"
+                ];
+                port = 8448;
+                resources = [
+                  {
+                    compress = true;
+                    names = [ "client" ];
+                  }
+                  {
+                    compress = false;
+                    names = [ "federation" ];
+                  }
+                ];
+                tls = false;
+                type = "http";
+                x_forwarded = false;
+              }
+            ];
+          };
+        };
+
+        networking.firewall.allowedTCPPorts = [ 8448 ];
+
+        environment.systemPackages = [
+          (pkgs.writeShellScriptBin "register_alertmanager_user" ''
+            exec ${pkgs.matrix-synapse}/bin/register_new_matrix_user \
+              -u alertmanager \
+              -p alertmanager-password \
+              --admin \
+              --shared-secret supersecret-registration \
+              http://localhost:8448
+          '')
+          # This is needed to solve a chicken and egg
+          # problem. Matrix-alertmanager expects a token for authentication,
+          # but a token is created after the user has been registered. This
+          # changes the token in the database to match the one specified in
+          # the service settings.
+          (pkgs.writers.writePython3Bin "hardcode_matrix_values"
+            {
+              libraries = with pkgs.python3Packages; [
+                sqlite-utils
+              ];
+            }
+            ''
+              import sqlite3
+              con = sqlite3.connect("/var/lib/matrix-synapse/homeserver.db")
+              cur = con.cursor()
+              cur.execute(
+                  "update access_tokens set token='%s' where user_id = '%s'"
+                  % ("faketoken", "@alertmanager:homeserver")
+              )
+              con.commit()
+              con.close()
+            ''
+          )
+        ];
+      };
+
+    matrix_alertmanager =
+      { config, pkgs, ... }:
+      {
+        environment.etc.token-file.source = "${secret-files}/token.txt";
+        environment.etc.secret-file.source = "${secret-files}/secret.txt";
+        services.matrix-alertmanager = {
+          enable = true;
+          tokenFile = "/etc/${config.environment.etc.token-file.target}";
+          secretFile = "/etc/${config.environment.etc.secret-file.target}";
+          homeserverUrl = "http://homeserver:8448";
+          # Matrix-alertmanager expects at least a room in its configuration
+          # in order to start. However, the room doesn't have to exist for
+          # matrix-alertmanager to start, so this is a configuration only
+          # placeholder.
+          matrixRooms = [
+            {
+              receivers = [ "matrix" ];
+              roomId = "!room_id:homeserver";
+            }
+          ];
+          matrixUser = "alertmanager";
+        };
+      };
+  };
+
+  testScript = ''
+    with subtest("start homeserver"):
+      homeserver.start()
+      homeserver.wait_for_unit("matrix-synapse.service")
+      homeserver.wait_until_succeeds("curl --fail -L http://localhost:8448/")
+
+    with subtest("register user"):
+      # register alertmanager user
+      homeserver.succeed("register_alertmanager_user")
+
+    with subtest("hardcode matrix values for matrix-alertmanager to use"):
+      homeserver.succeed("hardcode_matrix_values")
+
+    with subtest("start matrix_alertmanager"):
+      matrix_alertmanager.start()
+      matrix_alertmanager.wait_for_unit("matrix-alertmanager.service")
+      matrix_alertmanager.wait_until_succeeds("curl --fail -L http://localhost:3000/")
+      matrix_alertmanager.wait_for_console_text("matrix-alertmanager initialized and ready")
+  '';
+}


### PR DESCRIPTION
Initializes a module for [matrix-alertmanager](https://github.com/jaywink/matrix-alertmanager) which is already packaged. Also initializes a test for it which is a modified version of the `matri/mjolnir.nix` test.

I'm running this on my alertmanager and Matrix homeserver and works fine for a week now.

The test has a chicken and egg problem that I'm not sure if I've solved in the best possible way. Matrix-alertmanager expects a token for authentication and not a password, but the token is created randomly when the user is created. As such, we can't know the token when setting up the service. My solution to this was to update the token in the database via a script when `testScript` is run. Please let me know if there's a Nix way to solve this problem.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
