### PR TITLE
osrm-backend: fix build with boost187

### DIFF
--- a/pkgs/servers/osrm-backend/boost187-compat.patch
+++ b/pkgs/servers/osrm-backend/boost187-compat.patch
@@ -1,0 +1,14 @@
+diff --git a/include/server/server.hpp b/include/server/server.hpp
+index 34b8982e67a..02b0dda050d 100644
+--- a/include/server/server.hpp
++++ b/include/server/server.hpp
+@@ -53,8 +53,7 @@ class Server
+         const auto port_string = std::to_string(port);
+ 
+         boost::asio::ip::tcp::resolver resolver(io_context);
+-        boost::asio::ip::tcp::resolver::query query(address, port_string);
+-        boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
++        boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(address, port_string).begin();
+ 
+         acceptor.open(endpoint.protocol());
+ #ifdef SO_REUSEPORT

--- a/pkgs/servers/osrm-backend/default.nix
+++ b/pkgs/servers/osrm-backend/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  fetchpatch,
   cmake,
   pkg-config,
   bzip2,
@@ -16,7 +15,7 @@
   nixosTests,
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation {
   pname = "osrm-backend";
   version = "5.27.1-unstable-2024-11-03";
 
@@ -26,6 +25,11 @@ stdenv.mkDerivation rec {
     rev = "3614af7f6429ee35c3f2e836513b784a74664ab6";
     hash = "sha256-iix++G49cC13wZGZIpXu1SWGtVAcqpuX3GhsIaETzUU=";
   };
+
+  patches = [
+    # Taken from https://github.com/Project-OSRM/osrm-backend/pull/7073.
+    ./boost187-compat.patch
+  ];
 
   nativeBuildInputs = [
     cmake


### PR DESCRIPTION
Vendoring the relevant part of the patch from https://github.com/Project-OSRM/osrm-backend/pull/7073.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
