### PR TITLE
Certmgr fixes

### DIFF
--- a/nixos/modules/services/cluster/kubernetes/pki.nix
+++ b/nixos/modules/services/cluster/kubernetes/pki.nix
@@ -148,6 +148,18 @@ in
         address = "0.0.0.0";
         tlsCert = cfsslCert;
         tlsKey = cfsslKey;
+        disable = lib.concatStringsSep "," [
+          "bundle"
+          "certinfo"
+          "crl"
+          "health"
+          "init_ca"
+          "newcert"
+          "newkey"
+          "revoke"
+          "scan"
+          "scaninfo"
+        ];
         configFile = toString (
           pkgs.writeText "cfssl-config.json" (
             builtins.toJSON {

--- a/nixos/modules/services/security/certmgr.nix
+++ b/nixos/modules/services/security/certmgr.nix
@@ -48,7 +48,7 @@ in
 
     defaultRemote = lib.mkOption {
       type = lib.types.str;
-      default = "127.0.0.1:8888";
+      default = "http://127.0.0.1:8888";
       description = "The default CA host:port to use.";
     };
 

--- a/nixos/tests/certmgr.nix
+++ b/nixos/tests/certmgr.nix
@@ -36,8 +36,7 @@ let
           owner = "nginx";
           path = "/var/ssl/${host}-ca.pem";
         };
-        label = "www_ca";
-        profile = "three-month";
+        profile = "default";
         remote = "localhost:8888";
         auth_key_file = toString authKey;
       };
@@ -168,7 +167,12 @@ let
 
             systemd.services.nginx.wantedBy = lib.mkForce [ ];
 
-            systemd.services.certmgr.after = [ "cfssl.service" ];
+            systemd.services.certmgr.after = [
+              "cfssl.service"
+              # make sure nginx starts up first so we can check that certmgr
+              # restarts it
+              "nginx.service"
+            ];
             services.certmgr = {
               enable = true;
               inherit svcManager;

--- a/pkgs/by-name/ce/certmgr/package.nix
+++ b/pkgs/by-name/ce/certmgr/package.nix
@@ -16,6 +16,10 @@ buildGoModule rec {
     hash = "sha256-MgNPU06bv31tdfUnigcmct8UTVztNLXcmTg3H/J7mic=";
   };
 
+  patches = [
+    ./uri-san.patch
+  ];
+
   vendorHash = null;
 
   ldflags = [

--- a/pkgs/by-name/ce/certmgr/uri-san.patch
+++ b/pkgs/by-name/ce/certmgr/uri-san.patch
@@ -1,0 +1,52 @@
+commit 5c77efdad3f260eeb72431aab99470168249ec1b
+Author: Thomas Dy <thatsmydoing@gmail.com>
+Date:   Tue Feb 4 20:00:46 2025 +0900
+
+    Support certificates using URI SANs
+    
+    URI SANs were silently being stripped and that caused the certs to
+    always be out of sync.
+    
+    The cfssl code was fixed in https://github.com/cloudflare/cfssl/commit/763faa7f5632a49d4d40eb2c282c33ad352e23a6
+
+diff --git a/cert/verification.go b/cert/verification.go
+index 39f255c..baee7d9 100644
+--- a/cert/verification.go
++++ b/cert/verification.go
+@@ -20,11 +20,14 @@ func CertificateMatchesHostname(hosts []string, cert *x509.Certificate) bool {
+ 			a[idx] = ip.String()
+ 		}
+ 	}
+-	b := make([]string, len(cert.DNSNames), len(cert.DNSNames)+len(cert.IPAddresses))
++	b := make([]string, len(cert.DNSNames), len(cert.DNSNames)+len(cert.IPAddresses)+len(cert.URIs))
+ 	copy(b, cert.DNSNames)
+ 	for idx := range cert.IPAddresses {
+ 		b = append(b, cert.IPAddresses[idx].String())
+ 	}
++	for idx := range cert.URIs {
++		b = append(b, cert.URIs[idx].String())
++	}
+ 
+ 	if len(a) != len(b) {
+ 		return false
+diff --git a/vendor/github.com/cloudflare/cfssl/transport/ca/cfssl_provider.go b/vendor/github.com/cloudflare/cfssl/transport/ca/cfssl_provider.go
+index 8541855..421559d 100644
+--- a/vendor/github.com/cloudflare/cfssl/transport/ca/cfssl_provider.go
++++ b/vendor/github.com/cloudflare/cfssl/transport/ca/cfssl_provider.go
+@@ -206,12 +206,15 @@ func (cap *CFSSL) SignCSR(csrPEM []byte) (cert []byte, err error) {
+ 		return nil, err
+ 	}
+ 
+-	hosts := make([]string, len(csr.DNSNames), len(csr.DNSNames)+len(csr.IPAddresses))
++	hosts := make([]string, len(csr.DNSNames), len(csr.DNSNames)+len(csr.IPAddresses)+len(csr.URIs))
+ 	copy(hosts, csr.DNSNames)
+ 
+ 	for i := range csr.IPAddresses {
+ 		hosts = append(hosts, csr.IPAddresses[i].String())
+ 	}
++	for i := range csr.URIs {
++		hosts = append(hosts, csr.URIs[i].String())
++	}
+ 
+ 	sreq := &signer.SignRequest{
+ 		Hosts:   hosts,


### PR DESCRIPTION
This PR generally fixes some issues we've run into with cfssl / certmgr with kubernetes.

1. ~Add a `disable` option to `cfssl`~ https://github.com/NixOS/nixpkgs/pull/393943
2. Disable insecure `cfssl` endpoints when used with kubernetes `easyCerts`
3. Add a patch to fix `certmgr` restarting various kubernetes components every 30m
4. ~Fix the `cfssl` and `certmgr` nixos tests~ https://github.com/NixOS/nixpkgs/pull/435141

cfssl / certmgr haven't had a new release in recent years. The github repos are somewhat updated but I wouldn't really say they're active projects. Given the amount of gotchas with them it would be nice to replace them with something nicer. That said, migrating an `easyCerts` deployment to whatever new thing sounds like it would be painful and I don't really have time to go work on it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [X] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [X] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests)) - I tested `certmgr` and `kubernetes`
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [X] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
