### PR TITLE
python3Packages.langgraph*: Ecosystem update 20250207

### DIFF
--- a/pkgs/development/python-modules/langgraph-checkpoint-duckdb/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-duckdb/default.nix
@@ -9,21 +9,18 @@
   pytestCheckHook,
   langgraph-sdk,
   poetry-core,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-duckdb";
-  version = "2.0.1";
+  version = "2.0.2";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpointduckdb==${version}";
-    hash = "sha256-wSrlFBfTcTgyE46uwv9GCyxRT1xVafgWyP2g87KUTAU=";
+    hash = "sha256-ppgViNRkkCTOGPfdB04DOnEzFgHN1KGDLLVjuwhRgNE=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint-duckdb";
@@ -49,10 +46,9 @@ buildPythonPackage rec {
   disabledTests = [ "test_basic_store_ops" ]; # depends on networking
 
   passthru = {
-    updateScript = langgraph-sdk.updateScript;
+    inherit (langgraph-sdk) updateScript;
 
-    # multiple tags confuse the bulk updater
-    skipBulkUpdate = true;
+    skipBulkUpdate = true; # Broken, see https://github.com/NixOS/nixpkgs/issues/379898
   };
 
   meta = {

--- a/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint-sqlite/default.nix
@@ -8,21 +8,18 @@
   pytestCheckHook,
   langgraph-sdk,
   poetry-core,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint-sqlite";
-  version = "2.0.1";
+  version = "2.0.3";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpointsqlite==${version}";
-    hash = "sha256-dh+cjcOp6rGFntz82VNfVyetcrQBdBFdXk5xFb0aR5c=";
+    hash = "sha256-u3tKh63bOu+Ko2YynEfxQ/nGElEfwwTQ6Z1RhqF51Qs=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint-sqlite";
@@ -45,10 +42,8 @@ buildPythonPackage rec {
   ];
 
   passthru = {
-    updateScript = langgraph-sdk.updateScript;
-
-    # multiple tags confuse the bulk updater
-    skipBulkUpdate = true;
+    inherit (langgraph-sdk) updateScript;
+    skipBulkUpdate = true; # Broken, see https://github.com/NixOS/nixpkgs/issues/379898
   };
 
   meta = {

--- a/pkgs/development/python-modules/langgraph-checkpoint/default.nix
+++ b/pkgs/development/python-modules/langgraph-checkpoint/default.nix
@@ -10,21 +10,18 @@
   pytest-asyncio,
   pytest-mock,
   pytestCheckHook,
-  pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph-checkpoint";
-  version = "2.0.8";
+  version = "2.0.10";
   pyproject = true;
-
-  disabled = pythonOlder "3.9";
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "checkpoint==${version}";
-    hash = "sha256-obDK6wn+oo8zDQsidogwKTIgT5wuUH/l4y+12cttkd0=";
+    hash = "sha256-Bs8XWSyI/6a756iWXT40vvNIe/XZ/vnMsZbXjTW3770=";
   };
 
   sourceRoot = "${src.name}/libs/checkpoint";
@@ -53,9 +50,7 @@ buildPythonPackage rec {
 
   passthru = {
     updateScript = langgraph-sdk.updateScript;
-
-    # multiple tags confuse the bulk updater
-    skipBulkUpdate = true;
+    skipBulkUpdate = true; # Broken, see https://github.com/NixOS/nixpkgs/issues/379898
   };
 
   meta = {

--- a/pkgs/development/python-modules/langgraph-cli/default.nix
+++ b/pkgs/development/python-modules/langgraph-cli/default.nix
@@ -3,16 +3,22 @@
   buildPythonPackage,
   click,
   fetchFromGitHub,
-  nix-update-script,
   poetry-core,
+
+  # for update script
+  langgraph-sdk,
+
+  # testing
   pytest-asyncio,
   pytestCheckHook,
+  docker-compose,
+
   pythonOlder,
 }:
 
 buildPythonPackage rec {
   pname = "langgraph-cli";
-  version = "0.1.52";
+  version = "0.1.71";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -21,7 +27,7 @@ buildPythonPackage rec {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "cli==${version}";
-    hash = "sha256-zTBeDJB1Xu/rWsvEC/L4BRzxyh04lPYV7HQNHoJcskk=";
+    hash = "sha256-bTW+je4wuoR0YX5T1wdAee4w/T2jMTQybLLpCxouJxA=";
   };
 
   sourceRoot = "${src.name}/libs/cli";
@@ -33,6 +39,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytest-asyncio
     pytestCheckHook
+    docker-compose
   ];
 
   pytestFlagsArray = [ "tests/unit_tests" ];
@@ -48,17 +55,14 @@ buildPythonPackage rec {
     "test_config_to_compose_end_to_end"
     "test_config_to_compose_simple_config"
     "test_config_to_compose_watch"
+    # Tests exit value, needs to happen in a passthru test
+    "test_dockerfile_command_with_docker_compose"
   ];
 
-  passthru.updateScript = nix-update-script {
-    extraArgs = [
-      "--version-regex"
-      "cli==(.*)"
-    ];
+  passthru = {
+    inherit (langgraph-sdk) updateScript;
+    skipBulkUpdate = true; # Broken, see https://github.com/NixOS/nixpkgs/issues/379898
   };
-
-  # multiple tags confuse the bulk updater
-  passthru.skipBulkUpdate = true;
 
   meta = {
     description = "Official CLI for LangGraph API";

--- a/pkgs/development/python-modules/langgraph-sdk/default.nix
+++ b/pkgs/development/python-modules/langgraph-sdk/default.nix
@@ -10,6 +10,7 @@
   httpx,
   httpx-sse,
   orjson,
+  typing-extensions,
 
   # passthru
   writeScript,
@@ -17,14 +18,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph-sdk";
-  version = "0.1.43";
+  version = "0.1.51";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
     tag = "sdk==${version}";
-    hash = "sha256-mG04V36Aa5Df5pUgr+xWej8i2XYx+O/N61sSzxwN9Go=";
+    hash = "sha256-BkwH9O59gG/OtnFWYEFe2WD0sIidptlkPACX9i7kCb8=";
   };
 
   sourceRoot = "${src.name}/libs/sdk-py";
@@ -35,6 +36,7 @@ buildPythonPackage rec {
     httpx
     httpx-sse
     orjson
+    typing-extensions
   ];
 
   disabledTests = [ "test_aevaluate_results" ]; # Compares execution time to magic number
@@ -54,9 +56,7 @@ buildPythonPackage rec {
       nix-update --commit --version-regex 'checkpointpostgres==(.*)' python3Packages.langgraph-checkpoint-postgres
       nix-update --commit --version-regex 'checkpointsqlite==(.*)' python3Packages.langgraph-checkpoint-sqlite
     '';
-
-    # multiple tags confuse the bulk updater
-    skipBulkUpdate = true;
+    skipBulkUpdate = true; # Broken, see https://github.com/NixOS/nixpkgs/issues/379898
   };
 
   meta = {

--- a/pkgs/development/python-modules/langgraph/default.nix
+++ b/pkgs/development/python-modules/langgraph/default.nix
@@ -35,14 +35,14 @@
 
 buildPythonPackage rec {
   pname = "langgraph";
-  version = "0.2.56";
+  version = "0.2.70";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "langchain-ai";
     repo = "langgraph";
-    tag = version;
-    hash = "sha256-X/IMNEmggu9bSJFUaTohbFYxGZBguf+eFb3ObmQGplk=";
+    tag = "${version}";
+    hash = "sha256-Vz2ZoikEZuMvt3j9tvBIcXCwWSrCV8MI7x9PIHodl8Y=";
   };
 
   postgresqlTestSetupPost = ''
@@ -112,12 +112,14 @@ buildPythonPackage rec {
     # psycopg.errors.InsufficientPrivilege: permission denied to create database
     "tests/test_pregel_async.py"
     "tests/test_pregel.py"
+    "tests/test_large_cases.py"
+    "tests/test_large_cases_async.py"
   ];
 
-  passthru.updateScript = langgraph-sdk.updateScript;
-
-  # multiple tags confuse the bulk updater
-  passthru.skipBulkUpdate = true;
+  passthru = {
+    inherit (langgraph-sdk) updateScript;
+    skipBulkUpdate = true; # Broken, see https://github.com/NixOS/nixpkgs/issues/379898
+  };
 
   meta = {
     description = "Build resilient language agents as graphs";


### PR DESCRIPTION
1. Updates:
 * python3Packages.langgraph: 0.2.56 -> 0.2.70
 * python3Packages.langgraph-sdk: 0.1.46 -> 0.1.51
 * python3Packages.langgraph-cli: 0.1.52 -> 0.1.70
 * python3Packages.langgraph-checkpoint: 2.0.8 -> 2.0.10
 * python3Packages.langgraph-checkpoint-duckdb: 2.0.1 -> 2.0.2
 * python3Packages.langgraph-checkpoint-postgres: 2.0.8 -> 2.0.13
 * python3Packages.langgraph-checkpoint-sqlite: 2.0.1 -> 2.0.3
2. Disables batch updates due to broken updater, see #379898
3. Repairs improper updates from staging.
4. Removes `pythonOlder` when <= 3.9

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
