### PR TITLE
nixos/klipper: support extra settings

### DIFF
--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -112,6 +112,12 @@ in
         '';
       };
 
+      extraSettings = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = "Extra lines to append to the generated Klipper configuration.";
+      };
+
       firmwares = lib.mkOption {
         description = "Firmwares klipper should manage";
         default = { };
@@ -180,7 +186,13 @@ in
           + lib.optionalString (cfg.apiSocket != null) " --api-server=${cfg.apiSocket}"
           + lib.optionalString (cfg.logFile != null) " --logfile=${cfg.logFile}";
         printerConfig =
-          if cfg.settings != null then format.generate "klipper.cfg" cfg.settings else cfg.configFile;
+          if cfg.settings != null then
+            pkgs.concatText "klipper.cfg" [
+              (format.generate "klipper.cfg" cfg.settings)
+              (pkgs.writeText "klipper-extra.cfg" cfg.extraSettings)
+            ]
+          else
+            cfg.configFile;
       in
       {
         description = "Klipper 3D Printer Firmware";

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -172,6 +172,10 @@ in
         assertion = (cfg.configFile != null) != (cfg.settings != null);
         message = "You need to either specify services.klipper.settings or services.klipper.configFile.";
       }
+      {
+        assertion = (cfg.configFile != null) && (cfg.extraSettings != null);
+        message = "You can't use services.klipper.extraSettings with services.klipper.configFile.";
+      }
     ];
 
     services.klipper = lib.mkIf cfg.octoprintIntegration {

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -173,7 +173,7 @@ in
         message = "You need to either specify services.klipper.settings or services.klipper.configFile.";
       }
       {
-        assertion = (cfg.configFile != null) -> (cfg.extraSettings != "");
+        assertion = (cfg.configFile != null) -> (cfg.extraSettings == "");
         message = "You can't use services.klipper.extraSettings with services.klipper.configFile.";
       }
     ];

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -187,10 +187,7 @@ in
           + lib.optionalString (cfg.logFile != null) " --logfile=${cfg.logFile}";
         printerConfig =
           if cfg.settings != null then
-            pkgs.concatText "klipper.cfg" [
-              (format.generate "klipper.cfg" cfg.settings)
-              (pkgs.writeText "klipper-extra.cfg" cfg.extraSettings)
-            ]
+              builtins.toFile "klipper.cfg" ((format.generate "" cfg.settings).text + cfg.extraSettings)
           else
             cfg.configFile;
       in

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -187,7 +187,7 @@ in
           + lib.optionalString (cfg.logFile != null) " --logfile=${cfg.logFile}";
         printerConfig =
           if cfg.settings != null then
-              builtins.toFile "klipper.cfg" ((format.generate "" cfg.settings).text + cfg.extraSettings)
+            builtins.toFile "klipper.cfg" ((format.generate "" cfg.settings).text + cfg.extraSettings)
           else
             cfg.configFile;
       in

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -173,7 +173,7 @@ in
         message = "You need to either specify services.klipper.settings or services.klipper.configFile.";
       }
       {
-        assertion = (cfg.configFile != null) && (cfg.extraSettings != null);
+        assertion = (cfg.configFile != null) && (cfg.extraSettings != "");
         message = "You can't use services.klipper.extraSettings with services.klipper.configFile.";
       }
     ];

--- a/nixos/modules/services/misc/klipper.nix
+++ b/nixos/modules/services/misc/klipper.nix
@@ -173,7 +173,7 @@ in
         message = "You need to either specify services.klipper.settings or services.klipper.configFile.";
       }
       {
-        assertion = (cfg.configFile != null) && (cfg.extraSettings != "");
+        assertion = (cfg.configFile != null) -> (cfg.extraSettings != "");
         message = "You can't use services.klipper.extraSettings with services.klipper.configFile.";
       }
     ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
The order of some Klipper settings is important (e.g. a `thermistor` must appear before it is used in a `temperature_sensor`). There's no way to specify an ordering in `lib.generators.toINI`, so this seemed like the next best option.

I'm using this to define a custom thermistor type for a temperature sensor as follows:

```nix
services.klipper.extraSettings = ''
  [thermistor CMFB103F3950FANT]
  temperature1: 0.0
  resistance1: 32116.0
  temperature2: 40.0
  resistance2: 5309.0
  temperature3: 80.0
  resistance3: 1228.0

  [temperature_sensor chamber]
  sensor_type: CMFB103F3950FANT
  sensor_pin: picobilical:gpio28
  pullup_resistor: 2200
  min_temp: 0
  max_temp: 100
  gcode_id: C
'';
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
