### PR TITLE
cassandra: 4.1.7 -> 4.1.8, cassandra_3_11: 3.11.12 -> 3.11.18, cassandra_3_0: 3.0.28 -> 3.0.31

### DIFF
--- a/pkgs/servers/nosql/cassandra/3.0.json
+++ b/pkgs/servers/nosql/cassandra/3.0.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.0.28",
-  "sha256": "1x06sxzppipi0jg0qvk26iicqwf28y0aik7c732r0yd1vz4vdwq6"
+  "version": "3.0.31",
+  "sha256": "sha256-NKElcojNVjAXusDXGlPeFYOzSrS01hZnk0U+1va4EuQ="
 }

--- a/pkgs/servers/nosql/cassandra/3.11.json
+++ b/pkgs/servers/nosql/cassandra/3.11.json
@@ -1,4 +1,4 @@
 {
-  "version": "3.11.12",
-  "sha256": "16j58l7r47qrfh8q7fm92y935ykgvnbj3qn984c42qda15x92hkw"
+  "version": "3.11.18",
+  "sha256": "sha256-eb9+d1nVQ1mMKY9+O0f1gIIlpxQ8FYQeAU4/Msad5Ro="
 }

--- a/pkgs/servers/nosql/cassandra/4.json
+++ b/pkgs/servers/nosql/cassandra/4.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.1.7",
-  "sha256": "0qnsz1zvjs1ax9p58g5b8bf3xyjg47sskkcb9nfafp6nzfdy0a2w"
+  "version": "4.1.8",
+  "sha256": "sha256-jsMCNuHxTzPki3lYQ5QiRw+Y8JtVJ+8FyAfeQpf4lyE="
 }


### PR DESCRIPTION
Fixes CVE-2025-24860, CVE-2025-23015 and CVE-2024-27137.

https://github.com/apache/cassandra/blob/cassandra-4.1.8/CHANGES.txt
https://github.com/apache/cassandra/blob/cassandra-3.11.18/CHANGES.txt
https://github.com/apache/cassandra/blob/cassandra-3.0.31/CHANGES.txt

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## `nixpkgs-review` result

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review pr 379398`

---
### `x86_64-linux`
<details>
  <summary>:white_check_mark: 3 packages built:</summary>
  <ul>
    <li>cassandra</li>
    <li>cassandra_3_0</li>
    <li>cassandra_3_11</li>
  </ul>
</details>
<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
