### PR TITLE
httptap: init at 0.0.8

### DIFF
--- a/pkgs/by-name/ht/httptap/package.nix
+++ b/pkgs/by-name/ht/httptap/package.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildGoModule,
+  fetchFromGitHub,
+  fetchpatch,
+}:
+
+buildGoModule rec {
+  pname = "httptap";
+  version = "0.0.8";
+
+  src = fetchFromGitHub {
+    owner = "monasticacademy";
+    repo = "httptap";
+    tag = "v${version}";
+    hash = "sha256-1BtV5ao5dAKSINdUdJD/wxTMFXXiP8Vy1A7gQfVIsUQ=";
+  };
+
+  patches = [
+    # this patch updates go.mod to include missing dependencies
+    # https://github.com/monasticacademy/httptap/pull/13
+    (fetchpatch {
+      name = "update-go-mod";
+      url = "https://github.com/monasticacademy/httptap/commit/3b520725c784d6435be6a51c58ae847bae729962.patch";
+      hash = "sha256-0dPq0Ldu1m8YZKctFtoUcbQdmx6sqjA8EVhTeMwNWx8=";
+    })
+  ];
+
+  vendorHash = "sha256-+TtHw2KdeNHCgnMnkxJJ9shqsrlbeTzYwbPH0dJmCjM=";
+
+  env.CGO_ENABLED = 0;
+
+  subPackages = [
+    "."
+  ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = {
+    description = "View HTTP/HTTPS requests made by any Linux program";
+    homepage = "https://github.com/monasticacademy/httptap";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ jpetrucciani ];
+    mainProgram = "httptap";
+  };
+}


### PR DESCRIPTION
This PR adds [httptap](https://github.com/monasticacademy/httptap), a new tool for observing inbound and outbound http requests by other applications, with a nice cli wrapper!

cc @SuperSandro2000 (from https://github.com/monasticacademy/httptap/pull/13)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [X] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [X] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
