### PR TITLE
openterface-qt: add udev rules for user access

### DIFF
--- a/pkgs/by-name/op/openterface-qt/package.nix
+++ b/pkgs/by-name/op/openterface-qt/package.nix
@@ -4,9 +4,22 @@
   makeDesktopItem,
   copyDesktopItems,
   fetchFromGitHub,
+  writeText,
   qt6,
   libusb1,
 }:
+let
+  # Based on upstream instructions: https://github.com/TechxArtisanStudio/Openterface_QT#for-linux-users
+  udevRules = writeText "60-openterface.rules" ''
+    # Serial to HID converter for keyboard/mouse control.
+    # ID 1a86:7523 QinHeng Electronics CH340 serial converter
+    KERNEL=="ttyUSB[0-9]*", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", TAG+="uaccess"
+
+    # "hidraw" device for accessing the host-target toggleable USB port.
+    # ID 534d:2109 MacroSilicon Openterface
+    KERNEL=="hidraw*", ATTRS{idVendor}=="534d", ATTRS{idProduct}=="2109", TAG+="uaccess"
+  '';
+in
 stdenv.mkDerivation (final: {
   pname = "openterface-qt";
   version = "0.1.0";
@@ -33,7 +46,9 @@ stdenv.mkDerivation (final: {
     mkdir -p $out/bin
     cp ./openterfaceQT $out/bin/
     mkdir -p $out/share/pixmaps
-    cp ./images/icon_256.png $out/share/pixmaps/${final.pname}.png
+    cp ./images/icon_256.png $out/share/pixmaps/openterface-qt.png
+    mkdir -p $out/etc/udev/rules.d
+    cp ${udevRules} $out/etc/udev/rules.d/60-openterface.rules
     runHook postInstall
   '';
 


### PR DESCRIPTION
This adds udev rules for the USB devices contained in the Openterface Mini-KVM solution, so that the logged in user can use the device with the following in their configuration:

```nix
{
    environment.systemPackages = [ pkgs.openterface-qt ];
    services.udev.packages = [ pkgs.openterface-qt ];
}
```

This is based upon [the upstream instructions](https://github.com/TechxArtisanStudio/Openterface_QT/blob/b1ed50672913ab30dc64e93be121647974403316/README.md#for-linux-users), but implements tighter rules by matching on USB device IDs, as well as utilizing the modern `uaccess` mechanism (see e.g. [Arch wiki](https://wiki.archlinux.org/title/Udev#Allowing_regular_users_to_use_devices)) which will grant the access to the current "seat", rather than giving a group or the world access to the devices.

Tested that both keyboard-mouse and the toggleable USB port work with these rules.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
