### PR TITLE
bash: Make interactive by default

### DIFF
--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -22,7 +22,7 @@
   pkg-config,
   texinfo,
   bison,
-  bash,
+  bashNonInteractive,
 }:
 
 stdenv.mkDerivation rec {
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
   buildInputs =
     [
       perl
-      bash
+      bashNonInteractive
     ]
     ++ lib.optionals enableGhostscript [
       ghostscript

--- a/pkgs/by-name/li/libxo/package.nix
+++ b/pkgs/by-name/li/libxo/package.nix
@@ -1,7 +1,7 @@
 {
   lib,
   autoreconfHook,
-  bash,
+  bashNonInteractive,
   libtool,
   fetchFromGitHub,
   nix-update-script,
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
   buildInputs = [
     autoreconfHook
     # For patchShebangs in postInstall
-    bash
+    bashNonInteractive
     perl
   ];
 

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -24,7 +24,7 @@
 , zlib
 
 # platform-specific dependencies
-, bash
+, bashNonInteractive
 , darwin
 , windows
 
@@ -235,7 +235,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
 
   inherit nativeBuildInputs;
   buildInputs = lib.optionals (!stdenv.hostPlatform.isWindows) [
-    bash # only required for patchShebangs
+    bashNonInteractive # only required for patchShebangs
   ] ++ buildInputs;
 
   prePatch = optionalString stdenv.hostPlatform.isDarwin ''
@@ -329,7 +329,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
 
   postPatch = optionalString (!stdenv.hostPlatform.isWindows) ''
     substituteInPlace Lib/subprocess.py \
-      --replace-fail "'/bin/sh'" "'${bash}/bin/sh'"
+      --replace-fail "'/bin/sh'" "'${bashNonInteractive}/bin/sh'"
   '' + optionalString mimetypesSupport ''
     substituteInPlace Lib/mimetypes.py \
       --replace-fail "@mime-types@" "${mailcap}"
@@ -611,7 +611,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   ] ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
     # Ensure we don't have references to build-time packages.
     # These typically end up in shebangs.
-    pythonOnBuildForHost buildPackages.bash
+    pythonOnBuildForHost buildPackages.bashNonInteractive
   ];
 
   separateDebugInfo = true;

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -3,7 +3,7 @@
   lib,
   fetchurl,
   libiconv,
-  bash,
+  bashNonInteractive,
   updateAutotoolsGnuConfigScriptsHook,
 }:
 
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
   ];
   buildInputs =
     lib.optionals (!stdenv.hostPlatform.isMinGW) [
-      bash
+      bashNonInteractive
     ]
     ++ lib.optionals (!stdenv.hostPlatform.isLinux && !stdenv.hostPlatform.isCygwin) [
       # HACK, see #10874 (and 14664)

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -5,7 +5,7 @@
   fetchurl,
   perl,
   libintl,
-  bash,
+  bashNonInteractive,
   updateAutotoolsGnuConfigScriptsHook,
   gnulib,
   gawk,
@@ -83,7 +83,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook ];
   buildInputs =
     [
-      bash
+      bashNonInteractive
       libintl
     ]
     ++ optionals stdenv.hostPlatform.isSunOS [

--- a/pkgs/development/tools/misc/texinfo/packages.nix
+++ b/pkgs/development/tools/misc/texinfo/packages.nix
@@ -6,7 +6,7 @@
   fetchurl,
   perl,
   libintl,
-  bash,
+  bashNonInteractive,
   updateAutotoolsGnuConfigScriptsHook,
   gnulib,
   gawk,
@@ -57,7 +57,7 @@ let
       xz
       libintl
       libiconv
-      bash
+      bashNonInteractive
       gnulib
       gawk
       freebsd

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -6,8 +6,7 @@
 , bison
 , util-linux
 
-  # patch for cygwin requires readline support
-, interactive ? stdenv.hostPlatform.isCygwin
+, interactive ? true
 , readline
 , withDocs ? null
 , forFHSEnv ? false

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -9,8 +9,7 @@
   # patch for cygwin requires readline support
 , interactive ? stdenv.hostPlatform.isCygwin
 , readline
-, withDocs ? false
-, texinfo
+, withDocs ? null
 , forFHSEnv ? false
 
 , pkgsStatic
@@ -22,6 +21,9 @@ let
     inherit sha256;
   });
 in
+lib.warnIf (withDocs != null) ''
+  bash: `.override { withDocs = true; }` is deprecated, the docs are always included.
+''
 stdenv.mkDerivation rec {
   pname = "bash${lib.optionalString interactive "-interactive"}";
   version = "5.2${patch_suffix}";
@@ -101,7 +103,6 @@ stdenv.mkDerivation rec {
   # Note: Bison is needed because the patches above modify parse.y.
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [ updateAutotoolsGnuConfigScriptsHook bison ]
-    ++ lib.optional withDocs texinfo
     ++ lib.optional stdenv.hostPlatform.isDarwin stdenv.cc.bintools;
 
   buildInputs = lib.optional interactive readline;

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -74,7 +74,7 @@ let
     expand-response-params = "";
     bsdcp = linkBootstrap { paths = [ "bin/bsdcp" ]; };
     patchelf = linkBootstrap { paths = [ "bin/patchelf" ]; };
-    bash = linkBootstrap {
+    bashNonInteractive = linkBootstrap {
       paths = [
         "bin/bash"
         "bin/sh"
@@ -376,13 +376,13 @@ let
         gawk
         diffutils
         patch
-        bash
+        bashNonInteractive
         xz
         gzip
         bzip2
         bsdcp
       ];
-      shell = "${prevStage.bash}/bin/bash";
+      shell = "${prevStage.bashNonInteractive}/bin/bash";
       stdenvNoCC = import ../generic {
         inherit
           config
@@ -471,7 +471,7 @@ in
         # we CAN'T import LLVM because the compiler built here is used to build the final compiler and the final compiler must not be built by the bootstrap compiler
         inherit (bootstrapTools)
           patchelf
-          bash
+          bashNonInteractive
           curl
           coreutils
           diffutils

--- a/pkgs/stdenv/generic/common-path.nix
+++ b/pkgs/stdenv/generic/common-path.nix
@@ -10,7 +10,7 @@
   pkgs.gzip
   pkgs.bzip2.bin
   pkgs.gnumake
-  pkgs.bash
+  pkgs.bashNonInteractive
   pkgs.patch
   pkgs.xz.bin
 

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -770,7 +770,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               bzip2
               xz
               zlib
-              bash
+              bashNonInteractive
               binutils
               coreutils
               diffutils
@@ -806,7 +806,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               gzip
               bzip2
               xz
-              bash
+              bashNonInteractive
               binutils.bintools
               coreutils
               diffutils
@@ -866,7 +866,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
               gzip
               bzip2
               xz
-              bash
+              bashNonInteractive
               coreutils
               diffutils
               findutils

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
-  bash,
+  bashNonInteractive,
   gnugrep,
   fixDarwinDylibNames,
   file,
@@ -37,7 +37,7 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ cmake ] ++ lib.optional stdenv.hostPlatform.isDarwin fixDarwinDylibNames;
-  buildInputs = lib.optional stdenv.hostPlatform.isUnix bash;
+  buildInputs = lib.optional stdenv.hostPlatform.isUnix bashNonInteractive;
 
   patches = [
     # This patches makes sure we do not attempt to use the MD5 implementation

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5586,17 +5586,18 @@ with pkgs;
   ### SHELLS
 
   runtimeShell = "${runtimeShellPackage}${runtimeShellPackage.shellPath}";
-  runtimeShellPackage = bash;
+  runtimeShellPackage = bashNonInteractive;
 
-  bash = lowPrio (callPackage ../shells/bash/5.nix { });
+  bash = callPackage ../shells/bash/5.nix { };
+  bashNonInteractive = lowPrio (callPackage ../shells/bash/5.nix {
+    interactive = false;
+  });
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
-  bashInteractive = callPackage ../shells/bash/5.nix {
-    interactive = true;
-  };
-  bashInteractiveFHS = callPackage ../shells/bash/5.nix {
-    interactive = true;
+  bashInteractive = bash;
+  bashFHS = callPackage ../shells/bash/5.nix {
     forFHSEnv = true;
   };
+  bashInteractiveFHS = bashFHS;
 
   carapace = callPackage ../shells/carapace {
     buildGoModule = buildGo123Module;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5592,11 +5592,9 @@ with pkgs;
   # WARNING: this attribute is used by nix-shell so it shouldn't be removed/renamed
   bashInteractive = callPackage ../shells/bash/5.nix {
     interactive = true;
-    withDocs = true;
   };
   bashInteractiveFHS = callPackage ../shells/bash/5.nix {
     interactive = true;
-    withDocs = true;
     forFHSEnv = true;
   };
 


### PR DESCRIPTION
This is a continuation of @Artturin's https://github.com/NixOS/nixpkgs/pull/151227, which I only saw after I was done with this one :sweat_smile: 

---

The status quo of `bash` not being interactive is frustrating for many users, because trying to use it interactively is just messed up, and `bashInteractive` is not intuitive and barely discoverable.

This was brought to my (and many others) attention by @stahnma in his [talk at CfgMgmtCamp 2025](https://cfp.cfgmgmtcamp.org/ghent2025/talk/YUVUTN/), where he highlighted this as one of the frustrations he ran into when learning Nix.

Why this is fine to change:

- No reason for not making interactive the default was given in the original commit (6c6ff6f36ff26932aa730875bd237c8e37210f0e), but probably it was due to the increase in closure size

- The closure size only increases by 6.9MiB (19.5%) today, with the added dependency on the store paths for readline and ncurses, which are needed on systems in almost all cases anyways. Even `systemd-minimal` includes them

- If somebody really needs to get a more minimal system without those paths, they can use the newly-introduced `bashNonInteractive` instead now

- Though to apply it consistently, they'll need to do that in an overlay like

  ```nix
  final: prev: {
    bash = self.bashNonInteractive;
  }
  ```

  Or alternatively using the `system.replaceDependencies.replacements` NixOS option approach.

While there's also other such `*Interactive` packages that could use the same treatment, `bash` is a great start.

This was already attempted before in <https://github.com/NixOS/nixpkgs/pull/151227>, but was not continued for unknown reason.

To avoid stdenv becoming bigger, all uses of bash in the (working) stdenv's are changed to the explicitly non-interactive version here.

This commit will however still cause a mass rebuild for all packages (and reverse deps) making use of the default bash.

In addition to this main change I've also done a minor bash cleanup in the first commit.

Closes https://github.com/NixOS/nixpkgs/pull/151227

## Things done

- [x] Check that the main `stdenv`'s don't change (linux, darwin, freebsd, cross)

---

This work is funded by [Tweag](https://tweag.io) and [Antithesis](https://antithesis.com/) :sparkles:

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
