### PR TITLE
README: Updated dead link for nix channel manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ system, [Hydra](https://hydra.nixos.org/).
 Artifacts successfully built with Hydra are published to cache at
 https://cache.nixos.org/. When successful build and test criteria are
 met, the Nixpkgs expressions are distributed via [Nix
-channels](https://nixos.org/manual/nix/stable/package-management/channels.html).
+channels](https://nix.dev/manual/nix/2.24/command-ref/nix-channel.html).
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ system, [Hydra](https://hydra.nixos.org/).
 Artifacts successfully built with Hydra are published to cache at
 https://cache.nixos.org/. When successful build and test criteria are
 met, the Nixpkgs expressions are distributed via [Nix
-channels](https://nix.dev/manual/nix/2.24/command-ref/nix-channel.html).
+channels](https://nix.dev/manual/nix/stable/command-ref/nix-channel.html).
 
 # Contributing
 


### PR DESCRIPTION
The current link for nix channels leads to a dead manual page.

The new link would lead to the nix-channel command on the manual. However it would also be reasonable for it to lead to the [wiki](https://nixos.wiki/wiki/Nix_channels) entry on nix channels, or on the channels section of the [FAQ](https://nix.dev/concepts/faq#channel-branches), however the ladder option already leads to the nix-channel command manual entry "for more information".



<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

Updated README.md file to redirect the nix-channel link to an existing page on the manual, since the original link doesn't work anymore.
 

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
