### PR TITLE
polylux2pdfpc: 0.3.1 -> 0.4.0

### DIFF
--- a/pkgs/by-name/po/polylux2pdfpc/package.nix
+++ b/pkgs/by-name/po/polylux2pdfpc/package.nix
@@ -13,7 +13,7 @@ rustPlatform.buildRustPackage rec {
   version = "0.4.0";
 
   src = fetchFromGitHub {
-    owner = "andreasKroepelin";
+    owner = "polylux-typ";
     repo = "polylux";
     rev = "v${version}";
     sparseCheckout = [ dirname ];
@@ -28,7 +28,7 @@ rustPlatform.buildRustPackage rec {
 
   meta = with lib; {
     description = "Tool to make pdfpc interpret slides created by polylux correctly";
-    homepage = "https://github.com/andreasKroepelin/polylux/tree/main/pdfpc-extractor";
+    homepage = "https://github.com/polylux-typ/polylux/tree/main/pdfpc-extractor";
     license = licenses.mit;
     mainProgram = "polylux2pdfpc";
     maintainers = [ maintainers.diogotcorreia ];

--- a/pkgs/by-name/po/polylux2pdfpc/package.nix
+++ b/pkgs/by-name/po/polylux2pdfpc/package.nix
@@ -10,14 +10,14 @@ let
 in
 rustPlatform.buildRustPackage rec {
   pname = "polylux2pdfpc";
-  version = "0.3.1";
+  version = "0.4.0";
 
   src = fetchFromGitHub {
     owner = "andreasKroepelin";
     repo = "polylux";
     rev = "v${version}";
     sparseCheckout = [ dirname ];
-    hash = "sha256-GefX7XsUfOMCp2THstSizRGpKAoq7yquVukWQjGuFgc=";
+    hash = "sha256-41FgRejonvVTmE89WGm0Cqumm8lb6kkfxtkWV74UKJA=";
   };
   sourceRoot = "${src.name}/${dirname}";
 


### PR DESCRIPTION
[Nothing new](https://github.com/NixOS/nixpkgs/pull/379583#issuecomment-2636568974) in this specific crate, but upstream has bumped version.
https://github.com/polylux-typ/polylux/releases/tag/v0.4.0

Also, upstream has moved the repository to a GitHub org, so I've updated `owner` and links accordingly.

Closes #379583

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
