### PR TITLE
rustc: use `targetPlatform` to detect `pkgsLLVM`, unbreak with LLVM and musl

### DIFF
--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -421,10 +421,13 @@ stdenv.mkDerivation (finalAttrs: {
     # If rustc can't target a platform, we also can't build rustc for
     # that platform.
     badPlatforms = rustc.badTargetPlatforms;
-    # Builds, but can't actually compile anything
+    # `-gnu` ABI targets do not support partial GNU userlands like `pkgsLLVM`, only `-musl` ABI targets do
+    # https://github.com/rust-lang/rust/issues/119504#issuecomment-1873544519
+    #
+    # It *can* still build, but it won't actually compile anything
     # https://github.com/NixOS/nixpkgs/issues/311930
     # https://github.com/rust-lang/rust/issues/55120
     # https://github.com/rust-lang/rust/issues/82521
-    broken = stdenv.targetPlatform.useLLVM;
+    broken = stdenv.targetPlatform.useLLVM && stdenv.targetPlatform.libc != "musl";
   };
 })

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -353,7 +353,7 @@ stdenv.mkDerivation (finalAttrs: {
       zlib
     ]
     ++ optional (!withBundledLLVM) llvmShared.lib
-    ++ optional (useLLVM && !withBundledLLVM && !stdenv.targetPlatform.isFreeBSD) [
+    ++ optionals (useLLVM && !withBundledLLVM && !stdenv.targetPlatform.isFreeBSD) [
       llvmPackages.libunwind
       # Hack which is used upstream https://github.com/gentoo/gentoo/blob/master/dev-lang/rust/rust-1.78.0.ebuild#L284
       (runCommandLocal "libunwind-libgcc" { } ''

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -425,6 +425,6 @@ stdenv.mkDerivation (finalAttrs: {
     # https://github.com/NixOS/nixpkgs/issues/311930
     # https://github.com/rust-lang/rust/issues/55120
     # https://github.com/rust-lang/rust/issues/82521
-    broken = stdenv.hostPlatform.useLLVM;
+    broken = stdenv.targetPlatform.useLLVM;
   };
 })

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -11,7 +11,6 @@
   llvmSharedForHost,
   llvmSharedForTarget,
   llvmPackages,
-  runCommandLocal,
   fetchurl,
   file,
   python3,
@@ -355,12 +354,6 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optional (!withBundledLLVM) llvmShared.lib
     ++ optionals (useLLVM && !withBundledLLVM && !stdenv.targetPlatform.isFreeBSD) [
       llvmPackages.libunwind
-      # Hack which is used upstream https://github.com/gentoo/gentoo/blob/master/dev-lang/rust/rust-1.78.0.ebuild#L284
-      (runCommandLocal "libunwind-libgcc" { } ''
-        mkdir -p $out/lib
-        ln -s ${llvmPackages.libunwind}/lib/libunwind.so $out/lib/libgcc_s.so
-        ln -s ${llvmPackages.libunwind}/lib/libunwind.so $out/lib/libgcc_s.so.1
-      '')
     ];
 
   outputs = [


### PR DESCRIPTION
Pseudo-alternative to https://github.com/NixOS/nixpkgs/pull/330037

Following https://github.com/NixOS/nixpkgs/pull/376988, it seems `pkgsLLVM.pkgsMusl` and similar combinations work as expected! This has led me to do a bit of testing based on [this](https://github.com/rust-lang/rust/issues/119504) comment from a Rust developer on using LLVM/libunwind:

> Systems without a GNU userland shouldn't use the *-linux-unknown-gnu toolchains, which explicitly require a GNU userland. Your supposed to use *-linux-unknown-musl.

Sure enough after a little tweaking, `pkgsLLVM.pkgsMusl.rustc` appears to be fully functional :)

Tested against https://github.com/NixOS/nixpkgs/pull/375030 and with the following:

```
> nix build -f . pkgsLLVM.pkgsMusl.rustc.unwrapped.tests.{fd.tests,ripgrep} --print-out-paths
/nix/store/mlbxa62xnyq1sbdvhnxxvsaspcgpbql7-fd-x86_64-unknown-linux-musl-10.2.0-test-version
/nix/store/axbmix7qmp670xllvny8w9s4xiyfw46f-ripgrep-x86_64-unknown-linux-musl-14.1.1
```

We should of course continue looking for ways to get `pkgsLLVM` alone to build `rustc` properly, but hopefully this can hold us over until a solution is found

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
