### PR TITLE
umu-launcher: enable `multiArch`

### DIFF
--- a/pkgs/by-name/um/umu-launcher/package.nix
+++ b/pkgs/by-name/um/umu-launcher/package.nix
@@ -4,6 +4,7 @@
   umu-launcher-unwrapped,
   extraPkgs ? pkgs: [ ],
   extraLibraries ? pkgs: [ ],
+  withMultiArch ? true, # Many Wine games need 32-bit libraries.
 }:
 buildFHSEnv {
   pname = "umu-launcher";
@@ -17,6 +18,7 @@ buildFHSEnv {
     ]
     ++ extraPkgs pkgs;
   multiPkgs = extraLibraries;
+  multiArch = withMultiArch;
 
   executableName = umu-launcher-unwrapped.meta.mainProgram;
   runScript = lib.getExe umu-launcher-unwrapped;


### PR DESCRIPTION
Issue reported by @fufexan: https://github.com/fufexan/nix-gaming/pull/233#issuecomment-2635110991

```
libGL: Can't open configuration file /etc/drirc: No such file or directory.
libGL: Can't open configuration file /home/mihai/.drirc: No such file or directory.
libGL: using driver amdgpu for 83
libGL: Can't open configuration file /etc/drirc: No such file or directory.
libGL: Can't open configuration file /home/mihai/.drirc: No such file or directory.
libGL: pci id for fd 83: 1002:1638, driver radeonsi
libGL: MESA-LOADER: failed to open /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri/radeonsi_dri.so: /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri/radeonsi_dri.so: wrong ELF class: ELFCLASS64
libGL error: MESA-LOADER: failed to open radeonsi: /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri/radeonsi_dri.so: wrong ELF class: ELFCLASS64 (search paths /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri)
libGL error: failed to load driver: radeonsi
libGL: MESA-LOADER: failed to open /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri/swrast_dri.so: /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri/swrast_dri.so: wrong ELF class: ELFCLASS64
libGL error: MESA-LOADER: failed to open swrast: /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri/swrast_dri.so: wrong ELF class: ELFCLASS64 (search paths /usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu/dri)
libGL error: failed to load driver: swrast
X Error of failed request:  GLXBadContext
  Major opcode of failed request:  150 (GLX)
  Minor opcode of failed request:  6 (X_GLXIsDirect)
  Serial number of failed request:  551
  Current serial number in output stream:  550
```

Resolved by enabling multi-arch in the FHS environment.

This matches the implementation used by Heroic:
https://github.com/NixOS/nixpkgs/blob/6fa3f3d31de8fa71b5cea27b21be36338feaf20c/pkgs/games/heroic/fhsenv.nix#L14-L15

And the impl previously used by the upstream umu-launcher flake, before it was refactored to override the nixpkgs package:
https://github.com/Open-Wine-Components/umu-launcher/blob/0cac244cc89ee69bf33ad60a3953cfde188ee8a6/packaging/nix/umu-run.nix#L14
(Added by https://github.com/Open-Wine-Components/umu-launcher/pull/252)

cc @LovingMelody


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
