### PR TITLE
epson_201207w: 1.0.0 -> 1.0.1

### DIFF
--- a/pkgs/by-name/ep/epson_201207w/package.nix
+++ b/pkgs/by-name/ep/epson_201207w/package.nix
@@ -10,7 +10,8 @@
 }:
 
 let
-  version = "1.0.0";
+  version = "1.0.1";
+  filterVersion = "1.0.2";
 in
 stdenv.mkDerivation {
 
@@ -20,10 +21,10 @@ stdenv.mkDerivation {
   src = fetchurl {
     # NOTE: Don't forget to update the webarchive link too!
     urls = [
-      "https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201207w-${version}-1lsb3.2.src.rpm"
-      "https://web.archive.org/web/https://download.ebz.epson.net/dsc/op/stable/SRPMS/epson-inkjet-printer-201207w-${version}-1lsb3.2.src.rpm"
+      "https://download3.ebz.epson.net/dsc/f/03/00/15/64/87/25d34a13841e5e95d80266e6fd8dfcdf67c95634/epson-inkjet-printer-201207w-1.0.1-1.src.rpm"
+      "https://web.archive.org/web/https://download3.ebz.epson.net/dsc/f/03/00/15/64/87/25d34a13841e5e95d80266e6fd8dfcdf67c95634/epson-inkjet-printer-201207w-1.0.1-1.src.rpm"
     ];
-    sha256 = "1ixnhn2dk83nh9v8sdivzgc2bm9z2phvsbx8bc6ainbjq6vn7lns";
+    sha256 = "0icbsd3m8ij1zm55q8vms81dxd79nf5m33i2g4knddljsfv7nxdc";
   };
 
   nativeBuildInputs = [
@@ -40,12 +41,12 @@ stdenv.mkDerivation {
   unpackPhase = ''
     rpmextract $src
     tar -zxf epson-inkjet-printer-201207w-${version}.tar.gz
-    tar -zxf epson-inkjet-printer-filter-${version}.tar.gz
+    tar -zxf epson-inkjet-printer-filter-${filterVersion}.tar.gz
     for ppd in epson-inkjet-printer-201207w-${version}/ppds/*; do
       substituteInPlace $ppd --replace "/opt/epson-inkjet-printer-201207w" "$out"
       substituteInPlace $ppd --replace "/cups/lib" "/lib/cups"
     done
-    cd epson-inkjet-printer-filter-${version}
+    cd epson-inkjet-printer-filter-${filterVersion}
   '';
 
   preConfigure = ''
@@ -86,7 +87,7 @@ stdenv.mkDerivation {
         };
     '';
     license = with licenses; [
-      lgpl21
+      lgpl21Plus
       epson
     ];
     maintainers = [ maintainers.romildo ];


### PR DESCRIPTION
This package was outdated and failing to build. So I updated it and now it works again.

The download links have changed and seem to have random parts. Thus I remove the version variable from it, since in future updates the link will have to be fetched manually.

The filter version is also different from the package version, so a separate variable was set to reference it.

The filter licence was also set to the more specific lgpl21Plus.


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
