### PR TITLE
picoscope: 7.1.17-1r17318 -> 7.1.46-1r4685

### DIFF
--- a/pkgs/by-name/pi/picoscope/sources.json
+++ b/pkgs/by-name/pi/picoscope/sources.json
@@ -1,69 +1,104 @@
 {
   "x86_64-linux": {
     "libpicocv": {
-      "sha256": "c0c5bec33c2c7fdd0f26b035ed942175f87012e33d6764c3abf1da31b5626037",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicocv/libpicocv_1.1.34-beta2r172_amd64.deb",
-      "version": "1.1.34-beta2r172"
+      "sha256": "9a94dfc533ecf00d66be576ce913cfc533eaba9251b9ee365c9eee2895eca7c2",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicocv/libpicocv_1.1.40-beta2r340_amd64.deb",
+      "version": "1.1.40-beta2r340"
+    },
+    "libpicohrdl": {
+      "sha256": "4a9d9fc8c3bd603a374285c94e0c86d3fcdafcdfb7aedaa2798cd11267acd642",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicohrdl/libpicohrdl_2.0.146-1r6147_amd64.deb",
+      "version": "2.0.146-1r6147"
     },
     "libpicoipp": {
       "sha256": "4a84f0af7f4e8cba91fad620eac0cd23c36b2fdda4637904be564286b10ffe1d",
       "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpicoipp/libpicoipp_1.4.0-4r161_amd64.deb",
       "version": "1.4.0-4r161"
     },
+    "libpl1000": {
+      "sha256": "497793ff281b8ed281e73ab042d704cd3c4ef1d2d0c20d3415c8528e9cdf853d",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpl1000/libpl1000_2.0.146-1r6147_amd64.deb",
+      "version": "2.0.146-1r6147"
+    },
+    "libplcm3": {
+      "sha256": "0d20357d556a5b76e74dc7699b0819bd3d03d450664095bdf716200cb714b6e4",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libplcm3/libplcm3_2.0.146-1r6147_amd64.deb",
+      "version": "2.0.146-1r6147"
+    },
     "libps2000": {
-      "sha256": "473b065e79a7414c1e2b8c8468c8d2654333ac28f3a8c33b535626b33c60d2ca",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000/libps2000_3.0.127-3r5552_amd64.deb",
-      "version": "3.0.127-3r5552"
+      "sha256": "f87e7e515ff9657836663d9610c1717bd5df11c09e1ccdf439530e8df79949f3",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000/libps2000_3.0.146-3r6147_amd64.deb",
+      "version": "3.0.146-3r6147"
     },
     "libps2000a": {
-      "sha256": "8eba0052f9c7ef327710f2fba5aa11bec0c20225b39d77bb7b69cf80055c039c",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000a/libps2000a_2.1.127-5r5552_amd64.deb",
-      "version": "2.1.127-5r5552"
+      "sha256": "cce0cacb310e29a4be825e70b29b6e17a97798efc82abdec8b91765136285193",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps2000a/libps2000a_2.2.150-5r6523_amd64.deb",
+      "version": "2.2.150-5r6523"
     },
     "libps3000": {
-      "sha256": "4e786036b8de0dd0f922aed947f30a53d31bed46b2df5132e8c9480c8a5d93e9",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000/libps3000_4.0.127-3r5552_amd64.deb",
-      "version": "4.0.127-3r5552"
+      "sha256": "6ccc6b1c16bb1e05e287624e99b24feb04e8269c64c6e3325e4b30a7dc98632e",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000/libps3000_4.0.146-3r6147_amd64.deb",
+      "version": "4.0.146-3r6147"
     },
     "libps3000a": {
-      "sha256": "d2bb1e5bb151b0953ed30ca5421bb93d05dab898c33cdc89927e943ea991867a",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000a/libps3000a_2.1.127-6r5552_amd64.deb",
-      "version": "2.1.127-6r5552"
+      "sha256": "b35182256b83b009196abea8a840f76541afe7c89ca541b0eb634f223daef59a",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps3000a/libps3000a_2.1.147-6r7513_amd64.deb",
+      "version": "2.1.147-6r7513"
     },
     "libps4000": {
-      "sha256": "4c127e67949835b5ab5c5c8caa55f73c69df354d761aa53d6df99c8f8ac39009",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000/libps4000_2.1.127-2r5552_amd64.deb",
-      "version": "2.1.127-2r5552"
+      "sha256": "27076d454d7c36c7b1e8a26333cd6b638dfa6540f91217ee17e8ce23a77edc74",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000/libps4000_2.1.148-2r6156_amd64.deb",
+      "version": "2.1.148-2r6156"
     },
     "libps4000a": {
-      "sha256": "26df82bc946e5bb30d599c4c365247bdbaa01e830d4d00630b46a6abcc1eef04",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000a/libps4000a_2.1.127-2r5552_amd64.deb",
-      "version": "2.1.127-2r5552"
+      "sha256": "21268b6604537cd9c42ad58f8679014a6b32cb6caab54fda3e330c9f488a0f85",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps4000a/libps4000a_2.2.176-2r7647_amd64.deb",
+      "version": "2.2.176-2r7647"
     },
     "libps5000": {
-      "sha256": "106ef17862e98c3621f95c377f271c843664f481f84ef918d9eadd013561cd1b",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000/libps5000_2.1.127-3r5552_amd64.deb",
-      "version": "2.1.127-3r5552"
+      "sha256": "831b0432829e1da3021ec54b369b17a1a754bd2d1bb2f9889957da5286385d4f",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000/libps5000_2.1.148-3r6156_amd64.deb",
+      "version": "2.1.148-3r6156"
     },
     "libps5000a": {
-      "sha256": "fe9def134ef9df6654485911f14ece7b2ee3d79113aeee7826dd6e36bb5de3b4",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000a/libps5000a_2.1.127-5r5552_amd64.deb",
-      "version": "2.1.127-5r5552"
+      "sha256": "210650fef5c4cc7b76c5c0ef6dd312a9e2e584b001927b627b0f92feff096646",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps5000a/libps5000a_2.2.4-5r5042_amd64.deb",
+      "version": "2.2.4-5r5042"
     },
     "libps6000": {
-      "sha256": "9b08c5b7fb2d34b0e2e98f2e0452a59105f612cd445a9e45d3cac14d931d18f2",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000/libps6000_2.1.127-6r5552_amd64.deb",
-      "version": "2.1.127-6r5552"
+      "sha256": "a078cbf63adec2fcc7fcab7f7d1043cf3963f32fb67f59d26f1381a735a611e0",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000/libps6000_2.1.148-6r6156_amd64.deb",
+      "version": "2.1.148-6r6156"
     },
     "libps6000a": {
-      "sha256": "2a23ccad72b9be83b87d449b6bb8ded23fd29c85ec9f78a45b6d45b38ccf335b",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000a/libps6000a_1.0.127-0r5552_amd64.deb",
-      "version": "1.0.127-0r5552"
+      "sha256": "1c63bec9f829282af29567fc64c1a89f682d2532d1f8dc7c0e3c87eebf67016e",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libps6000a/libps6000a_2.0.148-0r93_amd64.deb",
+      "version": "2.0.148-0r93"
+    },
+    "libpsospa": {
+      "sha256": "8905df5f45f969704e794fa9d1ad73040934f65dde24af8b39d04f4f1d96b664",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libp/libpsospa/libpsospa_1.0.115-0r5654_amd64.deb",
+      "version": "1.0.115-0r5654"
+    },
+    "libusbdrdaq": {
+      "sha256": "c84fb36942cb119f7f0355eb5938360aee097476e413d92207901f34ffc0a813",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libu/libusbdrdaq/libusbdrdaq_2.0.146-1r6147_amd64.deb",
+      "version": "2.0.146-1r6147"
+    },
+    "libusbpt104": {
+      "sha256": "49bcd37bb1c89973c684ff977994290a8731509d98270824e67da24e26f522e3",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libu/libusbpt104/libusbpt104_2.0.146-1r6147_amd64.deb",
+      "version": "2.0.146-1r6147"
+    },
+    "libusbtc08": {
+      "sha256": "ace0178860211aac5b613223617d40608c8174d29219198ef520757866f3e6da",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/libu/libusbtc08/libusbtc08_2.0.146-1r6147_amd64.deb",
+      "version": "2.0.146-1r6147"
     },
     "picoscope": {
-      "sha256": "d95f269171da7273b596dae95452789e889f12ef0f15c3baea26dd1b3a8117fc",
-      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/p/picoscope/picoscope_7.1.17-1r17318_amd64.deb",
-      "version": "7.1.17-1r17318"
+      "sha256": "7334336cf748f9f0de0f737ed2f0576c54d364dfa7ae112b85eb7f1d57e2e9e1",
+      "url": "https://labs.picotech.com/rc/picoscope7/debian/pool/main/p/picoscope/picoscope_7.1.46-1r4685_amd64.deb",
+      "version": "7.1.46-1r4685"
     }
   }
 }


### PR DESCRIPTION
This updates picoscope to the latest version, in the hope that it will fix the issues from the previous update

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
