### PR TITLE
gdk-pixbuf: fix static

### DIFF
--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation (finalAttrs: {
   patches = [
     # Move installed tests to a separate output
     ./installed-tests-path.patch
+
+    ./static-deps.patch
+    ./static-lerc.patch
   ];
 
   # gdk-pixbuf-thumbnailer is not wrapped therefore strictDeps will work
@@ -88,12 +91,16 @@ stdenv.mkDerivation (finalAttrs: {
     libpng
   ];
 
-  mesonFlags = [
-    "-Dgio_sniffing=false"
-    (lib.mesonBool "gtk_doc" withIntrospection)
-    (lib.mesonEnable "introspection" withIntrospection)
-    (lib.mesonEnable "others" true)
-  ];
+  mesonFlags =
+    [
+      "-Dgio_sniffing=false"
+      (lib.mesonBool "gtk_doc" withIntrospection)
+      (lib.mesonEnable "introspection" withIntrospection)
+      (lib.mesonEnable "others" true)
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isStatic [
+      "-Dbuiltin_loaders=all"
+    ];
 
   postPatch = ''
     chmod +x build-aux/* # patchShebangs only applies to executables

--- a/pkgs/development/libraries/gdk-pixbuf/static-deps.patch
+++ b/pkgs/development/libraries/gdk-pixbuf/static-deps.patch
@@ -1,0 +1,31 @@
+From 1b7cac1cbdb7078f575a3222be451a9bf1ac35ec Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Wed, 31 Jan 2024 15:33:02 +0100
+Subject: [PATCH] build: add missing dependency to gdkpixbuf_dep
+
+This should match the dependencies passed to the library() call that
+creates gdkpixbuf.  Otherwise, linking the gdkpixbuf_bin executables
+will fail if -Ddefault_library=static, because static libraries don't
+carry dependency information themselves.
+---
+Link: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/161
+
+ gdk-pixbuf/meson.build | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gdk-pixbuf/meson.build b/gdk-pixbuf/meson.build
+index a11926eee..450484d68 100644
+--- a/gdk-pixbuf/meson.build
++++ b/gdk-pixbuf/meson.build
+@@ -269,7 +269,7 @@ endif
+ gdkpixbuf_dep = declare_dependency(
+   link_with: gdkpixbuf,
+   include_directories: root_inc,
+-  dependencies: gdk_pixbuf_deps,
++  dependencies: [ gdk_pixbuf_deps, included_loaders_deps ],
+   sources: [ gdkpixbuf_enum_h, built_girs ],
+ )
+ meson.override_dependency('gdk-pixbuf-2.0', gdkpixbuf_dep)
+-- 
+GitLab
+

--- a/pkgs/development/libraries/gdk-pixbuf/static-lerc.patch
+++ b/pkgs/development/libraries/gdk-pixbuf/static-lerc.patch
@@ -1,0 +1,79 @@
+From 3bca69d889fe545dda4ed9a8fab8ff3fe38ba487 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Wed, 5 Feb 2025 19:37:27 +0100
+Subject: [PATCH] build: fix linking with libtiff with lerc support
+
+Lerc is written in C++.  When C and C++ objects are linked, a C++
+linker should be used to ensure C++-specific things are correctly
+handled.  See e.g. this comment in the Meson source for reference[1].
+One symptom of using a C linker to link with C++ objects is that
+libstdc++ won't be linked when building static executables, causing
+link failures.
+
+Unfortunately, Meson does not know whether dependencies found by
+pkg-config are C++, and therefore require a C++ linker, so we have to
+tell it ourselves to use a C++ linker.  There's no way to check
+whether libtiff is built with Lerc support, so we always use a C++
+linker if one is available and libtiff support is enabled.  If a C++
+linker ends up being used to link only C objects, it shouldn't do any
+harm.
+
+[1]: https://github.com/mesonbuild/meson/blob/9fd5281befe7881c9d1210c9e6865382bc0f2b08/mesonbuild/build.py#L1558-L1565
+---
+Link: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/merge_requests/181
+
+ gdk-pixbuf/meson.build | 6 ++++++
+ meson.build            | 6 ++++++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/gdk-pixbuf/meson.build b/gdk-pixbuf/meson.build
+index 570625bfe..5cc11355f 100644
+--- a/gdk-pixbuf/meson.build
++++ b/gdk-pixbuf/meson.build
+@@ -333,6 +333,11 @@ gdkpixbuf_bin = [
+   [ 'gdk-pixbuf-query-loaders', [ 'queryloaders.c' ] ],
+ ]
+ 
++bin_link_language = 'c'
++if loaders_cpp
++  bin_link_language = 'cpp'
++endif
++
+ foreach bin: gdkpixbuf_bin
+   bin_name = bin[0]
+   bin_source = bin.get(1, bin_name + '.c')
+@@ -342,6 +347,7 @@ foreach bin: gdkpixbuf_bin
+                    dependencies: gdk_pixbuf_deps + [ gdkpixbuf_dep ],
+                    include_directories: [ root_inc, gdk_pixbuf_inc ],
+                    c_args: common_cflags + gdk_pixbuf_cflags,
++                   link_language : bin_link_language,
+                    install: true)
+   meson.override_find_program(bin_name, bin)
+ 
+diff --git a/meson.build b/meson.build
+index f0d4812f4..31b3197fc 100644
+--- a/meson.build
++++ b/meson.build
+@@ -345,6 +345,8 @@ endif
+ 
+ # Don't check and build the tiff loader if native_windows_loaders is true
+ tiff_opt = get_option('tiff')
++tiff_dep = dependency('', required: false)
++loaders_cpp = false
+ if not tiff_opt.disabled() and not native_windows_loaders
+   # We currently don't have a fallback subproject, but this handles error
+   # reporting if tiff_opt is enabled.
+@@ -353,6 +355,10 @@ if not tiff_opt.disabled() and not native_windows_loaders
+   if tiff_dep.found()
+     enabled_loaders += 'tiff'
+     loaders_deps += tiff_dep
++
++    # If libtiff is built with LERC support, it should be linked with
++    # a C++ linker.
++    loaders_cpp = loaders_cpp or add_languages('cpp', required: false, native: false)
+   endif
+ endif
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
We're unfortunately going to have to patch here, because an equivalent of static-deps.patch has been submitted upstream at least 3 times at this point, but these merge requests have all been ignored for more than a year.  I have submitted static-lerc.patch upstream as well, but I'm not holding out hope…


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
