### PR TITLE
foundationdb: make operational on nixos

### DIFF
--- a/nixos/modules/services/databases/foundationdb.nix
+++ b/nixos/modules/services/databases/foundationdb.nix
@@ -333,12 +333,6 @@ in
       '';
     };
 
-    pidfile = lib.mkOption {
-      type = lib.types.path;
-      default = "/run/foundationdb.pid";
-      description = "Path to pidfile for fdbmonitor.";
-    };
-
     traceFormat = lib.mkOption {
       type = lib.types.enum [
         "xml"
@@ -389,7 +383,7 @@ in
       "d /etc/foundationdb 0755 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.dataDir}' 0770 ${cfg.user} ${cfg.group} - -"
       "d '${cfg.logDir}' 0770 ${cfg.user} ${cfg.group} - -"
-      "F '${cfg.pidfile}' - ${cfg.user} ${cfg.group} - -"
+      "d /run/foundationdb 0770 ${cfg.user} ${cfg.group} - -"
     ];
 
     systemd.services.foundationdb = {
@@ -406,7 +400,7 @@ in
           rwpaths = [
             cfg.dataDir
             cfg.logDir
-            cfg.pidfile
+            "/run/foundationdb"
             "/etc/foundationdb"
           ] ++ cfg.extraReadWritePaths;
         in
@@ -416,9 +410,7 @@ in
           RestartSec = 5;
           User = cfg.user;
           Group = cfg.group;
-          PIDFile = "${cfg.pidfile}";
 
-          PermissionsStartOnly = true; # setup needs root perms
           TimeoutSec = 120; # give reasonable time to shut down
 
           # Security options
@@ -448,7 +440,7 @@ in
         fi
       '';
 
-      script = "exec fdbmonitor --lockfile ${cfg.pidfile} --conffile ${configFile}";
+      script = "exec fdbmonitor --lockfile /run/foundationdb/fdbmonitor.pid --conffile ${configFile}";
 
       postStart = ''
         if [ -e "${cfg.dataDir}/.first_startup" ]; then

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -518,6 +518,7 @@ in
     inherit runTest;
     forgejoPackage = pkgs.forgejo-lts;
   };
+  foundationdb = runTest ./foundationdb.nix { };
   freenet = runTest ./freenet.nix;
   freeswitch = handleTest ./freeswitch.nix { };
   freetube = discoverTests (import ./freetube.nix);

--- a/nixos/tests/foundationdb.nix
+++ b/nixos/tests/foundationdb.nix
@@ -1,0 +1,35 @@
+import ./make-test-python.nix (
+  {
+    pkgs,
+    lib,
+    package ? pkgs.foundationdb,
+    ...
+  }:
+  {
+    name = "foundationdb";
+    meta.maintainers = with lib.maintainers; [ siriobalmelli ];
+
+    nodes = {
+      server =
+        { _, ... }:
+        {
+          services.foundationdb = {
+            inherit package;
+            enable = true;
+            serverProcesses = 1;
+            traceFormat = "json";
+          };
+
+          # fail test if unable to start the first time
+          systemd.services.foundationdb.serviceConfig.Restart = lib.mkForce "no";
+        };
+    };
+
+    testScript =
+      { nodes, ... }:
+      ''
+        server.wait_for_unit("foundationdb.service")
+        server.succeed("fdbcli --exec status")
+      '';
+  }
+)

--- a/pkgs/development/python-modules/foundationdb/default.nix
+++ b/pkgs/development/python-modules/foundationdb/default.nix
@@ -1,0 +1,27 @@
+{
+  buildPythonPackage,
+  lib,
+  foundationdb,
+}:
+
+buildPythonPackage {
+  pname = "foundationdb";
+  version = foundationdb.version;
+
+  src = foundationdb.pythonsrc;
+  unpackCmd = "tar xf $curSrc";
+
+  patchPhase = ''
+    substituteInPlace ./fdb/impl.py \
+      --replace libfdb_c.so "${foundationdb.lib}/lib/libfdb_c.so"
+  '';
+
+  doCheck = false;
+
+  meta = {
+    description = "Python bindings for FoundationDB";
+    homepage = "https://www.foundationdb.org";
+    license = with lib.licenses; [ asl20 ];
+    maintainers = with lib.maintainers; [ thoughtpolice ];
+  };
+}

--- a/pkgs/servers/foundationdb/cmake.nix
+++ b/pkgs/servers/foundationdb/cmake.nix
@@ -162,14 +162,14 @@ let
         "pythonsrc"
       ];
 
-      meta = with lib; {
+      meta = {
         description = "Open source, distributed, transactional key-value store";
         homepage = "https://www.foundationdb.org";
-        license = licenses.asl20;
-        platforms = [ "x86_64-linux" ] ++ lib.optionals (!(avxEnabled version)) [ "aarch64-linux" ];
+        lib.license = lib.licenses.asl20;
+        lib.platforms = [ "x86_64-linux" ] ++ lib.optionals (!(avxEnabled version)) [ "aarch64-linux" ];
         # Fails when cross-compiling with "/bin/sh: gcc-ar: not found"
         broken = stdenv.buildPlatform != stdenv.hostPlatform;
-        maintainers = with maintainers; [
+        maintainers = with lib.maintainers; [
           thoughtpolice
           lostnet
         ];

--- a/pkgs/servers/foundationdb/cmake.nix
+++ b/pkgs/servers/foundationdb/cmake.nix
@@ -13,7 +13,7 @@
   toml11,
   jemalloc,
   doctest,
-
+  zlib,
   gccStdenv,
   llvmPackages,
   useClang ? false,
@@ -58,6 +58,7 @@ let
         msgpack-cxx
         toml11
         jemalloc
+        zlib
       ];
 
       checkInputs = [ doctest ];

--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -17,6 +17,8 @@
   toml11,
   jemalloc,
   doctest,
+
+  nixosTests,
 }@args:
 
 let
@@ -45,5 +47,9 @@ in
         hash = "sha256-ZLIcmcfirm1+96DtTIr53HfM5z38uTLZrRNHAmZL6rc=";
       })
     ];
+  };
+
+  passthru = {
+    tests.foundationdb = nixosTests.foundationdb;
   };
 }

--- a/pkgs/servers/foundationdb/default.nix
+++ b/pkgs/servers/foundationdb/default.nix
@@ -17,6 +17,7 @@
   toml11,
   jemalloc,
   doctest,
+  zlib,
 
   nixosTests,
 }@args:
@@ -26,8 +27,8 @@ let
 in
 {
   foundationdb73 = cmakeBuild {
-    version = "7.3.42";
-    hash = "sha256-jQcm+HLai5da2pZZ7iLdN6fpQZxf5+/kkfv9OSXQ57c=";
+    version = "7.3.62";
+    hash = "sha256-tPB/jJbdC11wQvPOI5KtlpQgw9yVLBhxABGgDSBpwBU=";
     boost = boost186;
     ssl = openssl;
 

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -5187,8 +5187,8 @@ self: super: with self; {
 
   fortiosapi = callPackage ../development/python-modules/fortiosapi { };
 
-  foundationdb73 = callPackage ../servers/foundationdb/python.nix {
-    foundationdb = pkgs.foundationdb73;
+  foundationdb = callPackage ../development/python-modules/foundationdb {
+    inherit (pkgs) foundationdb;
   };
 
   fountains = callPackage ../development/python-modules/fountains { };


### PR DESCRIPTION
Make foundationdb usable/operational

This is a WIP PR:

- [x] update the foundationdb package to the latest release
- [I/P] fix foundationdb so it is not segfaulting
- [x] add NixOS test for foundationdb
- [x] fix NixOS foundationdb module

See #319537 and #378888

cc @PaulGrandperrin @lostnet @thoughtpolice

## Things done

WIP, will update when finished

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
