### PR TITLE
erlang_26: 26.2.5.6 -> 26.2.5.7

### DIFF
--- a/pkgs/development/interpreters/erlang/26.nix
+++ b/pkgs/development/interpreters/erlang/26.nix
@@ -1,6 +1,6 @@
 { mkDerivation }:
 
 mkDerivation {
-  version = "26.2.5.6";
-  sha256 = "sha256-5FsLAhbWqXjP18UQGNkbNQmFXlHiNoLY1aTzutLubZI=";
+  version = "26.2.5.7";
+  sha256 = "sha256-SpiovwRjmV+hIIY+qXPs2QOgjhzo3sRtW+cXhOdiwCs=";
 }


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

A new release of OTP 26 https://github.com/erlang/otp/releases/tag/OTP-26.2.5.7

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

```
--------- Report for 'x86_64-linux' ---------
42 packages built:
akkoma beam26Packages.elixir beam26Packages.elixir-ls beam26Packages.elixir_1_14 beam26Packages.elixir_1_15 beam26Packages.elixir_1_16 beam26Packages.elixir_1_17 beam26Packages.elvis-erlang beam26Packages.erlang beam26Packages.erlang-ls beam26Packages.erlfmt beam26Packages.ex_doc beam26Packages.hex beam26Packages.lfe beam26Packages.pc beam26Packages.rebar beam26Packages.rebar3 beam26Packages.rebar3-nix beam26Packages.rebar3-proper beam26Packages.webdriver beamMinimal26Packages.elixir beamMinimal26Packages.elixir-ls beamMinimal26Packages.elixir_1_14 beamMinimal26Packages.elixir_1_15 beamMinimal26Packages.elixir_1_16 beamMinimal26Packages.elixir_1_17 beamMinimal26Packages.elvis-erlang beamMinimal26Packages.erlang beamMinimal26Packages.erlang-ls beamMinimal26Packages.erlfmt beamMinimal26Packages.ex_doc beamMinimal26Packages.hex beamMinimal26Packages.lfe beamMinimal26Packages.pc beamMinimal26Packages.rebar beamMinimal26Packages.rebar3 beamMinimal26Packages.rebar3-nix beamMinimal26Packages.rebar3-proper beamMinimal26Packages.webdriver mobilizon owmods-cli pleroma
```

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
