### PR TITLE
Add Thinkpad NXP1001 NFC support using libnfc-nci and PC/SC

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -111,6 +111,8 @@
 
 - [waagent](https://github.com/Azure/WALinuxAgent), the Microsoft Azure Linux Agent (waagent) manages Linux provisioning and VM interaction with the Azure Fabric Controller. Available with [services.waagent](options.html#opt-services.waagent.enable).
 
+- [nfc-nci](https://github.com/StarGate01/ifdnfc-nci), an alternative NFC stack and PC/SC driver for the NXP PN54x chipset, commonly found in Lenovo systems as NXP1001 (NPC300). Available as [hardware.nfc-nci](#opt-hardware.nfc-nci.enable).
+
 - [duckdns](https://www.duckdns.org), free dynamic DNS. Available with [services.duckdns](options.html#opt-services.duckdns.enable)
 
 - [nostr-rs-relay](https://git.sr.ht/~gheartsfield/nostr-rs-relay/), This is a nostr relay, written in Rust. Available as [services.nostr-rs-relay](options.html#opt-services.nostr-rs-relay.enable).

--- a/nixos/modules/hardware/nfc-nci.nix
+++ b/nixos/modules/hardware/nfc-nci.nix
@@ -1,0 +1,205 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.hardware.nfc-nci;
+
+  # To understand these settings in more detail, refer to the upstream configuration templates
+  # available at https://github.com/NXPNFCLinux/linux_libnfc-nci/tree/master/conf .
+  # Settings in curly braces are NCI commands, the "NFC Controller Interface Specification"
+  # as well as the "NFC Digital Protocol Technical Specification" can be found online.
+  # These default settings have been specifically engineered for the Lenovo NXP1001 (NPC300) chipset.
+  defaultSettings = {
+    # This block will be emitted into /etc/libnfc-nci.conf
+    nci = {
+      # Set up general logging
+      APPL_TRACE_LEVEL = "0x01";
+      PROTOCOL_TRACE_LEVEL = "0x01";
+      # Set up which NFC technologies are enabled (due to e.g. local regulation or patent law)
+      HOST_LISTEN_TECH_MASK = "0x07";
+      POLLING_TECH_MASK = "0xEF";
+      P2P_LISTEN_TECH_MASK = "0xC5";
+    };
+    # This block will be emitted into /etc/libnfc-nxp-init.conf
+    init = {
+      # Setup logging of the individual userland library components
+      NXPLOG_GLOBAL_LOGLEVEL = "0x01";
+      NXPLOG_EXTNS_LOGLEVEL = "0x01";
+      NXPLOG_NCIHAL_LOGLEVEL = "0x01";
+      NXPLOG_NCIX_LOGLEVEL = "0x01";
+      NXPLOG_NCIR_LOGLEVEL = "0x01";
+      NXPLOG_FWDNLD_LOGLEVEL = "0x00";
+      NXPLOG_TML_LOGLEVEL = "0x01";
+      # Where to find the kernel device node
+      NXP_NFC_DEV_NODE = ''"/dev/pn544"'';
+      # Enable the NXP proprietary features of the chip
+      NXP_ACT_PROP_EXTN = "{2F, 02, 00}";
+      # Configure the NFC Forum profile:
+      # 0xA0 0x44: POLL_PROFILE_SEL_CFG = 0x00 (Use NFC Forum profile default configuration values. Specifically, not EMVCo.)
+      NXP_NFC_PROFILE_EXTN = ''
+        {20, 02, 05, 01,
+          A0, 44, 01, 00
+        }
+      '';
+      # Enable chip standby mode
+      NXP_CORE_STANDBY = "{2F, 00, 01, 01}";
+      # Enable NCI packet fragmentation on the I2C bus
+      NXP_I2C_FRAGMENTATION_ENABLED = "0x01";
+    };
+    # This block will be emitted into /etc/libnfc-nxp-pn547.conf as well as /etc/libnfc-nxp-pn548.conf
+    # Which file is actually used is decided by the library at runtime depending on chip variant, both files are required.
+    pn54x = {
+      # Enable Mifare Classic reader functionality
+      MIFARE_READER_ENABLE = "0x01";
+      # Configure clock source - use XTAL (hardware crystal) instead of PLL (synthetic clock)
+      NXP_SYS_CLK_SRC_SEL = "0x01";
+      NXP_SYS_CLK_FREQ_SEL = "0x00";
+      NXP_SYS_CLOCK_TO_CFG = "0x01";
+      # Configure the non-propriety NCI settings in EEPROM:
+      # 0x28: PN_NFC_DEP_SPEED = 0x00 (Data exchange: Highest Available Bit Rates)
+      # 0x21: PI_BIT_RATE = 0x00 (Maximum allowed bit rate: 106 Kbit/s)
+      # 0x30: LA_BIT_FRAME_SDD = 0x08 (Bit Frame SDD value to be sent in Byte 1 of SENS_RES)
+      # 0x31: LA_PLATFORM_CONFIG = 0x03 (Platform Configuration value to be sent in Byte 2 of SENS_RES)
+      # 0x33: LA_NFCID1 = [ 0x04 0x03 0x02 0x01 ] ("Unique" NFCID1 ID in SENS_RES)
+      # 0x54: LF_CON_BITR_F = 0x06 (Bit rates to listen for: Both)
+      # 0x50: LF_PROTOCOL_TYPE = 0x02 (Protocols supported in Listen Mode for NFC-F: NFC-DEP)
+      # 0x5B: LI_BIT_RATE = 0x00 (Maximum supported bit rate: 106 Kbit/s)
+      # 0x60: LN_WT = 0x0E (Waiting Time NFC-DEP WT_MAX default for Initiator)
+      # 0x80: RF_FIELD_INFO = 0x01 (Chip is allowed to emit RF Field Information Notifications)
+      # 0x81: RF_NFCEE_ACTION = 0x01 (Chip should send trigger notification for the default set of NFCEE actions)
+      # 0x82: NFCDEP_OP = 0x0E (NFC-DEP protocol behavior: Default flags, but also enable RTOX requests)
+      # 0x18: PF_BIT_RATE = 0x01 (NFC-F discovery polling initial bit rate: 106 Kbit/s)
+      NXP_CORE_CONF = ''
+        {20, 02, 2B, 0D,
+          28, 01, 00,
+          21, 01, 00,
+          30, 01, 08,
+          31, 01, 03,
+          33, 04, 04, 03, 02, 01,
+          54, 01, 06,
+          50, 01, 02,
+          5B, 01, 00,
+          60, 01, 0E,
+          80, 01, 01,
+          81, 01, 01,
+          82, 01, 0E,
+          18, 01, 01
+        }
+      '';
+      # Configure the proprietary NXP extension to the NCI standard in EEPROM:
+      # 0xA0 0x5E: JEWEL_RID_CFG = 0x01 (Enable sending RID to T1T on RF)
+      # 0xA0 0x40: TAG_DETECTOR_CFG = 0x00 (Tag detector: Disable both AGC based detection and trace mode)
+      # 0xA0 0x43: TAG_DETECTOR_FALLBACK_CNT_CFG = 0x00 (Tag detector: Disable hybrid mode, only use LPCD to initiate polling)
+      # 0xA0 0x0F: DH_EEPROM_AREA_1 = [ 32 bytes of opaque Lenovo data ] (Custom configuration for the Lenovo customized chip firmware)
+      # See also https://github.com/nfc-tools/libnfc/issues/455#issuecomment-2221979571
+      NXP_CORE_CONF_EXTN = ''
+        {20, 02, 30, 04,
+          A0, 5E, 01, 01,
+          A0, 40, 01, 00,
+          A0, 43, 01, 00,
+          A0, 0F, 20,
+          00, 03, 1D, 01, 03, 00, 02, 00,
+          01, 00, 01, 00, 00, 00, 00, 00,
+          00, 00, 00, 00, 00, 00, 00, 00,
+          00, 00, 00, 00, 00, 00, 00, 00
+        }
+      '';
+      # Firmware-specific protocol configuration parameters (one byte per protocol)
+      NXP_NFC_PROPRIETARY_CFG = "{05:FF:FF:06:81:80:70:FF:FF}";
+      # Configure power supply of chip, use Lenovo driver configuration, which deviates a bit from the spec:
+      # 0xA0 0x0E: PMU_CFG = [ 0x16, 0x09, 0x00 ] (VBAT1 connected to 5V, TVDD monitoring: 3.6V, TxLDO Voltage in reader and card mode: 3.3V)
+      NXP_EXT_TVDD_CFG = "0x01";
+      NXP_EXT_TVDD_CFG_1 = ''
+        {20, 02, 07, 01,
+          A0, 0E, 03, 16, 09, 00
+        }
+      '';
+      # Use the default for NFA_EE_MAX_EE_SUPPORTED stack size (concerns HCI)
+      NXP_NFC_MAX_EE_SUPPORTED = "0x00";
+    };
+  };
+
+  generateSettings =
+    cfgName:
+    let
+      toKeyValueLines =
+        obj: builtins.concatStringsSep "\n" (map (key: "${key}=${obj.${key}}") (builtins.attrNames obj));
+    in
+    toKeyValueLines (defaultSettings.${cfgName} // (cfg.settings.${cfgName} or { }));
+in
+{
+  options.hardware.nfc-nci = {
+    enable = lib.mkEnableOption "PN5xx kernel module with udev rules, libnfc-nci userland, and optional ifdnfc-nci PC/SC driver";
+
+    settings = lib.mkOption {
+      default = defaultSettings;
+      description = ''
+        Configuration to be written to the libncf-nci configuration files.
+        To understand the configuration format, refer to https://github.com/NXPNFCLinux/linux_libnfc-nci/tree/master/conf.
+      '';
+      type = lib.types.attrs;
+    };
+
+    enableIFD = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Register ifdnfc-nci as a serial reader with pcscd.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages =
+      [
+        pkgs.libnfc-nci
+      ]
+      ++ lib.optionals cfg.enableIFD [
+        pkgs.ifdnfc-nci
+      ];
+
+    environment.etc = {
+      "libnfc-nci.conf".text = generateSettings "nci";
+      "libnfc-nxp-init.conf".text = generateSettings "init";
+      "libnfc-nxp-pn547.conf".text = generateSettings "pn54x";
+      "libnfc-nxp-pn548.conf".text = generateSettings "pn54x";
+    };
+
+    services.udev.packages = [
+      config.boot.kernelPackages.nxp-pn5xx
+    ];
+
+    boot.blacklistedKernelModules = [
+      "nxp_nci_i2c"
+      "nxp_nci"
+    ];
+
+    boot.extraModulePackages = [
+      config.boot.kernelPackages.nxp-pn5xx
+    ];
+
+    boot.kernelModules = [
+      "nxp-pn5xx"
+    ];
+
+    services.pcscd.readerConfigs = lib.mkIf cfg.enableIFD [
+      ''
+        FRIENDLYNAME "NFC NCI"
+        LIBPATH      ${pkgs.ifdnfc-nci}/lib/libifdnfc-nci.so
+        CHANNELID    0
+      ''
+    ];
+
+    # NFC chip looses power when system goes to sleep / hibernate,
+    # and needs to be re-initialized upon wakeup
+    powerManagement.resumeCommands = lib.mkIf cfg.enableIFD ''
+      systemctl restart pcscd.service
+    '';
+  };
+
+  meta.maintainers = with lib.maintainers; [ stargate01 ];
+}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -85,6 +85,7 @@
   ./hardware/network/eg25-manager.nix
   ./hardware/network/intel-2200bg.nix
   ./hardware/new-lg4ff.nix
+  ./hardware/nfc-nci.nix
   ./hardware/nitrokey.nix
   ./hardware/onlykey/default.nix
   ./hardware/openrazer.nix

--- a/pkgs/by-name/if/ifdnfc-nci/package.nix
+++ b/pkgs/by-name/if/ifdnfc-nci/package.nix
@@ -1,0 +1,39 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  cmake,
+  pcsclite,
+  libnfc-nci,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "ifdnfc-nci";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "StarGate01";
+    repo = "ifdnfc-nci";
+    tag = "v${finalAttrs.version}";
+    sha256 = "sha256-I2MNzmaxQUh4bN3Uytf2bQRthByEaFWM7c79CKZJQZA=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    pcsclite
+    libnfc-nci
+  ];
+
+  meta = {
+    description = "PC/SC IFD Handler based on linux_libnfc-nci";
+    homepage = "https://github.com/StarGate01/ifdnfc-nci";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+    maintainers = with lib.maintainers; [ stargate01 ];
+  };
+})

--- a/pkgs/by-name/li/libnfc-nci/package.nix
+++ b/pkgs/by-name/li/libnfc-nci/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  autoreconfHook,
+  pkg-config,
+  config,
+  debug ? config.libnfc-nci.debug or false,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "libnfc-nci";
+  version = "2.4.1-unstable-2024-08-05";
+
+  src = fetchFromGitHub {
+    owner = "StarGate01";
+    repo = "linux_libnfc-nci";
+    rev = "7ce9c8aad0e37850a49b6d8dcc22ae5c783268e7";
+    sha256 = "sha256-iSvDiae+A2hUok426Lj5TMn3Q9G+vH1G0jajP48PehQ=";
+  };
+
+  buildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+
+  configureFlags =
+    [
+      "--enable-i2c"
+    ]
+    ++ lib.optionals debug [
+      "--enable-debug"
+    ];
+  dontStrip = debug;
+
+  postInstall = ''
+    rm -rf $out/etc
+  '';
+
+  meta = {
+    description = "Linux NFC stack for NCI based NXP NFC Controllers";
+    homepage = "https://github.com/NXPNFCLinux/linux_libnfc-nci";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ stargate01 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/os-specific/linux/nxp-pn5xx/default.nix
+++ b/pkgs/os-specific/linux/nxp-pn5xx/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  kernel,
+  kernelModuleMakeFlags,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "nxp-pn5xx";
+  version = "0.4-unstable-2025-02-08-${kernel.version}";
+
+  src = fetchFromGitHub {
+    owner = "jr64";
+    repo = "nxp-pn5xx";
+    rev = "07411e0ce3445e7dcb970df1837f0ad74b7b0a7a";
+    hash = "sha256-jVkcvURFlihKW2vFvAaqzKdtexPXywRa2LkPkIhmdeU=";
+  };
+
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  makeFlags = kernelModuleMakeFlags ++ [
+    "KERNELRELEASE=${kernel.modDirVersion}"
+    "BUILD_KERNEL_PATH=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
+    "INSTALL_MOD_PATH=$(out)/lib/modules/${kernel.modDirVersion}"
+  ];
+
+  postInstall = ''
+    mkdir -p $out/etc/udev/rules.d
+    echo 'SUBSYSTEM=="misc", KERNEL=="pn544", MODE="0666", GROUP="dialout"' > $out/etc/udev/rules.d/99-nxp-pn5xx.rules
+  '';
+
+  meta = {
+    description = "NXP's NFC Open Source Kernel mode driver with ACPI configuration support";
+    homepage = "https://github.com/jr64/nxp-pn5xx";
+    license = lib.licenses.gpl2Only;
+    maintainers = with lib.maintainers; [ stargate01 ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/top-level/linux-kernels.nix
+++ b/pkgs/top-level/linux-kernels.nix
@@ -457,6 +457,8 @@ in {
     nvidia_x11_stable_open       = nvidiaPackages.stable.open;
     nvidia_x11_vulkan_beta_open  = nvidiaPackages.vulkan_beta.open;
 
+    nxp-pn5xx = callPackage ../os-specific/linux/nxp-pn5xx { };
+
     openrazer = callPackage ../os-specific/linux/openrazer/driver.nix { };
 
     ply = callPackage ../os-specific/linux/ply { };


### PR DESCRIPTION
This PR adds a new NFC stack based on the NXP libnfc-nci userland, an ACPI-configured kernel driver, and a pcscd-lite module for easy use.

This module specifically targets the NFC chipset commonly found in Lenovo Thinkpads, the NXP `NXP1001` module. Unfortunately this chipset has no proper support in either `libnfc` or `neard` (i.e. the upstream Linux kernel).

The implementation and configuration has been engineered in a community effort over a few years. For details, please refer to https://github.com/nfc-tools/libnfc/issues/455 , specifically https://github.com/nfc-tools/libnfc/issues/455#issuecomment-2210704361 , https://github.com/nfc-tools/libnfc/issues/455#issuecomment-2221979571 , and https://github.com/nfc-tools/libnfc/issues/455#issuecomment-2229756225 for my implementation.

The PR adds the following new packages / modules:
- **linuxPackages.nxp-pn5xx: init at 0.4-unstable**: The kernel driver, sourced from https://github.com/jr64/nxp-pn5xx , which in turn is a fork of the original sources by NXP (https://github.com/NXPNFCLinux/nxp-pn5xx), with the added capability of automatic hardware configuration via the ACPI tables, and updates for compilation with modern recent kernel version.
- **libnfc-nci: init at 2.4.1-unstable**: The userland library which interfaces the kernel driver, sourced from https://github.com/StarGate01/linux_libnfc-nci/ . This is a fork of the original NXP library (https://github.com/NXPNFCLinux/linux_libnfc-nci) with quite a few patches and configurations from the community and myself, in order to make the library work properly for the Lenovo chipset.
- **ifdnfc-nci: init at 0.2.1**: The pcsc-lite IFD handler to expose the NFC chip as a PC/SC compliant reader for APDU exchange. Sourced from https://github.com/StarGate01/ifdnfc-nci , uses the modified libnfc-nci library. This enables other applications like Firefox, Yubico Authenticator, and KeePassXC to use the NFC chip as NFC a smartcard reader.
- **pcscd: allow multiple readerConfig entries**: Does what it says. This is used by the nixos module to automatically add the IFD handler to the pscs-lite configuration file.
- **nixos/nfc-nci: init**: Adds a new NixOS module to enable and configure this entire stack et once via `config.hardware.nfc-nci`. It sets up:
  - Blacklisted (conflicting) kernel modules: `nxp_nci_i2c` and `nxp_nci` (default, configurable via `config.hardware.nfc-nci.blacklistedKernelModules`
  - libnfc-nci required configuration files at `/etc/libnfc-{nci,nxp-init,nxp-pn547,nxp-pn548}.conf`, with the values taken from `config.hardware.nfc-nci.settings.{nci,init,pn54x}`, respectively. The default values provide a sane configuration for the Lenovo module.
  - Udev rules for the `/dev/pn544` device node, this rule is exposed by the kernel package.
  - Add the kernel module to the list of loaded modules and enable it
  - Set up the pcsc-lite IFD handler, this can be controlled by `config.hardware.nfc-nci.enableIFD`.
  - Set up a systemd rule to recover the NFC module from hibernation-induced powerdown

I do realize this is quite a big PR, and I invite the community and also all the people from https://github.com/nfc-tools/libnfc/issues/455 to critique and improve this PR. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
