### PR TITLE
nixos/beszel-agent: init

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -877,6 +877,7 @@
   ./services/monitoring/apcupsd.nix
   ./services/monitoring/arbtt.nix
   ./services/monitoring/below.nix
+  ./services/monitoring/beszel.nix
   ./services/monitoring/bosun.nix
   ./services/monitoring/cadvisor.nix
   ./services/monitoring/certspotter.nix

--- a/nixos/modules/services/monitoring/beszel.nix
+++ b/nixos/modules/services/monitoring/beszel.nix
@@ -1,0 +1,94 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  meta.maintainers = with lib.maintainers; [ arunoruto ];
+
+  options.services.beszel-agent = {
+    enable = lib.mkEnableOption "Enable the beszel agent service";
+    package = lib.mkPackageOption pkgs "beszel" { };
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 45876;
+      description = "The port for the beszel agent service";
+    };
+    key = lib.mkOption {
+      type = lib.types.str;
+      default = null;
+      description = "The raw value of the key";
+    };
+    keyFile = lib.mkOption {
+      type = lib.types.path or lib.types.str;
+      default = null;
+      description = "The file location where the key for the beszel agent service is located";
+    };
+    extraFilesystems = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "The extra filesystems to be mounted";
+    };
+    gpu = lib.mkEnableOption "Enable GPU support";
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "debug"
+        "info"
+        "warn"
+        "error"
+      ];
+      default = "info";
+      description = "The log level for the beszel agent service. Valid values are debug, info, warn, error.";
+    };
+  };
+
+  config =
+    let
+      cfg = config.services.beszel-agent;
+    in
+    lib.mkIf cfg.enable {
+      systemd = {
+        services.beszel-agent = {
+          # This ensures that nvidia-smi is in the path if GPU=true
+          path = [ "/run/current-system/sw" ];
+          unitConfig = {
+            Description = "Beszel Agent Service";
+            Wants = "network-online.target";
+            After = "network-online.target";
+          };
+          serviceConfig = {
+            Environment = lib.lists.map (x: ''"${x}"'') [
+              "LOG_LEVEL=${cfg.logLevel}"
+              "PORT=${builtins.toString cfg.port}"
+              "KEY=${cfg.key}"
+              "KEY_FILE=${cfg.keyFile}"
+              "GPU=${if cfg.gpu then "true" else "false"}"
+              "EXTRA_FILESYSTEMS=${lib.strings.concatStringsSep "," cfg.extraFilesystems}"
+            ];
+            ExecStart = "${cfg.package}/bin/beszel-agent";
+            # User = "beszel";
+            Restart = "on-failure";
+            RestartSec = "5";
+            StateDirectory = "beszel-agent";
+
+            # Security/sandboxing settings
+            KeyringMode = "private";
+            LockPersonality = "yes";
+            NoNewPrivileges = "yes";
+            PrivateTmp = "yes";
+            ProtectClock = "yes";
+            ProtectHome = "read-only";
+            ProtectHostname = "yes";
+            ProtectKernelLogs = "yes";
+            ProtectKernelTunables = "yes";
+            ProtectSystem = "strict";
+            RemoveIPC = "yes";
+            RestrictSUIDSGID = "true";
+            SystemCallArchitectures = "native";
+          };
+          wantedBy = [ "multi-user.target" ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Added the beszel agent as a systemd service with a few options to be set.
Currently waiting for the environment variable `KEY_FILE` to be available in a new release. This will be kept as a draft so long the issue https://github.com/henrygd/beszel/issues/411 isn't closed. A fix has already been merged in https://github.com/henrygd/beszel/pull/412.

Until then, the `KEY` variable can be still used, albeit `builtins.readFile` can only be used in using `--impure`.

@bot-wxt1221 could give some feedback, since you are the maintainer of the package?

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
