### PR TITLE
python312: 3.12.8 -> 3.12.9; python313; 3.13.1 -> 3.13.2

### DIFF
--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -252,7 +252,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
     # (since it will do a futile invocation of gcc (!) to find
     # libuuid, slowing down program startup a lot).
     noldconfigPatch
-  ] ++ optionals (!isPy313) [
+  ] ++ optionals (!isPy312 && !isPy313) [
     # https://www.cve.org/CVERecord?id=CVE-2025-0938
     ./CVE-2025-0938.patch
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
@@ -297,7 +297,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (pythonOlder "3.12") [
     # https://github.com/python/cpython/issues/90656
     ./loongarch-support.patch
-  ] ++ optionals (isPy312 || isPy314) [
+  ] ++ optionals isPy314 [
     ./3.12/CVE-2024-12254.patch
   ] ++ optionals (pythonAtLeast "3.11" && pythonOlder "3.13") [
     # backport fix for https://github.com/python/cpython/issues/95855

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -252,6 +252,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
     # (since it will do a futile invocation of gcc (!) to find
     # libuuid, slowing down program startup a lot).
     noldconfigPatch
+  ] ++ optionals (!isPy313) [
     # https://www.cve.org/CVERecord?id=CVE-2025-0938
     ./CVE-2025-0938.patch
   ] ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
@@ -296,7 +297,7 @@ in with passthru; stdenv.mkDerivation (finalAttrs: {
   ] ++ optionals (pythonOlder "3.12") [
     # https://github.com/python/cpython/issues/90656
     ./loongarch-support.patch
-  ] ++ optionals (pythonAtLeast "3.12" && pythonOlder "3.14") [
+  ] ++ optionals (isPy312 || isPy314) [
     ./3.12/CVE-2024-12254.patch
   ] ++ optionals (pythonAtLeast "3.11" && pythonOlder "3.13") [
     # backport fix for https://github.com/python/cpython/issues/95855

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -20,10 +20,10 @@
       sourceVersion = {
         major = "3";
         minor = "12";
-        patch = "8";
+        patch = "9";
         suffix = "";
       };
-      hash = "sha256-yQkVe7JewRTlhpEkzCqcSk1MHpV8pP9VPx7caSEBFU4=";
+      hash = "sha256-ciCDXZ+Qs3wAbphCqN/0WAqspDGGdPlHMCuNKPP4ERI=";
     };
   };
 

--- a/pkgs/development/interpreters/python/default.nix
+++ b/pkgs/development/interpreters/python/default.nix
@@ -87,10 +87,10 @@ in {
     sourceVersion = {
       major = "3";
       minor = "13";
-      patch = "1";
+      patch = "2";
       suffix = "";
     };
-    hash = "sha256-nPlCe+6eIkLjh33Q9rZBwYU8pGHznWUDziYKWcgL8Nk=";
+    hash = "sha256-2YS8xXzWfKqyb33vQuUjscAVu8XcB4Ns9PC2P6FZ61Y=";
     inherit passthruFun;
   };
 

--- a/pkgs/development/interpreters/python/passthrufun.nix
+++ b/pkgs/development/interpreters/python/passthrufun.nix
@@ -119,6 +119,8 @@ rec {
   isPy310 = pythonVersion == "3.10";
   isPy311 = pythonVersion == "3.11";
   isPy312 = pythonVersion == "3.12";
+  isPy313 = pythonVersion == "3.13";
+  isPy314 = pythonVersion == "3.14";
   isPy2 = lib.strings.substring 0 1 pythonVersion == "2";
   isPy3 = lib.strings.substring 0 1 pythonVersion == "3";
   isPy3k = isPy3;

--- a/pkgs/development/interpreters/python/python-packages-base.nix
+++ b/pkgs/development/interpreters/python/python-packages-base.nix
@@ -126,6 +126,8 @@ in
     isPy310
     isPy311
     isPy312
+    isPy313
+    isPy314
     isPy3k
     isPyPy
     pythonAtLeast

--- a/pkgs/development/python-modules/aiohttp/default.nix
+++ b/pkgs/development/python-modules/aiohttp/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   buildPythonPackage,
   fetchFromGitHub,
+  fetchpatch2,
   substituteAll,
   isPy310,
   isPyPy,
@@ -45,14 +46,14 @@
 
 buildPythonPackage rec {
   pname = "aiohttp";
-  version = "3.11.11";
+  version = "3.11.12";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "aio-libs";
     repo = "aiohttp";
     tag = "v${version}";
-    hash = "sha256-a4h8oFJxo1TSuhIjdUC0wqJSsepmzq6vjn5mwjw4bIw=";
+    hash = "sha256-GveluMxw100ZllDF+MT4QkZVD9q7UWHwF7IBK85J/j0=";
   };
 
   patches = [
@@ -60,6 +61,12 @@ buildPythonPackage rec {
       src = ./unvendor-llhttp.patch;
       llhttpDev = lib.getDev llhttp;
       llhttpLib = lib.getLib llhttp;
+    })
+    (fetchpatch2 {
+      # https://github.com/aio-libs/aiohttp/issues/10421
+      # https://github.com/aio-libs/aiohttp/pull/10423
+      url = "https://github.com/aio-libs/aiohttp/commit/51daf7190e7674773c22011a4e443df8b5e66437.patch";
+      hash = "sha256-fADetk2tqg92J2sSgzKVTEhbQRSYl6430dxdVZuFx5I=";
     })
   ];
 

--- a/pkgs/development/python-modules/hypothesis/default.nix
+++ b/pkgs/development/python-modules/hypothesis/default.nix
@@ -13,6 +13,7 @@
   python,
   sortedcontainers,
   stdenv,
+  pythonAtLeast,
   pythonOlder,
   sphinxHook,
   sphinx-rtd-theme,
@@ -23,7 +24,7 @@
 
 buildPythonPackage rec {
   pname = "hypothesis";
-  version = "6.124.1";
+  version = "6.125.2";
   pyproject = true;
 
   disabled = pythonOlder "3.7";
@@ -32,7 +33,7 @@ buildPythonPackage rec {
     owner = "HypothesisWorks";
     repo = "hypothesis";
     rev = "hypothesis-python-${version}";
-    hash = "sha256-d8uvkCiEASP5sF6kvuxqAss/KC0RNgG9n9ZdCcBTPCs=";
+    hash = "sha256-W+rTh9ymJTvq7KA4w8YrG6Z10tcfrtKGJ1MW716nVHs=";
   };
 
   # I tried to package sphinx-selective-exclude, but it throws
@@ -86,6 +87,9 @@ buildPythonPackage rec {
       "test_observability"
       "test_assume_has_status_reason"
       "test_observability_captures_stateful_reprs"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      "test_clean_source"
     ];
 
   pythonImportsCheck = [ "hypothesis" ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux (`python312.tests`; `python313.tests`)
  - [x] aarch64-linux (`python312.tests`; `pyython313.tests` w/o `cpython-gdb` tests)
  - [x] x86_64-darwin (`python312.tests`, `python313.tests`)
  - [x] aarch64-darwin (`python312.tests`, `python313.tests`)
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
