### PR TITLE
python3Packages.zarr: 3.0.1 -> 2.18.3

### DIFF
--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -46,6 +46,9 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "zarr" ];
 
+  # FIXME remove once zarr's reverse dependencies support v3
+  passthru.skipBulkUpdate = true;
+
   meta = {
     description = "Implementation of chunked, compressed, N-dimensional arrays for Python";
     homepage = "https://github.com/zarr-developers/zarr";

--- a/pkgs/development/python-modules/zarr/default.nix
+++ b/pkgs/development/python-modules/zarr/default.nix
@@ -5,68 +5,43 @@
   pythonOlder,
 
   # build-system
-  hatchling,
-  hatch-vcs,
+  setuptools-scm,
 
   # dependencies
   asciitree,
-  donfig,
   numpy,
   fasteners,
   numcodecs,
 
   # tests
-  aiohttp,
-  botocore,
-  fsspec,
-  hypothesis,
-  pytest-asyncio,
   pytestCheckHook,
-  requests,
-  rich,
 }:
 
 buildPythonPackage rec {
   pname = "zarr";
-  version = "3.0.1";
+  version = "2.18.3";
   format = "pyproject";
 
   disabled = pythonOlder "3.8";
 
   src = fetchPypi {
     inherit pname version;
-    hash = "sha256-AzhZxWA9ycKeU69JTt4ktC8bdh0rtiVGaZCjuKmvt5I=";
+    hash = "sha256-JYDYy23YRiF3GhDTHE13fcqKJ3BqGomyn0LS034t9c4=";
   };
 
   build-system = [
-    hatchling
-    hatch-vcs
+    setuptools-scm
   ];
 
   dependencies = [
     asciitree
-    donfig
     numpy
     fasteners
     numcodecs
-  ] ++ numcodecs.optional-dependencies.crc32c;
+  ] ++ numcodecs.optional-dependencies.msgpack;
 
   nativeCheckInputs = [
-    aiohttp
-    botocore
-    fsspec
-    hypothesis
-    pytest-asyncio
     pytestCheckHook
-    requests
-    rich
-  ];
-
-  disabledTests = [
-    # flaky
-    "test_vindex"
-    "test_zarr_hierarchy"
-    "test_zarr_store"
   ];
 
   pythonImportsCheck = [ "zarr" ];


### PR DESCRIPTION
This reverts commit d63c6c91866921a7c64a0d6a15a75a8f5b459351.

Most dependencies of `zarr` are broken by the 3.x bump. [This is due to lack of upstream support, not due to old versions in Nixpkgs.]
See https://github.com/NixOS/nixpkgs/pull/373248 for an incomplete list.

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
