### PR TITLE
ocamlPackages.httpun-lwt{,-unix}: init at 0.2.0

### DIFF
--- a/pkgs/development/ocaml-modules/httpun/lwt-unix.nix
+++ b/pkgs/development/ocaml-modules/httpun/lwt-unix.nix
@@ -1,0 +1,20 @@
+{
+  buildDunePackage,
+  httpun-lwt,
+  gluten-lwt-unix,
+}:
+
+buildDunePackage {
+  pname = "httpun-lwt-unix";
+
+  inherit (httpun-lwt) version src;
+
+  propagatedBuildInputs = [
+    httpun-lwt
+    gluten-lwt-unix
+  ];
+
+  meta = httpun-lwt.meta // {
+    description = "Lwt + Unix support for httpun";
+  };
+}

--- a/pkgs/development/ocaml-modules/httpun/lwt.nix
+++ b/pkgs/development/ocaml-modules/httpun/lwt.nix
@@ -1,0 +1,24 @@
+{
+  buildDunePackage,
+  httpun,
+  lwt,
+  gluten,
+  gluten-lwt,
+}:
+
+buildDunePackage {
+  pname = "httpun-lwt";
+
+  inherit (httpun) version src;
+
+  propagatedBuildInputs = [
+    gluten
+    gluten-lwt
+    httpun
+    lwt
+  ];
+
+  meta = httpun.meta // {
+    description = "Lwt support for httpun";
+  };
+}

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -709,6 +709,8 @@ let
 
     httpun-eio = callPackage ../development/ocaml-modules/httpun/eio.nix { };
 
+    httpun-lwt = callPackage ../development/ocaml-modules/httpun/lwt.nix { };
+
     httpun-types = callPackage ../development/ocaml-modules/httpun/types.nix { };
 
     httpun-ws = callPackage ../development/ocaml-modules/httpun-ws { };

--- a/pkgs/top-level/ocaml-packages.nix
+++ b/pkgs/top-level/ocaml-packages.nix
@@ -711,6 +711,8 @@ let
 
     httpun-lwt = callPackage ../development/ocaml-modules/httpun/lwt.nix { };
 
+    httpun-lwt-unix = callPackage ../development/ocaml-modules/httpun/lwt-unix.nix { };
+
     httpun-types = callPackage ../development/ocaml-modules/httpun/types.nix { };
 
     httpun-ws = callPackage ../development/ocaml-modules/httpun-ws { };


### PR DESCRIPTION
## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
