### PR TITLE
pypy3Packages.tkinter: enable and make no-op

### DIFF
--- a/pkgs/development/python-modules/tkinter/default.nix
+++ b/pkgs/development/python-modules/tkinter/default.nix
@@ -13,9 +13,8 @@ buildPythonPackage {
   src = py;
   format = "other";
 
-  disabled = isPyPy;
-
-  installPhase =
+  # tkinter is included in PyPy, making this package a no-op.
+  installPhase = lib.optionalString (!isPyPy) (
     ''
       # Move the tkinter module
       mkdir -p $out/${py.sitePackages}
@@ -26,7 +25,8 @@ buildPythonPackage {
       old_rpath=$(patchelf --print-rpath $out/${py.sitePackages}/_tkinter*)
       new_rpath=$(sed "s#${py}#${python}#g" <<< "$old_rpath" )
       patchelf --set-rpath $new_rpath $out/${py.sitePackages}/_tkinter*
-    '';
+    ''
+  );
 
   meta = py.meta // {
     # Based on first sentence from https://docs.python.org/3/library/tkinter.html


### PR DESCRIPTION
PyPy always includes the tkinter module without further setup.

Try: `pypy3 -m idlelib` with plain `pypy3` package. IDLE (requires Tkinter) should pop up.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).