### PR TITLE
podman-desktop: 1.13.2 -> 1.16.2

### DIFF
--- a/pkgs/applications/virtualization/podman-desktop/default.nix
+++ b/pkgs/applications/virtualization/podman-desktop/default.nix
@@ -3,7 +3,7 @@
 , fetchFromGitHub
 , makeWrapper
 , copyDesktopItems
-, electron_33
+, electron
 , nodejs
 , pnpm_9
 , makeDesktopItem
@@ -13,20 +13,20 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "podman-desktop";
-  version = "1.13.2";
+  version = "1.16.2";
 
   passthru.updateScript = nix-update-script { };
 
   src = fetchFromGitHub {
     owner = "containers";
     repo = "podman-desktop";
-    rev = "v${finalAttrs.version}";
-    sha256 = "sha256-07lf9jy22JUT+Vc5y9Tu1nkWaXU5RTdu3GibcvQsSs8=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-Ekprt+cWuvJck+H1aexIdTDQosBdDsTLlkBgIgd77dk=";
   };
 
   pnpmDeps = pnpm_9.fetchDeps {
     inherit (finalAttrs) pname version src;
-    hash = "sha256-LPsNRd1c/cQeyBn3LZKnKeAsZ981sOkLYTnXIZL82LA=";
+    hash = "sha256-pChWWQ5YgekcEsXagv0lWTDNXGKK1EbOgdWF48Nn3Hs=";
   };
 
   patches = [
@@ -34,21 +34,14 @@ stdenv.mkDerivation (finalAttrs: {
     ./patches/extension-no-download-podman.patch
   ];
 
-  postPatch = ''
-    for file in packages/main/src/tray-animate-icon.ts packages/main/src/plugin/certificates.ts; do
-      substituteInPlace "$file" \
-        --replace-fail 'process.resourcesPath' "'$out/share/lib/podman-desktop/resources'"
-    done
-    substituteInPlace "extensions/podman/packages/extension/src/util.ts" \
-      --replace-fail '(process as any).resourcesPath' "'$out/share/lib/podman-desktop/resources'"
-  '';
-
   ELECTRON_SKIP_BINARY_DOWNLOAD = "1";
 
   nativeBuildInputs = [
-    makeWrapper nodejs pnpm_9.configHook
+    nodejs
+    pnpm_9.configHook
   ] ++ lib.optionals (!stdenv.hostPlatform.isDarwin) [
     copyDesktopItems
+    makeWrapper
   ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
     autoSignDarwinBinariesHook
   ];
@@ -56,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildPhase = ''
     runHook preBuild
 
-    cp -r ${electron_33.dist} electron-dist
+    cp -r ${electron.dist} electron-dist
     chmod -R u+w electron-dist
 
     pnpm build
@@ -64,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
       --dir \
       --config .electron-builder.config.cjs \
       -c.electronDist=electron-dist \
-      -c.electronVersion=${electron_33.version}
+      -c.electronVersion=${electron.version}
 
     runHook postBuild
   '';
@@ -72,19 +65,16 @@ stdenv.mkDerivation (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p "$out/share/lib/podman-desktop"
   '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    mkdir -p $out/{Applications,bin}
+    mkdir -p $out/Applications
     mv dist/mac*/Podman\ Desktop.app $out/Applications
-    ln -s $out/Applications/Podman\ Desktop.app/Contents/Resources "$out/share/lib/podman-desktop/resources"
-
-    makeWrapper "$out/Applications/Podman Desktop.app/Contents/MacOS/Podman Desktop" $out/bin/podman-desktop
   '' + lib.optionalString (!stdenv.hostPlatform.isDarwin) ''
+    mkdir -p "$out/share/lib/podman-desktop"
     cp -r dist/*-unpacked/{locales,resources{,.pak}} "$out/share/lib/podman-desktop"
 
     install -Dm644 buildResources/icon.svg "$out/share/icons/hicolor/scalable/apps/podman-desktop.svg"
 
-    makeWrapper '${electron_33}/bin/electron' "$out/bin/podman-desktop" \
+    makeWrapper '${electron}/bin/electron' "$out/bin/podman-desktop" \
       --add-flags "$out/share/lib/podman-desktop/resources/app.asar" \
       --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations --enable-wayland-ime=true}}" \
       --inherit-argv0
@@ -113,7 +103,7 @@ stdenv.mkDerivation (finalAttrs: {
     changelog = "https://github.com/containers/podman-desktop/releases/tag/v${finalAttrs.version}";
     license = lib.licenses.asl20;
     maintainers = with lib.maintainers; [ booxter panda2134 ];
-    inherit (electron_33.meta) platforms;
+    inherit (electron.meta) platforms;
     mainProgram = "podman-desktop";
   };
 })

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -4683,6 +4683,7 @@ with pkgs;
 
   podman-desktop = callPackage ../applications/virtualization/podman-desktop {
     inherit (darwin) autoSignDarwinBinariesHook;
+    electron = electron_34;
   };
 
   polaris = callPackage ../servers/polaris { };


### PR DESCRIPTION
Now that electron 34 is packaged, we can upgrade the version.

This patch also drops podman-desktop wrapper on MacOS (which is not how
MacOS users generally start their GUI apps).

It also drops several in-place substitutions that no longer apply to the
current state of the code, and which look like addressing a problem no
longer present. (There was some work to adopt getAppPath() work done in
the project that I believe addresses whatever the resource loading
issues may have been present in the past.)

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
