### PR TITLE
python313Packages.calmjs: disable more argparse-related tests, misc. cleanup

### DIFF
--- a/pkgs/development/python-modules/calmjs/default.nix
+++ b/pkgs/development/python-modules/calmjs/default.nix
@@ -5,18 +5,23 @@
   calmjs-types,
   calmjs-parse,
   pytestCheckHook,
+  setuptools,
 }:
 
 buildPythonPackage rec {
   pname = "calmjs";
   version = "3.4.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchPypi {
     inherit pname version;
     hash = "sha256-73NQiY1RMdBrMIlm/VTvHY4dCHL1pQoj6a48CWRos3o=";
     extension = "zip";
   };
+
+  build-system = [
+    setuptools
+  ];
 
   propagatedBuildInputs = [
     calmjs-parse
@@ -28,6 +33,10 @@ buildPythonPackage rec {
   disabledTests = [
     # spacing changes in argparse output
     "test_integration_choices_in_list"
+    # formatting changes in argparse output
+    "test_sorted_case_insensitivity"
+    "test_sorted_simple_first"
+    "test_sorted_standard"
   ];
 
   # ModuleNotFoundError: No module named 'calmjs.types'


### PR DESCRIPTION
https://hydra.nixos.org/build/284328550/nixlog/1

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).