### PR TITLE
python312Packages.manga-ocr: fix definition

### DIFF
--- a/pkgs/development/python-modules/manga-ocr/default.nix
+++ b/pkgs/development/python-modules/manga-ocr/default.nix
@@ -1,15 +1,25 @@
 {
   lib,
   fetchFromGitHub,
-  python3Packages,
+  buildPythonPackage,
+  setuptools,
+  setuptools-scm,
+  fire,
+  fugashi,
+  jaconv,
+  loguru,
+  numpy,
+  pillow,
+  pyperclip,
+  torch,
+  transformers,
+  unidic-lite,
 }:
-
-with python3Packages;
 
 buildPythonPackage rec {
   pname = "manga-ocr";
   version = "0.1.14";
-  format = "pyproject";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "kha-white";


### PR DESCRIPTION
`with python3Packages;` breaks the package for anything besides the default Python

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).