### PR TITLE
neovim: dont wrap rtp when wrapRc=false

### DIFF
--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -124,10 +124,6 @@ let
               # vim accepts a limited number of commands so we join all the provider ones
               "--add-flags" ''--cmd "lua ${providerLuaRc}"''
             ]
-            ++ lib.optionals (finalAttrs.packpathDirs.myNeovimPackages.start != [] || finalAttrs.packpathDirs.myNeovimPackages.opt != []) [
-              "--add-flags" ''--cmd "set packpath^=${finalPackdir}"''
-              "--add-flags" ''--cmd "set rtp^=${finalPackdir}"''
-            ]
             ++ lib.optionals finalAttrs.withRuby [
               "--set" "GEM_HOME" "${rubyEnv}/${rubyEnv.ruby.gemPath}"
             ] ++ lib.optionals (finalAttrs.runtimeDeps != []) [
@@ -148,8 +144,15 @@ let
     finalMakeWrapperArgs =
       [ "${neovim-unwrapped}/bin/nvim" "${placeholder "out"}/bin/nvim" ]
       ++ [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ]
-      ++ lib.optionals finalAttrs.wrapRc [ "--add-flags" "-u ${writeText "init.lua" rcContent}" ]
       ++ finalAttrs.generatedWrapperArgs
+      # for home-manager scenario or case the user wants full control over plugins folder/init.lua
+      ++ lib.optionals finalAttrs.wrapRc (
+        [ "--add-flags" "-u ${writeText "init.lua" rcContent}" ]
+        ++ lib.optionals (finalAttrs.packpathDirs.myNeovimPackages.start != [] || finalAttrs.packpathDirs.myNeovimPackages.opt != []) [
+          "--add-flags" ''--cmd "set packpath^=${finalPackdir}"''
+          "--add-flags" ''--cmd "set rtp^=${finalPackdir}"''
+        ]
+        )
       ;
 
     perlEnv = perl.withPackages (p: [ p.NeovimExt p.Appcpanminus ]);

--- a/pkgs/applications/editors/neovim/wrapper.nix
+++ b/pkgs/applications/editors/neovim/wrapper.nix
@@ -48,6 +48,11 @@ let
     # set to false if you want to control where to save the generated config
     # (e.g., in ~/.config/init.vim or project/.nvimrc)
     , wrapRc ? true
+
+    # appends `--set packpath=... --set rtp^=...` to the wrapper
+    # hopefully we can get rid of it
+    , wrapPackpath ? true
+
     # vimL code that should be sourced as part of the generated init.lua file
     , neovimRcContent ? null
     # lua code to put into the generated init.lua file
@@ -146,13 +151,11 @@ let
       ++ [ "--set" "NVIM_SYSTEM_RPLUGIN_MANIFEST" "${placeholder "out"}/rplugin.vim" ]
       ++ finalAttrs.generatedWrapperArgs
       # for home-manager scenario or case the user wants full control over plugins folder/init.lua
-      ++ lib.optionals finalAttrs.wrapRc (
-        [ "--add-flags" "-u ${writeText "init.lua" rcContent}" ]
-        ++ lib.optionals (finalAttrs.packpathDirs.myNeovimPackages.start != [] || finalAttrs.packpathDirs.myNeovimPackages.opt != []) [
+      ++ lib.optionals finalAttrs.wrapRc [ "--add-flags" "-u ${writeText "init.lua" rcContent}" ]
+      ++ lib.optionals (wrapPackpath && (finalAttrs.packpathDirs.myNeovimPackages.start != [] || finalAttrs.packpathDirs.myNeovimPackages.opt != [])) [
           "--add-flags" ''--cmd "set packpath^=${finalPackdir}"''
           "--add-flags" ''--cmd "set rtp^=${finalPackdir}"''
         ]
-        )
       ;
 
     perlEnv = perl.withPackages (p: [ p.NeovimExt p.Appcpanminus ]);


### PR DESCRIPTION
In home-manager we dont want to add "--set packpatk/rtp" otherwise packages are loaded twice see:
https://github.com/nix-community/home-manager/pull/5964

Since the wrapper args are easily added by the user (by using `finalAttrs.packpathDirs`), I propose we dont set them when wrapRc is set as well.
It's a breaking change for anyone using wrapRc.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
