### PR TITLE
ctestCheckHook: init, {pdal,gifticlib,zynaddsubfx}: migrate to ctestCheckHook

### DIFF
--- a/doc/hooks/cmake.section.md
+++ b/doc/hooks/cmake.section.md
@@ -33,3 +33,21 @@ The default value is `build`.
 #### `dontUseCmakeConfigure` {#dont-use-cmake-configure}
 
 When set to true, don't use the predefined `cmakeConfigurePhase`.
+
+## Controlling CTest invocation {#cmake-ctest}
+
+By default tests are run by make in [`checkPhase`](#ssec-check-phase) or by [ninja](#ninja) if `ninja` is
+available in `nativeBuildInputs`. Makefile and Ninja generators produce the `test` target, which invokes `ctest` under the hood.
+This makes passing additional arguments to `ctest` difficult, so it's possible to invoke it directly in `checkPhase`
+by adding `ctestCheckHook` to `nativeCheckInputs`.
+
+### CTest Variables {#cmake-ctest-variables}
+
+#### `disabledTests` {#cmake-ctest-disabled-tests}
+
+Allows to disable running a list of tests. Note that regular expressions are not supported by `disabledTests`, but
+it can be combined with `--exclude-regex` option.
+
+#### `ctestFlags` {#cmake-ctest-flags}
+
+Additional options passed to `ctest` together with `checkFlags`.

--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -5,6 +5,18 @@
   "chap-release-notes": [
     "release-notes.html#chap-release-notes"
   ],
+  "cmake-ctest": [
+    "index.html#cmake-ctest"
+  ],
+  "cmake-ctest-disabled-tests": [
+    "index.html#cmake-ctest-disabled-tests"
+  ],
+  "cmake-ctest-flags": [
+    "index.html#cmake-ctest-flags"
+  ],
+  "cmake-ctest-variables": [
+    "index.html#cmake-ctest-variables"
+  ],
   "ex-build-helpers-extendMkDerivation": [
     "index.html#ex-build-helpers-extendMkDerivation"
   ],

--- a/pkgs/applications/audio/zynaddsubfx/default.nix
+++ b/pkgs/applications/audio/zynaddsubfx/default.nix
@@ -45,6 +45,7 @@
   # Test dependencies
   cxxtest,
   ruby,
+  ctestCheckHook,
 }:
 
 assert builtins.any (g: guiModule == g) [
@@ -151,28 +152,19 @@ stdenv.mkDerivation rec {
   nativeCheckInputs = [
     cxxtest
     ruby
+    ctestCheckHook
   ];
 
-  # TODO: Update cmake hook to make it simpler to selectively disable cmake tests: #113829
-  checkPhase =
-    let
-      disabledTests =
-        # PortChecker is non-deterministic. It's fixed in the master
-        # branch, but backporting would require an update to rtosc, so
-        # we'll just disable it until the next release.
-        [ "PortChecker" ]
-
-        # Tests fail on aarch64
-        ++ lib.optionals stdenv.hostPlatform.isAarch64 [
-          "MessageTest"
-          "UnisonTest"
-        ];
-    in
-    ''
-      runHook preCheck
-      ctest --output-on-failure -E '^${lib.concatStringsSep "|" disabledTests}$'
-      runHook postCheck
-    '';
+  disabledTests =
+    # PortChecker is non-deterministic. It's fixed in the master
+    # branch, but backporting would require an update to rtosc, so
+    # we'll just disable it until the next release.
+    [ "PortChecker" ]
+    # Tests fail on aarch64
+    ++ lib.optionals stdenv.hostPlatform.isAarch64 [
+      "MessageTest"
+      "UnisonTest"
+    ];
 
   # Use Zyn-Fusion logo for zest build
   # An SVG version of the logo isn't hosted anywhere we can fetch, I

--- a/pkgs/by-name/ct/ctestCheckHook/ctest-check-hook.sh
+++ b/pkgs/by-name/ct/ctestCheckHook/ctest-check-hook.sh
@@ -1,0 +1,44 @@
+# shellcheck shell=bash disable=SC2154
+
+ctestCheckHook() {
+    echo "Executing ctestCheckHook"
+
+    runHook preCheck
+
+    local buildCores=1
+
+    if [ "${enableParallelChecking-1}" ]; then
+        buildCores="$NIX_BUILD_CORES"
+    fi
+
+    local flagsArray=(
+        "-j$buildCores"
+        # This is enabled by the cmakeConfigurePhase by exporting
+        # CTEST_OUTPUT_ON_FAILURE, but it makes sense it enable it globally here
+        # as well.
+        "--output-on-failure"
+    )
+
+    local disabledTestsArray=()
+    concatTo disabledTestsArray disabledTests
+
+    if [ ${#disabledTestsArray[@]} -ne 0 ]; then
+        local ctestExcludedTestsFile=$NIX_BUILD_TOP/.ctest-excluded-tests
+        disabledTestsString="$(concatStringsSep "\n" disabledTestsArray)"
+        echo -e "$disabledTestsString" >"$ctestExcludedTestsFile"
+        flagsArray+=("--exclude-from-file" "$ctestExcludedTestsFile")
+    fi
+
+    concatTo flagsArray ctestFlags checkFlags checkFlagsArray
+
+    echoCmd 'ctest flags' "${flagsArray[@]}"
+    ctest "${flagsArray[@]}"
+
+    echo "Finished ctestCheckHook"
+
+    runHook postCheck
+}
+
+if [ -z "${dontUseCTestCheck-}" ] && [ -z "${checkPhase-}" ]; then
+    checkPhase=ctestCheckHook
+fi

--- a/pkgs/by-name/ct/ctestCheckHook/package.nix
+++ b/pkgs/by-name/ct/ctestCheckHook/package.nix
@@ -1,0 +1,9 @@
+{
+  makeSetupHook,
+  cmake,
+}:
+
+makeSetupHook {
+  name = "ctestCheckHook";
+  propagatedBuildInputs = [ cmake ];
+} ./ctest-check-hook.sh

--- a/pkgs/by-name/gi/gifticlib/package.nix
+++ b/pkgs/by-name/gi/gifticlib/package.nix
@@ -6,6 +6,7 @@
   expat,
   nifticlib,
   zlib,
+  ctestCheckHook,
 }:
 
 stdenv.mkDerivation {
@@ -33,11 +34,11 @@ stdenv.mkDerivation {
 
   # without the test data, this is only a few basic tests
   doCheck = !stdenv.hostPlatform.isDarwin;
-  checkPhase = ''
-    runHook preCheck
-    ctest -LE 'NEEDS_DATA'
-    runHook postCheck
-  '';
+  nativeCheckInputs = [ ctestCheckHook ];
+  checkFlags = [
+    "-LE"
+    "NEEDS_DATA"
+  ];
 
   meta = with lib; {
     homepage = "https://www.nitrc.org/projects/gifti";

--- a/pkgs/by-name/pd/pdal/package.nix
+++ b/pkgs/by-name/pd/pdal/package.nix
@@ -2,6 +2,7 @@
   lib,
   stdenv,
   callPackage,
+  ctestCheckHook,
   fetchFromGitHub,
   testers,
 
@@ -92,6 +93,9 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   doCheck = true;
+  # tests are flaky and they seem to fail less often when they don't run in
+  # parallel
+  enableParallelChecking = false;
 
   disabledTests = [
     # Tests failing due to TileDB library implementation, disabled also
@@ -116,15 +120,8 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeCheckInputs = [
     gdal # gdalinfo
+    ctestCheckHook
   ];
-
-  checkPhase = ''
-    runHook preCheck
-    # tests are flaky and they seem to fail less often when they don't run in
-    # parallel
-    ctest -j 1 --output-on-failure -E '^${lib.concatStringsSep "|" finalAttrs.disabledTests}$'
-    runHook postCheck
-  '';
 
   postInstall = ''
     patchShebangs --update --build $out/bin/pdal-config


### PR DESCRIPTION
Motivation for this hook is simple: there's no single documented
way to do trivial things with ctest:

1. Pass additional flags to ctest invocation.
2. Selectively disable tests in a mechanism similar to python's
   `disabledTests` or rust's composable skips in `checkFlags`.
3. Disable parallel checking.

Current state of things has lead to several different solutions:

1. Completely overriding `checkPhase` [1] and invoking ctest manually
   with the necessary flags. This is most often coupled with `-E` for
   disabling test or setting parallel level.
2. Wrangling with weird double string/regex escaping and trying to stuff
   additional parameters and/or exclusion regex via `CMAKE_CTEST_ARGUMENTS`.
   This approach is especially painful when test names have spaces. This is
   the reason I originally decided to implement this hook after wrangling with
   failing darwin tests here [2].
3. Stuffing additional arguments into `checkFlagsArray` with the
   `ARGS` makefile parameter [3].

I don't see any reason to keep the status-quo. Doing something along these
lines has been suggested [4] for both `ctest` and `meson`. Meson setup-hook
has switched from `ninja` to `meson` in [5] with little friction. Doing
the same for cmake in a single sweep would prove problematic due to the
aforementioned zoo of workarounds and hacks for `ctest`. Doing it via
a separate hook would allow us to refactor things piecemeal and without
going through staging. The benefit of the hook is immediately clear and it
would allow to drive the refactor tractor at a comfortable pace.

[1]: pd/pdal/package.nix:117, cc/ccache/package.nix:108, gl/glog/package.nix:79
[2]: https://github.com/NixOS/nixpkgs/pull/375955
[3]: op/open62541/package.nix:114
[4]: https://github.com/NixOS/nixpkgs/issues/113829
[5]: https://github.com/NixOS/nixpkgs/pull/213845

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
