### PR TITLE
emacs: move the setup hook from elisp build helper to emacs

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/elpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/elpa.nix
@@ -5,7 +5,6 @@
   stdenv,
   emacs,
   texinfo,
-  writeText,
 }:
 
 let
@@ -15,7 +14,6 @@ let
       stdenv
       emacs
       texinfo
-      writeText
       ;
   };
   libBuildHelper = import ./lib-build-helper.nix;

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -5,26 +5,11 @@
   stdenv,
   emacs,
   texinfo,
-  writeText,
   ...
 }:
 
 let
   inherit (lib) optionalAttrs;
-
-  setupHook = writeText "setup-hook.sh" ''
-    source ${./emacs-funcs.sh}
-
-    if [[ ! -v emacsHookDone ]]; then
-      emacsHookDone=1
-
-      # If this is for a wrapper derivation, emacs and the dependencies are all
-      # run-time dependencies. If this is for precompiling packages into bytecode,
-      # emacs is a compile-time dependency of the package.
-      addEnvHooks "$hostOffset" addEmacsVars
-      addEnvHooks "$targetOffset" addEmacsVars
-    fi
-  '';
 
   libBuildHelper = import ./lib-build-helper.nix;
 
@@ -75,8 +60,6 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (
     propagatedBuildInputs = finalAttrs.packageRequires ++ propagatedBuildInputs;
     propagatedUserEnvPkgs = finalAttrs.packageRequires ++ propagatedUserEnvPkgs;
 
-    setupHook = args.setupHook or setupHook;
-
     strictDeps = args.strictDeps or true;
 
     inherit turnCompilationWarningToError ignoreCompilationError;
@@ -102,7 +85,6 @@ libBuildHelper.extendMkDerivation' stdenv.mkDerivation (
         # the current package's elisp files are in the load path, otherwise
         # (require 'file-b) from file-a.el in the same package will fail.
         mkdir -p $out/share/emacs/native-lisp
-        source ${./emacs-funcs.sh}
         addEmacsVars "$out"
 
         # package-activate-all is used to activate packages.  In other builder

--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -7,7 +7,6 @@
   fetchFromGitHub,
   emacs,
   texinfo,
-  writeText,
 }:
 
 let
@@ -17,7 +16,6 @@ let
       stdenv
       emacs
       texinfo
-      writeText
       ;
   };
   libBuildHelper = import ./lib-build-helper.nix;

--- a/pkgs/applications/editors/emacs/make-emacs.nix
+++ b/pkgs/applications/editors/emacs/make-emacs.nix
@@ -61,6 +61,7 @@
   texinfo,
   webkitgtk_4_0,
   wrapGAppsHook3,
+  writeText,
   zlib,
 
   # Boolean flags
@@ -507,6 +508,8 @@ mkDerivation (finalAttrs: {
     patchelf --add-rpath ${lib.makeLibraryPath [ libXcursor ]} $out/bin/emacs
     patchelf --add-needed "libXcursor.so.1" "$out/bin/emacs"
   '';
+
+  setupHook = ./setup-hook.sh;
 
   passthru = {
     inherit withNativeCompilation;

--- a/pkgs/applications/editors/emacs/setup-hook.sh
+++ b/pkgs/applications/editors/emacs/setup-hook.sh
@@ -21,3 +21,5 @@ addEmacsVars () {
     addToEmacsNativeLoadPath "$1/share/emacs/native-lisp"
   fi
 }
+
+addEnvHooks "$targetOffset" addEmacsVars


### PR DESCRIPTION
The hook is used to construct EMACSLOADPATH and EMACSNATIVELOADPATH from elisp packages in buildInputs for emacs in nativeBuildInputs to use during the build of an elisp package.  Emacs is the right place to set this hook, which is similar to the fact that cc-wrapper[1] is the right place to set a hook[2] constructing NIX_CFLAGS_COMPILE.

[1]: https://github.com/NixOS/nixpkgs/blob/17bfa4436fdbee1374b1797c8a9ddc8a3570cf51/pkgs/build-support/cc-wrapper/default.nix#L461
[2]: https://github.com/NixOS/nixpkgs/blob/17bfa4436fdbee1374b1797c8a9ddc8a3570cf51/pkgs/build-support/cc-wrapper/setup-hook.sh#L86


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
