### PR TITLE
Revert "nixos/tests/userborn: fix setting hostPlatform"

### DIFF
--- a/nixos/tests/userborn-immutable-etc.nix
+++ b/nixos/tests/userborn-immutable-etc.nix
@@ -20,7 +20,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { pkgs, ... }:
+    { config, ... }:
     {
       imports = [ common ];
 
@@ -36,8 +36,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs.hostPlatform = {
-            inherit (pkgs.stdenv.hostPlatform) system;
+          nixpkgs = {
+            inherit (config.nixpkgs) hostPlatform;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-immutable-users.nix
+++ b/nixos/tests/userborn-immutable-users.nix
@@ -16,7 +16,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { pkgs, ... }:
+    { config, ... }:
     {
       imports = [ common ];
 
@@ -32,8 +32,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs.hostPlatform = {
-            inherit (pkgs.stdenv.hostPlatform) system;
+          nixpkgs = {
+            inherit (config.nixpkgs) hostPlatform;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-mutable-etc.nix
+++ b/nixos/tests/userborn-mutable-etc.nix
@@ -20,7 +20,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { pkgs, ... }:
+    { config, ... }:
     {
       imports = [ common ];
 
@@ -36,8 +36,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs.hostPlatform = {
-            inherit (pkgs.stdenv.hostPlatform) system;
+          nixpkgs = {
+            inherit (config.nixpkgs) hostPlatform;
           };
           imports = [ common ];
 

--- a/nixos/tests/userborn-mutable-users.nix
+++ b/nixos/tests/userborn-mutable-users.nix
@@ -16,7 +16,7 @@ in
   meta.maintainers = with lib.maintainers; [ nikstur ];
 
   nodes.machine =
-    { pkgs, ... }:
+    { config, ... }:
     {
       imports = [ common ];
 
@@ -33,8 +33,8 @@ in
       specialisation.new-generation = {
         inheritParentConfig = false;
         configuration = {
-          nixpkgs.hostPlatform = {
-            inherit (pkgs.stdenv.hostPlatform) system;
+          nixpkgs = {
+            inherit (config.nixpkgs) hostPlatform;
           };
           imports = [ common ];
 


### PR DESCRIPTION
Reverts NixOS/nixpkgs#378940

Since the [original PR for which the changes were made](https://github.com/NixOS/nixpkgs/pull/376988) was [reverted](https://github.com/NixOS/nixpkgs/pull/379615), let's also revert this one