### PR TITLE
mas: 1.8.6 -> 1.9.0

### DIFF
--- a/pkgs/by-name/ma/mas/package.nix
+++ b/pkgs/by-name/ma/mas/package.nix
@@ -2,27 +2,44 @@
   lib,
   stdenvNoCC,
   fetchurl,
-  installShellFiles,
+  libarchive,
+  p7zip,
   testers,
   mas,
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "mas";
-  version = "1.8.6";
+  version = "1.9.0";
 
   src = fetchurl {
-    # Use the tarball until https://github.com/mas-cli/mas/issues/452 is fixed.
-    # Even though it looks like an OS/arch specific build it is actually a universal binary.
-    url = "https://github.com/mas-cli/mas/releases/download/v${version}/mas-${version}.monterey.bottle.tar.gz";
-    sha256 = "0q4skdhymgn5xrwafyisfshx327faia682yv83mf68r61m2jl10d";
+    url = "https://github.com/mas-cli/mas/releases/download/v${version}/mas-${version}.pkg";
+    hash = "sha256-MiSrCHLby3diTAzDPCYX1ZwdmzcHwOx/UJuWrlRJe54=";
   };
 
-  nativeBuildInputs = [ installShellFiles ];
+  nativeBuildInputs = [
+    libarchive
+    p7zip
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    7z x $src
+    bsdtar -xf Payload~
+
+    runHook postUnpack
+  '';
+
+  dontBuild = true;
 
   installPhase = ''
-    install -D './${version}/bin/mas' "$out/bin/mas"
-    installShellCompletion --cmd mas --bash './${version}/etc/bash_completion.d/mas'
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp mas $out/bin
+
+    runHook postInstall
   '';
 
   passthru.tests = {


### PR DESCRIPTION
Notably, this switches back to the .pkg from the tarball, since mas-cli/mas#452 was fixed about three years ago (just after this package was last bumped) and tarballs are no longer published. Also, the Bash completion file isn’t included in the pkg (but it’s still in the repo).

Here are the intervening release notes:
- https://github.com/mas-cli/mas/releases/tag/v1.8.7
- https://github.com/mas-cli/mas/releases/tag/v1.8.8
- https://github.com/mas-cli/mas/releases/tag/v1.9.0

And the list of (almost 600) commits since the version currently in Nixpkgs: https://github.com/mas-cli/mas/compare/v1.8.6...v1.9.0


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
