### PR TITLE
gnuradioPackages.lora_sdr: init at unstable-2025-01-09

### DIFF
--- a/pkgs/development/gnuradio-modules/lora_sdr/default.nix
+++ b/pkgs/development/gnuradio-modules/lora_sdr/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  mkDerivation,
+  fetchFromGitHub,
+  gnuradio,
+  cmake,
+  pkg-config,
+  logLib,
+  mpir,
+  gmp,
+  boost,
+  python,
+  gnuradioOlder,
+}:
+
+mkDerivation {
+  pname = "gr-lora_sdr";
+  version = "unstable-2025-01-09";
+
+  src = fetchFromGitHub {
+    owner = "tapparelj";
+    repo = "gr-lora_sdr";
+    rev = "9befbad3e6120529918acf1a742e25465f6b95e4";
+    hash = "sha256-9oBdzoS2aWWXmiUk5rI0gG3g+BJqUDgMu3/PmZSUkuU=";
+  };
+  disabled = gnuradioOlder "3.10";
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs =
+    [
+      logLib
+      mpir
+      gmp
+      boost
+    ]
+    ++ lib.optionals (gnuradio.hasFeature "python-support") [
+      python.pkgs.pybind11
+      python.pkgs.numpy
+    ];
+
+  cmakeFlags = [
+    (lib.cmakeBool "ENABLE_PYTHON" (gnuradio.hasFeature "python-support"))
+  ];
+
+  meta = {
+    description = "Fully-functional GNU Radio software-defined radio (SDR) implementation of a LoRa transceiver";
+    homepage = "https://www.epfl.ch/labs/tcl/resources-and-sw/lora-phy/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ chuangzhu ];
+    platforms = lib.platforms.unix;
+  };
+}

--- a/pkgs/top-level/gnuradio-packages.nix
+++ b/pkgs/top-level/gnuradio-packages.nix
@@ -37,6 +37,8 @@ in {
 
   bladeRF = callPackage ../development/gnuradio-modules/bladeRF/default.nix { };
 
+  lora_sdr = callPackage ../development/gnuradio-modules/lora_sdr/default.nix { };
+
   osmosdr = callPackage ../development/gnuradio-modules/osmosdr/default.nix { };
 
   fosphor = callPackage ../development/gnuradio-modules/fosphor/default.nix { };


### PR DESCRIPTION
https://www.epfl.ch/labs/tcl/resources-and-sw/lora-phy/

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
