### PR TITLE
python312Packages.bork: relax urllib3 dependency

### DIFF
--- a/pkgs/development/python-modules/bork/default.nix
+++ b/pkgs/development/python-modules/bork/default.nix
@@ -35,6 +35,7 @@ buildPythonPackage rec {
 
   pythonRelaxDeps = [
     "packaging"
+    "urllib3"
   ];
 
   dependencies =


### PR DESCRIPTION
Broken since urllib3 2.3.0 #375144

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).