### PR TITLE
Unbork journals audit logs and introduce audit option

### DIFF
--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -116,6 +116,8 @@ in
         "syslog.socket"
       ];
 
+    systemd.sockets.systemd-journald-audit.wantedBy = [ "systemd-journald.service" "sockets.target" ];
+
     environment.etc = {
       "systemd/journald.conf".text = ''
         [Journal]

--- a/nixos/modules/system/boot/systemd/journald.nix
+++ b/nixos/modules/system/boot/systemd/journald.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  utils,
   ...
 }:
 let
@@ -78,6 +79,23 @@ in
       '';
     };
 
+    services.journald.audit = lib.mkOption {
+      default = null;
+      type = lib.types.nullOr lib.types.bool;
+      description = ''
+        If enabled systemd-journald will turn on auditing on start-up.
+        If disabled it will turn it off. If unset it will neither enable nor disable it, leaving the previous state unchanged.
+
+        NixOS defaults to leaving this unset as enabling audit without auditd running leads to spamming /dev/kmesg with random messages
+        and if you enable auditd then auditd is responsible for turning auditing on.
+
+        If you want to have audit logs in journald and do not mind audit logs also ending up in /dev/kmesg you can set this option to true.
+
+        If you want to for some ununderstandable reason disable auditing if auditd enabled it then you can set this option to false.
+        It is of NixOS' opinion that setting this to false is definitely the wrong thing to do - but it's an option.
+      '';
+    };
+
     services.journald.extraConfig = lib.mkOption {
       default = "";
       type = lib.types.lines;
@@ -116,7 +134,10 @@ in
         "syslog.socket"
       ];
 
-    systemd.sockets.systemd-journald-audit.wantedBy = [ "systemd-journald.service" "sockets.target" ];
+    systemd.sockets.systemd-journald-audit.wantedBy = [
+      "systemd-journald.service"
+      "sockets.target"
+    ];
 
     environment.etc = {
       "systemd/journald.conf".text = ''
@@ -131,6 +152,7 @@ in
         ${lib.optionalString (cfg.forwardToSyslog) ''
           ForwardToSyslog=yes
         ''}
+        Audit=${utils.systemdUtils.lib.toOption cfg.audit}
         ${cfg.extraConfig}
       '';
     };

--- a/nixos/tests/systemd-journal.nix
+++ b/nixos/tests/systemd-journal.nix
@@ -7,12 +7,49 @@ import ./make-test-python.nix (
       maintainers = [ lewo ];
     };
 
-    nodes.machine = { };
+    nodes.machine = {
+      environment.systemPackages = [ pkgs.audit ];
+    };
+    nodes.auditd = {
+      security.auditd.enable = true;
+      environment.systemPackages = [ pkgs.audit ];
+    };
+    nodes.journaldAudit = {
+      services.journald.audit = true;
+      environment.systemPackages = [ pkgs.audit ];
+    };
 
     testScript = ''
       machine.wait_for_unit("multi-user.target")
-
       machine.succeed("journalctl --grep=systemd")
+
+      with subtest("no audit messages"):
+        machine.fail("journalctl _TRANSPORT=audit --grep 'unit=systemd-journald'")
+        machine.fail("journalctl _TRANSPORT=kernel --grep 'unit=systemd-journald'")
+
+      with subtest("auditd enabled"):
+        auditd.wait_for_unit("multi-user.target")
+
+        # logs should end up in the journald
+        auditd.succeed("journalctl _TRANSPORT=audit --grep 'unit=systemd-journald'")
+        # logs should end up in the auditd audit log
+        auditd.succeed("grep 'unit=systemd-journald' /var/log/audit/audit.log")
+        # logs should not end up in kmesg
+        machine.fail("journalctl _TRANSPORT=kernel --grep 'unit=systemd-journald'")
+
+
+      with subtest("journald audit"):
+        journaldAudit.wait_for_unit("multi-user.target")
+
+        # logs should end up in the journald
+        journaldAudit.succeed("journalctl _TRANSPORT=audit --grep 'unit=systemd-journald'")
+        # logs should NOT end up in audit log
+        journaldAudit.fail("grep 'unit=systemd-journald' /var/log/audit/audit.log")
+        # FIXME: If systemd fixes #15324 this test will start failing.
+        # You can fix this text by removing the below line.
+        # logs ideally should NOT end up in kmesg, but they do due to
+        # https://github.com/systemd/systemd/issues/15324
+        journaldAudit.succeed("journalctl _TRANSPORT=kernel --grep 'unit=systemd-journald'")
     '';
   }
 )


### PR DESCRIPTION
This was broken due to https://github.com/systemd/systemd/pull/25687
but we never noticed.

introduce audit option:

We default this option to null ; which is different from upstream which defaults this to true.

Defaulting this to true leads to log-spam in /dev/kmesg and thus in our opinion is a bad default https://github.com/systemd/systemd/issues/15324

This means that this PR by default doesn't change any behavior. By default no audit logs are shipped to journald.

However, audit logs **are** shipped to journald if yo either enable `security.auditd.enable` or if you enable `services.journald.audit = true;`.  In the second case you do run into the bug of also spamming `/dev/kmesg` but that's not our bug. Hence not defaulting to true.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
