### PR TITLE
duckdb: 1.1.3 -> 1.2.0

### DIFF
--- a/pkgs/by-name/ha/harlequin/package.nix
+++ b/pkgs/by-name/ha/harlequin/package.nix
@@ -25,6 +25,7 @@ python3Packages.buildPythonApplication rec {
     "numpy"
     "pyarrow"
     "textual"
+    "syrupy"
   ];
 
   build-system = with python3Packages; [ poetry-core ];

--- a/pkgs/development/libraries/duckdb/update.sh
+++ b/pkgs/development/libraries/duckdb/update.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env nix-shell
-#!nix-shell --pure -i bash -p cacert curl jq moreutils nix-prefetch
+#!nix-shell -i bash -p cacert jq git moreutils nix nix-prefetch-github
 # shellcheck shell=bash
 
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
-
-nixpkgs=$(
-  while [[ ! -e .git ]]; do
-    [[ ${PWD} != / ]] || exit 1
-    cd ..
-  done
-  echo "${PWD}"
-)
 
 repo=duckdb
 owner=duckdb
@@ -21,34 +13,25 @@ msg() {
 }
 
 json_get() {
-  jq -r "$1" < 'versions.json'
+  jq -r "$1" < ./versions.json
 }
 
 json_set() {
-  jq --arg x "$2" "$1 = \$x" < 'versions.json' | sponge 'versions.json'
+  jq --arg x "$2" "$1 = \$x" < ./versions.json | sponge 'versions.json'
 }
 
 get_latest() {
-  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s \
-    "https://api.github.com/repos/${owner}/${repo}/releases/latest" | jq -r .tag_name
+  gh release --repo "${owner}/${repo}" list \
+    --exclude-pre-releases \
+    --limit 1 \
+    --json tagName \
+    --jq '.[].tagName'
 }
 
-get_sha() {
-  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s \
-    "https://api.github.com/repos/${owner}/${repo}/git/ref/tags/$1" | jq -r .object.sha
-}
+tag="$(get_latest | sed 's/^v//g')"
 
-tag=$(get_latest)
-version=${tag/v/}
+json=$(nix-prefetch-github "${owner}" "${repo}" --rev "v${tag}")
 
-[[ ${version} == $(json_get .version) ]] && {
-  msg "${version} is up to date"
-  exit 0
-}
-
-sha=$(get_sha "${tag}")
-sri=$(nix-prefetch -I nixpkgs="${nixpkgs}" -E "duckdb.overrideAttrs { version = \"${version}\"; }")
-
-json_set ".version" "${version}"
-json_set ".rev" "${sha}"
-json_set ".hash" "${sri}"
+json_set ".version" "${tag}"
+json_set ".rev" "$(jq -r '.rev' <<< "${json}")"
+json_set ".hash" "$(jq -r '.hash' <<< "${json}")"

--- a/pkgs/development/libraries/duckdb/update.sh
+++ b/pkgs/development/libraries/duckdb/update.sh
@@ -5,37 +5,46 @@
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-nixpkgs=$(while [[ ! -e .git ]]; do [[ ${PWD} != / ]] || exit 1; cd ..; done; echo "${PWD}")
+nixpkgs=$(
+  while [[ ! -e .git ]]; do
+    [[ ${PWD} != / ]] || exit 1
+    cd ..
+  done
+  echo "${PWD}"
+)
 
 repo=duckdb
 owner=duckdb
 
 msg() {
-    echo "$*" >&2
+  echo "$*" >&2
 }
 
 json_get() {
-    jq -r "$1" < 'versions.json'
+  jq -r "$1" < 'versions.json'
 }
 
 json_set() {
-    jq --arg x "$2" "$1 = \$x" < 'versions.json' | sponge 'versions.json'
+  jq --arg x "$2" "$1 = \$x" < 'versions.json' | sponge 'versions.json'
 }
 
 get_latest() {
-    curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s \
-        "https://api.github.com/repos/${owner}/${repo}/releases/latest" | jq -r .tag_name
+  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s \
+    "https://api.github.com/repos/${owner}/${repo}/releases/latest" | jq -r .tag_name
 }
 
 get_sha() {
-    curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s \
-        "https://api.github.com/repos/${owner}/${repo}/git/ref/tags/$1" | jq -r .object.sha
+  curl ${GITHUB_TOKEN:+" -u \":$GITHUB_TOKEN\""} -s \
+    "https://api.github.com/repos/${owner}/${repo}/git/ref/tags/$1" | jq -r .object.sha
 }
 
 tag=$(get_latest)
 version=${tag/v/}
 
-[[ ${version} = $(json_get .version) ]] && { msg "${version} is up to date"; exit 0; }
+[[ ${version} == $(json_get .version) ]] && {
+  msg "${version} is up to date"
+  exit 0
+}
 
 sha=$(get_sha "${tag}")
 sri=$(nix-prefetch -I nixpkgs="${nixpkgs}" -E "duckdb.overrideAttrs { version = \"${version}\"; }")

--- a/pkgs/development/libraries/duckdb/versions.json
+++ b/pkgs/development/libraries/duckdb/versions.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
-  "rev": "19864453f7d0ed095256d848b46e7b8630989bac",
-  "hash": "sha256-Inaawm6mAy1CPCPfGO5LNBgaF/QcZOTAjm1aGjrJp6w="
+  "version": "1.2.0",
+  "rev": "5f5512b827df6397afd31daedb4bbdee76520019",
+  "hash": "sha256-93iBUsNKXRGdnN1ZRSWJfnSNM23U/M0sudgHk6HGIhM="
 }

--- a/pkgs/development/python-modules/dask-expr/default.nix
+++ b/pkgs/development/python-modules/dask-expr/default.nix
@@ -13,7 +13,7 @@
   pyarrow,
 
   # checks
-  distributed,
+  jinja2,
   pytestCheckHook,
   xarray,
 }:
@@ -49,7 +49,7 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "dask_expr" ];
 
   nativeCheckInputs = [
-    distributed
+    jinja2
     pytestCheckHook
     xarray
   ];

--- a/pkgs/development/python-modules/duckdb/default.nix
+++ b/pkgs/development/python-modules/duckdb/default.nix
@@ -38,7 +38,6 @@ buildPythonPackage rec {
     '';
 
   env = {
-    BUILD_HTTPFS = 1;
     DUCKDB_BUILD_UNITY = 1;
     OVERRIDE_GIT_DESCRIBE = "v${version}-0-g${rev}";
   };

--- a/pkgs/development/python-modules/pytest-textual-snapshot/default.nix
+++ b/pkgs/development/python-modules/pytest-textual-snapshot/default.nix
@@ -36,6 +36,10 @@ buildPythonPackage rec {
     textual
   ];
 
+  pythonRelaxDeps = [
+    "syrupy"
+  ];
+
   # Module has no tests
   doCheck = false;
 


### PR DESCRIPTION
Bump duckdb from 1.1.3 -> 1.2.0

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
