### PR TITLE
python3Packages.rumps: init at unstable-2025-02-02

### DIFF
--- a/pkgs/development/python-modules/pyobjc-core/default.nix
+++ b/pkgs/development/python-modules/pyobjc-core/default.nix
@@ -1,0 +1,61 @@
+{
+  buildPythonPackage,
+  darwin,
+  fetchFromGitHub,
+  lib,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-core";
+  version = "11.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ronaldoussoren";
+    repo = "pyobjc";
+    tag = "v${version}";
+    hash = "sha256-RhB0Ht6vyDxYwDGS+A9HZL9ySIjWlhdB4S+gHxvQQBg=";
+  };
+
+  sourceRoot = "source/pyobjc-core";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    darwin.DarwinTools
+    darwin.libffi
+  ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
+  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
+  postPatch = ''
+    for file in Modules/objc/test/*.m; do
+      substituteInPlace "$file" --replace "[[clang::suppress]]" ""
+    done
+
+    substituteInPlace setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion"
+  '';
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=cast-function-type-mismatch"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [ "objc" ];
+
+  meta = with lib; {
+    description = "Python <-> Objective-C bridge";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
+++ b/pkgs/development/python-modules/pyobjc-framework-Cocoa/default.nix
@@ -1,0 +1,59 @@
+{
+  buildPythonPackage,
+  darwin,
+  fetchFromGitHub,
+  lib,
+  pyobjc-core,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "pyobjc-framework-Cocoa";
+  version = "11.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "ronaldoussoren";
+    repo = "pyobjc";
+    tag = "v${version}";
+    hash = "sha256-RhB0Ht6vyDxYwDGS+A9HZL9ySIjWlhdB4S+gHxvQQBg=";
+  };
+
+  sourceRoot = "source/pyobjc-framework-Cocoa";
+
+  build-system = [ setuptools ];
+
+  buildInputs = [
+    darwin.libffi
+    darwin.DarwinTools
+  ];
+
+  nativeBuildInputs = [
+    darwin.DarwinTools # sw_vers
+  ];
+
+  # See https://github.com/ronaldoussoren/pyobjc/pull/641. Unfortunately, we
+  # cannot just pull that diff with fetchpatch due to https://discourse.nixos.org/t/how-to-apply-patches-with-sourceroot/59727.
+  postPatch = ''
+    substituteInPlace pyobjc_setup.py \
+      --replace-fail "-buildversion" "-buildVersion" \
+      --replace-fail "-productversion" "-productVersion"
+  '';
+
+  dependencies = [ pyobjc-core ];
+
+  env.NIX_CFLAGS_COMPILE = toString [
+    "-I${darwin.libffi.dev}/include"
+    "-Wno-error=unused-command-line-argument"
+  ];
+
+  pythonImportsCheck = [ "Cocoa" ];
+
+  meta = with lib; {
+    description = "PyObjC wrappers for the Cocoa frameworks on macOS";
+    homepage = "https://github.com/ronaldoussoren/pyobjc";
+    license = licenses.mit;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/development/python-modules/rumps/default.nix
+++ b/pkgs/development/python-modules/rumps/default.nix
@@ -1,0 +1,33 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  lib,
+  pyobjc-framework-Cocoa,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "rumps";
+  version = "unstable-2025-02-02";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jaredks";
+    repo = "rumps";
+    rev = "8730e7cff5768dfabecff478c0d5e3688862c1c6";
+    hash = "sha256-oNJBpRaCGyOKCgBueRx4YhpNW1OnbIEWEEvlGfyoxUA=";
+  };
+
+  build-system = [ setuptools ];
+  dependencies = [ pyobjc-framework-Cocoa ];
+
+  pythonImportsCheck = [ "rumps" ];
+
+  meta = with lib; {
+    description = "Ridiculously Uncomplicated macOS Python Statusbar apps";
+    homepage = "https://github.com/jaredks/rumps";
+    license = licenses.bsd2;
+    platforms = platforms.darwin;
+    maintainers = with maintainers; [ samuela ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12317,6 +12317,8 @@ self: super: with self; {
 
   pyobihai = callPackage ../development/python-modules/pyobihai { };
 
+  pyobjc-core = callPackage ../development/python-modules/pyobjc-core { };
+
   pyocd = callPackage ../development/python-modules/pyocd { };
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -12319,6 +12319,8 @@ self: super: with self; {
 
   pyobjc-core = callPackage ../development/python-modules/pyobjc-core { };
 
+  pyobjc-framework-Cocoa = callPackage ../development/python-modules/pyobjc-framework-Cocoa { };
+
   pyocd = callPackage ../development/python-modules/pyocd { };
 
   pyocd-pemicro = callPackage ../development/python-modules/pyocd-pemicro { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -14441,6 +14441,8 @@ self: super: with self; {
 
   rules = callPackage ../development/python-modules/rules { };
 
+  rumps = callPackage ../development/python-modules/rumps { };
+
   runs = callPackage ../development/python-modules/runs { };
 
   runstats = callPackage ../development/python-modules/runstats { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Introduces rumps, pyobjc-core, and pyobjc-framework-Cocoa. Fixes https://github.com/NixOS/nixpkgs/issues/101360.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
