### PR TITLE
python312Packages.openslide: fix patch

### DIFF
--- a/pkgs/development/python-modules/openslide/default.nix
+++ b/pkgs/development/python-modules/openslide/default.nix
@@ -25,7 +25,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace openslide/lowlevel.py \
-      --replace-fail "return cdll.LoadLibrary(name)" "return cdll.LoadLibrary(f'${lib.getLib openslide}/lib/{name}')"
+      --replace-fail "return cdll.LoadLibrary(names[0])" "return cdll.LoadLibrary(f'${lib.getLib openslide}/lib/{names[0]}')"
   '';
 
   build-system = [ setuptools ];


### PR DESCRIPTION
Broken since #375144

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).