### PR TITLE
Petsc

### DIFF
--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -5,6 +5,7 @@
   cctools,
   gfortran,
   python3,
+  withPetsc4py ? false,
   blas,
   lapack,
   mpiSupport ? true,
@@ -37,11 +38,19 @@ stdenv.mkDerivation rec {
   };
 
   strictDeps = true;
-  nativeBuildInputs = [
-    python3
-    gfortran
-    pkg-config
-  ] ++ lib.optional mpiSupport mpi;
+
+  nativeBuildInputs =
+    [
+      python3
+      gfortran
+      pkg-config
+    ]
+    ++ lib.optional mpiSupport mpi
+    ++ lib.optionals withPetsc4py [
+      python3.pkgs.setuptools
+      python3.pkgs.cython
+    ];
+
   buildInputs =
     [
       blas
@@ -53,6 +62,8 @@ stdenv.mkDerivation rec {
       metis
       parmetis
     ];
+
+  propagatedBuildInputs = lib.optional withPetsc4py python3.pkgs.numpy;
 
   postPatch =
     ''
@@ -71,6 +82,7 @@ stdenv.mkDerivation rec {
       "--with-precision=${petsc-precision}"
       "--with-mpi=${if mpiSupport then "1" else "0"}"
     ]
+    ++ lib.optional withPetsc4py "--with-petsc4py=1"
     ++ lib.optionals mpiSupport [
       "--CC=mpicc"
       "--with-cxx=mpicxx"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -20,6 +20,10 @@
   withParmetis ? false,
   scotch,
   withPtscotch ? false,
+  scalapack,
+  withScalapack ? false,
+  mumps_par,
+  withMumps ? false,
   pkg-config,
   p4est,
   zlib, # propagated by p4est but required by petsc
@@ -35,6 +39,8 @@ assert petsc-withp4est -> p4est.mpiSupport;
 assert withParmetis -> (withMetis && mpiSupport);
 
 assert withPtscotch -> mpiSupport;
+assert withScalapack -> mpiSupport;
+assert withMumps -> withScalapack;
 
 stdenv.mkDerivation rec {
   pname = "petsc";
@@ -68,7 +74,9 @@ stdenv.mkDerivation rec {
     ++ lib.optional petsc-withp4est p4est
     ++ lib.optional withMetis metis
     ++ lib.optional withParmetis parmetis
-    ++ lib.optional withPtscotch scotch;
+    ++ lib.optional withPtscotch scotch
+    ++ lib.optional withScalapack scalapack
+    ++ lib.optional withMumps mumps_par;
 
   propagatedBuildInputs = lib.optional withPetsc4py python3.pkgs.numpy;
 
@@ -107,6 +115,14 @@ stdenv.mkDerivation rec {
       "--with-ptscotch=1"
       "--with-ptscotch-include=${scotch.dev}/include"
       "--with-ptscotch-lib=[-L${scotch}/lib,-lptscotch,-lptesmumps,-lptscotchparmetisv3,-lptscotcherr,-lesmumps,-lscotch,-lscotcherr]"
+    ]
+    ++ lib.optionals withScalapack [
+      "--with-scalapack=1"
+      "--with-scalapack-dir=${scalapack}"
+    ]
+    ++ lib.optionals withMumps [
+      "--with-mumps=1"
+      "--with-mumps-dir=${mumps_par}"
     ]
     ++ lib.optionals petsc-withp4est [
       "--with-p4est=1"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -29,11 +29,11 @@ assert petsc-withp4est -> p4est.mpiSupport;
 
 stdenv.mkDerivation rec {
   pname = "petsc";
-  version = "3.21.4";
+  version = "3.22.3";
 
   src = fetchzip {
     url = "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-${version}.tar.gz";
-    hash = "sha256-l7v+ASBL9FLbBmBGTRWDwBihjwLe3uLz+GwXtn8u7e0=";
+    hash = "sha256-MPcOdHp5rMhIA9Yw/btOLcwYn4CpNZkRgPb5nh+9wko=";
   };
 
   strictDeps = true;

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -15,6 +15,7 @@
   hdf5-support ? false,
   hdf5,
   metis,
+  withMetis ? false,
   parmetis,
   withParmetis ? false,
   pkg-config,
@@ -27,6 +28,9 @@
 
 # This version of PETSc does not support a non-MPI p4est build
 assert petsc-withp4est -> p4est.mpiSupport;
+
+# Package parmetis depend on metis and mpi support
+assert withParmetis -> (withMetis && mpiSupport);
 
 stdenv.mkDerivation rec {
   pname = "petsc";
@@ -58,10 +62,8 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional hdf5-support hdf5
     ++ lib.optional petsc-withp4est p4est
-    ++ lib.optionals withParmetis [
-      metis
-      parmetis
-    ];
+    ++ lib.optional withMetis metis
+    ++ lib.optional withParmetis parmetis;
 
   propagatedBuildInputs = lib.optional withPetsc4py python3.pkgs.numpy;
 
@@ -88,9 +90,11 @@ stdenv.mkDerivation rec {
       "--with-cxx=mpicxx"
       "--with-fc=mpif90"
     ]
-    ++ lib.optionals (mpiSupport && withParmetis) [
+    ++ lib.optionals withMetis [
       "--with-metis=1"
       "--with-metis-dir=${metis}"
+    ]
+    ++ lib.optionals withParmetis [
       "--with-parmetis=1"
       "--with-parmetis-dir=${parmetis}"
     ]

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -42,49 +42,64 @@ stdenv.mkDerivation rec {
     gfortran
     pkg-config
   ] ++ lib.optional mpiSupport mpi;
-  buildInputs = [
-    blas
-    lapack
-  ] ++ lib.optional hdf5-support hdf5 ++ lib.optional petsc-withp4est p4est ++ lib.optionals withParmetis [ metis parmetis ];
+  buildInputs =
+    [
+      blas
+      lapack
+    ]
+    ++ lib.optional hdf5-support hdf5
+    ++ lib.optional petsc-withp4est p4est
+    ++ lib.optionals withParmetis [
+      metis
+      parmetis
+    ];
 
-  postPatch = ''
-    patchShebangs ./lib/petsc/bin
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace config/install.py \
-      --replace /usr/bin/install_name_tool ${cctools}/bin/install_name_tool
-  '';
+  postPatch =
+    ''
+      patchShebangs ./lib/petsc/bin
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace config/install.py \
+        --replace /usr/bin/install_name_tool ${cctools}/bin/install_name_tool
+    '';
 
-  configureFlags = [
-    "--with-blas=1"
-    "--with-lapack=1"
-    "--with-scalar-type=${petsc-scalar-type}"
-    "--with-precision=${petsc-precision}"
-    "--with-mpi=${if mpiSupport then "1" else "0"}"
-  ] ++ lib.optionals mpiSupport [
-    "--CC=mpicc"
-    "--with-cxx=mpicxx"
-    "--with-fc=mpif90"
-  ] ++ lib.optionals (mpiSupport && withParmetis) [
-    "--with-metis=1"
-    "--with-metis-dir=${metis}"
-    "--with-parmetis=1"
-    "--with-parmetis-dir=${parmetis}"
-  ] ++ lib.optionals petsc-withp4est [
-    "--with-p4est=1"
-    "--with-zlib-include=${zlib.dev}/include"
-    "--with-zlib-lib=[-L${zlib}/lib,-lz]"
-  ] ++ lib.optionals hdf5-support [
-    "--with-hdf5=1"
-    "--with-hdf5-fortran-bindings=1"
-    "--with-hdf5-include=${hdf5.dev}/include"
-    "--with-hdf5-lib=[-L${hdf5}/lib,-lhdf5]"
-  ] ++ lib.optionals petsc-optimized [
-    "--with-debugging=0"
-    "COPTFLAGS=-O3"
-    "FOPTFLAGS=-O3"
-    "CXXOPTFLAGS=-O3"
-    "CXXFLAGS=-O3"
-  ];
+  configureFlags =
+    [
+      "--with-blas=1"
+      "--with-lapack=1"
+      "--with-scalar-type=${petsc-scalar-type}"
+      "--with-precision=${petsc-precision}"
+      "--with-mpi=${if mpiSupport then "1" else "0"}"
+    ]
+    ++ lib.optionals mpiSupport [
+      "--CC=mpicc"
+      "--with-cxx=mpicxx"
+      "--with-fc=mpif90"
+    ]
+    ++ lib.optionals (mpiSupport && withParmetis) [
+      "--with-metis=1"
+      "--with-metis-dir=${metis}"
+      "--with-parmetis=1"
+      "--with-parmetis-dir=${parmetis}"
+    ]
+    ++ lib.optionals petsc-withp4est [
+      "--with-p4est=1"
+      "--with-zlib-include=${zlib.dev}/include"
+      "--with-zlib-lib=[-L${zlib}/lib,-lz]"
+    ]
+    ++ lib.optionals hdf5-support [
+      "--with-hdf5=1"
+      "--with-hdf5-fortran-bindings=1"
+      "--with-hdf5-include=${hdf5.dev}/include"
+      "--with-hdf5-lib=[-L${hdf5}/lib,-lhdf5]"
+    ]
+    ++ lib.optionals petsc-optimized [
+      "--with-debugging=0"
+      "COPTFLAGS=-O3"
+      "FOPTFLAGS=-O3"
+      "CXXOPTFLAGS=-O3"
+      "CXXFLAGS=-O3"
+    ];
 
   hardeningDisable = lib.optionals (!petsc-optimized) [
     "fortify"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -18,6 +18,8 @@
   withMetis ? false,
   parmetis,
   withParmetis ? false,
+  scotch,
+  withPtscotch ? false,
   pkg-config,
   p4est,
   zlib, # propagated by p4est but required by petsc
@@ -31,6 +33,8 @@ assert petsc-withp4est -> p4est.mpiSupport;
 
 # Package parmetis depend on metis and mpi support
 assert withParmetis -> (withMetis && mpiSupport);
+
+assert withPtscotch -> mpiSupport;
 
 stdenv.mkDerivation rec {
   pname = "petsc";
@@ -63,7 +67,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional hdf5-support hdf5
     ++ lib.optional petsc-withp4est p4est
     ++ lib.optional withMetis metis
-    ++ lib.optional withParmetis parmetis;
+    ++ lib.optional withParmetis parmetis
+    ++ lib.optional withPtscotch scotch;
 
   propagatedBuildInputs = lib.optional withPetsc4py python3.pkgs.numpy;
 
@@ -97,6 +102,11 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withParmetis [
       "--with-parmetis=1"
       "--with-parmetis-dir=${parmetis}"
+    ]
+    ++ lib.optionals withPtscotch [
+      "--with-ptscotch=1"
+      "--with-ptscotch-include=${scotch.dev}/include"
+      "--with-ptscotch-lib=[-L${scotch}/lib,-lptscotch,-lptesmumps,-lptscotchparmetisv3,-lptscotcherr,-lesmumps,-lscotch,-lscotcherr]"
     ]
     ++ lib.optionals petsc-withp4est [
       "--with-p4est=1"

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10288,6 +10288,8 @@ self: super: with self; {
 
   pesq = callPackage ../development/python-modules/pesq { };
 
+  petsc4py = toPythonModule (pkgs.petsc.override { python3 = python; withPetsc4py = true; });
+
   pex = callPackage ../development/python-modules/pex { };
 
   pexif = callPackage ../development/python-modules/pexif { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

1. refactor configure phase.
3. petsc4py enabled (petsc 3.21.4->3.22.3 needed for python313Packages.petsc4py module support)
4. add some optional dependency which will be used by firedrake/fenics.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
