### PR TITLE
buildPythonPackage: redirect pre/postCheck to pre/postInstallCheck

### DIFF
--- a/doc/release-notes/rl-2611.section.md
+++ b/doc/release-notes/rl-2611.section.md
@@ -40,6 +40,28 @@
 
 - `databricks-cli` has been updated from `0.290.2` to `1.x.x`, the first major release. OAuth tokens for interactive logins (`auth_type = databricks-cli`) are now stored in the OS-native secure store by default (Secret Service on Linux) instead of `~/.databricks/token-cache.json`; cached tokens from older versions are not migrated, so run `databricks auth login` once per profile after upgrading. To keep the previous file-backed storage, set `DATABRICKS_AUTH_STORAGE=plaintext` or add `auth_storage = plaintext` under `[__settings__]` in `~/.databrickscfg`. Additionally, the `vector_search_endpoints` DABs resource renamed `min_qps` to `target_qps` (and the `vector-search-endpoints` command renamed `--min-qps` to `--target-qps`). See the [upstream changelog](https://github.com/databricks/cli/blob/main/CHANGELOG.md) for details.
 
+- `python3Packages.buildPythonPackage` and `python3Packages.buildPythonApplication` are moving toward direct specification of `installCheck` attributes, away from the historical check-to-installCheck mapping.
+  This enforces the attribute correctness of `finalAttrs`.
+
+  We provide best-effort compatibility that doesn't contradict with the goal of attribute correctness, but the compatibility behaviours would be removed in future releases.
+  The compatibility layer currently does the following:
+  - Append all `check` arguments to the `installCheck` argumenst when passing the `installCheck` attributes, with the exception for `doCheck` and `checkPhase`.
+  - Run `preCheckHooks` after `preInstallCheck` (and `preInstallCheckHooks`); the same applies to `postCheckHooks`.
+  - When `checkPhase` is specified instead of `installCheckPhase`, replace its `runHook preCheck` and `runHook postCheck` with proper `installCheck` values and pass as `installCheckPhase`.
+
+    When both `installCheckPhase` and `checkPhase` is specified, warn and take only `installCheckPhase`.
+
+  Other backward incompatibility worth noticing:
+  - Hooks aiming to provide defalut installCheckPhase commands for `buildPythonPackage`/`buildPythonApplication` -constructed packages
+    should now provide themself as a default value of `installCheckHook`,
+    and should `runHook preInstallCheck` instead of `runHook preCheck`.
+    The in-tree test hooks `pytestCheckHook` and `unittestCheckHook` has been converted as stated.
+  - As test commands in `pytestCheckHook` and `unittestCheckHook` now runs as `installCheckPhase` instead of one of the `preDistPhases`.
+  This shifts their execution forward.
+
+  Package and hook authors should make sure not to pollute the environment for later-executed commands.
+  For example, [arbitrary locale changes break Sphinx document generation](https://github.com/NixOS/nixpkgs/pull/383766), as `sphinxHook` is now executed after `pytestCheckHook`.
+
 - `hurl` has been updated to `8.x.x` which has some breaking changes. See [upstream changelog](https://github.com/Orange-OpenSource/hurl/releases/tag/8.0.0) for details.
 
 - The existing `wasm32-wasi` target has become `wasm32-wasip1` and `pkgsCross.wasi32` has become `pkgsCross.wasm32-wasip1`, aligning with LLVM's nomenclature. Aliases are in place and old forms will continue to be parsed but there might be some breakage if you're relying on the exact form of these (e.g., in sysroot paths).

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -96,5 +96,5 @@ EOF
 
 if [ -z "${dontUsePytestCheck-}" ] && [ -z "${installCheckPhase-}" ]; then
     echo "Using pytestCheckPhase"
-    appendToVar preDistPhases pytestCheckPhase
+    installCheckPhase=pytestCheckPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/pytest-check-hook.sh
@@ -22,7 +22,7 @@ function _pytestIncludeExcludeExpr() {
 
 function pytestCheckPhase() {
     echo "Executing pytestCheckPhase"
-    runHook preCheck
+    runHook preInstallCheck
 
     # Compose arguments
     local -a flagsArray=(-m pytest)
@@ -90,7 +90,7 @@ EOF
     echoCmd 'pytest flags' "${flagsArray[@]}"
     @pythonCheckInterpreter@ "${flagsArray[@]}"
 
-    runHook postCheck
+    runHook postInstallCheck
     echo "Finished executing pytestCheckPhase"
 }
 

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -22,5 +22,5 @@ unittestCheckPhase() {
 
 if [[ -z "${dontUseUnittestCheck-}" ]] && [[ -z "${installCheckPhase-}" ]]; then
     echo "Using unittestCheckPhase"
-    appendToVar preDistPhases unittestCheckPhase
+    installCheckPhase=unittestCheckPhase
 fi

--- a/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
+++ b/pkgs/development/interpreters/python/hooks/unittest-check-hook.sh
@@ -5,7 +5,7 @@ echo "Sourcing unittest-check-hook"
 
 unittestCheckPhase() {
     echo "Executing unittestCheckPhase"
-    runHook preCheck
+    runHook preInstallCheck
 
     local -a flagsArray=()
 
@@ -16,7 +16,7 @@ unittestCheckPhase() {
     echoCmd 'unittest flags' "${flagsArray[@]}"
     @pythonCheckInterpreter@ -m unittest discover "${flagsArray[@]}"
 
-    runHook postCheck
+    runHook postInstallCheck
     echo "Finished executing unittestCheckPhase"
 }
 

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -102,6 +102,8 @@ let
   cleanAttrs = flip removeAttrs [
     "disabled"
     "checkPhase"
+    "preCheck"
+    "postCheck"
     "checkInputs"
     "nativeCheckInputs"
     "doCheck"
@@ -433,7 +435,17 @@ let
     // optionalAttrs (attrs ? checkPhase) {
       # If given use the specified checkPhase, otherwise use the setup hook.
       # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-      installCheckPhase = attrs.checkPhase;
+      installCheckPhase =
+        lib.replaceStrings
+          [ "runHook preCheck\n" "runHook postCheck\n" ]
+          [ "runHook preInstallCheck\n" "runHook postInstallCheck\n" ]
+          attrs.checkPhase;
+    }
+    // optionalAttrs (attrs ? preCheck) {
+      preInstallCheck = attrs.preInstallCheck or attrs.preCheck;
+    }
+    // optionalAttrs (attrs ? postCheck) {
+      postInstallCheck = attrs.postInstallCheck or attrs.postCheck;
     }
     //
       lib.mapAttrs

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -120,7 +120,6 @@ lib.extendMkDerivation {
     "checkInputs"
     "nativeCheckInputs"
     "doCheck"
-    "doInstallCheck"
     "pyproject"
     "format"
     "stdenv"
@@ -142,7 +141,7 @@ lib.extendMkDerivation {
       buildInputs ? [ ],
 
       # Dependencies needed for running the checkPhase.
-      # These are added to buildInputs when doCheck = true.
+      # These are added to buildInputs when doInstallCheck = true.
       checkInputs ? [ ],
       nativeCheckInputs ? [ ],
 
@@ -210,7 +209,7 @@ lib.extendMkDerivation {
 
       meta ? { },
 
-      doCheck ? true,
+      doInstallCheck ? true,
 
       ...
     }@attrs:
@@ -402,7 +401,21 @@ lib.extendMkDerivation {
 
       # Python packages don't have a checkPhase, only an installCheckPhase
       doCheck = false;
-      doInstallCheck = attrs.doCheck or true;
+      doInstallCheck =
+        if attrs ? doCheck then
+          if attrs ? doInstallCheck then
+            let
+              pos = lib.unsafeGetAttrPos "doCheck" attrs;
+            in
+            lib.warn ''
+              buildPythonPackage: $name: Both doInstallCheck and doCheck specified, taking only `doInstallCheck`.
+                The check -> installCheck mapping is being deprecated in favour of specifying the installCheck arguments.
+                At ${pos.file}:${toString pos.line}
+            '' doInstallCheck
+          else
+            attrs.doCheck
+        else
+          doInstallCheck;
       nativeInstallCheckInputs = nativeCheckInputs ++ attrs.nativeInstallCheckInputs or [ ];
       installCheckInputs = checkInputs ++ attrs.installCheckInputs or [ ];
 
@@ -448,19 +461,19 @@ lib.extendMkDerivation {
       # If given use the specified checkPhase, otherwise use the setup hook.
       # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
       installCheckPhase =
-        if lib.defaultTo "" args.checkPhase or null != "" then
-          if lib.defaultTo "" args.installCheckPhase or null != "" then
+        if lib.defaultTo "" attrs.checkPhase or null != "" then
+          if lib.defaultTo "" attrs.installCheckPhase or null != "" then
             lib.warn ''
               buildPythonPackgae: Both `installCheckPhase` and `checkPhase` are specified, taking only `installCheckPhase`.
                 The check -> installCheck mapping is being deprecated in favour of specifying the installCheck arguments.
-            '' args.installCheckPhase
+            '' attrs.installCheckPhase
           else
             lib.replaceStrings
               [ "runHook preCheck\n" "runHook postCheck\n" ]
               [ "runHook preInstallCheck\n" "runHook postInstallCheck\n" ]
               (lib.defaultTo "" attrs.checkPhase or null)
         else
-          lib.defaultTo "" args.installCheckPhase or null;
+          lib.defaultTo "" attrs.installCheckPhase or null;
       preInstallCheck =
         appendToNonEmptyString "\n" (lib.defaultTo "" attrs.preCheck or null)
         + lib.defaultTo "" attrs.preInstallCheck or null

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -104,6 +104,9 @@ let
   bootstrappedRuntimeDepsCheckHook = pythonRuntimeDepsCheckHook.override {
     inherit (python.pythonOnBuildForHost.pkgs.bootstrap) packaging;
   };
+
+  appendToNonEmptyString =
+    prefix: string: if lib.isString string && string != "" then prefix + string else string;
 in
 
 lib.extendMkDerivation {
@@ -112,6 +115,8 @@ lib.extendMkDerivation {
   excludeDrvArgNames = [
     "disabled"
     "checkPhase"
+    "preCheck"
+    "postCheck"
     "checkInputs"
     "nativeCheckInputs"
     "doCheck"
@@ -440,11 +445,38 @@ lib.extendMkDerivation {
         isBuildPythonPackage = python.meta.platforms;
       }
       // meta;
-    }
-    // optionalAttrs (attrs ? checkPhase) {
       # If given use the specified checkPhase, otherwise use the setup hook.
       # Longer-term we should get rid of `checkPhase` and use `installCheckPhase`.
-      installCheckPhase = attrs.checkPhase;
+      installCheckPhase =
+        if lib.defaultTo "" args.checkPhase or null != "" then
+          if lib.defaultTo "" args.installCheckPhase or null != "" then
+            lib.warn ''
+              buildPythonPackgae: Both `installCheckPhase` and `checkPhase` are specified, taking only `installCheckPhase`.
+                The check -> installCheck mapping is being deprecated in favour of specifying the installCheck arguments.
+            '' args.installCheckPhase
+          else
+            lib.replaceStrings
+              [ "runHook preCheck\n" "runHook postCheck\n" ]
+              [ "runHook preInstallCheck\n" "runHook postInstallCheck\n" ]
+              (lib.defaultTo "" attrs.checkPhase or null)
+        else
+          lib.defaultTo "" args.installCheckPhase or null;
+      preInstallCheck =
+        appendToNonEmptyString "\n" (lib.defaultTo "" attrs.preCheck or null)
+        + lib.defaultTo "" attrs.preInstallCheck or null
+        # Backward compatibility to user-defined preCheckHooks
+        # TODO(@ShamrockLee): Remove after Nixpkgs 26.05 EOL.
+        + ''
+          runHook preCheck
+        '';
+      postInstallCheck =
+        appendToNonEmptyString "\n" (lib.defaultTo "" attrs.postCheck or null)
+        + lib.defaultTo "" attrs.postInstallCheck or null
+        # Backward compatibility to user-defined postCheckHooks
+        # TODO(@ShamrockLee): Remove after Nixpkgs 26.05 EOL.
+        + ''
+          runHook postCheck
+        '';
     }
     // (
       let


### PR DESCRIPTION
This PR unifies the <pkg>.overrideAttrs interface for Python packages regarding `preInstallCheck` and `postInstallCheck` in a compatible way.

- Specify preInstallCheck/postInstallCheck as preCheck/postCheck if the latter is not specified.
- Use preInstallCheck/postInstallCheck in buildPython* setup hooks.
- When the checkPhase argument is specified, replace `runHook pre/postCheck` with `runHook pre/postInstallCheck` before assigning it to `installCheckPhase`.

After this change, `pytestCheckPhase` now precedes `sphinxBuildPhase` if both invoked, and locale changes left by `pytestCheckPhase` could trigger Sphinx's failure (sphinx-doc/sphinx#11739) (despite the topic of the linked issue, the error also occurs on Linux). As a result, this PR depends on a treewide locale cleanup:
-  #383766

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
