### PR TITLE
python3Packages.kconfiglib: add patch to parse 'modules' option

### DIFF
--- a/pkgs/development/python-modules/kconfiglib/0001-Add-rudimentary-support-for-modules-property.patch
+++ b/pkgs/development/python-modules/kconfiglib/0001-Add-rudimentary-support-for-modules-property.patch
@@ -1,0 +1,41 @@
+From 3161fec0b9ff9154dbd952c3481400118fabb744 Mon Sep 17 00:00:00 2001
+From: Helmut Grohne <helmut.grohne@intenta.de>
+Date: Thu, 21 Apr 2022 10:07:53 +0200
+Subject: [PATCH] Add rudimentary support for modules property
+
+In linux commit 6dd85ff178cd76851e2184b13e545f5a88d1be30, Linux Torvalds
+changed "option modules" to plain "modules" since it was the only option
+left. kconfiglib does not have much support for either besides parsing
+it and suppressing warnings when it is applied to the 'MODULES' symbol.
+Mirror this behaviour for the newer "modules" property.
+
+Fixes: #106
+---
+ kconfiglib.py | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/kconfiglib.py b/kconfiglib.py
+index c67895c..ccef123 100644
+--- a/kconfiglib.py
++++ b/kconfiglib.py
+@@ -3263,6 +3263,20 @@ def _parse_props(self, node):
+                 else:
+                     self._parse_error("unrecognized option")
+ 
++            elif t0 is _T_MODULES:
++                # 'modules' formerly was 'option modules'. See above for why
++                # and when it is ignored. It was changed in
++                # linux commit 6dd85ff178cd76851e2184b13e545f5a88d1be30.
++                if node.item is not self.modules:
++                    self._warn("the 'modules' property is not supported. Let "
++                               "me know if this is a problem for you, as it "
++                               "wouldn't be that hard to implement. Note that "
++                               "modules are supported -- Kconfiglib just "
++                               "assumes the symbol name MODULES, like older "
++                               "versions of the C implementation did when "
++                               "'modules' wasn't used.",
++                               self.filename, self.linenr)
++
+             elif t0 is _T_OPTIONAL:
+                 if node.item.__class__ is not Choice:
+                     self._parse_error('"optional" is only valid for choices')

--- a/pkgs/development/python-modules/kconfiglib/default.nix
+++ b/pkgs/development/python-modules/kconfiglib/default.nix
@@ -14,6 +14,11 @@ buildPythonPackage rec {
     sha256 = "0g690bk789hsry34y4ahvly5c8w8imca90ss4njfqf7m2qicrlmy";
   };
 
+  patches = [
+    # see https://github.com/ulfalizer/Kconfiglib/pull/119
+    ./0001-Add-rudimentary-support-for-modules-property.patch
+  ];
+
   # doesnt work out of the box but might be possible
   doCheck = false;
 


### PR DESCRIPTION
The upstream version of kconfiglib has not been maintained since 2020, and as a result, this version is no longer compatible with the Linux kernel as of 2021. A patch is available that restores kconfiglib's functionality (which is also being [used by Debian](https://sources.debian.org/patches/kconfiglib/14.1.0-4/)). I recommend adding this patch to nixpkgs until Zephyr assumes maintainership and releases their fork on PyPI.
 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
