### PR TITLE
nixos/wireshark: usbmon permissions

### DIFF
--- a/nixos/modules/programs/wireshark.nix
+++ b/nixos/modules/programs/wireshark.nix
@@ -16,12 +16,31 @@ in
         type = lib.types.bool;
         default = false;
         description = ''
-          Whether to add Wireshark to the global environment and configure a
-          setcap wrapper for 'dumpcap' for users in the 'wireshark' group.
+          Whether to add Wireshark to the global environment and create a 'wireshark'
+          group. To configure what users can capture, set the `dumpcap.enable` and
+          `usbmon.enable` options. By default, users in the 'wireshark' group are
+          allowed to capture network traffic but not USB traffic.
         '';
       };
       package = lib.mkPackageOption pkgs "wireshark-cli" {
         example = "wireshark";
+      };
+      dumpcap.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to allow users in the 'wireshark' group to capture network traffic. This
+          configures a setcap wrapper for 'dumpcap' for users in the 'wireshark' group.
+        '';
+      };
+      usbmon.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to allow users in the 'wireshark' group to capture USB traffic. This adds
+          udev rules to give users in the 'wireshark' group read permissions to all devices
+          in the usbmon subsystem.
+        '';
       };
     };
   };
@@ -30,12 +49,18 @@ in
     environment.systemPackages = [ wireshark ];
     users.groups.wireshark = { };
 
-    security.wrappers.dumpcap = {
+    security.wrappers.dumpcap = lib.mkIf cfg.dumpcap.enable {
       source = "${wireshark}/bin/dumpcap";
       capabilities = "cap_net_raw,cap_net_admin+eip";
       owner = "root";
       group = "wireshark";
       permissions = "u+rx,g+x";
     };
+
+    services.udev.packages = lib.mkIf cfg.usbmon.enable [
+      (pkgs.writeTextDir "etc/udev/rules.d/85-wireshark-usbmon.rules" ''
+        SUBSYSTEM=="usbmon", MODE="0640", GROUP="wireshark"
+      '')
+    ];
   };
 }


### PR DESCRIPTION
This PR fixes #375657. It adds two boolean options:

- `wireshark.usbmon.enable`: If set to true, adds an /etc/udev/rules.d rule to set permissions on `usbmon` devices to 640, which allows users in the `wireshark` group to capture USB traffic. Defaults to false for backward compatibility.
- `wireshark.dumpcap.enable`: If set to true, gives users in the `wireshark` rules permissions for capturing network traffic. Defaults to true for backward compatibility. Adding this option allows users that want to capture USB traffic but not network traffic to set the correct permissions.

The PR also updates the description to reflect the new options.

@bjornfor @fpletz 

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [X] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
