### PR TITLE
tparted: init at 2025-01-24

### DIFF
--- a/pkgs/by-name/tp/tparted/package.nix
+++ b/pkgs/by-name/tp/tparted/package.nix
@@ -1,0 +1,93 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  parted,
+  util-linux,
+  dosfstools,
+  exfatprogs,
+  e2fsprogs,
+  ntfs3g,
+  btrfs-progs,
+  xfsprogs,
+  jfsutils,
+  f2fs-tools,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "tparted";
+  version = "2025-01-24";
+
+  src = fetchurl {
+    url = "https://github.com/Kagamma/tparted/releases/download/${finalAttrs.version}/linux_x86-64_tparted_${finalAttrs.version}.tar.gz";
+    hash = "sha256-7V3bdsP4uqZ5zyw3j/s8fhMYFCyQ1Rz5Z1JiPFc1oFY=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  postFixup = ''
+    wrapProgram $out/bin/tparted \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          parted
+          util-linux
+          dosfstools
+          exfatprogs
+          e2fsprogs
+          ntfs3g
+          btrfs-progs
+          xfsprogs
+          jfsutils
+          f2fs-tools
+        ]
+      }
+  '';
+
+  runtimeDependencies = [
+    parted
+    util-linux
+    dosfstools
+    exfatprogs
+    e2fsprogs
+    ntfs3g
+    btrfs-progs
+    xfsprogs
+    jfsutils
+    f2fs-tools
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    tar xf $src
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    cp tparted $out/bin/
+    mkdir -p $out/opt/tparted
+    cp -r locale $out/opt/tparted/
+    runHook postInstall
+  '';
+
+  passthru = {
+    updateScript = nix-update-script { };
+  };
+
+  meta = {
+    description = "Text-based user interface (TUI) frontend for parted";
+    homepage = "https://github.com/Kagamma/tparted";
+    changelog = "https://github.com/Kagamma/tparted/releases/tag/${finalAttrs.version}";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ liberodark ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    mainProgram = "tparted";
+  };
+})


### PR DESCRIPTION
Fix : https://github.com/NixOS/nixpkgs/issues/379408

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
