### PR TITLE
volatility2-bin: init at 2.6.1

### DIFF
--- a/pkgs/by-name/vo/volatility2-bin/package.nix
+++ b/pkgs/by-name/vo/volatility2-bin/package.nix
@@ -1,0 +1,70 @@
+{
+  stdenv,
+  fetchzip,
+  lib,
+  autoPatchelfHook,
+  libz,
+}:
+let
+  throwSystem = throw "Unsupported system: ${stdenv.hostPlatform.system}";
+  suffix =
+    {
+      x86_64-linux = "lin64_standalone";
+      x86_64-darwin = "mac64_standalone";
+    }
+    .${stdenv.hostPlatform.system} or throwSystem;
+  hash =
+    {
+      x86_64-linux = "sha256-ucG6oR4gBRUjMmHRr9QNenc04ENvwLvyCzSAqIoAiwM=";
+      x86_64-darwin = "sha256-BObRSSGUra1y/oo3ZFfIGi2PdHDX2gZy315x7R9DQPk=";
+    }
+    .${stdenv.hostPlatform.system} or throwSystem;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "volatility2-bin";
+  version = "2.6.1";
+
+  src = fetchzip {
+    url = "https://github.com/volatilityfoundation/volatility/releases/download/${finalAttrs.version}/volatility_${lib.versions.majorMinor finalAttrs.version}_${suffix}.zip";
+    stripRoot = true;
+    inherit hash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  buildInputs = [
+    libz
+  ];
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install $src/volatility_2.6_${suffix} -D -T $out/bin/volatility2
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      ${stdenv.cc.targetPrefix}install_name_tool \
+        -change /usr/lib/libz.1.dylib "${libz}/lib/libz.1.dylib" \
+        $out/bin/volatility2
+    ''}
+    ln -s $out/bin/volatility2 $out/bin/vol2
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    homepage = "https://volatilityfoundation.org/";
+    mainProgram = "volatility2";
+    description = "An advanced memory forensics framework";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+    ];
+    maintainers = with lib.maintainers; [ ivyfanchiang ];
+    license = lib.licenses.gpl2Plus;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    changelog = "https://github.com/volatilityfoundation/volatility/releases/tag/${finalAttrs.version}";
+  };
+})


### PR DESCRIPTION
Volatility is a memory forensics tool. While volatility2 has been superseded by volatility3 (which is faster and based on Python 3), volatility2 still sees regular use due to its larger number of plugins and features. As such, many users performing memory forensics use a combination of both versions of volatility.

A previous pull request (#184782) trying to reintroduce a volatility2 source package was closed due to Python 2 being EOL, which is why this pull request uses the volatility2 standalone release binaries.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
