### PR TITLE
tree-sitter: 0.24.6 -> 0.25.1

### DIFF
--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -26,7 +26,7 @@ let
   # to update:
   # 1) change all these hashes
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
-  # 3) Set GITHUB_TOKEN env variable to avoid api rate limit (Use a Personal Access Token from https://github.com/settings/tokens It does not need any permissions)
+  # 3) Set NIXPKGS_GITHUB_TOKEN env variable to avoid api rate limit (Use a Personal Access Token from https://github.com/settings/tokens It does not need any permissions)
   # 4) run the ./result script that is output by that (it updates ./grammars)
   version = "0.25.1";
   hash = "sha256-xnUhiIeRxD4ZKMUQ6pNEetDqiFqiJsa57BRM2zqNFro=";

--- a/pkgs/development/tools/parsing/tree-sitter/default.nix
+++ b/pkgs/development/tools/parsing/tree-sitter/default.nix
@@ -28,8 +28,8 @@ let
   # 2) nix-build -A tree-sitter.updater.update-all-grammars
   # 3) Set GITHUB_TOKEN env variable to avoid api rate limit (Use a Personal Access Token from https://github.com/settings/tokens It does not need any permissions)
   # 4) run the ./result script that is output by that (it updates ./grammars)
-  version = "0.24.6";
-  hash = "sha256-L7F2/S22knqEdB2hxfqLe5Tcgk0WQqBdFQ7BvHFl4EI=";
+  version = "0.25.1";
+  hash = "sha256-xnUhiIeRxD4ZKMUQ6pNEetDqiFqiJsa57BRM2zqNFro=";
 
   src = fetchFromGitHub {
     owner = "tree-sitter";
@@ -171,7 +171,7 @@ rustPlatform.buildRustPackage {
   inherit src version;
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-wrMqeJxOj9Jp3luy6ir6UzNQClRglqP8pfoqWk+Ky+w=";
+  cargoHash = "sha256-YaXeApg0U97Bm+kBdFdmfnkgg9GBxxYdaDzgCVN2sbY=";
 
   buildInputs = [ installShellFiles ];
   nativeBuildInputs = [ which ] ++ lib.optionals webUISupport [ emscripten ];

--- a/pkgs/development/tools/parsing/tree-sitter/remove-web-interface.patch
+++ b/pkgs/development/tools/parsing/tree-sitter/remove-web-interface.patch
@@ -2,8 +2,9 @@ diff --git a/cli/src/lib.rs b/cli/src/lib.rs
 index 4a00747e..e17d253b 100644
 --- a/cli/src/lib.rs
 +++ b/cli/src/lib.rs
-@@ -5,7 +5,6 @@ pub mod highlight;
+@@ -6,7 +6,6 @@ pub mod highlight;
  pub mod init;
+ pub mod input;
  pub mod logger;
  pub mod parse;
 -pub mod playground;
@@ -15,15 +16,15 @@ index 1758fada..4bc56cc2 100644
 --- a/cli/src/main.rs
 +++ b/cli/src/main.rs
 @@ -23,7 +23,7 @@ use tree_sitter_cli::{
-     init::{generate_grammar_files, get_root_path, migrate_package_json, JsonConfigOpts},
+     input::{get_input, get_tmp_source_file, CliInput},
      logger,
-     parse::{self, ParseFileOptions, ParseOutput},
--    playground, query, tags,
-+    query, tags,
-     test::{self, TestOptions},
-     test_highlight, test_tags, util, wasm,
- };
-@@ -1205,10 +1205,8 @@ impl Tags {
+     parse::{self, ParseDebugType, ParseFileOptions, ParseOutput, ParseTheme},
+-    playground, query,
++    query,
+     tags::{self, TagsOptions},
+     test::{self, TestOptions, TestStats},
+     test_highlight, test_tags, util, version, wasm,
+@@ -1614,10 +1614,8 @@ impl Tags {
  
  impl Playground {
      fn run(self, current_dir: &Path) -> Result<()> {


### PR DESCRIPTION
## Things done

Release notes: https://github.com/tree-sitter/tree-sitter/releases/tag/v0.25.1

I couldn't update the grammars, first because of the wrong token environment variable, and then because I _still_ got rate limited on the computer I used to run the update.

I'll say that I expect a lot of churn on the patch file to disable the playground, compared to when it used to just `substituteInPlace` a few lines.

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
