### PR TITLE
hyprpanel: init at 0-unstable-2025-06-20

### DIFF
--- a/pkgs/by-name/hy/hyprpanel/package.nix
+++ b/pkgs/by-name/hy/hyprpanel/package.nix
@@ -1,0 +1,127 @@
+{
+  lib,
+  config,
+  ags,
+  astal,
+  bluez,
+  bluez-tools,
+  brightnessctl,
+  btop,
+  dart-sass,
+  fetchFromGitHub,
+  glib,
+  glib-networking,
+  gnome-bluetooth,
+  gpu-screen-recorder,
+  gpustat,
+  grimblast,
+  gtksourceview3,
+  gvfs,
+  hyprpicker,
+  libgtop,
+  libnotify,
+  libsoup_3,
+  matugen,
+  networkmanager,
+  nix-update-script,
+  python3,
+  pywal,
+  stdenv,
+  swww,
+  upower,
+  wireplumber,
+  wl-clipboard,
+  writeShellScript,
+
+  enableCuda ? config.cudaSupport,
+}:
+ags.bundle {
+  pname = "hyprpanel";
+  version = "0-unstable-2025-06-20";
+
+  __structuredAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "Jas-SinghFSU";
+    repo = "HyprPanel";
+    rev = "d563cdb1f6499d981901336bd0f86303ab95c4a5";
+    hash = "sha256-oREAoOQeAExqWMkw2r3BJfiaflh7QwHFkp8Qm0qDu6o=";
+  };
+
+  # keep in sync with https://github.com/Jas-SinghFSU/HyprPanel/blob/master/flake.nix#L42
+  dependencies = [
+    astal.apps
+    astal.battery
+    astal.bluetooth
+    astal.cava
+    astal.hyprland
+    astal.mpris
+    astal.network
+    astal.notifd
+    astal.powerprofiles
+    astal.tray
+    astal.wireplumber
+
+    bluez
+    bluez-tools
+    brightnessctl
+    btop
+    dart-sass
+    glib
+    gnome-bluetooth
+    grimblast
+    gtksourceview3
+    gvfs
+    hyprpicker
+    libgtop
+    libnotify
+    libsoup_3
+    matugen
+    networkmanager
+    pywal
+    swww
+    upower
+    wireplumber
+    wl-clipboard
+    (python3.withPackages (
+      ps:
+      with ps;
+      [
+        dbus-python
+        pygobject3
+      ]
+      ++ lib.optional enableCuda gpustat
+    ))
+  ] ++ (lib.optionals (stdenv.hostPlatform.system == "x86_64-linux") [ gpu-screen-recorder ]);
+
+  passthru.updateScript = nix-update-script { extraArgs = [ "--version=branch" ]; };
+
+  postFixup =
+    let
+      script = writeShellScript "hyprpanel" ''
+        export GIO_EXTRA_MODULES='${glib-networking}/lib/gio/modules'
+        if [ "$#" -eq 0 ]; then
+          exec @out@/bin/.hyprpanel
+        else
+          exec ${astal.io}/bin/astal -i hyprpanel "$*"
+        fi
+      '';
+    in
+    # bash
+    ''
+      mv "$out/bin/hyprpanel" "$out/bin/.hyprpanel"
+      cp '${script}' "$out/bin/hyprpanel"
+      substituteInPlace "$out/bin/hyprpanel" \
+        --replace-fail '@out@' "$out"
+    '';
+
+  meta = {
+    description = "Bar/Panel for Hyprland with extensive customizability";
+    homepage = "https://github.com/Jas-SinghFSU/HyprPanel";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ perchun ];
+    mainProgram = "hyprpanel";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

> [!NOTE]  
> I daily drive everything from this PR and #374302 since 2025 new year, so everything is pretty well tested

https://github.com/Jas-SinghFSU/HyprPanel: Bar/Panel for Hyprland with extensive customizability

Fixes #350324
Closes https://github.com/Jas-SinghFSU/HyprPanel/issues/371

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
