### PR TITLE
petsc: refactor and add petsc4py support

### DIFF
--- a/pkgs/by-name/pe/petsc/fix-petsc4py-install-prefix.patch
+++ b/pkgs/by-name/pe/petsc/fix-petsc4py-install-prefix.patch
@@ -1,0 +1,22 @@
+diff --git a/config/BuildSystem/config/packages/petsc4py.py b/config/BuildSystem/config/packages/petsc4py.py
+index 4a58243..831aa04 100644
+--- a/config/BuildSystem/config/packages/petsc4py.py
++++ b/config/BuildSystem/config/packages/petsc4py.py
+@@ -37,7 +37,7 @@ class Configure(config.package.Package):
+ 
+   def Install(self):
+     import os
+-    installLibPath = os.path.join(self.installDir, 'lib')
++    installLibPath = os.path.join(self.installDir, 'lib', '@PYTHON_SITEPACKAGES@')
+     if self.setCompilers.isDarwin(self.log):
+       apple = 'You may need to\n (csh/tcsh) setenv MACOSX_DEPLOYMENT_TARGET 10.X\n (sh/bash) MACOSX_DEPLOYMENT_TARGET=10.X; export MACOSX_DEPLOYMENT_TARGET\nbefore running make on PETSc'
+     else:
+@@ -70,7 +70,7 @@ class Configure(config.package.Package):
+       newdir += 'NUMPY_INCLUDE="'+numpy_include+'" '
+ 
+     self.addDefine('HAVE_PETSC4PY',1)
+-    self.addDefine('PETSC4PY_INSTALL_PATH','"'+os.path.join(self.installdir.dir,'lib')+'"')
++    self.addDefine('PETSC4PY_INSTALL_PATH','"'+installLibPath+'"')
+     self.addMakeMacro('PETSC4PY','yes')
+     self.addMakeRule('petsc4pybuild','', \
+                        ['@echo "*** Building petsc4py ***"',\

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -42,49 +42,64 @@ stdenv.mkDerivation rec {
     gfortran
     pkg-config
   ] ++ lib.optional mpiSupport mpi;
-  buildInputs = [
-    blas
-    lapack
-  ] ++ lib.optional hdf5-support hdf5 ++ lib.optional petsc-withp4est p4est ++ lib.optionals withParmetis [ metis parmetis ];
+  buildInputs =
+    [
+      blas
+      lapack
+    ]
+    ++ lib.optional hdf5-support hdf5
+    ++ lib.optional petsc-withp4est p4est
+    ++ lib.optionals withParmetis [
+      metis
+      parmetis
+    ];
 
-  postPatch = ''
-    patchShebangs ./lib/petsc/bin
-  '' + lib.optionalString stdenv.hostPlatform.isDarwin ''
-    substituteInPlace config/install.py \
-      --replace /usr/bin/install_name_tool ${cctools}/bin/install_name_tool
-  '';
+  postPatch =
+    ''
+      patchShebangs ./lib/petsc/bin
+    ''
+    + lib.optionalString stdenv.hostPlatform.isDarwin ''
+      substituteInPlace config/install.py \
+        --replace /usr/bin/install_name_tool ${cctools}/bin/install_name_tool
+    '';
 
-  configureFlags = [
-    "--with-blas=1"
-    "--with-lapack=1"
-    "--with-scalar-type=${petsc-scalar-type}"
-    "--with-precision=${petsc-precision}"
-    "--with-mpi=${if mpiSupport then "1" else "0"}"
-  ] ++ lib.optionals mpiSupport [
-    "--CC=mpicc"
-    "--with-cxx=mpicxx"
-    "--with-fc=mpif90"
-  ] ++ lib.optionals (mpiSupport && withParmetis) [
-    "--with-metis=1"
-    "--with-metis-dir=${metis}"
-    "--with-parmetis=1"
-    "--with-parmetis-dir=${parmetis}"
-  ] ++ lib.optionals petsc-withp4est [
-    "--with-p4est=1"
-    "--with-zlib-include=${zlib.dev}/include"
-    "--with-zlib-lib=[-L${zlib}/lib,-lz]"
-  ] ++ lib.optionals hdf5-support [
-    "--with-hdf5=1"
-    "--with-hdf5-fortran-bindings=1"
-    "--with-hdf5-include=${hdf5.dev}/include"
-    "--with-hdf5-lib=[-L${hdf5}/lib,-lhdf5]"
-  ] ++ lib.optionals petsc-optimized [
-    "--with-debugging=0"
-    "COPTFLAGS=-O3"
-    "FOPTFLAGS=-O3"
-    "CXXOPTFLAGS=-O3"
-    "CXXFLAGS=-O3"
-  ];
+  configureFlags =
+    [
+      "--with-blas=1"
+      "--with-lapack=1"
+      "--with-scalar-type=${petsc-scalar-type}"
+      "--with-precision=${petsc-precision}"
+      "--with-mpi=${if mpiSupport then "1" else "0"}"
+    ]
+    ++ lib.optionals mpiSupport [
+      "--CC=mpicc"
+      "--with-cxx=mpicxx"
+      "--with-fc=mpif90"
+    ]
+    ++ lib.optionals (mpiSupport && withParmetis) [
+      "--with-metis=1"
+      "--with-metis-dir=${metis}"
+      "--with-parmetis=1"
+      "--with-parmetis-dir=${parmetis}"
+    ]
+    ++ lib.optionals petsc-withp4est [
+      "--with-p4est=1"
+      "--with-zlib-include=${zlib.dev}/include"
+      "--with-zlib-lib=[-L${zlib}/lib,-lz]"
+    ]
+    ++ lib.optionals hdf5-support [
+      "--with-hdf5=1"
+      "--with-hdf5-fortran-bindings=1"
+      "--with-hdf5-include=${hdf5.dev}/include"
+      "--with-hdf5-lib=[-L${hdf5}/lib,-lhdf5]"
+    ]
+    ++ lib.optionals petsc-optimized [
+      "--with-debugging=0"
+      "COPTFLAGS=-O3"
+      "FOPTFLAGS=-O3"
+      "CXXOPTFLAGS=-O3"
+      "CXXFLAGS=-O3"
+    ];
 
   hardeningDisable = lib.optionals (!petsc-optimized) [
     "fortify"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -19,6 +19,10 @@
   withParmetis ? false,
   scotch,
   withPtscotch ? false,
+  scalapack,
+  withScalapack ? false,
+  mumps_par,
+  withMumps ? false,
   pkg-config,
   p4est,
   zlib, # propagated by p4est but required by petsc
@@ -34,6 +38,8 @@ assert petsc-withp4est -> p4est.mpiSupport;
 assert withParmetis -> (withMetis && mpiSupport);
 
 assert withPtscotch -> mpiSupport;
+assert withScalapack -> mpiSupport;
+assert withMumps -> withScalapack;
 
 stdenv.mkDerivation rec {
   pname = "petsc";
@@ -59,7 +65,9 @@ stdenv.mkDerivation rec {
     ++ lib.optional petsc-withp4est p4est
     ++ lib.optional withMetis metis
     ++ lib.optional withParmetis parmetis
-    ++ lib.optional withPtscotch scotch;
+    ++ lib.optional withPtscotch scotch
+    ++ lib.optional withScalapack scalapack
+    ++ lib.optional withMumps mumps_par;
 
   postPatch =
     ''
@@ -95,6 +103,14 @@ stdenv.mkDerivation rec {
       "--with-ptscotch=1"
       "--with-ptscotch-include=${scotch.dev}/include"
       "--with-ptscotch-lib=[-L${scotch}/lib,-lptscotch,-lptesmumps,-lptscotchparmetisv3,-lptscotcherr,-lesmumps,-lscotch,-lscotcherr]"
+    ]
+    ++ lib.optionals withScalapack [
+      "--with-scalapack=1"
+      "--with-scalapack-dir=${scalapack}"
+    ]
+    ++ lib.optionals withMumps [
+      "--with-mumps=1"
+      "--with-mumps-dir=${mumps_par}"
     ]
     ++ lib.optionals petsc-withp4est [
       "--with-p4est=1"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -14,7 +14,7 @@
   mpiCheckPhaseHook,
 
   # Build options
-  petsc-optimized ? false,
+  petsc-optimized ? true,
   petsc-scalar-type ? "real",
   petsc-precision ? "double",
   mpiSupport ? true,
@@ -22,7 +22,7 @@
   withFullDeps ? false, # full External libraries support
 
   # External libraries options
-  withHdf5 ? withFullDeps,
+  withHdf5 ? true,
   withMetis ? withFullDeps,
   withParmetis ? false, # parmetis is unfree and should be enabled manualy
   withPtscotch ? withFullDeps,

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -7,32 +7,38 @@
   replaceVars,
   python3,
   python3Packages,
-  withPetsc4py ? false,
   blas,
   lapack,
-  mpiSupport ? true,
+  zlib, # propagated by p4est but required by petsc
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
-  withP4est ? withFullDeps,
-  withHdf5 ? withFullDeps,
-  hdf5,
-  metis,
-  withMetis ? withFullDeps,
-  parmetis,
-  withParmetis ? false, # parmetis is unfree and should be enabled manualy
-  scotch,
-  withPtscotch ? withFullDeps,
-  scalapack,
-  withScalapack ? withFullDeps,
-  mumps_par,
-  withMumps ? withFullDeps,
-  pkg-config,
-  p4est,
-  zlib, # propagated by p4est but required by petsc
+
+  # Build options
   petsc-optimized ? false,
   petsc-scalar-type ? "real",
   petsc-precision ? "double",
-  withFullDeps ? false
+  mpiSupport ? true,
+  withPetsc4py ? false, # petsc python binding
+  withFullDeps ? false, # full External libraries support
+
+  # External libraries options
+  withHdf5 ? withFullDeps,
+  withMetis ? withFullDeps,
+  withParmetis ? false, # parmetis is unfree and should be enabled manualy
+  withPtscotch ? withFullDeps,
+  withScalapack ? withFullDeps,
+  withMumps ? withFullDeps,
+  withP4est ? withFullDeps,
+
+  # External libraries
+  hdf5,
+  metis,
+  parmetis,
+  scotch,
+  scalapack,
+  mumps_par,
+  pkg-config,
+  p4est,
 }:
 
 # This version of PETSc does not support a non-MPI p4est build

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -14,6 +14,7 @@
   hdf5-support ? false,
   hdf5,
   metis,
+  withMetis ? false,
   parmetis,
   withParmetis ? false,
   pkg-config,
@@ -26,6 +27,9 @@
 
 # This version of PETSc does not support a non-MPI p4est build
 assert petsc-withp4est -> p4est.mpiSupport;
+
+# Package parmetis depend on metis and mpi support
+assert withParmetis -> (withMetis && mpiSupport);
 
 stdenv.mkDerivation rec {
   pname = "petsc";
@@ -49,10 +53,8 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional hdf5-support hdf5
     ++ lib.optional petsc-withp4est p4est
-    ++ lib.optionals withParmetis [
-      metis
-      parmetis
-    ];
+    ++ lib.optional withMetis metis
+    ++ lib.optional withParmetis parmetis;
 
   postPatch =
     ''
@@ -76,9 +78,11 @@ stdenv.mkDerivation rec {
       "--with-cxx=mpicxx"
       "--with-fc=mpif90"
     ]
-    ++ lib.optionals (mpiSupport && withParmetis) [
+    ++ lib.optionals withMetis [
       "--with-metis=1"
       "--with-metis-dir=${metis}"
+    ]
+    ++ lib.optionals withParmetis [
       "--with-parmetis=1"
       "--with-parmetis-dir=${parmetis}"
     ]

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -13,25 +13,26 @@
   mpiSupport ? true,
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
-  petsc-withp4est ? false,
-  hdf5-support ? false,
+  petsc-withp4est ? withFullDeps,
+  hdf5-support ? withFullDeps,
   hdf5,
   metis,
-  withMetis ? false,
+  withMetis ? withFullDeps,
   parmetis,
-  withParmetis ? false,
+  withParmetis ? false, # parmetis is unfree and should be enabled manualy
   scotch,
-  withPtscotch ? false,
+  withPtscotch ? withFullDeps,
   scalapack,
-  withScalapack ? false,
+  withScalapack ? withFullDeps,
   mumps_par,
-  withMumps ? false,
+  withMumps ? withFullDeps,
   pkg-config,
   p4est,
   zlib, # propagated by p4est but required by petsc
   petsc-optimized ? false,
   petsc-scalar-type ? "real",
   petsc-precision ? "double",
+  withFullDeps ? false
 }:
 
 # This version of PETSc does not support a non-MPI p4est build

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -13,8 +13,8 @@
   mpiSupport ? true,
   mpi, # generic mpi dependency
   mpiCheckPhaseHook,
-  petsc-withp4est ? withFullDeps,
-  hdf5-support ? withFullDeps,
+  withP4est ? withFullDeps,
+  withHdf5 ? withFullDeps,
   hdf5,
   metis,
   withMetis ? withFullDeps,
@@ -36,7 +36,7 @@
 }:
 
 # This version of PETSc does not support a non-MPI p4est build
-assert petsc-withp4est -> p4est.mpiSupport;
+assert withP4est -> (p4est.mpiSupport && mpiSupport);
 
 # Package parmetis depend on metis and mpi support
 assert withParmetis -> (withMetis && mpiSupport);
@@ -73,8 +73,8 @@ stdenv.mkDerivation rec {
       blas
       lapack
     ]
-    ++ lib.optional hdf5-support hdf5
-    ++ lib.optional petsc-withp4est p4est
+    ++ lib.optional withHdf5 hdf5
+    ++ lib.optional withP4est p4est
     ++ lib.optional withMetis metis
     ++ lib.optional withParmetis parmetis
     ++ lib.optional withPtscotch scotch
@@ -133,12 +133,12 @@ stdenv.mkDerivation rec {
       "--with-mumps=1"
       "--with-mumps-dir=${mumps_par}"
     ]
-    ++ lib.optionals petsc-withp4est [
+    ++ lib.optionals withP4est [
       "--with-p4est=1"
       "--with-zlib-include=${zlib.dev}/include"
       "--with-zlib-lib=[-L${zlib}/lib,-lz]"
     ]
-    ++ lib.optionals hdf5-support [
+    ++ lib.optionals withHdf5 [
       "--with-hdf5=1"
       "--with-hdf5-fortran-bindings=1"
       "--with-hdf5-include=${hdf5.dev}/include"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -122,8 +122,8 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals withPtscotch [
       "--with-ptscotch=1"
-      "--with-ptscotch-include=${scotch.dev}/include"
-      "--with-ptscotch-lib=[-L${scotch}/lib,-lptscotch,-lptesmumps,-lptscotchparmetisv3,-lptscotcherr,-lesmumps,-lscotch,-lscotcherr]"
+      "--with-ptscotch-include=${lib.getDev scotch}/include"
+      "--with-ptscotch-lib=[-L${lib.getLib scotch}/lib,-lptscotch,-lptesmumps,-lptscotchparmetisv3,-lptscotcherr,-lesmumps,-lscotch,-lscotcherr]"
     ]
     ++ lib.optionals withScalapack [
       "--with-scalapack=1"
@@ -135,14 +135,14 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optionals withP4est [
       "--with-p4est=1"
-      "--with-zlib-include=${zlib.dev}/include"
-      "--with-zlib-lib=[-L${zlib}/lib,-lz]"
+      "--with-zlib-include=${lib.getDev zlib}/include"
+      "--with-zlib-lib=[-L${lib.getLib zlib}/lib,-lz]"
     ]
     ++ lib.optionals withHdf5 [
       "--with-hdf5=1"
       "--with-hdf5-fortran-bindings=1"
-      "--with-hdf5-include=${hdf5.dev}/include"
-      "--with-hdf5-lib=[-L${hdf5}/lib,-lhdf5]"
+      "--with-hdf5-include=${lib.getDev hdf5}/include"
+      "--with-hdf5-lib=[-L${lib.getLib hdf5}/lib,-lhdf5]"
     ]
     ++ lib.optionals petsc-optimized [
       "--with-debugging=0"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -17,6 +17,8 @@
   withMetis ? false,
   parmetis,
   withParmetis ? false,
+  scotch,
+  withPtscotch ? false,
   pkg-config,
   p4est,
   zlib, # propagated by p4est but required by petsc
@@ -30,6 +32,8 @@ assert petsc-withp4est -> p4est.mpiSupport;
 
 # Package parmetis depend on metis and mpi support
 assert withParmetis -> (withMetis && mpiSupport);
+
+assert withPtscotch -> mpiSupport;
 
 stdenv.mkDerivation rec {
   pname = "petsc";
@@ -54,7 +58,8 @@ stdenv.mkDerivation rec {
     ++ lib.optional hdf5-support hdf5
     ++ lib.optional petsc-withp4est p4est
     ++ lib.optional withMetis metis
-    ++ lib.optional withParmetis parmetis;
+    ++ lib.optional withParmetis parmetis
+    ++ lib.optional withPtscotch scotch;
 
   postPatch =
     ''
@@ -85,6 +90,11 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withParmetis [
       "--with-parmetis=1"
       "--with-parmetis-dir=${parmetis}"
+    ]
+    ++ lib.optionals withPtscotch [
+      "--with-ptscotch=1"
+      "--with-ptscotch-include=${scotch.dev}/include"
+      "--with-ptscotch-lib=[-L${scotch}/lib,-lptscotch,-lptesmumps,-lptscotchparmetisv3,-lptscotcherr,-lesmumps,-lscotch,-lscotcherr]"
     ]
     ++ lib.optionals petsc-withp4est [
       "--with-p4est=1"

--- a/pkgs/by-name/pe/petsc/package.nix
+++ b/pkgs/by-name/pe/petsc/package.nix
@@ -31,7 +31,7 @@
   withP4est ? withFullDeps,
 
   # External libraries
-  hdf5,
+  hdf5-fortran-mpi,
   metis,
   parmetis,
   scotch,
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
       blas
       lapack
     ]
-    ++ lib.optional withHdf5 hdf5
+    ++ lib.optional withHdf5 hdf5-fortran-mpi
     ++ lib.optional withP4est p4est
     ++ lib.optional withMetis metis
     ++ lib.optional withParmetis parmetis
@@ -147,8 +147,8 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withHdf5 [
       "--with-hdf5=1"
       "--with-hdf5-fortran-bindings=1"
-      "--with-hdf5-include=${lib.getDev hdf5}/include"
-      "--with-hdf5-lib=[-L${lib.getLib hdf5}/lib,-lhdf5]"
+      "--with-hdf5-include=${lib.getDev hdf5-fortran-mpi}/include"
+      "--with-hdf5-lib=[-L${lib.getLib hdf5-fortran-mpi}/lib,-lhdf5]"
     ]
     ++ lib.optionals petsc-optimized [
       "--with-debugging=0"

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17075,7 +17075,7 @@ with pkgs;
   ### SCIENCE/GEOLOGY
   pflotran = callPackage ../by-name/pf/pflotran/package.nix {
     petsc = petsc.override {
-      hdf5-support = true;
+      withHdf5 = true;
       hdf5 = hdf5-fortran-mpi;
       petsc-optimized = true;
     };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17072,14 +17072,6 @@ with pkgs;
 
   ### SCIENCE/PROGRAMMING
 
-  ### SCIENCE/GEOLOGY
-  pflotran = callPackage ../by-name/pf/pflotran/package.nix {
-    petsc = petsc.override {
-      withHdf5 = true;
-      petsc-optimized = true;
-    };
-  };
-
   ### SCIENCE/LOGIC
 
   abella = callPackage ../applications/science/logic/abella {

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -17076,7 +17076,6 @@ with pkgs;
   pflotran = callPackage ../by-name/pf/pflotran/package.nix {
     petsc = petsc.override {
       withHdf5 = true;
-      hdf5 = hdf5-fortran-mpi;
       petsc-optimized = true;
     };
   };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10347,7 +10347,6 @@ self: super: with self; {
     python3Packages = self;
     withPetsc4py = true;
     withFullDeps = true;
-    petsc-optimized = true;
   });
 
   pex = callPackage ../development/python-modules/pex { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10346,6 +10346,8 @@ self: super: with self; {
     python3 = python;
     python3Packages = self;
     withPetsc4py = true;
+    withFullDeps = true;
+    petsc-optimized = true;
   });
 
   pex = callPackage ../development/python-modules/pex { };

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -10342,6 +10342,12 @@ self: super: with self; {
 
   pesq = callPackage ../development/python-modules/pesq { };
 
+  petsc4py = toPythonModule (pkgs.petsc.override {
+    python3 = python;
+    python3Packages = self;
+    withPetsc4py = true;
+  });
+
   pex = callPackage ../development/python-modules/pex { };
 
   pexif = callPackage ../development/python-modules/pexif { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->
1. refactor configure phase.
2. add some optional dependency which will be used by firedrake/fenics.
3. petsc4py enabled (petsc 3.21.4->3.22.3 needed for python313Packages.petsc4py module support)

petsc install petsc4py under $out/lib which is not the desired behavior $out/lib/${python3.sitePackages} and cannot be
configured via flags or envrionment.
So i patched the configure file in petsc source code.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
