### PR TITLE
[24.11] xonsh: 0.18.4 -> 0.19.1

### DIFF
--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -12,7 +12,7 @@ let
 
   argset = {
     pname = "xonsh";
-    version = "0.18.4";
+    version = "0.19.0";
     pyproject = true;
 
     # PyPI package ships incomplete tests
@@ -20,7 +20,7 @@ let
       owner = "xonsh";
       repo = "xonsh";
       rev = "refs/tags/${argset.version}";
-      hash = "sha256-L5UwmwwM42E3l+sIBwXgMf/q5r22cUoRbE2cqM09bZA=";
+      hash = "sha256-rt402MKnhjC/AYz9Rm6B5RkivcVxveVW2rM/nT/xcNo=";
     };
 
     nativeBuildInputs = with pythonPackages; [

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -3,8 +3,8 @@
   coreutils,
   fetchFromGitHub,
   git,
-  gitUpdater,
   glibcLocales,
+  nix-update-script,
   pythonPackages,
 }:
 
@@ -12,7 +12,7 @@ let
 
   argset = {
     pname = "xonsh";
-    version = "0.19.0";
+    version = "0.19.1";
     pyproject = true;
 
     # PyPI package ships incomplete tests
@@ -20,7 +20,7 @@ let
       owner = "xonsh";
       repo = "xonsh";
       rev = "refs/tags/${argset.version}";
-      hash = "sha256-rt402MKnhjC/AYz9Rm6B5RkivcVxveVW2rM/nT/xcNo=";
+      hash = "sha256-20egNKlJjJO1wdy1anApz0ADBnaHPUSqhfrsPe3QQIs=";
     };
 
     nativeBuildInputs = with pythonPackages; [
@@ -112,7 +112,7 @@ let
       shellPath = "/bin/xonsh";
       python = pythonPackages.python; # To the wrapper
       wrapper = throw "The top-level xonsh package is now wrapped. Use it directly.";
-      updateScript = gitUpdater { };
+      updateScript = nix-update-script { };
     };
 
     meta = {

--- a/pkgs/by-name/xo/xonsh/unwrapped.nix
+++ b/pkgs/by-name/xo/xonsh/unwrapped.nix
@@ -2,10 +2,12 @@
   lib,
   coreutils,
   fetchFromGitHub,
-  git,
+  gitMinimal,
   glibcLocales,
   nix-update-script,
   pythonPackages,
+  addBinToPathHook,
+  writableTmpDirAsHomeHook,
 }:
 
 let
@@ -19,7 +21,7 @@ let
     src = fetchFromGitHub {
       owner = "xonsh";
       repo = "xonsh";
-      rev = "refs/tags/${argset.version}";
+      tag = argset.version;
       hash = "sha256-20egNKlJjJO1wdy1anApz0ADBnaHPUSqhfrsPe3QQIs=";
     };
 
@@ -39,8 +41,10 @@ let
 
     nativeCheckInputs =
       [
-        git
+        addBinToPathHook
+        gitMinimal
         glibcLocales
+        writableTmpDirAsHomeHook
       ]
       ++ (with pythonPackages; [
         pip
@@ -77,6 +81,9 @@ let
 
       # https://github.com/xonsh/xonsh/issues/5569
       "test_spec_decorator_alias_output_format"
+
+      # Broken test
+      "test_repath_backslash"
     ];
 
     disabledTestPaths = [
@@ -101,11 +108,6 @@ let
         sed -ie 's|/usr/bin/env|${lib.getExe' coreutils "env"}|' $script
       done
       patchShebangs .
-    '';
-
-    preCheck = ''
-      export HOME=$TMPDIR
-      export PATH=$out/bin:$PATH
     '';
 
     passthru = {


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/379630

From now on, xonsh updates will be backported to stable unless there's major breaking change.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [X] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
