### PR TITLE
python312Packages.mariadb: add missing propagated build input

### DIFF
--- a/pkgs/development/python-modules/mariadb/default.nix
+++ b/pkgs/development/python-modules/mariadb/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   libmysqlclient,
+  packaging,
   lib,
   pythonOlder,
   setuptools,
@@ -28,6 +29,10 @@ buildPythonPackage rec {
   ];
 
   buildInputs = [ libmysqlclient ];
+
+  dependencies = [
+    packaging # do not rely on pythonImportsCheck when removing, it pulls in build-system dependencies
+  ];
 
   # Requires a running MariaDB instance
   doCheck = false;


### PR DESCRIPTION
## Things done
Adds `propagatedBuildInputs = [ packaging ];` to the mariadb python package.

This was missing so far, e.g.:
```
➜ nix shell --expr '(builtins.getFlake 
  "github:NixOS/nixpkgs/730c3a8ddf044683369f6184e47a23431f19823d")
  .legacyPackages.x86_64-linux.python3.withPackages (ps: [ps.mariadb])
  ' -c python -c "import mariadb"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/nix/store/3bd4a5qp01xbakb62f9bn3d9mgdvkn7q-python3-3.12.8-env/lib/python3.12/site-packages/mariadb/__init__.py", line 29, in <module>
    from mariadb.connections import Connection
  File "/nix/store/3bd4a5qp01xbakb62f9bn3d9mgdvkn7q-python3-3.12.8-env/lib/python3.12/site-packages/mariadb/connections.py", line 25, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

I'm not entirely sure why this wasn't discovered by the `pythonImportsCheck`, but most likely it's because `packaging` is a dependency of `setup-tools`, so it's available during the check, but not propagated when building an env.

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
