### PR TITLE
emacs: replace ad hoc implementation with lib.extendMkDerivation

### DIFF
--- a/pkgs/applications/editors/emacs/build-support/elpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/elpa.nix
@@ -16,40 +16,41 @@ let
       texinfo
       ;
   };
-  libBuildHelper = import ./lib-build-helper.nix;
 
 in
 
-libBuildHelper.extendMkDerivation' genericBuild (
-  finalAttrs:
+lib.extendMkDerivation {
+  constructDrv = genericBuild;
+  extendDrvArgs =
+    finalAttrs:
 
-  {
-    pname,
-    dontUnpack ? true,
-    meta ? { },
-    ...
-  }@args:
+    {
+      pname,
+      dontUnpack ? true,
+      meta ? { },
+      ...
+    }@args:
 
-  {
+    {
 
-    elpa2nix = args.elpa2nix or ./elpa2nix.el;
+      elpa2nix = args.elpa2nix or ./elpa2nix.el;
 
-    inherit dontUnpack;
+      inherit dontUnpack;
 
-    installPhase =
-      args.installPhase or ''
-        runHook preInstall
+      installPhase =
+        args.installPhase or ''
+          runHook preInstall
 
-        emacs --batch -Q -l "$elpa2nix" \
-            -f elpa2nix-install-package \
-            "$src" "$out/share/emacs/site-lisp/elpa"
+          emacs --batch -Q -l "$elpa2nix" \
+              -f elpa2nix-install-package \
+              "$src" "$out/share/emacs/site-lisp/elpa"
 
-        runHook postInstall
-      '';
+          runHook postInstall
+        '';
 
-    meta = {
-      homepage = args.src.meta.homepage or "https://elpa.gnu.org/packages/${pname}.html";
-    } // meta;
-  }
+      meta = {
+        homepage = args.src.meta.homepage or "https://elpa.gnu.org/packages/${pname}.html";
+      } // meta;
+    };
 
-)
+}

--- a/pkgs/applications/editors/emacs/build-support/generic.nix
+++ b/pkgs/applications/editors/emacs/build-support/generic.nix
@@ -11,100 +11,100 @@
 let
   inherit (lib) optionalAttrs;
 
-  libBuildHelper = import ./lib-build-helper.nix;
-
 in
 
-libBuildHelper.extendMkDerivation' stdenv.mkDerivation (
-  finalAttrs:
+lib.extendMkDerivation {
+  constructDrv = stdenv.mkDerivation;
+  extendDrvArgs =
+    finalAttrs:
 
-  {
-    buildInputs ? [ ],
-    nativeBuildInputs ? [ ],
-    packageRequires ? [ ],
-    propagatedBuildInputs ? [ ],
-    propagatedUserEnvPkgs ? [ ],
-    postInstall ? "",
-    meta ? { },
-    turnCompilationWarningToError ? false,
-    ignoreCompilationError ? false,
-    ...
-  }@args:
+    {
+      buildInputs ? [ ],
+      nativeBuildInputs ? [ ],
+      packageRequires ? [ ],
+      propagatedBuildInputs ? [ ],
+      propagatedUserEnvPkgs ? [ ],
+      postInstall ? "",
+      meta ? { },
+      turnCompilationWarningToError ? false,
+      ignoreCompilationError ? false,
+      ...
+    }@args:
 
-  {
-    name = args.name or "emacs-${finalAttrs.pname}-${finalAttrs.version}";
+    {
+      name = args.name or "emacs-${finalAttrs.pname}-${finalAttrs.version}";
 
-    unpackCmd =
-      args.unpackCmd or ''
-        case "$curSrc" in
-          *.el)
-            # keep original source filename without the hash
-            local filename=$(basename "$curSrc")
-            filename="''${filename:33}"
-            cp $curSrc $filename
-            chmod +w $filename
-            sourceRoot="."
-            ;;
-          *)
-            _defaultUnpack "$curSrc"
-            ;;
-        esac
-      '';
+      unpackCmd =
+        args.unpackCmd or ''
+          case "$curSrc" in
+            *.el)
+              # keep original source filename without the hash
+              local filename=$(basename "$curSrc")
+              filename="''${filename:33}"
+              cp $curSrc $filename
+              chmod +w $filename
+              sourceRoot="."
+              ;;
+            *)
+              _defaultUnpack "$curSrc"
+              ;;
+          esac
+        '';
 
-    inherit packageRequires;
-    buildInputs = [ emacs ] ++ buildInputs;
-    nativeBuildInputs = [
-      emacs
-      texinfo
-    ] ++ nativeBuildInputs;
-    propagatedBuildInputs = finalAttrs.packageRequires ++ propagatedBuildInputs;
-    propagatedUserEnvPkgs = finalAttrs.packageRequires ++ propagatedUserEnvPkgs;
+      inherit packageRequires;
+      buildInputs = [ emacs ] ++ buildInputs;
+      nativeBuildInputs = [
+        emacs
+        texinfo
+      ] ++ nativeBuildInputs;
+      propagatedBuildInputs = finalAttrs.packageRequires ++ propagatedBuildInputs;
+      propagatedUserEnvPkgs = finalAttrs.packageRequires ++ propagatedUserEnvPkgs;
 
-    strictDeps = args.strictDeps or true;
+      strictDeps = args.strictDeps or true;
 
-    inherit turnCompilationWarningToError ignoreCompilationError;
+      inherit turnCompilationWarningToError ignoreCompilationError;
 
-    meta =
-      {
-        broken = false;
-        platforms = emacs.meta.platforms;
-      }
-      // optionalAttrs ((args.src.meta.homepage or "") != "") {
-        homepage = args.src.meta.homepage;
-      }
-      // meta;
-  }
+      meta =
+        {
+          broken = false;
+          platforms = emacs.meta.platforms;
+        }
+        // optionalAttrs ((args.src.meta.homepage or "") != "") {
+          homepage = args.src.meta.homepage;
+        }
+        // meta;
+    }
 
-  // optionalAttrs (emacs.withNativeCompilation or false) {
+    // optionalAttrs (emacs.withNativeCompilation or false) {
 
-    addEmacsNativeLoadPath = args.addEmacsNativeLoadPath or true;
+      addEmacsNativeLoadPath = args.addEmacsNativeLoadPath or true;
 
-    postInstall =
-      ''
-        # Besides adding the output directory to the native load path, make sure
-        # the current package's elisp files are in the load path, otherwise
-        # (require 'file-b) from file-a.el in the same package will fail.
-        mkdir -p $out/share/emacs/native-lisp
-        addEmacsVars "$out"
+      postInstall =
+        ''
+          # Besides adding the output directory to the native load path, make sure
+          # the current package's elisp files are in the load path, otherwise
+          # (require 'file-b) from file-a.el in the same package will fail.
+          mkdir -p $out/share/emacs/native-lisp
+          addEmacsVars "$out"
 
-        # package-activate-all is used to activate packages.  In other builder
-        # helpers, package-initialize is used for this purpose because
-        # package-activate-all is not available before Emacs 27.
-        find $out/share/emacs -type f -name '*.el' -not -name ".dir-locals.el" -print0 \
-          | xargs --verbose -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
-              "emacs \
-                 --batch \
-                 -f package-activate-all \
-                 --eval '(setq native-comp-eln-load-path (cdr native-comp-eln-load-path))' \
-                 --eval '(let ((default-directory \"$out/share/emacs/site-lisp\")) (normal-top-level-add-subdirs-to-load-path))' \
-                 --eval '(setq large-file-warning-threshold nil)' \
-                 --eval '(setq byte-compile-error-on-warn ${
-                   if finalAttrs.turnCompilationWarningToError then "t" else "nil"
-                 })' \
-                 -f batch-native-compile {} \
-               || exit ${if finalAttrs.ignoreCompilationError then "0" else "\\$?"}"
-      ''
-      + postInstall;
-  }
+          # package-activate-all is used to activate packages.  In other builder
+          # helpers, package-initialize is used for this purpose because
+          # package-activate-all is not available before Emacs 27.
+          find $out/share/emacs -type f -name '*.el' -not -name ".dir-locals.el" -print0 \
+            | xargs --verbose -0 -I {} -n 1 -P $NIX_BUILD_CORES sh -c \
+                "emacs \
+                   --batch \
+                   -f package-activate-all \
+                   --eval '(setq native-comp-eln-load-path (cdr native-comp-eln-load-path))' \
+                   --eval '(let ((default-directory \"$out/share/emacs/site-lisp\")) (normal-top-level-add-subdirs-to-load-path))' \
+                   --eval '(setq large-file-warning-threshold nil)' \
+                   --eval '(setq byte-compile-error-on-warn ${
+                     if finalAttrs.turnCompilationWarningToError then "t" else "nil"
+                   })' \
+                   -f batch-native-compile {} \
+                 || exit ${if finalAttrs.ignoreCompilationError then "0" else "\\$?"}"
+        ''
+        + postInstall;
+    };
 
-)
+}

--- a/pkgs/applications/editors/emacs/build-support/lib-build-helper.nix
+++ b/pkgs/applications/editors/emacs/build-support/lib-build-helper.nix
@@ -1,5 +1,0 @@
-{
-  extendMkDerivation' =
-    mkDerivationBase: attrsOverlay: fpargs:
-    (mkDerivationBase fpargs).overrideAttrs attrsOverlay;
-}

--- a/pkgs/applications/editors/emacs/build-support/melpa.nix
+++ b/pkgs/applications/editors/emacs/build-support/melpa.nix
@@ -18,7 +18,6 @@ let
       texinfo
       ;
   };
-  libBuildHelper = import ./lib-build-helper.nix;
 
   packageBuild = stdenv.mkDerivation {
     name = "package-build";
@@ -42,156 +41,158 @@ let
 
 in
 
-libBuildHelper.extendMkDerivation' genericBuild (
-  finalAttrs:
+lib.extendMkDerivation {
+  constructDrv = genericBuild;
+  extendDrvArgs =
+    finalAttrs:
 
-  {
-    /*
-      pname: Nix package name without special symbols and without version or
-      "emacs-" prefix.
-    */
-    pname,
-    /*
-      ename: Original Emacs package name, possibly containing special symbols.
-      Default: pname
-    */
-    ename ? pname,
-    /*
-      version: Either a stable version such as "1.2" or an unstable version.
-      An unstable version can use either Nix format (preferred) such as
-      "1.2-unstable-2024-06-01" or MELPA format such as "20240601.1230".
-    */
-    version,
-    /*
-      commit: Optional package history commit.
-      Default: src.rev or "unknown"
-      This will be written into the generated package but it is not needed during
-      the build process.
-    */
-    commit ? (finalAttrs.src.rev or "unknown"),
-    /*
-      files: Optional recipe property specifying the files used to build the package.
-      If null, do not set it in recipe, keeping the default upstream behaviour.
-      Default: null
-    */
-    files ? null,
-    /*
-      recipe: Optional MELPA recipe.
-      Default: a minimally functional recipe
-      This can be a path of a recipe file, a string of the recipe content or an empty string.
-      The default value is used if it is an empty string.
-    */
-    recipe ? "",
-    preUnpack ? "",
-    postUnpack ? "",
-    meta ? { },
-    ...
-  }@args:
+    {
+      /*
+        pname: Nix package name without special symbols and without version or
+        "emacs-" prefix.
+      */
+      pname,
+      /*
+        ename: Original Emacs package name, possibly containing special symbols.
+        Default: pname
+      */
+      ename ? pname,
+      /*
+        version: Either a stable version such as "1.2" or an unstable version.
+        An unstable version can use either Nix format (preferred) such as
+        "1.2-unstable-2024-06-01" or MELPA format such as "20240601.1230".
+      */
+      version,
+      /*
+        commit: Optional package history commit.
+        Default: src.rev or "unknown"
+        This will be written into the generated package but it is not needed during
+        the build process.
+      */
+      commit ? (finalAttrs.src.rev or "unknown"),
+      /*
+        files: Optional recipe property specifying the files used to build the package.
+        If null, do not set it in recipe, keeping the default upstream behaviour.
+        Default: null
+      */
+      files ? null,
+      /*
+        recipe: Optional MELPA recipe.
+        Default: a minimally functional recipe
+        This can be a path of a recipe file, a string of the recipe content or an empty string.
+        The default value is used if it is an empty string.
+      */
+      recipe ? "",
+      preUnpack ? "",
+      postUnpack ? "",
+      meta ? { },
+      ...
+    }@args:
 
-  {
+    {
 
-    elpa2nix = args.elpa2nix or ./elpa2nix.el;
-    melpa2nix = args.melpa2nix or ./melpa2nix.el;
+      elpa2nix = args.elpa2nix or ./elpa2nix.el;
+      melpa2nix = args.melpa2nix or ./melpa2nix.el;
 
-    inherit
-      commit
-      ename
-      files
-      recipe
-      ;
+      inherit
+        commit
+        ename
+        files
+        recipe
+        ;
 
-    packageBuild = args.packageBuild or packageBuild;
+      packageBuild = args.packageBuild or packageBuild;
 
-    melpaVersion =
-      args.melpaVersion or (
-        let
-          parsed =
-            lib.flip builtins.match version
-              # match <version>-unstable-YYYY-MM-DD format
-              "^.*-unstable-([[:digit:]]{4})-([[:digit:]]{2})-([[:digit:]]{2})$";
-          unstableVersionInNixFormat = parsed != null; # heuristics
-          date = builtins.concatStringsSep "" parsed;
-          time = "0"; # unstable version in nix format lacks this info
-        in
-        if unstableVersionInNixFormat then date + "." + time else finalAttrs.version
-      );
+      melpaVersion =
+        args.melpaVersion or (
+          let
+            parsed =
+              lib.flip builtins.match version
+                # match <version>-unstable-YYYY-MM-DD format
+                "^.*-unstable-([[:digit:]]{4})-([[:digit:]]{2})-([[:digit:]]{2})$";
+            unstableVersionInNixFormat = parsed != null; # heuristics
+            date = builtins.concatStringsSep "" parsed;
+            time = "0"; # unstable version in nix format lacks this info
+          in
+          if unstableVersionInNixFormat then date + "." + time else finalAttrs.version
+        );
 
-    preUnpack =
-      ''
-            mkdir -p "$NIX_BUILD_TOP/recipes"
-            recipeFile="$NIX_BUILD_TOP/recipes/$ename"
-            if [ -r "$recipe" ]; then
-              ln -s "$recipe" "$recipeFile"
-              nixInfoLog "link recipe"
-            elif [ -n "$recipe" ]; then
-              printf "%s" "$recipe" > "$recipeFile"
-              nixInfoLog "write recipe"
-            else
-              cat > "$recipeFile" <<'EOF'
-        (${finalAttrs.ename} :fetcher git :url "" ${
-          lib.optionalString (finalAttrs.files != null) ":files ${finalAttrs.files}"
-        })
-        EOF
-              nixInfoLog "use default recipe"
-            fi
-            nixInfoLog "recipe content:" "$(< $recipeFile)"
-            unset -v recipeFile
+      preUnpack =
+        ''
+              mkdir -p "$NIX_BUILD_TOP/recipes"
+              recipeFile="$NIX_BUILD_TOP/recipes/$ename"
+              if [ -r "$recipe" ]; then
+                ln -s "$recipe" "$recipeFile"
+                nixInfoLog "link recipe"
+              elif [ -n "$recipe" ]; then
+                printf "%s" "$recipe" > "$recipeFile"
+                nixInfoLog "write recipe"
+              else
+                cat > "$recipeFile" <<'EOF'
+          (${finalAttrs.ename} :fetcher git :url "" ${
+            lib.optionalString (finalAttrs.files != null) ":files ${finalAttrs.files}"
+          })
+          EOF
+                nixInfoLog "use default recipe"
+              fi
+              nixInfoLog "recipe content:" "$(< $recipeFile)"
+              unset -v recipeFile
 
-            ln -s "$packageBuild" "$NIX_BUILD_TOP/package-build"
+              ln -s "$packageBuild" "$NIX_BUILD_TOP/package-build"
 
-            mkdir -p "$NIX_BUILD_TOP/packages"
-      ''
-      + preUnpack;
+              mkdir -p "$NIX_BUILD_TOP/packages"
+        ''
+        + preUnpack;
 
-    postUnpack =
-      ''
-        mkdir -p "$NIX_BUILD_TOP/working"
-        ln -s "$NIX_BUILD_TOP/$sourceRoot" "$NIX_BUILD_TOP/working/$ename"
-      ''
-      + postUnpack;
+      postUnpack =
+        ''
+          mkdir -p "$NIX_BUILD_TOP/working"
+          ln -s "$NIX_BUILD_TOP/$sourceRoot" "$NIX_BUILD_TOP/working/$ename"
+        ''
+        + postUnpack;
 
-    buildPhase =
-      args.buildPhase or ''
-        runHook preBuild
+      buildPhase =
+        args.buildPhase or ''
+          runHook preBuild
 
-        # This is modified from stdenv buildPhase. foundMakefile is used in stdenv checkPhase.
-        if [[ ! ( -z "''${makeFlags-}" && -z "''${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ) ]]; then
-          foundMakefile=1
-        fi
+          # This is modified from stdenv buildPhase. foundMakefile is used in stdenv checkPhase.
+          if [[ ! ( -z "''${makeFlags-}" && -z "''${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ) ]]; then
+            foundMakefile=1
+          fi
 
-        pushd "$NIX_BUILD_TOP"
+          pushd "$NIX_BUILD_TOP"
 
-        emacs --batch -Q \
-            -L "$NIX_BUILD_TOP/package-build" \
-            -l "$melpa2nix" \
-            -f melpa2nix-build-package \
-            $ename $melpaVersion $commit
+          emacs --batch -Q \
+              -L "$NIX_BUILD_TOP/package-build" \
+              -l "$melpa2nix" \
+              -f melpa2nix-build-package \
+              $ename $melpaVersion $commit
 
-        popd
+          popd
 
-        runHook postBuild
-      '';
+          runHook postBuild
+        '';
 
-    installPhase =
-      args.installPhase or ''
-        runHook preInstall
+      installPhase =
+        args.installPhase or ''
+          runHook preInstall
 
-        archive="$NIX_BUILD_TOP/packages/$ename-$melpaVersion.el"
-        if [ ! -f "$archive" ]; then
-            archive="$NIX_BUILD_TOP/packages/$ename-$melpaVersion.tar"
-        fi
+          archive="$NIX_BUILD_TOP/packages/$ename-$melpaVersion.el"
+          if [ ! -f "$archive" ]; then
+              archive="$NIX_BUILD_TOP/packages/$ename-$melpaVersion.tar"
+          fi
 
-        emacs --batch -Q \
-            -l "$elpa2nix" \
-            -f elpa2nix-install-package \
-            "$archive" "$out/share/emacs/site-lisp/elpa"
+          emacs --batch -Q \
+              -l "$elpa2nix" \
+              -f elpa2nix-install-package \
+              "$archive" "$out/share/emacs/site-lisp/elpa"
 
-        runHook postInstall
-      '';
+          runHook postInstall
+        '';
 
-    meta = {
-      homepage = args.src.meta.homepage or "https://melpa.org/#/${pname}";
-    } // meta;
-  }
+      meta = {
+        homepage = args.src.meta.homepage or "https://melpa.org/#/${pname}";
+      } // meta;
+    };
 
-)
+}

--- a/pkgs/applications/editors/emacs/build-support/trivial.nix
+++ b/pkgs/applications/editors/emacs/build-support/trivial.nix
@@ -2,40 +2,38 @@
 
 { callPackage, lib, ... }@envargs:
 
-let
-  libBuildHelper = import ./lib-build-helper.nix;
-in
+lib.extendMkDerivation {
+  constructDrv = callPackage ./generic.nix envargs;
+  extendDrvArgs =
+    finalAttrs:
 
-libBuildHelper.extendMkDerivation' (callPackage ./generic.nix envargs) (
-  finalAttrs:
+    args:
 
-  args:
+    {
+      buildPhase =
+        args.buildPhase or ''
+          runHook preBuild
 
-  {
-    buildPhase =
-      args.buildPhase or ''
-        runHook preBuild
+          # This is modified from stdenv buildPhase. foundMakefile is used in stdenv checkPhase.
+          if [[ ! ( -z "''${makeFlags-}" && -z "''${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ) ]]; then
+            foundMakefile=1
+          fi
 
-        # This is modified from stdenv buildPhase. foundMakefile is used in stdenv checkPhase.
-        if [[ ! ( -z "''${makeFlags-}" && -z "''${makefile:-}" && ! ( -e Makefile || -e makefile || -e GNUmakefile ) ) ]]; then
-          foundMakefile=1
-        fi
+          emacs -l package -f package-initialize -L . --batch -f batch-byte-compile *.el
 
-        emacs -l package -f package-initialize -L . --batch -f batch-byte-compile *.el
+          runHook postBuild
+        '';
 
-        runHook postBuild
-      '';
+      installPhase =
+        args.installPhase or ''
+          runHook preInstall
 
-    installPhase =
-      args.installPhase or ''
-        runHook preInstall
+          LISPDIR=$out/share/emacs/site-lisp
+          install -d $LISPDIR
+          install *.el *.elc $LISPDIR
 
-        LISPDIR=$out/share/emacs/site-lisp
-        install -d $LISPDIR
-        install *.el *.elc $LISPDIR
+          runHook postInstall
+        '';
+    };
 
-        runHook postInstall
-      '';
-  }
-
-)
+}


### PR DESCRIPTION
This causes 0 rebuilds.

Unfortunately, diff has quite low signal-to-noise ratio due to formatting.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
