### PR TITLE
nixos/picom: update configuration format

### DIFF
--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -23,40 +23,38 @@ let
   # Basically a tinkered lib.generators.mkKeyValueDefault
   # It either serializes a top-level definition "key: { values };"
   # or an expression "key = { values };"
-  mkAttrsString = 
+  mkAttrsString =
     top: toList:
-      mapAttrsToList (
-        k: v: 
-        let
-          sep =
-            if (top && isAttrs v)
-            then ": "
-            else " = ";
+    mapAttrsToList (
+      k: v:
+      let
+        sep = if (top && isAttrs v) then ": " else " = ";
       in
-        "${escape [sep] k}${sep}${mkValueString toList v};"
-      );
+      "${escape [ sep ] k}${sep}${mkValueString toList v};"
+    );
 
-    # This serializes a Nix expression to the libconfig format.
-    mkValueString = top: v:
-      if types.bool.check v then 
-        boolToString v
-      else if types.int.check v then
-        toString v
-      else if types.float.check v then
-        toString v
-      else if types.str.check v then
-        ''"${escape [''"''] v}"''
-      else if (builtins.isList v && top) then
-        "( ${concatMapStringsSep " ,\n" (mkValueString false) v} )" # it's LIST according to libconfig settings (ARRAY!=LIST)
-      else if (builtins.isList v && (!top)) then
-        "[ ${concatMapStringsSep " , " (mkValueString false) v} ]" # it's ARRAY according to libconfig settings (ARRAY!=LIST)
-      else if types.attrs.check v then
-        "{ ${concatStringsSep "\n" (mkAttrsString false false v)} }"
-      else
-        throw ''
-          invalid expression used in option services.picom.settings:
-          ${v}
-        '';
+  # This serializes a Nix expression to the libconfig format.
+  mkValueString =
+    top: v:
+    if types.bool.check v then
+      boolToString v
+    else if types.int.check v then
+      toString v
+    else if types.float.check v then
+      toString v
+    else if types.str.check v then
+      ''"${escape [ ''"'' ] v}"''
+    else if (builtins.isList v && top) then
+      "( ${concatMapStringsSep " ,\n" (mkValueString false) v} )" # it's LIST according to libconfig settings (ARRAY!=LIST)
+    else if (builtins.isList v && (!top)) then
+      "[ ${concatMapStringsSep " , " (mkValueString false) v} ]" # it's ARRAY according to libconfig settings (ARRAY!=LIST)
+    else if types.attrs.check v then
+      "{ ${concatStringsSep "\n" (mkAttrsString false false v)} }"
+    else
+      throw ''
+        invalid expression used in option services.picom.settings:
+        ${v}
+      '';
 
   toConf = attrs: concatStringsSep "\n" (mkAttrsString true cfg.settings);
 

--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -20,39 +20,40 @@ let
 
   mkDefaultAttrs = mapAttrs (n: v: mkDefault v);
 
-  # Basically a tinkered lib.generators.mkKeyValueDefault
-  # It either serializes a top-level definition "key: { values };"
-  # or an expression "key = { values };"
-  mkAttrsString =
-    top:
-    mapAttrsToList (
-      k: v:
-      let
-        sep = if (top && isAttrs v) then ":" else "=";
+  mkAttrsString = 
+    top: toList:
+      mapAttrsToList (
+        k: v: 
+        let
+          sep =
+            if (top && isAttrs v)
+            then ": "
+            else " = ";
       in
-      "${escape [ sep ] k}${sep}${mkValueString v};"
-    );
+        "${escape [sep] k}${sep}${mkValueString toList v};"
+      );
 
-  # This serializes a Nix expression to the libconfig format.
-  mkValueString =
-    v:
-    if types.bool.check v then
-      boolToString v
-    else if types.int.check v then
-      toString v
-    else if types.float.check v then
-      toString v
-    else if types.str.check v then
-      "\"${escape [ "\"" ] v}\""
-    else if builtins.isList v then
-      "[ ${concatMapStringsSep " , " mkValueString v} ]"
-    else if types.attrs.check v then
-      "{ ${concatStringsSep " " (mkAttrsString false v)} }"
-    else
-      throw ''
-        invalid expression used in option services.picom.settings:
-        ${v}
-      '';
+    # This serializes a Nix expression to the libconfig format.
+    mkValueString = top: v:
+      if types.bool.check v then 
+        boolToString v
+      else if types.int.check v then
+        toString v
+      else if types.float.check v then
+        toString v
+      else if types.str.check v then
+        ''"${escape [''"''] v}"''
+      else if (builtins.isList v && top) then
+        "( ${concatMapStringsSep " ,\n" (mkValueString false) v} )" # it's LIST according to libconfig settings (ARRAY!=LIST)
+      else if (builtins.isList v && (!top)) then
+        "[ ${concatMapStringsSep " , " (mkValueString false) v} ]" # it's ARRAY according to libconfig settings (ARRAY!=LIST)
+      else if types.attrs.check v then
+        "{ ${concatStringsSep "\n" (mkAttrsString false false v)} }"
+      else
+        throw ''
+          invalid expression used in option services.picom.settings:
+          ${v}
+        '';
 
   toConf = attrs: concatStringsSep "\n" (mkAttrsString true cfg.settings);
 

--- a/nixos/modules/services/x11/picom.nix
+++ b/nixos/modules/services/x11/picom.nix
@@ -20,6 +20,9 @@ let
 
   mkDefaultAttrs = mapAttrs (n: v: mkDefault v);
 
+  # Basically a tinkered lib.generators.mkKeyValueDefault
+  # It either serializes a top-level definition "key: { values };"
+  # or an expression "key = { values };"
   mkAttrsString = 
     top: toList:
       mapAttrsToList (


### PR DESCRIPTION
Currently, there is no way to configure picom's options via `()`, which is required when working with "rules" or "animations"; This PR resolves that issue along with a few code optimizations

Feel free to propose edits I'll be sure to read them and make changes accordingly; Thanks!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
