### PR TITLE
exiled-exchange-2: init at 0.9.4

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -8908,6 +8908,12 @@
     githubId = 6578603;
     name = "Jonas Rembser";
   };
+  guno327 = {
+    name = "Gunnar Hovik";
+    github = "Guno327";
+    githubId = 95594654;
+    email = "gunnarhovik@outlook.com";
+  };
   gurjaka = {
     name = "Gurami Esartia";
     email = "esartia.gurika@gmail.com";

--- a/pkgs/by-name/ex/exiled-exchange-2/package.nix
+++ b/pkgs/by-name/ex/exiled-exchange-2/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  appimageTools,
+  fetchurl,
+  makeDesktopItem,
+  nix-update-script,
+}:
+let
+  version = "0.9.4";
+  pname = "exiled-exchange-2";
+
+  src = fetchurl {
+    url = "https://github.com/Kvan7/Exiled-Exchange-2/releases/download/v${version}/Exiled-Exchange-2-${version}.AppImage";
+    sha256 = "sha256-RhidU7W5aIvl1958FIoQlmni9JLYe/iKI7gkfqO5oEs=";
+  };
+
+  appimageContents = appimageTools.extract { inherit pname version src; };
+
+  desktopItem = makeDesktopItem {
+    name = "exiled-exchange-2";
+    exec = "exiled-exchange-2";
+    icon = "exiled-exchange-2";
+    type = "Application";
+    comment = "Path of Exile 2 overlay";
+    desktopName = "Exiled Exchange 2";
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraInstallCommands = ''
+    install -m 444 -D ${desktopItem}/share/applications/exiled-exchange-2.desktop $out/share/applications/exiled-exchange-2.desktop
+    install -m 444 -D ${appimageContents}/usr/share/icons/hicolor/512x512/apps/exiled-exchange-2.png \
+       $out/share/icons/hicolor/512x512/apps/exiled-exchange-2.png
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    mainProgram = "exiled-exchange-2";
+    description = "Path of Exile 2 overlay program";
+    homepage = "https://github.com/Kvan7/Exiled-Exchange-2";
+    downloadPage = "https://kvan7.github.io/Exiled-Exchange-2/download";
+    changelog = "https://github.com/Kvan7/Exiled-Exchange-2/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ guno327 ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Packaged Exiled Exchange 2 for nixos and added myself as maintainer. This package was not available in nixpkgs so I decided to package it myself. With the growing popularity of Path of Exile 2, I thought others might find this package useful.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
