### PR TITLE
Rename c3-lsp binary to c3lsp

### DIFF
--- a/pkgs/by-name/c3/c3-lsp/package.nix
+++ b/pkgs/by-name/c3/c3-lsp/package.nix
@@ -20,7 +20,7 @@ buildGoModule rec {
   vendorHash = "sha256-eT+Qirl0R1+di3JvXxggGK/nK9+nqw+8QEur+ldJXSc=";
 
   postInstall = ''
-    mv $out/bin/lsp $out/bin/c3-lsp
+    mv $out/bin/lsp $out/bin/c3lsp
   '';
 
   meta = {
@@ -29,7 +29,7 @@ buildGoModule rec {
     changelog = "https://github.com/pherrymason/c3-lsp/blob/${src.rev}/changelog.md";
     license = lib.licenses.gpl3Only;
     maintainers = with lib.maintainers; [ arthsmn ];
-    mainProgram = "c3-lsp";
+    mainProgram = "c3lsp";
     platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
Renamed c3-lsp binary to c3lsp (see https://github.com/pherrymason/c3-lsp/issues/115#issuecomment-2635919660). I'm not sure if a symlink for backwards compatibility should be included, as some tools may still reference `c3-lsp`.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).