### PR TITLE
fishPlugins.nvm: init at 2.2.16

### DIFF
--- a/pkgs/shells/fish/plugins/default.nix
+++ b/pkgs/shells/fish/plugins/default.nix
@@ -52,6 +52,8 @@ lib.makeScope newScope (self: with self; {
 
   hydro = callPackage ./hydro.nix { };
 
+  nvm = callPackage ./nvm.nix { };
+
   pisces = callPackage ./pisces.nix { };
 
   plugin-git = callPackage ./plugin-git.nix { };

--- a/pkgs/shells/fish/plugins/nvm.nix
+++ b/pkgs/shells/fish/plugins/nvm.nix
@@ -1,0 +1,24 @@
+{
+  buildFishPlugin,
+  fetchFromGitHub,
+  lib,
+}:
+buildFishPlugin rec {
+  pname = "nvm";
+  version = "2.2.16";
+  src = fetchFromGitHub {
+    owner = "jorgebucaran";
+    repo = "nvm.fish";
+    tag = version;
+    hash = "sha256-GTEkCm+OtxMS3zJI5gnFvvObkrpepq1349/LcEPQRDo=";
+  };
+
+  meta = {
+    description = "The Node.js version manager you'll adore, crafted just for Fish";
+    homepage = "https://github.com/jorgebucaran/nvm.fish";
+    changelog = "https://github.com/jorgebucaran/nvm.fish/releases/tag/${version}/CHANGELOG.md";
+    downloadPage = "https://github.com/jorgebucaran/nvm.fish/releases";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pta2002 ];
+  };
+}


### PR DESCRIPTION
Adds the [nvm.fish](https://github.com/jorgebucaran/nvm.fish) fish plugin, a port of [nvm](https://github.com/nvm-sh/nvm) so that it works on the fish shell.

---

**Sidenote:** I noticed that the `default.nix` for the fish-plugins is not yet following the RFC style, should I edit it to fit the new style since I happened to touch it? I'm assuming no since the CI isn't complaining, but I'm not sure.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
