### PR TITLE
onionbalance: init at 0.2.3

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -4625,6 +4625,11 @@
     githubId = 87764;
     name = "Ben Ford";
   };
+  commiterate = {
+    github = "commiterate";
+    githubId = 111539270;
+    name = "commiterate";
+  };
   CompEng0001 = {
     email = "sb1501@canterbury.ac.uk";
     github = "CompEng0001";
@@ -6875,6 +6880,12 @@
     email = "emily+nix@downunderctf.com";
     github = "emilytrau";
     githubId = 13267947;
+  };
+  Emin017 = {
+    email = "cchuqiming@gmail.com";
+    github = "Emin017";
+    githubId = 99674037;
+    name = "Qiming Chu";
   };
   emmabastas = {
     email = "emma.bastas@protonmail.com";
@@ -15850,6 +15861,12 @@
     github = "mudrii";
     githubId = 220262;
     name = "Ion Mudreac";
+  };
+  MulliganSecurity = {
+    email = "mulligansecurity@riseup.net";
+    github = "MulliganSecurity";
+    githubId = 196982523;
+    name = "MulliganSecurity";
   };
   multisn8 = {
     email = "all-things-nix@multisamplednight.com";

--- a/pkgs/by-name/on/onionbalance/package.nix
+++ b/pkgs/by-name/on/onionbalance/package.nix
@@ -1,0 +1,90 @@
+{
+  fetchFromGitLab,
+  python312Packages,
+  python312,
+  python3,
+  tor,
+  lib,
+  symlinkJoin,
+}:
+
+let
+  src = fetchFromGitLab {
+    domain = "gitlab.torproject.org";
+    owner = "tpo";
+    repo = "onion-services/onionbalance";
+    rev = "2de68025d2ba786936cc9dad67b62360e0a1294b";
+    sha256 = "sha256-Fn62GtA62kkjqHsMmDLIenM5+mxVcVUSS32ADUYGND4=";
+  };
+
+  onionbalance = python312Packages.buildPythonPackage rec {
+    inherit src;
+    pname = "onionbalance";
+    version = "0.2.3";
+    doCheck = false;
+    format = "pyproject";
+    dontCheckRuntimeDeps = true;
+    buildInputs = [ tor ];
+    propagatedBuildInputs = [
+      (python312.withPackages (
+        ps: with ps; [
+          cryptography
+          pycryptodomex
+          pyyaml
+          setproctitle
+          setuptools
+          stem
+        ]
+      ))
+    ];
+
+    meta = {
+      description = "Load balancing for onion services";
+      homepage = "https://gitlab.torproject.org/tpo/onion-services/onionbalance";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ MulliganSecurity ];
+      mainProgram = "onionbalance";
+      changelog = "https://gitlab.torproject.org/tpo/onion-services/onionbalance/-/tags/0.2.3";
+    };
+
+  };
+  onionbalance-config = python312Packages.buildPythonPackage rec {
+    inherit src;
+    pname = "onionbalance-config";
+    version = "0.2.3";
+    doCheck = false;
+    format = "pyproject";
+    dontCheckRuntimeDeps = true;
+    buildInputs = [ tor ];
+    propagatedBuildInputs = [
+      (python312.withPackages (
+        ps: with ps; [
+          cryptography
+          pycryptodomex
+          pyyaml
+          setproctitle
+          setuptools
+          stem
+        ]
+      ))
+    ];
+
+    meta = {
+      description = "onionbalance config generator";
+      homepage = "https://gitlab.torproject.org/tpo/onion-services/onionbalance";
+      license = lib.licenses.mit;
+      maintainers = with lib.maintainers; [ MulliganSecurity ];
+      platforms = platforms.linux;
+      mainProgram = "onionbalance-config";
+    };
+
+  };
+
+in
+symlinkJoin {
+  name = "onionbalance";
+  paths = [
+    onionbalance
+    onionbalance-config
+  ];
+}

--- a/pkgs/by-name/on/onionbalance/package.nix
+++ b/pkgs/by-name/on/onionbalance/package.nix
@@ -43,7 +43,7 @@ with python312Packages;
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ MulliganSecurity ];
       mainProgram = "onionbalance";
-      changelog = "https://gitlab.torproject.org/tpo/onion-services/onionbalance/-/tags/0.2.3";
+      changelog = "https://gitlab.torproject.org/tpo/onion-services/onionbalance/-/tags/${version}";
     };
 
   };

--- a/pkgs/by-name/on/onionbalance/package.nix
+++ b/pkgs/by-name/on/onionbalance/package.nix
@@ -52,7 +52,7 @@ with python312Packages;
     pname = "onionbalance-config";
     version = "0.2.3";
     doCheck = false;
-    format = "pyproject";
+    pyproject = true;
     dontCheckRuntimeDeps = true;
     buildInputs = [ tor ];
     dependencies = with python312Packages; [

--- a/pkgs/by-name/on/onionbalance/package.nix
+++ b/pkgs/by-name/on/onionbalance/package.nix
@@ -70,7 +70,7 @@ let
     ];
 
     meta = {
-      description = "onionbalance config generator";
+      description = "Onionbalance config generator";
       homepage = "https://gitlab.torproject.org/tpo/onion-services/onionbalance";
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ MulliganSecurity ];

--- a/pkgs/by-name/on/onionbalance/package.nix
+++ b/pkgs/by-name/on/onionbalance/package.nix
@@ -26,8 +26,7 @@ let
     dontCheckRuntimeDeps = true;
     buildInputs = [ tor ];
     propagatedBuildInputs = [
-      (python312.withPackages (
-        ps: with ps; [
+with python312Packages;
           cryptography
           pycryptodomex
           pyyaml

--- a/pkgs/by-name/on/onionbalance/package.nix
+++ b/pkgs/by-name/on/onionbalance/package.nix
@@ -55,9 +55,7 @@ with python312Packages;
     format = "pyproject";
     dontCheckRuntimeDeps = true;
     buildInputs = [ tor ];
-    propagatedBuildInputs = [
-      (python312.withPackages (
-        ps: with ps; [
+    dependencies = with python312Packages; [
           cryptography
           pycryptodomex
           pyyaml

--- a/pkgs/by-name/on/onionbalance/package.nix
+++ b/pkgs/by-name/on/onionbalance/package.nix
@@ -74,7 +74,7 @@ let
       homepage = "https://gitlab.torproject.org/tpo/onion-services/onionbalance";
       license = lib.licenses.mit;
       maintainers = with lib.maintainers; [ MulliganSecurity ];
-      platforms = platforms.linux;
+      platforms = lib.platforms.linux;
       mainProgram = "onionbalance-config";
     };
 


### PR DESCRIPTION
Onionbalance allows users to setup load balancing for onion services on tor.

Add onionbalance and onionbalance-config

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
