### PR TITLE
gitlab-container-registry: Add workaround for failing upstream tests

### DIFF
--- a/pkgs/by-name/gi/gitlab-container-registry/package.nix
+++ b/pkgs/by-name/gi/gitlab-container-registry/package.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoModule,
   fetchFromGitLab,
+  fetchpatch,
 }:
 
 buildGoModule rec {
@@ -19,14 +20,35 @@ buildGoModule rec {
 
   vendorHash = "sha256-aKE/yr2Sh+4yw4TmpaVF84rJOI6cjs0DKY326+aXO1o=";
 
+  env = {
+    # required for multiple azure tests
+    # https://gitlab.com/gitlab-org/container-registry/-/issues/1494
+    AZURE_DRIVER_VERSION = "azure_v2";
+  };
+
+  patches = [
+    # remove with >= 4.15.3
+    (fetchpatch {
+      url = "https://gitlab.com/gitlab-org/container-registry/-/commit/268689a2f30880b7d122469a4260ca46cbc55ccd.patch";
+      hash = "sha256-RslK4qvcqCaG7ju2LgN/tI9cImrTj3Nry+mCv3zoWiA=";
+    })
+  ];
+
   postPatch = ''
     # Disable flaky inmemory storage driver test
     rm registry/storage/driver/inmemory/driver_test.go
 
     substituteInPlace health/checks/checks_test.go \
-      --replace \
+      --replace-fail \
         'func TestHTTPChecker(t *testing.T) {' \
         'func TestHTTPChecker(t *testing.T) { t.Skip("Test requires network connection")'
+
+    # Add workaround for failing test due to function type mismatch (args vs return) by upstream
+    # https://gitlab.com/gitlab-org/container-registry/-/issues/1495
+    substituteInPlace registry/storage/driver/base/regulator_test.go \
+      --replace-fail \
+        'require.Equal(t, limit, r.available, "r.available")' \
+        'require.Equal(t, limit, int(r.available), "r.available")'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Running 

```
export AZURE_DRIVER_VERSION=azure_v2
go test -count 1 -run TestAzureDriver_parseParameters_Bool ./...
```

fixes https://github.com/NixOS/nixpkgs/issues/379071

reading https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/go/module.nix#L164 hopefully sets that variable also during `go test`

Upstream issues:

* https://gitlab.com/gitlab-org/container-registry/-/issues/1494
* https://gitlab.com/gitlab-org/container-registry/-/issues/1495
* https://gitlab.com/gitlab-org/container-registry/-/issues/1496