### PR TITLE
pinball: 0.3.20201218 -> 0.3.20201218-unstable-2024-11-14

### DIFF
--- a/pkgs/by-name/pi/pinball/package.nix
+++ b/pkgs/by-name/pi/pinball/package.nix
@@ -1,23 +1,26 @@
 {
   lib,
   stdenv,
-  fetchurl,
+  fetchFromGitHub,
   autoreconfHook,
   pkg-config,
   libglvnd,
-  SDL,
-  SDL_image,
-  SDL_mixer,
+  libtool,
+  SDL2,
+  SDL2_image,
+  SDL2_mixer,
   xorg,
 }:
 
 stdenv.mkDerivation rec {
   pname = "pinball";
-  version = "0.3.20201218";
+  version = "0.3.20201218-unstable-2024-11-14";
 
-  src = fetchurl {
-    url = "mirror://sourceforge/pinball/pinball-${version}.tar.gz";
-    sha256 = "0vacypp3ksq1hs6hxpypx7nrfkprbl4ksfywcncckwrh4qcir631";
+  src = fetchFromGitHub {
+    owner = "adoptware";
+    repo = "pinball";
+    rev = "7f6887d8912340c0eee7f96b4c4bb84c8d889246";
+    hash = "sha256-8wuux7eC0OkgL/m20eyRGRrAF1lBGAbd7Gmid9cNPto=";
   };
 
   postPatch = ''
@@ -30,26 +33,23 @@ stdenv.mkDerivation rec {
   ];
   buildInputs = [
     libglvnd
-    SDL
-    SDL_image
-    SDL_mixer
+    libtool
+    SDL2
+    SDL2_image
+    SDL2_mixer
     xorg.libSM
   ];
   strictDeps = true;
 
-  configureFlags = [
-    "--with-sdl-prefix=${lib.getDev SDL}"
-  ];
-
   env.NIX_CFLAGS_COMPILE = toString [
-    "-I${lib.getDev SDL_image}/include/SDL"
-    "-I${lib.getDev SDL_mixer}/include/SDL"
+    "-I${lib.getDev SDL2_image}/include/SDL2"
+    "-I${lib.getDev SDL2_mixer}/include/SDL2"
   ];
 
   enableParallelBuilding = true;
 
   meta = with lib; {
-    homepage = "https://purl.org/rzr/pinball";
+    homepage = "https://github.com/adoptware/pinball";
     description = "Emilia Pinball simulator";
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ qyliss ];


### PR DESCRIPTION
Fixes build, and uses modern SDL.  Source repo and homepage are updated to GitHub repo linked from the old Sourceforge one.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
