### PR TITLE
systemd: fix typo in boot.kernelParams (hierachy → hierarchy)

### DIFF
--- a/nixos/modules/system/boot/systemd.nix
+++ b/nixos/modules/system/boot/systemd.nix
@@ -716,7 +716,7 @@ in
       (mkRemovedOptionModule [ "systemd" "generator-packages" ] "Use systemd.packages instead.")
       (mkRemovedOptionModule ["systemd" "enableUnifiedCgroupHierarchy"] ''
           In 256 support for cgroup v1 ('legacy' and 'hybrid' hierarchies) is now considered obsolete and systemd by default will refuse to boot under it.
-          To forcibly reenable cgroup v1 support, you can set boot.kernelParams = [ "systemd.unified_cgroup_hierachy=0" "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1" ].
+          To forcibly reenable cgroup v1 support, you can set boot.kernelParams = [ "systemd.unified_cgroup_hierarchy=0" "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1" ].
           NixOS does not officially support this configuration and might cause your system to be unbootable in future versions. You are on your own.
       '')
     ];


### PR DESCRIPTION

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

I have a project that, due to legacy requirements, needs to use cgroup v1. Following the instructions in nixpkgs, I updated my configuration.nix, but it didn’t work. 

```
To forcibly reenable cgroup v1 support, you can set boot.kernelParams = [ "systemd.unified_cgroup_hierachy=0" "SYSTEMD_CGROUP_ENABLE_LEGACY_FORCE=1" ].
```

This issue troubled me for a long time and wasted a lot of my time debugging. Eventually, I realized the problem was caused by a typo in the instructions, which was very misleading: "hierachy" should be corrected to "hierarchy".

While cgroup v1 might be removed entirely in the future, I believe it is necessary to fix this typo to prevent others from facing the same confusion.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


---

