### PR TITLE
git-wait: init at 0.4.0-unstable-2024-12-01

### DIFF
--- a/pkgs/by-name/gi/git-wait/package.nix
+++ b/pkgs/by-name/gi/git-wait/package.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  stdenv,
+  darwin,
+  git,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "git-wait";
+  version = "0.4.0-unstable-2024-12-01";
+
+  src = fetchFromGitHub {
+    owner = "darshanparajuli";
+    repo = "git-wait";
+    # no tags upstream
+    rev = "1d610f694dd1cd4a0970e97b886053ffc7c76244";
+    hash = "sha256-Va917eD9M3oUVmLrDab6cx/LvmBlk95U4mRHqPpBB5I=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-tA0WjghBB2K71IlZ1u9K67tZWGe9VNFOfI2YdrqCUw0=";
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.CoreServices
+  ];
+
+  checkFlags = lib.optionals stdenv.hostPlatform.isDarwin [
+    "--skip=tests::wait_if_index_lock_is_present"
+  ];
+
+  # versionCheckHook is too complex to use here
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ git ];
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    stdout=$(set -x; $out/bin/git-wait -v 2>&1)
+    if ! grep <<<"$stdout" -q ${lib.escapeShellArg git.version}; then
+      >&2 echo "ERROR: version check failed!" ${lib.escapeShellArg git.version} "was not found."
+      >&2 echo "Output was"
+      >&2 echo "$stdout"
+    fi
+
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "A simple git wrapper that waits until index.lock file is removed when present before running the command";
+    homepage = "https://github.com/darshanparajuli/git-wait";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ pbsds ];
+    mainProgram = "git-wait";
+  };
+}


### PR DESCRIPTION
https://github.com/darshanparajuli/git-wait

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
