### PR TITLE
accountsservice: fix build for musl

### DIFF
--- a/pkgs/by-name/ac/accountsservice/no-check-wtmp-path.patch
+++ b/pkgs/by-name/ac/accountsservice/no-check-wtmp-path.patch
@@ -1,0 +1,12 @@
+diff --git a/meson.build b/meson.build
+index 4a509e7..8bcaa97 100644
+--- a/meson.build
++++ b/meson.build
+@@ -104,7 +104,6 @@ elif cc.has_header_symbol('paths.h', '_PATH_WTMPX')
+   config_h.set('PATH_WTMP', '_PATH_WTMPX')
+ else
+   path_wtmp = '/var/log/utx.log'
+-  assert(run_command('test', '-e', path_wtmp, check: false).returncode() == 0, 'Do not know which filename to watch for wtmp changes')
+   config_h.set_quoted('PATH_WTMP', path_wtmp)
+ endif
+ 

--- a/pkgs/by-name/ac/accountsservice/package.nix
+++ b/pkgs/by-name/ac/accountsservice/package.nix
@@ -54,6 +54,12 @@ stdenv.mkDerivation rec {
     # Detect DM type from config file.
     # `readlink display-manager.service` won't return any of the candidates.
     ./get-dm-type-from-config.patch
+
+    # Don't assert on the existence of a path in /var/log, which will
+    # never exist inside the sandbox.
+    # Upstream is on board, but it's stalled:
+    # https://gitlab.freedesktop.org/accountsservice/accountsservice/-/merge_requests/97#note_1756635
+    ./no-check-wtmp-path.patch
   ];
 
   nativeBuildInputs =

--- a/pkgs/by-name/fl/flatpak/package.nix
+++ b/pkgs/by-name/fl/flatpak/package.nix
@@ -62,6 +62,7 @@
   withMan ? true,
   withSELinuxModule ? false,
   withSystemd ? true,
+  pkgsMusl,
 }:
 
 stdenv.mkDerivation (finalAttrs: {
@@ -235,6 +236,8 @@ stdenv.mkDerivation (finalAttrs: {
       '';
 
       version = testers.testVersion { package = finalAttrs.finalPackage; };
+
+      musl = pkgsMusl.flatpak;
     };
 
     updateScript = nix-update-script { };


### PR DESCRIPTION
This is now a transitive dependency of flatpak, which was previously buildable for musl.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
