### PR TITLE
proton-ge-bin: remove uneeded changes

### DIFF
--- a/pkgs/by-name/pr/proton-ge-bin/package.nix
+++ b/pkgs/by-name/pr/proton-ge-bin/package.nix
@@ -34,16 +34,14 @@ stdenvNoCC.mkDerivation (finalAttrs: {
 
     mkdir $steamcompattool
     ln -s $src/* $steamcompattool
-    rm $steamcompattool/{compatibilitytool.vdf,proton,version}
-    cp $src/{compatibilitytool.vdf,proton,version} $steamcompattool
+    rm $steamcompattool/compatibilitytool.vdf
+    cp $src/compatibilitytool.vdf $steamcompattool
 
     runHook postInstall
   '';
 
   preFixup = ''
     substituteInPlace "$steamcompattool/compatibilitytool.vdf" \
-      --replace-fail "${finalAttrs.version}" "${steamDisplayName}"
-    substituteInPlace "$steamcompattool/proton" \
       --replace-fail "${finalAttrs.version}" "${steamDisplayName}"
   '';
 


### PR DESCRIPTION
This package modifies some of the files so that steam automatically switches when the package is updated. However, from my testing, it seems the proton script doesn't need to be patched. The name that was being changed in that file is only used by the script when updating the prefix.

maintainers: @NotAShelf @Shawn8901  
