### PR TITLE
docopts: install shell helper script

### DIFF
--- a/pkgs/by-name/do/docopts/package.nix
+++ b/pkgs/by-name/do/docopts/package.nix
@@ -3,6 +3,10 @@
   buildGoModule,
   fetchFromGitHub,
   fetchpatch,
+  bash,
+  gawk,
+  gnugrep,
+  gnused,
 }:
 buildGoModule rec {
   pname = "docopts";
@@ -24,6 +28,30 @@ buildGoModule rec {
   ];
 
   vendorHash = "sha256-+pMgaHB69itbQ+BDM7/oaJg3HrT1UN+joJL7BO/2vxE=";
+
+  # Only build the main CLI; json_t and test_json_load are test/helper binaries
+  subPackages = [ "." ];
+
+  # Install docopts.sh in PATH to allow sourcing, and replace any binary reference
+  # with nixpkgs binary paths.
+  postInstall = ''
+    install -D -m 444 $src/docopts.sh $out/bin/docopts.sh
+    substituteInPlace $out/bin/docopts.sh \
+      --replace-fail '#!/usr/bin/env bash' '#!${bash}/bin/bash'
+    # Replace commands only in non-comment lines.
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^[[:space:]]*# ]]; then
+        printf '%s\n' "$line"
+      else
+        line="''${line// awk / ${gawk}/bin/awk }"
+        line="''${line//sed / ${gnused}/bin/sed }"
+        line="''${line// docopts / $out/bin/docopts }"
+        line="''${line//'| grep "'/'| ${gnugrep}/bin/grep "'}"
+        printf '%s\n' "$line"
+      fi
+    done < $out/bin/docopts.sh > $out/bin/docopts.sh.tmp
+    mv $out/bin/docopts.sh.tmp $out/bin/docopts.sh
+  '';
 
   meta = {
     homepage = "https://github.com/docopt/docopts";

--- a/pkgs/by-name/do/docopts/package.nix
+++ b/pkgs/by-name/do/docopts/package.nix
@@ -34,6 +34,8 @@ buildGoModule rec {
 
   # Install docopts.sh in PATH to allow sourcing, and replace any binary reference
   # with nixpkgs binary paths.
+  # When updating the package, check very carefully if new dependencies
+  # were added in docopts.sh and add them below accordingly.
   postInstall = ''
     install -D -m 444 $src/docopts.sh $out/bin/docopts.sh
     substituteInPlace $out/bin/docopts.sh \


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

In https://github.com/NixOS/nixpkgs/pull/318612 `docopts` package has been migrated to `buildGoModule`. The `postInstall` phase was not copied over to the new module, resulting in the lack of `docopts.sh` in `$PATH`. This [shell helper](https://github.com/docopt/docopts/blob/62aed3d4cb02f36864ace03ecb89f8a200e311ca/docs/README.md#docopts-documentation) is widely used across docopts documentation (and I expect also used in the wild) as the entry point when developing BASH scripts using docopts, so the lack of it is problematic.

I'm not sure if it's worth a changelog entry, happy to add one if you think so.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
