### PR TITLE
nexusmods-app: 0.7.2 -> 0.7.3

### DIFF
--- a/pkgs/by-name/ne/nexusmods-app/deps.json
+++ b/pkgs/by-name/ne/nexusmods-app/deps.json
@@ -780,9 +780,19 @@
     "hash": "sha256-idb2hvuDlxl83x0yttGHnTgEQmwLLdUT7QfMeGDXVJE="
   },
   {
+    "pname": "Jamarino.IntervalTree",
+    "version": "1.2.2",
+    "hash": "sha256-L8vFWl+1OUviHB+TOkw7Po0+IBLnJMZ1fnvqcYQOuRQ="
+  },
+  {
     "pname": "JetBrains.Annotations",
     "version": "2024.3.0",
     "hash": "sha256-BQYhE7JDJ9Bw588KyWzOvQFvQTiRa0K9maVkI9lZgBc="
+  },
+  {
+    "pname": "Jitbit.FastCache",
+    "version": "1.1.0",
+    "hash": "sha256-UJjNHEyBsi+XRkTF/D5EIIhVMchybD9INtXthXo49bg="
   },
   {
     "pname": "K4os.Compression.LZ4",
@@ -798,6 +808,11 @@
     "pname": "LinqGen",
     "version": "0.3.1",
     "hash": "sha256-Yyt1uShHigHVCIjPT8jL2Kth9L9yq1MGrCM5w2+tj9o="
+  },
+  {
+    "pname": "LinuxDesktopUtils.XDGDesktopPortal",
+    "version": "1.0.0",
+    "hash": "sha256-DTxWI/DI01Flb4yfSxukaEw6roSzD9iy4Twy1I8/5Mg="
   },
   {
     "pname": "LiveChartsCore",
@@ -893,6 +908,11 @@
     "pname": "Microsoft.Bcl.AsyncInterfaces",
     "version": "7.0.0",
     "hash": "sha256-1e031E26iraIqun84ad0fCIR4MJZ1hcQo4yFN+B7UfE="
+  },
+  {
+    "pname": "Microsoft.Bcl.AsyncInterfaces",
+    "version": "8.0.0",
+    "hash": "sha256-9aWmiwMJKrKr9ohD1KSuol37y+jdDxPGJct3m2/Bknw="
   },
   {
     "pname": "Microsoft.Build.Tasks.Git",
@@ -1606,18 +1626,18 @@
   },
   {
     "pname": "NexusMods.MnemonicDB",
-    "version": "0.9.97",
-    "hash": "sha256-b0k/hM6UYvMTZN2QMk53QN9Fw/pomXJ88k9QqfrAF+s="
+    "version": "0.9.98",
+    "hash": "sha256-1B1PBH/iUuLOPsUo5WAsSAkDGWQBTlY8sk/sAiugpB0="
   },
   {
     "pname": "NexusMods.MnemonicDB.Abstractions",
-    "version": "0.9.97",
-    "hash": "sha256-EnWQMeXMKwziMoBXKf7t+Ru6EHZBml4Pt3h1eSP1Ud0="
+    "version": "0.9.98",
+    "hash": "sha256-rZ9UP6BcxYPlHKqyGj0G5q+woEjvpRS/jg69UY4aWDE="
   },
   {
     "pname": "NexusMods.MnemonicDB.SourceGenerator",
-    "version": "0.9.97",
-    "hash": "sha256-KOZVhS3H/qY6bRW9HmSF1Ud4fXv5oEWORDdYET9Ochw="
+    "version": "0.9.98",
+    "hash": "sha256-jP07gJZQ9ZT9DXyWIQOlgmZx0onqiUe3w2JiN55NA94="
   },
   {
     "pname": "NexusMods.Paths",
@@ -1638,6 +1658,11 @@
     "pname": "NexusMods.Paths.TestingHelpers",
     "version": "0.15.0",
     "hash": "sha256-xUZIAND1Ob0SRuoTTuJqw7N2j/4ncIlck3lgfeWxd5M="
+  },
+  {
+    "pname": "NLog",
+    "version": "5.2.8",
+    "hash": "sha256-IrCChiy703DRIebN//M4wwXW7gayuCVD/dHKXCoQcPw="
   },
   {
     "pname": "NLog",
@@ -2163,6 +2188,11 @@
     "pname": "SkiaSharp.NativeAssets.Win32",
     "version": "2.88.9",
     "hash": "sha256-kP5XM5GgwHGfNJfe4T2yO5NIZtiF71Ddp0pd1vG5V/4="
+  },
+  {
+    "pname": "SmartFormat",
+    "version": "3.5.1",
+    "hash": "sha256-NwvJBCT2BBfJgGa/LMbvan0XqZhRBYzlpMLtC3l5SOM="
   },
   {
     "pname": "Spectre.Console",
@@ -3078,6 +3108,11 @@
     "pname": "TextMateSharp.Grammars",
     "version": "1.0.64",
     "hash": "sha256-ykBZOyvaX1/iFmZjue754qJG4jfPx38ZdHevEZvh7w8="
+  },
+  {
+    "pname": "Tmds.DBus.Protocol",
+    "version": "0.18.0",
+    "hash": "sha256-u5bRK7XbxU/NdMu8PZqxb3fmRdPTbimQ/YIe5/scPOo="
   },
   {
     "pname": "Tmds.DBus.Protocol",

--- a/pkgs/by-name/ne/nexusmods-app/package.nix
+++ b/pkgs/by-name/ne/nexusmods-app/package.nix
@@ -25,12 +25,12 @@ let
 in
 buildDotnetModule (finalAttrs: {
   inherit pname;
-  version = "0.7.2";
+  version = "0.7.3";
 
   src = fetchgit {
     url = "https://github.com/Nexus-Mods/NexusMods.App.git";
     rev = "refs/tags/v${finalAttrs.version}";
-    hash = "sha256-Kss1K1ZqXLZ/WbbyY3ZQRe8Kvmjdu3tRGfcagE7Q42Q=";
+    hash = "sha256-p3MTxuLR/mkVrL+hwW2R13/eVHWWulZPRh9OsuHq9kU=";
     fetchSubmodules = true;
     fetchLFS = true;
   };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Bump version: 0.7.2 -> 0.7.3
- [Upstream's changelog](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.7.3)
- [Previous update PR](https://github.com/NixOS/nixpkgs/pull/375824)

Also:
- Still need .NET 8 runtime available while building 😦
- The package's tests have been flaky, I didn't try them this time.

## Notes for end-users

> [!TIP]
> When upgrading from version 0.7.0 or newer, it _should_ be safe to upgrade **without** resetting/uninstalling.

> [!CAUTION]
> When upgrading from a **version older than 0.7.0**, you will need a fresh start.
> If you have configuration leftover from an old version, the updated app will crash.
>
> See upstream's guide on [how to uninstall the app](https://nexus-mods.github.io/NexusMods.App/users/Uninstall).

<details><summary>Resetting tips</summary>
<p>

You can reset all modded games and wipe your nexusmods-app config using:
```
NexusMods.App uninstall-app
```
- This should be done **before** updating the app.
- **Be careful**: There's no way to recover a wiped config!

If you've run the appimage version from upstream, or a pre-0.6 nixpkgs version, you may also need to remove old desktop entries to avoid other issues:
```
rm ~/.local/share/applications/com.nexusmods.app.desktop
```


</p>
</details>

> [!CAUTION]
> Known issues are listed on the [changelog](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.7.3), but include:
> - On Windows, a Command Prompt window will appear behind the app while it is running.
> - When viewing a read-only collection, it is still possible to toggle individual mods on and off, but this does not affect your loadout.
> - Stardew Valley (Native Linux version) is not detected when installed via Heroic Launcher on Linux. The Windows version of the game can be used instead until this issue is fixed.
> - Bundled mods included with collections do not appear in the UI but are still applied to your game.
> - The success rating for collections does not show the correct value.
> - The game version is not checked when adding a collection meaning you can install outdated mods without being warned.
> - The "Switch View" option does not persist in the Library/Installed Mods view.
> - The "Load Order" heading toggle does not persist in the Load Order view.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

