### PR TITLE
ocamlPackages.multipart_form{,-lwt}: init at 0.6.0

### DIFF
--- a/pkgs/development/ocaml-modules/multipart_form/default.nix
+++ b/pkgs/development/ocaml-modules/multipart_form/default.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  buildDunePackage,
+  fetchurl,
+  angstrom,
+  base64,
+  bigstringaf,
+  fmt,
+  ke,
+  logs,
+  pecu,
+  prettym,
+  unstrctrd,
+  uutf,
+}:
+
+buildDunePackage rec {
+  pname = "multipart_form";
+  version = "0.6.0";
+
+  src = fetchurl {
+    url = "https://github.com/dinosaure/multipart_form/releases/download/v${version}/multipart_form-${version}.tbz";
+    hash = "sha256-oOMpwyPP+q1BZ81a+HpooeaglUZgDxdz2MDNLygGIRY=";
+  };
+
+  propagatedBuildInputs = [
+    angstrom
+    base64
+    bigstringaf
+    fmt
+    ke
+    logs
+    pecu
+    prettym
+    unstrctrd
+    uutf
+  ];
+
+  meta = {
+    description = "Implementation of RFC7578 in OCaml";
+    homepage = "https://github.com/dinosaure/multipart_form";
+    license = lib.licenses.mit;
+    maintainers = [ lib.maintainers.vbgl ];
+  };
+}

--- a/pkgs/development/ocaml-modules/multipart_form/lwt.nix
+++ b/pkgs/development/ocaml-modules/multipart_form/lwt.nix
@@ -1,0 +1,17 @@
+{
+  buildDunePackage,
+  multipart_form,
+  lwt,
+}:
+
+buildDunePackage {
+  pname = "multipart_form-lwt";
+
+  inherit (multipart_form) version src meta;
+
+  propagatedBuildInputs = [
+    lwt
+    multipart_form
+
+  ];
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1246,6 +1246,8 @@ let
 
     multipart_form =  callPackage ../development/ocaml-modules/multipart_form { };
 
+    multipart_form-lwt =  callPackage ../development/ocaml-modules/multipart_form/lwt.nix { };
+
     multipart-form-data =  callPackage ../development/ocaml-modules/multipart-form-data { };
 
     mustache =  callPackage ../development/ocaml-modules/mustache { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -1244,6 +1244,8 @@ let
 
     multicore-magic =  callPackage ../development/ocaml-modules/multicore-magic { };
 
+    multipart_form =  callPackage ../development/ocaml-modules/multipart_form { };
+
     multipart-form-data =  callPackage ../development/ocaml-modules/multipart-form-data { };
 
     mustache =  callPackage ../development/ocaml-modules/mustache { };


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
