### PR TITLE
kew: 1.5.2->3.0.3, darwin support, add maintainer

### DIFF
--- a/pkgs/by-name/ke/kew/makefile.patch
+++ b/pkgs/by-name/ke/kew/makefile.patch
@@ -1,0 +1,130 @@
+diff --git a/Makefile b/Makefile
+index f4fd22d..020c256 100644
+--- a/Makefile
++++ b/Makefile
+@@ -7,9 +7,8 @@ PKG_CONFIG ?= pkg-config
+ # To disable faad2, run:
+ # make USE_FAAD=0
+ 
+-# Detect system and architecture
++# Detect system for dbus auto-detection
+ UNAME_S := $(shell uname -s)
+-ARCH := $(shell uname -m)
+ 
+ # Default USE_DBUS to auto-detect if not set by user
+ ifeq ($(origin USE_DBUS), undefined)
+@@ -20,82 +19,49 @@ ifeq ($(origin USE_DBUS), undefined)
+   endif
+ endif
+ 
+-# Adjust the PREFIX for macOS and Linux
+-ifeq ($(UNAME_S), Darwin)
+-    ifeq ($(ARCH), arm64)
+-        PREFIX ?= /usr/local
+-        PKG_CONFIG_PATH := /opt/homebrew/lib/pkgconfig:/opt/homebrew/share/pkgconfig:$(PKG_CONFIG_PATH)
+-    else
+-        PREFIX ?= /usr/local
+-        PKG_CONFIG_PATH := /usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:$(PKG_CONFIG_PATH)
+-    endif
+-else
+-    PREFIX ?= /usr
+-    PKG_CONFIG_PATH := /usr/lib/pkgconfig:/usr/share/pkgconfig:$(PKG_CONFIG_PATH)
+-endif
++PREFIX ?= /usr
+ 
+-# Default USE_FAAD to auto-detect if not set by user
++# Default USE_FAAD to auto-detect using pkg-config if not set by user
+ ifeq ($(origin USE_FAAD), undefined)
+-
+-  USE_FAAD = $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --exists faad && echo 1 || echo 0)
+-
+-  ifeq ($(USE_FAAD), 0)
+-    # If pkg-config fails, try to find libfaad dynamically in common paths
+-    USE_FAAD = $(shell [ -f /usr/lib/libfaad.so ] || [ -f /usr/local/lib/libfaad.so ] || \
+-                       [ -f /opt/local/lib/libfaad.so ] || [ -f /opt/homebrew/lib/libfaad.dylib ] || \
+-                       [ -f /opt/homebrew/opt/faad2/lib/libfaad.dylib ] || \
+-                       [ -f /usr/local/lib/libfaad.dylib ] || [ -f /lib/x86_64-linux-gnu/libfaad.so.2 ] && echo 1 || echo 0)
+-  endif
++  USE_FAAD = $(shell $(PKG_CONFIG) --exists faad2 && echo 1 || echo 0)
+ endif
+ 
+-# Compiler flags
+-COMMONFLAGS = -I/usr/include -I/opt/homebrew/include -I/usr/local/include -I/usr/lib -Iinclude/minimp4 \
+-         -I/usr/include/chafa -I/usr/lib/chafa/include -I/usr/include/ogg -I/usr/include/opus \
+-         -I/usr/include/stb -Iinclude/stb_image -I/usr/include/glib-2.0 \
+-         -I/usr/lib/glib-2.0/include -Iinclude/miniaudio -I/usr/include/gdk-pixbuf-2.0 -O2
++# TagLib flags (C++ only)
++TAGLIB_CFLAGS = $(shell $(PKG_CONFIG) --cflags taglib)
++TAGLIB_LIBS = $(shell $(PKG_CONFIG) --libs taglib)
+ 
+-COMMONFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --cflags gio-2.0 chafa fftw3f opus opusfile vorbis ogg glib-2.0 taglib)
++# Compiler flags
++COMMONFLAGS = $(shell $(PKG_CONFIG) --cflags gio-2.0 chafa fftw3f opus opusfile vorbis ogg glib-2.0)
++COMMONFLAGS += -I@miniaudio@ -I@miniaudio@/extras
++COMMONFLAGS += -I@stb@/include/stb
+ COMMONFLAGS += -fstack-protector-strong -Wformat -Werror=format-security -fPIE -D_FORTIFY_SOURCE=2
+ COMMONFLAGS += -Wall -Wextra -Wpointer-arith -flto
+ 
+ CFLAGS = $(COMMONFLAGS)
+-
+-# Compiler flags for C++ code
+ CXXFLAGS = $(COMMONFLAGS) -std=c++11
+ 
+ # Libraries
+-LIBS = -L/usr/lib -lm -lopusfile -lglib-2.0 -lpthread $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --libs gio-2.0 chafa fftw3f opus opusfile ogg vorbis vorbisfile glib-2.0 taglib)
++LIBS = -lm $(shell $(PKG_CONFIG) --libs gio-2.0 chafa fftw3f opus opusfile ogg vorbis vorbisfile glib-2.0)
+ LIBS += -lstdc++
+ 
+-LDFLAGS = -logg -lz -flto
++LDFLAGS = -flto
+ 
+ ifeq ($(UNAME_S), Linux)
+-  CFLAGS += -fPIE
+-  CXXFLAGS += -fPIE
+   LDFLAGS += -pie -Wl,-z,relro -s
+ endif
+ 
+-# Conditionally add  USE_DBUS is enabled
++# Conditionally add DBUS if USE_DBUS is enabled
+ ifeq ($(USE_DBUS), 1)
+   DEFINES += -DUSE_DBUS
+ endif
+ 
+ # Conditionally add faad2 support if USE_FAAD is enabled
+ ifeq ($(USE_FAAD), 1)
+-  ifeq ($(ARCH), arm64)
+-    CFLAGS += -I/opt/homebrew/opt/faad2/include
+-    LIBS += -L/opt/homebrew/opt/faad2/lib -lfaad
+-  else
+-    CFLAGS += -I/usr/local/include
+-    LIBS += -L/usr/local/lib -lfaad
+-  endif
++  COMMONFLAGS += $(shell $(PKG_CONFIG) --cflags faad2)
++  LIBS += $(shell $(PKG_CONFIG) --libs faad2)
+   DEFINES += -DUSE_FAAD
+ endif
+ 
+-ifeq ($(origin CC),default)
+-    CC := gcc
+-endif
+-
+ ifneq ($(findstring gcc,$(CC)),)
+     ifeq ($(UNAME_S), Linux)
+         LIBS += -latomic
+@@ -123,14 +89,14 @@ $(OBJDIR)/%.o: src/%.c Makefile | $(OBJDIR)
+ 
+ # Compile the C++ wrapper with g++
+ $(WRAPPER_OBJ): $(WRAPPER_SRC) Makefile | $(OBJDIR)
+-	$(CXX) $(CXXFLAGS) -c -o $@ $<
++	$(CXX) $(CXXFLAGS) $(TAGLIB_CFLAGS) -c -o $@ $<
+ 
+ $(OBJDIR):
+ 	mkdir -p $(OBJDIR)
+ 
+ # Link all objects together
+ kew: $(OBJS) $(WRAPPER_OBJ) Makefile
+-	$(CC) -o kew $(OBJS) $(WRAPPER_OBJ) $(LIBS) $(LDFLAGS)
++	$(CC) -o kew $(OBJS) $(WRAPPER_OBJ) $(LIBS) $(TAGLIB_LIBS) $(LDFLAGS)
+ 
+ .PHONY: install
+ install: all

--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -63,7 +63,10 @@ stdenv.mkDerivation rec {
     homepage = "https://github.com/ravachol/kew";
     platforms = platforms.unix;
     license = licenses.gpl2Only;
-    maintainers = with maintainers; [ demine ];
+    maintainers = with maintainers; [
+      demine
+      matteopacini
+    ];
     mainProgram = "kew";
   };
 }

--- a/pkgs/by-name/ke/kew/package.nix
+++ b/pkgs/by-name/ke/kew/package.nix
@@ -1,27 +1,57 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, ffmpeg
-, fftwFloat
-, chafa
-, freeimage
-, glib
-, pkg-config
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  pkg-config,
+  glib,
+  faad2,
+  taglib,
+  fftwFloat,
+  libopus,
+  opusfile,
+  libvorbis,
+  libogg,
+  chafa,
+  miniaudio,
+  stb,
 }:
 
 stdenv.mkDerivation rec {
   pname = "kew";
-  version = "1.5.2";
+  version = "3.0.3";
 
   src = fetchFromGitHub {
     owner = "ravachol";
     repo = "kew";
     rev = "v${version}";
-    hash = "sha256-Om7v8eTlYxXQYf1MG+L0I5ICQ2LS7onouhPGosuK8NM=";
+    hash = "sha256-DzJ+7PanA15A9nIbFPWZ/tdxq4aDyParJORcuqHV7jc=";
   };
 
+  patches = [
+    ./makefile.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "@miniaudio@" "${miniaudio}"
+      substituteInPlace Makefile \
+      --replace "@stb@" "${stb}"
+  '';
+
   nativeBuildInputs = [ pkg-config ];
-  buildInputs = [ ffmpeg freeimage fftwFloat chafa glib ];
+  buildInputs = [
+    glib.dev
+    faad2
+    taglib
+    fftwFloat.dev
+    libopus
+    opusfile
+    libvorbis
+    libogg
+    chafa
+    miniaudio
+    stb
+  ];
 
   installFlags = [
     "MAN_DIR=${placeholder "out"}/share/man"
@@ -31,7 +61,7 @@ stdenv.mkDerivation rec {
   meta = with lib; {
     description = "Command-line music player for Linux";
     homepage = "https://github.com/ravachol/kew";
-    platforms = platforms.linux;
+    platforms = platforms.unix;
     license = licenses.gpl2Only;
     maintainers = with maintainers; [ demine ];
     mainProgram = "kew";

--- a/pkgs/by-name/st/stb/package.nix
+++ b/pkgs/by-name/st/stb/package.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "stb";
-  version = "unstable-2023-01-29";
+  version = "unstable-2024-11-09";
 
   src = fetchFromGitHub {
     owner = "nothings";
     repo = "stb";
-    rev = "5736b15f7ea0ffb08dd38af21067c314d6a3aae9";
-    hash = "sha256-s2ASdlT3bBNrqvwfhhN6skjbmyEnUgvNOrvhgUSRj98=";
+    rev = "5c205738c191bcb0abc65c4febfa9bd25ff35234";
+    hash = "sha256-JeVkoaGZnxSE3EAIwImz/ArPcOee2++5Q8c3mwfLCr0=";
   };
 
   nativeBuildInputs = [ copyPkgconfigItems ];


### PR DESCRIPTION
- Upgraded derivation to v3.0.3 (not based on ffmpeg anymore, but uses audio libraries instead)
    - Updated also stb as a newer version of it is required (this is the one causing most rebuilds)
- Made sure it also works on Darwin
    - Seems to be a bit slow when starting for the first time, I think it's an upstream issue 
    - Screenshot taken on aarch64-darwin, **Wezterm** ![image](https://github.com/user-attachments/assets/abd73084-07ab-4499-9912-c11aae8c1de5)

- Added myself as darwin/extra maintainer

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
