### PR TITLE
python3Packages.devpi-ldap: init at 2.1.1-unstable 2023-11-28

### DIFF
--- a/pkgs/development/python-modules/devpi-ldap/default.nix
+++ b/pkgs/development/python-modules/devpi-ldap/default.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  buildPythonPackage,
+  devpi-server,
+  fetchFromGitHub,
+  ldap3,
+  mock,
+  pytest-cov-stub,
+  pytest-flake8,
+  pytestCheckHook,
+  pythonOlder,
+  pyyaml,
+  setuptools,
+  webtest,
+}:
+
+buildPythonPackage rec {
+  pname = "devpi-ldap";
+  version = "2.1.1-unstable-2023-11-28";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "devpi";
+    repo = "devpi-ldap";
+    rev = "281a21d4e8d11bfec7dca2cf23fa39660a6d5796";
+    hash = "sha256-vwX0bOb2byN3M6iBk0tZJy8H39fjwBYvA0Nxi7OTzFQ=";
+  };
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    devpi-server
+    pyyaml
+    ldap3
+  ];
+
+  nativeCheckInputs = [
+    devpi-server
+    mock
+    pytest-cov-stub
+    pytest-flake8
+    pytestCheckHook
+    webtest
+  ];
+
+  pythonImportsCheck = [ "devpi_ldap" ];
+
+  meta = {
+    homepage = "https://github.com/devpi/devpi-ldap";
+    description = "LDAP authentication for devpi-server";
+    changelog = "https://github.com/devpi/devpi-ldap/blob/main/CHANGELOG.rst";
+    license = lib.licenses.mit; # according to its setup.py
+    maintainers = with lib.maintainers; [ confus ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -3238,6 +3238,8 @@ self: super: with self; {
 
   devpi-common = callPackage ../development/python-modules/devpi-common { };
 
+  devpi-ldap = callPackage ../development/python-modules/devpi-ldap { };
+
   devtools = callPackage ../development/python-modules/devtools { };
 
   dfdiskcache = callPackage ../development/python-modules/dfdiskcache { };


### PR DESCRIPTION
adds devpi-ldap, a plugin for devpi-server

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
