### PR TITLE
ocamlPackages.postgresql: 5.0.0 → 5.1.3

### DIFF
--- a/pkgs/development/ocaml-modules/postgresql/default.nix
+++ b/pkgs/development/ocaml-modules/postgresql/default.nix
@@ -1,26 +1,24 @@
-{ lib, fetchFromGitHub, buildDunePackage, dune-configurator, libpq }:
+{ lib, fetchurl, buildDunePackage, pkg-config, dune-configurator, libpq }:
 
 buildDunePackage rec {
   pname = "postgresql";
-  version = "5.0.0";
+  version = "5.1.3";
 
-  useDune2 = true;
+  minimalOCamlVersion = "4.12";
 
-  minimalOCamlVersion = "4.08";
-
-  src = fetchFromGitHub {
-    owner = "mmottl";
-    repo = "postgresql-ocaml";
-    rev = version;
-    sha256 = "1i4pnh2v00i0s7s9pcwz1x6s4xcd77d08gjjkvy0fmda6mqq6ghn";
+  src = fetchurl {
+    url = "https://github.com/mmottl/postgresql-ocaml/releases/download/${version}/postgresql-${version}.tbz";
+    hash = "sha256-RipVP8mj+tYwO8LrVASvVc36ZAJYjMI4x6Uj5J50Eww=";
   };
 
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [ dune-configurator ];
   propagatedBuildInputs = [ libpq ];
 
   meta = {
     description = "Bindings to the PostgreSQL library";
     license = lib.licenses.lgpl21Plus;
+    changelog = "https://raw.githubusercontent.com/mmottl/postgresql-ocaml/refs/tags/${version}/CHANGES.md";
     maintainers = with lib.maintainers; [ bcc32 ];
     homepage = "https://mmottl.github.io/postgresql-ocaml";
   };


### PR DESCRIPTION
Also fix build (that started failing recently: probably since 546ece569b66f3995839ffe87726177831aca72e).

cc maintainer @bcc32.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
