### PR TITLE
topiary: 0.5.1 -> 0.6.0

### DIFF
--- a/pkgs/by-name/to/topiary/package.nix
+++ b/pkgs/by-name/to/topiary/package.nix
@@ -11,20 +11,20 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "topiary";
-  version = "0.5.1";
+  version = "0.6.0";
 
   src = fetchFromGitHub {
     owner = "tweag";
     repo = "topiary";
     tag = "v${version}";
-    hash = "sha256-Vsyl4tZ9AWTydpXw9IyvrD2tYiG8ySAD39lPwxRflSc=";
+    hash = "sha256-nRVxjdEtYvgF8Vpw0w64hUd1scZh7f+NjFtbTg8L5Qc=";
   };
 
   nativeBuildInputs = [ installShellFiles ];
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-bk5993v0wn/emzJKvxaPBYjqCmP0BpOuFMga7ZOyqXg=";
+  cargoHash = "sha256-EqalIF1wx3F/5CiD21IaYsPdks6Mv1VfwL8OTRWsWaU=";
 
   # https://github.com/NixOS/nixpkgs/pull/359145#issuecomment-2542418786
   depsExtraArgs.postBuild = ''
@@ -46,12 +46,14 @@ rustPlatform.buildRustPackage rec {
     "--skip=test_fmt_dir"
     "--skip=test_fmt_files"
     "--skip=test_fmt_files_query_fallback"
+    "--skip=test_fmt_invalid"
     "--skip=test_fmt_stdin"
     "--skip=test_fmt_stdin_query"
     "--skip=test_fmt_stdin_query_fallback"
     "--skip=test_vis"
     "--skip=formatted_query_tester"
     "--skip=input_output_tester"
+    "--skip=coverage_tester"
   ];
 
   env.TOPIARY_LANGUAGE_DIR = "${placeholder "out"}/share/queries";


### PR DESCRIPTION
-------

Updated Topiary to v0.6.0

Release: https://github.com/tweag/topiary/releases/tag/v0.6.0

Changelog: https://github.com/tweag/topiary/blob/v0.6.0/CHANGELOG.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc