### PR TITLE
fix `release-cuda` eval errors

### DIFF
--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -355,10 +355,12 @@ filterAndCreateOverrides {
       ];
 
       brokenConditions = prevAttrs.brokenConditions // {
-        # Older releases require boost 1.70, which is deprecated in Nixpkgs
-        "CUDA too old (<11.8)" = cudaOlder "11.8";
         "Qt 5 missing (<2022.4.2.1)" = !(versionOlder version "2022.4.2.1" -> qt5 != null);
         "Qt 6 missing (>=2022.4.2.1)" = !(versionAtLeast version "2022.4.2.1" -> qt6 != null);
+      };
+      badPlatformsConditions = prevAttrs.badPlatformsConditions // {
+        # Older releases require boost 1.70, which is deprecated in Nixpkgs
+        "CUDA too old (<11.8)" = cudaOlder "11.8";
       };
     };
 

--- a/pkgs/development/cuda-modules/cuda/overrides.nix
+++ b/pkgs/development/cuda-modules/cuda/overrides.nix
@@ -367,7 +367,7 @@ filterAndCreateOverrides {
   nvidia_driver =
     { }:
     prevAttrs: {
-      brokenConditions = prevAttrs.brokenConditions // {
+      badPlatformsConditions = prevAttrs.badPlatformsConditions // {
         "Package is not supported; use drivers from linuxPackages" = true;
       };
     };

--- a/pkgs/development/cuda-modules/cudnn/fixup.nix
+++ b/pkgs/development/cuda-modules/cudnn/fixup.nix
@@ -20,13 +20,13 @@ finalAttrs: prevAttrs: {
   src = fetchurl { inherit (package) url hash; };
 
   # Useful for inspecting why something went wrong.
-  brokenConditions =
+  badPlatformsConditions =
     let
       cudaTooOld = strings.versionOlder cudaVersion package.minCudaVersion;
       cudaTooNew =
         (package.maxCudaVersion != null) && strings.versionOlder package.maxCudaVersion cudaVersion;
     in
-    prevAttrs.brokenConditions
+    prevAttrs.badPlatformsConditions
     // {
       "CUDA version is too old" = cudaTooOld;
       "CUDA version is too new" = cudaTooNew;

--- a/pkgs/development/cuda-modules/tensorrt/fixup.nix
+++ b/pkgs/development/cuda-modules/tensorrt/fixup.nix
@@ -109,5 +109,10 @@ finalAttrs: prevAttrs: {
       ++ lib.optionals (targetArch == "unsupported") [ hostPlatform.system ];
     homepage = "https://developer.nvidia.com/tensorrt";
     maintainers = prevAttrs.meta.maintainers ++ [ maintainers.aidalgol ];
+
+    # Building TensorRT on Hydra is impossible because of the non-redistributable
+    # license and because the source needs to be manually downloaded from the
+    # NVIDIA Developer Program (see requireFile above).
+    hydraPlatforms = lib.platforms.none;
   };
 }

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -140,7 +140,7 @@ let
         pymc = linux;
         pyrealsense2WithCuda = linux;
         pytorch-lightning = linux;
-        scikitimage = linux;
+        scikit-image = linux;
         scikit-learn = linux; # Only affected by MKL?
         scipy = linux; # Only affected by MKL?
         spacy-transformers = linux;

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -42,6 +42,9 @@ in
       inherit allowUnfreePredicate;
       "${variant}Support" = true;
       inHydra = true;
+
+      # Don't evaluate duplicate and/or deprecated attributes
+      allowAliases = false;
     };
 
     __allowFileset = false;

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -126,7 +126,7 @@ let
         grad-cam = linux;
         jaxlib = linux;
         jax = linux;
-        Keras = linux;
+        keras = linux;
         kornia = linux;
         mmcv = linux;
         mxnet = linux;

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -70,7 +70,7 @@ let
 
   # Package sets to evaluate whole
   packageSets = builtins.filter (lib.strings.hasPrefix "cudaPackages") (builtins.attrNames pkgs);
-  evalPackageSet = pset: mapTestOn { ${pset} = packagePlatforms pkgs.${pset}; };
+  evalPackageSet = pset: packagePlatforms pkgs.${pset};
 
   jobs =
     mapTestOn {
@@ -159,6 +159,6 @@ let
         vllm = linux;
       };
     }
-    // (lib.genAttrs packageSets evalPackageSet);
+    // mapTestOn (lib.genAttrs packageSets evalPackageSet);
 in
 jobs

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -148,7 +148,6 @@ let
         tensorflow = linux;
         tensorflow-probability = linux;
         tesserocr = linux;
-        Theano = linux;
         tiny-cuda-nn = linux;
         torchaudio = linux;
         torch = linux;

--- a/pkgs/top-level/release-cuda.nix
+++ b/pkgs/top-level/release-cuda.nix
@@ -140,7 +140,6 @@ let
         pymc = linux;
         pyrealsense2WithCuda = linux;
         pytorch-lightning = linux;
-        pytorch = linux;
         scikitimage = linux;
         scikit-learn = linux; # Only affected by MKL?
         scipy = linux; # Only affected by MKL?


### PR DESCRIPTION
Currently, the nix-community CUDA builder has a bunch of Eval Errors. This PR fixes some of the "lower hanging fruit" among those eval errors.

You can see the list of current eval errors by opening [the "Evaluation Errors" tab for the `nixpkgs:cuda` jobset](https://hydra.nix-community.org/jobset/nixpkgs/cuda#tabs-errors). Note that the "Evaluation Errors" tab for individual runs is currently **broken**, so only the jobset-level "Evaluation Errors" tab is populated (which contains evaluation errors for the latest job).

You can reproduce the evaluation errors locally by running
```sh
hydra-eval-jobs pkgs/top-level/release-cuda.nix -I . --arg 'supportedSystems' '[ "x86_64-linux" ]'
```
(`hydra-eval-jobs` is provided by the `hydra` package). When reviewing this PR, I recommend running the above command on each commit starting with the merge base and then `diff`ing the json data printed on `stdout` to verify that each commit does what I claim it does.

## Things done

- a8e9088d1a95b24f3e9557b44f4b1ddaa48ba609 rename the jobs so that they don't repeat the `cudaPackages*` prefix twice

This is mostly a cosmetic change so that the job name matches the nixpkgs attribute path.

The next bunch of commits remove the accidental use of non-standard aliases for package names and then sets `allowAliases = false` to ensure that aliases aren't used in the future.
- e0d45da20395d0f2a2d0173ccb142b82a1bda56f removes `Theano` from the list of evaluated packages (Theano was removed from nixpkgs)
- 108123b38aa5042fd51d728688eff103d49682b7 removes `pytorch` which is a deprecated alias for `torch` which is already being evaluated
- 5c0092eeaf36738c72f2a9932d7eb6aa5a37dfe1 changes `Keras` (deprecated alias) to `keras`
- 0c12821eec1363b9d53a461ed7cca8a967ee3cdf changes `scikitimage` (deprecated alias) to `scikit-image`
- 8027d0b28bbee429af069029cf11c1b7428f21b4 sets `allowAliases = false` (this ensures that aliases aren't used accidentally in the future)

Notably, the last commit also stops trying to evaluate the deprecated `cudaPackages_10_*` package sets and should also automatically stop evaluating CUDA versions prior to 12.0 after 25.05 gets released.

- 7d9676c1b7150f3cb76e1ad5035bd18a63fec4eb some minor refactoring and helpful comments in `release-cuda.nix`

The next few commits disable the evaluation of "known" broken derivations by moving some `brokenConditions` to `badPlatformConditions`:

- 0f7fe9c0043251b05f45b792e977e58beba278f2 `cudnn`
- ebd16a4537b4933486f59d32e028046557f11fa7 `nsight_systems`
- 992b38572f2eace38772b37305a427a9f4fec3f5 `nvidia_driver`

Additionally, the `cudaPackages.tensorrt` package is marked with `hydraPlatforms = none`, because this package is fundamentally impossible to build on Hydra due to `requireFile`d sources and its non-redistributable LICENSE.

- 98e9f51707ea6063b13cbc33dbf1848a78088bf3 `tensorrt`

Applying the above changes should fix 238 out of 259 eval errors that are currently happening in the `nixpkgs:cuda` jobset on the nix-community builders. The remaining 21 errors are slightly more tricky, so I am leaving them for a later PR.

---

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- ~Built~ Evaluated on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
