### PR TITLE
Revert "mdds: 2.1.1 -> 3.0.0"

### DIFF
--- a/pkgs/by-name/md/mdds/package.nix
+++ b/pkgs/by-name/md/mdds/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "mdds";
-  version = "3.0.0";
+  version = "2.1.1";
 
   src = fetchFromGitLab {
     owner = "mdds";
     repo = "mdds";
     rev = finalAttrs.version;
-    hash = "sha256-XIfrbnjY3bpnbRBnE44dQNJm3lhL0Y1Mm0sayh3T2aY=";
+    hash = "sha256-a412LpgDiYM8TMToaUrTlHtblYS1HehzrDOwvIAAxiA=";
   };
 
   nativeBuildInputs = [ autoreconfHook ];


### PR DESCRIPTION
Reverts #379088

This broke *all* reverse dependencies of this package. From r-ryantm's own review:

> ❌ 34 packages failed to build
> ✅ 1 package built

Example log:
```
error: builder for '/nix/store/pk28w0g050xhs2mllxgw1smib6kib48n-libixion-0.19.0.drv' failed with exit code 1;
       last 25 log lines:
       > checking for inline... inline
       > checking for mode_t... yes
       > checking for size_t... yes
       > checking for working strtod... yes
       > checking size of void *... 8
       > checking for Boost headers version >= 1.36.0... yes
       > checking for Boost's header version... 1_87
       > checking for the toolset name used by Boost for g++ -std=c++17... configure: WARNING: could not figure out which toolset name to use for g++ -std=c++17
       >
       > checking for boost/system/error_code.hpp... yes
       > checking for the Boost system library... yes
       > checking for boost/filesystem/path.hpp... yes
       > checking for the Boost filesystem library... (cached) yes
       > checking pkg-config is at least version 0.9.0... yes
       > checking for mdds-2.1 >= 2.0.99... no
       > configure: error: Package requirements (mdds-2.1 >= 2.0.99) were not met:
       >
       > No package 'mdds-2.1' found
       >
       > Consider adjusting the PKG_CONFIG_PATH environment variable if you
       > installed software in a non-standard prefix.
       >
       > Alternatively, you may set the environment variables MDDS_CFLAGS
       > and MDDS_LIBS to avoid the need to call pkg-config.
       > See the pkg-config man page for more details.
       For full logs, run 'nix log /nix/store/pk28w0g050xhs2mllxgw1smib6kib48n-libixion-0.19.0.drv'.
```

Short-term, revert so libreoffice builds again.

CC @AndersonTorres

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
