### PR TITLE
rustc: use more complete meta.platforms list when doing cross compilation

### DIFF
--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -119,6 +119,7 @@ rec {
         "armv6l-netbsd"
         "mipsel-netbsd"
         "riscv64-netbsd"
+        "x86_64-none"
         "x86_64-redox"
         "wasm32-wasi"
       ];

--- a/pkgs/development/compilers/rust/binary.nix
+++ b/pkgs/development/compilers/rust/binary.nix
@@ -75,7 +75,8 @@ rec {
     passthru = rec {
       tier1TargetPlatforms = [
         # Platforms with host tools from
-        # https://doc.rust-lang.org/nightly/rustc/platform-support.html
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-1-with-host-tools
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2-with-host-tools
         "x86_64-darwin"
         "i686-darwin"
         "aarch64-darwin"
@@ -104,7 +105,8 @@ rec {
       ];
       targetPlatforms = tier1TargetPlatforms ++ [
         # Platforms without host tools from
-        # https://doc.rust-lang.org/nightly/rustc/platform-support.html
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-2-without-host-tools
+        # https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-3
         "armv7a-darwin"
         "armv5tel-linux"
         "armv7a-linux"

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -417,7 +417,12 @@ stdenv.mkDerivation (finalAttrs: {
       licenses.mit
       licenses.asl20
     ];
-    platforms = rustc.tier1TargetPlatforms;
+    # if we do cross compilation, we can target platforms with no host compiler support, too
+    platforms =
+      if (stdenv.buildPlatform != stdenv.hostPlatform) then
+        rustc.targetPlatforms
+      else
+        rustc.tier1TargetPlatforms;
     # If rustc can't target a platform, we also can't build rustc for
     # that platform.
     badPlatforms = rustc.badTargetPlatforms;


### PR DESCRIPTION
Before building rust-hypervisor-firmware failed like:

```
 ➜ nix eval -f. rust-hypervisor-firmware
...
...
       error: Package ‘rust-hypervisor-firmware-0.4.2’ in nixpkgs/pkgs/applications/virtualization/rust-hypervisor-firmware/default.nix:60 is not available on the requested hostPlatform:
         hostPlatform.config = "x86_64-elf"
         package.meta.platforms = [ ]
         package.meta.badPlatforms = [
           {
             abi = {
               abi = "n32";
             };
             cpu = {
               bits = 64;
               family = "mips";
             };
           }
         ]
       , refusing to evaluate.

       a) To temporarily allow packages that are unsupported for this system, you can use an environment variable
          for a single invocation of the nix tools.

            $ export NIXPKGS_ALLOW_UNSUPPORTED_SYSTEM=1

          Note: When using `nix shell`, `nix build`, `nix develop`, etc with a flake,
                then pass `--impure` in order to allow use of environment variables.

       b) For `nixos-rebuild` you can set
         { nixpkgs.config.allowUnsupportedSystem = true; }
       in configuration.nix to override this.

       c) For `nix-env`, `nix-build`, `nix-shell` or any other Nix command you can add
         { allowUnsupportedSystem = true; }
       to ~/.config/nixpkgs/config.nix.
```



with this change it can be compiled properly:

```
 ➜ nix eval -f. rust-hypervisor-firmware
/nix/store/b0hlzbvj8wyrpxavb1jxww6c4v674wsa-rust-hypervisor-firmware-x86_64-elf-0.4.2.drv
```

Motivated by #377247

cc @astro 

Reviewer note: to successful test this you must cherry-pick #378694

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
