### PR TITLE
freeipa: 4.12.1 -> 4.12.3

### DIFF
--- a/pkgs/os-specific/linux/freeipa/default.nix
+++ b/pkgs/os-specific/linux/freeipa/default.nix
@@ -189,7 +189,10 @@ stdenv.mkDerivation rec {
     '';
     homepage = "https://www.freeipa.org/";
     license = licenses.gpl3Plus;
-    maintainers = [ maintainers.s1341 ];
+    maintainers = with maintainers; [
+      s1341
+      benley
+    ];
     platforms = platforms.linux;
     mainProgram = "ipa";
   };

--- a/pkgs/os-specific/linux/freeipa/default.nix
+++ b/pkgs/os-specific/linux/freeipa/default.nix
@@ -2,6 +2,7 @@
   stdenv,
   lib,
   fetchurl,
+  fetchpatch,
   pkg-config,
   autoconf,
   automake,
@@ -34,6 +35,7 @@
   lesscpy,
   jansson,
   runtimeShell,
+  versionCheckHook,
 }:
 
 let
@@ -66,12 +68,25 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "freeipa";
-  version = "4.12.1";
+  version = "4.12.3";
 
   src = fetchurl {
     url = "https://releases.pagure.org/freeipa/freeipa-${version}.tar.gz";
-    sha256 = "sha256-SPZ+QgssDKG1Hz1oqtVdg864qtcvncuOlzTWjN4+loM=";
+    sha256 = "sha256-bVttsyn99DX01CmthIxzxuJPGgqZB2+pgamviO4LBJI=";
   };
+
+  patches = [
+    (fetchpatch {
+      name = "support-pyca-44.0";
+      url = "https://github.com/freeipa/freeipa/pull/7619/commits/2dc4133920fe58ce414c545102c74173d40d1997.patch";
+      hash = "sha256-PROnPc/1qS3hcO8s5sel55tsyZ1VPjEKLcua8Pd4DP0=";
+    })
+    (fetchpatch {
+      name = "fix-tripledes-cipher-warnings";
+      url = "https://github.com/freeipa/freeipa/pull/7619/commits/e2bf6e4091c7b5320ec6387dab2d5cabe4a9a42d.patch";
+      hash = "sha256-AyMK0hjXMrFK4/qIcjPMFH9DKvnvYOK2QS83Otcc+l4=";
+    })
+  ];
 
   nativeBuildInputs = [
     python3.pkgs.wrapPython
@@ -155,6 +170,13 @@ stdenv.mkDerivation rec {
     wrapPythonPrograms
     rm -rf $out/etc/ipa $out/var/lib/ipa-client/sysrestore
   '';
+
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgram = "${placeholder "out"}/bin/${meta.mainProgram}";
+  versionCheckProgramArg = "--version";
+  doInstallCheck = true;
 
   meta = with lib; {
     description = "Identity, Policy and Audit system";


### PR DESCRIPTION
freeipa 4.12.1 was broken in unstable due to incompatibility with
cryptography 44.0.

## Things done

- Version bump
- Add required patches (merged upstream, but not in a release yet) for
  cryptography and PyCA 44.0
- Add versionCheckHook so we catch similar breakage in the future
- Add benley to maintainers

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
