### PR TITLE
nixos/fex: init module

### DIFF
--- a/nixos/doc/manual/release-notes/rl-2605.section.md
+++ b/nixos/doc/manual/release-notes/rl-2605.section.md
@@ -106,6 +106,8 @@
 
 - [Dawarich](https://dawarich.app/), a self-hostable location history tracker. Available as [services.dawarich](#opt-services.dawarich.enable).
 
+- [FEX](https://github.com/FEX-Emu/FEX), a fast x86 emulator. Available as [virtualisation.fex](#opt-virtualisation.fex.enable).
+
 - [Howdy](https://github.com/boltgolt/howdy), a Windows Hello™ style facial authentication program for Linux.
 
 - [linux-enable-ir-emitter](https://github.com/EmixamPP/linux-enable-ir-emitter), a tool used to set up IR cameras, used with Howdy.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1998,6 +1998,7 @@
   ./virtualisation/docker-rootless.nix
   ./virtualisation/docker.nix
   ./virtualisation/ecs-agent.nix
+  ./virtualisation/fex.nix
   ./virtualisation/hyperv-guest.nix
   ./virtualisation/incus-agent.nix
   ./virtualisation/incus.nix

--- a/nixos/modules/virtualisation/fex.nix
+++ b/nixos/modules/virtualisation/fex.nix
@@ -1,0 +1,493 @@
+{
+  config,
+  pkgs,
+  lib,
+  utils,
+  ...
+}:
+
+let
+  cfg = config.virtualisation.fex;
+
+  common = {
+    # Settings taken from the files in `lib/binfmt.d` of the `fex` package
+    preserveArgvZero = true;
+    openBinary = true;
+    matchCredentials = true;
+    fixBinary = true;
+    offset = 0;
+    interpreter = lib.getExe' cfg.package "FEXInterpreter";
+    wrapInterpreterInShell = false;
+  };
+
+  # Discard string context to avoid pulling in each guest library as a
+  # dependency of the system.
+  mkLibPath' = drv: builtins.unsafeDiscardStringContext (mkLibPath drv);
+  mkLibPath = drv: "${lib.getLib drv}/lib";
+
+  wrapThunk =
+    {
+      name,
+      rpath,
+    }:
+    pkgs.runCommandLocal "fex-host-thunk-${name}"
+      {
+        buildInputs = [ pkgs.patchelf ];
+
+        thunkName = "${name}-host.so";
+        thunkPath = "lib/fex-emu/HostThunks";
+      }
+      ''
+        doPatch() {
+          mkdir -p "$(dirname "$out/$1")"
+          patchelf "$1" --output "$out/$1" --add-rpath "${rpath}"
+        }
+
+        echo "wrapping thunk '${name}'..."
+        pushd "${cfg.package}"
+
+        doPatch "$thunkPath/$thunkName"
+
+        if [ -f "''${thunkPath}_32/$thunkName" ]; then
+          doPatch "''${thunkPath}_32/$thunkName"
+        fi
+      '';
+
+  forwardedLibrarySubmodule = lib.types.submodule (
+    { name, config, ... }:
+    {
+      options = {
+        # TODO: reading back the option names/descriptions, literally *none* of
+        # them make sense, they should all be rewritten
+
+        enable = lib.mkEnableOption "forwarding this library" // {
+          default = true;
+        };
+
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = name;
+          defaultText = "‹name›";
+          description = ''
+            The thunk name of the library to be forwarded.
+            The value "{option}`name`-host.so" will be used as the host thunk
+            name, and "{option}`name`-guest.so" as the guest thunk name.
+          '';
+        };
+
+        packages = lib.mkOption {
+          type = lib.types.functionTo (lib.types.listOf lib.types.package);
+          default = pkgs: [ pkgs.${config.name} ];
+          defaultText = lib.literalExpression "pkgs: [ pkgs.‹name› ]";
+          description = ''
+            Packages to add to both {option}`hostPackages` and
+            {option}`guestPackages`.
+          '';
+        };
+
+        hostPackages = lib.mkOption {
+          type = lib.types.listOf lib.types.package;
+          default = [ ];
+          description = ''
+            The list of host packages that contain this library. These packages
+            will be built, and their library paths (suffixed with `/lib`) will be
+            added as RPATHs to the host thunk.
+          '';
+        };
+
+        extraHostPaths = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = ''
+            Extra list of paths which will be added verbatim as RPATHs to the
+            host thunk.
+          '';
+        };
+
+        guestPackages = lib.mkOption {
+          type = lib.types.functionTo (lib.types.listOf lib.types.package);
+          default = pkgs: [ ];
+          defaultText = lib.literalExpression "pkgs: [ ]";
+          description = ''
+            The list of guest packages that contain this library. These packages
+            will not be built, but their paths (suffixed with {option}`names`)
+            will be redirected at runtime to the guest thunk.
+          '';
+        };
+
+        extraGuestPaths = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = lib.literalExpression ''[ "@PREFIX_LIB@" ]'';
+          description = ''
+            Extra list of prefixes, which will be suffixed with {option}`names`
+            and redirected at runtime to the guest thunk.
+          '';
+        };
+
+        names = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ "${name}.so" ];
+          defaultText = lib.literalExpression ''[ "‹name›.so" ]'';
+          description = ''
+            The possible names of the object file of this library. They will be
+            prefixed with {option}`extraGuestPaths` and {option}`guestPackages`,
+            and the resulting paths will be redirected at runtime to the guest
+            thunk.
+          '';
+        };
+
+        # === private === #
+
+        wrappedThunk = lib.mkOption {
+          type = lib.types.package;
+          visible = false;
+          internal = true;
+          readOnly = true;
+          description = ''
+            The wrapped host thunk for this library.
+          '';
+        };
+
+        overlayPaths = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          visible = false;
+          internal = true;
+          readOnly = true;
+          description = ''
+            The final list of paths to forward to the guest thunk.
+          '';
+        };
+      };
+
+      config =
+        let
+          hostPackages = config.packages pkgs ++ config.hostPackages;
+          hostPaths = lib.map mkLibPath hostPackages ++ config.extraHostPaths;
+          guestPackages = lib.concatMap (
+            set: config.packages set ++ config.guestPackages set
+          ) cfg.guestPackageSets;
+          guestPaths = lib.map mkLibPath' guestPackages ++ config.extraGuestPaths;
+        in
+        {
+          wrappedThunk = wrapThunk {
+            inherit (config) name;
+            rpath = lib.concatStringsSep ":" hostPaths;
+          };
+
+          overlayPaths = lib.map (x: "${x.path}/${x.name}") (
+            lib.cartesianProduct {
+              name = config.names;
+              path = guestPaths;
+            }
+          );
+        };
+    }
+  );
+
+  wrappedHostThunks = pkgs.symlinkJoin {
+    name = "fex-host-thunks";
+    paths = lib.mapAttrsToList (_: library: library.wrappedThunk) cfg.forwardedLibraries;
+  };
+
+  enumSuffixes =
+    base: suffixes:
+    lib.map (x: x.base + x.suffix) (
+      lib.cartesianProduct {
+        base = [ base ];
+        suffix = suffixes ++ [ "" ];
+      }
+    );
+
+  # Fex's config format is not quite JSON, there are some trivial differences,
+  # like they represent booleans as "1" and "0", but also, the way they
+  # represent arrays is by having a repeating key multiple times... So we
+  # basically build each item as JSON and then hand-roll sandwiching them
+  # together.
+
+  convertConfig =
+    attrs:
+    let
+      /**
+        Removes the first and last character of a string. So `{"key":"value"}`
+        becomes `"key":"value"`
+      */
+      strip = str: builtins.substring 1 ((builtins.stringLength str) - 2) str;
+
+      /**
+        Builds a JSON key-value pair like `"key":"value"`
+      */
+      kv = key: value: strip (builtins.toJSON { ${key} = value; });
+
+      /**
+        The main conversion logic
+      */
+      convertValue =
+        key: value:
+        if builtins.isBool value then
+          [ (kv key (if value then "1" else "0")) ]
+        else if builtins.isInt value then
+          [ (kv key (toString value)) ]
+        else if builtins.isList value then
+          builtins.concatMap (convertValue key) value
+        else if builtins.isAttrs value then
+          # Idk how they represent attrs, I don't think anything in the config uses
+          # them.
+          throw "Nested attribute sets are not supported for FEX settings."
+        else
+          [ (kv key "${value}") ];
+
+      kvs = builtins.concatLists (lib.mapAttrsToList convertValue attrs);
+    in
+    "{${lib.concatStringsSep "," kvs}}";
+
+  fexConfig =
+    let
+      main = pkgs.writeTextDir "Config.json" ''
+        {
+          "Config": ${convertConfig cfg.settings},
+          "ThunksDB": ${convertConfig (lib.mapAttrs (_: library: library.enable) cfg.forwardedLibraries)}
+        }
+      '';
+      thunksDB = pkgs.writeTextDir "ThunksDB.json" (
+        builtins.toJSON {
+          DB = lib.mapAttrs (_: library: {
+            Library = "${library.name}-guest.so";
+            Overlay = library.overlayPaths;
+          }) cfg.forwardedLibraries;
+        }
+      );
+      appConfig = pkgs.buildEnv {
+        name = "fex-appconfig";
+        paths = [ "${cfg.package}/share/fex-emu" ];
+        pathsToLink = [ "/AppConfig" ];
+      };
+    in
+    pkgs.symlinkJoin {
+      name = "fex-config";
+      paths = [
+        main
+        thunksDB
+        appConfig
+      ];
+    };
+
+  # TODO clean this up
+
+  guestPaths32 = [
+    "@PREFIX_LIB@"
+    "/lib"
+    "/lib32"
+    "/usr/lib"
+    "/usr/lib32"
+    "/lib/i386-linux-gnu"
+    "/usr/lib/i386-linux-gnu"
+    "/usr/local/lib/i386-linux-gnu"
+    "/usr/lib/pressure-vessel/overrides/lib/i386-linux-gnu"
+  ];
+
+  guestPaths64 = [
+    "@PREFIX_LIB@"
+    "/lib64"
+    "/usr/lib64"
+    "/lib/x86_64-linux-gnu"
+    "/usr/lib/x86_64-linux-gnu"
+    "/usr/local/lib/x86_64-linux-gnu"
+    "/usr/lib/pressure-vessel/overrides/lib/x86_64-linux-gnu"
+  ];
+in
+
+{
+  options.virtualisation.fex = {
+    enable = lib.mkEnableOption "the FEX x86 emulator";
+    package = lib.mkPackageOption pkgs "fex" { };
+
+    addToNixSandbox = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      example = false;
+      description = ''
+        Whether to add FEX to {option}`nix.settings.extra-platforms`. Disable
+        this to use remote builders for x86 platforms, while allowing testing
+        binaries locally.
+      '';
+    };
+
+    guestPackageSets = lib.mkOption {
+      type = lib.types.listOf lib.types.pkgs;
+      default = [
+        pkgs.pkgsCross.gnu32
+        pkgs.pkgsCross.gnu64
+      ];
+      defaultText = lib.literalExpression ''
+        [
+          pkgs.pkgsCross.gnu32
+          pkgs.pkgsCross.gnu64
+        ]
+      '';
+      example = lib.literalExpression ''
+        [
+          nixpkgs.legacyPackages.i686-linux
+          nixpkgs.legacyPackages.x86_64-linux
+        ]
+      '';
+      description = ''
+        The list of package sets used to retrieve library paths from on the
+        guest.
+      '';
+    };
+
+    forwardedLibraries = lib.mkOption {
+      type = lib.types.attrsOf forwardedLibrarySubmodule;
+      default = { };
+      defaultText = "(all libraries supported by FEX)";
+      description = "Guest libraries to forward to host-native versions.";
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.attrsOf (
+        lib.types.oneOf [
+          lib.types.bool
+          lib.types.str
+          lib.types.int
+          (lib.types.listOf (
+            lib.types.oneOf [
+              lib.types.bool
+              lib.types.str
+              lib.types.int
+            ]
+          ))
+        ]
+      );
+      default = { };
+      example = {
+        SilentLog = false;
+        OutputLog = "stderr";
+      };
+      description = ''
+        Settings to add to the FEX configuration.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = lib.singleton {
+      assertion = pkgs.stdenv.hostPlatform.isAarch64;
+      message = "FEX emulation is only supported on aarch64.";
+    };
+
+    # TODO split lib paths in FEX package so unwrapped host thunks don't get put in path
+    environment.systemPackages = [ cfg.package ];
+    boot.binfmt.registrations = {
+      "FEX-x86" = common // utils.binfmtMagics.i386-linux;
+      "FEX-x86_64" = common // utils.binfmtMagics.x86_64-linux;
+    };
+
+    # for steam to work - the steam runtime is like a container or something
+    # and has its own /etc so putting the config in /etc/fex-emu won't work
+    environment.sessionVariables = {
+      FEX_APP_CONFIG_LOCATION = "${fexConfig}/";
+    };
+
+    virtualisation.fex.settings = {
+      ThunkHostLibs = "${wrappedHostThunks}/lib/fex-emu/HostThunks";
+      ThunkGuestLibs = "${cfg.package}/share/fex-emu/GuestThunks";
+    };
+
+    # Libraries that are forwarded by default. NOTE: added libraries must have
+    # a corresponding `{name}-{host,guest}.so` shared object built by FEX. The
+    # below configuration encompasses all such libraries currently in FEX.
+    virtualisation.fex.forwardedLibraries = {
+      GL = {
+        name = "libGL";
+        names = enumSuffixes "libGL.so" [
+          ".1"
+          ".1.2.0"
+          ".1.7.0"
+        ];
+        extraHostPaths = [ "/run/opengl-driver/lib" ];
+        extraGuestPaths = guestPaths32 ++ guestPaths64;
+      };
+
+      EGL = {
+        name = "libEGL";
+        packages = pkgs: [ pkgs.libglvnd ];
+        names = enumSuffixes "libEGL.so" [
+          ".1"
+          ".1.1.0"
+        ];
+        extraHostPaths = [ "/run/opengl-driver/lib" ];
+        extraGuestPaths = guestPaths32 ++ guestPaths64;
+      };
+
+      Vulkan = {
+        name = "libvulkan";
+        packages = pkgs: [ pkgs.vulkan-loader ];
+        names = enumSuffixes "libvulkan.so" [
+          ".1"
+          ".1.3.239"
+          ".1.4.313"
+          ".1.4.341"
+        ];
+        hostPackages = with pkgs; [
+          libx11
+          libxcb
+          libxrandr
+          libxrender
+          xorgproto
+        ];
+        extraHostPaths = [ "/run/opengl-driver/lib" ];
+        extraGuestPaths = guestPaths64;
+      };
+
+      drm = {
+        name = "libdrm";
+        names = enumSuffixes "libdrm.so" [
+          ".2"
+          ".2.4.0"
+          ".2.124.0"
+        ];
+        extraGuestPaths = guestPaths64;
+      };
+
+      asound = {
+        # TODO: this breaks steam
+        enable = lib.mkDefault false;
+        name = "libasound";
+        packages = pkgs: [ pkgs.alsa-lib ];
+        names = enumSuffixes "libasound.so" [
+          ".2"
+          ".2.0.0"
+        ];
+        extraGuestPaths = guestPaths64;
+      };
+
+      WaylandClient = {
+        name = "libwayland-client";
+        packages = pkgs: [ pkgs.wayland ];
+        names = enumSuffixes "libwayland-client.so" [
+          ".0"
+          ".0.3.0"
+          ".0.20.0"
+          ".0.24.0"
+        ];
+        extraGuestPaths = guestPaths32 ++ guestPaths64;
+      };
+    };
+
+    nix.settings = lib.mkIf cfg.addToNixSandbox {
+      extra-platforms = [
+        "x86_64-linux"
+        "i386-linux"
+      ];
+      extra-sandbox-paths = [
+        "/run/binfmt"
+        "${cfg.package}"
+        "${wrappedHostThunks}"
+      ]
+      ++ lib.mapAttrsToList (_: library: "${library.wrappedThunk}") cfg.forwardedLibraries;
+    };
+  };
+
+  meta.maintainers = with lib.maintainers; [ andre4ik3 ];
+}

--- a/pkgs/by-name/fe/fex/package.nix
+++ b/pkgs/by-name/fe/fex/package.nix
@@ -14,6 +14,7 @@
   range-v3,
   catch2_3,
   nasm,
+  withLibraryForwarding ? true,
   buildEnv,
   writeText,
   pkgsCross,
@@ -48,55 +49,73 @@ let
 
   pkgsCross32 = pkgsCross.gnu32;
   pkgsCross64 = pkgsCross.gnu64;
-  devRootFS = buildEnv {
-    name = "fex-dev-rootfs";
-    paths = [
-      pkgsCross64.stdenv.cc.libc_dev
-      pkgsCross32.stdenv.cc.libc_dev
-      pkgsCross64.stdenv.cc.cc
-      pkgsCross32.stdenv.cc.cc
-    ]
-    ++ libForwardingInputs;
-    ignoreCollisions = true;
-    pathsToLink = [
-      "/include"
-      "/lib"
-    ];
 
-    postBuild = ''
-      mkdir -p $out/usr
-      ln -s $out/include $out/usr/
+  devRootFS =
+    let
+      mkRoot =
+        pkgs:
+        buildEnv {
+          name = "fex-dev-rootfs-${pkgs.buildPackages.stdenv.targetPlatform.parsed.cpu.name}";
+          paths = with pkgs.stdenv.cc; [
+            cc
+            cc.lib
+            libc_dev
+          ];
+          pathsToLink = [
+            "/include"
+            "/lib"
+          ];
+        };
+
+      root32 = mkRoot pkgsCross32;
+      root64 = mkRoot pkgsCross64;
+      includes = buildEnv {
+        name = "fex-dev-rootfs-include";
+        paths = libForwardingInputs;
+        pathsToLink = [ "/include" ];
+        ignoreCollisions = true;
+      };
+    in
+    buildEnv {
+      name = "fex-dev-rootfs";
+      paths = [
+        root32
+        root64
+        includes
+      ];
+      ignoreCollisions = true;
+      pathsToLink = [
+        "/include"
+        "/lib"
+      ];
+      postBuild = ''
+        mkdir -p $out/usr
+        ln -s $out/include $out/usr/
+      '';
+    };
+
+  mkToolchain =
+    {
+      pkgs,
+      extraFlags ? "",
+    }:
+    let
+      arch = pkgs.stdenv.targetPlatform.parsed.cpu.name; # i686 or x86_64
+      platform = pkgs.stdenv.targetPlatform.config; # i686-unknown-linux-gnu or x86_64-unknown-linux-gnu
+    in
+    writeText "fex-thunk-toolchain-${arch}.txt" ''
+      set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+      set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
+      set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld -lstdc++")
+      set(CMAKE_SYSTEM_PROCESSOR ${arch})
+      set(CMAKE_C_COMPILER ${pkgs.clang}/bin/${platform}-clang)
+      set(CMAKE_CXX_COMPILER ${pkgs.clang}/bin/${platform}-clang++)
+      set(CLANG_FLAGS "-nodefaultlibs -nostartfiles -target ${platform} ${extraFlags} --sysroot=${devRootFS} -iwithsysroot/usr/include")
+      set(CMAKE_C_FLAGS "''${CMAKE_C_FLAGS} ''${CLANG_FLAGS}")
+      set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} ''${CLANG_FLAGS}")
     '';
-  };
-
-  toolchain32 = writeText "toolchain_nix_x86_32.txt" ''
-    set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
-    set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
-    set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
-    set(CMAKE_SYSTEM_PROCESSOR i686)
-    set(CMAKE_C_COMPILER clang)
-    set(CMAKE_CXX_COMPILER clang++)
-    set(CMAKE_C_COMPILER ${pkgsCross32.buildPackages.clang}/bin/i686-unknown-linux-gnu-clang)
-    set(CMAKE_CXX_COMPILER ${pkgsCross32.buildPackages.clang}/bin/i686-unknown-linux-gnu-clang++)
-    set(CLANG_FLAGS "-nodefaultlibs -nostartfiles -target i686-linux-gnu -msse2 -mfpmath=sse --sysroot=${devRootFS} -iwithsysroot/usr/include")
-    set(CMAKE_C_FLAGS "''${CMAKE_C_FLAGS} ''${CLANG_FLAGS}")
-    set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} ''${CLANG_FLAGS}")
-  '';
-
-  toolchain = writeText "toolchain_nix_x86_64.txt" ''
-    set(CMAKE_EXE_LINKER_FLAGS_INIT "-fuse-ld=lld")
-    set(CMAKE_MODULE_LINKER_FLAGS_INIT "-fuse-ld=lld")
-    set(CMAKE_SHARED_LINKER_FLAGS_INIT "-fuse-ld=lld")
-    set(CMAKE_SYSTEM_PROCESSOR x86_64)
-    set(CMAKE_C_COMPILER clang)
-    set(CMAKE_CXX_COMPILER clang++)
-    set(CMAKE_C_COMPILER ${pkgsCross64.buildPackages.clang}/bin/x86_64-unknown-linux-gnu-clang)
-    set(CMAKE_CXX_COMPILER ${pkgsCross64.buildPackages.clang}/bin/x86_64-unknown-linux-gnu-clang++)
-    set(CLANG_FLAGS "-nodefaultlibs -nostartfiles -target x86_64-linux-gnu --sysroot=${devRootFS} -iwithsysroot/usr/include")
-    set(CMAKE_C_FLAGS "''${CMAKE_C_FLAGS} ''${CLANG_FLAGS}")
-    set(CMAKE_CXX_FLAGS "''${CMAKE_CXX_FLAGS} ''${CLANG_FLAGS}")
-  '';
 in
+
 llvmPackages.stdenv.mkDerivation (finalAttrs: {
   pname = "fex";
   version = "2604";
@@ -143,7 +162,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     # Add include paths for thunkgen invocation
     substituteInPlace ThunkLibs/HostLibs/CMakeLists.txt \
       --replace-fail "-- " "-- $(cat ${llvmPackages.stdenv.cc}/nix-support/libc-cflags) $(cat ${llvmPackages.stdenv.cc}/nix-support/libcxx-cxxflags) ${
-        lib.concatMapStrings (x: "-isystem " + x + "/include ") libForwardingInputs
+        lib.concatMapStrings (x: "-isystem ${x}/include ") libForwardingInputs
       }"
     substituteInPlace ThunkLibs/GuestLibs/CMakeLists.txt \
       --replace-fail "-- " "-- $(cat ${llvmPackages.stdenv.cc}/nix-support/libcxx-cxxflags) "
@@ -152,23 +171,6 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     substituteInPlace FEXCore/Scripts/config_generator.py \
       --replace-fail ".Dd {0}" ".Dd" \
       --replace-fail "output_man.write(header.format(" "output_man.write(header) #"
-
-    # Patch any references to library wrapper paths
-    substituteInPlace FEXCore/Source/Interface/Config/Config.json.in \
-      --replace-fail "ThunkGuestLibs" "UnusedThunkGuestLibs" \
-      --replace-fail "ThunkHostLibs" "UnusedThunkHostLibs"
-    substituteInPlace FEXCore/Source/Interface/Config/Config.cpp \
-      --replace-fail "FEXCore::Config::CONFIG_THUNKGUESTLIBS" "FEXCore::Config::CONFIG_UNUSEDTHUNKGUESTLIBS" \
-      --replace-fail "FEXCore::Config::CONFIG_THUNKHOSTLIBS" "FEXCore::Config::CONFIG_UNUSEDTHUNKHOSTLIBS"
-    substituteInPlace Source/Tools/LinuxEmulation/VDSO_Emulation.cpp \
-      --replace-fail "FEX_CONFIG_OPT(ThunkGuestLibs, THUNKGUESTLIBS);" "auto ThunkGuestLibs = []() { return \"$out/share/fex-emu/GuestThunks/\"; };"
-    substituteInPlace Source/Tools/LinuxEmulation/LinuxSyscalls/FileManagement.h \
-      --replace-fail "FEX_CONFIG_OPT(ThunkGuestLibs, THUNKGUESTLIBS);" "fextl::string ThunkGuestLibs() { return \"$out/share/fex-emu/GuestThunks/\"; }"
-    substituteInPlace Source/Tools/LinuxEmulation/Thunks.cpp \
-      --replace-fail "FEX_CONFIG_OPT(ThunkHostLibsPath, THUNKHOSTLIBS);" "fextl::string ThunkHostLibsPath() { return \"$out/lib/fex-emu/HostThunks/\"; }"
-    substituteInPlace Source/Tools/FEXConfig/main.qml \
-      --replace-fail "config: \"Thunk" "config: \"UnusedThunk" \
-      --replace-fail "title: qsTr(\"Library forwarding:\")" "visible: false; title: qsTr(\"Library forwarding:\")"
 
     # Temporarily disable failing tests. TODO: investigate the root cause of these failures
     rm \
@@ -197,12 +199,16 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
     libxml2
     openssl
     range-v3
-    pkgsCross64.buildPackages.clang
-    pkgsCross32.buildPackages.clang
-    libclang
-    libllvm
   ]
-  ++ libForwardingInputs
+  ++ lib.optionals withLibraryForwarding (
+    [
+      pkgsCross64.buildPackages.clang
+      pkgsCross32.buildPackages.clang
+      libclang
+      libllvm
+    ]
+    ++ libForwardingInputs
+  )
   ++ lib.optionals withQt [
     qt6.qtbase
     qt6.qtdeclarative
@@ -211,10 +217,17 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   cmakeFlags = [
     (lib.cmakeFeature "USE_LINKER" "lld")
     (lib.cmakeFeature "OVERRIDE_VERSION" finalAttrs.version)
-    (lib.cmakeBool "BUILD_THUNKS" true)
     (lib.cmakeBool "BUILD_FEXCONFIG" withQt)
-    (lib.cmakeFeature "X86_32_TOOLCHAIN_FILE" "${toolchain32}")
-    (lib.cmakeFeature "X86_64_TOOLCHAIN_FILE" "${toolchain}")
+  ]
+  ++ lib.optionals withLibraryForwarding [
+    (lib.cmakeBool "BUILD_THUNKS" true)
+    (lib.cmakeFeature "X86_32_TOOLCHAIN_FILE" "${mkToolchain {
+      pkgs = pkgsCross32.buildPackages;
+      extraFlags = "-msse2 -mfpmath=sse";
+    }}")
+    (lib.cmakeFeature "X86_64_TOOLCHAIN_FILE" "${mkToolchain {
+      pkgs = pkgsCross64.buildPackages;
+    }}")
     (lib.cmakeFeature "X86_DEV_ROOTFS" "${devRootFS}")
   ];
 
@@ -256,6 +269,7 @@ llvmPackages.stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
+    inherit devRootFS;
     updateScript = nix-update-script { };
   };
 


### PR DESCRIPTION
This adds a simple FEX module to NixOS, allowing emulation of x86 or x86_64 binaries on aarch64 hosts. It supports library forwarding by wrapping thunks at build-time with the required dependencies. With this module, it's possible to run x86 binaries by using the following:

```
virtualisation.fex.enable = true;
```

It's also possible to build x86 packages using FEX:

```
virtualisation.fex.addToNixSandbox = true;
```

Since the FEX module uses some of the same magics as in the binfmt support of NixOS, I also moved those out of `binfmt.nix` into `binary-magics.json` in the same folder, in order to reuse it in the FEX module.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
