### PR TITLE
nixos/gnome/gcr-ssh-agent: init

### DIFF
--- a/doc/release-notes/rl-2511.section.md
+++ b/doc/release-notes/rl-2511.section.md
@@ -17,6 +17,8 @@
 
 - `base16-builder` node package has been removed due to lack of upstream maintenance.
 
+- `gnome-keyring` no longer ships with an SSH agent anymore because it has been deprecated upstream. You should use `gcr_4` instead, which provides the same features. More information on why this was done can be found on [the relevant GCR upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67).
+
 ## Other Notable Changes {#sec-nixpkgs-release-25.11-notable-changes}
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->

--- a/nixos/doc/manual/release-notes/rl-2511.section.md
+++ b/nixos/doc/manual/release-notes/rl-2511.section.md
@@ -38,3 +38,5 @@
 
 - `amdgpu` kernel driver overdrive mode can now be enabled by setting [hardware.amdgpu.overdrive.enable](#opt-hardware.amdgpu.overdrive.enable) and customized through [hardware.amdgpu.overdrive.ppfeaturemask](#opt-hardware.amdgpu.overdrive.ppfeaturemask).
   This allows for fine-grained control over the GPU's performance and maybe required by overclocking softwares like Corectrl and Lact. These new options replace old options such as {option}`programs.corectrl.gpuOverclock.enable` and {option}`programs.tuxclocker.enableAMD`.
+
+- [](#opt-services.gnome.gnome-keyring.enable) does not ship with an SSH agent anymore, as this is now handled by the `gcr_4` package instead of `gnome-keyring`. A new module has been added to support this, under [](#opt-services.gnome.gcr-ssh-agent.enable) (its default value has been set to [](#opt-services.gnome.gnome-keyring.enable) to ensure a smooth transition). See the [relevant upstream PR](https://gitlab.gnome.org/GNOME/gcr/-/merge_requests/67) for more details.

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -547,6 +547,7 @@
   ./services/desktops/geoclue2.nix
   ./services/desktops/gnome/at-spi2-core.nix
   ./services/desktops/gnome/evolution-data-server.nix
+  ./services/desktops/gnome/gcr-ssh-agent.nix
   ./services/desktops/gnome/glib-networking.nix
   ./services/desktops/gnome/gnome-browser-connector.nix
   ./services/desktops/gnome/gnome-initial-setup.nix

--- a/nixos/modules/services/desktop-managers/gnome.nix
+++ b/nixos/modules/services/desktop-managers/gnome.nix
@@ -327,6 +327,7 @@ in
       services.gnome.at-spi2-core.enable = true;
       services.gnome.evolution-data-server.enable = true;
       services.gnome.gnome-keyring.enable = true;
+      services.gnome.gcr-ssh-agent.enable = mkDefault true;
       services.gnome.gnome-online-accounts.enable = mkDefault true;
       services.gnome.localsearch.enable = mkDefault true;
       services.gnome.tinysparql.enable = mkDefault true;

--- a/nixos/modules/services/desktops/gnome/gcr-ssh-agent.nix
+++ b/nixos/modules/services/desktops/gnome/gcr-ssh-agent.nix
@@ -1,0 +1,49 @@
+{
+  config,
+  options,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  cfg = config.services.gnome.gcr-ssh-agent;
+  opts = options.services.gnome.gcr-ssh-agent;
+  sshCfg = config.programs.ssh;
+  sshOpts = options.programs.ssh;
+in
+{
+  meta = {
+    maintainers = lib.teams.gnome.members;
+  };
+
+  options = {
+    services.gnome.gcr-ssh-agent = {
+      enable = lib.mkOption {
+        default = config.services.gnome.gnome-keyring.enable;
+        defaultText = lib.literalExpression "config.services.gnome.gnome-keyring.enable";
+        example = true;
+        description = "Whether to enable GCR SSH agent.";
+        type = lib.types.bool;
+      };
+
+      package = lib.mkPackageOption pkgs "GCR" {
+        default = [ "gcr_4" ];
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = lib.singleton {
+      assertion = !sshCfg.startAgent;
+      message = ''
+        `${sshOpts.startAgent}' (defined in ${lib.showFiles sshOpts.startAgent.files}) and `${opts.enable}' (defined in ${lib.showFiles opts.enable.files}) cannot both be enabled at the same time.
+        These options conflict because only one SSH agent can be installed at a time.'';
+    };
+
+    systemd = {
+      packages = [ cfg.package ];
+      user.services.gcr-ssh-agent.wantedBy = [ "default.target" ];
+      user.sockets.gcr-ssh-agent.wantedBy = [ "sockets.target" ];
+    };
+  };
+}

--- a/nixos/modules/services/x11/desktop-managers/budgie.nix
+++ b/nixos/modules/services/x11/desktop-managers/budgie.nix
@@ -253,6 +253,7 @@ in
     services.gnome.evolution-data-server.enable = mkDefault true;
     services.gnome.glib-networking.enable = mkDefault true;
     services.gnome.gnome-keyring.enable = mkDefault true;
+    services.gnome.gcr-ssh-agent.enable = mkDefault true;
     services.gnome.gnome-settings-daemon.enable = mkDefault true;
     services.gvfs.enable = mkDefault true;
 

--- a/nixos/modules/services/x11/desktop-managers/cinnamon.nix
+++ b/nixos/modules/services/x11/desktop-managers/cinnamon.nix
@@ -116,6 +116,7 @@ in
       services.gnome.evolution-data-server.enable = true;
       services.gnome.glib-networking.enable = true;
       services.gnome.gnome-keyring.enable = true;
+      services.gnome.gcr-ssh-agent.enable = mkDefault true;
       services.gvfs.enable = true;
       services.power-profiles-daemon.enable = mkDefault true;
       services.switcherooControl.enable = mkDefault true; # xapp-gpu-offload-helper

--- a/nixos/modules/services/x11/desktop-managers/deepin.nix
+++ b/nixos/modules/services/x11/desktop-managers/deepin.nix
@@ -63,6 +63,7 @@ in
     services.gvfs.enable = mkDefault true;
     services.gnome.glib-networking.enable = mkDefault true;
     services.gnome.gnome-keyring.enable = mkDefault true;
+    services.gnome.gcr-ssh-agent.enable = mkDefault true;
     services.bamf.enable = mkDefault true;
 
     services.libinput.enable = mkDefault true;

--- a/nixos/modules/services/x11/desktop-managers/mate.nix
+++ b/nixos/modules/services/x11/desktop-managers/mate.nix
@@ -92,6 +92,7 @@ in
       services.gnome.at-spi2-core.enable = true;
       services.gnome.glib-networking.enable = true;
       services.gnome.gnome-keyring.enable = true;
+      services.gnome.gcr-ssh-agent.enable = mkDefault true;
       services.udev.packages = [ pkgs.mate.mate-settings-daemon ];
       services.gvfs.enable = true;
       services.upower.enable = config.powerManagement.enable;

--- a/nixos/modules/services/x11/desktop-managers/pantheon.nix
+++ b/nixos/modules/services/x11/desktop-managers/pantheon.nix
@@ -152,6 +152,7 @@ in
       services.gnome.evolution-data-server.enable = true;
       services.gnome.glib-networking.enable = true;
       services.gnome.gnome-keyring.enable = true;
+      services.gnome.gcr-ssh-agent.enable = mkDefault true;
       services.gvfs.enable = true;
       services.gnome.rygel.enable = mkDefault true;
       services.udisks2.enable = true;

--- a/pkgs/by-name/gn/gnome-keyring/package.nix
+++ b/pkgs/by-name/gn/gnome-keyring/package.nix
@@ -16,12 +16,10 @@
   libcap_ng,
   libselinux,
   p11-kit,
-  openssh,
   wrapGAppsNoGuiHook,
   docbook-xsl-nons,
   docbook_xml_dtd_43,
   gnome,
-  writeText,
   useWrappedDaemon ? true,
 }:
 
@@ -55,7 +53,6 @@ stdenv.mkDerivation rec {
     glib
     libgcrypt
     pam
-    openssh
     libcap_ng
     libselinux
     gcr
@@ -71,16 +68,8 @@ stdenv.mkDerivation rec {
     # installation directories
     "-Dpkcs11-config=${placeholder "out"}/etc/pkcs11" # todo: this should probably be /share/p11-kit/modules
     "-Dpkcs11-modules=${placeholder "out"}/lib/pkcs11"
-    # gnome-keyring doesn't build with ssh-agent by default anymore, we need to
-    # switch to using gcr https://github.com/NixOS/nixpkgs/issues/140824
-    "-Dssh-agent=true"
     # TODO: enable socket activation
     "-Dsystemd=disabled"
-    "--cross-file=${writeText "crossfile.ini" ''
-      [binaries]
-      ssh-add = '${lib.getExe' openssh "ssh-add"}'
-      ssh-agent = '${lib.getExe' openssh "ssh-agent"}'
-    ''}"
   ];
 
   # Tends to fail non-deterministically.

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/default.nix
@@ -19,7 +19,6 @@
   meson,
   ninja,
 }:
-
 stdenv.mkDerivation rec {
   pname = "elementary-session-settings";
   version = "8.0.1";
@@ -30,6 +29,14 @@ stdenv.mkDerivation rec {
     rev = version;
     sha256 = "sha256-4B7lUjHEa4LdKrmsFCB3iFIsdVd/rgwmtQUAgAj3rXs=";
   };
+
+  /*
+    This allows `elementary-session-settings` to not use gnome-keyring's ssh capabilities anymore, as they have been
+    moved to gcr upstream, in an effort to modularize gnome-keyring.
+
+    More info can be found here: https://gitlab.gnome.org/GNOME/gnome-keyring/-/merge_requests/60
+  */
+  patches = [ ./no-gnome-keyring-ssh-autostart.patch ];
 
   nativeBuildInputs = [
     desktop-file-utils

--- a/pkgs/desktops/pantheon/desktop/elementary-session-settings/no-gnome-keyring-ssh-autostart.patch
+++ b/pkgs/desktops/pantheon/desktop/elementary-session-settings/no-gnome-keyring-ssh-autostart.patch
@@ -1,0 +1,12 @@
+diff --git a/session/meson.build b/session/meson.build
+index 501e836..3254658 100644
+--- a/session/meson.build
++++ b/session/meson.build
+@@ -79,7 +79,6 @@ if get_option('detect-program-prefixes') == true
+   autostarts = {
+     'gnome-keyring-pkcs11': join_paths(gnome_keyring_prefix, 'etc/xdg/autostart', 'gnome-keyring-pkcs11.desktop'),
+     'gnome-keyring-secrets': join_paths(gnome_keyring_prefix, 'etc/xdg/autostart', 'gnome-keyring-secrets.desktop'),
+-    'gnome-keyring-ssh': join_paths(gnome_keyring_prefix, 'etc/xdg/autostart', 'gnome-keyring-ssh.desktop'),
+     'onboard-autostart': join_paths(onboard_prefix, 'etc/xdg/autostart', 'onboard-autostart.desktop'),
+     'orca-autostart': join_paths(orca_prefix, 'etc/xdg/autostart', 'orca-autostart.desktop'),
+   }

--- a/pkgs/development/libraries/gcr/4.nix
+++ b/pkgs/development/libraries/gcr/4.nix
@@ -1,4 +1,5 @@
 {
+  pkgs,
   stdenv,
   lib,
   fetchurl,
@@ -25,7 +26,9 @@
   shared-mime-info,
   systemdSupport ? lib.meta.availableOn stdenv.hostPlatform systemd,
 }:
-
+let
+  ini = pkgs.formats.ini { };
+in
 stdenv.mkDerivation (finalAttrs: {
   pname = "gcr";
   version = "4.4.0.1";
@@ -80,11 +83,20 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   mesonFlags = [
-    # We are still using ssh-agent from gnome-keyring.
-    # https://github.com/NixOS/nixpkgs/issues/140824
-    "-Dssh_agent=false"
     "-Dgpg_path=${lib.getBin gnupg}/bin/gpg"
     (lib.mesonEnable "systemd" systemdSupport)
+    "--cross-file=${
+      ini.generate "cross-file.conf" {
+        binaries =
+          {
+            ssh-add = "'${lib.getExe' openssh "ssh-add"}'";
+            ssh-agent = "'${lib.getExe' openssh "ssh-agent"}'";
+          }
+          // lib.optionalAttrs systemdSupport {
+            systemctl = "'${lib.getExe' systemd "systemctl"}'";
+          };
+      }
+    }"
   ];
 
   doCheck = false; # fails 21 out of 603 tests, needs dbus daemon


### PR DESCRIPTION
This PR effectively deprecates `gnome-keyring` for SSH functions, in favor of `gcr`, that has been [deprecated since version 1.46.0](https://gitlab.gnome.org/GNOME/gnome-keyring/-/commit/25c5a1982467802fa12c6852b03c57924553ba73).  A new option has been added under `services.gnome.gcr-ssh-agent.enable` in order to set it up. Fixes #140824

- `gcr_4` has been updated to build with the ssh agent
- `gnome-keyring` has been updated to completely remove the now deprecated ssh component
-  An option has been added, under `services.gnome.gcr-ssh-agent.enable`, which effectively sets up systemd services and `SSH_AUTH_SOCK`

Since this PR adds a GNOME module, I also want to make sure the GNOME team approves of it.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [x] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
