### PR TITLE
gamja: v1.0.0-beta.9 -> v1.0.0-beta.10

### DIFF
--- a/pkgs/by-name/ga/gamja/package.nix
+++ b/pkgs/by-name/ga/gamja/package.nix
@@ -1,23 +1,24 @@
 {
   lib,
-  fetchFromSourcehut,
+  fetchFromGitea,
   buildNpmPackage,
   writeText,
-  # https://git.sr.ht/~emersion/gamja/tree/master/doc/config-file.md
+  # https://codeberg.org/emersion/gamja/src/branch/master/doc/config-file.md
   gamjaConfig ? null,
 }:
 buildNpmPackage rec {
   pname = "gamja";
-  version = "1.0.0-beta.9";
+  version = "1.0.0-beta.10";
 
-  src = fetchFromSourcehut {
-    owner = "~emersion";
+  src = fetchFromGitea {
+    domain = "codeberg.org";
+    owner = "emersion";
     repo = "gamja";
     rev = "v${version}";
-    hash = "sha256-09rCj9oMzldRrxMGH4rUnQ6wugfhfmJP3rHET5b+NC8=";
+    hash = "sha256-JqnEiPnYRGSeIZm34Guu7MgMfwcySc42aTXweMqL8BQ=";
   };
 
-  npmDepsHash = "sha256-LxShwZacCctKAfMNCUMyrSaI1hIVN80Wseq/d8WITkc=";
+  npmDepsHash = "sha256-dAfbluNNBF1e9oagej+SRxO/YffCdLLAUUgt8krnWvg=";
 
   installPhase = ''
     runHook preInstall


### PR DESCRIPTION
The old upstream[1] has a note that it has moved to codeberg. Move the source and bump the version.

[1]: https://git.sr.ht/~emersion/gamja/commit/32012bbea536eff9eea393ec1d66b048e4bbf024#README.md

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


Also tested on my own gamja instance. Works as expected, I didn't even need to re-login. The interface is just nicer. :)