### PR TITLE
python312Packages.numpydoc: cleanup and skip failing tests

### DIFF
--- a/pkgs/development/python-modules/numpydoc/default.nix
+++ b/pkgs/development/python-modules/numpydoc/default.nix
@@ -2,13 +2,19 @@
   lib,
   buildPythonPackage,
   fetchPypi,
-  isPy27,
+
+  # build-system
   setuptools,
+
+  # dependencies
   jinja2,
   sphinx,
   tabulate,
-  pytestCheckHook,
+
+  # tests
   matplotlib,
+  pytest-cov-stub,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
@@ -16,23 +22,15 @@ buildPythonPackage rec {
   version = "1.8.0";
   pyproject = true;
 
-  disabled = isPy27;
-
   src = fetchPypi {
     inherit pname;
     inherit version;
     hash = "sha256-AiOQq3RkpE+HN/efizHOHTz6S0r3nMqhqsXoNo21h/s=";
   };
 
-  postPatch = ''
-    substituteInPlace pyproject.toml \
-      --replace "--cov-report=" "" \
-      --replace "--cov=numpydoc" ""
-  '';
+  build-system = [ setuptools ];
 
-  nativeBuildInputs = [ setuptools ];
-
-  propagatedBuildInputs = [
+  dependencies = [
     jinja2
     sphinx
     tabulate
@@ -40,6 +38,7 @@ buildPythonPackage rec {
 
   nativeCheckInputs = [
     matplotlib
+    pytest-cov-stub
     pytestCheckHook
   ];
 
@@ -47,7 +46,11 @@ buildPythonPackage rec {
     # https://github.com/numpy/numpydoc/issues/373
     "test_MyClass"
     "test_my_function"
-    "test_reference"
+
+    # AttributeError: 'MockApp' object has no attribute '_exception_on_warning'
+    "test_mangle_docstring_validation_exclude"
+    "test_mangle_docstring_validation_warnings"
+    "test_mangle_docstrings_overrides"
   ];
 
   pythonImportsCheck = [ "numpydoc" ];


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
