### PR TITLE
androidenv: simplify updating, track latest, and recurseIntoAttrs all packages

### DIFF
--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -88,6 +88,9 @@ The following parameters are supported:
   have an aarch64-linux compile).
 * `platformVersions` specifies which platform SDK versions should be included.
   It defaults to including only the latest API level, though you can add more.
+* `numLatestPlatformVersions` specifies how many of the latest API levels to include,
+  if you are using the default for `platformVersions`. It defaults to 1, though you can
+  increase this to, for example, 5 to get the last 5 years of Android API packages.
 * `minPlatformVersion` and `maxPlatformVersion` take priority over `platformVersions`
   if both are provided. Note that `maxPlatformVersion` always defaults to the latest
   Android SDK platform version, allowing you to specify `minPlatformVersion` to describe

--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -27,7 +27,7 @@ buildInputs = [
 ];
 ```
 
-These will export ANDROID_SDK_ROOT and ANDROID_NDK_ROOT to the SDK and NDK directories
+These will export `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` to the SDK and NDK directories
 in the specified Android build environment.
 
 ## Deploying an Android SDK installation with plugins {#deploying-an-android-sdk-installation-with-plugins}
@@ -57,7 +57,7 @@ exceptions are the tools, platform-tools and build-tools sub packages.
 
 The following parameters are supported:
 
-* `cmdLineToolsVersion `, specifies the version of the `cmdline-tools` package to use.
+* `cmdLineToolsVersion` specifies the version of the `cmdline-tools` package to use.
   It defaults to the latest.
 * `toolsVersion`, specifies the version of the `tools` package. Notice `tools` is
   obsolete, and currently only `26.1.1` is available, so there's not a lot of
@@ -69,14 +69,14 @@ The following parameters are supported:
   use. It defaults to the latest.
 * `includeEmulator` specifies whether to deploy the emulator package (`false`
   by default). When enabled, the version of the emulator to deploy can be
-  specified by setting the `emulatorVersion` parameter. If set to `null` or
+  specified by setting the `emulatorVersion` parameter. If set to
   `"if-supported"`, it will deploy the emulator if it's supported by the system.
 * `includeCmake` specifies whether CMake should be included. It defaults to true
-  on x86-64 and Darwin platforms, and also supports `null` and `"if-supported"`.
+  on x86-64 and Darwin platforms, and also supports `"if-supported"`.
 * `cmakeVersions` specifies which CMake versions should be deployed.
   It defaults to the latest.
 * `includeNDK` specifies that the Android NDK bundle should be included.
-  Defaults to: `false` though can be set to `true`, `null`, or `"if-supported"`.
+  Defaults to `false` though can be set to `true` or `"if-supported"`.
 * `ndkVersions` specifies the NDK versions that we want to use. These are linked
   under the `ndk` directory of the SDK root, and the first is linked under the
   `ndk-bundle` directory. It defaults to the latest.
@@ -84,8 +84,8 @@ The following parameters are supported:
   `ndkVersions` overrides this parameter if provided.
 * `includeExtras` is an array of identifier strings referring to arbitrary
   add-on packages that should be installed. Note that extras may not be compatible
-  with all platforms (for example, the Google TV head unit does not have an aarch64-linux
-  compile).
+  with all platforms (for example, the Google TV head unit, which does not
+  have an aarch64-linux compile).
 * `platformVersions` specifies which platform SDK versions should be included.
   It defaults to including only the latest API level, though you can add more.
 
@@ -313,17 +313,9 @@ android {
 ## Querying the available versions of each plugin {#querying-the-available-versions-of-each-plugin}
 
 All androidenv packages are available on [search.nixos.org](https://search.nixos.org).
-
-Additionally, repo.json provides all the options in one file now.
-
-A shell script in the `pkgs/development/mobile/androidenv/` subdirectory can be used to retrieve all
-possible options:
-
-```bash
-./querypackages.sh packages
-```
-
-The above command-line instruction queries all package versions in repo.json.
+Note that `aarch64-linux` compatibility is currently spotty, though `x86_64-linux` and `aarch64-darwin`
+are well supported. This is because Google's repository definitions mark some packages for "all" architectures
+that are really only for `x86_64` or `aarch64`.
 
 ## Updating the generated expressions {#updating-the-generated-expressions}
 

--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -39,24 +39,12 @@ with import <nixpkgs> {};
 
 let
   androidComposition = androidenv.composeAndroidPackages {
-    cmdLineToolsVersion = "8.0";
-    toolsVersion = "26.1.1";
-    platformToolsVersion = "30.0.5";
-    buildToolsVersions = [ "30.0.3" ];
-    includeEmulator = false;
-    emulatorVersion = "30.3.4";
-    platformVersions = [ "28" "29" "30" ];
-    includeSources = false;
-    includeSystemImages = false;
+    platformVersions = [ "34" "35" ];
     systemImageTypes = [ "google_apis_playstore" ];
     abiVersions = [ "armeabi-v7a" "arm64-v8a" ];
-    cmakeVersions = [ "3.10.2" ];
     includeNDK = true;
-    ndkVersions = ["22.0.7026061"];
-    useGoogleAPIs = false;
-    useGoogleTVAddOns = false;
     includeExtras = [
-      "extras;google;gcm"
+      "extras;google;auto"
     ];
   };
 in
@@ -69,27 +57,37 @@ exceptions are the tools, platform-tools and build-tools sub packages.
 
 The following parameters are supported:
 
-* `cmdLineToolsVersion `, specifies the version of the `cmdline-tools` package to use
+* `cmdLineToolsVersion `, specifies the version of the `cmdline-tools` package to use.
+  It defaults to the latest.
 * `toolsVersion`, specifies the version of the `tools` package. Notice `tools` is
   obsolete, and currently only `26.1.1` is available, so there's not a lot of
-  options here, however, you can set it as `null` if you don't want it.
-* `platformsToolsVersion` specifies the version of the `platform-tools` plugin
+  options here, however, you can set it as `null` if you don't want it. It defaults
+  to the latest.
+* `platformToolsVersion` specifies the version of the `platform-tools` plugin.
+  It defaults to the latest.
 * `buildToolsVersions` specifies the versions of the `build-tools` plugins to
-  use.
+  use. It defaults to the latest.
 * `includeEmulator` specifies whether to deploy the emulator package (`false`
   by default). When enabled, the version of the emulator to deploy can be
-  specified by setting the `emulatorVersion` parameter.
+  specified by setting the `emulatorVersion` parameter. If set to `null` or
+  `"if-supported"`, it will deploy the emulator if it's supported by the system.
+* `includeCmake` specifies whether CMake should be included. It defaults to true
+  on x86-64 and Darwin platforms, and also supports `null` and `"if-supported"`.
 * `cmakeVersions` specifies which CMake versions should be deployed.
+  It defaults to the latest.
 * `includeNDK` specifies that the Android NDK bundle should be included.
-  Defaults to: `false`.
+  Defaults to: `false` though can be set to `true`, `null`, or `"if-supported"`.
 * `ndkVersions` specifies the NDK versions that we want to use. These are linked
   under the `ndk` directory of the SDK root, and the first is linked under the
-  `ndk-bundle` directory.
+  `ndk-bundle` directory. It defaults to the latest.
 * `ndkVersion` is equivalent to specifying one entry in `ndkVersions`, and
   `ndkVersions` overrides this parameter if provided.
 * `includeExtras` is an array of identifier strings referring to arbitrary
-  add-on packages that should be installed.
+  add-on packages that should be installed. Note that extras may not be compatible
+  with all platforms (for example, the Google TV head unit does not have an aarch64-linux
+  compile).
 * `platformVersions` specifies which platform SDK versions should be included.
+  It defaults to including only the latest API level, though you can add more.
 
 For each platform version that has been specified, we can apply the following
 options:
@@ -108,9 +106,10 @@ For each requested system image we can specify the following options:
 * `systemImageTypes` specifies what kind of system images should be included.
   Defaults to: `default`.
 * `abiVersions` specifies what kind of ABI version of each system image should
-  be included. Defaults to: `armeabi-v7a`.
+  be included. Defaults to `armeabi-v7a` and `arm64-v8a`.
 
-Most of the function arguments have reasonable default settings.
+Most of the function arguments have reasonable default settings, preferring the latest
+versions of tools when possible.
 
 You can specify license names:
 
@@ -127,7 +126,8 @@ pull from:
   by running `generate.sh`, which in turn will call into `mkrepo.rb`.
 * `repoXmls` is an attribute set containing paths to repo XML files. If specified,
   it takes priority over `repoJson`, and will trigger a local build writing out a
-  repo.json to the Nix store based on the given repository XMLs.
+  repo.json to the Nix store based on the given repository XMLs. Note that this uses
+  import-from-derivation.
 
 ```nix
 {
@@ -312,7 +312,9 @@ android {
 
 ## Querying the available versions of each plugin {#querying-the-available-versions-of-each-plugin}
 
-repo.json provides all the options in one file now.
+All androidenv packages are available on [search.nixos.org](https://search.nixos.org).
+
+Additionally, repo.json provides all the options in one file now.
 
 A shell script in the `pkgs/development/mobile/androidenv/` subdirectory can be used to retrieve all
 possible options:
@@ -326,12 +328,14 @@ The above command-line instruction queries all package versions in repo.json.
 ## Updating the generated expressions {#updating-the-generated-expressions}
 
 repo.json is generated from XML files that the Android Studio package manager uses.
-To update the expressions run the `generate.sh` script that is stored in the
+To update the expressions run the `update.sh` script that is stored in the
 `pkgs/development/mobile/androidenv/` subdirectory:
 
 ```bash
-./generate.sh
+./update.sh
 ```
+
+This is run automatically by the nixpkgs update script.
 
 ## Building an Android application with Ant {#building-an-android-application-with-ant}
 

--- a/doc/languages-frameworks/android.section.md
+++ b/doc/languages-frameworks/android.section.md
@@ -88,6 +88,10 @@ The following parameters are supported:
   have an aarch64-linux compile).
 * `platformVersions` specifies which platform SDK versions should be included.
   It defaults to including only the latest API level, though you can add more.
+* `minPlatformVersion` and `maxPlatformVersion` take priority over `platformVersions`
+  if both are provided. Note that `maxPlatformVersion` always defaults to the latest
+  Android SDK platform version, allowing you to specify `minPlatformVersion` to describe
+  the minimum SDK version your Android composition supports.
 
 For each platform version that has been specified, we can apply the following
 options:

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -58,6 +58,11 @@
   - A new `pkgs.mattermost.buildPlugin` function has been added, which allows plugins to be built from source, including webapp frontends with a supported package-lock.json. See the Mattermost NixOS test and [manual](https://nixos.org/manual/nixpkgs/unstable/#sec-mattermost-plugins-build) for an example.
   - Note that the Mattermost module will create an account _without_ a well-known UID if the username differs from the default (`mattermost`). If you used Mattermost with a nonstandard username, you may want to review the module changes before upgrading.
 
+- androidenv has been updated:
+  - All versions specified in composeAndroidPackages now track latest. Android packages are automatically updated on unstable, and run the androidenv test suite on every update.
+  - Some androidenv packages are now searchable on [search.nixos.org](https://search.nixos.org).
+  - We now use the latest Google repositories, which should improve aarch64-darwin compatibility. The SDK now additionally evaluates on aarch64-linux, though not all packages are functional.
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## New Modules {#sec-release-25.05-new-modules}

--- a/pkgs/development/mobile/androidenv/build-app.nix
+++ b/pkgs/development/mobile/androidenv/build-app.nix
@@ -6,6 +6,7 @@
   jdk,
   gnumake,
   gawk,
+  meta,
 }:
 
 {
@@ -64,6 +65,8 @@ stdenv.mkDerivation (
       mkdir -p $out/nix-support
       echo "file binary-dist \"$(echo $out/*.apk)\"" > $out/nix-support/hydra-build-products
     '';
+
+    inherit meta;
   }
   // extraArgs
 )

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,7 +1,7 @@
-{deployAndroidPackage, lib, stdenv, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta}:
+{deployAndroidPackage, lib, stdenv, package, os, arch, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta}:
 
 deployAndroidPackage {
-  inherit package;
+  inherit package os arch;
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
   buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.zlib pkgs.ncurses5 pkgs.libcxx ]

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, stdenv, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall}:
+{deployAndroidPackage, lib, stdenv, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta}:
 
 deployAndroidPackage {
   inherit package;
@@ -24,4 +24,6 @@ deployAndroidPackage {
     cd $out/libexec/android-sdk
   '' + postInstall;
   noAuditTmpdir = true; # The checker script gets confused by the build-tools path that is incorrectly identified as a reference to /build
+
+  inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/build-tools.nix
+++ b/pkgs/development/mobile/androidenv/build-tools.nix
@@ -1,28 +1,55 @@
-{deployAndroidPackage, lib, stdenv, package, os, arch, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta}:
+{
+  deployAndroidPackage,
+  lib,
+  stdenv,
+  package,
+  os,
+  arch,
+  autoPatchelfHook,
+  makeWrapper,
+  pkgs,
+  pkgsi686Linux,
+  postInstall,
+  meta,
+}:
 
 deployAndroidPackage {
   inherit package os arch;
-  nativeBuildInputs = [ makeWrapper ]
-    ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc pkgs.zlib pkgs.ncurses5 pkgs.libcxx ]
-    ++ lib.optionals (os == "linux" && stdenv.isx86_64) (with pkgsi686Linux; [ glibc zlib ncurses5 ]);
-  patchInstructions = ''
-    ${lib.optionalString (os == "linux") ''
-      addAutoPatchelfSearchPath $packageBaseDir/lib
-      if [[ -d $packageBaseDir/lib64 ]]; then
-        addAutoPatchelfSearchPath $packageBaseDir/lib64
-        autoPatchelf --no-recurse $packageBaseDir/lib64
-      fi
-      autoPatchelf --no-recurse $packageBaseDir
-    ''}
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
+  buildInputs =
+    lib.optionals (os == "linux") [
+      pkgs.glibc
+      pkgs.zlib
+      pkgs.ncurses5
+      pkgs.libcxx
+    ]
+    ++ lib.optionals (os == "linux" && stdenv.isx86_64) (
+      with pkgsi686Linux;
+      [
+        glibc
+        zlib
+        ncurses5
+      ]
+    );
+  patchInstructions =
+    ''
+      ${lib.optionalString (os == "linux") ''
+        addAutoPatchelfSearchPath $packageBaseDir/lib
+        if [[ -d $packageBaseDir/lib64 ]]; then
+          addAutoPatchelfSearchPath $packageBaseDir/lib64
+          autoPatchelf --no-recurse $packageBaseDir/lib64
+        fi
+        autoPatchelf --no-recurse $packageBaseDir
+      ''}
 
-    ${lib.optionalString (lib.toInt (lib.versions.major package.revision) < 33) ''
-      wrapProgram $PWD/mainDexClasses \
-        --prefix PATH : ${pkgs.jdk8}/bin
-    ''}
+      ${lib.optionalString (lib.toInt (lib.versions.major package.revision) < 33) ''
+        wrapProgram $PWD/mainDexClasses \
+          --prefix PATH : ${pkgs.jdk8}/bin
+      ''}
 
-    cd $out/libexec/android-sdk
-  '' + postInstall;
+      cd $out/libexec/android-sdk
+    ''
+    + postInstall;
   noAuditTmpdir = true; # The checker script gets confused by the build-tools path that is incorrectly identified as a reference to /build
 
   inherit meta;

--- a/pkgs/development/mobile/androidenv/cmake.nix
+++ b/pkgs/development/mobile/androidenv/cmake.nix
@@ -1,7 +1,7 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs, stdenv, meta}:
+{deployAndroidPackage, lib, package, os, arch, autoPatchelfHook, pkgs, stdenv, meta}:
 
 deployAndroidPackage {
-  inherit package;
+  inherit package os arch;
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
   buildInputs = lib.optionals (os == "linux") [ pkgs.stdenv.cc.libc pkgs.stdenv.cc.cc pkgs.ncurses5 ];
   patchInstructions = lib.optionalString (os == "linux") ''

--- a/pkgs/development/mobile/androidenv/cmake.nix
+++ b/pkgs/development/mobile/androidenv/cmake.nix
@@ -1,9 +1,23 @@
-{deployAndroidPackage, lib, package, os, arch, autoPatchelfHook, pkgs, stdenv, meta}:
+{
+  deployAndroidPackage,
+  lib,
+  package,
+  os,
+  arch,
+  autoPatchelfHook,
+  pkgs,
+  stdenv,
+  meta,
+}:
 
 deployAndroidPackage {
   inherit package os arch;
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.stdenv.cc.libc pkgs.stdenv.cc.cc pkgs.ncurses5 ];
+  buildInputs = lib.optionals (os == "linux") [
+    pkgs.stdenv.cc.libc
+    pkgs.stdenv.cc.cc
+    pkgs.ncurses5
+  ];
   patchInstructions = lib.optionalString (os == "linux") ''
     autoPatchelf $packageBaseDir/bin
   '';

--- a/pkgs/development/mobile/androidenv/cmake.nix
+++ b/pkgs/development/mobile/androidenv/cmake.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs, stdenv}:
+{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs, stdenv, meta}:
 
 deployAndroidPackage {
   inherit package;
@@ -7,4 +7,8 @@ deployAndroidPackage {
   patchInstructions = lib.optionalString (os == "linux") ''
     autoPatchelf $packageBaseDir/bin
   '';
+
+  meta = meta // {
+    license = lib.licenses.bsd3;
+  };
 }

--- a/pkgs/development/mobile/androidenv/cmdline-tools.nix
+++ b/pkgs/development/mobile/androidenv/cmdline-tools.nix
@@ -8,6 +8,7 @@
   pkgs,
   stdenv,
   postInstall,
+  meta,
 }:
 
 deployAndroidPackage {
@@ -46,5 +47,5 @@ deployAndroidPackage {
     ${postInstall}
   '';
 
-  meta.license = lib.licenses.unfree;
+  inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/cmdline-tools.nix
+++ b/pkgs/development/mobile/androidenv/cmdline-tools.nix
@@ -5,6 +5,7 @@
   autoPatchelfHook,
   makeWrapper,
   os,
+  arch,
   pkgs,
   stdenv,
   postInstall,
@@ -13,7 +14,7 @@
 
 deployAndroidPackage {
   name = "androidsdk";
-  inherit package os;
+  inherit package os arch;
   nativeBuildInputs = [
     makeWrapper
   ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -244,14 +244,14 @@ let
       true
     else if check == false then
       false
-    else if check == null || check == "if-supported" then
+    else if check == "if-supported" then
       let
         hasSrc =
           package: package.src != null && (builtins.isList package.src -> builtins.length package.src > 0);
       in
       packages != [ ] && lib.all hasSrc packages
     else
-      throw "Invalid argument ${toString check}; use true, false, or null/if-supported";
+      throw "Invalid argument ${toString check}; use true, false, or if-supported";
 
   # Function that automatically links all plugins for which multiple versions can coexist
   linkPlugins =

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -82,6 +82,7 @@ in
   emulatorVersion ? repo.latest.emulator,
   minPlatformVersion ? null,
   maxPlatformVersion ? coerceInt repo.latest.platforms,
+  numLatestPlatformVersions ? 1,
   platformVersions ?
     if minPlatformVersion != null && maxPlatformVersion != null then
       let
@@ -92,7 +93,14 @@ in
         lib.max minPlatformVersionInt maxPlatformVersionInt
       )
     else
-      map coerceInt [ repo.latest.platforms ],
+      let
+        minPlatformVersionInt = if minPlatformVersion == null then 1 else coerceInt minPlatformVersion;
+        latestPlatformVersionInt = lib.max minPlatformVersionInt (coerceInt repo.latest.platforms);
+        firstPlatformVersionInt = lib.max minPlatformVersionInt (
+          latestPlatformVersionInt - (lib.max 1 numLatestPlatformVersions) + 1
+        );
+      in
+      lib.range firstPlatformVersionInt latestPlatformVersionInt,
   includeSources ? false,
   includeSystemImages ? false,
   systemImageTypes ? [

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -163,6 +163,7 @@ let
               archive:
               (fetchurl {
                 inherit (archive) url sha1;
+                preferLocalBuild = true;
                 passthru = {
                   info = packageInfo;
                 };

--- a/pkgs/development/mobile/androidenv/compose-android-packages.nix
+++ b/pkgs/development/mobile/androidenv/compose-android-packages.nix
@@ -1,112 +1,162 @@
-{ callPackage, stdenv, stdenvNoCC, lib, fetchurl, ruby, writeText
-, licenseAccepted ? false, meta
+{
+  callPackage,
+  stdenv,
+  stdenvNoCC,
+  lib,
+  fetchurl,
+  ruby,
+  writeText,
+  licenseAccepted ? false,
+  meta,
 }:
 
-{ repoJson ? ./repo.json
-, repoXmls ? null
-, repo ? (
-  # Reads the repo JSON. If repoXmls is provided, will build a repo JSON into the Nix store.
-  if repoXmls != null then
-    let
-      # Uses mkrepo.rb to create a repo spec.
-      mkRepoJson = { packages ? [], images ? [], addons ? [] }: let
-        mkRepoRuby = (ruby.withPackages (pkgs: with pkgs; [ slop nokogiri ]));
-        mkRepoRubyArguments = lib.lists.flatten [
-          (map (package: ["--packages" "${package}"]) packages)
-          (map (image: ["--images" "${image}"]) images)
-          (map (addon: ["--addons" "${addon}"]) addons)
-        ];
+{
+  repoJson ? ./repo.json,
+  repoXmls ? null,
+  repo ? (
+    # Reads the repo JSON. If repoXmls is provided, will build a repo JSON into the Nix store.
+    if repoXmls != null then
+      let
+        # Uses mkrepo.rb to create a repo spec.
+        mkRepoJson =
+          {
+            packages ? [ ],
+            images ? [ ],
+            addons ? [ ],
+          }:
+          let
+            mkRepoRuby = (
+              ruby.withPackages (
+                pkgs: with pkgs; [
+                  slop
+                  nokogiri
+                ]
+              )
+            );
+            mkRepoRubyArguments = lib.lists.flatten [
+              (map (package: [
+                "--packages"
+                "${package}"
+              ]) packages)
+              (map (image: [
+                "--images"
+                "${image}"
+              ]) images)
+              (map (addon: [
+                "--addons"
+                "${addon}"
+              ]) addons)
+            ];
+          in
+          stdenvNoCC.mkDerivation {
+            name = "androidenv-repo-json";
+            buildInputs = [ mkRepoRuby ];
+            preferLocalBuild = true;
+            unpackPhase = "true";
+            buildPhase = ''
+              ruby ${./mkrepo.rb} ${lib.escapeShellArgs mkRepoRubyArguments} > repo.json
+            '';
+            installPhase = ''
+              mv repo.json $out
+            '';
+          };
+        repoXmlSpec = {
+          packages = repoXmls.packages or [ ];
+          images = repoXmls.images or [ ];
+          addons = repoXmls.addons or [ ];
+        };
       in
-      stdenvNoCC.mkDerivation {
-        name = "androidenv-repo-json";
-        buildInputs = [ mkRepoRuby ];
-        preferLocalBuild = true;
-        unpackPhase = "true";
-        buildPhase = ''
-          ruby ${./mkrepo.rb} ${lib.escapeShellArgs mkRepoRubyArguments} > repo.json
-        '';
-        installPhase = ''
-          mv repo.json $out
-        '';
-      };
-       repoXmlSpec = {
-         packages = repoXmls.packages or [];
-         images = repoXmls.images or [];
-         addons = repoXmls.addons or [];
-       };
-    in
       lib.importJSON "${mkRepoJson repoXmlSpec}"
-  else
-    lib.importJSON repoJson
-  )
-, cmdLineToolsVersion ? repo.latest.cmdline-tools
-, toolsVersion ? repo.latest.tools
-, platformToolsVersion ? repo.latest.platform-tools
-, buildToolsVersions ? [ repo.latest.build-tools ]
-, includeEmulator ? false
-, emulatorVersion ? repo.latest.emulator
-, platformVersions ? [ repo.latest.platforms ]
-, includeSources ? false
-, includeSystemImages ? false
-, systemImageTypes ? [ "google_apis" "google_apis_playstore" ]
-, abiVersions ? [ "x86" "x86_64" "armeabi-v7a" "arm64-v8a" ]
+    else
+      lib.importJSON repoJson
+  ),
+  cmdLineToolsVersion ? repo.latest.cmdline-tools,
+  toolsVersion ? repo.latest.tools,
+  platformToolsVersion ? repo.latest.platform-tools,
+  buildToolsVersions ? [ repo.latest.build-tools ],
+  includeEmulator ? false,
+  emulatorVersion ? repo.latest.emulator,
+  platformVersions ? [ repo.latest.platforms ],
+  includeSources ? false,
+  includeSystemImages ? false,
+  systemImageTypes ? [
+    "google_apis"
+    "google_apis_playstore"
+  ],
+  abiVersions ? [
+    "x86"
+    "x86_64"
+    "armeabi-v7a"
+    "arm64-v8a"
+  ],
   # cmake has precompiles on x86_64 and Darwin platforms. Default to true there for compatibility.
-, includeCmake ? stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isDarwin
-, cmakeVersions ? [ repo.latest.cmake ]
-, includeNDK ? false
-, ndkVersion ? repo.latest.ndk
-, ndkVersions ? [ ndkVersion ]
-, useGoogleAPIs ? false
-, useGoogleTVAddOns ? false
-, includeExtras ? []
-, extraLicenses ? []
+  includeCmake ? stdenv.hostPlatform.isx86_64 || stdenv.hostPlatform.isDarwin,
+  cmakeVersions ? [ repo.latest.cmake ],
+  includeNDK ? false,
+  ndkVersion ? repo.latest.ndk,
+  ndkVersions ? [ ndkVersion ],
+  useGoogleAPIs ? false,
+  useGoogleTVAddOns ? false,
+  includeExtras ? [ ],
+  extraLicenses ? [ ],
 }:
 
 let
   # Determine the Android os identifier from Nix's system identifier
-  os = {
+  os =
+    {
       x86_64-linux = "linux";
       x86_64-darwin = "macosx";
       aarch64-linux = "linux";
       aarch64-darwin = "macosx";
-  }.${stdenv.hostPlatform.system} or "all";
+    }
+    .${stdenv.hostPlatform.system} or "all";
 
   # Determine the Android arch identifier from Nix's system identifier
-  arch = {
+  arch =
+    {
       x86_64-linux = "x64";
       x86_64-darwin = "x64";
       aarch64-linux = "aarch64";
       aarch64-darwin = "aarch64";
-  }.${stdenv.hostPlatform.system} or "all";
+    }
+    .${stdenv.hostPlatform.system} or "all";
 
   # Converts all 'archives' keys in a repo spec to fetchurl calls.
-  fetchArchives = attrSet:
-    lib.attrsets.mapAttrsRecursive
-      (path: value:
-        if (builtins.elemAt path (builtins.length path - 1)) == "archives" then
-          let
-            validArchives = builtins.filter (archive:
-              let
-                isTargetOs = if builtins.hasAttr "os" archive then
-                  archive.os == os || archive.os == "all" else true;
-                isTargetArch = if builtins.hasAttr "arch" archive then
-                  archive.arch == arch || archive.arch == "all" else true;
-              in
-                isTargetOs && isTargetArch
-            ) value;
-            packageInfo = lib.attrByPath (lib.sublist 0 (builtins.length path - 1) path) null attrSet;
-          in
-          lib.optionals (builtins.length validArchives > 0)
-            (lib.last (map (archive:
+  fetchArchives =
+    attrSet:
+    lib.attrsets.mapAttrsRecursive (
+      path: value:
+      if (builtins.elemAt path (builtins.length path - 1)) == "archives" then
+        let
+          validArchives = builtins.filter (
+            archive:
+            let
+              isTargetOs =
+                if builtins.hasAttr "os" archive then archive.os == os || archive.os == "all" else true;
+              isTargetArch =
+                if builtins.hasAttr "arch" archive then archive.arch == arch || archive.arch == "all" else true;
+            in
+            isTargetOs && isTargetArch
+          ) value;
+          packageInfo = lib.attrByPath (lib.sublist 0 (builtins.length path - 1) path) null attrSet;
+        in
+        lib.optionals (builtins.length validArchives > 0) (
+          lib.last (
+            map (
+              archive:
               (fetchurl {
                 inherit (archive) url sha1;
                 passthru = {
                   info = packageInfo;
                 };
               })
-            ) validArchives))
-        else value
-      ) attrSet;
+            ) validArchives
+          )
+        )
+      else
+        value
+    ) attrSet;
 
   # Converts the repo attrset into fetch calls.
   allArchives = {
@@ -120,28 +170,28 @@ let
   # and add recurseIntoAttrs to all of them.
   allPackages =
     let
-      liftedArchives = lib.attrsets.mapAttrsRecursiveCond
-        (value: !(builtins.hasAttr "archives" value))
-        (path: value:
-          if (value.archives or null) != null && (value.archives or [ ]) != [ ] then
-            lib.dontRecurseIntoAttrs value.archives
-          else
-            null
-        ) allArchives;
+      liftedArchives = lib.attrsets.mapAttrsRecursiveCond (value: !(builtins.hasAttr "archives" value)) (
+        path: value:
+        if (value.archives or null) != null && (value.archives or [ ]) != [ ] then
+          lib.dontRecurseIntoAttrs value.archives
+        else
+          null
+      ) allArchives;
 
       # Creates a version key from a name.
       # Converts things like 'extras;google;auto' to 'extras-google-auto'
-      toVersionKey = name:
+      toVersionKey =
+        name:
         lib.optionalString (lib.match "^[0-9].*" name != null) "v"
-          + lib.concatStringsSep "_" (lib.splitVersion (lib.replaceStrings [ ";" ] [ "-" ] name));
+        + lib.concatStringsSep "_" (lib.splitVersion (lib.replaceStrings [ ";" ] [ "-" ] name));
 
-      recurse = lib.mapAttrs'
-        (name: value:
-          if builtins.isAttrs value && (value.recurseForDerivations or true) then
-            lib.nameValuePair (toVersionKey name) (lib.recurseIntoAttrs (recurse value))
-          else
-            lib.nameValuePair (toVersionKey name) value
-        );
+      recurse = lib.mapAttrs' (
+        name: value:
+        if builtins.isAttrs value && (value.recurseForDerivations or true) then
+          lib.nameValuePair (toVersionKey name) (lib.recurseIntoAttrs (recurse value))
+        else
+          lib.nameValuePair (toVersionKey name) value
+      );
     in
     lib.recurseIntoAttrs (recurse liftedArchives);
 
@@ -150,39 +200,45 @@ let
 
   # Converts a list of license names to a flattened list of license texts.
   # Just used for displaying licenses.
-  mkLicenseTexts = licenseNames:
-    lib.lists.flatten
-      (builtins.map
-        (licenseName:
-          builtins.map
-            (licenseText: "--- ${licenseName} ---\n${licenseText}")
-            (mkLicenses licenseName))
-      licenseNames);
+  mkLicenseTexts =
+    licenseNames:
+    lib.lists.flatten (
+      builtins.map (
+        licenseName:
+        builtins.map (licenseText: "--- ${licenseName} ---\n${licenseText}") (mkLicenses licenseName)
+      ) licenseNames
+    );
 
   # Converts a license name to a list of license hashes.
-  mkLicenseHashes = licenseName:
-    builtins.map
-      (licenseText: builtins.hashString "sha1" licenseText)
-      (mkLicenses licenseName);
+  mkLicenseHashes =
+    licenseName:
+    builtins.map (licenseText: builtins.hashString "sha1" licenseText) (mkLicenses licenseName);
 
   # The list of all license names we're accepting. Put android-sdk-license there
   # by default.
-  licenseNames = lib.lists.unique ([
-    "android-sdk-license"
-  ] ++ extraLicenses);
+  licenseNames = lib.lists.unique (
+    [
+      "android-sdk-license"
+    ]
+    ++ extraLicenses
+  );
 
   # put a much nicer error message that includes the available options.
-  check-version = packages: package: version:
+  check-version =
+    packages: package: version:
     if lib.hasAttrByPath [ package version ] packages then
       packages.${package}.${version}
     else
       throw ''
         The version ${version} is missing in package ${package}.
-        The only available versions are ${builtins.concatStringsSep ", " (builtins.attrNames packages.${package})}.
+        The only available versions are ${
+          builtins.concatStringsSep ", " (builtins.attrNames packages.${package})
+        }.
       '';
 
   # Returns true if we should link the specified plugins.
-  shouldLink = check: packages:
+  shouldLink =
+    check: packages:
     assert builtins.isList packages;
     if check == true then
       true
@@ -190,14 +246,20 @@ let
       false
     else if check == null || check == "if-supported" then
       let
-        hasSrc = package: package.src != null && (builtins.isList package.src -> builtins.length package.src > 0);
+        hasSrc =
+          package: package.src != null && (builtins.isList package.src -> builtins.length package.src > 0);
       in
-      packages != [] && lib.all hasSrc packages
+      packages != [ ] && lib.all hasSrc packages
     else
       throw "Invalid argument ${toString check}; use true, false, or null/if-supported";
 
   # Function that automatically links all plugins for which multiple versions can coexist
-  linkPlugins = {name, plugins, check ? true}:
+  linkPlugins =
+    {
+      name,
+      plugins,
+      check ? true,
+    }:
     lib.optionalString (shouldLink check plugins) ''
       mkdir -p ${name}
       ${lib.concatMapStrings (plugin: ''
@@ -206,7 +268,13 @@ let
     '';
 
   # Function that automatically links all NDK plugins.
-  linkNdkPlugins = {name, plugins, rootName ? name, check ? true}:
+  linkNdkPlugins =
+    {
+      name,
+      plugins,
+      rootName ? name,
+      check ? true,
+    }:
     lib.optionalString (shouldLink check plugins) ''
       mkdir -p ${rootName}
       ${lib.concatMapStrings (plugin: ''
@@ -215,29 +283,46 @@ let
     '';
 
   # Function that automatically links the default NDK plugin.
-  linkNdkPlugin = {name, plugin, check}:
-    lib.optionalString (shouldLink check [plugin]) ''
+  linkNdkPlugin =
+    {
+      name,
+      plugin,
+      check,
+    }:
+    lib.optionalString (shouldLink check [ plugin ]) ''
       ln -s ${plugin}/libexec/android-sdk/${name} ${name}
     '';
 
   # Function that automatically links a plugin for which only one version exists
-  linkPlugin = {name, plugin, check ? true}:
-    lib.optionalString (shouldLink check [plugin]) ''
+  linkPlugin =
+    {
+      name,
+      plugin,
+      check ? true,
+    }:
+    lib.optionalString (shouldLink check [ plugin ]) ''
       ln -s ${plugin}/libexec/android-sdk/${name} ${name}
     '';
 
-  linkSystemImages = { images, check }: lib.optionalString (shouldLink check images) ''
-    mkdir -p system-images
-    ${lib.concatMapStrings (system-image: ''
-      apiVersion=$(basename $(echo ${system-image}/libexec/android-sdk/system-images/*))
-      type=$(basename $(echo ${system-image}/libexec/android-sdk/system-images/*/*))
-      mkdir -p system-images/$apiVersion
-      ln -s ${system-image}/libexec/android-sdk/system-images/$apiVersion/$type system-images/$apiVersion/$type
-    '') images}
-  '';
+  linkSystemImages =
+    { images, check }:
+    lib.optionalString (shouldLink check images) ''
+      mkdir -p system-images
+      ${lib.concatMapStrings (system-image: ''
+        apiVersion=$(basename $(echo ${system-image}/libexec/android-sdk/system-images/*))
+        type=$(basename $(echo ${system-image}/libexec/android-sdk/system-images/*/*))
+        mkdir -p system-images/$apiVersion
+        ln -s ${system-image}/libexec/android-sdk/system-images/$apiVersion/$type system-images/$apiVersion/$type
+      '') images}
+    '';
 
   # Links all plugins related to a requested platform
-  linkPlatformPlugins = {name, plugins, check}:
+  linkPlatformPlugins =
+    {
+      name,
+      plugins,
+      check,
+    }:
     lib.optionalString (shouldLink check plugins) ''
       mkdir -p ${name}
       ${lib.concatMapStrings (plugin: ''
@@ -248,140 +333,228 @@ let
 in
 lib.recurseIntoAttrs rec {
   deployAndroidPackages = callPackage ./deploy-androidpackages.nix {
-    inherit stdenv lib mkLicenses meta os arch;
+    inherit
+      stdenv
+      lib
+      mkLicenses
+      meta
+      os
+      arch
+      ;
   };
 
-  deployAndroidPackage = ({package, buildInputs ? [], patchInstructions ? "", meta ? {}, ...}@args:
+  deployAndroidPackage = (
+    {
+      package,
+      buildInputs ? [ ],
+      patchInstructions ? "",
+      meta ? { },
+      ...
+    }@args:
     let
-      extraParams = removeAttrs args [ "package" "os" "arch" "buildInputs" "patchInstructions" ];
+      extraParams = removeAttrs args [
+        "package"
+        "os"
+        "arch"
+        "buildInputs"
+        "patchInstructions"
+      ];
     in
-    deployAndroidPackages ({
-      inherit buildInputs;
-      packages = [ package ];
-      patchesInstructions = { "${package.name}" = patchInstructions; };
-    } // extraParams
-  ));
+    deployAndroidPackages (
+      {
+        inherit buildInputs;
+        packages = [ package ];
+        patchesInstructions = {
+          "${package.name}" = patchInstructions;
+        };
+      }
+      // extraParams
+    )
+  );
 
   all = allPackages;
 
   platform-tools = callPackage ./platform-tools.nix {
-    inherit deployAndroidPackage os arch meta;
+    inherit
+      deployAndroidPackage
+      os
+      arch
+      meta
+      ;
     package = check-version allArchives.packages "platform-tools" platformToolsVersion;
   };
 
   tools = callPackage ./tools.nix {
-    inherit deployAndroidPackage os arch meta;
+    inherit
+      deployAndroidPackage
+      os
+      arch
+      meta
+      ;
     package = check-version allArchives.packages "tools" toolsVersion;
 
     postInstall = ''
-      ${linkPlugin { name = "platform-tools"; plugin = platform-tools; }}
-      ${linkPlugin { name = "emulator"; plugin = emulator; check = includeEmulator; }}
+      ${linkPlugin {
+        name = "platform-tools";
+        plugin = platform-tools;
+      }}
+      ${linkPlugin {
+        name = "emulator";
+        plugin = emulator;
+        check = includeEmulator;
+      }}
     '';
   };
 
-  build-tools = map (version:
+  build-tools = map (
+    version:
     callPackage ./build-tools.nix {
-      inherit deployAndroidPackage os arch meta;
+      inherit
+        deployAndroidPackage
+        os
+        arch
+        meta
+        ;
       package = check-version allArchives.packages "build-tools" version;
 
       postInstall = ''
-        ${linkPlugin { name = "tools"; plugin = tools; check = toolsVersion != null; }}
+        ${linkPlugin {
+          name = "tools";
+          plugin = tools;
+          check = toolsVersion != null;
+        }}
       '';
     }
   ) buildToolsVersions;
 
-  emulator =
-    callPackage ./emulator.nix {
-      inherit deployAndroidPackage os arch meta;
-      package = check-version allArchives.packages "emulator" emulatorVersion;
+  emulator = callPackage ./emulator.nix {
+    inherit
+      deployAndroidPackage
+      os
+      arch
+      meta
+      ;
+    package = check-version allArchives.packages "emulator" emulatorVersion;
 
-      postInstall = ''
-        ${linkSystemImages { images = system-images; check = includeSystemImages; }}
-      '';
-    };
+    postInstall = ''
+      ${linkSystemImages {
+        images = system-images;
+        check = includeSystemImages;
+      }}
+    '';
+  };
 
-  platforms = map (version:
+  platforms = map (
+    version:
     deployAndroidPackage {
       package = check-version allArchives.packages "platforms" version;
     }
   ) platformVersions;
 
-  sources = map (version:
+  sources = map (
+    version:
     deployAndroidPackage {
       package = check-version allArchives.packages "sources" version;
     }
   ) platformVersions;
 
-  system-images = lib.flatten (map (apiVersion:
-    map (type:
-      # Deploy all system images with the same  systemImageType in one derivation to avoid the `null` problem below
-      # with avdmanager when trying to create an avd!
-      #
-      # ```
-      # $ yes "" | avdmanager create avd --force --name testAVD --package 'system-images;android-33;google_apis;x86_64'
-      # Error: Package path is not valid. Valid system image paths are:
-      # null
-      # ```
-      let
-        availablePackages = map (abiVersion:
-          allArchives.system-images.${apiVersion}.${type}.${abiVersion}
-        ) (builtins.filter (abiVersion:
-          lib.hasAttrByPath [apiVersion type abiVersion] allArchives.system-images
-        ) abiVersions);
+  system-images = lib.flatten (
+    map (
+      apiVersion:
+      map (
+        type:
+        # Deploy all system images with the same  systemImageType in one derivation to avoid the `null` problem below
+        # with avdmanager when trying to create an avd!
+        #
+        # ```
+        # $ yes "" | avdmanager create avd --force --name testAVD --package 'system-images;android-33;google_apis;x86_64'
+        # Error: Package path is not valid. Valid system image paths are:
+        # null
+        # ```
+        let
+          availablePackages =
+            map (abiVersion: allArchives.system-images.${apiVersion}.${type}.${abiVersion})
+              (
+                builtins.filter (
+                  abiVersion: lib.hasAttrByPath [ apiVersion type abiVersion ] allArchives.system-images
+                ) abiVersions
+              );
 
-        instructions = builtins.listToAttrs (map (package: {
-            name = package.name;
-            value = lib.optionalString (lib.hasPrefix "google_apis" type) ''
-              # Patch 'google_apis' system images so they're recognized by the sdk.
-              # Without this, `android list targets` shows 'Tag/ABIs : no ABIs' instead
-              # of 'Tag/ABIs : google_apis*/*' and the emulator fails with an ABI-related error.
-              sed -i '/^Addon.Vendor/d' source.properties
-            '';
-          }) availablePackages
-        );
-      in
-      lib.optionals (availablePackages != [])
-        (deployAndroidPackages {
+          instructions = builtins.listToAttrs (
+            map (package: {
+              name = package.name;
+              value = lib.optionalString (lib.hasPrefix "google_apis" type) ''
+                # Patch 'google_apis' system images so they're recognized by the sdk.
+                # Without this, `android list targets` shows 'Tag/ABIs : no ABIs' instead
+                # of 'Tag/ABIs : google_apis*/*' and the emulator fails with an ABI-related error.
+                sed -i '/^Addon.Vendor/d' source.properties
+              '';
+            }) availablePackages
+          );
+        in
+        lib.optionals (availablePackages != [ ]) (deployAndroidPackages {
           packages = availablePackages;
           patchesInstructions = instructions;
         })
-    ) systemImageTypes
-  ) platformVersions);
+      ) systemImageTypes
+    ) platformVersions
+  );
 
-  cmake = map (version:
+  cmake = map (
+    version:
     callPackage ./cmake.nix {
-      inherit deployAndroidPackage os arch meta;
+      inherit
+        deployAndroidPackage
+        os
+        arch
+        meta
+        ;
       package = check-version allArchives.packages "cmake" version;
     }
   ) cmakeVersions;
 
   # All NDK bundles.
-  ndk-bundles = let
-    # Creates a NDK bundle.
-    makeNdkBundle = package:
-      callPackage ./ndk-bundle {
-        inherit deployAndroidPackage os arch platform-tools meta package;
-      };
-  in lib.flatten (
-    map (version:
-      let
-        package = makeNdkBundle (allArchives.packages.ndk-bundle.${ndkVersion} or allArchives.packages.ndk.${ndkVersion});
-      in
-      lib.optional (shouldLink includeNDK [package]) package
-    ) ndkVersions
-  );
+  ndk-bundles =
+    let
+      # Creates a NDK bundle.
+      makeNdkBundle =
+        package:
+        callPackage ./ndk-bundle {
+          inherit
+            deployAndroidPackage
+            os
+            arch
+            platform-tools
+            meta
+            package
+            ;
+        };
+    in
+    lib.flatten (
+      map (
+        version:
+        let
+          package = makeNdkBundle (
+            allArchives.packages.ndk-bundle.${ndkVersion} or allArchives.packages.ndk.${ndkVersion}
+          );
+        in
+        lib.optional (shouldLink includeNDK [ package ]) package
+      ) ndkVersions
+    );
 
   # The "default" NDK bundle.
-  ndk-bundle = if ndk-bundles == [] then null else lib.head ndk-bundles;
+  ndk-bundle = if ndk-bundles == [ ] then null else lib.head ndk-bundles;
 
   # Makes a Google API bundle.
-  google-apis = map (version:
+  google-apis = map (
+    version:
     deployAndroidPackage {
       package = (check-version allArchives "addons" version).google_apis;
     }
   ) (builtins.filter (platformVersion: lib.versionOlder platformVersion "26") platformVersions); # API level 26 and higher include Google APIs by default
 
-  google-tv-addons = map (version:
+  google-tv-addons = map (
+    version:
     deployAndroidPackage {
       package = (check-version allArchives "addons" version).google_tv_addon;
     }
@@ -392,79 +565,143 @@ lib.recurseIntoAttrs rec {
   # This derivation deploys the tools package and symlinks all the desired
   # plugins that we want to use. If the license isn't accepted, prints all the licenses
   # requested and throws.
-  androidsdk = if !licenseAccepted then throw ''
-    ${builtins.concatStringsSep "\n\n" (mkLicenseTexts licenseNames)}
+  androidsdk =
+    if !licenseAccepted then
+      throw ''
+        ${builtins.concatStringsSep "\n\n" (mkLicenseTexts licenseNames)}
 
-    You must accept the following licenses:
-    ${lib.concatMapStringsSep "\n" (str: "  - ${str}") licenseNames}
+        You must accept the following licenses:
+        ${lib.concatMapStringsSep "\n" (str: "  - ${str}") licenseNames}
 
-    a)
-      by setting nixpkgs config option 'android_sdk.accept_license = true;'.
-    b)
-      by an environment variable for a single invocation of the nix tools.
-        $ export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
-  '' else callPackage ./cmdline-tools.nix {
-    inherit deployAndroidPackage os arch meta;
+        a)
+          by setting nixpkgs config option 'android_sdk.accept_license = true;'.
+        b)
+          by an environment variable for a single invocation of the nix tools.
+            $ export NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE=1
+      ''
+    else
+      callPackage ./cmdline-tools.nix {
+        inherit
+          deployAndroidPackage
+          os
+          arch
+          meta
+          ;
 
-    package = cmdline-tools-package;
+        package = cmdline-tools-package;
 
-    postInstall = ''
-      # Symlink all requested plugins
-      ${linkPlugin { name = "platform-tools"; plugin = platform-tools; }}
-      ${linkPlugin { name = "tools"; plugin = tools; check = toolsVersion != null; }}
-      ${linkPlugins { name = "build-tools"; plugins = build-tools; }}
-      ${linkPlugin { name = "emulator"; plugin = emulator; check = includeEmulator; }}
-      ${linkPlugins { name = "platforms"; plugins = platforms; }}
-      ${linkPlatformPlugins { name = "sources"; plugins = sources; check = includeSources; }}
-      ${linkPlugins { name = "cmake"; plugins = cmake; check = includeCmake; }}
-      ${linkNdkPlugins { name = "ndk-bundle"; rootName = "ndk"; plugins = ndk-bundles; check = includeNDK; }}
-      ${linkNdkPlugin { name = "ndk-bundle"; plugin = ndk-bundle; check = includeNDK; }}
-      ${linkSystemImages { images = system-images; check = includeSystemImages; }}
-      ${linkPlatformPlugins { name = "add-ons"; plugins = google-apis; check = useGoogleAPIs; }}
-      ${linkPlatformPlugins { name = "add-ons"; plugins = google-tv-addons; check = useGoogleTVAddOns; }}
+        postInstall = ''
+          # Symlink all requested plugins
+          ${linkPlugin {
+            name = "platform-tools";
+            plugin = platform-tools;
+          }}
+          ${linkPlugin {
+            name = "tools";
+            plugin = tools;
+            check = toolsVersion != null;
+          }}
+          ${linkPlugins {
+            name = "build-tools";
+            plugins = build-tools;
+          }}
+          ${linkPlugin {
+            name = "emulator";
+            plugin = emulator;
+            check = includeEmulator;
+          }}
+          ${linkPlugins {
+            name = "platforms";
+            plugins = platforms;
+          }}
+          ${linkPlatformPlugins {
+            name = "sources";
+            plugins = sources;
+            check = includeSources;
+          }}
+          ${linkPlugins {
+            name = "cmake";
+            plugins = cmake;
+            check = includeCmake;
+          }}
+          ${linkNdkPlugins {
+            name = "ndk-bundle";
+            rootName = "ndk";
+            plugins = ndk-bundles;
+            check = includeNDK;
+          }}
+          ${linkNdkPlugin {
+            name = "ndk-bundle";
+            plugin = ndk-bundle;
+            check = includeNDK;
+          }}
+          ${linkSystemImages {
+            images = system-images;
+            check = includeSystemImages;
+          }}
+          ${linkPlatformPlugins {
+            name = "add-ons";
+            plugins = google-apis;
+            check = useGoogleAPIs;
+          }}
+          ${linkPlatformPlugins {
+            name = "add-ons";
+            plugins = google-tv-addons;
+            check = useGoogleTVAddOns;
+          }}
 
-      # Link extras
-      ${lib.concatMapStrings (identifier:
-        let
-          package = allArchives.extras.${identifier};
-          path = package.path;
-          extras = callPackage ./extras.nix {
-            inherit deployAndroidPackage package os arch meta;
-          };
-        in
-        ''
-          targetDir=$(dirname ${path})
-          mkdir -p $targetDir
-          ln -s ${extras}/libexec/android-sdk/${path} $targetDir
-        '') includeExtras}
+          # Link extras
+          ${lib.concatMapStrings (
+            identifier:
+            let
+              package = allArchives.extras.${identifier};
+              path = package.path;
+              extras = callPackage ./extras.nix {
+                inherit
+                  deployAndroidPackage
+                  package
+                  os
+                  arch
+                  meta
+                  ;
+              };
+            in
+            ''
+              targetDir=$(dirname ${path})
+              mkdir -p $targetDir
+              ln -s ${extras}/libexec/android-sdk/${path} $targetDir
+            ''
+          ) includeExtras}
 
-      # Expose common executables in bin/
-      mkdir -p $out/bin
+          # Expose common executables in bin/
+          mkdir -p $out/bin
 
-      for i in ${platform-tools}/bin/*; do
-          ln -s $i $out/bin
-      done
+          for i in ${platform-tools}/bin/*; do
+              ln -s $i $out/bin
+          done
 
-      ${lib.optionalString (shouldLink includeEmulator [emulator]) ''
-        for i in ${emulator}/bin/*; do
-            ln -s $i $out/bin
-        done
-      ''}
+          ${lib.optionalString (shouldLink includeEmulator [ emulator ]) ''
+            for i in ${emulator}/bin/*; do
+                ln -s $i $out/bin
+            done
+          ''}
 
-      find $ANDROID_SDK_ROOT/${cmdline-tools-package.path}/bin -type f -executable | while read i; do
-          ln -s $i $out/bin
-      done
+          find $ANDROID_SDK_ROOT/${cmdline-tools-package.path}/bin -type f -executable | while read i; do
+              ln -s $i $out/bin
+          done
 
-      # Write licenses
-      mkdir -p licenses
-      ${lib.concatMapStrings (licenseName:
-        let
-          licenseHashes = builtins.concatStringsSep "\n" (mkLicenseHashes licenseName);
-          licenseHashFile = writeText "androidenv-${licenseName}" licenseHashes;
-        in
-        ''
-          ln -s ${licenseHashFile} licenses/${licenseName}
-        '') licenseNames}
-    '';
-  };
+          # Write licenses
+          mkdir -p licenses
+          ${lib.concatMapStrings (
+            licenseName:
+            let
+              licenseHashes = builtins.concatStringsSep "\n" (mkLicenseHashes licenseName);
+              licenseHashFile = writeText "androidenv-${licenseName}" licenseHashes;
+            in
+            ''
+              ln -s ${licenseHashFile} licenses/${licenseName}
+            ''
+          ) licenseNames}
+        '';
+      };
 }

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -18,16 +18,7 @@ lib.recurseIntoAttrs rec {
   };
 
   androidPkgs = composeAndroidPackages {
-    platformVersions = [
-      "28"
-      "29"
-      "30"
-      "31"
-      "32"
-      "33"
-      "34"
-      "35"
-    ];
+    minPlatformVersion = 28;
     includeEmulator = "if-supported";
     includeSystemImages = "if-supported";
     includeNDK = "if-supported";

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -29,15 +29,9 @@ lib.recurseIntoAttrs rec {
       "34"
       "35"
     ];
-    includeEmulator =
-      with pkgs.stdenv.hostPlatform;
-      system == "x86_64-linux" || system == "x86_64-darwin" || system == "aarch64-darwin";
-    includeSystemImages =
-      with pkgs.stdenv.hostPlatform;
-      system == "x86_64-linux" || system == "x86_64-darwin" || system == "aarch64-darwin";
-    includeNDK =
-      with pkgs.stdenv.hostPlatform;
-      system == "x86_64-linux" || system == "x86_64-darwin" || system == "aarch64-darwin";
+    includeEmulator = "if-supported";
+    includeSystemImages = "if-supported";
+    includeNDK = "if-supported";
   };
 
   test-suite = pkgs.callPackage ./test-suite.nix {

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,9 +1,7 @@
 {
   lib,
-  config,
   pkgs ? import <nixpkgs> { },
-  licenseAccepted ?
-    config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
+  licenseAccepted ? pkgs.callPackage ./license.nix { },
 }:
 
 lib.recurseIntoAttrs rec {

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -1,21 +1,21 @@
 {
+  lib,
   config,
   pkgs ? import <nixpkgs> { },
-  licenseAccepted ?
-    config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
+  licenseAccepted ? config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
 }:
 
-rec {
+lib.recurseIntoAttrs rec {
   composeAndroidPackages = pkgs.callPackage ./compose-android-packages.nix {
-    inherit licenseAccepted;
+    inherit licenseAccepted meta;
   };
 
   buildApp = pkgs.callPackage ./build-app.nix {
-    inherit composeAndroidPackages;
+    inherit composeAndroidPackages meta;
   };
 
   emulateApp = pkgs.callPackage ./emulate-app.nix {
-    inherit composeAndroidPackages;
+    inherit composeAndroidPackages meta;
   };
 
   androidPkgs = composeAndroidPackages {
@@ -40,12 +40,16 @@ rec {
       system == "x86_64-linux" || system == "x86_64-darwin" || system == "aarch64-darwin";
   };
 
-  test-suite = pkgs.callPackage ./test-suite.nix { };
+  test-suite = pkgs.callPackage ./test-suite.nix {
+    inherit meta;
+  };
 
-  meta = with pkgs.lib; {
-    description = "Android SDK & sdkmanager";
-    homepage = "https://developer.android.com/tools/sdkmanager";
-    maintainers = with maintainers; [
+  meta = {
+    homepage = "https://developer.android.com/tools";
+    description = "Android SDK tools, packaged in Nixpkgs";
+    license = lib.licenses.unfree;
+    platforms = lib.platforms.all;
+    maintainers = with lib.maintainers; [
       numinit
       hadilq
     ];

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -18,7 +18,8 @@ lib.recurseIntoAttrs rec {
   };
 
   androidPkgs = composeAndroidPackages {
-    minPlatformVersion = 28;
+    # Support roughly the last 5 years of Android packages and system images by default in nixpkgs.
+    numLatestPlatformVersions = 5;
     includeEmulator = "if-supported";
     includeSystemImages = "if-supported";
     includeNDK = "if-supported";

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -2,7 +2,8 @@
   lib,
   config,
   pkgs ? import <nixpkgs> { },
-  licenseAccepted ? config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
+  licenseAccepted ?
+    config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
 }:
 
 lib.recurseIntoAttrs rec {

--- a/pkgs/development/mobile/androidenv/default.nix
+++ b/pkgs/development/mobile/androidenv/default.nix
@@ -38,6 +38,8 @@ lib.recurseIntoAttrs rec {
     inherit meta;
   };
 
+  inherit (test-suite) passthru;
+
   meta = {
     homepage = "https://developer.android.com/tools";
     description = "Android SDK tools, packaged in Nixpkgs";

--- a/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
+++ b/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
@@ -1,30 +1,59 @@
-{stdenv, lib, unzip, mkLicenses, os, arch, meta}:
-{packages, nativeBuildInputs ? [], buildInputs ? [], patchesInstructions ? {}, ...}@args:
+{
+  stdenv,
+  lib,
+  unzip,
+  mkLicenses,
+  os,
+  arch,
+  meta,
+}:
+{
+  packages,
+  nativeBuildInputs ? [ ],
+  buildInputs ? [ ],
+  patchesInstructions ? { },
+  ...
+}@args:
 
 let
-  extraParams = removeAttrs args [ "packages" "os" "buildInputs" "nativeBuildInputs" "patchesInstructions" ];
+  extraParams = removeAttrs args [
+    "packages"
+    "os"
+    "buildInputs"
+    "nativeBuildInputs"
+    "patchesInstructions"
+  ];
   sortedPackages = builtins.sort (x: y: builtins.lessThan x.name y.name) packages;
 
-  mkXmlAttrs = attrs:
-    lib.concatStrings (lib.mapAttrsToList (name: value: " ${name}=\"${value}\"") attrs);
-  mkXmlValues = attrs:
-    lib.concatStrings (lib.mapAttrsToList (name: value:
-      let
-        tag = builtins.head (builtins.match "([^:]+).*" name);
-      in
+  mkXmlAttrs =
+    attrs: lib.concatStrings (lib.mapAttrsToList (name: value: " ${name}=\"${value}\"") attrs);
+  mkXmlValues =
+    attrs:
+    lib.concatStrings (
+      lib.mapAttrsToList (
+        name: value:
+        let
+          tag = builtins.head (builtins.match "([^:]+).*" name);
+        in
         if builtins.typeOf value == "string" then "<${tag}>${value}</${tag}>" else mkXmlDoc name value
-    ) attrs);
-  mkXmlDoc = name: doc:
-      let
-        tag = builtins.head (builtins.match "([^:]+).*" name);
-        hasXmlAttrs = builtins.hasAttr "element-attributes" doc;
-        xmlValues = removeAttrs doc [ "element-attributes" ];
-        hasXmlValues = builtins.length (builtins.attrNames xmlValues) > 0;
-      in
-        if hasXmlAttrs && hasXmlValues then "<${tag}${mkXmlAttrs doc.element-attributes}>${mkXmlValues xmlValues }</${tag}>"
-        else if hasXmlAttrs && !hasXmlValues then "<${tag}${mkXmlAttrs doc.element-attributes}/>"
-        else if !hasXmlAttrs && hasXmlValues then "<${tag}>${mkXmlValues xmlValues}</${tag}>"
-        else "<${tag}/>";
+      ) attrs
+    );
+  mkXmlDoc =
+    name: doc:
+    let
+      tag = builtins.head (builtins.match "([^:]+).*" name);
+      hasXmlAttrs = builtins.hasAttr "element-attributes" doc;
+      xmlValues = removeAttrs doc [ "element-attributes" ];
+      hasXmlValues = builtins.length (builtins.attrNames xmlValues) > 0;
+    in
+    if hasXmlAttrs && hasXmlValues then
+      "<${tag}${mkXmlAttrs doc.element-attributes}>${mkXmlValues xmlValues}</${tag}>"
+    else if hasXmlAttrs && !hasXmlValues then
+      "<${tag}${mkXmlAttrs doc.element-attributes}/>"
+    else if !hasXmlAttrs && hasXmlValues then
+      "<${tag}>${mkXmlValues xmlValues}</${tag}>"
+    else
+      "<${tag}/>";
   mkXmlPackage = package: ''
     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
     <ns2:repository
@@ -44,81 +73,88 @@ let
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <license id="${package.license}" type="text">${lib.concatStringsSep "---" (mkLicenses package.license)}</license>
       <localPackage path="${builtins.replaceStrings [ "/" ] [ ";" ] package.path}" obsolete="${
-          if (lib.hasAttrByPath [ "obsolete" ] package)
-          then package.obsolete else "false"
-        }">
+        if (lib.hasAttrByPath [ "obsolete" ] package) then package.obsolete else "false"
+      }">
         ${mkXmlDoc "type-details" package.type-details}
         ${mkXmlDoc "revision" package.revision-details}
-        ${lib.optionalString (lib.hasAttrByPath [ "dependencies" ] package)
-          (mkXmlDoc "dependencies" package.dependencies)
-        }
+        ${lib.optionalString (lib.hasAttrByPath [ "dependencies" ] package) (
+          mkXmlDoc "dependencies" package.dependencies
+        )}
         <display-name>${package.displayName}</display-name>
         <uses-license ref="${package.license}"/>
       </localPackage>
     </ns2:repository>
   '';
 in
-stdenv.mkDerivation ({
-  inherit buildInputs;
-  pname = "android-sdk-${lib.concatMapStringsSep "-" (package: package.name) sortedPackages}";
-  version = lib.concatMapStringsSep "-" (package: package.revision) sortedPackages;
-  src = lib.flatten (map (package: package.archives) packages);
-  inherit os arch;
-  nativeBuildInputs = [ unzip ] ++ nativeBuildInputs;
-  preferLocalBuild = true;
+stdenv.mkDerivation (
+  {
+    inherit buildInputs;
+    pname = "android-sdk-${lib.concatMapStringsSep "-" (package: package.name) sortedPackages}";
+    version = lib.concatMapStringsSep "-" (package: package.revision) sortedPackages;
+    src = lib.flatten (map (package: package.archives) packages);
+    inherit os arch;
+    nativeBuildInputs = [ unzip ] ++ nativeBuildInputs;
+    preferLocalBuild = true;
 
-  unpackPhase = ''
-    runHook preUnpack
-    if [ -z "$src" ]; then
-      echo "$pname did not have any sources available for os=$os, arch=$arch." >&2
-      echo "Are packages available for this architecture?" >&2
-      exit 1
-    fi
-    buildDir=$PWD
-    i=0
-    for srcArchive in $src; do
-      extractedZip="extractedzip-$i"
-      i=$((i+1))
-      cd "$buildDir"
-      mkdir "$extractedZip"
-      cd "$extractedZip"
-      unpackFile "$srcArchive"
-    done
-    runHook postUnpack
-  '';
+    unpackPhase = ''
+      runHook preUnpack
+      if [ -z "$src" ]; then
+        echo "$pname did not have any sources available for os=$os, arch=$arch." >&2
+        echo "Are packages available for this architecture?" >&2
+        exit 1
+      fi
+      buildDir=$PWD
+      i=0
+      for srcArchive in $src; do
+        extractedZip="extractedzip-$i"
+        i=$((i+1))
+        cd "$buildDir"
+        mkdir "$extractedZip"
+        cd "$extractedZip"
+        unpackFile "$srcArchive"
+      done
+      runHook postUnpack
+    '';
 
-  installPhase = ''
-    runHook preInstall
-  '' + lib.concatStrings (lib.imap0 (i: package: ''
-    cd $buildDir/extractedzip-${toString i}
+    installPhase =
+      ''
+        runHook preInstall
+      ''
+      + lib.concatStrings (
+        lib.imap0 (i: package: ''
+          cd $buildDir/extractedzip-${toString i}
 
-    # Most Android Zip packages have a root folder, but some don't. We unpack
-    # the zip file in a folder and we try to discover whether it has a single root
-    # folder. If this is the case, we adjust the current working folder.
-    if [ "$(find . -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ]; then
-        cd "$(find . -mindepth 1 -maxdepth 1 -type d)"
-    fi
-    extractedZip="$PWD"
+          # Most Android Zip packages have a root folder, but some don't. We unpack
+          # the zip file in a folder and we try to discover whether it has a single root
+          # folder. If this is the case, we adjust the current working folder.
+          if [ "$(find . -mindepth 1 -maxdepth 1 -type d | wc -l)" -eq 1 ]; then
+              cd "$(find . -mindepth 1 -maxdepth 1 -type d)"
+          fi
+          extractedZip="$PWD"
 
-    packageBaseDir=$out/libexec/android-sdk/${package.path}
-    mkdir -p $packageBaseDir
-    cd $packageBaseDir
-    cp -a $extractedZip/* .
-    ${patchesInstructions.${package.name}}
+          packageBaseDir=$out/libexec/android-sdk/${package.path}
+          mkdir -p $packageBaseDir
+          cd $packageBaseDir
+          cp -a $extractedZip/* .
+          ${patchesInstructions.${package.name}}
 
-    if [ ! -f $packageBaseDir/package.xml ]; then
-      cat << EOF > $packageBaseDir/package.xml
-    ${mkXmlPackage package}
-    EOF
-    fi
-  '') packages) + ''
-    runHook postInstall
-  '';
+          if [ ! -f $packageBaseDir/package.xml ]; then
+            cat << EOF > $packageBaseDir/package.xml
+          ${mkXmlPackage package}
+          EOF
+          fi
+        '') packages
+      )
+      + ''
+        runHook postInstall
+      '';
 
-  # Some executables that have been patched with patchelf may not work any longer after they have been stripped.
-  dontStrip = true;
-  dontPatchELF = true;
-  dontAutoPatchelf = true;
+    # Some executables that have been patched with patchelf may not work any longer after they have been stripped.
+    dontStrip = true;
+    dontPatchELF = true;
+    dontAutoPatchelf = true;
 
-  inherit meta;
-} // extraParams)
+    inherit meta;
+  }
+  // extraParams
+)

--- a/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
+++ b/pkgs/development/mobile/androidenv/deploy-androidpackages.nix
@@ -1,5 +1,5 @@
-{stdenv, lib, unzip, mkLicenses}:
-{packages, nativeBuildInputs ? [], buildInputs ? [], patchesInstructions ? {}, meta ? {}, ...}@args:
+{stdenv, lib, unzip, mkLicenses, meta}:
+{packages, nativeBuildInputs ? [], buildInputs ? [], patchesInstructions ? {}, ...}@args:
 
 let
   extraParams = removeAttrs args [ "packages" "os" "buildInputs" "nativeBuildInputs" "patchesInstructions" ];
@@ -108,7 +108,5 @@ stdenv.mkDerivation ({
   dontPatchELF = true;
   dontAutoPatchelf = true;
 
-  meta = {
-    description = lib.concatMapStringsSep "\n" (package: package.displayName) packages;
-  } // meta;
+  inherit meta;
 } // extraParams)

--- a/pkgs/development/mobile/androidenv/emulate-app.nix
+++ b/pkgs/development/mobile/androidenv/emulate-app.nix
@@ -3,6 +3,7 @@
   stdenv,
   lib,
   runtimeShell,
+  meta,
 }:
 {
   name,
@@ -195,5 +196,7 @@ stdenv.mkDerivation {
     chmod +x $out/bin/run-test-emulator
   '';
 
-  meta.mainProgram = "run-test-emulator";
+  meta = meta // {
+    mainProgram = "run-test-emulator";
+  };
 }

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -36,6 +36,8 @@ deployAndroidPackage {
         nss
         nspr
         alsa-lib
+        llvmPackages_15.libllvm.lib
+        waylandpp.lib
       ]
     )
     ++ (with pkgs.xorg; [
@@ -52,6 +54,7 @@ deployAndroidPackage {
       libICE
       libSM
       libxkbfile
+      libxshmfence
     ])
     ++ lib.optional (os == "linux" && stdenv.isx86_64) pkgsi686Linux.glibc;
   patchInstructions = lib.optionalString (os == "linux") ''
@@ -64,6 +67,10 @@ deployAndroidPackage {
     # This library is linked against a version of libtiff that nixpkgs doesn't have
     for file in $out/libexec/android-sdk/emulator/*/qt/plugins/imageformats/libqtiffAndroidEmu.so; do
       patchelf --replace-needed libtiff.so.5 libtiff.so "$file" || true
+    done
+
+    for file in $out/libexec/android-sdk/emulator/lib64/vulkan/libvulkan_lvp.so; do
+      patchelf --replace-needed libLLVM-15.so.1 libLLVM-15.so "$file" || true
     done
 
     autoPatchelf $out

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -1,27 +1,44 @@
-{ deployAndroidPackage, lib, stdenv, package, os, arch, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta }:
+{
+  deployAndroidPackage,
+  lib,
+  stdenv,
+  package,
+  os,
+  arch,
+  autoPatchelfHook,
+  makeWrapper,
+  pkgs,
+  pkgsi686Linux,
+  postInstall,
+  meta,
+}:
 
 deployAndroidPackage {
   inherit package os arch;
-  nativeBuildInputs = [ makeWrapper ]
-    ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
-  buildInputs = lib.optionals (os == "linux") (with pkgs; [
-      glibc
-      libcxx
-      libGL
-      libpulseaudio
-      libtiff
-      libuuid
-      zlib
-      libbsd
-      ncurses5
-      libdrm
-      stdenv.cc.cc
-      expat
-      freetype
-      nss
-      nspr
-      alsa-lib
-    ]) ++ (with pkgs.xorg; [
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
+  buildInputs =
+    lib.optionals (os == "linux") (
+      with pkgs;
+      [
+        glibc
+        libcxx
+        libGL
+        libpulseaudio
+        libtiff
+        libuuid
+        zlib
+        libbsd
+        ncurses5
+        libdrm
+        stdenv.cc.cc
+        expat
+        freetype
+        nss
+        nspr
+        alsa-lib
+      ]
+    )
+    ++ (with pkgs.xorg; [
       libX11
       libXext
       libXdamage
@@ -35,7 +52,8 @@ deployAndroidPackage {
       libICE
       libSM
       libxkbfile
-    ]) ++ lib.optional (os == "linux" && stdenv.isx86_64) pkgsi686Linux.glibc;
+    ])
+    ++ lib.optional (os == "linux" && stdenv.isx86_64) pkgsi686Linux.glibc;
   patchInstructions = lib.optionalString (os == "linux") ''
     addAutoPatchelfSearchPath $packageBaseDir/lib
     addAutoPatchelfSearchPath $packageBaseDir/lib64
@@ -52,10 +70,12 @@ deployAndroidPackage {
 
     # Wrap emulator so that it can load required libraries at runtime
     wrapProgram $out/libexec/android-sdk/emulator/emulator \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [
-        pkgs.dbus
-        pkgs.systemd
-      ]} \
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath [
+          pkgs.dbus
+          pkgs.systemd
+        ]
+      } \
       --set QT_XKB_CONFIG_ROOT ${pkgs.xkeyboard_config}/share/X11/xkb \
       --set QTCOMPOSE ${pkgs.xorg.libX11.out}/share/X11/locale
 

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -1,7 +1,7 @@
-{ deployAndroidPackage, lib, stdenv, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta }:
+{ deployAndroidPackage, lib, stdenv, package, os, arch, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta }:
 
 deployAndroidPackage {
-  inherit package;
+  inherit package os arch;
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
   buildInputs = lib.optionals (os == "linux") (with pkgs; [

--- a/pkgs/development/mobile/androidenv/emulator.nix
+++ b/pkgs/development/mobile/androidenv/emulator.nix
@@ -1,4 +1,4 @@
-{ deployAndroidPackage, lib, stdenv, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall }:
+{ deployAndroidPackage, lib, stdenv, package, os, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta }:
 
 deployAndroidPackage {
   inherit package;
@@ -69,4 +69,6 @@ deployAndroidPackage {
     ${postInstall}
   '';
   dontMoveLib64 = true;
+
+  inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -186,22 +186,25 @@ pkgs.mkShell rec {
             jdk
           ];
         }
-        (pkgs.lib.optionalString emulatorSupported ''
-          export ANDROID_USER_HOME=$PWD/.android
-          mkdir -p $ANDROID_USER_HOME
+        (
+          pkgs.lib.optionalString emulatorSupported ''
+            export ANDROID_USER_HOME=$PWD/.android
+            mkdir -p $ANDROID_USER_HOME
 
-          avdmanager delete avd -n testAVD || true
-          echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-35;google_apis;x86_64'
-          result=$(avdmanager list avd)
+            avdmanager delete avd -n testAVD || true
+            echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-35;google_apis;x86_64'
+            result=$(avdmanager list avd)
 
-          if [[ ! $result =~ "Name: testAVD" ]]; then
-            echo "avdmanager couldn't create the avd! The output is :''${result}"
-            exit 1
-          fi
+            if [[ ! $result =~ "Name: testAVD" ]]; then
+              echo "avdmanager couldn't create the avd! The output is :''${result}"
+              exit 1
+            fi
 
-          avdmanager delete avd -n testAVD || true
-        '' + ''
-          touch $out
-        '');
+            avdmanager delete avd -n testAVD || true
+          ''
+          + ''
+            touch $out
+          ''
+        );
   };
 }

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -19,10 +19,8 @@
     config.allowUnfree = true;
   },
 
-  config ? pkgs.config,
   # You probably need to set it to true to express consent.
-  licenseAccepted ?
-    config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
+  licenseAccepted ? pkgs.callPackage ../license.nix { },
 }:
 
 # Copy this file to your Android project.
@@ -36,14 +34,14 @@ let
     };
 
     androidEnv = pkgs.callPackage "${androidEnvNixpkgs}/pkgs/development/mobile/androidenv" {
-      inherit config pkgs;
+      inherit pkgs;
       licenseAccepted = true;
     };
   */
 
   # Otherwise, just use the in-tree androidenv:
   androidEnv = pkgs.callPackage ./.. {
-    inherit config pkgs licenseAccepted;
+    inherit pkgs licenseAccepted;
   };
 
   emulatorSupported = pkgs.stdenv.hostPlatform.isx86_64 || pkgs.stdenv.hostPlatform.isDarwin;

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -77,6 +77,7 @@ let
   };
   androidSdk = androidComposition.androidsdk;
   platformTools = androidComposition.platform-tools;
+  latestSdk = pkgs.lib.foldl' pkgs.lib.max 0 androidComposition.platformVersions;
   jdk = pkgs.jdk;
 in
 pkgs.mkShell rec {
@@ -122,8 +123,8 @@ pkgs.mkShell rec {
 
           packages=(
             "build-tools" "cmdline-tools" \
-            "platform-tools" "platforms;android-35" \
-            "system-images;android-35;google_apis;x86_64"
+            "platform-tools" "platforms;android-${toString latestSdk}" \
+            "system-images;android-${toString latestSdk};google_apis;x86_64"
           )
           ${pkgs.lib.optionalString emulatorSupported ''packages+=("emulator")''}
 
@@ -149,24 +150,17 @@ pkgs.mkShell rec {
           output="$(sdkmanager --list)"
           installed_packages_section=$(echo "''${output%%Available Packages*}" | awk 'NR>4 {print $1}')
 
-          excluded_packages=(
-            "platforms;android-23" "platforms;android-24" "platforms;android-25" "platforms;android-26" \
-            "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30" \
-            "platforms;android-31" "platforms;android-32" "platforms;android-33" "platforms;android-34" \
-            "sources;android-23" "sources;android-24" "sources;android-25" "sources;android-26" \
-            "sources;android-27" "sources;android-28" "sources;android-29" "sources;android-30" \
-            "sources;android-31" "sources;android-32" "sources;android-33" "sources;android-34" \
-            "system-images;android-28" \
-            "system-images;android-29" \
-            "system-images;android-30" \
-            "system-images;android-31" \
-            "system-images;android-32" \
-            "system-images;android-33" \
-            "ndk"
-          )
+          excluded_packages=(ndk)
+          for x in $(seq 1 ${toString latestSdk}); do
+            excluded_packages+=(
+              "platforms;android-$x"
+              "sources;android-$x"
+              "system-images;android-$x"
+            )
+          done
 
           for package in "''${excluded_packages[@]}"; do
-            if [[ $installed_packages_section =~ "$package" ]]; then
+            if [[ $installed_packages_section =~ ^"$package"$ ]]; then
               echo "$package package was installed, while it was excluded!"
               exit 1
             fi
@@ -190,7 +184,7 @@ pkgs.mkShell rec {
             mkdir -p $ANDROID_USER_HOME
 
             avdmanager delete avd -n testAVD || true
-            echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-35;google_apis;x86_64'
+            echo "" | avdmanager create avd --force --name testAVD --package 'system-images;android-${toString latestSdk};google_apis;x86_64'
             result=$(avdmanager list avd)
 
             if [[ ! $result =~ "Name: testAVD" ]]; then

--- a/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-with-emulator.nix
@@ -27,14 +27,6 @@
 
 # Copy this file to your Android project.
 let
-  # Declaration of versions for everything. This is useful since these
-  # versions may be used in multiple places in this Nix expression.
-  android = {
-    platforms = [ "35" ];
-    systemImageTypes = [ "google_apis" ];
-    abis = [ "x86_64" ];
-  };
-
   # If you copy this example out of nixpkgs, something like this will work:
   /*
     androidEnvNixpkgs = fetchTarball {
@@ -55,10 +47,6 @@ let
   };
 
   sdkArgs = {
-    platformVersions = android.platforms;
-    abiVersions = android.abis;
-    systemImageTypes = android.systemImageTypes;
-
     includeSystemImages = true;
     includeEmulator = true;
 
@@ -133,7 +121,7 @@ pkgs.mkShell rec {
           echo "installed_packages_section: ''${installed_packages_section}"
 
           packages=(
-            "build-tools;35.0.0" "cmdline-tools;13.0" \
+            "build-tools" "cmdline-tools" \
             "emulator" "platform-tools" "platforms;android-35" \
             "system-images;android-35;google_apis;x86_64"
           )

--- a/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
@@ -5,12 +5,12 @@
   # This example pins nixpkgs: https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.html
   /*
     nixpkgsSource ? (builtins.fetchTarball {
-    name = "nixpkgs-20.09";
-    url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
-    sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
+      name = "nixpkgs-20.09";
+      url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
+      sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
     }),
     pkgs ? import nixpkgsSource {
-    config.allowUnfree = true;
+      config.allowUnfree = true;
     },
   */
 
@@ -18,10 +18,8 @@
   pkgs ? import ../../../../.. {
     config.allowUnfree = true;
   },
-  config ? pkgs.config,
-  # You probably need to set it to true to express consent.
-  licenseAccepted ?
-    config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
+
+  licenseAccepted ? pkgs.callPackage ../license.nix { },
 }:
 
 # Copy this file to your Android project.
@@ -29,20 +27,20 @@ let
   # If you copy this example out of nixpkgs, something like this will work:
   /*
     androidEnvNixpkgs = fetchTarball {
-    name = "androidenv";
-    url = "https://github.com/NixOS/nixpkgs/archive/<fill me in from Git>.tar.gz";
-    sha256 = "<fill me in with nix-prefetch-url --unpack>";
+      name = "androidenv";
+      url = "https://github.com/NixOS/nixpkgs/archive/<fill me in from Git>.tar.gz";
+      sha256 = "<fill me in with nix-prefetch-url --unpack>";
     };
 
     androidEnv = pkgs.callPackage "${androidEnvNixpkgs}/pkgs/development/mobile/androidenv" {
-    inherit config pkgs;
-    licenseAccepted = true;
+      inherit pkgs;
+      licenseAccepted = true;
     };
   */
 
   # Otherwise, just use the in-tree androidenv:
   androidEnv = pkgs.callPackage ./.. {
-    inherit config pkgs licenseAccepted;
+    inherit pkgs licenseAccepted;
   };
 
   sdkArgs = {

--- a/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
@@ -26,17 +26,6 @@
 
 # Copy this file to your Android project.
 let
-  # Declaration of versions for everything. This is useful since these
-  # versions may be used in multiple places in this Nix expression.
-  android = {
-    versions = {
-      cmdLineToolsVersion = "13.0";
-      platformTools = "35.0.2";
-      buildTools = "35.0.0";
-    };
-    platforms = [ "35" ];
-  };
-
   # If you copy this example out of nixpkgs, something like this will work:
   /*
     androidEnvNixpkgs = fetchTarball {
@@ -57,10 +46,6 @@ let
   };
 
   sdkArgs = {
-    cmdLineToolsVersion = android.versions.cmdLineToolsVersion;
-    platformToolsVersion = android.versions.platformTools;
-    buildToolsVersions = [ android.versions.buildTools ];
-    platformVersions = android.platforms;
     includeNDK = false;
     includeSystemImages = false;
     includeEmulator = false;
@@ -126,7 +111,7 @@ pkgs.mkShell {
           echo "installed_packages_section: ''${installed_packages_section}"
 
           packages=(
-            "build-tools;35.0.0" "cmdline-tools;13.0" \
+            "build-tools" "cmdline-tools" \
             "platform-tools" "platforms;android-35"
           )
 

--- a/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell-without-emulator.nix
@@ -68,6 +68,7 @@ let
   androidComposition = androidEnv.composeAndroidPackages sdkArgs;
   androidSdk = androidComposition.androidsdk;
   platformTools = androidComposition.platform-tools;
+  latestSdk = pkgs.lib.foldl' pkgs.lib.max 0 androidComposition.platformVersions;
   jdk = pkgs.jdk;
 in
 pkgs.mkShell {
@@ -110,7 +111,7 @@ pkgs.mkShell {
 
           packages=(
             "build-tools" "cmdline-tools" \
-            "platform-tools" "platforms;android-35"
+            "platform-tools" "platforms;android-${toString latestSdk}"
           )
 
           for package in "''${packages[@]}"; do

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -17,10 +17,8 @@
     config.allowUnfree = true;
   },
 
-  config ? pkgs.config,
   # You probably need to set it to true to express consent.
-  licenseAccepted ?
-    config.android_sdk.accept_license or (builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"),
+  licenseAccepted ? pkgs.callPackage ../license.nix { },
 }:
 
 # Copy this file to your Android project.
@@ -34,14 +32,14 @@ let
     };
 
     androidEnv = pkgs.callPackage "${androidEnvNixpkgs}/pkgs/development/mobile/androidenv" {
-      inherit config pkgs;
+      inherit pkgs;
       licenseAccepted = true;
     };
   */
 
   # Otherwise, just use the in-tree androidenv:
   androidEnv = pkgs.callPackage ./.. {
-    inherit config pkgs licenseAccepted;
+    inherit pkgs licenseAccepted;
   };
 
   # The head unit only works on these platforms

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -1,14 +1,15 @@
 {
   # If you copy this example out of nixpkgs, use these lines instead of the next.
   # This example pins nixpkgs: https://nix.dev/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.html
-  /*nixpkgsSource ? (builtins.fetchTarball {
-    name = "nixpkgs-20.09";
-    url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
-    sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
-  }),
-  pkgs ? import nixpkgsSource {
-    config.allowUnfree = true;
-  },
+  /*
+    nixpkgsSource ? (builtins.fetchTarball {
+      name = "nixpkgs-20.09";
+      url = "https://github.com/NixOS/nixpkgs/archive/20.09.tar.gz";
+      sha256 = "1wg61h4gndm3vcprdcg7rc4s1v3jkm5xd7lw8r2f67w502y94gcy";
+    }),
+    pkgs ? import nixpkgsSource {
+      config.allowUnfree = true;
+    },
   */
 
   # If you want to use the in-tree version of nixpkgs:
@@ -25,16 +26,18 @@
 # Copy this file to your Android project.
 let
   # If you copy this example out of nixpkgs, something like this will work:
-  /*androidEnvNixpkgs = fetchTarball {
-    name = "androidenv";
-    url = "https://github.com/NixOS/nixpkgs/archive/<fill me in from Git>.tar.gz";
-    sha256 = "<fill me in with nix-prefetch-url --unpack>";
-  };
+  /*
+    androidEnvNixpkgs = fetchTarball {
+      name = "androidenv";
+      url = "https://github.com/NixOS/nixpkgs/archive/<fill me in from Git>.tar.gz";
+      sha256 = "<fill me in with nix-prefetch-url --unpack>";
+    };
 
-  androidEnv = pkgs.callPackage "${androidEnvNixpkgs}/pkgs/development/mobile/androidenv" {
-    inherit config pkgs;
-    licenseAccepted = true;
-  };*/
+    androidEnv = pkgs.callPackage "${androidEnvNixpkgs}/pkgs/development/mobile/androidenv" {
+      inherit config pkgs;
+      licenseAccepted = true;
+    };
+  */
 
   # Otherwise, just use the in-tree androidenv:
   androidEnv = pkgs.callPackage ./.. {
@@ -51,30 +54,48 @@ let
     includeNDK = "if-supported";
     useGoogleAPIs = true;
 
-    platformVersions = [ "23" "24" "25" "26" "27" "28" "29" "30" "31" "32" "33" "34" "35" ];
+    platformVersions = [
+      "23"
+      "24"
+      "25"
+      "26"
+      "27"
+      "28"
+      "29"
+      "30"
+      "31"
+      "32"
+      "33"
+      "34"
+      "35"
+    ];
 
     # If you want to use a custom repo JSON:
     # repoJson = ../repo.json;
 
     # If you want to use custom repo XMLs:
-    /*repoXmls = {
-      packages = [ ../xml/repository2-1.xml ];
-      images = [
-        ../xml/android-sys-img2-1.xml
-        ../xml/android-tv-sys-img2-1.xml
-        ../xml/android-wear-sys-img2-1.xml
-        ../xml/android-wear-cn-sys-img2-1.xml
-        ../xml/google_apis-sys-img2-1.xml
-        ../xml/google_apis_playstore-sys-img2-1.xml
-      ];
-      addons = [ ../xml/addon2-1.xml ];
-    };*/
+    /*
+      repoXmls = {
+        packages = [ ../xml/repository2-1.xml ];
+        images = [
+          ../xml/android-sys-img2-1.xml
+          ../xml/android-tv-sys-img2-1.xml
+          ../xml/android-wear-sys-img2-1.xml
+          ../xml/android-wear-cn-sys-img2-1.xml
+          ../xml/google_apis-sys-img2-1.xml
+          ../xml/google_apis_playstore-sys-img2-1.xml
+        ];
+        addons = [ ../xml/addon2-1.xml ];
+      };
+    */
 
-    includeExtras = [
-      "extras;google;gcm"
-    ] ++ pkgs.lib.optionals includeAuto [
-      "extras;google;auto"
-    ];
+    includeExtras =
+      [
+        "extras;google;gcm"
+      ]
+      ++ pkgs.lib.optionals includeAuto [
+        "extras;google;auto"
+      ];
 
     # Accepting more licenses declaratively:
     extraLicenses = [
@@ -99,7 +120,11 @@ let
 in
 pkgs.mkShell rec {
   name = "androidenv-demo";
-  packages = [ androidSdk platformTools jdk ];
+  packages = [
+    androidSdk
+    platformTools
+    jdk
+  ];
 
   LANG = "C.UTF-8";
   LC_ALL = "C.UTF-8";
@@ -128,53 +153,64 @@ pkgs.mkShell rec {
 
   passthru.tests = {
 
-    shell-sdkmanager-licenses-test = pkgs.runCommand "shell-sdkmanager-licenses-test" {
-      nativeBuildInputs = [ androidSdk jdk ];
-    } ''
-      if [[ ! "$(sdkmanager --licenses)" =~ "All SDK package licenses accepted." ]]; then
-        echo "At least one of SDK package licenses are not accepted."
-        exit 1
-      fi
-      touch $out
-    '';
+    shell-sdkmanager-licenses-test =
+      pkgs.runCommand "shell-sdkmanager-licenses-test"
+        {
+          nativeBuildInputs = [
+            androidSdk
+            jdk
+          ];
+        }
+        ''
+          if [[ ! "$(sdkmanager --licenses)" =~ "All SDK package licenses accepted." ]]; then
+            echo "At least one of SDK package licenses are not accepted."
+            exit 1
+          fi
+          touch $out
+        '';
 
-    shell-sdkmanager-packages-test = pkgs.runCommand "shell-sdkmanager-packages-test" {
-      nativeBuildInputs = [ androidSdk jdk ];
-    } ''
-      output="$(sdkmanager --list)"
-      installed_packages_section=$(echo "''${output%%Available Packages*}" | awk 'NR>4 {print $1}')
+    shell-sdkmanager-packages-test =
+      pkgs.runCommand "shell-sdkmanager-packages-test"
+        {
+          nativeBuildInputs = [
+            androidSdk
+            jdk
+          ];
+        }
+        ''
+          output="$(sdkmanager --list)"
+          installed_packages_section=$(echo "''${output%%Available Packages*}" | awk 'NR>4 {print $1}')
 
-      # FIXME couldn't find platforms;android-34, even though it's in the correct directory!! sdkmanager's bug?!
-      packages=(
-        "build-tools" "platform-tools" \
-        "platforms;android-23" "platforms;android-24" "platforms;android-25" "platforms;android-26" \
-        "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30" \
-        "platforms;android-31" "platforms;android-32" "platforms;android-33" "platforms;android-35" \
-        "sources;android-23" "sources;android-24" "sources;android-25" "sources;android-26" \
-        "sources;android-27" "sources;android-28" "sources;android-29" "sources;android-30" \
-        "sources;android-31" "sources;android-32" "sources;android-33" "sources;android-34" \
-        "sources;android-35" \
-        "system-images;android-28;google_apis_playstore;x86_64" \
-        "system-images;android-29;google_apis_playstore;x86_64" \
-        "system-images;android-30;google_apis_playstore;x86_64" \
-        "system-images;android-31;google_apis_playstore;x86_64" \
-        "system-images;android-32;google_apis_playstore;x86_64" \
-        "system-images;android-33;google_apis_playstore;x86_64" \
-        "system-images;android-34;google_apis;x86_64" \
-        "system-images;android-35;google_apis;x86_64" \
-        "extras;google;gcm"
-      )
-      ${pkgs.lib.optionalString includeAuto ''packages+=("extras;google;auto")''}
+          # FIXME couldn't find platforms;android-34, even though it's in the correct directory!! sdkmanager's bug?!
+          packages=(
+            "build-tools" "platform-tools" \
+            "platforms;android-23" "platforms;android-24" "platforms;android-25" "platforms;android-26" \
+            "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30" \
+            "platforms;android-31" "platforms;android-32" "platforms;android-33" "platforms;android-35" \
+            "sources;android-23" "sources;android-24" "sources;android-25" "sources;android-26" \
+            "sources;android-27" "sources;android-28" "sources;android-29" "sources;android-30" \
+            "sources;android-31" "sources;android-32" "sources;android-33" "sources;android-34" \
+            "sources;android-35" \
+            "system-images;android-28;google_apis_playstore;x86_64" \
+            "system-images;android-29;google_apis_playstore;x86_64" \
+            "system-images;android-30;google_apis_playstore;x86_64" \
+            "system-images;android-31;google_apis_playstore;x86_64" \
+            "system-images;android-32;google_apis_playstore;x86_64" \
+            "system-images;android-33;google_apis_playstore;x86_64" \
+            "system-images;android-34;google_apis;x86_64" \
+            "system-images;android-35;google_apis;x86_64" \
+            "extras;google;gcm"
+          )
+          ${pkgs.lib.optionalString includeAuto ''packages+=("extras;google;auto")''}
 
-      for package in "''${packages[@]}"; do
-        if [[ ! $installed_packages_section =~ "$package" ]]; then
-          echo "$package package was not installed."
-          exit 1
-        fi
-      done
+          for package in "''${packages[@]}"; do
+            if [[ ! $installed_packages_section =~ "$package" ]]; then
+              echo "$package package was not installed."
+              exit 1
+            fi
+          done
 
-      touch "$out"
-    '';
+          touch "$out"
+        '';
   };
 }
-

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -24,28 +24,6 @@
 
 # Copy this file to your Android project.
 let
-  # Declaration of versions for everything. This is useful since these
-  # versions may be used in multiple places in this Nix expression.
-  android = {
-    versions = {
-      cmdLineToolsVersion = "13.0";
-      platformTools = "35.0.2";
-      buildTools = "35.0.0";
-      ndk = [
-        "27.0.12077973"
-      ];
-      cmake = "3.6.4111459";
-      emulator = "35.1.4";
-    };
-
-    platforms = [ "23" "24" "25" "26" "27" "28" "29" "30" "31" "32" "33" "34" "35" ];
-    abis = [ "x86_64" ];
-    extras = [
-      "extras;google;gcm"
-      "extras;google;auto"
-    ];
-  };
-
   # If you copy this example out of nixpkgs, something like this will work:
   /*androidEnvNixpkgs = fetchTarball {
     name = "androidenv";
@@ -64,23 +42,13 @@ let
   };
 
   androidComposition = androidEnv.composeAndroidPackages {
-    cmdLineToolsVersion = android.versions.cmdLineToolsVersion;
-    platformToolsVersion = android.versions.platformTools;
-    buildToolsVersions = [android.versions.buildTools];
-    platformVersions = android.platforms;
-    abiVersions = android.abis;
-
     includeSources = true;
     includeSystemImages = true;
     includeEmulator = true;
-    emulatorVersion = android.versions.emulator;
-
     includeNDK = true;
-    ndkVersions = android.versions.ndk;
-    cmakeVersions = [android.versions.cmake];
-
     useGoogleAPIs = true;
-    includeExtras = android.extras;
+
+    platformVersions = [ "23" "24" "25" "26" "27" "28" "29" "30" "31" "32" "33" "34" "35" ];
 
     # If you want to use a custom repo JSON:
     # repoJson = ../repo.json;
@@ -98,6 +66,11 @@ let
       ];
       addons = [ ../xml/addon2-1.xml ];
     };*/
+
+    includeExtras = [
+      "extras;google;gcm"
+      "extras;google;auto"
+    ];
 
     # Accepting more licenses declaratively:
     extraLicenses = [
@@ -132,12 +105,12 @@ pkgs.mkShell rec {
   ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";
   ANDROID_NDK_ROOT = "${ANDROID_SDK_ROOT}/ndk-bundle";
 
-  # Ensures that we don't have to use a FHS env by using the nix store's aapt2.
-  GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${ANDROID_SDK_ROOT}/build-tools/${android.versions.buildTools}/aapt2";
-
   shellHook = ''
+    # Ensures that we don't have to use a FHS env by using the nix store's aapt2.
+    export GRADLE_OPTS="-Dorg.gradle.project.android.aapt2FromMavenOverride=$(echo "$ANDROID_SDK_ROOT/build-tools/"*"/aapt2")"
+
     # Add cmake to the path.
-    cmake_root="$(echo "$ANDROID_SDK_ROOT/cmake/${android.versions.cmake}"*/)"
+    cmake_root="$(echo "$ANDROID_SDK_ROOT/cmake/"*/)"
     export PATH="$cmake_root/bin:$PATH"
 
     # Write out local.properties for Android Studio.
@@ -169,7 +142,7 @@ pkgs.mkShell rec {
 
       # FIXME couldn't find platforms;android-34, even though it's in the correct directory!! sdkmanager's bug?!
       packages=(
-        "build-tools;35.0.0" "platform-tools" \
+        "build-tools" "platform-tools" \
         "platforms;android-23" "platforms;android-24" "platforms;android-25" "platforms;android-26" \
         "platforms;android-27" "platforms;android-28" "platforms;android-29" "platforms;android-30" \
         "platforms;android-31" "platforms;android-32" "platforms;android-33" "platforms;android-35" \

--- a/pkgs/development/mobile/androidenv/examples/shell.nix
+++ b/pkgs/development/mobile/androidenv/examples/shell.nix
@@ -41,11 +41,14 @@ let
     inherit config pkgs licenseAccepted;
   };
 
+  # The head unit only works on these platforms
+  includeAuto = pkgs.stdenv.hostPlatform.isx86_64 || pkgs.stdenv.hostPlatform.isDarwin;
+
   androidComposition = androidEnv.composeAndroidPackages {
     includeSources = true;
     includeSystemImages = true;
-    includeEmulator = true;
-    includeNDK = true;
+    includeEmulator = "if-supported";
+    includeNDK = "if-supported";
     useGoogleAPIs = true;
 
     platformVersions = [ "23" "24" "25" "26" "27" "28" "29" "30" "31" "32" "33" "34" "35" ];
@@ -69,6 +72,7 @@ let
 
     includeExtras = [
       "extras;google;gcm"
+    ] ++ pkgs.lib.optionals includeAuto [
       "extras;google;auto"
     ];
 
@@ -159,8 +163,8 @@ pkgs.mkShell rec {
         "system-images;android-34;google_apis;x86_64" \
         "system-images;android-35;google_apis;x86_64" \
         "extras;google;gcm"
-        "extras;google;auto"
       )
+      ${pkgs.lib.optionalString includeAuto ''packages+=("extras;google;auto")''}
 
       for package in "''${packages[@]}"; do
         if [[ ! $installed_packages_section =~ "$package" ]]; then

--- a/pkgs/development/mobile/androidenv/extras.nix
+++ b/pkgs/development/mobile/androidenv/extras.nix
@@ -6,6 +6,7 @@
   autoPatchelfHook,
   makeWrapper,
   pkgs,
+  meta,
 }:
 
 deployAndroidPackage {
@@ -36,4 +37,6 @@ deployAndroidPackage {
         }
     fi
   '';
+
+  inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/extras.nix
+++ b/pkgs/development/mobile/androidenv/extras.nix
@@ -3,6 +3,7 @@
   lib,
   package,
   os,
+  arch,
   autoPatchelfHook,
   makeWrapper,
   pkgs,
@@ -10,7 +11,7 @@
 }:
 
 deployAndroidPackage {
-  inherit package os;
+  inherit package os arch;
   nativeBuildInputs = [ makeWrapper ] ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
   buildInputs = lib.optionals (os == "linux") (
     with pkgs;

--- a/pkgs/development/mobile/androidenv/fetchrepo.sh
+++ b/pkgs/development/mobile/androidenv/fetchrepo.sh
@@ -8,7 +8,7 @@ die() {
 
 fetch() {
     local url="https://dl.google.com/android/repository/$1"
-    echo "$url -> $2"
+    echo "$url -> $2" >&2
     curl -s "$url" -o "$2" || die "Failed to fetch $url"
 }
 

--- a/pkgs/development/mobile/androidenv/generate.sh
+++ b/pkgs/development/mobile/androidenv/generate.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-./fetchrepo.sh && ./mkrepo.sh

--- a/pkgs/development/mobile/androidenv/license.nix
+++ b/pkgs/development/mobile/androidenv/license.nix
@@ -1,0 +1,9 @@
+{
+  config,
+}:
+
+# Accept the license in the test suite.
+config.android_sdk.accept_license or (
+  builtins.getEnv "NIXPKGS_ACCEPT_ANDROID_SDK_LICENSE" == "1"
+  || builtins.getEnv "UPDATE_NIX_ATTR_PATH" == "androidenv.test-suite"
+)

--- a/pkgs/development/mobile/androidenv/mkrepo.rb
+++ b/pkgs/development/mobile/androidenv/mkrepo.rb
@@ -4,6 +4,8 @@ require 'json'
 require 'rubygems'
 require 'nokogiri'
 require 'slop'
+require 'shellwords'
+require 'erb'
 
 # Returns a repo URL for a given package name.
 def repo_url value
@@ -487,16 +489,20 @@ end
 two_years_ago = today - 2 * 365
 
 input = {}
+prev_latest = {}
 begin
-  input_json = (STDIN.tty?) ? "{}" : $stdin.read
+  input_json = (STDIN.tty?) ? "{}" : STDIN.read
   if input_json != nil && !input_json.empty?
-    input =  expire_records(JSON.parse(input_json), two_years_ago)
+    input = expire_records(JSON.parse(input_json), two_years_ago)
+
+    # Just create a new set of latest packages.
+    prev_latest = input['latest'] || {}
+    input['latest'] = {}
   end
 rescue JSON::ParserError => e
-  $stderr.write(e.message)
+  STDERR.write(e.message)
   return
 end
-
 
 fixup_result = fixup(result)
 
@@ -505,4 +511,69 @@ fixup_result = fixup(result)
 # therefore the old packages will work as long as the links are working on the Google servers.
 output = merge input, fixup_result
 
-puts JSON.pretty_generate(sort_recursively(output))
+# See if there are any changes in the latest versions.
+cur_latest = output['latest'] || {}
+
+old_versions = []
+new_versions = []
+changes = []
+changed = false
+
+cur_latest.each do |k, v|
+  prev = prev_latest[k]
+  if prev && prev != v
+    old_versions << "#{k}:#{prev}"
+    new_versions << "#{k}:#{v}"
+    changes << "#{k}: #{prev} -> #{v}"
+    changed = true
+  end
+end
+
+# Output metadata for the nixpkgs update script.
+changed_paths = []
+if changed
+  if ENV['UPDATE_NIX_ATTR_PATH']
+    # Instantiate it.
+    test_result = `nix-shell ../../../../default.nix -A #{Shellwords.join [ENV['UPDATE_NIX_ATTR_PATH']]} 2>&1`
+    test_status = $?.exitstatus
+    tests_ran = true
+  else
+    tests_ran = false
+  end
+
+  template = ERB.new(<<-EOF, trim_mode: '<>-')
+androidenv: <%= changes.join('; ') %>
+
+Performed the following automatic androidenv updates:
+
+<% changes.each do |change| %>
+- <%= change -%>
+<% end %>
+
+<% if tests_ran %>
+Tests exited with status: <%= test_status -%>
+
+<% if test_status != 0 %>
+```
+<%= test_result -%>
+```
+<% end %>
+<% end %>
+EOF
+
+  changed_paths << {
+    attrPath: 'androidenv.androidPkgs.androidsdk',
+    oldVersion: old_versions.join('; '),
+    newVersion: new_versions.join('; '),
+    files: [
+      File.realpath('repo.json')
+    ],
+    commitMessage: template.result(binding)
+  }
+end
+
+# nix-update info is on stderr
+STDERR.puts JSON.pretty_generate(changed_paths)
+
+# repo is on stdout
+STDOUT.puts JSON.pretty_generate(sort_recursively(output))

--- a/pkgs/development/mobile/androidenv/mkrepo.rb
+++ b/pkgs/development/mobile/androidenv/mkrepo.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'json'
+require 'rubygems'
 require 'nokogiri'
 require 'slop'
 
@@ -465,6 +466,18 @@ opts[:addons].each do |filename|
   merge result['licenses'], licenses
   merge result['addons'], addons
   merge result['extras'], extras
+end
+
+result['latest'] = {}
+result['packages'].each do |name, versions|
+  max_version = Gem::Version.new('0')
+  versions.each do |version, package|
+    if package['license'] == 'android-sdk-license' && Gem::Version.correct?(package['revision'])
+      package_version = Gem::Version.new(package['revision'])
+      max_version = package_version if package_version > max_version
+    end
+  end
+  result['latest'][name] = max_version.to_s
 end
 
 # As we keep the old packages in the repo JSON file, we should have

--- a/pkgs/development/mobile/androidenv/mkrepo.sh
+++ b/pkgs/development/mobile/androidenv/mkrepo.sh
@@ -6,7 +6,6 @@ set -e
 pushd "$(dirname "$0")" &>/dev/null || exit 1
 
 echo "Writing repo.json" >&2
-pid=$BASHPID
 ruby mkrepo.rb \
     --packages ./xml/repository2-3.xml \
     --images ./xml/android-sys-img2-3.xml \
@@ -16,7 +15,5 @@ ruby mkrepo.rb \
     --images ./xml/android-automotive-sys-img2-3.xml \
     --images ./xml/google_apis-sys-img2-3.xml \
     --images ./xml/google_apis_playstore-sys-img2-3.xml \
-    --addons ./xml/addon2-3.xml <./repo.json 2>/proc/$pid/fd/1 \
-         | sponge repo.json
-
+    --addons ./xml/addon2-3.xml <./repo.json
 popd &>/dev/null

--- a/pkgs/development/mobile/androidenv/mkrepo.sh
+++ b/pkgs/development/mobile/androidenv/mkrepo.sh
@@ -6,7 +6,8 @@ set -e
 pushd "$(dirname "$0")" &>/dev/null || exit 1
 
 echo "Writing repo.json" >&2
-cat ./repo.json | ruby mkrepo.rb \
+pid=$BASHPID
+ruby mkrepo.rb \
     --packages ./xml/repository2-3.xml \
     --images ./xml/android-sys-img2-3.xml \
     --images ./xml/android-tv-sys-img2-3.xml \
@@ -15,7 +16,7 @@ cat ./repo.json | ruby mkrepo.rb \
     --images ./xml/android-automotive-sys-img2-3.xml \
     --images ./xml/google_apis-sys-img2-3.xml \
     --images ./xml/google_apis_playstore-sys-img2-3.xml \
-    --addons ./xml/addon2-3.xml \
+    --addons ./xml/addon2-3.xml <./repo.json 2>/proc/$pid/fd/1 \
          | sponge repo.json
 
 popd &>/dev/null

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -1,18 +1,47 @@
-{ stdenv, lib, pkgs, pkgsHostHost, makeWrapper, autoPatchelfHook
-, deployAndroidPackage, package, os, arch, platform-tools, meta
+{
+  stdenv,
+  lib,
+  pkgs,
+  pkgsHostHost,
+  makeWrapper,
+  autoPatchelfHook,
+  deployAndroidPackage,
+  package,
+  os,
+  arch,
+  platform-tools,
+  meta,
 }:
 
 let
-  runtime_paths = lib.makeBinPath (with pkgsHostHost; [
-    coreutils file findutils gawk gnugrep gnused jdk python3 which
-  ]) + ":${platform-tools}/platform-tools";
+  runtime_paths =
+    lib.makeBinPath (
+      with pkgsHostHost;
+      [
+        coreutils
+        file
+        findutils
+        gawk
+        gnugrep
+        gnused
+        jdk
+        python3
+        which
+      ]
+    )
+    + ":${platform-tools}/platform-tools";
 in
 deployAndroidPackage rec {
   inherit package os arch;
-  nativeBuildInputs = [ makeWrapper ]
-    ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+  nativeBuildInputs = [
+    makeWrapper
+  ] ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
   autoPatchelfIgnoreMissingDeps = [ "*" ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.zlib pkgs.libcxx (lib.getLib stdenv.cc.cc) ];
+  buildInputs = lib.optionals (os == "linux") [
+    pkgs.zlib
+    pkgs.libcxx
+    (lib.getLib stdenv.cc.cc)
+  ];
 
   patchElfBnaries = ''
     # Patch the executables of the toolchains, but not the libraries -- they are needed for crosscompiling
@@ -70,8 +99,8 @@ deployAndroidPackage rec {
     done
   '';
 
-  patchInstructions = patchOsAgnostic
-    + lib.optionalString stdenv.hostPlatform.isLinux patchElfBnaries;
+  patchInstructions =
+    patchOsAgnostic + lib.optionalString stdenv.hostPlatform.isLinux patchElfBnaries;
 
   noAuditTmpdir = true; # Audit script gets invoked by the build/ component in the path for the make standalone script
 

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, pkgs, pkgsHostHost, makeWrapper, autoPatchelfHook
-, deployAndroidPackage, package, os, platform-tools, meta
+, deployAndroidPackage, package, os, arch, platform-tools, meta
 }:
 
 let
@@ -8,7 +8,7 @@ let
   ]) + ":${platform-tools}/platform-tools";
 in
 deployAndroidPackage rec {
-  inherit package;
+  inherit package os arch;
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
   autoPatchelfIgnoreMissingDeps = [ "*" ];

--- a/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
+++ b/pkgs/development/mobile/androidenv/ndk-bundle/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, pkgs, pkgsHostHost, makeWrapper, autoPatchelfHook
-, deployAndroidPackage, package, os, platform-tools
+, deployAndroidPackage, package, os, platform-tools, meta
 }:
 
 let
@@ -74,4 +74,6 @@ deployAndroidPackage rec {
     + lib.optionalString stdenv.hostPlatform.isLinux patchElfBnaries;
 
   noAuditTmpdir = true; # Audit script gets invoked by the build/ component in the path for the make standalone script
+
+  inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/patcher.nix
+++ b/pkgs/development/mobile/androidenv/patcher.nix
@@ -3,12 +3,13 @@
   lib,
   package,
   os,
+  arch,
   autoPatchelfHook,
   stdenv,
 }:
 
 deployAndroidPackage {
-  inherit package os;
+  inherit package os arch;
   nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
   patchInstructions = lib.optionalString (os == "linux") ''
     autoPatchelf $packageBaseDir/bin

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,7 +1,7 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs, meta}:
+{deployAndroidPackage, lib, package, os, arch, autoPatchelfHook, pkgs, meta}:
 
 deployAndroidPackage {
-  inherit package;
+  inherit package os arch;
   nativeBuildInputs = lib.optionals (os == "linux") [ autoPatchelfHook ];
   buildInputs = lib.optionals (os == "linux") [ pkgs.glibc (lib.getLib pkgs.stdenv.cc.cc) pkgs.zlib pkgs.ncurses5 ];
 

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,21 +1,37 @@
-{deployAndroidPackage, lib, package, os, arch, autoPatchelfHook, pkgs, meta}:
+{
+  deployAndroidPackage,
+  lib,
+  package,
+  os,
+  arch,
+  autoPatchelfHook,
+  pkgs,
+  meta,
+}:
 
 deployAndroidPackage {
   inherit package os arch;
   nativeBuildInputs = lib.optionals (os == "linux") [ autoPatchelfHook ];
-  buildInputs = lib.optionals (os == "linux") [ pkgs.glibc (lib.getLib pkgs.stdenv.cc.cc) pkgs.zlib pkgs.ncurses5 ];
+  buildInputs = lib.optionals (os == "linux") [
+    pkgs.glibc
+    (lib.getLib pkgs.stdenv.cc.cc)
+    pkgs.zlib
+    pkgs.ncurses5
+  ];
 
-  patchInstructions = lib.optionalString (os == "linux") ''
-    addAutoPatchelfSearchPath $packageBaseDir/lib64
-    autoPatchelf --no-recurse $packageBaseDir/lib64
-    autoPatchelf --no-recurse $packageBaseDir
-  '' + ''
-    mkdir -p $out/bin
-    cd $out/bin
-    find $out/libexec/android-sdk/platform-tools -type f -executable -mindepth 1 -maxdepth 1 -not -name sqlite3 | while read i
-    do
-        ln -s $i
-    done
-  '';
+  patchInstructions =
+    lib.optionalString (os == "linux") ''
+      addAutoPatchelfSearchPath $packageBaseDir/lib64
+      autoPatchelf --no-recurse $packageBaseDir/lib64
+      autoPatchelf --no-recurse $packageBaseDir
+    ''
+    + ''
+      mkdir -p $out/bin
+      cd $out/bin
+      find $out/libexec/android-sdk/platform-tools -type f -executable -mindepth 1 -maxdepth 1 -not -name sqlite3 | while read i
+      do
+          ln -s $i
+      done
+    '';
   inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/platform-tools.nix
+++ b/pkgs/development/mobile/androidenv/platform-tools.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs}:
+{deployAndroidPackage, lib, package, os, autoPatchelfHook, pkgs, meta}:
 
 deployAndroidPackage {
   inherit package;
@@ -17,4 +17,5 @@ deployAndroidPackage {
         ln -s $i
     done
   '';
+  inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -12,7 +12,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -91,7 +91,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -156,7 +156,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -233,7 +233,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -280,7 +280,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -357,7 +357,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -404,7 +404,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -483,7 +483,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -576,7 +576,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -669,7 +669,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -762,7 +762,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -855,7 +855,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -948,7 +948,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -1041,7 +1041,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -1134,7 +1134,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -1227,7 +1227,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -1320,7 +1320,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -1413,7 +1413,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -1478,7 +1478,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1543,7 +1543,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1608,7 +1608,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1673,7 +1673,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1738,7 +1738,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1803,7 +1803,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1869,7 +1869,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1900,7 +1900,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1931,7 +1931,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1960,7 +1960,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -2010,7 +2010,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -2036,7 +2036,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -2072,7 +2072,7 @@
         }
       },
       "displayName": "Google Play services",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -2101,7 +2101,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -2130,7 +2130,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -2168,7 +2168,7 @@
         }
       },
       "displayName": "Google Repository",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -2197,7 +2197,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -2226,7 +2226,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -2256,7 +2256,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -2285,7 +2285,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -2314,7 +2314,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20139,
+      "last-available-day": 20174,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -2984,7 +2984,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -3030,7 +3030,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -3078,7 +3078,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -3130,7 +3130,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -3179,7 +3179,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -3229,7 +3229,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -3275,7 +3275,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -3323,7 +3323,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -3375,7 +3375,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -3431,7 +3431,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -3470,7 +3470,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -3516,7 +3516,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -3564,7 +3564,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -3616,7 +3616,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -3672,7 +3672,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -3711,7 +3711,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -3757,7 +3757,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3811,7 +3811,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3863,7 +3863,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3919,7 +3919,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3965,7 +3965,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -4013,7 +4013,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -4065,7 +4065,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -4121,7 +4121,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -4167,7 +4167,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -4215,7 +4215,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -4267,7 +4267,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -4316,7 +4316,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -4353,7 +4353,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -4392,7 +4392,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -4438,7 +4438,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -4484,7 +4484,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -4530,7 +4530,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -4571,7 +4571,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -4623,7 +4623,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -4675,7 +4675,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -4727,7 +4727,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -4776,7 +4776,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -4815,7 +4815,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -4861,7 +4861,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -4907,7 +4907,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -4953,7 +4953,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -4994,7 +4994,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -5046,7 +5046,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -5098,7 +5098,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -5150,7 +5150,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -5199,7 +5199,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -5243,7 +5243,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -5282,7 +5282,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -5328,7 +5328,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -5374,7 +5374,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -5420,7 +5420,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -5461,7 +5461,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -5513,7 +5513,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -5565,7 +5565,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -5617,7 +5617,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -5673,7 +5673,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -5712,7 +5712,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -5758,7 +5758,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -5804,7 +5804,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -5850,7 +5850,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -5898,7 +5898,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -5950,7 +5950,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -6002,7 +6002,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -6056,7 +6056,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -6112,7 +6112,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -6158,7 +6158,7 @@
             }
           },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -6202,7 +6202,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -6241,7 +6241,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -6287,7 +6287,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -6333,7 +6333,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -6374,7 +6374,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -6426,7 +6426,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -6478,7 +6478,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -6530,7 +6530,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -6584,7 +6584,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -6655,7 +6655,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -6701,7 +6701,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -6752,7 +6752,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -6796,7 +6796,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -6840,7 +6840,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -6891,7 +6891,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -6958,7 +6958,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -7025,7 +7025,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -7094,7 +7094,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -7150,7 +7150,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -7201,7 +7201,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -7245,7 +7245,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -7289,7 +7289,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -7340,7 +7340,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -7407,7 +7407,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -7476,7 +7476,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -7537,7 +7537,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -7582,7 +7582,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -7628,7 +7628,7 @@
             }
           },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -7679,7 +7679,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -7716,7 +7716,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -7753,7 +7753,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -7804,7 +7804,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -7871,7 +7871,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -7938,7 +7938,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -7997,7 +7997,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -8064,7 +8064,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -8131,7 +8131,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -8192,7 +8192,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -8252,7 +8252,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -8291,7 +8291,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -8354,7 +8354,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -8417,7 +8417,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -8450,8 +8450,8 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "5ef4888ce47a24a9e96e45418f9fd26f1c8e0f13",
-              "size": 1170272392,
+              "sha1": "f96b1ee677f1bd2ddcff0b93485e9c65db2e6160",
+              "size": 1170273162,
               "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-29_r13.zip"
             }
           ],
@@ -8468,7 +8468,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -8507,9 +8507,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "8dc45a7406b922116f2121f6826868c2e7087389",
-              "size": 1133056400,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-29_r12.zip"
+              "sha1": "7eb6ddbea82b94978f7c708fe09a05d8b977f9e9",
+              "size": 1136013362,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86-29_r13.zip"
             }
           ],
           "dependencies": {
@@ -8525,13 +8525,13 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
           "revision": "29-google_apis-x86",
           "revision-details": {
-            "major:0": "12"
+            "major:0": "13"
           },
           "type-details": {
             "abi:3": "x86",
@@ -8564,9 +8564,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "8392b93dc05c380bb0e6b2375ba318c14b263b37",
-              "size": 1313280930,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-29_r12.zip"
+              "sha1": "50c2953ab13f312ed797a961577ee74a911d087d",
+              "size": 1314706136,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-29_r13.zip"
             }
           ],
           "dependencies": {
@@ -8582,13 +8582,13 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
           "revision": "29-google_apis-x86_64",
           "revision-details": {
-            "major:0": "12"
+            "major:0": "13"
           },
           "type-details": {
             "abi:3": "x86_64",
@@ -8622,17 +8622,10 @@
           "archives": [
             {
               "arch": "all",
-              "os": "macosx",
-              "sha1": "47705387b8fbbfe87e3679d272c29f7064defba8",
-              "size": 1242979582,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-29_r09-darwin.zip"
-            },
-            {
-              "arch": "all",
-              "os": "linux",
-              "sha1": "47705387b8fbbfe87e3679d272c29f7064defba8",
-              "size": 1242979582,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-29_r09-linux.zip"
+              "os": "all",
+              "sha1": "4827a12df810087c899f522abe227f250a101548",
+              "size": 1167440660,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-29_r09.zip"
             }
           ],
           "dependencies": {
@@ -8648,7 +8641,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -8686,10 +8679,10 @@
           "archives": [
             {
               "arch": "all",
-              "os": "windows",
-              "sha1": "1c45e690e9ee6a44f40549e9fb68d3fd52ba4970",
-              "size": 1153916727,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-29_r08-windows.zip"
+              "os": "all",
+              "sha1": "f5cf2ac122f1a0d8a4a9361f786f79f48c54ccc3",
+              "size": 1161024570,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-29_r09.zip"
             },
             {
               "arch": "all",
@@ -8712,9 +8705,9 @@
                 "path": "emulator"
               },
               "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "9",
-                "minor:1": "1"
+                "major:0": "30",
+                "micro:2": "2",
+                "minor:1": "8"
               }
             },
             "dependency:1": {
@@ -8729,13 +8722,13 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
           "revision": "29-google_apis_playstore-x86",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "9"
           },
           "type-details": {
             "abi:3": "x86",
@@ -8767,10 +8760,10 @@
           "archives": [
             {
               "arch": "all",
-              "os": "windows",
-              "sha1": "94835980b4a6eaeeb41936d7fb1381698e48433a",
-              "size": 1322004798,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-29_r08-windows.zip"
+              "os": "all",
+              "sha1": "96569c901288b5c29f3699c481ac491eadf368d1",
+              "size": 1328071660,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-29_r09.zip"
             },
             {
               "arch": "all",
@@ -8793,9 +8786,9 @@
                 "path": "emulator"
               },
               "min-revision:0": {
-                "major:0": "28",
-                "micro:2": "9",
-                "minor:1": "1"
+                "major:0": "30",
+                "micro:2": "2",
+                "minor:1": "8"
               }
             },
             "dependency:1": {
@@ -8810,13 +8803,13 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
           "revision": "29-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "8"
+            "major:0": "9"
           },
           "type-details": {
             "abi:3": "x86_64",
@@ -8871,7 +8864,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -8931,7 +8924,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -8977,7 +8970,7 @@
             }
           },
           "displayName": "Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear/arm64-v8a",
@@ -9021,7 +9014,7 @@
             }
           },
           "displayName": "Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear/x86",
@@ -9060,7 +9053,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -9109,7 +9102,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -9160,7 +9153,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -9227,7 +9220,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -9294,7 +9287,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -9360,7 +9353,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -9441,7 +9434,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -9522,7 +9515,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -9593,7 +9586,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -9652,7 +9645,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -9703,7 +9696,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -9752,7 +9745,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -9813,7 +9806,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -9880,7 +9873,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -9956,7 +9949,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -10023,7 +10016,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -10084,7 +10077,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -10137,7 +10130,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -10192,7 +10185,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -10241,7 +10234,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -10302,7 +10295,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -10369,7 +10362,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -10445,7 +10438,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -10526,7 +10519,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -10587,7 +10580,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -10640,7 +10633,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -10705,7 +10698,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -10764,7 +10757,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -10810,7 +10803,7 @@
             }
           },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -10854,7 +10847,7 @@
             }
           },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -10905,7 +10898,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -10954,7 +10947,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -11015,7 +11008,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -11082,7 +11075,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -11151,7 +11144,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -11218,7 +11211,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -11293,7 +11286,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33-ext4/google_apis_playstore/arm64-v8a",
@@ -11342,7 +11335,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-33x-google_apis_playstore-x86_64",
           "path": "system-images/android-33-ext4/google_apis_playstore/x86_64",
@@ -11405,7 +11398,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -11465,7 +11458,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -11505,7 +11498,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -11542,7 +11535,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -11593,7 +11586,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -11642,7 +11635,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -11703,7 +11696,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -11771,7 +11764,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -11841,7 +11834,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34/google_apis_playstore/arm64-v8a",
@@ -11910,7 +11903,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34/google_apis_playstore/x86_64",
@@ -11973,7 +11966,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -12026,7 +12019,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -12095,7 +12088,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -12144,7 +12137,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-34x-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -12185,7 +12178,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -12217,7 +12210,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -12263,7 +12256,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -12308,7 +12301,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -12355,7 +12348,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
@@ -12413,7 +12406,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
@@ -12473,7 +12466,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore/arm64-v8a",
@@ -12531,7 +12524,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35/google_apis_playstore/x86_64",
@@ -12591,7 +12584,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-page_size_16kb-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
@@ -12653,7 +12646,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-35-page_size_16kb-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
@@ -12695,6 +12688,74 @@
       }
     },
     "35x": {
+      "android-wear": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "85f302e4038789563b3075c744645d06762a523c",
+              "size": 1235397800,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear/arm64-v8a-35-ext15_r01.zip"
+            }
+          ],
+          "displayName": "Wear OS 5.1 ARM 64 v8a System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-license",
+          "name": "system-image-35x-android-wear-arm64-v8a",
+          "path": "system-images/android-35-ext15/android-wear/arm64-v8a",
+          "revision": "35x-android-wear-arm64-v8a",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:4": "arm64-v8a",
+            "api-level:0": "35x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "15",
+            "tag:3": {
+              "display:1": "Wear OS 5.1",
+              "id:0": "android-wear"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "70b5cc9e0a070bb485113fba38df782aa3e21782",
+              "size": 1230585003,
+              "url": "https://dl.google.com/android/repository/sys-img/android-wear/x86_64-35-ext15_r01.zip"
+            }
+          ],
+          "displayName": "Wear OS 5.1 Intel x86_64 Atom System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-license",
+          "name": "system-image-35x-android-wear-x86_64",
+          "path": "system-images/android-35-ext15/android-wear/x86_64",
+          "revision": "35x-android-wear-x86_64",
+          "revision-details": {
+            "major:0": "1"
+          },
+          "type-details": {
+            "abi:4": "x86_64",
+            "api-level:0": "35x",
+            "base-extension:2": "false",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "15",
+            "tag:3": {
+              "display:1": "Wear OS 5.1",
+              "id:0": "android-wear"
+            }
+          }
+        }
+      },
       "google_apis_playstore": {
         "arm64-v8a": {
           "archives": [
@@ -12719,7 +12780,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext14/google_apis_playstore/arm64-v8a",
@@ -12768,7 +12829,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext14/google_apis_playstore/x86_64",
@@ -12789,6 +12850,316 @@
               "id:0": "google_apis_playstore"
             },
             "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      }
+    },
+    "36": {
+      "google_apis": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "82c8c75e78c73e80a663472f278e61ae3219ff7e",
+              "size": 1814357571,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-36_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "10",
+                "minor:1": "2"
+              }
+            }
+          },
+          "displayName": "Google APIs ARM 64 v8a System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36-google_apis-arm64-v8a",
+          "path": "system-images/android-36/google_apis/arm64-v8a",
+          "revision": "36-google_apis-arm64-v8a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:5": "arm64-v8a",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "069c5654cb549e7ff7c817e7023d0c680a623f8c",
+              "size": 1706610245,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-36_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "10",
+                "minor:1": "2"
+              }
+            }
+          },
+          "displayName": "Google APIs Intel x86_64 Atom System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-license",
+          "name": "system-image-36-google_apis-x86_64",
+          "path": "system-images/android-36/google_apis/x86_64",
+          "revision": "36-google_apis-x86_64",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:5": "x86_64",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Google APIs",
+              "id:0": "google_apis"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "google_apis_playstore": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "1605ca6608e2e83f250c4375e15489ade9169c52",
+              "size": 1835226829,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-36_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "10",
+                "minor:1": "2"
+              }
+            }
+          },
+          "displayName": "Google Play ARM 64 v8a System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36-google_apis_playstore-arm64-v8a",
+          "path": "system-images/android-36/google_apis_playstore/arm64-v8a",
+          "revision": "36-google_apis_playstore-arm64-v8a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:5": "arm64-v8a",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "b24c50ec8e211cc116f448b67f49ed482c55bd55",
+              "size": 1741001393,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-36_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "10",
+                "minor:1": "2"
+              }
+            }
+          },
+          "displayName": "Google Play Intel x86_64 Atom System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-license",
+          "name": "system-image-36-google_apis_playstore-x86_64",
+          "path": "system-images/android-36/google_apis_playstore/x86_64",
+          "revision": "36-google_apis_playstore-x86_64",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:5": "x86_64",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "Google Play",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:4": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        }
+      },
+      "page_size_16kb": {
+        "arm64-v8a": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "da544188ab47a89f4b3cf6614523cf3cb3440129",
+              "size": 1887754420,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-36_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "10",
+                "minor:1": "2"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-arm-dbt-license",
+          "name": "system-image-36-page_size_16kb-arm64-v8a",
+          "path": "system-images/android-36/google_apis_playstore_ps16k/arm64-v8a",
+          "revision": "36-page_size_16kb-arm64-v8a",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:6": "arm64-v8a",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
+              "display:1": "Google Inc.",
+              "id:0": "google"
+            }
+          }
+        },
+        "x86_64": {
+          "archives": [
+            {
+              "arch": "all",
+              "os": "all",
+              "sha1": "d1f4ccf971300511e5f8d606c6d5fabf97647b36",
+              "size": 1738939657,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-36_r05.zip"
+            }
+          ],
+          "dependencies": {
+            "dependency:0": {
+              "element-attributes": {
+                "path": "emulator"
+              },
+              "min-revision:0": {
+                "major:0": "35",
+                "micro:2": "10",
+                "minor:1": "2"
+              }
+            }
+          },
+          "displayName": "Pre-Release 16 KB Page Size Google Play ARM Intel x86_64 Atom System Image",
+          "last-available-day": 20174,
+          "license": "android-sdk-license",
+          "name": "system-image-36-page_size_16kb-x86_64",
+          "path": "system-images/android-36/google_apis_playstore_ps16k/x86_64",
+          "revision": "36-page_size_16kb-x86_64",
+          "revision-details": {
+            "major:0": "5"
+          },
+          "type-details": {
+            "abi:6": "x86_64",
+            "api-level:0": "36",
+            "base-extension:2": "true",
+            "element-attributes": {
+              "xsi:type": "ns12:sysImgDetailsType"
+            },
+            "extension-level:1": "17",
+            "tag:3": {
+              "display:1": "16 KB Page Size",
+              "id:0": "page_size_16kb"
+            },
+            "tag:4": {
+              "display:1": "Google APIs PlayStore",
+              "id:0": "google_apis_playstore"
+            },
+            "vendor:5": {
               "display:1": "Google Inc.",
               "id:0": "google"
             }
@@ -12821,7 +13192,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis/arm64-v8a",
@@ -12871,7 +13242,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis-x86_64",
           "path": "system-images/android-Baklava/google_apis/x86_64",
@@ -12923,7 +13294,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore/arm64-v8a",
@@ -12973,7 +13344,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis_playstore-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore/x86_64",
@@ -13025,7 +13396,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/arm64-v8a",
@@ -13079,7 +13450,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM Intel x86_64 Atom System Image",
-          "last-available-day": 20139,
+          "last-available-day": 20174,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-page_size_16kb-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/x86_64",
@@ -13900,16 +14271,16 @@
     }
   },
   "latest": {
-    "build-tools": "35.0.1",
-    "cmake": "3.31.5",
-    "cmdline-tools": "17.0",
-    "emulator": "35.4.8",
+    "build-tools": "36.0.0",
+    "cmake": "3.31.6",
+    "cmdline-tools": "19.0",
+    "emulator": "35.5.8",
     "ndk": "28.0.13004108",
     "ndk-bundle": "22.1.7171670",
     "platform-tools": "35.0.2",
-    "platforms": "35",
-    "skiaparser": "6",
-    "sources": "35",
+    "platforms": "36",
+    "skiaparser": "7",
+    "sources": "36",
     "tools": "26.1.1"
   },
   "licenses": {
@@ -13975,7 +14346,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14024,7 +14395,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14073,7 +14444,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14122,7 +14493,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14171,7 +14542,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14220,7 +14591,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14269,7 +14640,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14318,7 +14689,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14367,7 +14738,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -14415,7 +14786,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -14463,7 +14834,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14512,7 +14883,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14561,7 +14932,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14610,7 +14981,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14659,7 +15030,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14708,7 +15079,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -14756,7 +15127,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14805,7 +15176,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -14853,7 +15224,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14902,7 +15273,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -14950,7 +15321,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -14998,7 +15369,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -15046,7 +15417,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -15094,7 +15465,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -15142,7 +15513,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -15190,7 +15561,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -15238,7 +15609,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -15286,7 +15657,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -15334,7 +15705,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -15382,7 +15753,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -15430,7 +15801,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -15478,7 +15849,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -15526,7 +15897,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -15574,7 +15945,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -15622,7 +15993,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -15670,7 +16041,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -15718,7 +16089,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -15766,7 +16137,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -15814,7 +16185,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -15862,7 +16233,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15912,7 +16283,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15962,7 +16333,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -16010,7 +16381,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -16058,7 +16429,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -16106,7 +16477,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -16154,7 +16525,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16204,7 +16575,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16254,7 +16625,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16304,7 +16675,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -16352,7 +16723,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -16400,7 +16771,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -16448,7 +16819,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -16496,7 +16867,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -16544,7 +16915,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -16592,7 +16963,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -16633,7 +17004,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -16674,7 +17045,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -16715,7 +17086,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -16757,7 +17128,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -16798,7 +17169,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -16839,7 +17210,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -16880,7 +17251,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -16921,7 +17292,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -16962,7 +17333,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -17004,7 +17375,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -17046,7 +17417,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -17127,7 +17498,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -17168,7 +17539,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -17210,7 +17581,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -17252,7 +17623,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -17294,7 +17665,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -17336,7 +17707,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -17344,6 +17715,47 @@
         "revision-details": {
           "major:0": "35",
           "micro:2": "1",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.0.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "b0b6376977657e8ad9b969bacf4093601da2c6fb",
+            "size": 63737259,
+            "url": "https://dl.google.com/android/repository/build-tools_r36_linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "f16ccffd34de8790dede813a6c7d8e2c11a27b50",
+            "size": 58699878,
+            "url": "https://dl.google.com/android/repository/build-tools_r36_windows.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "199ae0047ee61e842f8ee0c6d3918e44fb9a1f83",
+            "size": 79121749,
+            "url": "https://dl.google.com/android/repository/build-tools_r36_macosx.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 36",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "build-tools",
+        "path": "build-tools/36.0.0",
+        "revision": "36.0.0",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "0",
           "minor:1": "0"
         },
         "type-details": {
@@ -17377,7 +17789,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -17419,7 +17831,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -17461,7 +17873,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -17503,7 +17915,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc5",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc5",
@@ -17554,7 +17966,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -17595,7 +18007,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -17636,7 +18048,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -17677,7 +18089,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -17718,7 +18130,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -17759,7 +18171,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -17800,7 +18212,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -17841,7 +18253,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -17882,7 +18294,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -17923,7 +18335,7 @@
           }
         ],
         "displayName": "CMake 3.31.5",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.5",
@@ -17931,6 +18343,47 @@
         "revision-details": {
           "major:0": "3",
           "micro:2": "5",
+          "minor:1": "31"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "3.31.6": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "a54551dabd5daf8cc99f7f51769fd00ca759be0a",
+            "size": 30771638,
+            "url": "https://dl.google.com/android/repository/cmake-3.31.6-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "78c3bf819d7bf6144783aeef06c5f9cbd3f8f5a9",
+            "size": 42861179,
+            "url": "https://dl.google.com/android/repository/cmake-3.31.6-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "1efbef168291afc5d6ae449b1a016f8bf034b0fc",
+            "size": 20491843,
+            "url": "https://dl.google.com/android/repository/cmake-3.31.6-windows.zip"
+          }
+        ],
+        "displayName": "CMake 3.31.6",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "cmake",
+        "path": "cmake/3.31.6",
+        "revision": "3.31.6",
+        "revision-details": {
+          "major:0": "3",
+          "micro:2": "6",
           "minor:1": "31"
         },
         "type-details": {
@@ -17971,7 +18424,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -18014,7 +18467,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -18054,7 +18507,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -18132,7 +18585,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -18248,7 +18701,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -18326,7 +18779,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -18366,7 +18819,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -18407,7 +18860,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -18448,7 +18901,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -18488,7 +18941,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -18529,13 +18982,53 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
         "revision": "17.0",
         "revision-details": {
           "major:0": "17",
+          "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "19.0": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "5fdcc763663eefb86a5b8879697aa6088b041e70",
+            "size": 164760899,
+            "url": "https://dl.google.com/android/repository/commandlinetools-linux-13114758_latest.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "c3e06a1959762e89167d1cbaa988605f6f7c1d24",
+            "size": 143250852,
+            "url": "https://dl.google.com/android/repository/commandlinetools-mac-13114758_latest.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "54a582f3bf73e04253602f2d1c80bd5868aac115",
+            "size": 143040480,
+            "url": "https://dl.google.com/android/repository/commandlinetools-win-13114758_latest.zip"
+          }
+        ],
+        "displayName": "Android SDK Command-line Tools",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "cmdline-tools",
+        "path": "cmdline-tools/19.0",
+        "revision": "19.0",
+        "revision-details": {
+          "major:0": "19",
           "minor:1": "0"
         },
         "type-details": {
@@ -18569,7 +19062,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0-alpha01",
@@ -18610,7 +19103,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -18651,7 +19144,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -18691,7 +19184,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -18731,7 +19224,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -18771,7 +19264,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -18811,7 +19304,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -18851,7 +19344,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -18891,7 +19384,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -18931,7 +19424,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -19960,6 +20453,54 @@
           }
         }
       },
+      "35.4.9": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "dc8d58c3948dcfa946417afaa60ad397c7329765",
+            "size": 298118508,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13025442.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "230baf96ebcb0d27779e5bd55ffeab7cfa98294c",
+            "size": 393818294,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13025442.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "08ff527ae85394e8d9957d5ea17fffdc14abf035",
+            "size": 311961707,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13025442.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "819cf13914861226713ca61beb9cbc01165d5044",
+            "size": 421982739,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13025442.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "35.4.9",
+        "revision-details": {
+          "major:0": "35",
+          "micro:2": "9",
+          "minor:1": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
       "35.5.2": {
         "archives": [
           {
@@ -20049,6 +20590,102 @@
           "major:0": "35",
           "micro:2": "3",
           "minor:1": "5"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "35.5.8": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "30a3e80f55f09d64ffc72e7ecd4dc962e2385fad",
+            "size": 301171981,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13181580.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "ab51e1aaa71e1c95ac96b0087af0442ac80a62d6",
+            "size": 394047089,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13181580.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "cee00a0495b1cdde264e71c364f411b6f84ca3bc",
+            "size": 312156337,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13181580.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "11fb3933985bb97b49861ef42299c8a3800bc9d7",
+            "size": 423381031,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13181580.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "35.5.8",
+        "revision-details": {
+          "major:0": "35",
+          "micro:2": "8",
+          "minor:1": "5"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "35.6.2": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "d895e040a36a339490b44187bb57d09aa0e9e514",
+            "size": 323950884,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13248170.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "5c46bfdbb66bad0926ea01028e7224b7c10ee1f7",
+            "size": 401371702,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13248170.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "8ef0aeaa7b1224bf66021c077885741eab64a42f",
+            "size": 319286666,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13248170.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "d9bbf3b50551e8a68df56b137c7cdb14428c8b5b",
+            "size": 429402312,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13248170.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20174,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "35.6.2",
+        "revision-details": {
+          "major:0": "35",
+          "micro:2": "2",
+          "minor:1": "6"
         },
         "type-details": {
           "element-attributes": {
@@ -20180,7 +20817,7 @@
           }
         },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -20242,7 +20879,7 @@
           }
         },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -20304,7 +20941,7 @@
           }
         },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -20366,7 +21003,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20429,7 +21066,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -20491,7 +21128,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20555,7 +21192,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20619,7 +21256,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -20681,7 +21318,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -20729,7 +21366,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -20778,7 +21415,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -20826,7 +21463,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -20882,7 +21519,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -20938,7 +21575,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -20993,7 +21630,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -21049,7 +21686,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -21104,7 +21741,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -21159,7 +21796,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -21214,7 +21851,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -21270,7 +21907,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -21325,7 +21962,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -21380,7 +22017,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -21436,7 +22073,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -21492,7 +22129,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -21548,7 +22185,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -21597,7 +22234,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -21646,7 +22283,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -21695,7 +22332,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -21743,7 +22380,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -21791,7 +22428,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -21839,7 +22476,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -21888,7 +22525,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -21937,7 +22574,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -21986,7 +22623,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -22034,7 +22671,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -22083,7 +22720,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -22132,7 +22769,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -22181,7 +22818,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -22230,7 +22867,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -22278,7 +22915,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -22326,7 +22963,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -22374,7 +23011,7 @@
           }
         },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -22416,7 +23053,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -22458,7 +23095,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -22499,7 +23136,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -22540,7 +23177,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -22581,7 +23218,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -22622,7 +23259,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -22664,7 +23301,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -22706,7 +23343,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -22747,7 +23384,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -22788,7 +23425,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -22829,7 +23466,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -22871,7 +23508,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -22913,7 +23550,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -22955,7 +23592,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.13004108",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.0.13004108",
@@ -22964,6 +23601,48 @@
           "major:0": "28",
           "micro:2": "13004108",
           "minor:1": "0"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "29.0.13113456-rc1": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "ec2d8801e42009edf66be853c1bab9ba216378f9",
+            "size": 773995428,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta1-linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "485c42ff6a04ef0ec9612420b3226de443f46e7a",
+            "size": 1027792565,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta1-darwin.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "90347ffa01dd1833b9ff116865958976fd66c264",
+            "size": 821548547,
+            "url": "https://dl.google.com/android/repository/android-ndk-r29-beta1-windows.zip"
+          }
+        ],
+        "displayName": "NDK (Side by side) 29.0.13113456",
+        "last-available-day": 20174,
+        "license": "android-sdk-preview-license",
+        "name": "ndk",
+        "path": "ndk/29.0.13113456",
+        "revision": "29.0.13113456-rc1",
+        "revision-details": {
+          "major:0": "29",
+          "micro:2": "13113456",
+          "minor:1": "0",
+          "preview:3": "1"
         },
         "type-details": {
           "element-attributes": {
@@ -23019,7 +23698,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23081,7 +23760,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23143,7 +23822,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23205,7 +23884,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23268,7 +23947,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23330,7 +24009,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23394,7 +24073,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23458,7 +24137,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23520,7 +24199,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23568,7 +24247,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23617,7 +24296,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23665,7 +24344,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23721,7 +24400,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23777,7 +24456,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23832,7 +24511,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23888,7 +24567,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23943,7 +24622,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23998,7 +24677,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24053,7 +24732,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24109,7 +24788,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24164,7 +24843,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24219,7 +24898,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24275,7 +24954,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24331,7 +25010,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24387,7 +25066,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24647,7 +25326,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -24676,7 +25355,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -24715,7 +25394,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -24754,7 +25433,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -24793,7 +25472,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -24832,7 +25511,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -24871,7 +25550,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -24910,7 +25589,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -24949,7 +25628,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -24988,7 +25667,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -25027,7 +25706,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -25080,7 +25759,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25120,7 +25799,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -25159,7 +25838,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -25198,7 +25877,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -25237,7 +25916,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -25276,7 +25955,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -25315,7 +25994,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -25354,7 +26033,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -25393,7 +26072,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -25432,7 +26111,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -25471,7 +26150,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -25524,7 +26203,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25564,7 +26243,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -25603,7 +26282,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -25642,7 +26321,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -25681,7 +26360,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -25721,7 +26400,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33-ext5",
@@ -25756,7 +26435,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25802,7 +26481,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-34-ext12",
@@ -25835,7 +26514,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -25873,7 +26552,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35-ext14",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35-ext14",
@@ -25888,6 +26567,39 @@
             "xsi:type": "ns11:platformDetailsType"
           },
           "extension-level:1": "14",
+          "layoutlib:3": {
+            "element-attributes": {
+              "api": "15"
+            }
+          }
+        }
+      },
+      "36": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "feed7041652a3744582bb233506013969dbadb46",
+            "size": 65749783,
+            "url": "https://dl.google.com/android/repository/platform-36_r01.zip"
+          }
+        ],
+        "displayName": "Android SDK Platform 36",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "platforms",
+        "path": "platforms/android-36",
+        "revision": "36",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "36",
+          "base-extension:2": "true",
+          "element-attributes": {
+            "xsi:type": "ns11:platformDetailsType"
+          },
+          "extension-level:1": "17",
           "layoutlib:3": {
             "element-attributes": {
               "api": "15"
@@ -25920,7 +26632,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25974,7 +26686,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26028,7 +26740,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26068,7 +26780,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -26107,7 +26819,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -26146,7 +26858,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -26185,7 +26897,7 @@
           }
         ],
         "displayName": "Android SDK Platform Baklava",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-Baklava",
@@ -26250,7 +26962,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26404,7 +27116,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
@@ -26522,44 +27234,62 @@
             "sha1": "28dde025a70a0f4819cf195c1cb6e0e2b4bf4514",
             "size": 6059180,
             "url": "https://dl.google.com/android/repository/skiaparser-7083912-win.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "linux",
-            "sha1": "0c0ba1581ecba105bd59b95c251f8a16a73e9555",
-            "size": 9057863,
-            "url": "https://dl.google.com/android/repository/skiaparser-12972467-linux-x64.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "macosx",
-            "sha1": "7fa586b1b677db7f0af7104bb8b273bae1f05567",
-            "size": 2933880,
-            "url": "https://dl.google.com/android/repository/skiaparser-12972467-darwin-x64.zip"
-          },
-          {
-            "arch": "aarch64",
-            "os": "macosx",
-            "sha1": "b4c308feff96c9ef112dd8959ee9d1e78c12d89b",
-            "size": 2598977,
-            "url": "https://dl.google.com/android/repository/skiaparser-12972467-darwin-aarch64.zip"
-          },
-          {
-            "arch": "x64",
-            "os": "windows",
-            "sha1": "6d65481e813ea9fa6447d8575b40f728bc252cd3",
-            "size": 2953603,
-            "url": "https://dl.google.com/android/repository/skiaparser-12972467-win-x64.zip"
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
         "revision": "6",
         "revision-details": {
           "major:0": "6"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "7": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "bb1f92866924dc64e035516d36866f6d851c5f6d",
+            "size": 9075303,
+            "url": "https://dl.google.com/android/repository/skiaparser-13188227-linux-x64.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "a4a0037269a48d8eca8cdb8bc289e7b35b829b45",
+            "size": 2939258,
+            "url": "https://dl.google.com/android/repository/skiaparser-13188227-darwin-x64.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "44c55cb986abfb8d5dc2293db3a625b8d81dc1f6",
+            "size": 2601969,
+            "url": "https://dl.google.com/android/repository/skiaparser-13188227-darwin-aarch64.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "9c47bdff5f0bb8947426d766d28b35a6f3bba988",
+            "size": 2956517,
+            "url": "https://dl.google.com/android/repository/skiaparser-13188227-win-x64.zip"
+          }
+        ],
+        "displayName": "Layout Inspector image server for API 31-36",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "skiaparser",
+        "path": "skiaparser/3",
+        "revision": "7",
+        "revision-details": {
+          "major:0": "7"
         },
         "type-details": {
           "element-attributes": {
@@ -26580,7 +27310,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -26610,7 +27340,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -26639,7 +27369,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -26668,7 +27398,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -26697,7 +27427,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -26726,7 +27456,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -26755,7 +27485,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -26784,7 +27514,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -26813,7 +27543,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -26842,7 +27572,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -26871,7 +27601,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -26900,7 +27630,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -26929,7 +27659,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -26958,7 +27688,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -26987,7 +27717,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -27016,7 +27746,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -27045,7 +27775,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -27074,7 +27804,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -27103,7 +27833,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -27132,7 +27862,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -27162,7 +27892,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -27192,7 +27922,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -27209,6 +27939,34 @@
             "xsi:type": "ns11:sourceDetailsType"
           },
           "extension-level:2": "13"
+        }
+      },
+      "36": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "all",
+            "sha1": "57b6cbc3acff91f6b1bc56f4083c9446052a9851",
+            "size": 51345538,
+            "url": "https://dl.google.com/android/repository/source-36_r01.zip"
+          }
+        ],
+        "displayName": "Sources for Android 36",
+        "last-available-day": 20174,
+        "license": "android-sdk-license",
+        "name": "sources",
+        "path": "sources/android-36",
+        "revision": "36",
+        "revision-details": {
+          "major:0": "1"
+        },
+        "type-details": {
+          "api-level:0": "36",
+          "base-extension:2": "true",
+          "element-attributes": {
+            "xsi:type": "ns11:sourceDetailsType"
+          },
+          "extension-level:1": "17"
         }
       }
     },
@@ -27261,7 +28019,7 @@
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20139,
+        "last-available-day": 20174,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",

--- a/pkgs/development/mobile/androidenv/repo.json
+++ b/pkgs/development/mobile/androidenv/repo.json
@@ -12,7 +12,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-10",
@@ -91,7 +91,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-11",
@@ -156,7 +156,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-12",
@@ -233,7 +233,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-12",
@@ -280,7 +280,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-13",
@@ -357,7 +357,7 @@
           }
         ],
         "displayName": "Google TV Addon",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-googletv-license",
         "name": "google_tv_addon",
         "path": "add-ons/addon-google_tv_addon-google-13",
@@ -404,7 +404,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-14",
@@ -483,7 +483,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-15",
@@ -576,7 +576,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-16",
@@ -669,7 +669,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-17",
@@ -762,7 +762,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-18",
@@ -855,7 +855,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-19",
@@ -948,7 +948,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-21",
@@ -1041,7 +1041,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-22",
@@ -1134,7 +1134,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-23",
@@ -1227,7 +1227,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-24",
@@ -1320,7 +1320,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-25",
@@ -1413,7 +1413,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-3",
@@ -1478,7 +1478,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-4",
@@ -1543,7 +1543,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-5",
@@ -1608,7 +1608,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-6",
@@ -1673,7 +1673,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-7",
@@ -1738,7 +1738,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-8",
@@ -1803,7 +1803,7 @@
           }
         ],
         "displayName": "Google APIs",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "google_apis",
         "path": "add-ons/addon-google_apis-google-9",
@@ -1869,7 +1869,7 @@
         }
       ],
       "displayName": "Android Support Repository",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-android-m2repository",
       "path": "extras/android/m2repository",
@@ -1900,7 +1900,7 @@
         }
       ],
       "displayName": "Android Emulator hypervisor driver (installer)",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-Android_Emulator_Hypervisor_Driver",
       "path": "extras/google/Android_Emulator_Hypervisor_Driver",
@@ -1931,7 +1931,7 @@
         }
       ],
       "displayName": "Google AdMob Ads SDK",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-admob_ads_sdk",
       "path": "extras/google/admob_ads_sdk",
@@ -1960,7 +1960,7 @@
         }
       ],
       "displayName": "Google Analytics App Tracking SDK",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-analytics_sdk_v2",
       "path": "extras/google/analytics_sdk_v2",
@@ -2010,7 +2010,7 @@
         }
       ],
       "displayName": "Android Auto Desktop Head Unit Emulator",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-auto",
       "path": "extras/google/auto",
@@ -2036,7 +2036,7 @@
         }
       ],
       "displayName": "Google Cloud Messaging for Android Library",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-gcm",
       "path": "extras/google/gcm",
@@ -2072,7 +2072,7 @@
         }
       },
       "displayName": "Google Play services",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services",
       "path": "extras/google/google_play_services",
@@ -2101,7 +2101,7 @@
         }
       ],
       "displayName": "Google Play services for Froyo",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-google_play_services_froyo",
       "path": "extras/google/google_play_services_froyo",
@@ -2130,7 +2130,7 @@
         }
       ],
       "displayName": "Google Play Instant Development SDK",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-instantapps",
       "path": "extras/google/instantapps",
@@ -2168,7 +2168,7 @@
         }
       },
       "displayName": "Google Repository",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-m2repository",
       "path": "extras/google/m2repository",
@@ -2197,7 +2197,7 @@
         }
       ],
       "displayName": "Google Play APK Expansion library",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-market_apk_expansion",
       "path": "extras/google/market_apk_expansion",
@@ -2226,7 +2226,7 @@
         }
       ],
       "displayName": "Google Play Licensing Library",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-market_licensing",
       "path": "extras/google/market_licensing",
@@ -2256,7 +2256,7 @@
         }
       ],
       "displayName": "Android Auto API Simulators",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-simulators",
       "path": "extras/google/simulators",
@@ -2285,7 +2285,7 @@
         }
       ],
       "displayName": "Google USB Driver",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-usb_driver",
       "path": "extras/google/usb_driver",
@@ -2314,7 +2314,7 @@
         }
       ],
       "displayName": "Google Web Driver",
-      "last-available-day": 20131,
+      "last-available-day": 20139,
       "license": "android-sdk-license",
       "name": "extras-google-webdriver",
       "path": "extras/google/webdriver",
@@ -2984,7 +2984,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-10-default-armeabi-v7a",
           "path": "system-images/android-10/default/armeabi-v7a",
@@ -3030,7 +3030,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-10-default-x86",
           "path": "system-images/android-10/default/x86",
@@ -3078,7 +3078,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-armeabi-v7a",
           "path": "system-images/android-10/google_apis/armeabi-v7a",
@@ -3130,7 +3130,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-10-google_apis-x86",
           "path": "system-images/android-10/google_apis/x86",
@@ -3179,7 +3179,7 @@
             }
           ],
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-14-default-armeabi-v7a",
           "path": "system-images/android-14/default/armeabi-v7a",
@@ -3229,7 +3229,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-15-default-armeabi-v7a",
           "path": "system-images/android-15/default/armeabi-v7a",
@@ -3275,7 +3275,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-15-default-x86",
           "path": "system-images/android-15/default/x86",
@@ -3323,7 +3323,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-armeabi-v7a",
           "path": "system-images/android-15/google_apis/armeabi-v7a",
@@ -3375,7 +3375,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-15-google_apis-x86",
           "path": "system-images/android-15/google_apis/x86",
@@ -3431,7 +3431,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-16-default-armeabi-v7a",
           "path": "system-images/android-16/default/armeabi-v7a",
@@ -3470,7 +3470,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "mips-android-sysimage-license",
           "name": "system-image-16-default-mips",
           "path": "system-images/android-16/default/mips",
@@ -3516,7 +3516,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-16-default-x86",
           "path": "system-images/android-16/default/x86",
@@ -3564,7 +3564,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-armeabi-v7a",
           "path": "system-images/android-16/google_apis/armeabi-v7a",
@@ -3616,7 +3616,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-16-google_apis-x86",
           "path": "system-images/android-16/google_apis/x86",
@@ -3672,7 +3672,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-17-default-armeabi-v7a",
           "path": "system-images/android-17/default/armeabi-v7a",
@@ -3711,7 +3711,7 @@
             }
           ],
           "displayName": "MIPS System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "mips-android-sysimage-license",
           "name": "system-image-17-default-mips",
           "path": "system-images/android-17/default/mips",
@@ -3757,7 +3757,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-17-default-x86",
           "path": "system-images/android-17/default/x86",
@@ -3811,7 +3811,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-armeabi-v7a",
           "path": "system-images/android-17/google_apis/armeabi-v7a",
@@ -3863,7 +3863,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-17-google_apis-x86",
           "path": "system-images/android-17/google_apis/x86",
@@ -3919,7 +3919,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-18-default-armeabi-v7a",
           "path": "system-images/android-18/default/armeabi-v7a",
@@ -3965,7 +3965,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-18-default-x86",
           "path": "system-images/android-18/default/x86",
@@ -4013,7 +4013,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-armeabi-v7a",
           "path": "system-images/android-18/google_apis/armeabi-v7a",
@@ -4065,7 +4065,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-18-google_apis-x86",
           "path": "system-images/android-18/google_apis/x86",
@@ -4121,7 +4121,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-19-default-armeabi-v7a",
           "path": "system-images/android-19/default/armeabi-v7a",
@@ -4167,7 +4167,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-19-default-x86",
           "path": "system-images/android-19/default/x86",
@@ -4215,7 +4215,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-armeabi-v7a",
           "path": "system-images/android-19/google_apis/armeabi-v7a",
@@ -4267,7 +4267,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-19-google_apis-x86",
           "path": "system-images/android-19/google_apis/x86",
@@ -4316,7 +4316,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-armeabi-v7a",
           "path": "system-images/android-21/android-tv/armeabi-v7a",
@@ -4353,7 +4353,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-android-tv-x86",
           "path": "system-images/android-21/android-tv/x86",
@@ -4392,7 +4392,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-default-arm64-v8a",
           "path": "system-images/android-21/default/arm64-v8a",
@@ -4438,7 +4438,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-default-armeabi-v7a",
           "path": "system-images/android-21/default/armeabi-v7a",
@@ -4484,7 +4484,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86",
           "path": "system-images/android-21/default/x86",
@@ -4530,7 +4530,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-default-x86_64",
           "path": "system-images/android-21/default/x86_64",
@@ -4571,7 +4571,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-arm64-v8a",
           "path": "system-images/android-21/google_apis/arm64-v8a",
@@ -4623,7 +4623,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-armeabi-v7a",
           "path": "system-images/android-21/google_apis/armeabi-v7a",
@@ -4675,7 +4675,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86",
           "path": "system-images/android-21/google_apis/x86",
@@ -4727,7 +4727,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-21-google_apis-x86_64",
           "path": "system-images/android-21/google_apis/x86_64",
@@ -4776,7 +4776,7 @@
             }
           ],
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-android-tv-x86",
           "path": "system-images/android-22/android-tv/x86",
@@ -4815,7 +4815,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-default-arm64-v8a",
           "path": "system-images/android-22/default/arm64-v8a",
@@ -4861,7 +4861,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-default-armeabi-v7a",
           "path": "system-images/android-22/default/armeabi-v7a",
@@ -4907,7 +4907,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86",
           "path": "system-images/android-22/default/x86",
@@ -4953,7 +4953,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-default-x86_64",
           "path": "system-images/android-22/default/x86_64",
@@ -4994,7 +4994,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-arm64-v8a",
           "path": "system-images/android-22/google_apis/arm64-v8a",
@@ -5046,7 +5046,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-armeabi-v7a",
           "path": "system-images/android-22/google_apis/armeabi-v7a",
@@ -5098,7 +5098,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86",
           "path": "system-images/android-22/google_apis/x86",
@@ -5150,7 +5150,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-22-google_apis-x86_64",
           "path": "system-images/android-22/google_apis/x86_64",
@@ -5199,7 +5199,7 @@
             }
           ],
           "displayName": "Android TV ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-armeabi-v7a",
           "path": "system-images/android-23/android-tv/armeabi-v7a",
@@ -5243,7 +5243,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-android-tv-x86",
           "path": "system-images/android-23/android-tv/x86",
@@ -5282,7 +5282,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-default-arm64-v8a",
           "path": "system-images/android-23/default/arm64-v8a",
@@ -5328,7 +5328,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-default-armeabi-v7a",
           "path": "system-images/android-23/default/armeabi-v7a",
@@ -5374,7 +5374,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86",
           "path": "system-images/android-23/default/x86",
@@ -5420,7 +5420,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-default-x86_64",
           "path": "system-images/android-23/default/x86_64",
@@ -5461,7 +5461,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-arm64-v8a",
           "path": "system-images/android-23/google_apis/arm64-v8a",
@@ -5513,7 +5513,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-armeabi-v7a",
           "path": "system-images/android-23/google_apis/armeabi-v7a",
@@ -5565,7 +5565,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86",
           "path": "system-images/android-23/google_apis/x86",
@@ -5617,7 +5617,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-23-google_apis-x86_64",
           "path": "system-images/android-23/google_apis/x86_64",
@@ -5673,7 +5673,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-android-tv-x86",
           "path": "system-images/android-24/android-tv/x86",
@@ -5712,7 +5712,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-default-arm64-v8a",
           "path": "system-images/android-24/default/arm64-v8a",
@@ -5758,7 +5758,7 @@
             }
           },
           "displayName": "ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-default-armeabi-v7a",
           "path": "system-images/android-24/default/armeabi-v7a",
@@ -5804,7 +5804,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86",
           "path": "system-images/android-24/default/x86",
@@ -5850,7 +5850,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-default-x86_64",
           "path": "system-images/android-24/default/x86_64",
@@ -5898,7 +5898,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-arm64-v8a",
           "path": "system-images/android-24/google_apis/arm64-v8a",
@@ -5950,7 +5950,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86",
           "path": "system-images/android-24/google_apis/x86",
@@ -6002,7 +6002,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis-x86_64",
           "path": "system-images/android-24/google_apis/x86_64",
@@ -6056,7 +6056,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-24-google_apis_playstore-x86",
           "path": "system-images/android-24/google_apis_playstore/x86",
@@ -6112,7 +6112,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-android-tv-x86",
           "path": "system-images/android-25/android-tv/x86",
@@ -6158,7 +6158,7 @@
             }
           },
           "displayName": "Android Wear ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-armeabi-v7a",
           "path": "system-images/android-25/android-wear/armeabi-v7a",
@@ -6202,7 +6202,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-android-wear-x86",
           "path": "system-images/android-25/android-wear/x86",
@@ -6241,7 +6241,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-default-arm64-v8a",
           "path": "system-images/android-25/default/arm64-v8a",
@@ -6287,7 +6287,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86",
           "path": "system-images/android-25/default/x86",
@@ -6333,7 +6333,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-default-x86_64",
           "path": "system-images/android-25/default/x86_64",
@@ -6374,7 +6374,7 @@
             }
           ],
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-arm64-v8a",
           "path": "system-images/android-25/google_apis/arm64-v8a",
@@ -6426,7 +6426,7 @@
             }
           },
           "displayName": "Google APIs ARM EABI v7a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-armeabi-v7a",
           "path": "system-images/android-25/google_apis/armeabi-v7a",
@@ -6478,7 +6478,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86",
           "path": "system-images/android-25/google_apis/x86",
@@ -6530,7 +6530,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis-x86_64",
           "path": "system-images/android-25/google_apis/x86_64",
@@ -6584,7 +6584,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-25-google_apis_playstore-x86",
           "path": "system-images/android-25/google_apis_playstore/x86",
@@ -6655,7 +6655,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-android-tv-x86",
           "path": "system-images/android-26/android-tv/x86",
@@ -6701,7 +6701,7 @@
             }
           },
           "displayName": "Android Wear Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-26-android-wear-x86",
           "path": "system-images/android-26/android-wear/x86",
@@ -6752,7 +6752,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-26-default-arm64-v8a",
           "path": "system-images/android-26/default/arm64-v8a",
@@ -6796,7 +6796,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86",
           "path": "system-images/android-26/default/x86",
@@ -6840,7 +6840,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-26-default-x86_64",
           "path": "system-images/android-26/default/x86_64",
@@ -6891,7 +6891,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-arm64-v8a",
           "path": "system-images/android-26/google_apis/arm64-v8a",
@@ -6958,7 +6958,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86",
           "path": "system-images/android-26/google_apis/x86",
@@ -7025,7 +7025,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-26-google_apis-x86_64",
           "path": "system-images/android-26/google_apis/x86_64",
@@ -7094,7 +7094,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-26-google_apis_playstore-x86",
           "path": "system-images/android-26/google_apis_playstore/x86",
@@ -7150,7 +7150,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-27-android-tv-x86",
           "path": "system-images/android-27/android-tv/x86",
@@ -7201,7 +7201,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-27-default-arm64-v8a",
           "path": "system-images/android-27/default/arm64-v8a",
@@ -7245,7 +7245,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86",
           "path": "system-images/android-27/default/x86",
@@ -7289,7 +7289,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-27-default-x86_64",
           "path": "system-images/android-27/default/x86_64",
@@ -7340,7 +7340,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-arm64-v8a",
           "path": "system-images/android-27/google_apis/arm64-v8a",
@@ -7407,7 +7407,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis-x86",
           "path": "system-images/android-27/google_apis/x86",
@@ -7476,7 +7476,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-27-google_apis_playstore-x86",
           "path": "system-images/android-27/google_apis_playstore/x86",
@@ -7537,7 +7537,7 @@
             }
           },
           "displayName": "Automotive Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-28-android-automotive-playstore-x86",
           "path": "system-images/android-28/android-automotive-playstore/x86",
@@ -7582,7 +7582,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-android-tv-x86",
           "path": "system-images/android-28/android-tv/x86",
@@ -7628,7 +7628,7 @@
             }
           },
           "displayName": "Wear OS Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-28-android-wear-x86",
           "path": "system-images/android-28/android-wear/x86",
@@ -7679,7 +7679,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-28-default-arm64-v8a",
           "path": "system-images/android-28/default/arm64-v8a",
@@ -7716,7 +7716,7 @@
             }
           ],
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86",
           "path": "system-images/android-28/default/x86",
@@ -7753,7 +7753,7 @@
             }
           ],
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-28-default-x86_64",
           "path": "system-images/android-28/default/x86_64",
@@ -7804,7 +7804,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-arm64-v8a",
           "path": "system-images/android-28/google_apis/arm64-v8a",
@@ -7871,7 +7871,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis-x86",
           "path": "system-images/android-28/google_apis/x86",
@@ -7938,7 +7938,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis-x86_64",
           "path": "system-images/android-28/google_apis/x86_64",
@@ -7997,7 +7997,7 @@
             }
           },
           "displayName": "Google ARM64-V8a Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-28-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-28/google_apis_playstore/arm64-v8a",
@@ -8064,7 +8064,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86",
           "path": "system-images/android-28/google_apis_playstore/x86",
@@ -8131,7 +8131,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-28-google_apis_playstore-x86_64",
           "path": "system-images/android-28/google_apis_playstore/x86_64",
@@ -8192,7 +8192,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-android-automotive-playstore-x86",
           "path": "system-images/android-29/android-automotive-playstore/x86",
@@ -8252,7 +8252,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-29-android-tv-x86",
           "path": "system-images/android-29/android-tv/x86",
@@ -8291,7 +8291,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-default-arm64-v8a",
           "path": "system-images/android-29/default/arm64-v8a",
@@ -8354,7 +8354,7 @@
             }
           },
           "displayName": "Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86",
           "path": "system-images/android-29/default/x86",
@@ -8417,7 +8417,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-default-x86_64",
           "path": "system-images/android-29/default/x86_64",
@@ -8468,7 +8468,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis-arm64-v8a",
           "path": "system-images/android-29/google_apis/arm64-v8a",
@@ -8525,7 +8525,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86",
           "path": "system-images/android-29/google_apis/x86",
@@ -8582,7 +8582,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis-x86_64",
           "path": "system-images/android-29/google_apis/x86_64",
@@ -8648,7 +8648,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-29-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-29/google_apis_playstore/arm64-v8a",
@@ -8729,7 +8729,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86",
           "path": "system-images/android-29/google_apis_playstore/x86",
@@ -8810,7 +8810,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-29-google_apis_playstore-x86_64",
           "path": "system-images/android-29/google_apis_playstore/x86_64",
@@ -8871,7 +8871,7 @@
             }
           },
           "displayName": "Automotive with Play Store Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-android-automotive-playstore-x86_64",
           "path": "system-images/android-30/android-automotive-playstore/x86_64",
@@ -8931,7 +8931,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-30-android-tv-x86",
           "path": "system-images/android-30/android-tv/x86",
@@ -8977,7 +8977,7 @@
             }
           },
           "displayName": "Wear OS 3 ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-arm64-v8a",
           "path": "system-images/android-30/android-wear/arm64-v8a",
@@ -9021,7 +9021,7 @@
             }
           },
           "displayName": "Wear OS 3 Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-android-wear-x86",
           "path": "system-images/android-30/android-wear/x86",
@@ -9060,7 +9060,7 @@
             }
           ],
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-default-arm64-v8a",
           "path": "system-images/android-30/default/arm64-v8a",
@@ -9109,7 +9109,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-default-x86_64",
           "path": "system-images/android-30/default/x86_64",
@@ -9160,7 +9160,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis-arm64-v8a",
           "path": "system-images/android-30/google_apis/arm64-v8a",
@@ -9227,7 +9227,7 @@
             }
           },
           "displayName": "Google APIs Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86",
           "path": "system-images/android-30/google_apis/x86",
@@ -9294,7 +9294,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis-x86_64",
           "path": "system-images/android-30/google_apis/x86_64",
@@ -9360,7 +9360,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-30/google_apis_playstore/arm64-v8a",
@@ -9441,7 +9441,7 @@
             }
           },
           "displayName": "Google Play Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-30-google_apis_playstore-x86",
           "path": "system-images/android-30/google_apis_playstore/x86",
@@ -9522,7 +9522,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-30-google_apis_playstore-x86_64",
           "path": "system-images/android-30/google_apis_playstore/x86_64",
@@ -9593,7 +9593,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-arm64-v8a",
           "path": "system-images/android-31/android-tv/arm64-v8a",
@@ -9652,7 +9652,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-31-android-tv-x86",
           "path": "system-images/android-31/android-tv/x86",
@@ -9703,7 +9703,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-31-default-arm64-v8a",
           "path": "system-images/android-31/default/arm64-v8a",
@@ -9752,7 +9752,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-31-default-x86_64",
           "path": "system-images/android-31/default/x86_64",
@@ -9813,7 +9813,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis-arm64-v8a",
           "path": "system-images/android-31/google_apis/arm64-v8a",
@@ -9880,7 +9880,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-31-google_apis-x86_64",
           "path": "system-images/android-31/google_apis/x86_64",
@@ -9956,7 +9956,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-31/google_apis_playstore/arm64-v8a",
@@ -10023,7 +10023,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-31-google_apis_playstore-x86_64",
           "path": "system-images/android-31/google_apis_playstore/x86_64",
@@ -10084,7 +10084,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play arm64-v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-arm64-v8a",
           "path": "system-images/android-32/android-automotive-playstore/arm64-v8a",
@@ -10137,7 +10137,7 @@
             }
           },
           "displayName": "Android Automotive with Google Play x86_64 System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-android-automotive-playstore-x86_64",
           "path": "system-images/android-32/android-automotive-playstore/x86_64",
@@ -10192,7 +10192,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-32-default-arm64-v8a",
           "path": "system-images/android-32/default/arm64-v8a",
@@ -10241,7 +10241,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-32-default-x86_64",
           "path": "system-images/android-32/default/x86_64",
@@ -10302,7 +10302,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis-arm64-v8a",
           "path": "system-images/android-32/google_apis/arm64-v8a",
@@ -10369,7 +10369,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis-x86_64",
           "path": "system-images/android-32/google_apis/x86_64",
@@ -10445,7 +10445,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-32-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-32/google_apis_playstore/arm64-v8a",
@@ -10526,7 +10526,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-32-google_apis_playstore-x86_64",
           "path": "system-images/android-32/google_apis_playstore/x86_64",
@@ -10587,7 +10587,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-arm64-v8a",
           "path": "system-images/android-33/android-automotive/arm64-v8a",
@@ -10640,7 +10640,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-android-automotive-x86_64",
           "path": "system-images/android-33/android-automotive/x86_64",
@@ -10705,7 +10705,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-arm64-v8a",
           "path": "system-images/android-33/android-tv/arm64-v8a",
@@ -10764,7 +10764,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-android-tv-x86",
           "path": "system-images/android-33/android-tv/x86",
@@ -10810,7 +10810,7 @@
             }
           },
           "displayName": "Wear OS 4 ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-arm64-v8a",
           "path": "system-images/android-33/android-wear/arm64-v8a",
@@ -10854,7 +10854,7 @@
             }
           },
           "displayName": "Wear OS 4 Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-android-wear-x86_64",
           "path": "system-images/android-33/android-wear/x86_64",
@@ -10905,7 +10905,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-default-arm64-v8a",
           "path": "system-images/android-33/default/arm64-v8a",
@@ -10954,7 +10954,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-default-x86_64",
           "path": "system-images/android-33/default/x86_64",
@@ -11015,7 +11015,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis-arm64-v8a",
           "path": "system-images/android-33/google_apis/arm64-v8a",
@@ -11082,7 +11082,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis-x86_64",
           "path": "system-images/android-33/google_apis/x86_64",
@@ -11151,7 +11151,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33/google_apis_playstore/arm64-v8a",
@@ -11218,7 +11218,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-33-google_apis_playstore-x86_64",
           "path": "system-images/android-33/google_apis_playstore/x86_64",
@@ -11293,7 +11293,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-33x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-33-ext4/google_apis_playstore/arm64-v8a",
@@ -11342,7 +11342,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-33x-google_apis_playstore-x86_64",
           "path": "system-images/android-33-ext4/google_apis_playstore/x86_64",
@@ -11405,7 +11405,7 @@
             }
           },
           "displayName": "Android TV ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-arm64-v8a",
           "path": "system-images/android-34/android-tv/arm64-v8a",
@@ -11465,7 +11465,7 @@
             }
           },
           "displayName": "Android TV Intel x86 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-android-tv-x86",
           "path": "system-images/android-34/android-tv/x86",
@@ -11505,7 +11505,7 @@
             }
           ],
           "displayName": "Wear OS 5 ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-arm64-v8a",
           "path": "system-images/android-34/android-wear/arm64-v8a",
@@ -11542,7 +11542,7 @@
             }
           ],
           "displayName": "Wear OS 5 Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-android-wear-x86_64",
           "path": "system-images/android-34/android-wear/x86_64",
@@ -11593,7 +11593,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-default-arm64-v8a",
           "path": "system-images/android-34/default/arm64-v8a",
@@ -11642,7 +11642,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-default-x86_64",
           "path": "system-images/android-34/default/x86_64",
@@ -11703,7 +11703,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis-arm64-v8a",
           "path": "system-images/android-34/google_apis/arm64-v8a",
@@ -11771,7 +11771,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis-x86_64",
           "path": "system-images/android-34/google_apis/x86_64",
@@ -11841,7 +11841,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34/google_apis_playstore/arm64-v8a",
@@ -11910,7 +11910,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34-google_apis_playstore-x86_64",
           "path": "system-images/android-34/google_apis_playstore/x86_64",
@@ -11973,7 +11973,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs arm64-v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-arm64-v8a",
           "path": "system-images/android-34-ext9/android-automotive/arm64-v8a",
@@ -12026,7 +12026,7 @@
             }
           },
           "displayName": "Android Automotive with Google APIs x86_64 System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34x-android-automotive-x86_64",
           "path": "system-images/android-34-ext9/android-automotive/x86_64",
@@ -12095,7 +12095,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-34x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-34-ext12/google_apis_playstore/arm64-v8a",
@@ -12144,7 +12144,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-34x-google_apis_playstore-x86_64",
           "path": "system-images/android-34-ext12/google_apis_playstore/x86_64",
@@ -12185,7 +12185,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-arm64-v8a",
           "path": "system-images/android-35/android-wear/arm64-v8a",
@@ -12217,7 +12217,7 @@
             }
           ],
           "displayName": "Wear OS 5.1 - Preview Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-preview-license",
           "name": "system-image-35-android-wear-x86_64",
           "path": "system-images/android-35/android-wear/x86_64",
@@ -12263,7 +12263,7 @@
             }
           },
           "displayName": "ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-35-default-arm64-v8a",
           "path": "system-images/android-35/default/arm64-v8a",
@@ -12308,7 +12308,7 @@
             }
           },
           "displayName": "Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-35-default-x86_64",
           "path": "system-images/android-35/default/x86_64",
@@ -12355,7 +12355,7 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis-arm64-v8a",
           "path": "system-images/android-35/google_apis/arm64-v8a",
@@ -12413,7 +12413,7 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis-x86_64",
           "path": "system-images/android-35/google_apis/x86_64",
@@ -12473,7 +12473,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore/arm64-v8a",
@@ -12531,7 +12531,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-35-google_apis_playstore-x86_64",
           "path": "system-images/android-35/google_apis_playstore/x86_64",
@@ -12591,7 +12591,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35-page_size_16kb-arm64-v8a",
           "path": "system-images/android-35/google_apis_playstore_ps16k/arm64-v8a",
@@ -12653,7 +12653,7 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-35-page_size_16kb-x86_64",
           "path": "system-images/android-35/google_apis_playstore_ps16k/x86_64",
@@ -12719,7 +12719,7 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-35x-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-35-ext14/google_apis_playstore/arm64-v8a",
@@ -12768,7 +12768,7 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-35x-google_apis_playstore-x86_64",
           "path": "system-images/android-35-ext14/google_apis_playstore/x86_64",
@@ -12803,9 +12803,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "9252bbb0cced0cfb7373a3236a7295ebf0f2945c",
-              "size": 1807500394,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-Baklava_r03.zip"
+              "sha1": "012427119cb7382eaea36bde92172cccd1eb2b7c",
+              "size": 1813124028,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/arm64-v8a-Baklava_r04.zip"
             }
           ],
           "dependencies": {
@@ -12821,13 +12821,13 @@
             }
           },
           "displayName": "Google APIs ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis/arm64-v8a",
           "revision": "Baklava-google_apis-arm64-v8a",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
@@ -12853,9 +12853,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "1548664b809576557fb4823e0f03e7c550fec443",
-              "size": 1814866164,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-Baklava_r03.zip"
+              "sha1": "a5158e787b4357422a8ebe971e2a310930adcb70",
+              "size": 1822731345,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis/x86_64-Baklava_r04.zip"
             }
           ],
           "dependencies": {
@@ -12871,13 +12871,13 @@
             }
           },
           "displayName": "Google APIs Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis-x86_64",
           "path": "system-images/android-Baklava/google_apis/x86_64",
           "revision": "Baklava-google_apis-x86_64",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "x86_64",
@@ -12905,9 +12905,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "029e0b3732aba5a4cb97621b84f5edea9b71775b",
-              "size": 1825799645,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-Baklava_r03.zip"
+              "sha1": "a04a36068b98b2fee3dea444425c4e38e6431876",
+              "size": 1832396476,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/arm64-v8a-Baklava_r04.zip"
             }
           ],
           "dependencies": {
@@ -12923,13 +12923,13 @@
             }
           },
           "displayName": "Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-google_apis_playstore-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore/arm64-v8a",
           "revision": "Baklava-google_apis_playstore-arm64-v8a",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "arm64-v8a",
@@ -12955,9 +12955,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "4fd21b8fa1b92c8f9a9f7838ffab55a1c344aa0a",
-              "size": 1848004792,
-              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-Baklava_r03.zip"
+              "sha1": "1b274676d5920772015689ce480763caf6c72cd7",
+              "size": 1856730222,
+              "url": "https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-Baklava_r04.zip"
             }
           ],
           "dependencies": {
@@ -12973,13 +12973,13 @@
             }
           },
           "displayName": "Google Play Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-google_apis_playstore-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore/x86_64",
           "revision": "Baklava-google_apis_playstore-x86_64",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:6": "x86_64",
@@ -13007,9 +13007,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "9ed66f7ad190fedf5b20989a3914501234fbeff2",
-              "size": 1623140308,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-Baklava_r03.zip"
+              "sha1": "fc3cf2d62ae0705ee0411d59e15fcb9d5e062f61",
+              "size": 1890722992,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/arm64-v8a-playstore-ps16k-Baklava_r04.zip"
             }
           ],
           "dependencies": {
@@ -13025,13 +13025,13 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM 64 v8a System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-arm-dbt-license",
           "name": "system-image-Baklava-page_size_16kb-arm64-v8a",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/arm64-v8a",
           "revision": "Baklava-page_size_16kb-arm64-v8a",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:7": "arm64-v8a",
@@ -13061,9 +13061,9 @@
             {
               "arch": "all",
               "os": "all",
-              "sha1": "8242bdada27c1db6209d8b2fa68bd86d7b3ee3b9",
-              "size": 1588410201,
-              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-Baklava_r03.zip"
+              "sha1": "10a84e0c1cbc56d6cd1cf6de17890603a88de395",
+              "size": 1862515759,
+              "url": "https://dl.google.com/android/repository/sys-img/page_size_16kb/x86_64-playstore-ps16k-Baklava_r04.zip"
             }
           ],
           "dependencies": {
@@ -13079,13 +13079,13 @@
             }
           },
           "displayName": "Pre-Release 16 KB Page Size Google Play ARM Intel x86_64 Atom System Image",
-          "last-available-day": 20131,
+          "last-available-day": 20139,
           "license": "android-sdk-license",
           "name": "system-image-Baklava-page_size_16kb-x86_64",
           "path": "system-images/android-Baklava/google_apis_playstore_ps16k/x86_64",
           "revision": "Baklava-page_size_16kb-x86_64",
           "revision-details": {
-            "major:0": "3"
+            "major:0": "4"
           },
           "type-details": {
             "abi:7": "x86_64",
@@ -13899,6 +13899,19 @@
       }
     }
   },
+  "latest": {
+    "build-tools": "35.0.1",
+    "cmake": "3.31.5",
+    "cmdline-tools": "17.0",
+    "emulator": "35.4.8",
+    "ndk": "28.0.13004108",
+    "ndk-bundle": "22.1.7171670",
+    "platform-tools": "35.0.2",
+    "platforms": "35",
+    "skiaparser": "6",
+    "sources": "35",
+    "tools": "26.1.1"
+  },
   "licenses": {
     "android-googletv-license": [
       "Terms and Conditions\n\nThis is the Google TV Add-on for the Android Software Development Kit License Agreement.\n\n1. Introduction\n\n1.1 The Google TV Add-on for the Android Software Development Kit (referred to in this License Agreement as the \"Google TV Add-on\" and specifically including the Android system files, packaged APIs, and Google APIs add-ons) is licensed to you subject to the terms of this License Agreement. This License Agreement forms a legally binding contract between you and Google in relation to your use of the Google TV Add-on.\n\n1.2 \"Google\" means Google Inc., a Delaware corporation with principal place of business at 1600 Amphitheatre Parkway, Mountain View, CA 94043, United States.\n\n2. Accepting this License Agreement\n\n2.1 In order to use the Google TV Add-on, you must first agree to this License Agreement. You may not use the Google TV Add-on if you do not accept this License Agreement.\n\n2.2 You can accept this License Agreement by:\n\n(A) clicking to accept or agree to this License Agreement, where this option is made available to you; or\n\n(B) by actually using the Google TV Add-on. In this case, you agree that use of the Google TV Add-on constitutes acceptance of the License Agreement from that point onwards.\n\n2.3 You may not use the Google TV Add-on and may not accept the Licensing Agreement if you are a person barred from receiving the Google TV Add-on under the laws of the United States or other countries including the country in which you are resident or from which you use the Google TV Add-on.\n\n2.4 If you are agreeing to be bound by this License Agreement on behalf of your employer or other entity, you represent and warrant that you have full legal authority to bind your employer or such entity to this License Agreement. If you do not have the requisite authority, you may not accept the Licensing Agreement or use the Google TV Add-on on behalf of your employer or other entity.\n\n3. Google TV Add-on License from Google\n\n3.1 Subject to the terms of this License Agreement, Google grants you a limited, worldwide, royalty-free, non- assignable and non-exclusive license to use the Google TV Add-on solely to develop applications to run on the Google TV platform.\n\n3.2 You agree that Google or third parties own all legal right, title and interest in and to the Google TV Add-on, including any Intellectual Property Rights that subsist in the Google TV Add-on. \"Intellectual Property Rights\" means any and all rights under patent law, copyright law, trade secret law, trademark law, and any and all other proprietary rights. Google reserves all rights not expressly granted to you.\n\n3.3 Except to the extent required by applicable third party licenses, you may not copy (except for backup purposes), modify, adapt, redistribute, decompile, reverse engineer, disassemble, or create derivative works of the Google TV Add-on or any part of the Google TV Add-on. Except to the extent required by applicable third party licenses, you may not load any part of the Google TV Add-on onto a mobile handset, television, or any other hardware device except a personal computer, combine any part of the Google TV Add-on with other software, or distribute any software or device incorporating a part of the Google TV Add-on.\n\n3.4 Use, reproduction and distribution of components of the Google TV Add-on licensed under an open source software license are governed solely by the terms of that open source software license and not this License Agreement.\n\n3.5 You agree that the form and nature of the Google TV Add-on that Google provides may change without prior notice to you and that future versions of the Google TV Add-on may be incompatible with applications developed on previous versions of the Google TV Add-on. You agree that Google may stop (permanently or temporarily) providing the Google TV Add-on (or any features within the Google TV Add-on) to you or to users generally at Google's sole discretion, without prior notice to you.\n\n3.6 Nothing in this License Agreement gives you a right to use any of Google's or it’s licensors’ trade names, trademarks, service marks, logos, domain names, or other distinctive brand features.\n\n3.7 You agree that you will not remove, obscure, or alter any proprietary rights notices (including copyright and trademark notices) that may be affixed to or contained within the Google TV Add-on.\n\n4. Use of the Google TV Add-on by You\n\n4.1 Google agrees that it obtains no right, title or interest from you (or your licensors) under this License Agreement in or to any software applications that you develop using the Google TV Add-on, including any intellectual property rights that subsist in those applications.\n\n4.2 You agree to use the Google TV Add-on and write applications only for purposes that are permitted by (a) this License Agreement and (b) any applicable law, regulation or generally accepted practices or guidelines in the relevant jurisdictions (including any laws regarding the export of data or software to and from the United States or other relevant countries).\n\n4.3 You agree that if you use the Google TV Add-on to develop applications for general public users, you will protect the privacy and legal rights of those users. If the users provide you with user names, passwords, or other login information or personal information, your must make the users aware that the information will be available to your application, and you must provide legally adequate privacy notice and protection for those users. If your application stores personal or sensitive information provided by users, it must do so securely. If the user provides your application with Google Account information, your application may only use that information to access the user's Google Account when, and for the limited purposes for which, the user has given you explicit permission to do so.\n\n4.4 You agree that you will not engage in any activity with the Google TV Add-on, including the development or distribution of an application, that interferes with, disrupts, damages, or accesses in an unauthorized manner the servers, networks, or other properties or services of any third party including, but not limited to, Google, Multichannel Video Program Distributors or any mobile communications carrier.\n\n4.5 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any data, content, or resources that you create, transmit or display through the Google TV platform and/or applications for the Google TV platform, and for the consequences of your actions (including any loss or damage which Google may suffer) by doing so.\n\n4.6 You agree that you are solely responsible for (and that Google has no responsibility to you or to any third party for) any breach of your obligations under this License Agreement, any applicable third party contract or Terms of Service, or any applicable law or regulation, and for the consequences (including any loss or damage which Google or any third party may suffer) of any such breach.\n\n5. Your Developer Credentials\n\n5.1 You agree that you are responsible for maintaining the confidentiality of any developer credentials that may be issued to you by Google or which you may choose yourself and that you will be solely responsible for all applications that are developed under your developer credentials.\n\n6. Privacy and Information\n\n6.1 In order to continually innovate and improve the Google TV Add-on, Google may collect certain usage statistics from the software including but not limited to a unique identifier, associated IP address, version number of the software, and information on which tools and/or services in the Google TV Add-on are being used and how they are being used. Before any of this information is collected, the Google TV Add-on will notify you and seek your consent. If you withhold consent, the information will not be collected.\n\n6.2 The data collected is examined in the aggregate to improve the Google TV Add-on and is maintained in accordance with Google's Privacy Policy.\n\n7. Third Party Applications for the Google TV Platform\n\n7.1 If you use the Google TV Add-on to run applications developed by a third party or that access data, content or resources provided by a third party, you agree that Google is not responsible for those applications, data, content, or resources. You understand that all data, content or resources which you may access through such third party applications are the sole responsibility of the person from which they originated and that Google is not liable for any loss or damage that you may experience as a result of the use or access of any of those third party applications, data, content, or resources.\n\n7.2 You should be aware the data, content, and resources presented to you through such a third party application may be protected by intellectual property rights which are owned by the providers (or by other persons or companies on their behalf). You may not modify, rent, lease, loan, sell, distribute or create derivative works based on these data, content, or resources (either in whole or in part) unless you have been specifically given permission to do so by the relevant owners.\n\n7.3 You acknowledge that your use of such third party applications, data, content, or resources may be subject to separate terms between you and the relevant third party. In that case, this License Agreement does not affect your legal relationship with these third parties.\n\n8. Using Google TV APIs\n\n8.1 If you use any Google TV API to retrieve data from Google, you acknowledge that the data (“Google TV API Content”) may be protected by intellectual property rights which are owned by Google or those parties that provide the data (or by other persons or companies on their behalf). Your use of any such API may be subject to additional Terms of Service. You may not modify, rent, lease, loan, sell, distribute or create derivative works based on this data (either in whole or in part) unless allowed by the relevant Terms of Service. Some portions of the Google TV API Content are licensed to Google by third parties, including but not limited to Tribune Media Services\n\n8.2 If you use any API to retrieve a user's data from Google, you acknowledge and agree that you shall retrieve data only with the user's explicit consent and only when, and for the limited purposes for which, the user has given you permission to do so.\n\n8.3 Except as explicitly permitted in Section 3 (Google TV Add-on License from Google), you must:\n\n(a) not modify nor format the Google TV API Content except to the extent reasonably and technically necessary to optimize the display such Google TV API Content in your application;\n\n(b) not edit the Google TV API Content in a manner that renders the Google TV API Content inaccurate of alters its inherent meaning (provided that displaying excerpts will not violate the foregoing); or\n\n(c) not create any commercial audience measurement tool or service using the Google TV API Content\n\n9. Terminating this License Agreement\n\n9.1 This License Agreement will continue to apply until terminated by either you or Google as set out below.\n\n9.2 If you want to terminate this License Agreement, you may do so by ceasing your use of the Google TV Add-on and any relevant developer credentials.\n\n9.3 Google may at any time, terminate this License Agreement with you if:\n\n(A) you have breached any provision of this License Agreement; or\n\n(B) Google is required to do so by law; or\n\n(C) the partner with whom Google offered certain parts of Google TV Add-on (such as APIs) to you has terminated its relationship with Google or ceased to offer certain parts of the Google TV Add-on to you; or\n\n(D) Google decides to no longer providing the Google TV Add-on or certain parts of the Google TV Add-on to users in the country in which you are resident or from which you use the service, or the provision of the Google TV Add-on or certain Google TV Add-on services to you by Google is, in Google's sole discretion, no longer commercially viable.\n\n9.4 When this License Agreement comes to an end, all of the legal rights, obligations and liabilities that you and Google have benefited from, been subject to (or which have accrued over time whilst this License Agreement has been in force) or which are expressed to continue indefinitely, shall be unaffected by this cessation, and the provisions of paragraph 14.7 shall continue to apply to such rights, obligations and liabilities indefinitely.\n\n10. DISCLAIMER OF WARRANTIES\n\n10.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT YOUR USE OF THE GOOGLE TV ADD-ON IS AT YOUR SOLE RISK AND THAT THE GOOGLE TV ADD-ON IS PROVIDED \"AS IS\" AND \"AS AVAILABLE\" WITHOUT WARRANTY OF ANY KIND FROM GOOGLE.\n\n10.2 YOUR USE OF THE GOOGLE TV ADD-ON AND ANY MATERIAL DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE GOOGLE TV ADD-ON IS AT YOUR OWN DISCRETION AND RISK AND YOU ARE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR OTHER DEVICE OR LOSS OF DATA THAT RESULTS FROM SUCH USE.\n\n10.3 GOOGLE FURTHER EXPRESSLY DISCLAIMS ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.\n\n11. LIMITATION OF LIABILITY\n\n11.1 YOU EXPRESSLY UNDERSTAND AND AGREE THAT GOOGLE, ITS SUBSIDIARIES AND AFFILIATES, AND ITS LICENSORS SHALL NOT BE LIABLE TO YOU UNDER ANY THEORY OF LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL CONSEQUENTIAL OR EXEMPLARY DAMAGES THAT MAY BE INCURRED BY YOU, INCLUDING ANY LOSS OF DATA, WHETHER OR NOT GOOGLE OR ITS REPRESENTATIVES HAVE BEEN ADVISED OF OR SHOULD HAVE BEEN AWARE OF THE POSSIBILITY OF ANY SUCH LOSSES ARISING.\n\n12. Indemnification\n\n12.1 To the maximum extent permitted by law, you agree to defend, indemnify and hold harmless Google, its affiliates and their respective directors, officers, employees and agents from and against any and all claims, actions, suits or proceedings, as well as any and all losses, liabilities, damages, costs and expenses (including reasonable attorneys fees) arising out of or accruing from (a) your use of the Google TV Add-on, (b) any application you develop on the Google TV Add-on that infringes any copyright, trademark, trade secret, trade dress, patent or other intellectual property right of any person or defames any person or violates their rights of publicity or privacy, and (c) any non-compliance by you with this License Agreement.\n\n13. Changes to the License Agreement\n\n13.1 Google may make changes to the License Agreement as it distributes new versions of the Google TV Add-on.\n\n14. General Legal Terms\n\n14.1 This License Agreement constitute the whole legal agreement between you and Google and govern your use of the Google TV Add-on (excluding any services which Google may provide to you under a separate written agreement), and completely replace any prior agreements between you and Google in relation to the Google TV Add-on.\n\n14.2 You agree that if Google does not exercise or enforce any legal right or remedy which is contained in this License Agreement (or which Google has the benefit of under any applicable law), this will not be taken to be a formal waiver of Google's rights and that those rights or remedies will still be available to Google.\n\n14.3 If any court of law, having the jurisdiction to decide on this matter, rules that any provision of this License Agreement is invalid, then that provision will be removed from this License Agreement without affecting the rest of this License Agreement. The remaining provisions of this License Agreement will continue to be valid and enforceable.\n\n14.4 You acknowledge and agree that Google’s API data licensors and each member of the group of companies of which Google is the parent shall be third party beneficiaries to this License Agreement and that such other companies shall be entitled to directly enforce, and rely upon, any provision of this License Agreement that confers a benefit on (or rights in favor of) them. Other than this, no other person or company shall be third party beneficiaries to this License Agreement.\n\n14.5 EXPORT RESTRICTIONS. THE GOOGLE TV ADD-ON IS SUBJECT TO UNITED STATES EXPORT LAWS AND REGULATIONS. YOU MUST COMPLY WITH ALL DOMESTIC AND INTERNATIONAL EXPORT LAWS AND REGULATIONS THAT APPLY TO THE GOOGLE TV ADD-ON. THESE LAWS INCLUDE RESTRICTIONS ON DESTINATIONS, END USERS AND END USE.\n\n14.6 The rights granted in this License Agreement may not be assigned or transferred by either you or Google without the prior written approval of the other party. Neither you nor Google shall be permitted to delegate their responsibilities or obligations under this License Agreement without the prior written approval of the other party.\n\n14.7 This License Agreement, and your relationship with Google under this License Agreement, shall be governed by the laws of the State of California without regard to its conflict of laws provisions. You and Google agree to submit to the exclusive jurisdiction of the courts located within the county of Santa Clara, California to resolve any legal matter arising from this License Agreement. Notwithstanding this, you agree that Google shall still be allowed to apply for injunctive remedies (or an equivalent type of urgent legal relief) in any jurisdiction.\n\n\nAugust 15, 2011"
@@ -13962,7 +13975,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 17",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14011,7 +14024,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14060,7 +14073,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14109,7 +14122,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 18.1.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14158,7 +14171,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14207,7 +14220,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14256,7 +14269,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14305,7 +14318,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14354,7 +14367,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 19.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/19.1.0",
@@ -14402,7 +14415,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 20",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/20.0.0",
@@ -14450,7 +14463,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14499,7 +14512,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14548,7 +14561,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14597,7 +14610,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14646,7 +14659,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14695,7 +14708,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 21.1.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/21.1.2",
@@ -14743,7 +14756,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14792,7 +14805,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 22.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/22.0.1",
@@ -14840,7 +14853,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -14889,7 +14902,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.1",
@@ -14937,7 +14950,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.2",
@@ -14985,7 +14998,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 23.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/23.0.3",
@@ -15033,7 +15046,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.0",
@@ -15081,7 +15094,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.1",
@@ -15129,7 +15142,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.2",
@@ -15177,7 +15190,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 24.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/24.0.3",
@@ -15225,7 +15238,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.0",
@@ -15273,7 +15286,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.1",
@@ -15321,7 +15334,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.2",
@@ -15369,7 +15382,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 25.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/25.0.3",
@@ -15417,7 +15430,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.0",
@@ -15465,7 +15478,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.1",
@@ -15513,7 +15526,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.2",
@@ -15561,7 +15574,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 26.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/26.0.3",
@@ -15609,7 +15622,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.0",
@@ -15657,7 +15670,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.1",
@@ -15705,7 +15718,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.2",
@@ -15753,7 +15766,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 27.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/27.0.3",
@@ -15801,7 +15814,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.0",
@@ -15849,7 +15862,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15899,7 +15912,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28-rc2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -15949,7 +15962,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.1",
@@ -15997,7 +16010,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.2",
@@ -16045,7 +16058,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 28.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/28.0.3",
@@ -16093,7 +16106,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.0",
@@ -16141,7 +16154,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16191,7 +16204,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16241,7 +16254,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29-rc3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "obsolete": "true",
@@ -16291,7 +16304,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.1",
@@ -16339,7 +16352,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.2",
@@ -16387,7 +16400,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 29.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/29.0.3",
@@ -16435,7 +16448,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.0",
@@ -16483,7 +16496,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.1",
@@ -16531,7 +16544,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.2",
@@ -16579,7 +16592,7 @@
           }
         },
         "displayName": "Android SDK Build-Tools 30.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/30.0.3",
@@ -16620,7 +16633,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 31",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/31.0.0",
@@ -16661,7 +16674,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/32.0.0",
@@ -16702,7 +16715,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 32.1-rc1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/32.1.0-rc1",
@@ -16744,7 +16757,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.0",
@@ -16785,7 +16798,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.1",
@@ -16826,7 +16839,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.2",
@@ -16867,7 +16880,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 33.0.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/33.0.3",
@@ -16908,7 +16921,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0",
@@ -16949,7 +16962,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc1",
@@ -16991,7 +17004,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc2",
@@ -17033,7 +17046,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 34-rc3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/34.0.0-rc3",
@@ -17114,7 +17127,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0",
@@ -17155,7 +17168,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc1",
@@ -17197,7 +17210,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc2",
@@ -17239,7 +17252,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc3",
@@ -17281,7 +17294,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35-rc4",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/35.0.0-rc4",
@@ -17323,7 +17336,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 35.0.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "build-tools",
         "path": "build-tools/35.0.1",
@@ -17364,7 +17377,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc1",
@@ -17406,7 +17419,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc3",
@@ -17448,7 +17461,7 @@
           }
         ],
         "displayName": "Android SDK Build-Tools 36-rc4",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "build-tools",
         "path": "build-tools/36.0.0-rc4",
@@ -17458,6 +17471,48 @@
           "micro:2": "0",
           "minor:1": "0",
           "preview:3": "4"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "36.0.0-rc5": {
+        "archives": [
+          {
+            "arch": "all",
+            "os": "linux",
+            "sha1": "68e91b122664fead061c7963643de494a0dbb73e",
+            "size": 61709567,
+            "url": "https://dl.google.com/android/repository/build-tools_r36-rc5_linux.zip"
+          },
+          {
+            "arch": "all",
+            "os": "windows",
+            "sha1": "9d1f6fbf7ff15be61a9b122a055221b5e0a0edf7",
+            "size": 58459079,
+            "url": "https://dl.google.com/android/repository/build-tools_r36-rc5_windows.zip"
+          },
+          {
+            "arch": "all",
+            "os": "macosx",
+            "sha1": "76aab21b11691d27c7012cd2288cb31f6e02e3b9",
+            "size": 78724827,
+            "url": "https://dl.google.com/android/repository/build-tools_r36-rc5_macosx.zip"
+          }
+        ],
+        "displayName": "Android SDK Build-Tools 36-rc5",
+        "last-available-day": 20139,
+        "license": "android-sdk-preview-license",
+        "name": "build-tools",
+        "path": "build-tools/36.0.0-rc5",
+        "revision": "36.0.0-rc5",
+        "revision-details": {
+          "major:0": "36",
+          "micro:2": "0",
+          "minor:1": "0",
+          "preview:3": "5"
         },
         "type-details": {
           "element-attributes": {
@@ -17499,7 +17554,7 @@
           }
         ],
         "displayName": "CMake 3.10.2.4988404",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.10.2.4988404",
@@ -17540,7 +17595,7 @@
           }
         ],
         "displayName": "CMake 3.18.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.18.1",
@@ -17581,7 +17636,7 @@
           }
         ],
         "displayName": "CMake 3.22.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.22.1",
@@ -17622,7 +17677,7 @@
           }
         ],
         "displayName": "CMake 3.30.3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.3",
@@ -17663,7 +17718,7 @@
           }
         ],
         "displayName": "CMake 3.30.4",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.4",
@@ -17704,7 +17759,7 @@
           }
         ],
         "displayName": "CMake 3.30.5",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.30.5",
@@ -17745,7 +17800,7 @@
           }
         ],
         "displayName": "CMake 3.31.0",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.0",
@@ -17786,7 +17841,7 @@
           }
         ],
         "displayName": "CMake 3.31.1",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.1",
@@ -17827,7 +17882,7 @@
           }
         ],
         "displayName": "CMake 3.31.4",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.4",
@@ -17868,7 +17923,7 @@
           }
         ],
         "displayName": "CMake 3.31.5",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.31.5",
@@ -17916,7 +17971,7 @@
           }
         ],
         "displayName": "CMake 3.6.4111459",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmake",
         "path": "cmake/3.6.4111459",
@@ -17959,7 +18014,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/1.0",
@@ -17999,7 +18054,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/10.0",
@@ -18077,7 +18132,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/11.0",
@@ -18193,7 +18248,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/12.0",
@@ -18271,7 +18326,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0",
@@ -18311,7 +18366,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/13.0-rc01",
@@ -18352,7 +18407,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/14.0-alpha01",
@@ -18393,7 +18448,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0",
@@ -18433,7 +18488,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/16.0-alpha01",
@@ -18474,7 +18529,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/17.0",
@@ -18514,7 +18569,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/19.0-alpha01",
@@ -18555,7 +18610,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "obsolete": "true",
@@ -18596,7 +18651,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/2.1",
@@ -18636,7 +18691,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/3.0",
@@ -18676,7 +18731,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/4.0",
@@ -18716,7 +18771,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/5.0",
@@ -18756,7 +18811,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/6.0",
@@ -18796,7 +18851,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/7.0",
@@ -18836,7 +18891,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/8.0",
@@ -18876,7 +18931,7 @@
           }
         ],
         "displayName": "Android SDK Command-line Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "cmdline-tools",
         "path": "cmdline-tools/9.0",
@@ -19809,6 +19864,54 @@
           }
         }
       },
+      "35.3.12": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "c859ea9c0aa625cc4cf43ad13ba665891155c101",
+            "size": 297030576,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-12990079.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "67d4cc43dfb3983ae210ab51371a3c698fe9b226",
+            "size": 392170242,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-12990079.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "074fd2fb62febe34ba75c4eed75668aff7c7cc03",
+            "size": 311190387,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-12990079.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "9319f59bf621430a0f8ec25f124343fadcc4912f",
+            "size": 419761989,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-12990079.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20139,
+        "license": "android-sdk-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "35.3.12",
+        "revision-details": {
+          "major:0": "35",
+          "micro:2": "12",
+          "minor:1": "3"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
       "35.4.8": {
         "archives": [
           {
@@ -19841,7 +19944,7 @@
           }
         ],
         "displayName": "Android Emulator",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "emulator",
         "path": "emulator",
@@ -19897,6 +20000,54 @@
         "revision-details": {
           "major:0": "35",
           "micro:2": "2",
+          "minor:1": "5"
+        },
+        "type-details": {
+          "element-attributes": {
+            "xsi:type": "ns5:genericDetailsType"
+          }
+        }
+      },
+      "35.5.3": {
+        "archives": [
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "cea757d3e73c0cf40bb6f74b2aa40831d9c3a87b",
+            "size": 303896991,
+            "url": "https://dl.google.com/android/repository/emulator-linux_x64-13023280.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "5f2004b9cf55db7473803069e77c5facce07a585",
+            "size": 401205692,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_x64-13023280.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "4c997b00e0814603fbab1a19821ecda469e0cbec",
+            "size": 319180896,
+            "url": "https://dl.google.com/android/repository/emulator-darwin_aarch64-13023280.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "7b1bdb613b34af21fd5888c811999ba173e553a9",
+            "size": 429277282,
+            "url": "https://dl.google.com/android/repository/emulator-windows_x64-13023280.zip"
+          }
+        ],
+        "displayName": "Android Emulator",
+        "last-available-day": 20139,
+        "license": "android-sdk-preview-license",
+        "name": "emulator",
+        "path": "emulator",
+        "revision": "35.5.3",
+        "revision-details": {
+          "major:0": "35",
+          "micro:2": "3",
           "minor:1": "5"
         },
         "type-details": {
@@ -20029,7 +20180,7 @@
           }
         },
         "displayName": "NDK (Side by side) 16.1.4479499",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/16.1.4479499",
@@ -20091,7 +20242,7 @@
           }
         },
         "displayName": "NDK (Side by side) 17.2.4988734",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/17.2.4988734",
@@ -20153,7 +20304,7 @@
           }
         },
         "displayName": "NDK (Side by side) 18.1.5063045",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/18.1.5063045",
@@ -20215,7 +20366,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.0.5232133",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20278,7 +20429,7 @@
           }
         },
         "displayName": "NDK (Side by side) 19.2.5345600",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/19.2.5345600",
@@ -20340,7 +20491,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5392854",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20404,7 +20555,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5471264",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "obsolete": "true",
@@ -20468,7 +20619,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.0.5594570",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.0.5594570",
@@ -20530,7 +20681,7 @@
           }
         },
         "displayName": "NDK (Side by side) 20.1.5948944",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/20.1.5948944",
@@ -20578,7 +20729,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6011959",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.0.6011959",
@@ -20627,7 +20778,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.0.6113669",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.0.6113669",
@@ -20675,7 +20826,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6210238",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6210238",
@@ -20731,7 +20882,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6273396",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6273396",
@@ -20787,7 +20938,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6352462",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.1.6352462",
@@ -20842,7 +20993,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.1.6363665",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/21.1.6363665",
@@ -20898,7 +21049,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.2.6472646",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.2.6472646",
@@ -20953,7 +21104,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.3.6528147",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.3.6528147",
@@ -21008,7 +21159,7 @@
           }
         },
         "displayName": "NDK (Side by side) 21.4.7075529",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/21.4.7075529",
@@ -21063,7 +21214,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.6917172",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/22.0.6917172",
@@ -21119,7 +21270,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.0.7026061",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.0.7026061",
@@ -21174,7 +21325,7 @@
           }
         },
         "displayName": "NDK (Side by side) 22.1.7171670",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/22.1.7171670",
@@ -21229,7 +21380,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7123448",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7123448",
@@ -21285,7 +21436,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7196353",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7196353",
@@ -21341,7 +21492,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7272597",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7272597",
@@ -21397,7 +21548,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7344513",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7344513",
@@ -21446,7 +21597,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7421159",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7421159",
@@ -21495,7 +21646,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7530507",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/23.0.7530507",
@@ -21544,7 +21695,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.0.7599858",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.0.7599858",
@@ -21592,7 +21743,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.1.7779620",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.1.7779620",
@@ -21640,7 +21791,7 @@
           }
         },
         "displayName": "NDK (Side by side) 23.2.8568313",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/23.2.8568313",
@@ -21688,7 +21839,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7856742",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7856742",
@@ -21737,7 +21888,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.7956693",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.7956693",
@@ -21786,7 +21937,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8079956",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/24.0.8079956",
@@ -21835,7 +21986,7 @@
           }
         },
         "displayName": "NDK (Side by side) 24.0.8215888",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/24.0.8215888",
@@ -21883,7 +22034,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8151533",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8151533",
@@ -21932,7 +22083,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8221429",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8221429",
@@ -21981,7 +22132,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8355429",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8355429",
@@ -22030,7 +22181,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8528842",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/25.0.8528842",
@@ -22079,7 +22230,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.0.8775105",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.0.8775105",
@@ -22127,7 +22278,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.1.8937393",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.1.8937393",
@@ -22175,7 +22326,7 @@
           }
         },
         "displayName": "NDK (Side by side) 25.2.9519653",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/25.2.9519653",
@@ -22223,7 +22374,7 @@
           }
         },
         "displayName": "NDK (Side by side) 26.0.10404224",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10404224",
@@ -22265,7 +22416,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10636728",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/26.0.10636728",
@@ -22307,7 +22458,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.0.10792818",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.0.10792818",
@@ -22348,7 +22499,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.1.10909125",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.1.10909125",
@@ -22389,7 +22540,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.2.11394342",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.2.11394342",
@@ -22430,7 +22581,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 26.3.11579264",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/26.3.11579264",
@@ -22471,7 +22622,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11718014",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11718014",
@@ -22513,7 +22664,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.11902837",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/27.0.11902837",
@@ -22555,7 +22706,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.0.12077973",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.0.12077973",
@@ -22596,7 +22747,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.1.12297006",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.1.12297006",
@@ -22637,7 +22788,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 27.2.12479018",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/27.2.12479018",
@@ -22678,7 +22829,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12433566",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12433566",
@@ -22720,7 +22871,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12674087",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12674087",
@@ -22762,7 +22913,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.12916984",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk",
         "path": "ndk/28.0.12916984",
@@ -22804,7 +22955,7 @@
           }
         ],
         "displayName": "NDK (Side by side) 28.0.13004108",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk",
         "path": "ndk/28.0.13004108",
@@ -22868,7 +23019,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -22930,7 +23081,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -22992,7 +23143,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23054,7 +23205,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23117,7 +23268,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23179,7 +23330,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23243,7 +23394,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "obsolete": "true",
@@ -23307,7 +23458,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23369,7 +23520,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23417,7 +23568,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23466,7 +23617,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23514,7 +23665,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23570,7 +23721,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23626,7 +23777,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23681,7 +23832,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23737,7 +23888,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23792,7 +23943,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23847,7 +23998,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23902,7 +24053,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -23958,7 +24109,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24013,7 +24164,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24068,7 +24219,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24124,7 +24275,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24180,7 +24331,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24236,7 +24387,7 @@
           }
         },
         "displayName": "NDK",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-preview-license",
         "name": "ndk-bundle",
         "path": "ndk-bundle",
@@ -24496,7 +24647,7 @@
           }
         ],
         "displayName": "Android SDK Platform-Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platform-tools",
         "path": "platform-tools",
@@ -24525,7 +24676,7 @@
           }
         ],
         "displayName": "Android SDK Platform 10",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-10",
@@ -24564,7 +24715,7 @@
           }
         ],
         "displayName": "Android SDK Platform 11",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-11",
@@ -24603,7 +24754,7 @@
           }
         ],
         "displayName": "Android SDK Platform 12",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-12",
@@ -24642,7 +24793,7 @@
           }
         ],
         "displayName": "Android SDK Platform 13",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-13",
@@ -24681,7 +24832,7 @@
           }
         ],
         "displayName": "Android SDK Platform 14",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-14",
@@ -24720,7 +24871,7 @@
           }
         ],
         "displayName": "Android SDK Platform 15",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-15",
@@ -24759,7 +24910,7 @@
           }
         ],
         "displayName": "Android SDK Platform 16",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-16",
@@ -24798,7 +24949,7 @@
           }
         ],
         "displayName": "Android SDK Platform 17",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-17",
@@ -24837,7 +24988,7 @@
           }
         ],
         "displayName": "Android SDK Platform 18",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-18",
@@ -24876,7 +25027,7 @@
           }
         ],
         "displayName": "Android SDK Platform 19",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-19",
@@ -24929,7 +25080,7 @@
           }
         ],
         "displayName": "Android SDK Platform 2",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -24969,7 +25120,7 @@
           }
         ],
         "displayName": "Android SDK Platform 20",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-20",
@@ -25008,7 +25159,7 @@
           }
         ],
         "displayName": "Android SDK Platform 21",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-21",
@@ -25047,7 +25198,7 @@
           }
         ],
         "displayName": "Android SDK Platform 22",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-22",
@@ -25086,7 +25237,7 @@
           }
         ],
         "displayName": "Android SDK Platform 23",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-23",
@@ -25125,7 +25276,7 @@
           }
         ],
         "displayName": "Android SDK Platform 24",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-24",
@@ -25164,7 +25315,7 @@
           }
         ],
         "displayName": "Android SDK Platform 25",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-25",
@@ -25203,7 +25354,7 @@
           }
         ],
         "displayName": "Android SDK Platform 26",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-26",
@@ -25242,7 +25393,7 @@
           }
         ],
         "displayName": "Android SDK Platform 27",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-27",
@@ -25281,7 +25432,7 @@
           }
         ],
         "displayName": "Android SDK Platform 28",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-28",
@@ -25320,7 +25471,7 @@
           }
         ],
         "displayName": "Android SDK Platform 29",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-29",
@@ -25373,7 +25524,7 @@
           }
         ],
         "displayName": "Android SDK Platform 3",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25413,7 +25564,7 @@
           }
         ],
         "displayName": "Android SDK Platform 30",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-30",
@@ -25452,7 +25603,7 @@
           }
         ],
         "displayName": "Android SDK Platform 31",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-31",
@@ -25491,7 +25642,7 @@
           }
         ],
         "displayName": "Android SDK Platform 32",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-32",
@@ -25530,7 +25681,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33",
@@ -25570,7 +25721,7 @@
           }
         ],
         "displayName": "Android SDK Platform 33-ext5",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-33-ext5",
@@ -25605,7 +25756,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25651,7 +25802,7 @@
           }
         ],
         "displayName": "Android SDK Platform 34-ext12",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-34-ext12",
@@ -25684,7 +25835,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35",
@@ -25722,7 +25873,7 @@
           }
         ],
         "displayName": "Android SDK Platform 35-ext14",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-35-ext14",
@@ -25769,7 +25920,7 @@
           }
         ],
         "displayName": "Android SDK Platform 4",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25823,7 +25974,7 @@
           }
         ],
         "displayName": "Android SDK Platform 5",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25877,7 +26028,7 @@
           }
         ],
         "displayName": "Android SDK Platform 6",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -25917,7 +26068,7 @@
           }
         ],
         "displayName": "Android SDK Platform 7",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-7",
@@ -25956,7 +26107,7 @@
           }
         ],
         "displayName": "Android SDK Platform 8",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-8",
@@ -25995,7 +26146,7 @@
           }
         ],
         "displayName": "Android SDK Platform 9",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-9",
@@ -26028,19 +26179,19 @@
           {
             "arch": "all",
             "os": "all",
-            "sha1": "69909269fe199e2d3817c10ecc13cd338da55d3b",
-            "size": 65460575,
-            "url": "https://dl.google.com/android/repository/platform-Baklava_r04.zip"
+            "sha1": "9dcd49009a005b0bdce2384cad0d9ca0fe74f1ce",
+            "size": 65604289,
+            "url": "https://dl.google.com/android/repository/platform-Baklava_r05.zip"
           }
         ],
         "displayName": "Android SDK Platform Baklava",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "path": "platforms/android-Baklava",
         "revision": "Baklava",
         "revision-details": {
-          "major:0": "4"
+          "major:0": "5"
         },
         "type-details": {
           "api-level:0": "35",
@@ -26099,7 +26250,7 @@
           }
         ],
         "displayName": "Android SDK Platform UpsideDownCake",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "platforms",
         "obsolete": "true",
@@ -26253,7 +26404,7 @@
           }
         ],
         "displayName": "Layout Inspector image server for API S",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/2",
@@ -26371,10 +26522,38 @@
             "sha1": "28dde025a70a0f4819cf195c1cb6e0e2b4bf4514",
             "size": 6059180,
             "url": "https://dl.google.com/android/repository/skiaparser-7083912-win.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "linux",
+            "sha1": "0c0ba1581ecba105bd59b95c251f8a16a73e9555",
+            "size": 9057863,
+            "url": "https://dl.google.com/android/repository/skiaparser-12972467-linux-x64.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "macosx",
+            "sha1": "7fa586b1b677db7f0af7104bb8b273bae1f05567",
+            "size": 2933880,
+            "url": "https://dl.google.com/android/repository/skiaparser-12972467-darwin-x64.zip"
+          },
+          {
+            "arch": "aarch64",
+            "os": "macosx",
+            "sha1": "b4c308feff96c9ef112dd8959ee9d1e78c12d89b",
+            "size": 2598977,
+            "url": "https://dl.google.com/android/repository/skiaparser-12972467-darwin-aarch64.zip"
+          },
+          {
+            "arch": "x64",
+            "os": "windows",
+            "sha1": "6d65481e813ea9fa6447d8575b40f728bc252cd3",
+            "size": 2953603,
+            "url": "https://dl.google.com/android/repository/skiaparser-12972467-win-x64.zip"
           }
         ],
         "displayName": "Layout Inspector image server for API 29-30",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "skiaparser",
         "path": "skiaparser/1",
@@ -26401,7 +26580,7 @@
           }
         ],
         "displayName": "Sources for Android 14",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "obsolete": "true",
@@ -26431,7 +26610,7 @@
           }
         ],
         "displayName": "Sources for Android 15",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-15",
@@ -26460,7 +26639,7 @@
           }
         ],
         "displayName": "Sources for Android 16",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-16",
@@ -26489,7 +26668,7 @@
           }
         ],
         "displayName": "Sources for Android 17",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-17",
@@ -26518,7 +26697,7 @@
           }
         ],
         "displayName": "Sources for Android 18",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-18",
@@ -26547,7 +26726,7 @@
           }
         ],
         "displayName": "Sources for Android 19",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-19",
@@ -26576,7 +26755,7 @@
           }
         ],
         "displayName": "Sources for Android 20",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-20",
@@ -26605,7 +26784,7 @@
           }
         ],
         "displayName": "Sources for Android 21",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-21",
@@ -26634,7 +26813,7 @@
           }
         ],
         "displayName": "Sources for Android 22",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-22",
@@ -26663,7 +26842,7 @@
           }
         ],
         "displayName": "Sources for Android 23",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-23",
@@ -26692,7 +26871,7 @@
           }
         ],
         "displayName": "Sources for Android 24",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-24",
@@ -26721,7 +26900,7 @@
           }
         ],
         "displayName": "Sources for Android 25",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-25",
@@ -26750,7 +26929,7 @@
           }
         ],
         "displayName": "Sources for Android 26",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-26",
@@ -26779,7 +26958,7 @@
           }
         ],
         "displayName": "Sources for Android 27",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-27",
@@ -26808,7 +26987,7 @@
           }
         ],
         "displayName": "Sources for Android 28",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-28",
@@ -26837,7 +27016,7 @@
           }
         ],
         "displayName": "Sources for Android 29",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-29",
@@ -26866,7 +27045,7 @@
           }
         ],
         "displayName": "Sources for Android 30",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-30",
@@ -26895,7 +27074,7 @@
           }
         ],
         "displayName": "Sources for Android 31",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-31",
@@ -26924,7 +27103,7 @@
           }
         ],
         "displayName": "Sources for Android 32",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-32",
@@ -26953,7 +27132,7 @@
           }
         ],
         "displayName": "Sources for Android 33",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-33",
@@ -26983,7 +27162,7 @@
           }
         ],
         "displayName": "Sources for Android 34",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-34",
@@ -27013,7 +27192,7 @@
           }
         ],
         "displayName": "Sources for Android 35",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "sources",
         "path": "sources/android-35",
@@ -27082,7 +27261,7 @@
           }
         },
         "displayName": "Android SDK Tools",
-        "last-available-day": 20131,
+        "last-available-day": 20139,
         "license": "android-sdk-license",
         "name": "tools",
         "obsolete": "true",

--- a/pkgs/development/mobile/androidenv/test-suite.nix
+++ b/pkgs/development/mobile/androidenv/test-suite.nix
@@ -2,6 +2,7 @@
   callPackage,
   lib,
   stdenv,
+  meta,
 }:
 let
   examples-shell = callPackage ./examples/shell.nix { licenseAccepted = true; };
@@ -25,5 +26,14 @@ stdenv.mkDerivation {
 
   passthru.tests = all-tests;
 
-  meta.timeout = 60;
+  # This is the toplevel package, so inherit the update script
+  passthru.updateScript = {
+    command = [ ./update.sh ];
+    attrPath = "androidenv.test-suite";
+    supportedFeatures = [ "commit" ];
+  };
+
+  meta = meta // {
+    timeout = 60;
+  };
 }

--- a/pkgs/development/mobile/androidenv/tools.nix
+++ b/pkgs/development/mobile/androidenv/tools.nix
@@ -1,8 +1,8 @@
-{deployAndroidPackage, lib, stdenv, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, postInstall, meta}:
+{deployAndroidPackage, lib, stdenv, package, os, arch, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta}:
 
 deployAndroidPackage {
   name = "androidsdk-tools";
-  inherit package;
+  inherit package os arch;
   nativeBuildInputs = [ makeWrapper ]
     ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
   buildInputs = lib.optional (os == "linux") (

--- a/pkgs/development/mobile/androidenv/tools.nix
+++ b/pkgs/development/mobile/androidenv/tools.nix
@@ -1,4 +1,4 @@
-{deployAndroidPackage, lib, stdenv, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, postInstall}:
+{deployAndroidPackage, lib, stdenv, package, autoPatchelfHook, makeWrapper, os, pkgs, pkgsi686Linux, postInstall, meta}:
 
 deployAndroidPackage {
   name = "androidsdk-tools";
@@ -40,5 +40,5 @@ deployAndroidPackage {
     ${postInstall}
   '';
 
-  meta.license = lib.licenses.unfree;
+  inherit meta;
 }

--- a/pkgs/development/mobile/androidenv/tools.nix
+++ b/pkgs/development/mobile/androidenv/tools.nix
@@ -1,17 +1,48 @@
-{deployAndroidPackage, lib, stdenv, package, os, arch, autoPatchelfHook, makeWrapper, pkgs, pkgsi686Linux, postInstall, meta}:
+{
+  deployAndroidPackage,
+  lib,
+  stdenv,
+  package,
+  os,
+  arch,
+  autoPatchelfHook,
+  makeWrapper,
+  pkgs,
+  pkgsi686Linux,
+  postInstall,
+  meta,
+}:
 
 deployAndroidPackage {
   name = "androidsdk-tools";
   inherit package os arch;
-  nativeBuildInputs = [ makeWrapper ]
-    ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
+  nativeBuildInputs = [ makeWrapper ] ++ lib.optionals (os == "linux") [ autoPatchelfHook ];
   buildInputs = lib.optional (os == "linux") (
-      (with pkgs; [ glibc freetype fontconfig fontconfig.lib
-        stdenv.cc.cc.libgcc or null # fix for https://github.com/NixOS/nixpkgs/issues/226357
-      ])
-      ++ (with pkgs.xorg; [ libX11 libXrender libXext ])
-      ++ lib.optionals (os == "linux" && stdenv.isx86_64) (with pkgsi686Linux; [ glibc xorg.libX11 xorg.libXrender xorg.libXext fontconfig.lib freetype zlib ])
-    );
+    (with pkgs; [
+      glibc
+      freetype
+      fontconfig
+      fontconfig.lib
+      stdenv.cc.cc.libgcc or null # fix for https://github.com/NixOS/nixpkgs/issues/226357
+    ])
+    ++ (with pkgs.xorg; [
+      libX11
+      libXrender
+      libXext
+    ])
+    ++ lib.optionals (os == "linux" && stdenv.isx86_64) (
+      with pkgsi686Linux;
+      [
+        glibc
+        xorg.libX11
+        xorg.libXrender
+        xorg.libXext
+        fontconfig.lib
+        freetype
+        zlib
+      ]
+    )
+  );
 
   patchInstructions = ''
     ${lib.optionalString (os == "linux") ''
@@ -31,7 +62,15 @@ deployAndroidPackage {
     # Wrap monitor script
     wrapProgram $PWD/monitor \
       --prefix PATH : ${pkgs.jdk8}/bin \
-      --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath (with pkgs; [ xorg.libX11 xorg.libXtst ])}
+      --prefix LD_LIBRARY_PATH : ${
+        lib.makeLibraryPath (
+          with pkgs;
+          [
+            xorg.libX11
+            xorg.libXtst
+          ]
+        )
+      }
 
     # Patch all script shebangs
     patchShebangs .

--- a/pkgs/development/mobile/androidenv/update.sh
+++ b/pkgs/development/mobile/androidenv/update.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+pushd "$(dirname "$0")" &>/dev/null || exit 1
+./fetchrepo.sh && ./mkrepo.sh
+popd &>/dev/null


### PR DESCRIPTION
We can figure out the latest version for every package in mkrepo.rb, instead of repeating ourselves in compose-android-packages.

Track the latest non-preview versions of all packages by default, and remove version hardcoding everywhere. Enable the update script.

Only eval supported packages on aarch64-linux.

Depends on #374102 and #360151, and reduces the effort required to maintain androidenv packages by an order of magnitude.

CC @NixOS/android team!

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [x] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
