### PR TITLE
lib.systems: deprecate `==` comparison between elaborated platforms

### DIFF
--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -41,6 +41,10 @@
 
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
+- Using `==` or `!=` to compare elaborated platform attrsets, such as `stdenv.hostPlatform` and `stdenv.buildPlatform`, is no longer supported and may produce a warning. In a future version, this warning will be replaced with an error. Instead, you should use the `canExecute`, `equals`, or `notEquals` functions included with platform attrsets or use `lib.systems.equals`.
+
+  - E.g. replace `hostPlatform == buildPlatform` with `buildPlatform.canExecute hostPlatform`.
+
 - `apptainer` and `singularity` deprecate the workaround of overriding `vendorHash` and related attributes via `<pkg>.override`,
   in favour of the unified overriding of the same group of attributes via `<pkg>.overrideAttrs`.
   The compatibility layer will be removed in future releases.

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -531,6 +531,10 @@ let
               "-uefi"
             ];
           };
+        }
+        // {
+          equals = equals final;
+          notEquals = platform: !final.equals platform;
         };
     in
     assert final.useAndroidPrebuilt -> final.isAndroid;

--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -20,6 +20,15 @@ let
 
   inherit (lib.strings) toJSON;
 
+  # define this binding in the top-level let-block so that it only prints once
+  warnAboutPlatformEquals = lib.warn (lib.concatStringsSep " " [
+    "It seems that you're comparing platform attrsets using plain == equality,"
+    "which is not supported, and will result in an error soon."
+    "Use `--abort-on-warn --show-trace` to find the location of this warning."
+    "If equality (e.g. host == build) was used, try (build.canExecute host) or (build.equals host) instead."
+    "If equality was not used, you may avoid this warning by filtering out the `warnAboutPlatformEquals` attribute."
+  ]) null;
+
   doubles = import ./doubles.nix { inherit lib; };
   parse = import ./parse.nix { inherit lib; };
   inspect = import ./inspect.nix { inherit lib; };
@@ -43,9 +52,9 @@ let
   */
   equals =
     let
-      removeFunctions = a: filterAttrs (_: v: !isFunction v) a;
+      removeUnwanted = filterAttrs (name: v: !(name == "warnAboutPlatformEquals" || isFunction v));
     in
-    a: b: removeFunctions a == removeFunctions b;
+    a: b: removeUnwanted a == removeUnwanted b;
 
   /**
     List of all Nix system doubles the nixpkgs flake will expose the package set
@@ -533,6 +542,7 @@ let
           };
         }
         // {
+          inherit warnAboutPlatformEquals;
           equals = equals final;
           notEquals = platform: !final.equals platform;
         };

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -280,10 +280,13 @@ lib.runTests (
                 isCompatible = null;
               } ? ${platformAttrName};
           };
-
       })
+      # x86_64-linux is an arbitrary choice, just to get all the elaborated attrNames
       (
-        lib.systems.elaborate "x86_64-linux" # arbitrary choice, just to get all the elaborated attrNames
+        builtins.removeAttrs (lib.systems.elaborate "x86_64-linux") [
+          # Avoid the warning
+          "warnAboutPlatformEquals"
+        ]
       )
 
 )

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -274,6 +274,8 @@ lib.runTests (
                 canExecute = null;
                 emulator = null;
                 emulatorAvailable = null;
+                equals = null;
+                notEquals = null;
                 staticEmulatorAvailable = null;
                 isCompatible = null;
               } ? ${platformAttrName};

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -267,18 +267,7 @@ lib.runTests (
           in
           {
             expr = lib.systems.equals (lib.systems.elaborate "x86_64-linux") modified;
-            expected =
-              {
-                # Changes in these attrs are not detectable because they're function.
-                # The functions should be derived from the data, so this is not a problem.
-                canExecute = null;
-                emulator = null;
-                emulatorAvailable = null;
-                equals = null;
-                notEquals = null;
-                staticEmulatorAvailable = null;
-                isCompatible = null;
-              } ? ${platformAttrName};
+            expected = false;
           };
       })
       # x86_64-linux is an arbitrary choice, just to get all the elaborated attrNames
@@ -286,6 +275,15 @@ lib.runTests (
         builtins.removeAttrs (lib.systems.elaborate "x86_64-linux") [
           # Avoid the warning
           "warnAboutPlatformEquals"
+          # Changes in these attrs are not detectable because they're function.
+          # The functions should be derived from the data, so this is not a problem.
+          "canExecute"
+          "emulator"
+          "emulatorAvailable"
+          "equals"
+          "isCompatible"
+          "notEquals"
+          "staticEmulatorAvailable"
         ]
       )
 

--- a/nixos/modules/config/nix.nix
+++ b/nixos/modules/config/nix.nix
@@ -145,7 +145,7 @@ let
         ${cfg.extraOptions}
       '';
       checkPhase = lib.optionalString cfg.checkConfig (
-        if pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform then
+        if pkgs.stdenv.hostPlatform.notEquals pkgs.stdenv.buildPlatform then
           ''
             echo "Ignoring validation for cross-compilation"
           ''

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -226,7 +226,15 @@ in
           elaborated = lib.systems.elaborate inputBuildPlatform;
         in
         if lib.systems.equals elaborated cfg.hostPlatform then
-          cfg.hostPlatform # make identical, so that `==` equality works; see https://github.com/NixOS/nixpkgs/issues/278001
+          # Make equivalent platforms actually identical, so that `==` equality works.
+          # See https://github.com/NixOS/nixpkgs/issues/278001
+          # NOTE: `==` between platforms was deprecated 2025-02-08.
+          # Users should instead use the `canExecute`, `equals`, or `notEquals`
+          # functions included with platform attrsets or use `lib.systems.equals`.
+          # See https://github.com/NixOS/nixpkgs/pull/380005
+          # TODO: Once users have had chance to migrate, this `apply` function
+          # can be simplified to `lib.systems.elaborate`.
+          cfg.hostPlatform
         else
           elaborated;
       defaultText = lib.literalExpression ''config.nixpkgs.hostPlatform'';

--- a/nixos/modules/misc/nixpkgs.nix
+++ b/nixos/modules/misc/nixpkgs.nix
@@ -73,7 +73,7 @@ let
   defaultPkgs =
     if opt.hostPlatform.isDefined then
       let
-        isCross = cfg.buildPlatform != cfg.hostPlatform;
+        isCross = cfg.buildPlatform.notEquals cfg.hostPlatform;
         systemArgs =
           if isCross then
             {

--- a/nixos/modules/services/databases/postgresql.nix
+++ b/nixos/modules/services/databases/postgresql.nix
@@ -715,7 +715,7 @@ in
     ];
 
     system.checks = lib.optional (
-      cfg.checkConfig && pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform
+      cfg.checkConfig && pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform
     ) configFileCheck;
 
     systemd.services.postgresql = {

--- a/nixos/modules/services/monitoring/nagios.nix
+++ b/nixos/modules/services/monitoring/nagios.nix
@@ -139,8 +139,8 @@ in
 
       validateConfig = lib.mkOption {
         type = lib.types.bool;
-        default = pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform;
-        defaultText = lib.literalExpression "pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform";
+        default = pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform;
+        defaultText = lib.literalExpression "pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform";
         description = "if true, the syntax of the nagios configuration file is checked at build time";
       };
 

--- a/nixos/modules/services/networking/ssh/sshd.nix
+++ b/nixos/modules/services/networking/ssh/sshd.nix
@@ -11,7 +11,7 @@ let
   # This middle-ground solution ensures *an* sshd can do their basic validation
   # on the configuration.
   validationPackage =
-    if pkgs.stdenv.buildPlatform == pkgs.stdenv.hostPlatform then
+    if pkgs.stdenv.buildPlatform.equals pkgs.stdenv.hostPlatform then
       cfg.package
     else
       pkgs.buildPackages.openssh;

--- a/nixos/modules/services/web-servers/caddy/default.nix
+++ b/nixos/modules/services/web-servers/caddy/default.nix
@@ -60,7 +60,7 @@ let
         '';
       in
       "${
-        if pkgs.stdenv.buildPlatform == pkgs.stdenv.hostPlatform then Caddyfile-formatted else Caddyfile
+        if pkgs.stdenv.buildPlatform.equals pkgs.stdenv.hostPlatform then Caddyfile-formatted else Caddyfile
       }/Caddyfile";
 
   etcConfigFile = "caddy/caddy_config";

--- a/nixos/modules/system/activation/switchable-system.nix
+++ b/nixos/modules/system/activation/switchable-system.nix
@@ -71,7 +71,7 @@ in
           ;
 
         chmod +x $out/bin/switch-to-configuration
-        ${lib.optionalString (pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform) ''
+        ${lib.optionalString (pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform) ''
           if ! output=$(${perlWrapped}/bin/perl -c $out/bin/switch-to-configuration 2>&1); then
             echo "switch-to-configuration syntax is not valid:"
             echo "$output"

--- a/nixos/modules/system/boot/stage-1.nix
+++ b/nixos/modules/system/boot/stage-1.nix
@@ -221,7 +221,7 @@ let
           patchelf --set-rpath $out/lib $i
         done
 
-        if [ -z "${toString (pkgs.stdenv.hostPlatform != pkgs.stdenv.buildPlatform)}" ]; then
+        if [ -z "${toString (pkgs.stdenv.hostPlatform.notEquals pkgs.stdenv.buildPlatform)}" ]; then
         # Make sure that the patchelf'ed binaries still work.
         echo "testing patched programs..."
         $out/bin/ash -c 'echo hello world' | grep "hello world"

--- a/pkgs/applications/audio/csound/default.nix
+++ b/pkgs/applications/audio/csound/default.nix
@@ -44,9 +44,7 @@ stdenv.mkDerivation {
     [ "-DBUILD_CSOUND_AC=0" ] # fails to find Score.hpp
     ++ lib.optional stdenv.hostPlatform.isDarwin "-DCS_FRAMEWORK_DEST=${placeholder "out"}/lib"
     # Ignore gettext in CMAKE_PREFIX_PATH on cross to prevent find_program picking up the wrong gettext
-    ++ lib.optional (
-      stdenv.hostPlatform != stdenv.buildPlatform
-    ) "-DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin";
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "-DCMAKE_IGNORE_PATH=${lib.getBin gettext}/bin";
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/applications/audio/faust/faust2.nix
+++ b/pkgs/applications/audio/faust/faust2.nix
@@ -92,11 +92,9 @@ let
         cd ..
         shopt -s globstar
         for f in **/Makefile **/Makefile.library **/CMakeLists.txt build/Make.llvm.static embedded/faustjava/faust2engine architecture/autodiff/autodiff.sh source/tools/faust2appls/* **/llvm.cmake tools/benchmark/faust2object; do
-          echo $f "llvm-config${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "-native"}"
+          echo $f "llvm-config${lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "-native"}"
           substituteInPlace $f \
-            --replace-quiet "llvm-config" "llvm-config${
-              lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "-native"
-            }"
+            --replace-quiet "llvm-config" "llvm-config${lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "-native"}"
         done
         shopt -u globstar
         cd build

--- a/pkgs/applications/editors/vim/default.nix
+++ b/pkgs/applications/editors/vim/default.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation {
       "--enable-multibyte"
       "--enable-nls"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) (
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) (
       [
         "vim_cv_toupper_broken=no"
         "--with-tlib=ncurses"

--- a/pkgs/applications/editors/vim/full.nix
+++ b/pkgs/applications/editors/vim/full.nix
@@ -129,7 +129,7 @@ stdenv.mkDerivation {
       "--disable-carbon_check"
       "--disable-gtktest"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "vim_cv_toupper_broken=no"
       "--with-tlib=ncurses"
       "vim_cv_terminfo=yes"

--- a/pkgs/applications/graphics/sane/backends/default.nix
+++ b/pkgs/applications/graphics/sane/backends/default.nix
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
 
   # autoconf check for HAVE_MMAP is never set on cross compilation.
   # The pieusb backend fails compilation if HAVE_MMAP is not set.
-  buildFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  buildFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "CFLAGS=-DHAVE_MMAP=${if stdenv.hostPlatform.isLinux then "1" else "0"}"
   ];
 

--- a/pkgs/applications/networking/browsers/chromium/common.nix
+++ b/pkgs/applications/networking/browsers/chromium/common.nix
@@ -692,7 +692,8 @@ let
 
       ''
       +
-        lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform && stdenv.hostPlatform.isAarch64)
+        lib.optionalString
+          (stdenv.hostPlatform.equals stdenv.buildPlatform && stdenv.hostPlatform.isAarch64)
           ''
             substituteInPlace build/toolchain/linux/BUILD.gn \
               --replace 'toolprefix = "aarch64-linux-gnu-"' 'toolprefix = ""'
@@ -739,7 +740,7 @@ let
         # We only build those specific toolchains when we cross-compile, as native non-cross-compilations would otherwise
         # end up building much more things than they need to (roughly double the build steps and time/compute):
       }
-      // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+      // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
         host_toolchain = "//build/toolchain/linux/unbundle:host";
         v8_snapshot_toolchain = "//build/toolchain/linux/unbundle:host";
       }

--- a/pkgs/applications/networking/browsers/elinks/default.nix
+++ b/pkgs/applications/networking/browsers/elinks/default.nix
@@ -23,7 +23,7 @@
   guile ? null,
   enablePython ? false,
   python ? null,
-  enablePerl ? (!stdenv.hostPlatform.isDarwin) && (stdenv.hostPlatform == stdenv.buildPlatform),
+  enablePerl ? (!stdenv.hostPlatform.isDarwin) && (stdenv.hostPlatform.equals stdenv.buildPlatform),
   perl ? null,
 # re-add javascript support when upstream supports modern spidermonkey
 }:

--- a/pkgs/applications/networking/browsers/firefox/common.nix
+++ b/pkgs/applications/networking/browsers/firefox/common.nix
@@ -131,7 +131,7 @@ in
   ),
   overrideCC,
   buildPackages,
-  pgoSupport ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform == stdenv.buildPlatform),
+  pgoSupport ? (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.equals stdenv.buildPlatform),
   xvfb-run,
   elfhackSupport ?
     isElfhackPlatform stdenv && !(stdenv.hostPlatform.isMusl && stdenv.hostPlatform.isAarch64),

--- a/pkgs/applications/networking/sniffers/wireshark/default.nix
+++ b/pkgs/applications/networking/sniffers/wireshark/default.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     ./patches/lookup-dumpcap-in-path.patch
   ];
 
-  depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  depsBuildBuild = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     buildPackages.stdenv.cc
   ];
 
@@ -163,7 +163,7 @@ stdenv.mkDerivation rec {
       "-DENABLE_APPLICATION_BUNDLE=${if isAppBundle then "ON" else "OFF"}"
       "-DLEMON_C_COMPILER=cc"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "-DHAVE_C99_VSNPRINTF_EXITCODE__TRYRUN_OUTPUT="
       "-DHAVE_C99_VSNPRINTF_EXITCODE=0"
     ];

--- a/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
+++ b/pkgs/applications/science/misc/openmodelica/omcompiler/default.nix
@@ -18,7 +18,7 @@
   mkOpenModelicaDerivation,
 }:
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   nativeOMCompiler = buildPackages.openmodelica.omcompiler;
 in
 mkOpenModelicaDerivation (

--- a/pkgs/applications/version-management/git/default.nix
+++ b/pkgs/applications/version-management/git/default.nix
@@ -33,7 +33,7 @@
   subversionClient,
   perlLibs,
   smtpPerlLibs,
-  perlSupport ? stdenv.buildPlatform == stdenv.hostPlatform,
+  perlSupport ? stdenv.buildPlatform.equals stdenv.hostPlatform,
   nlsSupport ? true,
   osxkeychainSupport ? stdenv.hostPlatform.isDarwin,
   guiSupport ? false,
@@ -178,7 +178,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       "ac_cv_prog_CURL_CONFIG=${lib.getDev curl}/bin/curl-config"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "ac_cv_fread_reads_directories=yes"
       "ac_cv_snprintf_returns_bogus=no"
       "ac_cv_iconv_omits_bom=no"
@@ -195,7 +195,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     # Git does not allow setting a shell separately for building and run-time.
     # Therefore lets leave it at the default /bin/sh when cross-compiling
-    ++ lib.optional (stdenv.buildPlatform == stdenv.hostPlatform) "SHELL_PATH=${stdenv.shell}"
+    ++ lib.optional (stdenv.buildPlatform.equals stdenv.hostPlatform) "SHELL_PATH=${stdenv.shell}"
     ++ (if perlSupport then [ "PERL_PATH=${perlPackages.perl}/bin/perl" ] else [ "NO_PERL=1" ])
     ++ (if pythonSupport then [ "PYTHON_PATH=${python3}/bin/python" ] else [ "NO_PYTHON=1" ])
     ++ lib.optionals stdenv.hostPlatform.isSunOS [
@@ -219,7 +219,7 @@ stdenv.mkDerivation (finalAttrs: {
     # See https://github.com/Homebrew/homebrew-core/commit/dfa3ccf1e7d3901e371b5140b935839ba9d8b706
     ++ lib.optional stdenv.hostPlatform.isDarwin "TKFRAMEWORK=/nonexistent";
 
-  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  disallowedReferences = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     stdenv.shellPackage
   ];
 

--- a/pkgs/applications/version-management/mercurial/default.nix
+++ b/pkgs/applications/version-management/mercurial/default.nix
@@ -186,7 +186,7 @@ let
         requiredSystemFeatures = [ "big-parallel" ];
 
         # Don't run tests if not-Linux or if cross-compiling.
-        meta.broken = !stdenv.hostPlatform.isLinux || stdenv.buildPlatform != stdenv.hostPlatform;
+        meta.broken = !stdenv.hostPlatform.isLinux || stdenv.buildPlatform.notEquals stdenv.hostPlatform;
       }
       ''
         addToSearchPathWithCustomDelimiter : PYTHONPATH "${mercurial}/${python.sitePackages}"

--- a/pkgs/applications/video/kodi/unwrapped.nix
+++ b/pkgs/applications/video/kodi/unwrapped.nix
@@ -410,7 +410,7 @@ stdenv.mkDerivation (finalAttrs: {
     ''
       cmakeFlagsArray+=("-DCORE_PLATFORM_NAME=${lib.concatStringsSep " " kodi_platforms}")
     ''
-    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       # Need these tools on the build system when cross compiling,
       # hacky, but have found no other way.
       CXX=$CXX_FOR_BUILD LD=ld make -C tools/depends/native/JsonSchemaBuilder

--- a/pkgs/applications/video/mplayer/default.nix
+++ b/pkgs/applications/video/mplayer/default.nix
@@ -114,7 +114,7 @@ let
     else
       null;
 
-  crossBuild = stdenv.hostPlatform != stdenv.buildPlatform;
+  crossBuild = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 
 in
 

--- a/pkgs/build-support/bintools-wrapper/default.nix
+++ b/pkgs/build-support/bintools-wrapper/default.nix
@@ -107,7 +107,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = optionalString (targetPlatform != hostPlatform) (targetPlatform.config + "-");
+  targetPrefix = optionalString (targetPlatform.notEquals hostPlatform) (targetPlatform.config + "-");
 
   bintoolsVersion = getVersion bintools;
   bintoolsName = removePrefix targetPrefix (getName bintools);

--- a/pkgs/build-support/go/module.nix
+++ b/pkgs/build-support/go/module.nix
@@ -342,7 +342,7 @@ lib.extendMkDerivation {
                 buildGoDir install "$pkg"
               done
             ''
-          + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+          + lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
             # normalize cross-compiled builds w.r.t. native builds
             (
               dir=$GOPATH/bin/''${GOOS}_''${GOARCH}

--- a/pkgs/build-support/lib/cmake.nix
+++ b/pkgs/build-support/lib/cmake.nix
@@ -8,7 +8,7 @@ let
     optionals
     ;
 
-  cmakeFlags' = optionals (stdenv.hostPlatform != stdenv.buildPlatform) (
+  cmakeFlags' = optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) (
     [
       "-DCMAKE_SYSTEM_NAME=${
         findFirst isString "Generic" (

--- a/pkgs/build-support/lib/meson.nix
+++ b/pkgs/build-support/lib/meson.nix
@@ -34,7 +34,7 @@ let
     cmake = 'cmake'
   '';
 
-  crossFlags = optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  crossFlags = optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "--cross-file=${crossFile}"
   ];
 

--- a/pkgs/build-support/pkg-config-wrapper/default.nix
+++ b/pkgs/build-support/pkg-config-wrapper/default.nix
@@ -30,7 +30,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = optionalString (targetPlatform != hostPlatform) (targetPlatform.config + "-");
+  targetPrefix = optionalString (targetPlatform.notEquals hostPlatform) (targetPlatform.config + "-");
 
   # See description in cc-wrapper.
   suffixSalt = replaceStrings [ "-" "." ] [ "_" "_" ] targetPlatform.config;

--- a/pkgs/build-support/rust/build-rust-crate/build-crate.nix
+++ b/pkgs/build-support/rust/build-rust-crate/build-crate.nix
@@ -35,7 +35,7 @@ let
       (mkRustcDepArgs dependencies crateRenames)
       (mkRustcFeatureArgs crateFeatures)
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--target"
       stdenv.hostPlatform.rust.rustcTargetSpec
     ]

--- a/pkgs/build-support/rust/build-rust-crate/test/default.nix
+++ b/pkgs/build-support/rust/build-rust-crate/test/default.nix
@@ -122,16 +122,16 @@ let
             ${lib.concatMapStringsSep "\n" (
               binary:
               # Can't actually run the binary when cross-compiling
-              (lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "type ") + binary
+              (lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "type ") + binary
             ) binaries}
             ${lib.optionalString isLib ''
               test -e ${crate}/lib/*.rlib || exit 1
-              ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "test -x "} \
+              ${lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "test -x "} \
                 ${libTestBinary}/bin/run-test-${crateName}
             ''}
             touch $out
           ''
-        else if stdenv.hostPlatform == stdenv.buildPlatform then
+        else if stdenv.hostPlatform.equals stdenv.buildPlatform then
           ''
             for file in ${crate}/tests/*; do
               $file 2>&1 >> $out
@@ -847,7 +847,7 @@ rec {
             nativeBuildInputs = [ pkg ];
           }
           (
-            if stdenv.hostPlatform == stdenv.buildPlatform then
+            if stdenv.hostPlatform.equals stdenv.buildPlatform then
               ''
                 ${pkg}/bin/brotli -c ${pkg}/bin/brotli > /dev/null && touch $out
               ''
@@ -888,7 +888,7 @@ rec {
             nativeBuildInputs = [ pkg ];
           }
           (
-            if stdenv.hostPlatform == stdenv.buildPlatform then
+            if stdenv.hostPlatform.equals stdenv.buildPlatform then
               ''
                 ${pkg}/bin/rcgen && touch $out
               ''

--- a/pkgs/build-support/rust/build-rust-package/default.nix
+++ b/pkgs/build-support/rust/build-rust-package/default.nix
@@ -142,7 +142,7 @@ lib.extendMkDerivation {
 
       patches = cargoPatches ++ patches;
 
-      PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform != stdenv.hostPlatform then 1 else 0;
+      PKG_CONFIG_ALLOW_CROSS = if stdenv.buildPlatform.notEquals stdenv.hostPlatform then 1 else 0;
 
       postUnpack =
         ''

--- a/pkgs/by-name/al/alsa-firmware/package.nix
+++ b/pkgs/by-name/al/alsa-firmware/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   configureFlags = [ "--with-hotplug-dir=$(out)/lib/firmware" ];
 
   depsBuildBuild = lib.optional (
-    stdenv.buildPlatform != stdenv.hostPlatform
+    stdenv.buildPlatform.notEquals stdenv.hostPlatform
     || stdenv.hostPlatform.isAarch64
     || stdenv.hostPlatform.isLoongArch64
     || stdenv.hostPlatform.isRiscV64

--- a/pkgs/by-name/ap/aprutil/package.nix
+++ b/pkgs/by-name/ap/aprutil/package.nix
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
       # For some reason, db version 6.9 is selected when cross-compiling.
       # It's unclear as to why, it requires someone with more autotools / configure knowledge to go deeper into that.
       # Always replacing the link flag with a generic link flag seems to help though, so let's do that for now.
-      lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+      lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
         substituteInPlace Makefile \
           --replace "-ldb-6.9" "-ldb"
         substituteInPlace apu-1-config \

--- a/pkgs/by-name/ar/argo-workflows/package.nix
+++ b/pkgs/by-name/ar/argo-workflows/package.nix
@@ -79,7 +79,7 @@ buildGoModule rec {
   postInstall = ''
     for shell in bash zsh; do
       ${
-        if (stdenv.buildPlatform == stdenv.hostPlatform) then
+        if (stdenv.buildPlatform.equals stdenv.hostPlatform) then
           "$out/bin/argo"
         else
           "${pkgsBuildBuild.argo}/bin/argo"

--- a/pkgs/by-name/ar/argyllcms/package.nix
+++ b/pkgs/by-name/ar/argyllcms/package.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
     }
   );
 
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     substituteInPlace Jambase \
       --replace "-m64" ""
   '';

--- a/pkgs/by-name/ar/arrow-cpp/package.nix
+++ b/pkgs/by-name/ar/arrow-cpp/package.nix
@@ -50,7 +50,7 @@
   zstd,
   testers,
   enableShared ? !stdenv.hostPlatform.isStatic,
-  enableFlight ? stdenv.buildPlatform == stdenv.hostPlatform,
+  enableFlight ? stdenv.buildPlatform.equals stdenv.hostPlatform,
   enableJemalloc ? !stdenv.hostPlatform.isDarwin && !stdenv.hostPlatform.isAarch64,
   enableS3 ? true,
   enableGcs ? !stdenv.hostPlatform.isDarwin,

--- a/pkgs/by-name/au/aubio/package.nix
+++ b/pkgs/by-name/au/aubio/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   ];
 
   strictDeps = true;
-  wafFlags = lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "--disable-tests";
+  wafFlags = lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "--disable-tests";
 
   postPatch = ''
     # U was removed in python 3.11 because it had no effect

--- a/pkgs/by-name/au/audit/package.nix
+++ b/pkgs/by-name/au/audit/package.nix
@@ -13,7 +13,7 @@
   # Enabling python support while cross compiling would be possible, but the
   # configure script tries executing python to gather info instead of relying on
   # python3-config exclusively
-  enablePython ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enablePython ? stdenv.hostPlatform.equals stdenv.buildPlatform,
 }:
 stdenv.mkDerivation (finalAttrs: {
   pname = "audit";

--- a/pkgs/by-name/au/authentik/package.nix
+++ b/pkgs/by-name/au/authentik/package.nix
@@ -31,7 +31,7 @@ let
     homepage = "https://goauthentik.io/";
     license = licenses.mit;
     platforms = platforms.linux;
-    broken = stdenvNoCC.buildPlatform != stdenvNoCC.hostPlatform;
+    broken = stdenvNoCC.buildPlatform.notEquals stdenvNoCC.hostPlatform;
     maintainers = with maintainers; [
       jvanbruegge
       risson

--- a/pkgs/by-name/au/autogen/package.nix
+++ b/pkgs/by-name/au/autogen/package.nix
@@ -96,7 +96,7 @@ stdenv.mkDerivation rec {
       perl
       autoreconfHook # patches applied
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # autogen needs a build autogen when cross-compiling
       buildPackages.buildPackages.autogen
       buildPackages.texinfo
@@ -123,7 +123,7 @@ stdenv.mkDerivation rec {
       "--enable-timeout=78"
       "CFLAGS=-D_FILE_OFFSET_BITS=64"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # the configure check for regcomp wants to run a host program
       "libopts_cv_with_libregex=yes"
       #"MAKEINFO=${buildPackages.texinfo}/bin/makeinfo"

--- a/pkgs/by-name/ba/babeltrace/package.nix
+++ b/pkgs/by-name/ba/babeltrace/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
       # --enable-debug-info (default) requires the configure script to run host
       # executables to determine the elfutils library version, which cannot be done
       # while cross compiling.
-      (lib.enableFeature (stdenv.hostPlatform == stdenv.buildPlatform) "debug-info")
+      (lib.enableFeature (stdenv.hostPlatform.equals stdenv.buildPlatform) "debug-info")
     ]
     ++ lib.optionals enablePython [
       # Using (lib.enableFeature enablePython "python-bindings") makes the

--- a/pkgs/by-name/ba/babeltrace2/package.nix
+++ b/pkgs/by-name/ba/babeltrace2/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
   configureFlags = [
     (lib.enableFeature enablePython "python-bindings")
     (lib.enableFeature enablePython "python-plugins")
-    (lib.enableFeature (stdenv.hostPlatform == stdenv.buildPlatform) "debug-info")
+    (lib.enableFeature (stdenv.hostPlatform.equals stdenv.buildPlatform) "debug-info")
   ];
 
   # For cross-compilation of Python bindings

--- a/pkgs/by-name/ba/babl/package.nix
+++ b/pkgs/by-name/ba/babl/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       "-Dprefix-dev=${placeholder "dev"}"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       # Docs are opt-out in native but opt-in in cross builds.
       "-Dwith-docs=true"
       "-Denable-gir=true"

--- a/pkgs/by-name/bi/bind/package.nix
+++ b/pkgs/by-name/bi/bind/package.nix
@@ -78,7 +78,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--with-libidn2"
     ]
     ++ lib.optional enableGSSAPI "--with-gssapi=${libkrb5.dev}/bin/krb5-config"
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "BUILD_CC=$(CC_FOR_BUILD)";
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "BUILD_CC=$(CC_FOR_BUILD)";
 
   postInstall = ''
     moveToOutput bin/bind9-config $dev

--- a/pkgs/by-name/bi/bison/package.nix
+++ b/pkgs/by-name/bi/bison/package.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   # there's a /bin/sh shebang in bin/yacc which when no strictDeps is patched with the build stdenv shell
   # however when cross-compiling it would still be patched with the build stdenv shell which would be wrong
   # cannot add bash to buildInputs due to infinite recursion
-  strictDeps = stdenv.hostPlatform != stdenv.buildPlatform;
+  strictDeps = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 
   nativeBuildInputs = [
     m4

--- a/pkgs/by-name/bo/boringssl/package.nix
+++ b/pkgs/by-name/bo/boringssl/package.nix
@@ -34,7 +34,7 @@ buildGoModule {
     ''
       cmakeConfigurePhase
     ''
-    + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       export GOARCH=$(go env GOHOSTARCH)
     '';
 

--- a/pkgs/by-name/bp/bpf-linker/package.nix
+++ b/pkgs/by-name/bp/bpf-linker/package.nix
@@ -47,6 +47,6 @@ rustPlatform.buildRustPackage rec {
     maintainers = with lib.maintainers; [ nickcao ];
     # llvm-sys crate locates llvm by calling llvm-config
     # which is not available when cross compiling
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/by-name/bu/bup/package.nix
+++ b/pkgs/by-name/bu/bup/package.nix
@@ -95,6 +95,6 @@ stdenv.mkDerivation {
     platforms = platforms.linux ++ platforms.darwin;
     maintainers = with maintainers; [ rnhmjoj ];
     # bespoke ./configure does not like cross
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/by-name/ca/cabextract/package.nix
+++ b/pkgs/by-name/ca/cabextract/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
 
   # Let's assume that fnmatch works for cross-compilation, otherwise it gives an error:
   # undefined reference to `rpl_fnmatch'.
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "ac_cv_func_fnmatch_works=yes"
   ];
 

--- a/pkgs/by-name/ca/cardinal/package.nix
+++ b/pkgs/by-name/ca/cardinal/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation rec {
       "SYSDEPS=true"
       "PREFIX=$(out)"
     ]
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "CROSS_COMPILING=true"
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "CROSS_COMPILING=true"
     ++ lib.optional headless "HEADLESS=true";
 
   postInstall = ''

--- a/pkgs/by-name/ca/caribou/package.nix
+++ b/pkgs/by-name/ca/caribou/package.nix
@@ -114,6 +114,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     # checking for a Python interpreter with version >= 2.4... none
     # configure: error: no suitable Python interpreter found
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/by-name/cc/cctools/package.nix
+++ b/pkgs/by-name/cc/cctools/package.nix
@@ -14,9 +14,7 @@
 
 let
   # The targetPrefix is prepended to binary names to allow multiple binuntils on the PATH to both be usable.
-  targetPrefix = lib.optionalString (
-    stdenv.targetPlatform != stdenv.hostPlatform
-  ) "${stdenv.targetPlatform.config}-";
+  targetPrefix = lib.optionalString (stdenv.targetPlatform.notEquals stdenv.hostPlatform) "${stdenv.targetPlatform.config}-";
 
   # First version with all the required files
   xnu = fetchFromGitHub {

--- a/pkgs/by-name/cd/cdrkit/package.nix
+++ b/pkgs/by-name/cd/cdrkit/package.nix
@@ -74,7 +74,9 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $out/bin/wodim $out/bin/cdrecord
   '';
 
-  cmakeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "-DBITFIELDS_HTOL=0" ];
+  cmakeFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
+    "-DBITFIELDS_HTOL=0"
+  ];
 
   makeFlags = [ "PREFIX=\$(out)" ];
 

--- a/pkgs/by-name/ci/cifs-utils/package.nix
+++ b/pkgs/by-name/ci/cifs-utils/package.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     [ "ROOTSBINDIR=$(out)/sbin" ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # AC_FUNC_MALLOC is broken on cross builds.
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/by-name/cm/cmake/package.nix
+++ b/pkgs/by-name/cm/cmake/package.nix
@@ -189,7 +189,7 @@ stdenv.mkDerivation (finalAttrs: {
   env.NIX_CFLAGS_COMPILE = "-Wno-unused-command-line-argument";
 
   # make install attempts to use the just-built cmake
-  preInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preInstall = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     sed -i 's|bin/cmake|${buildPackages.cmakeMinimal}/bin/cmake|g' Makefile
   '';
 

--- a/pkgs/by-name/cr/cracklib/package.nix
+++ b/pkgs/by-name/cr/cracklib/package.nix
@@ -36,16 +36,14 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  nativeBuildInputs = lib.optional (
-    stdenv.hostPlatform != stdenv.buildPlatform
-  ) buildPackages.cracklib;
+  nativeBuildInputs = lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) buildPackages.cracklib;
   buildInputs = [
     zlib
     gettext
   ];
 
   postPatch =
-    lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
       chmod +x util/cracklib-format
       patchShebangs util
 

--- a/pkgs/by-name/cr/criu/package.nix
+++ b/pkgs/by-name/cr/criu/package.nix
@@ -103,7 +103,7 @@ stdenv.mkDerivation rec {
       "ASCIIDOC=${buildPackages.asciidoc}/bin/asciidoc"
       "XMLTO=${buildPackages.xmlto}/bin/xmlto"
     ]
-    ++ (lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ (lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "ARCH=${linuxArchMapping."${stdenv.hostPlatform.linuxArch}"}"
       "CROSS_COMPILE=${stdenv.hostPlatform.config}-"
     ]);

--- a/pkgs/by-name/cu/curlMinimal/package.nix
+++ b/pkgs/by-name/cu/curlMinimal/package.nix
@@ -27,7 +27,7 @@
         # the "mig" tool does not configure its compiler correctly. This could be
         # fixed in mig, but losing gss support on cross compilation to darwin is
         # not worth the effort.
-        !(isDarwin && (stdenv.buildPlatform != stdenv.hostPlatform))
+        !(isDarwin && (stdenv.buildPlatform.notEquals stdenv.hostPlatform))
     ),
   libkrb5,
   http2Support ? true,
@@ -200,7 +200,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional gssSupport "--with-gssapi=${lib.getDev libkrb5}"
     # For the 'urandom', maybe it should be a cross-system option
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--with-random=/dev/urandom"
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "--with-random=/dev/urandom"
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # Disable default CA bundle, use NIX_SSL_CERT_FILE or fallback to nss-cacert from the default profile.
       # Without this curl might detect /etc/ssl/cert.pem at build time on macOS, causing curl to ignore NIX_SSL_CERT_FILE.

--- a/pkgs/by-name/cz/czkawka/package.nix
+++ b/pkgs/by-name/cz/czkawka/package.nix
@@ -66,7 +66,7 @@ let
 
     strictDeps = true;
 
-    doCheck = stdenv.hostPlatform.isLinux && (stdenv.hostPlatform == stdenv.buildPlatform);
+    doCheck = stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.equals stdenv.buildPlatform);
 
     checkPhase = ''
       runHook preCheck

--- a/pkgs/by-name/db/dbus-glib/package.nix
+++ b/pkgs/by-name/db/dbus-glib/package.nix
@@ -45,9 +45,7 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     [ "--exec-prefix=${placeholder "dev"}" ]
-    ++ lib.optional (
-      stdenv.buildPlatform != stdenv.hostPlatform
-    ) "--with-dbus-binding-tool=${buildPackages.dbus-glib.dev}/bin/dbus-binding-tool";
+    ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "--with-dbus-binding-tool=${buildPackages.dbus-glib.dev}/bin/dbus-binding-tool";
 
   doCheck = false;
 

--- a/pkgs/by-name/do/dovecot/package.nix
+++ b/pkgs/by-name/do/dovecot/package.nix
@@ -151,7 +151,7 @@ stdenv.mkDerivation rec {
       "--with-icu"
       "--with-textcat"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "i_cv_epoll_works=${if stdenv.hostPlatform.isLinux then "yes" else "no"}"
       "i_cv_posix_fallocate_works=${if stdenv.hostPlatform.isDarwin then "no" else "yes"}"
       "i_cv_inotify_works=${if stdenv.hostPlatform.isLinux then "yes" else "no"}"

--- a/pkgs/by-name/dr/drogon/package.nix
+++ b/pkgs/by-name/dr/drogon/package.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # this excludes you, pkgsStatic (cmake wants to run built binaries
   # in the buildPhase)
-  doInstallCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doInstallCheck = stdenv.buildPlatform.equals stdenv.hostPlatform;
 
   meta = with lib; {
     homepage = "https://github.com/drogonframework/drogon";

--- a/pkgs/by-name/el/element-desktop/keytar/default.nix
+++ b/pkgs/by-name/el/element-desktop/keytar/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false;
 
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     pkg-config() { "''${PKG_CONFIG}" "$@"; }
     export -f pkg-config
   '';

--- a/pkgs/by-name/el/elfutils/package.nix
+++ b/pkgs/by-name/el/elfutils/package.nix
@@ -143,8 +143,8 @@ stdenv.mkDerivation rec {
     !stdenv.hostPlatform.isMusl
     # Test suite tries using `uname` to determine whether certain tests
     # can be executed, so we need to match build and host platform exactly.
-    && (stdenv.hostPlatform == stdenv.buildPlatform);
-  doInstallCheck = !stdenv.hostPlatform.isMusl && (stdenv.hostPlatform == stdenv.buildPlatform);
+    && (stdenv.hostPlatform.equals stdenv.buildPlatform);
+  doInstallCheck = !stdenv.hostPlatform.isMusl && (stdenv.hostPlatform.equals stdenv.buildPlatform);
 
   passthru.updateScript = gitUpdater {
     url = "https://sourceware.org/git/elfutils.git";

--- a/pkgs/by-name/ep/epoll-shim/package.nix
+++ b/pkgs/by-name/ep/epoll-shim/package.nix
@@ -25,10 +25,12 @@ stdenv.mkDerivation (finalAttrs: {
       "-DCMAKE_INSTALL_PKGCONFIGDIR=${placeholder "out"}/lib/pkgconfig"
       "-DBUILD_TESTING=${lib.boolToString finalAttrs.finalPackage.doCheck}"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform && stdenv.hostPlatform.isFreeBSD) [
-      # fails in cross configurations for not being able to detect this value
-      "-DALLOWS_ONESHOT_TIMERS_WITH_TIMEOUT_ZERO=YES"
-    ];
+    ++ lib.optionals
+      (stdenv.buildPlatform.notEquals stdenv.hostPlatform && stdenv.hostPlatform.isFreeBSD)
+      [
+        # fails in cross configurations for not being able to detect this value
+        "-DALLOWS_ONESHOT_TIMERS_WITH_TIMEOUT_ZERO=YES"
+      ];
 
   # https://github.com/jiixyj/epoll-shim/issues/41
   # https://github.com/jiixyj/epoll-shim/pull/34

--- a/pkgs/by-name/fa/faustPhysicalModeling/package.nix
+++ b/pkgs/by-name/fa/faustPhysicalModeling/package.nix
@@ -65,6 +65,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.linux;
     maintainers = with maintainers; [ magnetophon ];
     # compiles stuff for the build platform, difficult to do properly
-    broken = stdenv.hostPlatform != stdenv.buildPlatform;
+    broken = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
   };
 }

--- a/pkgs/by-name/fi/fish/package.nix
+++ b/pkgs/by-name/fi/fish/package.nix
@@ -289,7 +289,7 @@ stdenv.mkDerivation (finalAttrs: {
       patchShebangs ./build_tools/git_version_gen.sh
       patchShebangs ./tests/test_driver.py
     ''
-    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       export CMAKE_PREFIX_PATH=
     '';
 

--- a/pkgs/by-name/fo/foot/package.nix
+++ b/pkgs/by-name/fo/foot/package.nix
@@ -91,7 +91,7 @@ let
 
   # PGO only makes sense if we are not cross compiling and
   # using a compiler which foot's PGO build supports (clang or gcc)
-  doPgo = allowPgo && (stdenv.hostPlatform == stdenv.buildPlatform) && compilerName != "unknown";
+  doPgo = allowPgo && (stdenv.hostPlatform.equals stdenv.buildPlatform) && compilerName != "unknown";
 
   terminfoDir = "${placeholder "terminfo"}/share/terminfo";
 in

--- a/pkgs/by-name/fo/foundationdb/package.nix
+++ b/pkgs/by-name/fo/foundationdb/package.nix
@@ -166,7 +166,7 @@ stdenv.mkDerivation rec {
     license = lib.licenses.asl20;
     platforms = [ "x86_64-linux" ] ++ lib.optionals (!(avxEnabled version)) [ "aarch64-linux" ];
     # Fails when cross-compiling with "/bin/sh: gcc-ar: not found"
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
     maintainers = with lib.maintainers; [
       thoughtpolice
       lostnet

--- a/pkgs/by-name/fr/freeipmi/package.nix
+++ b/pkgs/by-name/fr/freeipmi/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
     libgpg-error
   ];
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "ac_cv_file__dev_urandom=true"
     "ac_cv_file__dev_random=true"
   ];

--- a/pkgs/by-name/go/google-cloud-cpp/package.nix
+++ b/pkgs/by-name/go/google-cloud-cpp/package.nix
@@ -137,7 +137,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals (apis != [ "*" ]) [
       "-DGOOGLE_CLOUD_CPP_ENABLE=${lib.concatStringsSep ";" apis}"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "-DGOOGLE_CLOUD_CPP_GRPC_PLUGIN_EXECUTABLE=${lib.getBin pkgsBuildHost.grpc}/bin/grpc_cpp_plugin"
     ];
 

--- a/pkgs/by-name/gr/graphene/package.nix
+++ b/pkgs/by-name/gr/graphene/package.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
       "dev"
     ]
     ++ lib.optionals withDocumentation [ "devdoc" ]
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "installedTests" ];
+    ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [ "installedTests" ];
 
   src = fetchFromGitHub {
     owner = "ebassi";

--- a/pkgs/by-name/gr/groff/package.nix
+++ b/pkgs/by-name/gr/groff/package.nix
@@ -111,11 +111,11 @@ stdenv.mkDerivation rec {
       "--with-awk=${lib.getBin gawk}/bin/gawk"
       "--with-appresdir=${placeholder "out"}/lib/X11/app-defaults"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "gl_cv_func_signbit=yes"
     ];
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     # Trick to get the build system find the proper 'native' groff
     # http://www.mail-archive.com/bug-groff@gnu.org/msg01335.html
     "GROFF_BIN_PATH=${buildPackages.groff}/bin"

--- a/pkgs/by-name/gr/grpc/package.nix
+++ b/pkgs/by-name/gr/grpc/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     pkg-config
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) grpc;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) grpc;
   propagatedBuildInputs = [
     c-ares
     re2
@@ -77,7 +77,7 @@ stdenv.mkDerivation rec {
       "-DgRPC_ABSL_PROVIDER=package"
       "-DBUILD_SHARED_LIBS=ON"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "-D_gRPC_PROTOBUF_PROTOC_EXECUTABLE=${buildPackages.protobuf}/bin/protoc"
       "-D_gRPC_CPP_PLUGIN=${buildPackages.grpc}/bin/grpc_cpp_plugin"
     ]
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
   # LD_LIBRARY_PATH to enable this. When cross compiling we need to avoid this,
   # since it can cause the grpc_cpp_plugin executable from buildPackages to
   # crash if build and host architecture are compatible (e. g. pkgsLLVM).
-  preBuild = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  preBuild = lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
     export LD_LIBRARY_PATH=$(pwd)''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH
   '';
 

--- a/pkgs/by-name/gs/gsoap/package.nix
+++ b/pkgs/by-name/gs/gsoap/package.nix
@@ -14,7 +14,7 @@
 
 let
   majorVersion = "2.8";
-  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCross = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 
 in
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/gt/gts/package.nix
+++ b/pkgs/by-name/gt/gts/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
 
   doCheck = false; # fails with "permission denied"
 
-  preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preBuild = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     pushd src
     make CC=${buildPackages.stdenv.cc}/bin/cc predicates_init
     mv predicates_init predicates_init_build

--- a/pkgs/by-name/gu/gupnp-igd/package.nix
+++ b/pkgs/by-name/gu/gupnp-igd/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation rec {
   outputs = [
     "out"
     "dev"
-  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+  ] ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -50,8 +50,8 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
-    "-Dintrospection=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
+    "-Dgtk_doc=${lib.boolToString (stdenv.buildPlatform.equals stdenv.hostPlatform)}"
+    "-Dintrospection=${lib.boolToString (stdenv.buildPlatform.equals stdenv.hostPlatform)}"
   ];
 
   # Seems to get stuck sometimes.

--- a/pkgs/by-name/hp/hping/package.nix
+++ b/pkgs/by-name/hp/hping/package.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
       sed -i -e 's|#include <net/bpf.h>|#include <pcap/bpf.h>|' \
         libpcap_stuff.c script.c
     ''
-    + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       substituteInPlace configure --replace 'BYTEORDER=`./byteorder -m`' BYTEORDER=${
         {
           littleEndian = "__LITTLE_ENDIAN_BITFIELD";

--- a/pkgs/by-name/ht/html-tidy/package.nix
+++ b/pkgs/by-name/ht/html-tidy/package.nix
@@ -30,9 +30,9 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [
     cmake
     libxslt # manpage
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) html-tidy;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) html-tidy;
 
-  cmakeFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  cmakeFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "-DHOST_TIDY=tidy"
   ];
 

--- a/pkgs/by-name/in/inetutils/package.nix
+++ b/pkgs/by-name/in/inetutils/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   # https://git.congatec.com/yocto/meta-openembedded/blob/3402bfac6b595c622e4590a8ff5eaaa854e2a2a3/meta-networking/recipes-connectivity/inetutils/inetutils_1.9.1.bb#L44
   preConfigure =
     let
-      isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+      isCross = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
     in
     lib.optionalString isCross ''
       export HELP2MAN=true

--- a/pkgs/by-name/in/intltool/package.nix
+++ b/pkgs/by-name/in/intltool/package.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
       XMLParser
     ]);
 
-  postInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     for f in $out/bin/*; do
       substituteInPlace $f --replace "${buildPackages.perl}" "${perlPackages.perl}"
     done

--- a/pkgs/by-name/ip/iproute2/package.nix
+++ b/pkgs/by-name/ip/iproute2/package.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation rec {
       # all build .so plugins:
       "TC_CONFIG_NO_XT=y"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "HOSTCC=$(CC_FOR_BUILD)"
     ];
 

--- a/pkgs/by-name/iw/iwd/package.nix
+++ b/pkgs/by-name/iw/iwd/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
     "out"
     "man"
     "doc"
-  ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "test";
+  ] ++ lib.optional (stdenv.hostPlatform.equals stdenv.buildPlatform) "test";
   separateDebugInfo = true;
 
   nativeBuildInputs = [
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
 
   # wrapPython wraps the scripts in $test. They pull in gobject-introspection,
   # which doesn't cross-compile.
-  pythonPath = lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+  pythonPath = lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [
     python3Packages.dbus-python
     python3Packages.pygobject3
   ];
@@ -78,7 +78,7 @@ stdenv.mkDerivation rec {
       cp -a doc $doc/share/doc/iwd
       cp -a README AUTHORS TODO $doc/share/doc/iwd
     ''
-    + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
       mkdir -p $test/bin
       cp -a test/* $test/bin/
     '';

--- a/pkgs/by-name/ja/jam/package.nix
+++ b/pkgs/by-name/ja/jam/package.nix
@@ -59,7 +59,7 @@ stdenv.mkDerivation (finalAttrs: {
       # platform. This looks a little ridiculous because the vast majority of build
       # tools don't embed target-specific information into their binary, but in this
       # case we behave more like a compiler than a make(1)-alike.
-      lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+      lib.optionalString (stdenv.hostPlatform.notEquals stdenv.targetPlatform) ''
          cat >>jam.h <<EOF
          #undef OSMAJOR
          #undef OSMINOR

--- a/pkgs/by-name/js/jsoncpp/package.nix
+++ b/pkgs/by-name/js/jsoncpp/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
     # std::basic_string<..., Json::SecureAllocator<char>> vs.
     # std::basic_string<..., [default allocator]>
     ++ lib.optional (
-      (stdenv.buildPlatform != stdenv.hostPlatform) || secureMemory
+      (stdenv.buildPlatform.notEquals stdenv.hostPlatform) || secureMemory
     ) "-DJSONCPP_WITH_TESTS=OFF";
 
   meta = with lib; {

--- a/pkgs/by-name/kc/kcl/package.nix
+++ b/pkgs/by-name/kc/kcl/package.nix
@@ -80,6 +80,6 @@ buildGoModule rec {
       selfuryon
     ];
     mainProgram = "kcl";
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/by-name/kn/knightos-scas/package.nix
+++ b/pkgs/by-name/kn/knightos-scas/package.nix
@@ -9,7 +9,7 @@
 }:
 
 let
-  isCrossCompiling = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCrossCompiling = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/ld/ldb/package.nix
+++ b/pkgs/by-name/ld/ldb/package.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--builtin-libraries=replace"
       "--without-ldb-lmdb"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--cross-compile"
       "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
     ];

--- a/pkgs/by-name/ld/ldns/package.nix
+++ b/pkgs/by-name/ld/ldns/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
       "--disable-gost"
       "--with-examples"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"
     ];

--- a/pkgs/by-name/li/libaom/package.nix
+++ b/pkgs/by-name/li/libaom/package.nix
@@ -19,7 +19,7 @@
 }:
 
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
 in
 stdenv.mkDerivation rec {
   pname = "libaom";

--- a/pkgs/by-name/li/libasyncns/package.nix
+++ b/pkgs/by-name/li/libasyncns/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation rec {
       --replace '<arpa/nameser.h>' '<arpa/nameser_compat.h>'
   '';
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/by-name/li/libavif/package.nix
+++ b/pkgs/by-name/li/libavif/package.nix
@@ -111,7 +111,7 @@ stdenv.mkDerivation rec {
 
     ''
     # Cross-compiled gdk-pixbuf doesn't support thumbnailers
-    + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
       mkdir -p "$out/bin"
       makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer "$out/libexec/gdk-pixbuf-thumbnailer-avif" \
         --set GDK_PIXBUF_MODULE_FILE ${gdkPixbufModuleFile}

--- a/pkgs/by-name/li/libb64/package.nix
+++ b/pkgs/by-name/li/libb64/package.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
         hash = "sha256-CGslJUw0og/bBBirLm0J5Q7cf2WW/vniVAkXHlb6lbQ=";
       })
     ]
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) (fetchpatch {
+    ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) (fetchpatch {
       name = "0001-example-Do-not-run-the-tests.patch";
       url = "https://cgit.openembedded.org/meta-openembedded/plain/meta-oe/recipes-support/libb64/libb64/0001-example-Do-not-run-the-tests.patch?id=484e0de1e4ee107f21ae2a5c5f976ed987978baf";
       sha256 = "sha256-KTsiIWJe66BKlu/A43FWfW0XAu4E7lWX/RY4NITRrm4=";

--- a/pkgs/by-name/li/libcbor/package.nix
+++ b/pkgs/by-name/li/libcbor/package.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Tests are restricted while pkgsStatic.cmocka is broken. Tracked at:
   # https://github.com/NixOS/nixpkgs/issues/213623
-  doCheck = !stdenv.hostPlatform.isStatic && stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = !stdenv.hostPlatform.isStatic && stdenv.hostPlatform.equals stdenv.buildPlatform;
 
   nativeCheckInputs = [ cmocka ];
 

--- a/pkgs/by-name/li/libcddb/package.nix
+++ b/pkgs/by-name/li/libcddb/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libiconv ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/by-name/li/libchamplain/package.nix
+++ b/pkgs/by-name/li/libchamplain/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   outputs = [
     "out"
     "dev"
-  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+  ] ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/${pname}/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
       gobject-introspection
       vala
     ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [
       gtk-doc
       docbook_xsl
       docbook_xml_dtd_412
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    (lib.mesonBool "gtk_doc" (stdenv.buildPlatform == stdenv.hostPlatform))
+    (lib.mesonBool "gtk_doc" (stdenv.buildPlatform.equals stdenv.hostPlatform))
     "-Dvapi=true"
     (lib.mesonBool "libsoup3" withLibsoup3)
   ];

--- a/pkgs/by-name/li/libdaemon/package.nix
+++ b/pkgs/by-name/li/libdaemon/package.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation rec {
 
   configureFlags =
     [ "--disable-lynx" ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # Can't run this test while cross-compiling
       "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
     ];

--- a/pkgs/by-name/li/libelf/package.nix
+++ b/pkgs/by-name/li/libelf/package.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
     [ ]
     # Configure check for dynamic lib support is broken, see
     # http://lists.uclibc.org/pipermail/uclibc-cvs/2005-August/019383.html
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "mr_cv_target_elf=yes"
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "mr_cv_target_elf=yes"
     # Libelf's custom NLS macros fail to determine the catalog file extension
     # on Darwin, so disable NLS for now.
     ++ lib.optional stdenv.hostPlatform.isDarwin "--disable-nls";

--- a/pkgs/by-name/li/libgphoto2/package.nix
+++ b/pkgs/by-name/li/libgphoto2/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
   postInstall =
     let
       executablePrefix =
-        if stdenv.buildPlatform == stdenv.hostPlatform then "$out" else buildPackages.libgphoto2;
+        if stdenv.buildPlatform.equals stdenv.hostPlatform then "$out" else buildPackages.libgphoto2;
     in
     ''
       mkdir -p $out/lib/udev/{rules.d,hwdb.d}

--- a/pkgs/by-name/li/libgxps/package.nix
+++ b/pkgs/by-name/li/libgxps/package.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     [
       "-Denable-test=false"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "-Ddisable-introspection=true"
     ];
 

--- a/pkgs/by-name/li/libical/package.nix
+++ b/pkgs/by-name/li/libical/package.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  depsBuildBuild = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  depsBuildBuild = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     # provides ical-glib-src-generator that runs during build
     libical
   ];
@@ -83,7 +83,7 @@ stdenv.mkDerivation (finalAttrs: {
       "-DGOBJECT_INTROSPECTION=${if withIntrospection then "True" else "False"}"
       "-DICAL_GLIB_VAPI=${if withIntrospection then "True" else "False"}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "-DIMPORT_ICAL_GLIB_SRC_GENERATOR=${lib.getDev pkgsBuildBuild.libical}/lib/cmake/LibIcal/IcalGlibSrcGenerator.cmake"
     ];
 

--- a/pkgs/by-name/li/libinotify-kqueue/package.nix
+++ b/pkgs/by-name/li/libinotify-kqueue/package.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   configureFlags =
-    lib.optionals (with stdenv; buildPlatform != hostPlatform && hostPlatform.isFreeBSD)
+    lib.optionals (with stdenv; buildPlatform.notEquals hostPlatform && hostPlatform.isFreeBSD)
       [
         "ik_cv_have_note_extend_in=yes"
         "ik_cv_have_note_extend_out=yes"

--- a/pkgs/by-name/li/libjxl/package.nix
+++ b/pkgs/by-name/li/libjxl/package.nix
@@ -153,7 +153,7 @@ stdenv.mkDerivation rec {
         gdk-pixbuf-query-loaders --update-cache
     ''
     # Cross-compiled gdk-pixbuf doesn't support thumbnailers
-    + lib.optionalString (enablePlugins && stdenv.hostPlatform == stdenv.buildPlatform) ''
+    + lib.optionalString (enablePlugins && stdenv.hostPlatform.equals stdenv.buildPlatform) ''
       mkdir -p "$out/bin"
       makeWrapper ${gdk-pixbuf}/bin/gdk-pixbuf-thumbnailer "$out/libexec/gdk-pixbuf-thumbnailer-jxl" \
         --set GDK_PIXBUF_MODULE_FILE "$out/${loadersPath}"

--- a/pkgs/by-name/li/liblouis/package.nix
+++ b/pkgs/by-name/li/liblouis/package.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation (finalAttrs: {
       "doc"
     ]
     # configure: WARNING: cannot generate manual pages while cross compiling
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "man" ];
+    ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [ "man" ];
 
   src = fetchFromGitHub {
     owner = "liblouis";

--- a/pkgs/by-name/li/libmbim/package.nix
+++ b/pkgs/by-name/li/libmbim/package.nix
@@ -14,7 +14,7 @@
   withIntrospection ?
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
-  withDocs ? stdenv.hostPlatform == stdenv.buildPlatform,
+  withDocs ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   gobject-introspection,
 }:
 

--- a/pkgs/by-name/li/libmcrypt/package.nix
+++ b/pkgs/by-name/li/libmcrypt/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   configureFlags =
     lib.optionals disablePosixThreads [ "--disable-posix-threads" ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # AC_FUNC_MALLOC is broken on cross builds.
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/by-name/li/libndp/package.nix
+++ b/pkgs/by-name/li/libndp/package.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
   ];
 

--- a/pkgs/by-name/li/libnice/package.nix
+++ b/pkgs/by-name/li/libnice/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     "bin"
     "out"
     "dev"
-  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+  ] ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "https://libnice.freedesktop.org/releases/${pname}-${version}.tar.gz";
@@ -69,8 +69,10 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "enabled" else "disabled"}"
-    "-Dintrospection=${if (stdenv.buildPlatform == stdenv.hostPlatform) then "enabled" else "disabled"}"
+    "-Dgtk_doc=${if (stdenv.buildPlatform.equals stdenv.hostPlatform) then "enabled" else "disabled"}"
+    "-Dintrospection=${
+      if (stdenv.buildPlatform.equals stdenv.hostPlatform) then "enabled" else "disabled"
+    }"
     "-Dexamples=disabled" # requires many dependencies and probably not useful for our users
   ];
 

--- a/pkgs/by-name/li/libomxil-bellagio/package.nix
+++ b/pkgs/by-name/li/libomxil-bellagio/package.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
     sha256 = "0k6p6h4npn8p1qlgq6z3jbfld6n1bqswzvxzndki937gr0lhfg2r";
   };
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
   ];
 

--- a/pkgs/by-name/li/libosinfo/package.nix
+++ b/pkgs/by-name/li/libosinfo/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   outputs = [
     "out"
     "dev"
-  ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "devdoc";
+  ] ++ lib.optional (stdenv.hostPlatform.equals stdenv.buildPlatform) "devdoc";
 
   nativeBuildInputs = [
     pkg-config

--- a/pkgs/by-name/li/libpcap/package.nix
+++ b/pkgs/by-name/li/libpcap/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     ++ lib.optionals withRemote [
       "--enable-remote"
     ]
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "ac_cv_linux_vers=2" ];
+    ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [ "ac_cv_linux_vers=2" ];
 
   postInstall = ''
     if [ "$dontDisableStatic" -ne "1" ]; then

--- a/pkgs/by-name/li/librsync/package.nix
+++ b/pkgs/by-name/li/librsync/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     popt
   ];
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform;
+  dontStrip = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 
   meta = with lib; {
     description = "Implementation of the rsync remote-delta algorithm";

--- a/pkgs/by-name/li/libstartup_notification/package.nix
+++ b/pkgs/by-name/li/libstartup_notification/package.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
     sha256 = "3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a";
   };
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "lf_cv_sane_realloc=yes"
   ];
 

--- a/pkgs/by-name/li/libvirt-glib/package.nix
+++ b/pkgs/by-name/li/libvirt-glib/package.nix
@@ -16,7 +16,7 @@
     lib.meta.availableOn stdenv.hostPlatform gobject-introspection
     && stdenv.hostPlatform.emulatorAvailable buildPackages,
   gobject-introspection,
-  withDocs ? stdenv.hostPlatform == stdenv.buildPlatform,
+  withDocs ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   gtk-doc,
   docbook-xsl-nons,
 }:

--- a/pkgs/by-name/li/libvpx/package.nix
+++ b/pkgs/by-name/li/libvpx/package.nix
@@ -102,7 +102,7 @@ let
     || stdenv.hostPlatform.isRiscV;
 
   target =
-    if (stdenv.hostPlatform.isBSD || stdenv.hostPlatform != stdenv.buildPlatform) then
+    if (stdenv.hostPlatform.isBSD || stdenv.hostPlatform.notEquals stdenv.buildPlatform) then
       (if isGeneric then "generic-gnu" else "${cpu}-${kernel}-gcc")
     else
       null;

--- a/pkgs/by-name/li/libwebsockets/package.nix
+++ b/pkgs/by-name/li/libwebsockets/package.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation rec {
       "-DDISABLE_WERROR=ON"
       "-DLWS_BUILD_HASH=no_hash"
     ]
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "-DLWS_WITHOUT_TESTAPPS=ON"
     ++ lib.optional withExternalPoll "-DLWS_WITH_EXTERNAL_POLL=ON"
     ++ (
       if stdenv.hostPlatform.isStatic then

--- a/pkgs/by-name/li/libxklavier/package.nix
+++ b/pkgs/by-name/li/libxklavier/package.nix
@@ -13,7 +13,7 @@
   glib,
   isocodes,
   gobject-introspection,
-  withDoc ? (stdenv.buildPlatform == stdenv.hostPlatform),
+  withDoc ? (stdenv.buildPlatform.equals stdenv.hostPlatform),
 }:
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/li/linux-pam/package.nix
+++ b/pkgs/by-name/li/linux-pam/package.nix
@@ -29,7 +29,8 @@ stdenv.mkDerivation rec {
 
   # Case-insensitivity workaround for https://github.com/linux-pam/linux-pam/issues/569
   postPatch =
-    lib.optionalString (stdenv.buildPlatform.isDarwin && stdenv.buildPlatform != stdenv.hostPlatform)
+    lib.optionalString
+      (stdenv.buildPlatform.isDarwin && stdenv.buildPlatform.notEquals stdenv.hostPlatform)
       ''
         rm CHANGELOG
         touch ChangeLog

--- a/pkgs/by-name/ln/lnav/package.nix
+++ b/pkgs/by-name/ln/lnav/package.nix
@@ -20,7 +20,7 @@
   rustPlatform,
   rustc,
   libunistring,
-  prqlSupport ? stdenv.hostPlatform == stdenv.buildPlatform,
+  prqlSupport ? stdenv.hostPlatform.equals stdenv.buildPlatform,
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/ma/man-db/package.nix
+++ b/pkgs/by-name/ma/man-db/package.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  disallowedReferences = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  disallowedReferences = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     buildPackages.groff
   ];
 

--- a/pkgs/by-name/md/mdadm4/package.nix
+++ b/pkgs/by-name/md/mdadm4/package.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
       "RUN_DIR=/dev/.mdadm"
       "STRIP="
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/by-name/mg/mg/package.nix
+++ b/pkgs/by-name/mg/mg/package.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     hash = "sha256-+sp8Edu5UWv73TCNVZTeH5rl2Q5XarYrlTYHuQsroVs=";
   };
 
-  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postPatch = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
     substituteInPlace configure --replace "./conftest" "echo"
   '';
 

--- a/pkgs/by-name/ml/mlmmj/package.nix
+++ b/pkgs/by-name/ml/mlmmj/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     kyua
   ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     # AC_FUNC_MALLOC is broken on cross builds.
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/by-name/mo/monit/package.nix
+++ b/pkgs/by-name/mo/monit/package.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
           "--without-ssl"
         ]
     )
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # will need to check both these are true for musl
       "libmonit_cv_setjmp_available=yes"
       "libmonit_cv_vsnprintf_c99_conformant=yes"

--- a/pkgs/by-name/ms/msgpack/generic.nix
+++ b/pkgs/by-name/ms/msgpack/generic.nix
@@ -16,9 +16,7 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [ cmake ];
 
-  cmakeFlags = lib.optional (
-    stdenv.hostPlatform != stdenv.buildPlatform
-  ) "-DMSGPACK_BUILD_EXAMPLES=OFF";
+  cmakeFlags = lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "-DMSGPACK_BUILD_EXAMPLES=OFF";
 
   meta = with lib; {
     description = "MessagePack implementation for C and C++";

--- a/pkgs/by-name/ne/newt/package.nix
+++ b/pkgs/by-name/ne/newt/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     unset CPP
   '';
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
   ];
 

--- a/pkgs/by-name/nm/nmap/package.nix
+++ b/pkgs/by-name/nm/nmap/package.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     install_name_tool -change liblinear.so.5 ${liblinear.out}/lib/liblinear.5.dylib $out/bin/nmap
   '';
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "AR=${stdenv.cc.bintools.targetPrefix}ar"
     "RANLIB=${stdenv.cc.bintools.targetPrefix}ranlib"
     "CC=${stdenv.cc.targetPrefix}gcc"

--- a/pkgs/by-name/oe/oed/package.nix
+++ b/pkgs/by-name/oe/oed/package.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-bbV89YhrmL7tOgKly5OfQDRz4QE0UzZrVsmoXiJ7ZZw=";
   };
 
-  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postPatch = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
     substituteInPlace configure --replace "./conftest" "echo"
   '';
 

--- a/pkgs/by-name/of/offrss/package.nix
+++ b/pkgs/by-name/of/offrss/package.nix
@@ -22,7 +22,7 @@ stdenv.mkDerivation (finalAttrs: {
       curl
       libmrss
     ]
-    ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) podofo
+    ++ lib.optional (stdenv.hostPlatform.equals stdenv.buildPlatform) podofo
     ++ lib.optional (!stdenv.hostPlatform.isLinux) libiconv;
 
   # Workaround build failure on -fno-common toolchains:
@@ -38,7 +38,7 @@ stdenv.mkDerivation (finalAttrs: {
     + lib.optionalString (!stdenv.hostPlatform.isLinux) ''
       sed 's/#EXTRA/EXTRA/' -i Makefile
     ''
-    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       sed 's/^PDF/#PDF/' -i Makefile
     '';
 

--- a/pkgs/by-name/ok/oksh/package.nix
+++ b/pkgs/by-name/ok/oksh/package.nix
@@ -19,7 +19,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postPatch = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
     substituteInPlace configure --replace "./conftest" "echo"
   '';
 

--- a/pkgs/by-name/om/omxplayer/package.nix
+++ b/pkgs/by-name/om/omxplayer/package.nix
@@ -60,7 +60,7 @@ let
         "--arch=${stdenv.hostPlatform.parsed.cpu.name}"
         "--target_os=${stdenv.hostPlatform.parsed.kernel.name}"
       ]
-      ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
         "--cross-prefix=${stdenv.cc.targetPrefix}"
         "--enable-cross-compile"
       ];

--- a/pkgs/by-name/op/openfortivpn/package.nix
+++ b/pkgs/by-name/op/openfortivpn/package.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     ++ lib.optional withSystemd "--with-systemdsystemunitdir=${placeholder "out"}/lib/systemd/system"
     ++ lib.optional withPpp "--with-pppd=${ppp}/bin/pppd"
     # configure: error: cannot check for file existence when cross compiling
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--disable-proc";
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "--disable-proc";
 
   enableParallelBuilding = true;
 

--- a/pkgs/by-name/op/openldap/package.nix
+++ b/pkgs/by-name/op/openldap/package.nix
@@ -82,7 +82,7 @@ stdenv.mkDerivation rec {
       (lib.enableFeature withModules "argon2")
       (lib.enableFeature withModules "modules")
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--with-yielding_select=yes"
       "ac_cv_func_memcmp_working=yes"
     ]

--- a/pkgs/by-name/op/optipng/package.nix
+++ b/pkgs/by-name/op/optipng/package.nix
@@ -35,12 +35,12 @@ stdenv.mkDerivation rec {
       "--with-system-zlib"
       "--with-system-libpng"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       #"-prefix=$out"
     ];
 
   postInstall =
-    if stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isWindows then
+    if stdenv.hostPlatform.notEquals stdenv.buildPlatform && stdenv.hostPlatform.isWindows then
       ''
         mv "$out"/bin/optipng{,.exe}
       ''

--- a/pkgs/by-name/pa/pandoc/package.nix
+++ b/pkgs/by-name/pa/pandoc/package.nix
@@ -48,7 +48,7 @@ in
         -t ${pandoc-cli.scope.typst} \
         $out/bin/pandoc
     ''
-    + lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.equals stdenv.hostPlatform) ''
       mkdir -p $out/share/bash-completion/completions
       $out/bin/pandoc --bash-completion > $out/share/bash-completion/completions/pandoc
     ''

--- a/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
+++ b/pkgs/by-name/pk/pkg-config-unwrapped/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
       "CFLAGS=-DENABLE_NLS"
     ]
     # Can't run these tests while cross-compiling
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "glib_cv_stack_grows=no"
       "glib_cv_uscore=no"
       "ac_cv_func_posix_getpwuid_r=yes"

--- a/pkgs/by-name/po/poke/package.nix
+++ b/pkgs/by-name/po/poke/package.nix
@@ -18,7 +18,7 @@
 }:
 
 let
-  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCross = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "poke";

--- a/pkgs/by-name/po/postfix/package.nix
+++ b/pkgs/by-name/po/postfix/package.nix
@@ -109,7 +109,7 @@ stdenv.mkDerivation rec {
   ];
 
   postPatch =
-    lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       sed -e 's!bin/postconf!${buildPackages.postfix}/bin/postconf!' -i postfix-install
     ''
     + ''

--- a/pkgs/by-name/ps/psmisc/package.nix
+++ b/pkgs/by-name/ps/psmisc/package.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ ncurses ];
 
   preConfigure =
-    lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       # Goes past the rpl_malloc linking failure
       export ac_cv_func_malloc_0_nonnull=yes
       export ac_cv_func_realloc_0_nonnull=yes

--- a/pkgs/by-name/qi/qir-runner/package.nix
+++ b/pkgs/by-name/qi/qir-runner/package.nix
@@ -38,6 +38,6 @@ rustPlatform.buildRustPackage rec {
     maintainers = [ lib.maintainers.bbenno ];
     # llvm-sys crate locates llvm by calling llvm-config
     # which is not available when cross compiling
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/by-name/rc/rcs/package.nix
+++ b/pkgs/by-name/rc/rcs/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   DIFF = "${diffutils}/bin/diff";
   DIFF3 = "${diffutils}/bin/diff3";
 
-  disallowedReferences = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  disallowedReferences = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     buildPackages.diffutils
     buildPackages.ed
   ];

--- a/pkgs/by-name/re/redict/package.nix
+++ b/pkgs/by-name/re/redict/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation (finalAttrs: {
   # More cross-compiling fixes.
   makeFlags =
     [ "PREFIX=${placeholder "out"}" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "AR=${stdenv.cc.targetPrefix}ar"
       "RANLIB=${stdenv.cc.targetPrefix}ranlib"
     ]

--- a/pkgs/by-name/re/redis/package.nix
+++ b/pkgs/by-name/re/redis/package.nix
@@ -54,7 +54,7 @@ stdenv.mkDerivation (finalAttrs: {
   # More cross-compiling fixes.
   makeFlags =
     [ "PREFIX=${placeholder "out"}" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "AR=${stdenv.cc.targetPrefix}ar"
       "RANLIB=${stdenv.cc.targetPrefix}ranlib"
     ]

--- a/pkgs/by-name/rp/rpPPPoE/package.nix
+++ b/pkgs/by-name/rp/rpPPPoE/package.nix
@@ -24,9 +24,13 @@ stdenv.mkDerivation rec {
     export PPPD=${ppp}/sbin/pppd
   '';
 
-  configureFlags = [
-    "--enable-plugin=${ppp}/include"
-  ] ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "rpppoe_cv_pack_bitfields=rev" ];
+  configureFlags =
+    [
+      "--enable-plugin=${ppp}/include"
+    ]
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
+      "rpppoe_cv_pack_bitfields=rev"
+    ];
 
   postConfigure = ''
     sed -i Makefile -e 's@DESTDIR)/etc/ppp@out)/etc/ppp@'

--- a/pkgs/by-name/s9/s9fes/package.nix
+++ b/pkgs/by-name/s9/s9fes/package.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  isCrossCompiling = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCrossCompiling = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/sc/scanbd/package.nix
+++ b/pkgs/by-name/sc/scanbd/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
       "--with-scanbdconfdir=/etc/scanbd"
       "--with-systemdsystemunitdir=$out/lib/systemd/system"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # AC_FUNC_MALLOC is broken on cross builds.
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"

--- a/pkgs/by-name/sh/shadow/package.nix
+++ b/pkgs/by-name/sh/shadow/package.nix
@@ -23,7 +23,7 @@
 }:
 let
   glibc =
-    if stdenv.hostPlatform != stdenv.buildPlatform then
+    if stdenv.hostPlatform.notEquals stdenv.buildPlatform then
       glibcCross
     else
       assert stdenv.hostPlatform.libc == "glibc";
@@ -111,9 +111,7 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  disallowedReferences = lib.optional (
-    stdenv.buildPlatform != stdenv.hostPlatform
-  ) stdenv.shellPackage;
+  disallowedReferences = lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) stdenv.shellPackage;
 
   meta = with lib; {
     homepage = "https://github.com/shadow-maint/shadow";

--- a/pkgs/by-name/sh/shared-mime-info/package.nix
+++ b/pkgs/by-name/sh/shared-mime-info/package.nix
@@ -34,7 +34,7 @@ stdenv.mkDerivation rec {
     pkg-config
     gettext
     libxml2
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) shared-mime-info;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) shared-mime-info;
 
   buildInputs = [
     libxml2

--- a/pkgs/by-name/sh/shiori/package.nix
+++ b/pkgs/by-name/sh/shiori/package.nix
@@ -28,7 +28,7 @@ buildGoModule rec {
   ];
 
   nativeBuildInputs = [ installShellFiles ];
-  postInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     installShellCompletion --cmd shiori \
       --bash <($out/bin/shiori completion bash) \
       --fish <($out/bin/shiori completion fish) \

--- a/pkgs/by-name/so/sourceHighlight/package.nix
+++ b/pkgs/by-name/so/sourceHighlight/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
   # source-highlight uses it's own binary to generate documentation.
   # During cross-compilation, that binary was built for the target
   # platform architecture, so it can't run on the build host.
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     substituteInPlace Makefile.in --replace "src doc tests" "src tests"
   '';
 

--- a/pkgs/by-name/sp/spice-gtk/package.nix
+++ b/pkgs/by-name/sp/spice-gtk/package.nix
@@ -98,7 +98,7 @@ stdenv.mkDerivation rec {
       vala
       wrapGAppsHook3
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       mesonEmulatorHook
     ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [

--- a/pkgs/by-name/sq/squashfsTools/package.nix
+++ b/pkgs/by-name/sq/squashfsTools/package.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs =
     [ which ]
     # when cross-compiling help2man cannot run the cross-compiled binary
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ help2man ];
+    ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [ help2man ];
   buildInputs = [
     zlib
     xz

--- a/pkgs/by-name/ta/talloc/package.nix
+++ b/pkgs/by-name/ta/talloc/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       "--bundled-libraries=NONE"
       "--builtin-libraries=replace"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--cross-compile"
       "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
     ];

--- a/pkgs/by-name/tc/tcpdump/package.nix
+++ b/pkgs/by-name/tc/tcpdump/package.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [ libpcap ];
 
-  configureFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "ac_cv_linux_vers=2";
+  configureFlags = lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "ac_cv_linux_vers=2";
 
   meta = with lib; {
     description = "Network sniffer";

--- a/pkgs/by-name/td/tdb/package.nix
+++ b/pkgs/by-name/td/tdb/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation rec {
       "--bundled-libraries=NONE"
       "--builtin-libraries=replace"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--cross-compile"
       "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
     ];

--- a/pkgs/by-name/td/tdlib/package.nix
+++ b/pkgs/by-name/td/tdlib/package.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
 
-  preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  preConfigure = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
     cmake -B native-build \
       -DCMAKE_C_COMPILER=$CC_FOR_BUILD \
       -DCMAKE_CXX_COMPILER=$CXX_FOR_BUILD \

--- a/pkgs/by-name/te/tevent/package.nix
+++ b/pkgs/by-name/te/tevent/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       "--bundled-libraries=NONE"
       "--builtin-libraries=replace"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--cross-compile"
       "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
     ];

--- a/pkgs/by-name/te/texi2html/package.nix
+++ b/pkgs/by-name/te/texi2html/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
     patchShebangs separated_to_hash.pl
   '';
 
-  postInstall = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postInstall = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
     for f in $out/bin/*; do
       substituteInPlace $f --replace "${buildPackages.perl}" "${perl}"
     done

--- a/pkgs/by-name/ti/tilemaker/package.nix
+++ b/pkgs/by-name/ti/tilemaker/package.nix
@@ -58,7 +58,7 @@ stdenv.mkDerivation (finalAttrs: {
     zlib
   ];
 
-  cmakeFlags = lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) (
+  cmakeFlags = lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) (
     lib.cmakeFeature "PROTOBUF_PROTOC_EXECUTABLE" "${buildPackages.protobuf}/bin/protoc"
   );
 

--- a/pkgs/by-name/ti/tinycdb/package.nix
+++ b/pkgs/by-name/ti/tinycdb/package.nix
@@ -4,7 +4,7 @@
   fetchurl,
 }:
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   cross = "${stdenv.hostPlatform.config}";
   static = stdenv.hostPlatform.isStatic;
 

--- a/pkgs/by-name/to/totem-pl-parser/package.nix
+++ b/pkgs/by-name/to/totem-pl-parser/package.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     glib
   ];
 
-  mesonFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  mesonFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "-Dintrospection=false"
   ];
 

--- a/pkgs/by-name/to/totem/package.nix
+++ b/pkgs/by-name/to/totem/package.nix
@@ -116,6 +116,6 @@ stdenv.mkDerivation rec {
     license = licenses.gpl2Plus; # with exception to allow use of non-GPL compatible plug-ins
     platforms = platforms.linux;
     # gst-inspect-1.0 is not smart enough for cross compiling
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/by-name/tr/triton-llvm/package.nix
+++ b/pkgs/by-name/tr/triton-llvm/package.nix
@@ -61,7 +61,7 @@ let
     else
       python3Packages.python;
 
-  isNative = stdenv.hostPlatform == stdenv.buildPlatform;
+  isNative = stdenv.hostPlatform.equals stdenv.buildPlatform;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "triton-llvm";

--- a/pkgs/by-name/tz/tzdata/package.nix
+++ b/pkgs/by-name/tz/tzdata/package.nix
@@ -71,7 +71,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = true;
   checkTarget = "check";
 
-  installFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  installFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "zic=${buildPackages.tzdata.bin}/bin/zic"
   ];
 

--- a/pkgs/by-name/uc/uclibc-ng/package.nix
+++ b/pkgs/by-name/uc/uclibc-ng/package.nix
@@ -11,7 +11,7 @@
 
 let
   stdenv = stdenvNoLibc;
-  isCross = (stdenv.buildPlatform != stdenv.hostPlatform);
+  isCross = (stdenv.buildPlatform.notEquals stdenv.hostPlatform);
   configParser = ''
     function parseconfig {
         set -x

--- a/pkgs/by-name/ut/util-linux/package.nix
+++ b/pkgs/by-name/ut/util-linux/package.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation rec {
       (lib.enableFeature translateManpages "poman")
       "SYSCONFSTATICDIR=${placeholder "lib"}/lib"
     ]
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "scanf_cv_type_modifier=ms"
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "scanf_cv_type_modifier=ms"
     ++ lib.optionals stdenv.hostPlatform.isFreeBSD [
       # These features are all disabled in the freebsd-ports distribution
       "--disable-nls"

--- a/pkgs/by-name/va/valkey/package.nix
+++ b/pkgs/by-name/va/valkey/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
   # More cross-compiling fixes.
   makeFlags =
     [ "PREFIX=${placeholder "out"}" ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "AR=${stdenv.cc.targetPrefix}ar"
       "RANLIB=${stdenv.cc.targetPrefix}ranlib"
     ]

--- a/pkgs/by-name/va/vamp-plugin-sdk/package.nix
+++ b/pkgs/by-name/va/vamp-plugin-sdk/package.nix
@@ -28,7 +28,7 @@ stdenv.mkDerivation rec {
   makeFlags = [
     "AR:=$(AR)"
     "RANLIB:=$(RANLIB)"
-  ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-o test";
+  ] ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "-o test";
 
   meta = with lib; {
     description = "Audio processing plugin system for plugins that extract descriptive information from audio data";

--- a/pkgs/by-name/vc/vcv-rack/package.nix
+++ b/pkgs/by-name/vc/vcv-rack/package.nix
@@ -217,7 +217,7 @@ stdenv.mkDerivation rec {
   ];
 
   makeFlags =
-    lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ]
     ++ [

--- a/pkgs/by-name/vu/vulkan-loader/package.nix
+++ b/pkgs/by-name/vu/vulkan-loader/package.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation (finalAttrs: {
     ]
     ++ lib.optional stdenv.hostPlatform.isDarwin "-DSYSCONFDIR=${moltenvk}/share"
     ++ lib.optional stdenv.hostPlatform.isLinux "-DSYSCONFDIR=${addDriverRunpath.driverLink}/share"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "-DUSE_GAS=OFF";
+    ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "-DUSE_GAS=OFF";
 
   outputs = [
     "out"

--- a/pkgs/by-name/w3/w3m/package.nix
+++ b/pkgs/by-name/w3/w3m/package.nix
@@ -67,7 +67,7 @@ stdenv.mkDerivation rec {
     })
   ];
 
-  postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postPatch = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     ln -s ${mktable}/bin/mktable mktable
     # stop make from recompiling mktable
     sed -i -e 's!mktable.*:.*!mktable:!' Makefile.in
@@ -102,7 +102,7 @@ stdenv.mkDerivation rec {
       "--with-ssl=${openssl.dev}"
       "--with-gc=${boehmgc.dev}"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
     ]
     ++ lib.optional graphicsSupport "--enable-image=${lib.optionalString x11Support "x11,"}fb"

--- a/pkgs/by-name/we/webp-pixbuf-loader/package.nix
+++ b/pkgs/by-name/we/webp-pixbuf-loader/package.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
       # gdk-pixbuf disables the thumbnailer in cross-builds (https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/fc37708313a5fc52083cf10c9326f3509d67701f)
       # and therefore makeWrapper will fail because 'gdk-pixbuf-thumbnailer' the executable does not exist.
     ''
-    + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
       # It assumes gdk-pixbuf-thumbnailer can find the webp loader in the loaders.cache referenced by environment variable, breaking containment.
       # So we replace it with a wrapped executable.
       mkdir -p "$out/bin"

--- a/pkgs/by-name/wl/wlogout/package.nix
+++ b/pkgs/by-name/wl/wlogout/package.nix
@@ -16,7 +16,7 @@
   # on gobject-introspection.
   # Disable it when cross-compiling since it's an optional dependency.
   # This disables transparency support.
-  withGtkLayerShell ? (stdenv.buildPlatform == stdenv.hostPlatform),
+  withGtkLayerShell ? (stdenv.buildPlatform.equals stdenv.hostPlatform),
 }:
 
 stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/by-name/x2/x264/package.nix
+++ b/pkgs/by-name/x2/x264/package.nix
@@ -48,9 +48,7 @@ stdenv.mkDerivation {
   configureFlags =
     lib.optional enableShared "--enable-shared"
     ++ lib.optional (!stdenv.hostPlatform.isi686) "--enable-pic"
-    ++ lib.optional (
-      stdenv.buildPlatform != stdenv.hostPlatform
-    ) "--cross-prefix=${stdenv.cc.targetPrefix}";
+    ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "--cross-prefix=${stdenv.cc.targetPrefix}";
 
   makeFlags = [
     "BASHCOMPLETIONSDIR=$(out)/share/bash-completion/completions"

--- a/pkgs/by-name/x2/x265/package.nix
+++ b/pkgs/by-name/x2/x265/package.nix
@@ -34,7 +34,7 @@
 let
   mkFlag = optSet: flag: if optSet then "-D${flag}=ON" else "-D${flag}=OFF";
 
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
 in
 
 stdenv.mkDerivation rec {

--- a/pkgs/by-name/zi/zile/package.nix
+++ b/pkgs/by-name/zi/zile/package.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     ]
     # `help2man' wants to run Zile, which won't work when the
     # newly-produced binary can't be run at build-time.
-    ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) help2man;
+    ++ lib.optional (stdenv.hostPlatform.equals stdenv.buildPlatform) help2man;
 
   # Tests can't be run because most of them rely on the ability to
   # fiddle with the terminal.

--- a/pkgs/by-name/zs/zsh/package.nix
+++ b/pkgs/by-name/zs/zsh/package.nix
@@ -91,17 +91,19 @@ stdenv.mkDerivation {
       "--disable-site-fndir"
       # --enable-function-subdirs is not enabled due to it being slow at runtime in some cases
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform && !stdenv.hostPlatform.isStatic) [
-      # Also see: https://github.com/buildroot/buildroot/commit/2f32e668aa880c2d4a2cce6c789b7ca7ed6221ba
-      "zsh_cv_shared_environ=yes"
-      "zsh_cv_shared_tgetent=yes"
-      "zsh_cv_shared_tigetstr=yes"
-      "zsh_cv_sys_dynamic_clash_ok=yes"
-      "zsh_cv_sys_dynamic_rtld_global=yes"
-      "zsh_cv_sys_dynamic_execsyms=yes"
-      "zsh_cv_sys_dynamic_strip_exe=yes"
-      "zsh_cv_sys_dynamic_strip_lib=yes"
-    ];
+    ++ lib.optionals
+      (stdenv.hostPlatform.notEquals stdenv.buildPlatform && !stdenv.hostPlatform.isStatic)
+      [
+        # Also see: https://github.com/buildroot/buildroot/commit/2f32e668aa880c2d4a2cce6c789b7ca7ed6221ba
+        "zsh_cv_shared_environ=yes"
+        "zsh_cv_shared_tgetent=yes"
+        "zsh_cv_shared_tigetstr=yes"
+        "zsh_cv_sys_dynamic_clash_ok=yes"
+        "zsh_cv_sys_dynamic_rtld_global=yes"
+        "zsh_cv_sys_dynamic_execsyms=yes"
+        "zsh_cv_sys_dynamic_strip_exe=yes"
+        "zsh_cv_sys_dynamic_strip_lib=yes"
+      ];
 
   postPatch = ''
     substituteInPlace Src/Modules/pcre.mdd \
@@ -146,7 +148,7 @@ stdenv.mkDerivation {
     fi
     EOF
         ${
-          if stdenv.hostPlatform == stdenv.buildPlatform then
+          if stdenv.hostPlatform.equals stdenv.buildPlatform then
             ''
               $out/bin/zsh -c "zcompile $out/etc/zshenv"
             ''

--- a/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
+++ b/pkgs/desktops/gnome-2/platform/ORBit2/default.nix
@@ -47,7 +47,7 @@ stdenv.mkDerivation rec {
     ]
   );
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "--with-idl-compiler=${lib.getExe' buildPackages.gnome2.ORBit2 "orbit-idl-2"}"
     # https://github.com/void-linux/void-packages/blob/e5856e02aa6ef7e4f2725afbff2915f89d39024b/srcpkgs/ORBit2/template#L17-L35
     "ac_cv_alignof_CORBA_boolean=1"

--- a/pkgs/desktops/gnome-2/platform/libIDL/default.nix
+++ b/pkgs/desktops/gnome-2/platform/libIDL/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
     pkg-config
   ];
 
-  configureFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  configureFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     # before openembedded removed libIDL
     # the result was always ll https://lists.openembedded.org/g/openembedded-core/topic/85775262?p=%2C%2C%2C20%2C0%2C0%2C0%3A%3A%2C%2C%2C0%2C0%2C0%2C85775262
     "libIDL_cv_long_long_format=ll"

--- a/pkgs/desktops/lomiri/development/geonames/default.nix
+++ b/pkgs/desktops/lomiri/development/geonames/default.nix
@@ -118,7 +118,8 @@ stdenv.mkDerivation (finalAttrs: {
     # Cross requires hostPlatform emulation during build
     # https://gitlab.com/ubports/development/core/geonames/-/issues/1
     broken =
-      stdenv.buildPlatform != stdenv.hostPlatform && !stdenv.hostPlatform.emulatorAvailable buildPackages;
+      stdenv.buildPlatform.notEquals stdenv.hostPlatform
+      && !stdenv.hostPlatform.emulatorAvailable buildPackages;
     pkgConfigModules = [
       "geonames"
     ];

--- a/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
+++ b/pkgs/development/androidndk-pkgs/androidndk-pkgs.nix
@@ -69,7 +69,7 @@ let
   # targetInfo.triple is what Google thinks the toolchain should be, this is a little
   # different from what we use. We make it four parts to conform with the existing
   # standard more properly.
-  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (
+  targetPrefix = lib.optionalString (stdenv.targetPlatform.notEquals stdenv.hostPlatform) (
     stdenv.targetPlatform.config + "-"
   );
 in

--- a/pkgs/development/compilers/chicken/5/chicken.nix
+++ b/pkgs/development/compilers/chicken/5/chicken.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation (finalAttrs: {
       "LINKER_OPTIONS=-headerpad_max_install_names"
       "POSTINSTALL_PROGRAM=install_name_tool"
     ])
-    ++ (lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ (lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "HOSTSYSTEM=${stdenv.hostPlatform.config}"
       "TARGET_C_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}cc"
       "TARGET_CXX_COMPILER=${stdenv.cc}/bin/${stdenv.cc.targetPrefix}c++"

--- a/pkgs/development/compilers/fbc/default.nix
+++ b/pkgs/development/compilers/fbc/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation rec {
     "format"
   ];
 
-  makeFlags = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  makeFlags = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     "TARGET=${stdenv.hostPlatform.config}"
   ];
 
@@ -76,7 +76,7 @@ stdenv.mkDerivation rec {
     make rtlib -j$buildJobs \
       "FBC=$PWD/bin/fbc${stdenv.buildPlatform.extensions.executable} -i $PWD/inc" \
       ${
-        if (stdenv.buildPlatform == stdenv.hostPlatform) then
+        if (stdenv.buildPlatform.equals stdenv.hostPlatform) then
           "BUILD_PREFIX=${buildPackages.stdenv.cc.targetPrefix} LD=${buildPackages.stdenv.cc.targetPrefix}ld"
         else
           "TARGET=${stdenv.hostPlatform.config}"
@@ -84,11 +84,7 @@ stdenv.mkDerivation rec {
 
     echo Install patched build compiler and host rtlib to local directory
     make install-compiler prefix=$PWD/patched-fbc
-    make install-rtlib prefix=$PWD/patched-fbc ${
-      lib.optionalString (
-        stdenv.buildPlatform != stdenv.hostPlatform
-      ) "TARGET=${stdenv.hostPlatform.config}"
-    }
+    make install-rtlib prefix=$PWD/patched-fbc ${lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "TARGET=${stdenv.hostPlatform.config}"}
     make clean
 
     echo Compile patched host everything with previous patched stage
@@ -101,7 +97,7 @@ stdenv.mkDerivation rec {
 
   # Tests do not work when cross-compiling even if build platform can execute
   # host binaries, compiler struggles to find the cross compiler's libgcc_s
-  doCheck = stdenv.buildPlatform == stdenv.hostPlatform;
+  doCheck = stdenv.buildPlatform.equals stdenv.hostPlatform;
 
   checkTarget = "unit-tests warning-tests log-tests";
 

--- a/pkgs/development/compilers/ghc/8.10.7-binary.nix
+++ b/pkgs/development/compilers/ghc/8.10.7-binary.nix
@@ -22,7 +22,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert stdenv.targetPlatform.equals stdenv.hostPlatform;
 
 let
   downloadsUrl = "https://downloads.haskell.org/ghc";

--- a/pkgs/development/compilers/ghc/8.10.7.nix
+++ b/pkgs/development/compilers/ghc/8.10.7.nix
@@ -50,7 +50,7 @@ in
   gmp,
 
   # If enabled, use -fPIC when compiling static libs.
-  enableRelocatedStaticLibs ? stdenv.targetPlatform != stdenv.hostPlatform,
+  enableRelocatedStaticLibs ? stdenv.targetPlatform.notEquals stdenv.hostPlatform,
 
   # Exceeds Hydra output limit (at the time of writing ~3GB) when cross compiled to riscv64.
   # A riscv64 cross-compiler fits into the limit comfortably.
@@ -65,13 +65,13 @@ in
     !(
       stdenv.targetPlatform.isWindows
       # terminfo can't be built for cross
-      || (stdenv.buildPlatform != stdenv.hostPlatform)
-      || (stdenv.hostPlatform != stdenv.targetPlatform)
+      || (stdenv.buildPlatform.notEquals stdenv.hostPlatform)
+      || (stdenv.hostPlatform.notEquals stdenv.targetPlatform)
     ),
 
   # What flavour to build. An empty string indicates no
   # specific flavour and falls back to ghc default values.
-  ghcFlavour ? lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (
+  ghcFlavour ? lib.optionalString (stdenv.targetPlatform.notEquals stdenv.hostPlatform) (
     if useLLVM then "perf-cross" else "perf-cross-ncg"
   ),
 
@@ -84,7 +84,9 @@ in
 
   enableHaddockProgram ?
     # Disabled for cross; see note [HADDOCK_DOCS].
-    (stdenv.buildPlatform == stdenv.hostPlatform && stdenv.targetPlatform == stdenv.hostPlatform),
+    (
+      stdenv.buildPlatform.equals stdenv.hostPlatform && stdenv.targetPlatform.equals stdenv.hostPlatform
+    ),
 
   # Whether to disable the large address space allocator
   # necessary fix for iOS: https://www.reddit.com/r/haskell/comments/4ttdz1/building_an_osxi386_to_iosarm64_cross_compiler/d5qvd67/
@@ -102,17 +104,21 @@ assert !enableIntegerSimple -> gmp != null;
 # Cross cannot currently build the `haddock` program for silly reasons,
 # see note [HADDOCK_DOCS].
 assert
-  (stdenv.buildPlatform != stdenv.hostPlatform || stdenv.targetPlatform != stdenv.hostPlatform)
+  (
+    stdenv.buildPlatform.notEquals stdenv.hostPlatform
+    || stdenv.targetPlatform.notEquals stdenv.hostPlatform
+  )
   -> !enableHaddockProgram;
 
 # GHC does not support building when all 3 platforms are different.
-assert stdenv.buildPlatform == stdenv.hostPlatform || stdenv.hostPlatform == stdenv.targetPlatform;
+assert
+  stdenv.buildPlatform.equals stdenv.hostPlatform || stdenv.hostPlatform.equals stdenv.targetPlatform;
 
 let
   inherit (stdenv) buildPlatform hostPlatform targetPlatform;
 
   # TODO(@Ericson2314) Make unconditional
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+  targetPrefix = lib.optionalString (targetPlatform.notEquals hostPlatform) "${targetPlatform.config}-";
 
   buildMK =
     ''
@@ -144,7 +150,7 @@ let
         DYNAMIC_GHC_PROGRAMS = ${if enableShared then "YES" else "NO"}
         INTEGER_LIBRARY = ${if enableIntegerSimple then "integer-simple" else "integer-gmp"}
       ''
-    + lib.optionalString (targetPlatform != hostPlatform) ''
+    + lib.optionalString (targetPlatform.notEquals hostPlatform) ''
       Stage1Only = ${if targetPlatform.system == hostPlatform.system then "NO" else "YES"}
       CrossCompilePrefix = ${targetPrefix}
     ''
@@ -262,7 +268,7 @@ let
   #    target.
   targetLibs =
     let
-      basePackageSet = if hostPlatform != targetPlatform then targetPackages else pkgsHostTarget;
+      basePackageSet = if hostPlatform.notEquals targetPlatform then targetPackages else pkgsHostTarget;
     in
     {
       inherit (basePackageSet) gmp ncurses;
@@ -459,9 +465,13 @@ stdenv.mkDerivation (
     # GHC's usage of build, host, and target is non-standard.
     # See https://gitlab.haskell.org/ghc/ghc/-/wikis/building/cross-compiling
     # TODO(@Ericson2314): Always pass "--target" and always prefix.
-    configurePlatforms = [
-      "build"
-    ] ++ lib.optional (buildPlatform != hostPlatform || targetPlatform != hostPlatform) "target";
+    configurePlatforms =
+      [
+        "build"
+      ]
+      ++ lib.optional (
+        buildPlatform.notEquals hostPlatform || targetPlatform.notEquals hostPlatform
+      ) "target";
 
     # `--with` flags for libraries needed for RTS linker
     configureFlags =
@@ -477,18 +487,18 @@ stdenv.mkDerivation (
         "--with-ffi-includes=${targetLibs.libffi.dev}/include"
         "--with-ffi-libraries=${targetLibs.libffi.out}/lib"
       ]
-      ++ lib.optionals (targetPlatform == hostPlatform && !enableIntegerSimple) [
+      ++ lib.optionals (targetPlatform.equals hostPlatform && !enableIntegerSimple) [
         "--with-gmp-includes=${targetLibs.gmp.dev}/include"
         "--with-gmp-libraries=${targetLibs.gmp.out}/lib"
       ]
       ++
         lib.optionals
-          (targetPlatform == hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows)
+          (targetPlatform.equals hostPlatform && hostPlatform.libc != "glibc" && !targetPlatform.isWindows)
           [
             "--with-iconv-includes=${libiconv}/include"
             "--with-iconv-libraries=${libiconv}/lib"
           ]
-      ++ lib.optionals (targetPlatform != hostPlatform) [
+      ++ lib.optionals (targetPlatform.notEquals hostPlatform) [
         "--enable-bootstrap-with-devel-snapshot"
       ]
       ++ lib.optionals useLdGold [

--- a/pkgs/development/compilers/ghc/8.6.5-binary.nix
+++ b/pkgs/development/compilers/ghc/8.6.5-binary.nix
@@ -15,7 +15,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert stdenv.targetPlatform.equals stdenv.hostPlatform;
 
 let
   useLLVM =

--- a/pkgs/development/compilers/ghc/9.2.4-binary.nix
+++ b/pkgs/development/compilers/ghc/9.2.4-binary.nix
@@ -22,7 +22,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert stdenv.targetPlatform.equals stdenv.hostPlatform;
 
 let
   downloadsUrl = "https://downloads.haskell.org/ghc";

--- a/pkgs/development/compilers/ghc/9.6.3-binary.nix
+++ b/pkgs/development/compilers/ghc/9.6.3-binary.nix
@@ -22,7 +22,7 @@
 }:
 
 # Prebuilt only does native
-assert stdenv.targetPlatform == stdenv.hostPlatform;
+assert stdenv.targetPlatform.equals stdenv.hostPlatform;
 
 let
   downloadsUrl = "https://downloads.haskell.org/ghc";

--- a/pkgs/development/compilers/go/1.23.nix
+++ b/pkgs/development/compilers/go/1.23.nix
@@ -45,7 +45,7 @@ let
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
 
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+  isCross = stdenv.buildPlatform.notEquals stdenv.targetPlatform;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";

--- a/pkgs/development/compilers/go/1.24.nix
+++ b/pkgs/development/compilers/go/1.24.nix
@@ -45,7 +45,7 @@ let
   # to handle the cross-building case where build != host == target
   targetCC = pkgsBuildTarget.targetPackages.stdenv.cc;
 
-  isCross = stdenv.buildPlatform != stdenv.targetPlatform;
+  isCross = stdenv.buildPlatform.notEquals stdenv.targetPlatform;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "go";

--- a/pkgs/development/compilers/llvm/common/bintools.nix
+++ b/pkgs/development/compilers/llvm/common/bintools.nix
@@ -9,9 +9,7 @@
 }:
 
 let
-  targetPrefix = lib.optionalString (
-    stdenv.hostPlatform != stdenv.targetPlatform
-  ) "${stdenv.targetPlatform.config}-";
+  targetPrefix = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in
 runCommand "llvm-binutils-${version}"
   {

--- a/pkgs/development/compilers/llvm/common/clang/default.nix
+++ b/pkgs/development/compilers/llvm/common/clang/default.nix
@@ -262,7 +262,7 @@ stdenv.mkDerivation (
     env =
       lib.optionalAttrs
         (
-          stdenv.buildPlatform != stdenv.hostPlatform
+          stdenv.buildPlatform.notEquals stdenv.hostPlatform
           && !stdenv.hostPlatform.useLLVM
           && lib.versionAtLeast release_version "15"
         )

--- a/pkgs/development/compilers/llvm/common/lld/default.nix
+++ b/pkgs/development/compilers/llvm/common/lld/default.nix
@@ -67,9 +67,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   cmakeFlags =
     lib.optionals (lib.versionOlder release_version "14") [
-      (lib.cmakeFeature "LLVM_CONFIG_PATH" "${libllvm.dev}/bin/llvm-config${
-        lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) "-native"
-      }")
+      (lib.cmakeFeature "LLVM_CONFIG_PATH" "${libllvm.dev}/bin/llvm-config${lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "-native"}")
     ]
     ++ lib.optionals (lib.versionAtLeast release_version "15") [
       (lib.cmakeFeature "LLD_INSTALL_PACKAGE_DIR" "${placeholder "dev"}/lib/cmake/lld")

--- a/pkgs/development/compilers/llvm/common/llvm/default.nix
+++ b/pkgs/development/compilers/llvm/common/llvm/default.nix
@@ -324,7 +324,7 @@ stdenv.mkDerivation (
 
     propagatedBuildInputs =
       (lib.optional (
-        lib.versionAtLeast release_version "14" || stdenv.buildPlatform == stdenv.hostPlatform
+        lib.versionAtLeast release_version "14" || stdenv.buildPlatform.equals stdenv.hostPlatform
       ) ncurses)
       ++ [ zlib ];
 
@@ -649,7 +649,7 @@ stdenv.mkDerivation (
       ++
         optionals
           (
-            (stdenv.hostPlatform != stdenv.buildPlatform)
+            (stdenv.hostPlatform.notEquals stdenv.buildPlatform)
             && !(stdenv.buildPlatform.canExecute stdenv.hostPlatform)
           )
           [
@@ -713,7 +713,7 @@ stdenv.mkDerivation (
           if lib.versionOlder release_version "18" then "$shortVersion" else release_version
         }.dylib
       ''
-      + optionalString (stdenv.buildPlatform != stdenv.hostPlatform) (
+      + optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) (
         if stdenv.buildPlatform.canExecute stdenv.hostPlatform then
           ''
             ln -s $dev/bin/llvm-config $dev/bin/llvm-config-native
@@ -733,7 +733,7 @@ stdenv.mkDerivation (
       )
       && (!stdenv.hostPlatform.isMusl)
       && !(stdenv.hostPlatform.isPower64 && stdenv.hostPlatform.isBigEndian)
-      && (stdenv.hostPlatform == stdenv.buildPlatform);
+      && (stdenv.hostPlatform.equals stdenv.buildPlatform);
 
     checkTarget = "check-all";
 

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -89,7 +89,7 @@ stdenv.mkDerivation (
 
     buildInputs =
       [
-        (if stdenv.buildPlatform == stdenv.hostPlatform then llvm else targetLlvm)
+        (if stdenv.buildPlatform.equals stdenv.hostPlatform then llvm else targetLlvm)
       ]
       ++ lib.optionals (ompdSupport && ompdGdbSupport) [
         python3

--- a/pkgs/development/compilers/ocaml/generic.nix
+++ b/pkgs/development/compilers/ocaml/generic.nix
@@ -109,10 +109,12 @@ stdenv.mkDerivation (
         "DEFAULT_STRING=unsafe"
       ]
       ++ optional (stdenv.hostPlatform.isStatic && (lib.versionOlder version "4.08")) "-no-shared-libs"
-      ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform && lib.versionOlder version "4.08") [
-        "-host ${stdenv.hostPlatform.config}"
-        "-target ${stdenv.targetPlatform.config}"
-      ];
+      ++
+        optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform && lib.versionOlder version "4.08")
+          [
+            "-host ${stdenv.hostPlatform.config}"
+            "-target ${stdenv.targetPlatform.config}"
+          ];
     dontAddStaticConfigureFlags = lib.versionOlder version "4.08";
 
     # on aarch64-darwin using --host and --target causes the build to invoke

--- a/pkgs/development/compilers/rust/cargo-auditable.nix
+++ b/pkgs/development/compilers/rust/cargo-auditable.nix
@@ -39,7 +39,7 @@ let
         asl20
       ];
       maintainers = with maintainers; [ figsoda ];
-      broken = stdenv.hostPlatform != stdenv.buildPlatform;
+      broken = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
     };
   };
 

--- a/pkgs/development/compilers/rust/cargo.nix
+++ b/pkgs/development/compilers/rust/cargo.nix
@@ -102,7 +102,7 @@ rustPlatform.buildRustPackage.override
         ];
         platforms = platforms.unix;
         # https://github.com/alexcrichton/nghttp2-rs/issues/2
-        broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform != stdenv.hostPlatform;
+        broken = stdenv.hostPlatform.isx86 && stdenv.buildPlatform.notEquals stdenv.hostPlatform;
       };
     }
     //

--- a/pkgs/development/compilers/rust/default.nix
+++ b/pkgs/development/compilers/rust/default.nix
@@ -38,7 +38,8 @@ let
   };
   # Allow faster cross compiler generation by reusing Build artifacts
   fastCross =
-    (stdenv.buildPlatform == stdenv.hostPlatform) && (stdenv.hostPlatform != stdenv.targetPlatform);
+    (stdenv.buildPlatform.equals stdenv.hostPlatform)
+    && (stdenv.hostPlatform.notEquals stdenv.targetPlatform);
 in
 {
   lib = lib';
@@ -82,8 +83,8 @@ in
           else
             self.buildRustPackages.overrideScope (
               _: _:
-              lib.optionalAttrs (stdenv.buildPlatform == stdenv.hostPlatform)
-                (selectRustPackage pkgsBuildHost).packages.prebuilt
+              lib.optionalAttrs (stdenv.buildPlatform.equals stdenv.hostPlatform) (selectRustPackage pkgsBuildHost)
+              .packages.prebuilt
             );
         bootRustPlatform = makeRustPlatform bootstrapRustPackages;
       in

--- a/pkgs/development/compilers/rust/rustc.nix
+++ b/pkgs/development/compilers/rust/rustc.nix
@@ -168,13 +168,13 @@ stdenv.mkDerivation (finalAttrs: {
           # (build!=target): When cross-building a compiler we need to add
           # the build platform as well so rustc can compile build.rs
           # scripts.
-          ++ optionals (stdenv.buildPlatform != stdenv.targetPlatform && !fastCross) [
+          ++ optionals (stdenv.buildPlatform.notEquals stdenv.targetPlatform && !fastCross) [
             stdenv.buildPlatform.rust.rustcTargetSpec
           ]
           # (host!=target): When building a cross-targeting compiler we
           # need to add the host platform as well so rustc can compile
           # build.rs scripts.
-          ++ optionals (stdenv.hostPlatform != stdenv.targetPlatform && !fastCross) [
+          ++ optionals (stdenv.hostPlatform.notEquals stdenv.targetPlatform && !fastCross) [
             stdenv.hostPlatform.rust.rustcTargetSpec
           ]
         )

--- a/pkgs/development/compilers/vala/default.nix
+++ b/pkgs/development/compilers/vala/default.nix
@@ -66,7 +66,7 @@ let
       # when cross-compiling ./compiler/valac is valac for host
       # so add the build vala in nativeBuildInputs
       preBuild = lib.optionalString (
-        disableGraphviz && (stdenv.buildPlatform == stdenv.hostPlatform)
+        disableGraphviz && (stdenv.buildPlatform.equals stdenv.hostPlatform)
       ) "buildFlagsArray+=(\"VALAC=$(pwd)/compiler/valac\")";
 
       outputs = [
@@ -84,7 +84,7 @@ let
         ]
         ++ lib.optional (stdenv.hostPlatform.isDarwin) expat
         ++ lib.optional disableGraphviz autoreconfHook # if we changed our ./configure script, need to reconfigure
-        ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ vala ]
+        ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [ vala ]
         ++ extraNativeBuildInputs;
 
       buildInputs =

--- a/pkgs/development/compilers/zig/bintools.nix
+++ b/pkgs/development/compilers/zig/bintools.nix
@@ -6,9 +6,7 @@
   makeWrapper,
 }:
 let
-  targetPrefix = lib.optionalString (
-    stdenv.hostPlatform != stdenv.targetPlatform
-  ) "${stdenv.targetPlatform.config}-";
+  targetPrefix = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in
 runCommand "zig-bintools-${zig.version}"
   {

--- a/pkgs/development/compilers/zig/cc.nix
+++ b/pkgs/development/compilers/zig/cc.nix
@@ -6,9 +6,7 @@
   makeWrapper,
 }:
 let
-  targetPrefix = lib.optionalString (
-    stdenv.hostPlatform != stdenv.targetPlatform
-  ) "${stdenv.targetPlatform.config}-";
+  targetPrefix = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.targetPlatform) "${stdenv.targetPlatform.config}-";
 in
 runCommand "zig-cc-${zig.version}"
   {

--- a/pkgs/development/haskell-modules/configuration-common.nix
+++ b/pkgs/development/haskell-modules/configuration-common.nix
@@ -974,7 +974,7 @@ self: super:
   #
   # # Depends on itself for testing
   # doctest-discover = addBuildTool super.doctest-discover
-  #   (if pkgs.stdenv.buildPlatform != pkgs.stdenv.hostPlatform
+  #   (if pkgs.stdenv.buildPlatform.notEquals pkgs.stdenv.hostPlatform
   #    then self.buildHaskellPackages.doctest-discover
   #    else dontCheck super.doctest-discover);
   doctest-discover = dontCheck super.doctest-discover;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -43,7 +43,7 @@ self: super: {
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.6.x.nix
@@ -40,7 +40,7 @@ self: super: {
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -42,7 +42,7 @@ self: super: {
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.10.x.nix
@@ -48,7 +48,7 @@ self: super: {
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.12.x.nix
@@ -47,7 +47,7 @@ self: super: {
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       haskellLib.doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.14.x.nix
@@ -49,7 +49,7 @@ self: super: {
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       haskellLib.doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.2.x.nix
@@ -42,7 +42,7 @@ self: super: {
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.4.x.nix
@@ -51,7 +51,7 @@ in
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.6.x.nix
@@ -59,7 +59,7 @@ self: super:
   template-haskell = null;
   # terminfo is not built if GHC is a cross compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.8.x.nix
@@ -45,7 +45,7 @@ self: super:
   template-haskell = null;
   # GHC only builds terminfo if it is a native compiler
   terminfo =
-    if pkgs.stdenv.hostPlatform == pkgs.stdenv.buildPlatform then
+    if pkgs.stdenv.hostPlatform.equals pkgs.stdenv.buildPlatform then
       null
     else
       doDistribute self.terminfo_0_4_1_6;

--- a/pkgs/development/haskell-modules/generic-builder.nix
+++ b/pkgs/development/haskell-modules/generic-builder.nix
@@ -14,7 +14,7 @@
 }:
 
 let
-  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+  isCross = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
 
   # Note that ghc.isGhcjs != stdenv.hostPlatform.isGhcjs.
   # ghc.isGhcjs implies that we are using ghcjs, a project separate from GHC.

--- a/pkgs/development/interpreters/guile/1.8.nix
+++ b/pkgs/development/interpreters/guile/1.8.nix
@@ -35,11 +35,11 @@ stdenv.mkDerivation rec {
     ]
     # Guile needs patching to preset results for the configure tests about
     # pthreads, which work only in native builds.
-    ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "--with-threads=no";
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "--with-threads=no";
 
   depsBuildBuild = [
     buildPackages.stdenv.cc
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) pkgsBuildBuild.guile_1_8;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) pkgsBuildBuild.guile_1_8;
   nativeBuildInputs = [
     makeWrapper
     pkg-config

--- a/pkgs/development/interpreters/guile/2.0.nix
+++ b/pkgs/development/interpreters/guile/2.0.nix
@@ -39,7 +39,7 @@ builder rec {
 
   depsBuildBuild = [
     buildPackages.stdenv.cc
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) pkgsBuildBuild.guile_2_0;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) pkgsBuildBuild.guile_2_0;
 
   nativeBuildInputs = [
     makeWrapper

--- a/pkgs/development/interpreters/guile/2.2.nix
+++ b/pkgs/development/interpreters/guile/2.2.nix
@@ -39,7 +39,7 @@ builder rec {
 
   depsBuildBuild = [
     buildPackages.stdenv.cc
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) pkgsBuildBuild.guile_2_2;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) pkgsBuildBuild.guile_2_2;
   nativeBuildInputs = [
     makeWrapper
     pkg-config

--- a/pkgs/development/interpreters/guile/3.0.nix
+++ b/pkgs/development/interpreters/guile/3.0.nix
@@ -41,7 +41,7 @@ builder rec {
 
   depsBuildBuild = [
     buildPackages.stdenv.cc
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) pkgsBuildBuild.guile_3_0;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) pkgsBuildBuild.guile_3_0;
   nativeBuildInputs = [
     makeWrapper
     pkg-config
@@ -76,7 +76,7 @@ builder rec {
   # https://git.savannah.gnu.org/cgit/guix.git/tree/gnu/packages/guile.scm?h=a39207f7afd977e4e4299c6f0bb34bcb6d153818#n405
   # starting with Guile 3.0.8, parallel builds can be done
   # bit-reproducibly as long as we're not cross-compiling
-  enableParallelBuilding = stdenv.buildPlatform == stdenv.hostPlatform;
+  enableParallelBuilding = stdenv.buildPlatform.equals stdenv.hostPlatform;
 
   patches =
     [

--- a/pkgs/development/interpreters/lua-5/interpreter.nix
+++ b/pkgs/development/interpreters/lua-5/interpreter.nix
@@ -121,11 +121,7 @@ stdenv.mkDerivation (
       makeFlagsArray+=(CFLAGS='-O2 -fPIC${lib.optionalString compat compatFlags} $(${
         if lib.versionAtLeast luaversion "5.2" then "SYSCFLAGS" else "MYCFLAGS"
       })' )
-      makeFlagsArray+=(${lib.optionalString stdenv.hostPlatform.isDarwin "CC=\"$CC\""}${
-        lib.optionalString (
-          stdenv.buildPlatform != stdenv.hostPlatform
-        ) " 'AR=${stdenv.cc.targetPrefix}ar rcu'"
-      })
+      makeFlagsArray+=(${lib.optionalString stdenv.hostPlatform.isDarwin "CC=\"$CC\""}${lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) " 'AR=${stdenv.cc.targetPrefix}ar rcu'"})
 
       installFlagsArray=( TO_BIN="lua luac" INSTALL_DATA='cp -d' \
         TO_LIB="${

--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -33,7 +33,7 @@ let
                 # allow 'perlPackages.override { pkgs = pkgs // { imagemagick = imagemagickBig; }; }' like in python3Packages
                 # most perl packages aren't called with callPackage so it's not possible to override their arguments individually
                 # the conditional is because the // above won't be applied to __splicedPackages and hopefully no one is doing that when cross-compiling
-                pkgs = if stdenv.buildPlatform != stdenv.hostPlatform then pkgs.__splicedPackages else pkgs;
+                pkgs = if stdenv.buildPlatform.notEquals stdenv.hostPlatform then pkgs.__splicedPackages else pkgs;
                 inherit stdenv;
                 perl = self;
               };

--- a/pkgs/development/interpreters/python/cpython/2.7/default.nix
+++ b/pkgs/development/interpreters/python/cpython/2.7/default.nix
@@ -68,7 +68,7 @@ let
   inherit (passthru) pythonOnBuildForHost;
 
   pythonOnBuildForHostInterpreter =
-    if stdenv.hostPlatform == stdenv.buildPlatform then
+    if stdenv.hostPlatform.equals stdenv.buildPlatform then
       "$out/bin/python"
     else
       pythonOnBuildForHost.interpreter;
@@ -190,7 +190,7 @@ let
       # compiler when needed.
       ./python-2.7-distutils-C++.patch
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       ./cross-compile.patch
     ];
 
@@ -231,7 +231,7 @@ let
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       "--disable-toolbox-glue"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "PYTHON_FOR_BUILD=${lib.getBin buildPackages.python27}/bin/python"
       "ac_cv_buggy_getaddrinfo=no"
       # Assume little-endian IEEE 754 floating point when cross compiling
@@ -281,7 +281,7 @@ let
     ];
   nativeBuildInputs =
     [ autoreconfHook ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       buildPackages.stdenv.cc
       buildPackages.python27
     ];
@@ -292,7 +292,7 @@ let
   };
 
   # Python 2.7 needs this
-  crossCompileEnv = lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
+  crossCompileEnv = lib.optionalAttrs (stdenv.hostPlatform.notEquals stdenv.buildPlatform) {
     _PYTHON_HOST_PLATFORM = stdenv.hostPlatform.config;
   };
 

--- a/pkgs/development/interpreters/python/cpython/default.nix
+++ b/pkgs/development/interpreters/python/cpython/default.nix
@@ -199,7 +199,7 @@ let
       autoreconfHook
       pkg-config
     ]
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       buildPackages.stdenv.cc
       pythonOnBuildForHost
     ]
@@ -258,7 +258,7 @@ let
   hasDistutilsCxxPatch = !(stdenv.cc.isGNU or false);
 
   pythonOnBuildForHostInterpreter =
-    if stdenv.hostPlatform == stdenv.buildPlatform then
+    if stdenv.hostPlatform.equals stdenv.buildPlatform then
       "$out/bin/python"
     else
       pythonOnBuildForHost.interpreter;
@@ -326,7 +326,7 @@ stdenv.mkDerivation (finalAttrs: {
       # https://www.cve.org/CVERecord?id=CVE-2025-0938
       ./CVE-2025-0938.patch
     ]
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
+    ++ optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
       # Cross compilation only supports a limited number of "known good"
       # configurations. If you're reading this and it's been a long time
       # since this diff, consider submitting this patch upstream!
@@ -487,7 +487,7 @@ stdenv.mkDerivation (finalAttrs: {
       "CFLAGS=-I${libxcrypt}/include"
       "LIBS=-L${libxcrypt}/lib"
     ]
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "ac_cv_buggy_getaddrinfo=no"
       # Assume little-endian IEEE 754 floating point when cross compiling
       "ac_cv_little_endian_double=yes"
@@ -510,7 +510,7 @@ stdenv.mkDerivation (finalAttrs: {
       "ac_cv_file__dev_ptmx=${if stdenv.hostPlatform.isWindows then "no" else "yes"}"
       "ac_cv_file__dev_ptc=${if stdenv.hostPlatform.isWindows then "no" else "yes"}"
     ]
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform && pythonAtLeast "3.11") [
+    ++ optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform && pythonAtLeast "3.11") [
       "--with-build-python=${pythonOnBuildForHostInterpreter}"
     ]
     ++ optionals stdenv.hostPlatform.isLinux [
@@ -711,7 +711,7 @@ stdenv.mkDerivation (finalAttrs: {
       linkDLLsInfolder $out/lib/python*/lib-dynload/
     '';
 
-  preFixup = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preFixup = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     # Ensure patch-shebangs uses shebangs of host interpreter.
     export PATH=${lib.makeBinPath [ "$out" ]}:$PATH
   '';
@@ -753,7 +753,7 @@ stdenv.mkDerivation (finalAttrs: {
     lib.optionals (openssl != null && !static && !enableFramework) [
       openssl.dev
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # Ensure we don't have references to build-time packages.
       # These typically end up in shebangs.
       pythonOnBuildForHost

--- a/pkgs/development/interpreters/python/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/mk-python-derivation.nix
@@ -163,7 +163,7 @@ in
   # Raise an error if two packages are installed with the same name
   # TODO: For cross we probably need a different PYTHONPATH, or not
   # add the runtime deps until after buildPhase.
-  catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
+  catchConflicts ? (python.stdenv.hostPlatform.equals python.stdenv.buildPlatform),
 
   # Additional arguments to pass to the makeWrapper function, which wraps
   # generated binaries.
@@ -353,7 +353,7 @@ let
               pypaInstallHook
           )
         ]
-        ++ optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+        ++ optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [
           # This is a test, however, it should be ran independent of the checkPhase and checkInputs
           pythonImportsCheckHook
         ]
@@ -399,9 +399,11 @@ let
         + attrs.postFixup or "";
 
       # Python packages built through cross-compilation are always for the host platform.
-      disallowedReferences = optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
-        python.pythonOnBuildForHost
-      ];
+      disallowedReferences =
+        optionals (python.stdenv.hostPlatform.notEquals python.stdenv.buildPlatform)
+          [
+            python.pythonOnBuildForHost
+          ];
 
       outputs = outputs ++ optional withDistOutput "dist";
 

--- a/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
+++ b/pkgs/development/interpreters/python/python2/mk-python-derivation.nix
@@ -58,7 +58,7 @@
   # Raise an error if two packages are installed with the same name
   # TODO: For cross we probably need a different PYTHONPATH, or not
   # add the runtime deps until after buildPhase.
-  catchConflicts ? (python.stdenv.hostPlatform == python.stdenv.buildPlatform),
+  catchConflicts ? (python.stdenv.hostPlatform.equals python.stdenv.buildPlatform),
 
   # Additional arguments to pass to the makeWrapper function, which wraps
   # generated binaries.
@@ -226,7 +226,7 @@ let
           ++ lib.optionals (format != "other") [
             (pipInstallHook)
           ]
-          ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [
+          ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [
             # This is a test, however, it should be ran independent of the checkPhase and checkInputs
             pythonImportsCheckHook
           ]
@@ -264,9 +264,11 @@ let
           + attrs.postFixup or "";
 
         # Python packages built through cross-compilation are always for the host platform.
-        disallowedReferences = lib.optionals (python.stdenv.hostPlatform != python.stdenv.buildPlatform) [
-          python.pythonOnBuildForHost
-        ];
+        disallowedReferences =
+          lib.optionals (python.stdenv.hostPlatform.notEquals python.stdenv.buildPlatform)
+            [
+              python.pythonOnBuildForHost
+            ];
 
         outputs = outputs ++ lib.optional withDistOutput "dist";
 

--- a/pkgs/development/interpreters/python/tests.nix
+++ b/pkgs/development/interpreters/python/tests.nix
@@ -279,6 +279,6 @@ let
     };
 
 in
-lib.optionalAttrs (stdenv.hostPlatform == stdenv.buildPlatform) (
+lib.optionalAttrs (stdenv.hostPlatform.equals stdenv.buildPlatform) (
   environmentTests // integrationTests // overrideTests // condaTests // editableTests
 )

--- a/pkgs/development/interpreters/ruby/default.nix
+++ b/pkgs/development/interpreters/ruby/default.nix
@@ -131,7 +131,7 @@ let
             docSupport = false;
             rubygemsSupport = false;
           },
-          useBaseRuby ? stdenv.hostPlatform != stdenv.buildPlatform,
+          useBaseRuby ? stdenv.hostPlatform.notEquals stdenv.buildPlatform,
           gitUpdater,
         }:
         stdenv.mkDerivation (finalAttrs: {

--- a/pkgs/development/libraries/apr/default.nix
+++ b/pkgs/development/libraries/apr/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
   '';
 
   configureFlags =
-    lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # For cross builds, provide answers to the configure time tests.
       # These answers are valid on x86_64-linux and aarch64-linux.
       # TODO: provide all valid answers for BSD.

--- a/pkgs/development/libraries/aws-sdk-cpp/default.nix
+++ b/pkgs/development/libraries/aws-sdk-cpp/default.nix
@@ -108,7 +108,7 @@ stdenv.mkDerivation rec {
       "-DBUILD_DEPS=OFF"
     ]
     ++ lib.optional (!customMemoryManagement) "-DCUSTOM_MEMORY_MANAGEMENT=0"
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "-DENABLE_TESTING=OFF"
       "-DCURL_HAS_H2=1"
       "-DCURL_HAS_TLS_PROXY=1"

--- a/pkgs/development/libraries/boost/generic.nix
+++ b/pkgs/development/libraries/boost/generic.nix
@@ -31,7 +31,7 @@
   enableStatic ? !enableShared,
   enablePython ? false,
   enableNumpy ? false,
-  enableIcu ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableIcu ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   taggedLayout ? (
     (enableRelease && enableDebug)
     || (enableSingleThreaded && enableMultiThreaded)
@@ -74,7 +74,7 @@ let
   layout = if taggedLayout then "tagged" else "system";
 
   needUserConfig =
-    stdenv.hostPlatform != stdenv.buildPlatform
+    stdenv.hostPlatform.notEquals stdenv.buildPlatform
     || useMpi
     || (stdenv.hostPlatform.isDarwin && enableShared);
 
@@ -106,7 +106,7 @@ let
     ++
       lib.optionals
         (
-          stdenv.hostPlatform != stdenv.buildPlatform
+          stdenv.hostPlatform.notEquals stdenv.buildPlatform
           ||
             # required on mips; see 61d9f201baeef4c4bb91ad8a8f5f89b747e0dfe4
             (stdenv.hostPlatform.isMips && lib.versionAtLeast version "1.79")
@@ -280,7 +280,7 @@ stdenv.mkDerivation {
     # uniform way for clang and gcc (which works thanks to our cc-wrapper).
     # We pass toolset later which will make b2 invoke everything in the right
     # way -- the other toolset in user-config.jam will be ignored.
-    + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       cat << EOF >> user-config.jam
       using gcc : cross : ${stdenv.cc.targetPrefix}c++
         : <archiver>$AR

--- a/pkgs/development/libraries/check/default.nix
+++ b/pkgs/development/libraries/check/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
 
   # fortify breaks the libcompat vsnprintf implementation
   hardeningDisable = lib.optionals (
-    stdenv.hostPlatform.isMusl && (stdenv.hostPlatform != stdenv.buildPlatform)
+    stdenv.hostPlatform.isMusl && (stdenv.hostPlatform.notEquals stdenv.buildPlatform)
   ) [ "fortify" ];
 
   # Test can randomly fail: https://hydra.nixos.org/build/7243912

--- a/pkgs/development/libraries/clucene-core/2.x.nix
+++ b/pkgs/development/libraries/clucene-core/2.x.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
       "-DBUILD_CONTRIBS_LIB=ON"
       "-DCMAKE_BUILD_WITH_INSTALL_NAME_DIR=ON"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "-D_CL_HAVE_GCC_ATOMIC_FUNCTIONS=0"
       "-D_CL_HAVE_NAMESPACES_EXITCODE=0"
       "-D_CL_HAVE_NAMESPACES_EXITCODE__TRYRUN_OUTPUT="

--- a/pkgs/development/libraries/ffmpeg/generic.nix
+++ b/pkgs/development/libraries/ffmpeg/generic.nix
@@ -49,7 +49,7 @@
   withAom ? withHeadlessDeps, # AV1 reference encoder
   withAribb24 ? withFullDeps, # ARIB text and caption decoding
   withAribcaption ? withFullDeps && lib.versionAtLeast version "6.1", # ARIB STD-B24 Caption Decoder/Renderer
-  withAss ? withHeadlessDeps && stdenv.hostPlatform == stdenv.buildPlatform, # (Advanced) SubStation Alpha subtitle rendering
+  withAss ? withHeadlessDeps && stdenv.hostPlatform.equals stdenv.buildPlatform, # (Advanced) SubStation Alpha subtitle rendering
   withAvisynth ? withFullDeps, # AviSynth script files reading
   withBluray ? withHeadlessDeps, # BluRay reading
   withBs2b ? withFullDeps, # bs2b DSP library
@@ -77,7 +77,7 @@
       && !isAarch32
       && !hostPlatform.isLoongArch64
       && !hostPlatform.isRiscV
-      && hostPlatform == buildPlatform
+      && hostPlatform.equals buildPlatform
     ), # dynamically linked Nvidia code
   withFlite ? withFullDeps, # Voice Synthesis
   withFontconfig ? withHeadlessDeps, # Needed for drawtext filter
@@ -146,7 +146,7 @@
   withVoAmrwbenc ? withFullDeps && withVersion3, # AMR-WB encoder
   withVorbis ? withHeadlessDeps, # Vorbis de/encoding, native encoder exists
   withVpl ? false, # Hardware acceleration via intel libvpl
-  withVpx ? withHeadlessDeps && stdenv.buildPlatform == stdenv.hostPlatform, # VP8 & VP9 de/encoding
+  withVpx ? withHeadlessDeps && stdenv.buildPlatform.equals stdenv.hostPlatform, # VP8 & VP9 de/encoding
   withVulkan ? withHeadlessDeps && !stdenv.hostPlatform.isDarwin,
   withVvenc ? withFullDeps && lib.versionAtLeast version "7.1", # H.266/VVC encoding
   withWebp ? withHeadlessDeps, # WebP encoder
@@ -745,7 +745,7 @@ stdenv.mkDerivation (
         (enableFeature withExtraWarnings "extra-warnings")
         (enableFeature withStripping "stripping")
       ]
-      ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ++ optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
         "--cross-prefix=${stdenv.cc.targetPrefix}"
         "--enable-cross-compile"
         "--host-cc=${buildPackages.stdenv.cc}/bin/cc"
@@ -767,7 +767,7 @@ stdenv.mkDerivation (
       let
         toStrip =
           map placeholder (lib.remove "data" finalAttrs.outputs) # We want to keep references to the data dir.
-          ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) buildPackages.stdenv.cc
+          ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) buildPackages.stdenv.cc
           ++ lib.optional withMetal xcode;
       in
       "remove-references-to ${lib.concatStringsSep " " (map (o: "-t ${o}") toStrip)} config.h";

--- a/pkgs/development/libraries/fltk/common.nix
+++ b/pkgs/development/libraries/fltk/common.nix
@@ -42,7 +42,7 @@
   doxygen,
   graphviz,
 
-  withExamples ? (stdenv.buildPlatform == stdenv.hostPlatform),
+  withExamples ? (stdenv.buildPlatform.equals stdenv.hostPlatform),
   withShared ? true,
 }:
 

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
       # just <1MB; this is what you get when loading config fails for some reason
       "--with-default-fonts=${dejavu_fonts.minimal}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--with-arch=${stdenv.hostPlatform.parsed.cpu.name}"
     ];
 

--- a/pkgs/development/libraries/gdk-pixbuf/default.nix
+++ b/pkgs/development/libraries/gdk-pixbuf/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
       "man"
     ]
     ++ lib.optional withIntrospection "devdoc"
-    ++ lib.optional (stdenv.buildPlatform == stdenv.hostPlatform) "installedTests";
+    ++ lib.optional (stdenv.buildPlatform.equals stdenv.hostPlatform) "installedTests";
 
   src =
     let

--- a/pkgs/development/libraries/geoip/default.nix
+++ b/pkgs/development/libraries/geoip/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ autoreconfHook ];
 
   # Cross compilation shenanigans
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "ac_cv_func_malloc_0_nonnull=yes"
     "ac_cv_func_realloc_0_nonnull=yes"
   ];

--- a/pkgs/development/libraries/gettext/default.nix
+++ b/pkgs/development/libraries/gettext/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
     [
       "--disable-csharp"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       # On cross building, gettext supposes that the wchar.h from libc
       # does not fulfill gettext needs, so it tries to work with its
       # own wchar.h file, which does not cope well with the system's

--- a/pkgs/development/libraries/glew/1.10.nix
+++ b/pkgs/development/libraries/glew/1.10.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patchPhase = ''
     sed -i 's|lib64|lib|' config/Makefile.linux
-    ${lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    ${lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       sed -i -e 's/\(INSTALL.*\)-s/\1/' Makefile
     ''}
   '';

--- a/pkgs/development/libraries/glibc/default.nix
+++ b/pkgs/development/libraries/glibc/default.nix
@@ -75,12 +75,14 @@ in
             # Fix -Werror build failure when building glibc with musl with GCC >= 8, see:
             # https://github.com/NixOS/nixpkgs/pull/68244#issuecomment-544307798
             (lib.optional stdenv.hostPlatform.isMusl "-Wno-error=attribute-alias")
-            (lib.optionals ((stdenv.hostPlatform != stdenv.buildPlatform) || stdenv.hostPlatform.isMusl) [
-              # Ignore "error: '__EI___errno_location' specifies less restrictive attributes than its target '__errno_location'"
-              # New warning as of GCC 9
-              # Same for musl: https://github.com/NixOS/nixpkgs/issues/78805
-              "-Wno-error=missing-attributes"
-            ])
+            (lib.optionals ((stdenv.hostPlatform.notEquals stdenv.buildPlatform) || stdenv.hostPlatform.isMusl)
+              [
+                # Ignore "error: '__EI___errno_location' specifies less restrictive attributes than its target '__errno_location'"
+                # New warning as of GCC 9
+                # Same for musl: https://github.com/NixOS/nixpkgs/issues/78805
+                "-Wno-error=missing-attributes"
+              ]
+            )
             (lib.optionals (stdenv.hostPlatform.isPower64) [
               # Do not complain about the Processor Specific ABI (i.e. the
               # choice to use IEEE-standard `long double`).  We pass this

--- a/pkgs/development/libraries/gmime/2.nix
+++ b/pkgs/development/libraries/gmime/2.nix
@@ -37,7 +37,9 @@ stdenv.mkDerivation rec {
     [
       "--enable-introspection=yes"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "ac_cv_have_iconv_detect_h=yes" ];
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
+      "ac_cv_have_iconv_detect_h=yes"
+    ];
 
   postPatch = ''
     substituteInPlace tests/testsuite.c \
@@ -48,7 +50,7 @@ stdenv.mkDerivation rec {
       --replace /bin/mkdir mkdir
   '';
 
-  preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  preConfigure = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
     cp ${
       if stdenv.hostPlatform.isMusl then ./musl-iconv-detect.h else ./iconv-detect.h
     } ./iconv-detect.h

--- a/pkgs/development/libraries/gmime/3.nix
+++ b/pkgs/development/libraries/gmime/3.nix
@@ -46,7 +46,9 @@ stdenv.mkDerivation rec {
       "--enable-introspection=yes"
       "--enable-vala=yes"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "ac_cv_have_iconv_detect_h=yes" ];
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
+      "ac_cv_have_iconv_detect_h=yes"
+    ];
 
   postPatch =
     ''
@@ -64,7 +66,7 @@ stdenv.mkDerivation rec {
       PKG_CONFIG_VAPIGEN_VAPIGEN="$(type -p vapigen)"
       export PKG_CONFIG_VAPIGEN_VAPIGEN
     ''
-    + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       cp ${
         if stdenv.hostPlatform.isMusl then ./musl-iconv-detect.h else ./iconv-detect.h
       } ./iconv-detect.h

--- a/pkgs/development/libraries/gnutls/default.nix
+++ b/pkgs/development/libraries/gnutls/default.nix
@@ -55,7 +55,7 @@ let
   doCheck =
     !stdenv.hostPlatform.isFreeBSD
     && !stdenv.hostPlatform.isDarwin
-    && stdenv.buildPlatform == stdenv.hostPlatform;
+    && stdenv.buildPlatform.equals stdenv.hostPlatform;
 
   inherit (stdenv.hostPlatform) isDarwin;
 in

--- a/pkgs/development/libraries/gobject-introspection/default.nix
+++ b/pkgs/development/libraries/gobject-introspection/default.nix
@@ -105,7 +105,9 @@ stdenv.mkDerivation (finalAttrs: {
       finalAttrs.setupHook # move .gir files
       # can't use canExecute, we need prebuilt when cross
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ gobject-introspection-unwrapped ];
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
+      gobject-introspection-unwrapped
+    ];
 
   buildInputs = [
     (python3.withPackages pythonModules)
@@ -124,7 +126,7 @@ stdenv.mkDerivation (finalAttrs: {
     [
       "--datadir=${placeholder "dev"}/share"
       "-Dcairo=disabled"
-      "-Dgtk_doc=${lib.boolToString (stdenv.hostPlatform == stdenv.buildPlatform)}"
+      "-Dgtk_doc=${lib.boolToString (stdenv.hostPlatform.equals stdenv.buildPlatform)}"
     ]
     ++ lib.optionals (!stdenv.buildPlatform.canExecute stdenv.hostPlatform) [
       "-Dgi_cross_ldd_wrapper=${
@@ -141,7 +143,7 @@ stdenv.mkDerivation (finalAttrs: {
       "-Dgi_cross_binary_wrapper=${stdenv.hostPlatform.emulator buildPackages}"
       # can't use canExecute, we need prebuilt when cross
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "-Dgi_cross_use_prebuilt_gi=true"
     ];
 
@@ -153,7 +155,7 @@ stdenv.mkDerivation (finalAttrs: {
     patchShebangs tools/*
   '';
 
-  postInstall = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     cp -r ${buildPackages.gobject-introspection-unwrapped.devdoc} $devdoc
     # these are uncompiled c and header files which aren't installed when cross-compiling because
     # code that installs them is in tests/meson.build which is only run when not cross-compiling

--- a/pkgs/development/libraries/gstreamer/bad/default.nix
+++ b/pkgs/development/libraries/gstreamer/bad/default.nix
@@ -109,7 +109,7 @@
   # Causes every application using GstDeviceMonitor to send mDNS queries every 2 seconds
   microdnsSupport ? false,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   guiSupport ? true,
   gst-plugins-bad,

--- a/pkgs/development/libraries/gstreamer/base/default.nix
+++ b/pkgs/development/libraries/gstreamer/base/default.nix
@@ -45,7 +45,7 @@
   glib,
   testers,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
 }:
@@ -150,7 +150,7 @@ stdenv.mkDerivation (finalAttrs: {
       (lib.mesonEnable "doc" enableDocumentation)
       (lib.mesonEnable "libvisual" false)
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "-Dtests=disabled"
     ]
     ++ lib.optionals (!enableX11) [

--- a/pkgs/development/libraries/gstreamer/core/default.nix
+++ b/pkgs/development/libraries/gstreamer/core/default.nix
@@ -32,7 +32,7 @@
     lib.meta.availableOn stdenv.hostPlatform libunwind
     && lib.elem "libunwind" libunwind.meta.pkgConfigModules or [ ],
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
 }:

--- a/pkgs/development/libraries/gstreamer/devtools/default.nix
+++ b/pkgs/development/libraries/gstreamer/devtools/default.nix
@@ -18,7 +18,7 @@
   cargo,
   json-glib,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
   _experimental-update-script-combinators,

--- a/pkgs/development/libraries/gstreamer/ges/default.nix
+++ b/pkgs/development/libraries/gstreamer/ges/default.nix
@@ -15,7 +15,7 @@
   gettext,
   gobject-introspection,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
 }:

--- a/pkgs/development/libraries/gstreamer/good/default.nix
+++ b/pkgs/development/libraries/gstreamer/good/default.nix
@@ -58,7 +58,7 @@
   glib,
   openssl,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   gst-plugins-good,
   directoryListingUpdater,

--- a/pkgs/development/libraries/gstreamer/libav/default.nix
+++ b/pkgs/development/libraries/gstreamer/libav/default.nix
@@ -11,7 +11,7 @@
   gettext,
   ffmpeg-headless,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
 }:

--- a/pkgs/development/libraries/gstreamer/rs/default.nix
+++ b/pkgs/development/libraries/gstreamer/rs/default.nix
@@ -32,7 +32,7 @@
   plugins ? null,
   withGtkPlugins ? true,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform && plugins == null,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform && plugins == null,
   hotdoc,
   mopidy,
 }:

--- a/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
+++ b/pkgs/development/libraries/gstreamer/rtsp-server/default.nix
@@ -11,7 +11,7 @@
   gst-plugins-base,
   gst-plugins-bad,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
 }:

--- a/pkgs/development/libraries/gstreamer/ugly/default.nix
+++ b/pkgs/development/libraries/gstreamer/ugly/default.nix
@@ -21,7 +21,7 @@
   DiskArbitration,
   enableGplPlugins ? true,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
   gst-plugins-ugly,

--- a/pkgs/development/libraries/gstreamer/vaapi/default.nix
+++ b/pkgs/development/libraries/gstreamer/vaapi/default.nix
@@ -22,7 +22,7 @@
   libvpx,
   python3,
   # Checks meson.is_cross_build(), so even canExecute isn't enough.
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   hotdoc,
   directoryListingUpdater,
 }:

--- a/pkgs/development/libraries/gtk/2.x.nix
+++ b/pkgs/development/libraries/gtk/2.x.nix
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
       "--disable-introspection"
       "--disable-visibility"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "ac_cv_path_GTK_UPDATE_ICON_CACHE=${buildPackages.gtk2}/bin/gtk-update-icon-cache"
       "ac_cv_path_GDK_PIXBUF_CSOURCE=${buildPackages.gdk-pixbuf.dev}/bin/gdk-pixbuf-csource"
     ];

--- a/pkgs/development/libraries/gtk/3.x.nix
+++ b/pkgs/development/libraries/gtk/3.x.nix
@@ -36,7 +36,7 @@
   gnome,
   gsettings-desktop-schemas,
   sassc,
-  trackerSupport ? stdenv.hostPlatform.isLinux && (stdenv.buildPlatform == stdenv.hostPlatform),
+  trackerSupport ? stdenv.hostPlatform.isLinux && (stdenv.buildPlatform.equals stdenv.hostPlatform),
   tinysparql,
   x11Support ? stdenv.hostPlatform.isLinux,
   waylandSupport ? stdenv.hostPlatform.isLinux,
@@ -242,7 +242,7 @@ stdenv.mkDerivation (finalAttrs: {
         wrapProgram $f --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
       done
     ''
-    + lib.optionalString (stdenv.buildPlatform == stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.equals stdenv.hostPlatform) ''
       GTK_PATH="''${out:?}/lib/gtk-3.0/3.0.0/immodules/" ''${dev:?}/bin/gtk-query-immodules-3.0 > "''${out:?}/lib/gtk-3.0/3.0.0/immodules.cache"
     '';
 

--- a/pkgs/development/libraries/gupnp/default.nix
+++ b/pkgs/development/libraries/gupnp/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   outputs = [
     "out"
     "dev"
-  ] ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ "devdoc" ];
+  ] ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [ "devdoc" ];
 
   src = fetchurl {
     url = "mirror://gnome/sources/gupnp/${lib.versions.majorMinor version}/${pname}-${version}.tar.xz";
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
   ];
 
   mesonFlags = [
-    "-Dgtk_doc=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
+    "-Dgtk_doc=${lib.boolToString (stdenv.buildPlatform.equals stdenv.hostPlatform)}"
   ];
 
   # Bail out! ERROR:../tests/test-bugs.c:168:test_on_timeout: code should not be reached

--- a/pkgs/development/libraries/hamlib/4.nix
+++ b/pkgs/development/libraries/hamlib/4.nix
@@ -15,7 +15,7 @@
   libtool,
   pythonBindings ? true,
   tclBindings ? true,
-  perlBindings ? stdenv.buildPlatform == stdenv.hostPlatform,
+  perlBindings ? stdenv.buildPlatform.equals stdenv.hostPlatform,
   buildPackages,
 }:
 let

--- a/pkgs/development/libraries/hamlib/default.nix
+++ b/pkgs/development/libraries/hamlib/default.nix
@@ -15,7 +15,7 @@
   libtool,
   pythonBindings ? true,
   tclBindings ? true,
-  perlBindings ? stdenv.buildPlatform == stdenv.hostPlatform,
+  perlBindings ? stdenv.buildPlatform.equals stdenv.hostPlatform,
   buildPackages,
 }:
 let

--- a/pkgs/development/libraries/hspell/default.nix
+++ b/pkgs/development/libraries/hspell/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
 
   patches = [ ./remove-shared-library-checks.patch ];
   postPatch = "patchShebangs .";
-  preBuild = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preBuild = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     make CC='${buildPackages.stdenv.cc}/bin/cc -I${lib.getDev buildPackages.zlib}/include -L${buildPackages.zlib}/lib' find_sizes
     mv find_sizes find_sizes_build
     make clean

--- a/pkgs/development/libraries/icu/make-icu.nix
+++ b/pkgs/development/libraries/icu/make-icu.nix
@@ -70,9 +70,7 @@ let
     configureFlags =
       [ "--disable-debug" ]
       ++ lib.optional (stdenv.hostPlatform.isFreeBSD || stdenv.hostPlatform.isDarwin) "--enable-rpath"
-      ++ lib.optional (
-        stdenv.buildPlatform != stdenv.hostPlatform
-      ) "--with-cross-build=${nativeBuildRoot}"
+      ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "--with-cross-build=${nativeBuildRoot}"
       ++ lib.optional withStatic "--enable-static";
 
     enableParallelBuilding = true;

--- a/pkgs/development/libraries/kerberos/krb5.nix
+++ b/pkgs/development/libraries/kerberos/krb5.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation rec {
       "--disable-shared"
     ]
     ++ lib.optional stdenv.hostPlatform.isFreeBSD ''WARN_CFLAGS=''
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "krb5_cv_attr_constructor_destructor=yes,yes"
       "ac_cv_func_regcomp=yes"
       "ac_cv_printf_positional=yes"

--- a/pkgs/development/libraries/libcryptui/default.nix
+++ b/pkgs/development/libraries/libcryptui/default.nix
@@ -66,6 +66,6 @@ stdenv.mkDerivation rec {
     platforms = platforms.unix;
     # ImportError: lib/gobject-introspection/giscanner/_giscanner.cpython-312-x86_64-linux-gnu.so
     # cannot open shared object file: No such file or directory
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/development/libraries/libffi/3.3.nix
+++ b/pkgs/development/libraries/libffi/3.3.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
     NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
   '';
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+  dontStrip = stdenv.hostPlatform.notEquals stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
 
   inherit doCheck;
 

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -55,7 +55,7 @@ stdenv.mkDerivation (finalAttrs: {
     NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
   '';
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+  dontStrip = stdenv.hostPlatform.notEquals stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
 
   inherit doCheck;
 

--- a/pkgs/development/libraries/libiconv/default.nix
+++ b/pkgs/development/libraries/libiconv/default.nix
@@ -8,7 +8,7 @@
   enableDarwinABICompat ? false,
 }:
 
-# assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform != stdenv.buildPlatform; # TODO: improve on cross
+# assert !stdenv.hostPlatform.isLinux || stdenv.hostPlatform.notEquals stdenv.buildPlatform; # TODO: improve on cross
 
 stdenv.mkDerivation rec {
   pname = "libiconv";
@@ -36,7 +36,8 @@ stdenv.mkDerivation rec {
   postPatch =
     lib.optionalString
       (
-        (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isMinGW) || stdenv.cc.nativeLibc
+        (stdenv.hostPlatform.notEquals stdenv.buildPlatform && stdenv.hostPlatform.isMinGW)
+        || stdenv.cc.nativeLibc
       )
       ''
         sed '/^_GL_WARN_ON_USE (gets/d' -i srclib/stdio.in.h

--- a/pkgs/development/libraries/libinput/default.nix
+++ b/pkgs/development/libraries/libinput/default.nix
@@ -120,7 +120,7 @@ stdenv.mkDerivation rec {
     "--libexecdir=${placeholder "bin"}/libexec"
   ];
 
-  doCheck = testsSupport && stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = testsSupport && stdenv.hostPlatform.equals stdenv.buildPlatform;
 
   postPatch = ''
     patchShebangs \

--- a/pkgs/development/libraries/libpng/12.nix
+++ b/pkgs/development/libraries/libpng/12.nix
@@ -6,7 +6,7 @@
   testers,
 }:
 
-assert stdenv.hostPlatform == stdenv.buildPlatform -> zlib != null;
+assert stdenv.hostPlatform.equals stdenv.buildPlatform -> zlib != null;
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "libpng";

--- a/pkgs/development/libraries/libxml2/default.nix
+++ b/pkgs/development/libraries/libxml2/default.nix
@@ -15,7 +15,7 @@
   pythonSupport ?
     enableShared
     && (
-      stdenv.hostPlatform == stdenv.buildPlatform
+      stdenv.hostPlatform.equals stdenv.buildPlatform
       || stdenv.hostPlatform.isCygwin
       || stdenv.hostPlatform.isLinux
       || stdenv.hostPlatform.isWasi
@@ -106,7 +106,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   enableParallelBuilding = true;
 
-  doCheck = (stdenv.hostPlatform == stdenv.buildPlatform) && stdenv.hostPlatform.libc != "musl";
+  doCheck = (stdenv.hostPlatform.equals stdenv.buildPlatform) && stdenv.hostPlatform.libc != "musl";
   preCheck = lib.optional stdenv.hostPlatform.isDarwin ''
     export DYLD_LIBRARY_PATH="$PWD/.libs:$DYLD_LIBRARY_PATH"
   '';

--- a/pkgs/development/libraries/ncurses/default.nix
+++ b/pkgs/development/libraries/ncurses/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
         ]
       }"
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       "--with-build-cc=${buildPackages.stdenv.cc}/bin/${buildPackages.stdenv.cc.targetPrefix}cc"
     ]
     ++ (lib.optionals (stdenv.cc.bintools.isLLVM && lib.versionAtLeast stdenv.cc.bintools.version "17")
@@ -107,7 +107,7 @@ stdenv.mkDerivation (finalAttrs: {
       updateAutotoolsGnuConfigScriptsHook
       pkg-config
     ]
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       # for `tic`, build already depends on for build `cc` so it's weird the build doesn't just build `tic`.
       ncurses
     ];

--- a/pkgs/development/libraries/nss/generic.nix
+++ b/pkgs/development/libraries/nss/generic.nix
@@ -201,7 +201,7 @@ stdenv.mkDerivation rec {
 
   postFixup =
     let
-      isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+      isCross = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
       nss = if isCross then buildPackages.nss.tools else "$out";
     in
     (lib.optionalString enableFIPS (

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -628,7 +628,8 @@ effectiveStdenv.mkDerivation {
         withIpp = opencv4.override { enableIpp = true; };
       }
       // optionalAttrs (!enablePython) { pythonEnabled = pythonPackages.opencv4; }
-      // optionalAttrs (effectiveStdenv.buildPlatform != "x86_64-darwin") {
+      # FIXME: should this be `!buildPlatform.isDarwin` ?
+      // optionalAttrs (effectiveStdenv.buildPlatform.system != "x86_64-darwin") {
         opencv4-tests = callPackage ./tests.nix {
           inherit
             enableGStreamer

--- a/pkgs/development/libraries/opencv/4.x.nix
+++ b/pkgs/development/libraries/opencv/4.x.nix
@@ -343,7 +343,7 @@ effectiveStdenv.mkDerivation {
     ++ optionals enablePython [
       pythonPackages.python
     ]
-    ++ optionals (effectiveStdenv.buildPlatform == effectiveStdenv.hostPlatform) [
+    ++ optionals (effectiveStdenv.buildPlatform.equals effectiveStdenv.hostPlatform) [
       hdf5
     ]
     ++ optionals enableGtk2 [
@@ -454,7 +454,7 @@ effectiveStdenv.mkDerivation {
         pythonPackages.wheel
         pythonPackages.setuptools
       ]
-      ++ optionals (effectiveStdenv.hostPlatform == effectiveStdenv.buildPlatform) [
+      ++ optionals (effectiveStdenv.hostPlatform.equals effectiveStdenv.buildPlatform) [
         pythonPackages.pythonImportsCheckHook
       ]
     )

--- a/pkgs/development/libraries/openssl/default.nix
+++ b/pkgs/development/libraries/openssl/default.nix
@@ -124,7 +124,7 @@ let
           riscv64-linux = "./Configure linux64-riscv64";
         }
         .${stdenv.hostPlatform.system} or (
-          if stdenv.hostPlatform == stdenv.buildPlatform then
+          if stdenv.hostPlatform.equals stdenv.buildPlatform then
             "./config"
           else if stdenv.hostPlatform.isBSD then
             if stdenv.hostPlatform.isx86_64 then

--- a/pkgs/development/libraries/pcre/default.nix
+++ b/pkgs/development/libraries/pcre/default.nix
@@ -69,7 +69,8 @@ stdenv.mkDerivation rec {
   '';
 
   doCheck =
-    !(with stdenv.hostPlatform; isCygwin || isFreeBSD) && stdenv.hostPlatform == stdenv.buildPlatform;
+    !(with stdenv.hostPlatform; isCygwin || isFreeBSD)
+    && stdenv.hostPlatform.equals stdenv.buildPlatform;
   # XXX: test failure on Cygwin
   # we are running out of stack on both freeBSDs on Hydra
 

--- a/pkgs/development/libraries/qt-5/5.15/default.nix
+++ b/pkgs/development/libraries/qt-5/5.15/default.nix
@@ -392,7 +392,7 @@ let
         makeSetupHook {
           name = "qmake-hook";
           ${
-            if stdenv.buildPlatform == stdenv.hostPlatform then
+            if stdenv.buildPlatform.equals stdenv.hostPlatform then
               "propagatedBuildInputs"
             else
               "depsTargetTargetPropagated"
@@ -438,7 +438,7 @@ let
       # qttranslations causes eval-time infinite recursion when
       # cross-compiling; disabled for now.
       qttranslations =
-        if stdenv.buildPlatform == stdenv.hostPlatform then bootstrapScope.qttranslations else null;
+        if stdenv.buildPlatform.equals stdenv.hostPlatform then bootstrapScope.qttranslations else null;
     }
   );
 in

--- a/pkgs/development/libraries/qt-5/modules/qtbase.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtbase.nix
@@ -66,7 +66,7 @@
   libGLSupported ? !stdenv.hostPlatform.isDarwin,
   libGL,
   # qmake detection for libmysqlclient does not seem to work when cross compiling
-  mysqlSupport ? stdenv.hostPlatform == stdenv.buildPlatform,
+  mysqlSupport ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   libmysqlclient,
   buildExamples ? false,
   buildTests ? false,
@@ -176,7 +176,7 @@ stdenv.mkDerivation (
         ++ lib.optionals stdenv.hostPlatform.isDarwin [ xcbuild ];
 
     }
-    // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+    // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
       # `qtbase` expects to find `cc` (with no prefix) in the
       # `$PATH`, so the following is needed even if
       # `stdenv.buildPlatform.canExecute stdenv.hostPlatform`
@@ -326,7 +326,7 @@ stdenv.mkDerivation (
             [
               "-Wno-error=sign-compare" # freetype-2.5.4 changed signedness of some struct fields
             ]
-            ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+            ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
               "-Wno-warn=free-nonheap-object"
               "-Wno-free-nonheap-object"
               "-w"
@@ -345,7 +345,7 @@ stdenv.mkDerivation (
             ++ lib.optional decryptSslTraffic "-DQT_DECRYPT_SSL_TRAFFIC"
           );
         }
-        // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+        // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
           NIX_CFLAGS_COMPILE_FOR_BUILD = toString ([
             "-Wno-warn=free-nonheap-object"
             "-Wno-free-nonheap-object"
@@ -361,7 +361,7 @@ stdenv.mkDerivation (
       PSQL_LIBS = lib.optionalString (libpq != null) "-L${libpq}/lib -lpq";
 
     }
-    // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+    // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
       configurePlatforms = [ ];
     }
     // {
@@ -395,7 +395,7 @@ stdenv.mkDerivation (
           "${icu.dev}/include"
           "-pch"
         ]
-        ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+        ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
           "-device ${qtPlatformCross stdenv.hostPlatform}"
           "-device-option CROSS_COMPILE=${stdenv.cc.targetPrefix}"
         ]
@@ -404,7 +404,7 @@ stdenv.mkDerivation (
           "-developer-build"
           "-no-warnings-are-errors"
         ]
-        ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+        ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
           "-no-warnings-are-errors"
         ]
         ++ (

--- a/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebchannel.nix
@@ -15,5 +15,5 @@ qtModule {
   outputs = [
     "out"
     "dev"
-  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "bin" ];
+  ] ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [ "bin" ];
 }

--- a/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
+++ b/pkgs/development/libraries/qt-5/modules/qtwebengine.nix
@@ -105,7 +105,7 @@ qtModule (
         gn
         nodejs
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
         perl
         lndir
         (lib.getDev pkgsBuildTarget.targetPackages.qt5.qtbase)
@@ -289,7 +289,7 @@ qtModule (
     env =
       {
         NIX_CFLAGS_COMPILE = toString (
-          lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+          lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
             "-w "
           ]
           ++ lib.optionals stdenv.cc.isGNU [
@@ -312,7 +312,7 @@ qtModule (
           ]
         );
       }
-      // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+      // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
         NIX_CFLAGS_LINK = "-Wl,--no-warn-search-mismatch";
         "NIX_CFLAGS_LINK_${buildPackages.stdenv.cc.suffixSalt}" = "-Wl,--no-warn-search-mismatch";
       };
@@ -325,7 +325,7 @@ qtModule (
             QMAKEPATH="$PWD/tools/qmake''${QMAKEPATH:+:}$QMAKEPATH"
         fi
       ''
-      + lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+      + lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
         export QMAKE_CC=$CC
         export QMAKE_CXX=$CXX
         export QMAKE_LINK=$CXX
@@ -338,7 +338,7 @@ qtModule (
         "-system-ffmpeg"
       ]
       ++ lib.optional (
-        pipewireSupport && stdenv.buildPlatform == stdenv.hostPlatform
+        pipewireSupport && stdenv.buildPlatform.equals stdenv.hostPlatform
       ) "-webengine-webrtc-pipewire"
       ++ lib.optional enableProprietaryCodecs "-proprietary-codecs";
 
@@ -434,7 +434,7 @@ qtModule (
     dontUseNinjaInstall = true;
 
     postInstall =
-      lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+      lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
         mkdir -p $out/libexec
       ''
       + lib.optionalString stdenv.hostPlatform.isLinux ''
@@ -478,7 +478,7 @@ qtModule (
     };
 
   }
-  // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
     configurePlatforms = [ ];
     # to get progress output in `nix-build` and `nix build -L`
     preBuild = ''

--- a/pkgs/development/libraries/qt-5/qtModule.nix
+++ b/pkgs/development/libraries/qt-5/qtModule.nix
@@ -42,14 +42,14 @@ mkDerivation (
         perl
         qmake
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
         pkgsHostTarget.qt5.qtbase.dev
       ];
     propagatedBuildInputs =
       (lib.warnIf (args ? qtInputs) "qt5.qtModule's qtInputs argument is deprecated" args.qtInputs or [ ])
       ++ (args.propagatedBuildInputs or [ ]);
   }
-  // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
     depsBuildBuild = [ buildPackages.stdenv.cc ] ++ (args.depsBuildBuild or [ ]);
   }
   // {

--- a/pkgs/development/libraries/quictls/default.nix
+++ b/pkgs/development/libraries/quictls/default.nix
@@ -97,7 +97,7 @@ stdenv.mkDerivation rec {
           throw "unsupported ABI for ${stdenv.hostPlatform.system}";
     }
     .${stdenv.hostPlatform.system} or (
-      if stdenv.hostPlatform == stdenv.buildPlatform then
+      if stdenv.hostPlatform.equals stdenv.buildPlatform then
         "./config"
       else if stdenv.hostPlatform.isBSD && stdenv.hostPlatform.isx86_64 then
         "./Configure BSD-x86_64"

--- a/pkgs/development/libraries/science/math/openblas/default.nix
+++ b/pkgs/development/libraries/science/math/openblas/default.nix
@@ -234,7 +234,7 @@ stdenv.mkDerivation rec {
       INTERFACE64 = blas64;
       NO_STATIC = !enableStatic;
       NO_SHARED = !enableShared;
-      CROSS = stdenv.hostPlatform != stdenv.buildPlatform;
+      CROSS = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
       HOSTCC = "cc";
       # Makefile.system only checks defined status
       # This seems to be a bug in the openblas Makefile:
@@ -242,9 +242,9 @@ stdenv.mkDerivation rec {
       # but on aarch64 it expects NO_BINARY_MODE=0
       NO_BINARY_MODE =
         if stdenv.hostPlatform.isx86_64 then
-          toString (stdenv.hostPlatform != stdenv.buildPlatform)
+          toString (stdenv.hostPlatform.notEquals stdenv.buildPlatform)
         else
-          stdenv.hostPlatform != stdenv.buildPlatform;
+          stdenv.hostPlatform.notEquals stdenv.buildPlatform;
       # This disables automatic build job count detection (which honours neither enableParallelBuilding nor NIX_BUILD_CORES)
       # and uses the main make invocation's job count, falling back to 1 if no parallelism is used.
       # https://github.com/OpenMathLib/OpenBLAS/blob/v0.3.20/getarch.c#L1781-L1792

--- a/pkgs/development/libraries/science/math/p4est-sc/default.nix
+++ b/pkgs/development/libraries/science/math/p4est-sc/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation {
 
   # disallow Darwin checks due to prototype incompatibility of qsort_r
   # to be fixed in a future version of the source code
-  doCheck = !stdenv.hostPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform;
+  doCheck = !stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.equals stdenv.buildPlatform;
 
   meta = {
     branch = "prev3-develop";

--- a/pkgs/development/libraries/tbb/2020_3.nix
+++ b/pkgs/development/libraries/tbb/2020_3.nix
@@ -62,7 +62,7 @@ stdenv.mkDerivation rec {
     lib.optionals stdenv.cc.isClang [
       "compiler=clang"
     ]
-    ++ (lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) (
+    ++ (lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) (
       if stdenv.hostPlatform.isAarch64 then
         "arch=arm64"
       else if stdenv.hostPlatform.isx86_64 then

--- a/pkgs/development/libraries/wayland/default.nix
+++ b/pkgs/development/libraries/wayland/default.nix
@@ -9,7 +9,7 @@
   withTests ? stdenv.hostPlatform.isLinux,
   libffi,
   epoll-shim,
-  withDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  withDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   graphviz-nox,
   doxygen,
   libxslt,

--- a/pkgs/development/libraries/wayland/protocols.nix
+++ b/pkgs/development/libraries/wayland/protocols.nix
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: {
   version = "1.42";
 
   doCheck =
-    stdenv.hostPlatform == stdenv.buildPlatform
+    stdenv.hostPlatform.equals stdenv.buildPlatform
     &&
       # https://gitlab.freedesktop.org/wayland/wayland-protocols/-/issues/48
       stdenv.hostPlatform.linker == "bfd"

--- a/pkgs/development/libraries/wayland/scanner.nix
+++ b/pkgs/development/libraries/wayland/scanner.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
     meson
     pkg-config
     ninja
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) wayland-scanner;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) wayland-scanner;
 
   buildInputs = [
     expat

--- a/pkgs/development/libraries/waylandpp/default.nix
+++ b/pkgs/development/libraries/waylandpp/default.nix
@@ -43,7 +43,7 @@ stdenv.mkDerivation rec {
     [
       "-DCMAKE_INSTALL_DATADIR=${placeholder "dev"}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "-DWAYLAND_SCANNERPP=${buildPackages.waylandpp}/bin/wayland-scanner++"
     ];
 

--- a/pkgs/development/libraries/zlib/default.nix
+++ b/pkgs/development/libraries/zlib/default.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   dontConfigure = stdenv.hostPlatform.isMinGW;
 
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     export CHOST=${stdenv.hostPlatform.config}
   '';
 
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # We don't strip on static cross-compilation because of reports that native
   # stripping corrupted the target library; see commit 12e960f5 for the report.
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform && static;
+  dontStrip = stdenv.hostPlatform.notEquals stdenv.buildPlatform && static;
   configurePlatforms = [ ];
 
   installFlags = lib.optionals stdenv.hostPlatform.isMinGW [

--- a/pkgs/development/python-modules/conduit/default.nix
+++ b/pkgs/development/python-modules/conduit/default.nix
@@ -60,6 +60,6 @@ buildPythonPackage {
       ;
     maintainers = with lib.maintainers; [ GaetanLepage ];
     # Cross-compilation is broken
-    broken = stdenv.hostPlatform != stdenv.buildPlatform;
+    broken = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
   };
 }

--- a/pkgs/development/python-modules/m2crypto/default.nix
+++ b/pkgs/development/python-modules/m2crypto/default.nix
@@ -42,7 +42,7 @@ buildPythonPackage rec {
         "-Wno-error=incompatible-pointer-types"
       ]);
     }
-    // lib.optionalAttrs (stdenv.hostPlatform != stdenv.buildPlatform) {
+    // lib.optionalAttrs (stdenv.hostPlatform.notEquals stdenv.buildPlatform) {
       CPP = "${stdenv.cc.targetPrefix}cpp";
     };
 

--- a/pkgs/development/python-modules/psycopg/default.nix
+++ b/pkgs/development/python-modules/psycopg/default.nix
@@ -124,7 +124,7 @@ buildPythonPackage rec {
     [
       "out"
     ]
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [
       "doc"
     ];
 
@@ -151,7 +151,7 @@ buildPythonPackage rec {
     ]
     # building the docs fails with the following error when cross compiling
     #  AttributeError: module 'psycopg_c.pq' has no attribute '__impl__'
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [
       sphinx-autodoc-typehints
       sphinxHook
     ];

--- a/pkgs/development/python-modules/psycopg2/default.nix
+++ b/pkgs/development/python-modules/psycopg2/default.nix
@@ -65,7 +65,7 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "psycopg2" ];
 
-  disallowedReferences = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  disallowedReferences = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     buildPackages.libpq
   ];
 

--- a/pkgs/development/python-modules/pyqt/5.x.nix
+++ b/pkgs/development/python-modules/pyqt/5.x.nix
@@ -120,7 +120,7 @@ buildPythonPackage rec {
 
   nativeBuildInputs =
     [ pkg-config ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ libsForQt5.qmake ]
+    ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [ libsForQt5.qmake ]
     ++ [
       setuptools
       lndir
@@ -129,7 +129,7 @@ buildPythonPackage rec {
     ++ (
       with pkgsBuildTarget.targetPackages.libsForQt5;
       [ ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ qmake ]
+      ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [ qmake ]
       ++ [
         qtbase
         qtsvg
@@ -148,7 +148,7 @@ buildPythonPackage rec {
   buildInputs =
     with libsForQt5;
     [ dbus ]
-    ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ qtbase ]
+    ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [ qtbase ]
     ++ [
       qtsvg
       qtdeclarative

--- a/pkgs/development/python-modules/pyqtwebengine/default.nix
+++ b/pkgs/development/python-modules/pyqtwebengine/default.nix
@@ -48,8 +48,8 @@ buildPythonPackage (
         libsForQt5.qmake
         libsForQt5.wrapQtAppsHook
       ]
-      ++ lib.optionals (stdenv.buildPlatform == stdenv.hostPlatform) [ sip ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      ++ lib.optionals (stdenv.buildPlatform.equals stdenv.hostPlatform) [ sip ]
+      ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
         python.pythonOnBuildForHost.pkgs.sip
       ]
       ++ [
@@ -59,7 +59,7 @@ buildPythonPackage (
         pyqt-builder
         setuptools
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ libsForQt5.qtdeclarative ]
+      ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [ libsForQt5.qtdeclarative ]
       ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
         autoSignDarwinBinariesHook
       ];
@@ -71,7 +71,7 @@ buildPythonPackage (
         libsForQt5.qtsvg
         libsForQt5.qtwebengine
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
         libsForQt5.qtwebchannel
         libsForQt5.qtdeclarative
       ];
@@ -104,7 +104,7 @@ buildPythonPackage (
       hydraPlatforms = lib.lists.intersectLists libsForQt5.qtwebengine.meta.platforms mesa.meta.platforms;
     };
   }
-  // lib.optionalAttrs (stdenv.buildPlatform != stdenv.hostPlatform) {
+  // lib.optionalAttrs (stdenv.buildPlatform.notEquals stdenv.hostPlatform) {
     # TODO: figure out why the env hooks aren't adding these inclusions automatically
     env.NIX_CFLAGS_COMPILE = lib.concatStringsSep " " [
       "-I${lib.getDev libsForQt5.qtbase}/include/QtPrintSupport/"

--- a/pkgs/development/python-modules/sigrok/default.nix
+++ b/pkgs/development/python-modules/sigrok/default.nix
@@ -33,7 +33,7 @@ toPythonModule (
         swig
         numpy
       ]
-      ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+      ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [
         pythonImportsCheckHook
         pythonCatchConflictsHook
       ];

--- a/pkgs/development/python-modules/tpm2-pytss/default.nix
+++ b/pkgs/development/python-modules/tpm2-pytss/default.nix
@@ -20,7 +20,7 @@
 }:
 
 let
-  isCross = (stdenv.buildPlatform != stdenv.hostPlatform);
+  isCross = (stdenv.buildPlatform.notEquals stdenv.hostPlatform);
 in
 buildPythonPackage rec {
   pname = "tpm2-pytss";

--- a/pkgs/development/skaware-packages/s6-linux-init/default.nix
+++ b/pkgs/development/skaware-packages/s6-linux-init/default.nix
@@ -39,7 +39,7 @@ skawarePackages.buildPackage {
   ];
 
   # See ../s6-rc/default.nix for an explanation
-  postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+  postConfigure = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.targetPlatform) ''
     substituteInPlace src/init/s6-linux-init-maker.c \
         --replace-fail '<execline/config.h>' '"${targetPackages.execline.dev}/include/execline/config.h"' \
         --replace-fail '<s6/config.h>' '"${targetPackages.s6.dev}/include/s6/config.h"' \

--- a/pkgs/development/skaware-packages/s6-rc/default.nix
+++ b/pkgs/development/skaware-packages/s6-rc/default.nix
@@ -62,7 +62,7 @@ skawarePackages.buildPackage {
   # only time hostPlatform != targetPlatform.  When that happens we
   # modify s6-rc-compile to use the configuration headers for the
   # system we're cross-compiling for.
-  postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.targetPlatform) ''
+  postConfigure = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.targetPlatform) ''
     substituteInPlace src/s6-rc/s6-rc-compile.c \
         --replace-fail '<execline/config.h>' '"${targetPackages.execline.dev}/include/execline/config.h"' \
         --replace-fail '<s6/config.h>' '"${targetPackages.s6.dev}/include/s6/config.h"' \

--- a/pkgs/development/tools/godot/common.nix
+++ b/pkgs/development/tools/godot/common.nix
@@ -145,7 +145,7 @@ let
 
     strictDeps = true;
 
-    depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+    depsBuildBuild = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
       buildPackages.stdenv.cc
       pkg-config
     ];

--- a/pkgs/development/tools/misc/binutils/2.38/default.nix
+++ b/pkgs/development/tools/misc/binutils/2.38/default.nix
@@ -47,7 +47,7 @@ let
 
   #INFO: The targetPrefix prepended to binary names to allow multiple binuntils
   # on the PATH to both be usable.
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+  targetPrefix = lib.optionalString (targetPlatform.notEquals hostPlatform) "${targetPlatform.config}-";
 in
 
 stdenv.mkDerivation {
@@ -240,14 +240,14 @@ stdenv.mkDerivation {
 
   # Break dependency on pkgsBuildBuild.gcc when building a cross-binutils
   stripDebugList =
-    if stdenv.hostPlatform != stdenv.targetPlatform then
+    if stdenv.hostPlatform.notEquals stdenv.targetPlatform then
       "bin lib ${stdenv.hostPlatform.config}"
     else
       null;
 
   # INFO: Otherwise it fails with:
   # `./sanity.sh: line 36: $out/bin/size: not found`
-  doInstallCheck = (buildPlatform == hostPlatform) && (hostPlatform == targetPlatform);
+  doInstallCheck = (buildPlatform.equals hostPlatform) && (hostPlatform.equals targetPlatform);
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/binutils/default.nix
+++ b/pkgs/development/tools/misc/binutils/default.nix
@@ -37,7 +37,7 @@ let
 
   #INFO: The targetPrefix prepended to binary names to allow multiple binuntils
   # on the PATH to both be usable.
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+  targetPrefix = lib.optionalString (targetPlatform.notEquals hostPlatform) "${targetPlatform.config}-";
 in
 
 stdenv.mkDerivation (finalAttrs: {
@@ -100,7 +100,7 @@ stdenv.mkDerivation (finalAttrs: {
     # to $lib as binutils does not build target libraries. Let's make our
     # life slightly simpler by installing everything into $out for
     # cross-binutils.
-    ++ lib.optionals (targetPlatform == hostPlatform) [ "lib" ];
+    ++ lib.optionals (targetPlatform.equals hostPlatform) [ "lib" ];
 
   strictDeps = true;
   depsBuildBuild = [ buildPackages.stdenv.cc ];
@@ -253,14 +253,14 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Break dependency on pkgsBuildBuild.gcc when building a cross-binutils
   stripDebugList =
-    if stdenv.hostPlatform != stdenv.targetPlatform then
+    if stdenv.hostPlatform.notEquals stdenv.targetPlatform then
       "bin lib ${stdenv.hostPlatform.config}"
     else
       null;
 
   # INFO: Otherwise it fails with:
   # `./sanity.sh: line 36: $out/bin/size: not found`
-  doInstallCheck = (buildPlatform == hostPlatform) && (hostPlatform == targetPlatform);
+  doInstallCheck = (buildPlatform.equals hostPlatform) && (hostPlatform.equals targetPlatform);
 
   enableParallelBuilding = true;
 

--- a/pkgs/development/tools/misc/gdb/default.nix
+++ b/pkgs/development/tools/misc/gdb/default.nix
@@ -25,7 +25,7 @@
   sourceHighlight,
   libiconv,
 
-  pythonSupport ? stdenv.hostPlatform == stdenv.buildPlatform && !stdenv.hostPlatform.isCygwin,
+  pythonSupport ? stdenv.hostPlatform.equals stdenv.buildPlatform && !stdenv.hostPlatform.isCygwin,
   python3 ? null,
   enableDebuginfod ? lib.meta.availableOn stdenv.hostPlatform elfutils,
   elfutils,
@@ -44,9 +44,7 @@
 
 let
   basename = "gdb";
-  targetPrefix = lib.optionalString (
-    stdenv.targetPlatform != stdenv.hostPlatform
-  ) "${stdenv.targetPlatform.config}-";
+  targetPrefix = lib.optionalString (stdenv.targetPlatform.notEquals stdenv.hostPlatform) "${stdenv.targetPlatform.config}-";
 in
 
 assert pythonSupport -> python3 != null;

--- a/pkgs/development/tools/misc/luarocks/default.nix
+++ b/pkgs/development/tools/misc/luarocks/default.nix
@@ -118,7 +118,7 @@ stdenv.mkDerivation (finalAttrs: {
     export LUA_PATH="src/?.lua;''${LUA_PATH:-}"
   '';
 
-  disallowedReferences = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  disallowedReferences = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     lua.luaOnBuild
   ];
 

--- a/pkgs/development/tools/misc/texinfo/common.nix
+++ b/pkgs/development/tools/misc/texinfo/common.nix
@@ -41,7 +41,7 @@ let
     optionalString
     versionOlder
     ;
-  crossBuildTools = stdenv.hostPlatform != stdenv.buildPlatform;
+  crossBuildTools = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 in
 
 stdenv.mkDerivation {

--- a/pkgs/development/tools/misc/texlab/default.nix
+++ b/pkgs/development/tools/misc/texlab/default.nix
@@ -12,7 +12,7 @@
 }:
 
 let
-  isCross = stdenv.hostPlatform != stdenv.buildPlatform;
+  isCross = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
 in
 rustPlatform.buildRustPackage rec {
   pname = "texlab";

--- a/pkgs/development/tools/parsing/flex/2.5.35.nix
+++ b/pkgs/development/tools/parsing/flex/2.5.35.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
 
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     ac_cv_func_malloc_0_nonnull=yes
     ac_cv_func_realloc_0_nonnull=yes
   '';

--- a/pkgs/development/tools/parsing/flex/default.nix
+++ b/pkgs/development/tools/parsing/flex/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     ''
       patchShebangs tests
     ''
-    + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       substituteInPlace Makefile.in --replace "tests" " "
 
       substituteInPlace doc/Makefile.am --replace 'flex.1: $(top_srcdir)/configure.ac' 'flex.1: '
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   buildInputs = [ bison ];
   propagatedBuildInputs = [ m4 ];
 
-  preConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+  preConfigure = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
     export ac_cv_func_malloc_0_nonnull=yes
     export ac_cv_func_realloc_0_nonnull=yes
   '';
@@ -59,7 +59,7 @@ stdenv.mkDerivation rec {
     sed -i Makefile -e 's/-no-undefined//;'
   '';
 
-  dontDisableStatic = stdenv.buildPlatform != stdenv.hostPlatform;
+  dontDisableStatic = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
 
   postInstall = ''
     ln -s $out/bin/flex $out/bin/lex

--- a/pkgs/development/web/nodejs/nodejs.nix
+++ b/pkgs/development/web/nodejs/nodejs.nix
@@ -253,7 +253,7 @@ let
       outputs = [
         "out"
         "libv8"
-      ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [ "dev" ];
+      ] ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [ "dev" ];
       setOutputFlags = false;
       moveToDev = false;
 
@@ -457,7 +457,7 @@ let
             else
               "{bytecode_builtins_list_generator,mksnapshot,torque,node_js2c,gen-regexp-special-case}";
         in
-        lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+        lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
           mkdir -p $dev/bin
           cp out/Release/${tools} $dev/bin
         ''

--- a/pkgs/development/web/nodejs/v22.nix
+++ b/pkgs/development/web/nodejs/v22.nix
@@ -33,17 +33,19 @@ buildNodejs {
           })
         ]
     )
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
-      # This patch is concerning.
-      # https://github.com/nodejs/node/issues/54576
-      # It is only supposed to affect clang >= 17, but I'm seeing it on clang 19.
-      # I'm keeping the predicate for this patch pretty strict out of caution,
-      # so if you see the error it's supposed to prevent, feel free to loosen it.
-      (fetchpatch2 {
-        url = "https://raw.githubusercontent.com/rubyjs/libv8-node/62476a398d4c9c1a670240a3b070d69544be3761/patch/v8-no-assert-trivially-copyable.patch";
-        hash = "sha256-hSTLljmVzYmc3WAVeRq9EPYluXGXFeWVXkykufGQPVw=";
-      })
-    ]
+    ++
+      lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD)
+        [
+          # This patch is concerning.
+          # https://github.com/nodejs/node/issues/54576
+          # It is only supposed to affect clang >= 17, but I'm seeing it on clang 19.
+          # I'm keeping the predicate for this patch pretty strict out of caution,
+          # so if you see the error it's supposed to prevent, feel free to loosen it.
+          (fetchpatch2 {
+            url = "https://raw.githubusercontent.com/rubyjs/libv8-node/62476a398d4c9c1a670240a3b070d69544be3761/patch/v8-no-assert-trivially-copyable.patch";
+            hash = "sha256-hSTLljmVzYmc3WAVeRq9EPYluXGXFeWVXkykufGQPVw=";
+          })
+        ]
     ++ [
       ./configure-armv6-vfpv2.patch
       ./disable-darwin-v8-system-instrumentation-node19.patch

--- a/pkgs/development/web/nodejs/v23.nix
+++ b/pkgs/development/web/nodejs/v23.nix
@@ -33,17 +33,19 @@ buildNodejs {
           })
         ]
     )
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD) [
-      # This patch is concerning.
-      # https://github.com/nodejs/node/issues/54576
-      # It is only supposed to affect clang >= 17, but I'm seeing it on clang 19.
-      # I'm keeping the predicate for this patch pretty strict out of caution,
-      # so if you see the error it's supposed to prevent, feel free to loosen it.
-      (fetchpatch2 {
-        url = "https://raw.githubusercontent.com/rubyjs/libv8-node/62476a398d4c9c1a670240a3b070d69544be3761/patch/v8-no-assert-trivially-copyable.patch";
-        hash = "sha256-hSTLljmVzYmc3WAVeRq9EPYluXGXFeWVXkykufGQPVw=";
-      })
-    ]
+    ++
+      lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform && stdenv.hostPlatform.isFreeBSD)
+        [
+          # This patch is concerning.
+          # https://github.com/nodejs/node/issues/54576
+          # It is only supposed to affect clang >= 17, but I'm seeing it on clang 19.
+          # I'm keeping the predicate for this patch pretty strict out of caution,
+          # so if you see the error it's supposed to prevent, feel free to loosen it.
+          (fetchpatch2 {
+            url = "https://raw.githubusercontent.com/rubyjs/libv8-node/62476a398d4c9c1a670240a3b070d69544be3761/patch/v8-no-assert-trivially-copyable.patch";
+            hash = "sha256-hSTLljmVzYmc3WAVeRq9EPYluXGXFeWVXkykufGQPVw=";
+          })
+        ]
     ++ [
       ./configure-armv6-vfpv2.patch
       ./disable-darwin-v8-system-instrumentation-node19.patch

--- a/pkgs/games/nethack/default.nix
+++ b/pkgs/games/nethack/default.nix
@@ -131,7 +131,7 @@ stdenv.mkDerivation rec {
         -e 's,moc-qt4,moc,' \
         -i sys/unix/hints/linux-qt4
     ''}
-    ${lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform)
+    ${lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform)
       # If we're cross-compiling, replace the paths to the data generation tools
       # with the ones from the build platform's nethack package, since we can't
       # run the ones we've built here.

--- a/pkgs/misc/jackaudio/default.nix
+++ b/pkgs/misc/jackaudio/default.nix
@@ -113,9 +113,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ lib.optional (optDbus != null) "--dbus"
     ++ lib.optional (optLibffado != null) "--firewire"
     ++ lib.optional (optAlsaLib != null) "--alsa"
-    ++ lib.optional (
-      stdenv.hostPlatform != stdenv.buildPlatform
-    ) "--platform=${stdenv.hostPlatform.parsed.kernel.name}";
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "--platform=${stdenv.hostPlatform.parsed.kernel.name}";
 
   postInstall = (
     if libOnly then

--- a/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/install.nix
@@ -39,7 +39,7 @@ mkDerivation {
     makeMinimal
     mandoc
     groff
-    (if stdenv.hostPlatform == stdenv.buildPlatform then boot-install else install)
+    (if stdenv.hostPlatform.equals stdenv.buildPlatform then boot-install else install)
   ];
   skipIncludesPhase = true;
   buildInputs =
@@ -56,7 +56,7 @@ mkDerivation {
       "MK_WERROR=no"
       "TESTSDIR=${builtins.placeholder "test"}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.equals stdenv.buildPlatform) [
       "BOOTSTRAPPING=1"
       "INSTALL=boot-install"
     ];

--- a/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
+++ b/pkgs/os-specific/bsd/freebsd/pkgs/libnetbsd/package.nix
@@ -19,12 +19,12 @@ mkDerivation {
     makeMinimal
     mandoc
     groff
-    (if stdenv.hostPlatform == stdenv.buildPlatform then boot-install else install)
+    (if stdenv.hostPlatform.equals stdenv.buildPlatform then boot-install else install)
   ];
   makeFlags = [
     "STRIP=-s" # flag to install, not command
     "MK_WERROR=no"
-  ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "INSTALL=boot-install";
+  ] ++ lib.optional (stdenv.hostPlatform.equals stdenv.buildPlatform) "INSTALL=boot-install";
 
   alwaysKeepStatic = true;
 }

--- a/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/ICU/package.nix
@@ -48,7 +48,7 @@ let
       ++ lib.optionals (stdenv.hostPlatform.isFreeBSD || stdenv.hostPlatform.isDarwin) [
         (lib.enableFeature true "rpath")
       ]
-      ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+      ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
         (lib.withFeatureAs true "cross-build" nativeBuildRoot)
       ]
       ++ lib.optionals withStatic [ (lib.enableFeature true "static") ];

--- a/pkgs/os-specific/darwin/apple-source-releases/libffi/package.nix
+++ b/pkgs/os-specific/darwin/apple-source-releases/libffi/package.nix
@@ -85,7 +85,7 @@ mkAppleDerivation (finalAttrs: {
     NIX_HARDENING_ENABLE=''${NIX_HARDENING_ENABLE/fortify/}
   '';
 
-  dontStrip = stdenv.hostPlatform != stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
+  dontStrip = stdenv.hostPlatform.notEquals stdenv.buildPlatform; # Don't run the native `strip' when cross-compiling.
 
   inherit doCheck;
 

--- a/pkgs/os-specific/darwin/binutils/default.nix
+++ b/pkgs/os-specific/darwin/binutils/default.nix
@@ -7,12 +7,12 @@
   llvm,
   llvm-manpages,
   makeWrapper,
-  enableManpages ? stdenvNoCC.targetPlatform == stdenvNoCC.hostPlatform,
+  enableManpages ? stdenvNoCC.targetPlatform.equals stdenvNoCC.hostPlatform,
 }:
 
 let
   inherit (stdenvNoCC) targetPlatform hostPlatform;
-  targetPrefix = lib.optionalString (targetPlatform != hostPlatform) "${targetPlatform.config}-";
+  targetPrefix = lib.optionalString (targetPlatform.notEquals hostPlatform) "${targetPlatform.config}-";
 
   llvm_cmds = [
     "addr2line"

--- a/pkgs/os-specific/linux/apparmor/default.nix
+++ b/pkgs/os-specific/linux/apparmor/default.nix
@@ -13,10 +13,10 @@
   linuxHeaders ? stdenv.cc.libc.linuxHeaders,
   gawk,
   withPerl ?
-    stdenv.hostPlatform == stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform perl,
+    stdenv.hostPlatform.equals stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform perl,
   perl,
   withPython ?
-    stdenv.hostPlatform == stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform python3,
+    stdenv.hostPlatform.equals stdenv.buildPlatform && lib.meta.availableOn stdenv.hostPlatform python3,
   python3,
   swig,
   ncurses,

--- a/pkgs/os-specific/linux/busybox/default.nix
+++ b/pkgs/os-specific/linux/busybox/default.nix
@@ -105,7 +105,7 @@ stdenv.mkDerivation rec {
       url = "https://git.alpinelinux.org/aports/plain/main/busybox/CVE-2023-42364-CVE-2023-42365.patch?id=8a4bf5971168bf48201c05afda7bee0fbb188e13";
       hash = "sha256-nQPgT9eA1asCo38Z9X7LR9My0+Vz5YBPba3ARV3fWcc=";
     })
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) ./clang-cross.patch;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ./clang-cross.patch;
 
   separateDebugInfo = true;
 

--- a/pkgs/os-specific/linux/exfat/default.nix
+++ b/pkgs/os-specific/linux/exfat/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation rec {
       "KDIR=${kernel.dev}/lib/modules/${kernel.modDirVersion}/build"
       "ARCH=${stdenv.hostPlatform.linuxArch}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/os-specific/linux/klibc/default.nix
+++ b/pkgs/os-specific/linux/klibc/default.nix
@@ -44,9 +44,7 @@ stdenv.mkDerivation rec {
     # TODO(@Ericson2314): We now can get the ABI from
     # `stdenv.hostPlatform.parsed.abi`, is this still a good idea?
     ++ lib.optional (stdenv.hostPlatform.linuxArch == "arm") "CONFIG_AEABI=y"
-    ++ lib.optional (
-      stdenv.hostPlatform != stdenv.buildPlatform
-    ) "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
+    ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "CROSS_COMPILE=${stdenv.cc.targetPrefix}";
 
   # Install static binaries as well.
   postInstall = ''

--- a/pkgs/os-specific/linux/kmod/default.nix
+++ b/pkgs/os-specific/linux/kmod/default.nix
@@ -15,7 +15,7 @@
   xz,
   zstd,
   elf-header,
-  withDevdoc ? stdenv.hostPlatform == stdenv.buildPlatform,
+  withDevdoc ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   withStatic ? stdenv.hostPlatform.isStatic,
   gitUpdater,
 }:

--- a/pkgs/os-specific/linux/lvm2/common.nix
+++ b/pkgs/os-specific/linux/lvm2/common.nix
@@ -83,7 +83,7 @@ stdenv.mkDerivation rec {
       "--with-dmeventd-pidfile=/run/dmeventd/pid"
       "--with-default-dm-run-dir=/run/dmeventd"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"
     ]

--- a/pkgs/os-specific/linux/procps-ng/default.nix
+++ b/pkgs/os-specific/linux/procps-ng/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional withSystemd "--with-systemd"
     ++ lib.optional stdenv.hostPlatform.isMusl "--disable-w"
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "ac_cv_func_malloc_0_nonnull=yes"
       "ac_cv_func_realloc_0_nonnull=yes"
     ];

--- a/pkgs/os-specific/linux/rtl8723ds/default.nix
+++ b/pkgs/os-specific/linux/rtl8723ds/default.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     [
       "ARCH=${stdenv.hostPlatform.linuxArch}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/os-specific/linux/rtl8812au/default.nix
+++ b/pkgs/os-specific/linux/rtl8812au/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation {
       ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
       ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/os-specific/linux/rtl8821au/default.nix
+++ b/pkgs/os-specific/linux/rtl8821au/default.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
         + (if (stdenv.hostPlatform.isAarch32 || stdenv.hostPlatform.isAarch64) then "y" else "n")
       )
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/os-specific/linux/rtl8852au/default.nix
+++ b/pkgs/os-specific/linux/rtl8852au/default.nix
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
       ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
       ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/os-specific/linux/rtl8852bu/default.nix
+++ b/pkgs/os-specific/linux/rtl8852bu/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation rec {
       ("CONFIG_PLATFORM_I386_PC=" + (if stdenv.hostPlatform.isx86 then "y" else "n"))
       ("CONFIG_PLATFORM_ARM_RPI=" + (if stdenv.hostPlatform.isAarch then "y" else "n"))
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/os-specific/linux/systemd/default.nix
+++ b/pkgs/os-specific/linux/systemd/default.nix
@@ -864,7 +864,7 @@ stdenv.mkDerivation (finalAttrs: {
     '';
 
   disallowedReferences =
-    lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+    lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform)
       # 'or p' is for manually specified buildPackages as they dont have __spliced
       (builtins.map (p: p.__spliced.buildHost or p) finalAttrs.nativeBuildInputs);
 

--- a/pkgs/os-specific/linux/udisks/2-default.nix
+++ b/pkgs/os-specific/linux/udisks/2-default.nix
@@ -52,7 +52,7 @@ stdenv.mkDerivation rec {
     "out"
     "man"
     "dev"
-  ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "devdoc";
+  ] ++ lib.optional (stdenv.hostPlatform.equals stdenv.buildPlatform) "devdoc";
 
   patches = [
     (replaceVars ./fix-paths.patch {
@@ -116,7 +116,7 @@ stdenv.mkDerivation rec {
   preConfigure = "NOCONFIGURE=1 ./autogen.sh";
 
   configureFlags = [
-    (lib.enableFeature (stdenv.buildPlatform == stdenv.hostPlatform) "gtk-doc")
+    (lib.enableFeature (stdenv.buildPlatform.equals stdenv.hostPlatform) "gtk-doc")
     "--sysconfdir=/etc"
     "--localstatedir=/var"
     "--with-systemdsystemunitdir=$(out)/etc/systemd/system"

--- a/pkgs/os-specific/linux/wireguard/default.nix
+++ b/pkgs/os-specific/linux/wireguard/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     [
       "ARCH=${stdenv.hostPlatform.linuxArch}"
     ]
-    ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "CROSS_COMPILE=${stdenv.cc.targetPrefix}"
     ];
 

--- a/pkgs/servers/clickhouse/default.nix
+++ b/pkgs/servers/clickhouse/default.nix
@@ -250,6 +250,6 @@ mkDerivation rec {
 
     # not supposed to work on 32-bit https://github.com/ClickHouse/ClickHouse/pull/23959#issuecomment-835343685
     platforms = lib.filter (x: (lib.systems.elaborate x).is64bit) (platforms.linux ++ platforms.darwin);
-    broken = stdenv.buildPlatform != stdenv.hostPlatform;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
   };
 }

--- a/pkgs/servers/dns/knot-resolver/default.nix
+++ b/pkgs/servers/dns/knot-resolver/default.nix
@@ -134,7 +134,7 @@ let
         rm -r "$out"/lib/sysusers.d/ # ATM more likely to harm than help
       '';
 
-    doInstallCheck = with stdenv; hostPlatform == buildPlatform;
+    doInstallCheck = with stdenv; hostPlatform.equals buildPlatform;
     nativeInstallCheckInputs = [
       cmocka
       which

--- a/pkgs/servers/http/nginx/generic.nix
+++ b/pkgs/servers/http/nginx/generic.nix
@@ -170,9 +170,7 @@ stdenv.mkDerivation {
       [ "--with-http_geoip_module" ] ++ lib.optional withStream "--with-stream_geoip_module"
     )
     ++ lib.optional (with stdenv.hostPlatform; isLinux || isFreeBSD) "--with-file-aio"
-    ++ lib.optional (
-      stdenv.buildPlatform != stdenv.hostPlatform
-    ) "--crossbuild=${stdenv.hostPlatform.uname.system}::${stdenv.hostPlatform.uname.processor}"
+    ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "--crossbuild=${stdenv.hostPlatform.uname.system}::${stdenv.hostPlatform.uname.processor}"
     ++ configureFlags
     ++ map (mod: "--add-module=${mod.src}") modules;
 
@@ -232,7 +230,7 @@ stdenv.mkDerivation {
             # https://github.com/zlib-ng/patches/blob/5a036c0a00120c75ee573b27f4f44ade80d82ff2/nginx/README.md
             ./nginx-zlib-ng.patch
           ]
-      ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
         (fetchpatch {
           url = "https://raw.githubusercontent.com/openwrt/packages/c057dfb09c7027287c7862afab965a4cd95293a3/net/nginx/patches/102-sizeof_test_fix.patch";
           sha256 = "0i2k30ac8d7inj9l6bl0684kjglam2f68z8lf3xggcc2i5wzhh8a";

--- a/pkgs/servers/monitoring/zabbix/proxy.nix
+++ b/pkgs/servers/monitoring/zabbix/proxy.nix
@@ -12,7 +12,7 @@
   buildPackages,
   odbcSupport ? true,
   unixODBC,
-  snmpSupport ? stdenv.buildPlatform == stdenv.hostPlatform,
+  snmpSupport ? stdenv.buildPlatform.equals stdenv.hostPlatform,
   net-snmp,
   sshSupport ? true,
   libssh2,

--- a/pkgs/servers/pulseaudio/default.nix
+++ b/pkgs/servers/pulseaudio/default.nix
@@ -201,7 +201,7 @@ stdenv.mkDerivation rec {
       (lib.mesonEnable "elogind" false)
       # gsettings does not support cross-compilation
       (lib.mesonEnable "gsettings" (
-        stdenv.hostPlatform.isLinux && (stdenv.buildPlatform == stdenv.hostPlatform)
+        stdenv.hostPlatform.isLinux && (stdenv.buildPlatform.equals stdenv.hostPlatform)
       ))
       (lib.mesonEnable "gstreamer" false)
       (lib.mesonEnable "gtk" false)
@@ -256,11 +256,13 @@ stdenv.mkDerivation rec {
     '';
 
   preFixup =
-    lib.optionalString (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform == stdenv.buildPlatform)) ''
-      wrapProgram $out/libexec/pulse/gsettings-helper \
-       --prefix XDG_DATA_DIRS : "$out/share/gsettings-schemas/${pname}-${version}" \
-       --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"
-    ''
+    lib.optionalString
+      (stdenv.hostPlatform.isLinux && (stdenv.hostPlatform.equals stdenv.buildPlatform))
+      ''
+        wrapProgram $out/libexec/pulse/gsettings-helper \
+         --prefix XDG_DATA_DIRS : "$out/share/gsettings-schemas/${pname}-${version}" \
+         --prefix GIO_EXTRA_MODULES : "${lib.getLib dconf}/lib/gio/modules"
+      ''
     # add .so symlinks for modules to be found under macOS
     + lib.optionalString stdenv.hostPlatform.isDarwin ''
       for file in $out/lib/pulseaudio/modules/*.dylib; do

--- a/pkgs/servers/samba/4.x.nix
+++ b/pkgs/servers/samba/4.x.nix
@@ -125,7 +125,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optionals stdenv.hostPlatform.isLinux [
       buildPackages.stdenv.cc
     ]
-    ++ optional (stdenv.buildPlatform != stdenv.hostPlatform) samba # asn1_compile/compile_et
+    ++ optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) samba # asn1_compile/compile_et
     ++ optionals stdenv.hostPlatform.isDarwin [
       fixDarwinDylibNames
     ];
@@ -220,7 +220,7 @@ stdenv.mkDerivation (finalAttrs: {
     ++ optional enableProfiling "--with-profiling-data"
     ++ optional (!enableAcl) "--without-acl-support"
     ++ optional (!enablePam) "--without-pam"
-    ++ optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+    ++ optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
       "--bundled-libraries=!asn1_compile,!compile_et"
       "--cross-compile"
       "--cross-execute=${stdenv.hostPlatform.emulator buildPackages}"
@@ -253,7 +253,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   # Save asn1_compile and compile_et so they are available to run on the build
   # platform when cross-compiling
-  postInstall = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  postInstall = lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
     mkdir -p "$dev/bin"
     cp bin/asn1_compile bin/compile_et "$dev/bin"
   '';

--- a/pkgs/servers/sql/mariadb/default.nix
+++ b/pkgs/servers/sql/mariadb/default.nix
@@ -59,7 +59,7 @@ let
     }:
 
     let
-      isCross = stdenv.buildPlatform != stdenv.hostPlatform;
+      isCross = stdenv.buildPlatform.notEquals stdenv.hostPlatform;
 
       libExt = stdenv.hostPlatform.extensions.sharedLibrary;
 

--- a/pkgs/servers/x11/xorg/overrides.nix
+++ b/pkgs/servers/x11/xorg/overrides.nix
@@ -62,9 +62,7 @@
 let
   inherit (stdenv.hostPlatform) isDarwin;
 
-  malloc0ReturnsNullCrossFlag = lib.optional (
-    stdenv.hostPlatform != stdenv.buildPlatform
-  ) "--enable-malloc0returnsnull";
+  malloc0ReturnsNullCrossFlag = lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "--enable-malloc0returnsnull";
 
   addMainProgram =
     pkg:
@@ -367,7 +365,7 @@ self: super:
         "ac_cv_path_RAWCPP=${stdenv.cc.targetPrefix}cpp"
       ]
       ++
-        lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform)
+        lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform)
           # checking for /dev/urandom... configure: error: cannot check for file existence when cross compiling
           [
             "ac_cv_file__dev_urandom=true"
@@ -493,7 +491,7 @@ self: super:
       xorg.libXext
     ];
     configureFlags =
-      lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
         "xorg_cv_malloc0_returns_null=no"
       ]
       ++ lib.optional stdenv.hostPlatform.isStatic "--disable-shared";

--- a/pkgs/shells/bash/5.nix
+++ b/pkgs/shells/bash/5.nix
@@ -93,7 +93,7 @@ lib.warnIf (withDocs != null)
         "--without-bash-malloc"
         (if interactive then "--with-installed-readline" else "--disable-readline")
       ]
-      ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
         "bash_cv_job_control_missing=nomissing"
         "bash_cv_sys_named_pipes=nomissing"
         "bash_cv_getcwd_malloc=yes"

--- a/pkgs/stdenv/booter.nix
+++ b/pkgs/stdenv/booter.nix
@@ -118,16 +118,16 @@ let
                     pkgsBuildBuild = prevStage.buildPackages;
                     pkgsBuildHost = prevStage;
                     pkgsBuildTarget =
-                      if args.stdenv.targetPlatform == args.stdenv.hostPlatform then
+                      if args.stdenv.targetPlatform.equals args.stdenv.hostPlatform then
                         pkgsBuildHost
                       else
-                        assert args.stdenv.hostPlatform == args.stdenv.buildPlatform;
+                        assert args.stdenv.hostPlatform.equals args.stdenv.buildPlatform;
                         thisStage;
                     pkgsHostHost =
-                      if args.stdenv.hostPlatform == args.stdenv.targetPlatform then
+                      if args.stdenv.hostPlatform.equals args.stdenv.targetPlatform then
                         thisStage
                       else
-                        assert args.stdenv.buildPlatform == args.stdenv.hostPlatform;
+                        assert args.stdenv.buildPlatform.equals args.stdenv.hostPlatform;
                         pkgsBuildHost;
                     pkgsTargetTarget = nextStage;
                   };

--- a/pkgs/stdenv/cross/default.nix
+++ b/pkgs/stdenv/cross/default.nix
@@ -38,9 +38,9 @@ lib.init bootStages
     inherit config overlays;
     selfBuild = false;
     stdenv =
-      assert vanillaPackages.stdenv.buildPlatform == localSystem;
-      assert vanillaPackages.stdenv.hostPlatform == localSystem;
-      assert vanillaPackages.stdenv.targetPlatform == localSystem;
+      assert vanillaPackages.stdenv.buildPlatform.equals localSystem;
+      assert vanillaPackages.stdenv.hostPlatform.equals localSystem;
+      assert vanillaPackages.stdenv.targetPlatform.equals localSystem;
       vanillaPackages.stdenv.override { targetPlatform = crossSystem; };
     # It's OK to change the built-time dependencies
     allowCustomOverrides = true;

--- a/pkgs/stdenv/custom/default.nix
+++ b/pkgs/stdenv/custom/default.nix
@@ -7,7 +7,7 @@
   crossOverlays ? [ ],
 }:
 
-assert crossSystem == localSystem;
+assert crossSystem.equals localSystem;
 
 let
   bootStages = import ../. {
@@ -29,8 +29,8 @@ bootStages
   (vanillaPackages: {
     inherit config overlays;
     stdenv =
-      assert vanillaPackages.stdenv.hostPlatform == localSystem;
-      assert vanillaPackages.stdenv.targetPlatform == localSystem;
+      assert vanillaPackages.stdenv.hostPlatform.equals localSystem;
+      assert vanillaPackages.stdenv.targetPlatform.equals localSystem;
       config.replaceStdenv { pkgs = vanillaPackages; };
   })
 

--- a/pkgs/stdenv/darwin/default.nix
+++ b/pkgs/stdenv/darwin/default.nix
@@ -23,7 +23,7 @@
   ),
 }:
 
-assert crossSystem == localSystem;
+assert crossSystem.equals localSystem;
 
 let
   inherit (localSystem) system;
@@ -1207,7 +1207,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                 // {
                   inherit (prevStage.darwin) libSystem locale sigtool;
                 }
-                // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
+                // lib.optionalAttrs (super.stdenv.targetPlatform.equals localSystem) {
                   inherit (prevStage.darwin) binutils binutils-unwrapped;
                 }
               );
@@ -1215,7 +1215,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
             # These have to be dropped from the overlay when cross-compiling. Wrappers are obviously target-specific.
             # darwin.binutils is not yet ready to be target-independent.
             (
-              lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) (bintoolsPackages prevStage)
+              lib.optionalAttrs (super.stdenv.targetPlatform.equals localSystem) (bintoolsPackages prevStage)
               // {
                 inherit (prevStage.llvmPackages) clang;
               }
@@ -1237,7 +1237,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
                     // {
                       inherit (super."llvmPackages_${llvmVersion}") llvm-manpages;
                     }
-                    // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
+                    // lib.optionalAttrs (super.stdenv.targetPlatform.equals localSystem) {
                       inherit (prevStage.llvmPackages) clang;
                     }
                   );

--- a/pkgs/stdenv/default.nix
+++ b/pkgs/stdenv/default.nix
@@ -41,7 +41,7 @@ let
 
 in
 # Select the appropriate stages for the platform `system'.
-if crossSystem != localSystem || crossOverlays != [ ] then
+if crossSystem.notEquals localSystem || crossOverlays != [ ] then
   stagesCross
 else if config ? replaceStdenv then
   stagesCustom

--- a/pkgs/stdenv/freebsd/default.nix
+++ b/pkgs/stdenv/freebsd/default.nix
@@ -19,7 +19,7 @@
     files,
 }:
 
-assert crossSystem == localSystem;
+assert crossSystem.equals localSystem;
 let
   inherit (localSystem) system;
   mkExtraBuildCommands0 = cc: ''

--- a/pkgs/stdenv/generic/make-derivation.nix
+++ b/pkgs/stdenv/generic/make-derivation.nix
@@ -238,7 +238,7 @@ let
       #
       # TODO(@Ericson2314): Make [ "build" "host" ] always the default / resolve #87909
       configurePlatforms ?
-        optionals (stdenv.hostPlatform != stdenv.buildPlatform || config.configurePlatformsByDefault)
+        optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform || config.configurePlatformsByDefault)
           [
             "build"
             "host"
@@ -254,7 +254,7 @@ let
 
       # TODO(@Ericson2314): Make always true and remove / resolve #178468
       strictDeps ?
-        if config.strictDepsByDefault then true else stdenv.hostPlatform != stdenv.buildPlatform,
+        if config.strictDepsByDefault then true else stdenv.hostPlatform.notEquals stdenv.buildPlatform,
 
       enableParallelBuilding ? config.enableParallelBuildingByDefault,
 
@@ -443,7 +443,7 @@ let
                 # just used for their side-affects. Those might as well since the
                 # hash can't be the same. See #32986.
                 hostSuffix = optionalString (
-                  stdenv.hostPlatform != stdenv.buildPlatform && !dontAddHostSuffix
+                  stdenv.hostPlatform.notEquals stdenv.buildPlatform && !dontAddHostSuffix
                 ) "-${stdenv.hostPlatform.config}";
 
                 # Disambiguate statically built packages. This was originally

--- a/pkgs/stdenv/linux/default.nix
+++ b/pkgs/stdenv/linux/default.nix
@@ -116,7 +116,7 @@
     (config.replaceBootstrapFiles or lib.id) files,
 }:
 
-assert crossSystem == localSystem;
+assert crossSystem.equals localSystem;
 
 let
   inherit (localSystem) system;
@@ -899,7 +899,7 @@ assert bootstrapTools.passthru.isFromBootstrapFiles or false; # sanity check
 
             gnumake = super.gnumake.override { inBootstrap = false; };
           }
-          // lib.optionalAttrs (super.stdenv.targetPlatform == localSystem) {
+          // lib.optionalAttrs (super.stdenv.targetPlatform.equals localSystem) {
             # Need to get rid of these when cross-compiling.
             inherit (prevStage) binutils binutils-unwrapped;
             gcc = cc;

--- a/pkgs/stdenv/native/default.nix
+++ b/pkgs/stdenv/native/default.nix
@@ -7,7 +7,7 @@
   crossOverlays ? [ ],
 }:
 
-assert crossSystem == localSystem;
+assert crossSystem.equals localSystem;
 
 let
   inherit (localSystem) system;

--- a/pkgs/stdenv/nix/default.nix
+++ b/pkgs/stdenv/nix/default.nix
@@ -8,7 +8,7 @@
   ...
 }:
 
-assert crossSystem == localSystem;
+assert crossSystem.equals localSystem;
 
 bootStages
 ++ [

--- a/pkgs/test/cc-wrapper/default.nix
+++ b/pkgs/test/cc-wrapper/default.nix
@@ -9,7 +9,7 @@ let
   # Sanitizers are not supported on Darwin.
   # Sanitizer headers aren't available in older libc++ stdenvs due to a bug
   sanitizersWorking =
-    (stdenv.buildPlatform == stdenv.hostPlatform)
+    (stdenv.buildPlatform.equals stdenv.hostPlatform)
     && !stdenv.hostPlatform.isDarwin
     && !stdenv.hostPlatform.isMusl
     && (

--- a/pkgs/test/top-level/default.nix
+++ b/pkgs/test/top-level/default.nix
@@ -61,7 +61,7 @@ lib.recurseIntoAttrs {
       pkgsLocal = map nixpkgsFun configsLocal;
       pkgsCross = map nixpkgsFun configsCross;
     in
-    assert lib.all (p: p.buildPlatform == p.hostPlatform) pkgsLocal;
-    assert lib.all (p: p.buildPlatform != p.hostPlatform) pkgsCross;
+    assert lib.all (p: p.buildPlatform.equals p.hostPlatform) pkgsLocal;
+    assert lib.all (p: p.buildPlatform.notEquals p.hostPlatform) pkgsCross;
     pkgs.emptyFile;
 }

--- a/pkgs/tools/archivers/p7zip/default.nix
+++ b/pkgs/tools/archivers/p7zip/default.nix
@@ -41,7 +41,7 @@ stdenv.mkDerivation (finalAttrs: {
       # I think this is a typo and should be CXX? Either way let's kill it
       sed -i '/XX=\/usr/d' makefile.macosx_llvm_64bits
     ''
-    + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       substituteInPlace makefile.machine \
         --replace 'CC=gcc'  'CC=${stdenv.cc.targetPrefix}gcc' \
         --replace 'CXX=g++' 'CXX=${stdenv.cc.targetPrefix}g++'

--- a/pkgs/tools/backup/bacula/default.nix
+++ b/pkgs/tools/backup/bacula/default.nix
@@ -56,9 +56,9 @@ stdenv.mkDerivation rec {
       "--with-working-dir=/var/lib/bacula"
       "--mandir=\${out}/share/man"
     ]
-    ++
-      lib.optional (stdenv.buildPlatform != stdenv.hostPlatform)
-        "ac_cv_func_setpgrp_void=${if stdenv.hostPlatform.isBSD then "no" else "yes"}"
+    ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "ac_cv_func_setpgrp_void=${
+      if stdenv.hostPlatform.isBSD then "no" else "yes"
+    }"
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       # bacula’s `configure` script fails to detect CoreFoundation correctly,
       # but these symbols are available in the nixpkgs CoreFoundation framework.

--- a/pkgs/tools/backup/restic/default.nix
+++ b/pkgs/tools/backup/restic/default.nix
@@ -49,7 +49,7 @@ buildGoModule rec {
     ''
       wrapProgram $out/bin/restic --prefix PATH : '${rclone}/bin'
     ''
-    + lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+    + lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
       $out/bin/restic generate \
         --bash-completion restic.bash \
         --fish-completion restic.fish \

--- a/pkgs/tools/compression/zstd/default.nix
+++ b/pkgs/tools/compression/zstd/default.nix
@@ -12,8 +12,8 @@
   static ? stdenv.hostPlatform.isStatic, # generates static libraries *only*
   enableStatic ? static,
   # these need to be ran on the host, thus disable when cross-compiling
-  buildContrib ? stdenv.hostPlatform == stdenv.buildPlatform,
-  doCheck ? stdenv.hostPlatform == stdenv.buildPlatform,
+  buildContrib ? stdenv.hostPlatform.equals stdenv.buildPlatform,
+  doCheck ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   nix-update-script,
 
   # for passthru.tests

--- a/pkgs/tools/misc/coreutils/default.nix
+++ b/pkgs/tools/misc/coreutils/default.nix
@@ -44,7 +44,7 @@ let
     optionals
     optionalString
     ;
-  isCross = (stdenv.hostPlatform != stdenv.buildPlatform);
+  isCross = (stdenv.hostPlatform.notEquals stdenv.buildPlatform);
 in
 stdenv.mkDerivation rec {
   pname = "coreutils" + (optionalString (!minimal) "-full");

--- a/pkgs/tools/misc/file/default.nix
+++ b/pkgs/tools/misc/file/default.nix
@@ -37,7 +37,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     updateAutotoolsGnuConfigScriptsHook
-  ] ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) file;
+  ] ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) file;
   buildInputs = [ zlib ] ++ lib.optional stdenv.hostPlatform.isWindows libgnurx;
 
   # https://bugs.astron.com/view.php?id=382

--- a/pkgs/tools/misc/findutils/default.nix
+++ b/pkgs/tools/misc/findutils/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     && !stdenv.hostPlatform.isFreeBSD
     && !(stdenv.hostPlatform.libc == "glibc" && stdenv.hostPlatform.isi686)
     && (stdenv.hostPlatform.libc != "musl")
-    && stdenv.hostPlatform == stdenv.buildPlatform;
+    && stdenv.hostPlatform.equals stdenv.buildPlatform;
 
   outputs = [
     "out"

--- a/pkgs/tools/misc/grub/default.nix
+++ b/pkgs/tools/misc/grub/default.nix
@@ -593,7 +593,7 @@ in
       [
         "--enable-grub-mount" # dep of os-prober
       ]
-      ++ lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+      ++ lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
         # grub doesn't do cross-compilation as usual and tries to use unprefixed
         # tools to target the host. Provide toolchain information explicitly for
         # cross builds.

--- a/pkgs/tools/misc/toybox/default.nix
+++ b/pkgs/tools/misc/toybox/default.nix
@@ -26,7 +26,7 @@ stdenv.mkDerivation rec {
     sha256 = "sha256-D+tf2bJQlf2pLMNZdMUOoUdE3ea/KgkqoXGsnl1MVOE=";
   };
 
-  depsBuildBuild = optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  depsBuildBuild = optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     buildPackages.stdenv.cc
   ];
   buildInputs =

--- a/pkgs/tools/networking/curl-impersonate/chrome/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/chrome/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  depsBuildBuild = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     buildPackages.stdenv.cc
   ];
 

--- a/pkgs/tools/networking/curl-impersonate/firefox/default.nix
+++ b/pkgs/tools/networking/curl-impersonate/firefox/default.nix
@@ -57,7 +57,7 @@ stdenv.mkDerivation rec {
 
   strictDeps = true;
 
-  depsBuildBuild = lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [
+  depsBuildBuild = lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
     buildPackages.stdenv.cc
   ];
 

--- a/pkgs/tools/networking/networkmanager/default.nix
+++ b/pkgs/tools/networking/networkmanager/default.nix
@@ -117,7 +117,7 @@ stdenv.mkDerivation (finalAttrs: {
     # Miscellaneous
     # almost cross-compiles, however fails with
     # ** (process:9234): WARNING **: Failed to load shared library '/nix/store/...-networkmanager-aarch64-unknown-linux-gnu-1.38.2/lib/libnm.so.0' referenced by the typelib: /nix/store/...-networkmanager-aarch64-unknown-linux-gnu-1.38.2/lib/libnm.so.0: cannot open shared object file: No such file or directory
-    "-Ddocs=${lib.boolToString (stdenv.buildPlatform == stdenv.hostPlatform)}"
+    "-Ddocs=${lib.boolToString (stdenv.buildPlatform.equals stdenv.hostPlatform)}"
     # We don't use firewalld in NixOS
     "-Dfirewalld_zone=false"
     "-Dtests=no"
@@ -216,7 +216,7 @@ stdenv.mkDerivation (finalAttrs: {
     ln -s $PWD/src/libnm-client-impl/libnm.so.0 ${placeholder "out"}/lib/libnm.so.0
   '';
 
-  postFixup = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+  postFixup = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
     cp -r ${buildPackages.networkmanager.devdoc} $devdoc
     cp -r ${buildPackages.networkmanager.man} $man
   '';

--- a/pkgs/tools/networking/openconnect/common.nix
+++ b/pkgs/tools/networking/openconnect/common.nix
@@ -19,7 +19,7 @@
   vpnc-scripts,
   PCSC,
   useDefaultExternalBrowser ?
-    stdenv.hostPlatform.isLinux && stdenv.buildPlatform == stdenv.hostPlatform, # xdg-utils doesn't cross-compile
+    stdenv.hostPlatform.isLinux && stdenv.buildPlatform.equals stdenv.hostPlatform, # xdg-utils doesn't cross-compile
   xdg-utils,
   autoreconfHook,
 }:

--- a/pkgs/tools/networking/openssh/common.nix
+++ b/pkgs/tools/networking/openssh/common.nix
@@ -133,7 +133,7 @@ stdenv.mkDerivation (finalAttrs: {
   doCheck = false;
   enableParallelChecking = false;
   nativeCheckInputs = [ openssl ] ++ lib.optional (!stdenv.hostPlatform.isDarwin) hostname;
-  preCheck = lib.optionalString (stdenv.hostPlatform == stdenv.buildPlatform) ''
+  preCheck = lib.optionalString (stdenv.hostPlatform.equals stdenv.buildPlatform) ''
     # construct a dummy HOME
     export HOME=$(realpath ../dummy-home)
     mkdir -p ~/.ssh

--- a/pkgs/tools/package-management/apk-tools/default.nix
+++ b/pkgs/tools/package-management/apk-tools/default.nix
@@ -6,7 +6,7 @@
   scdoc,
   openssl,
   zlib,
-  luaSupport ? stdenv.hostPlatform == stdenv.buildPlatform,
+  luaSupport ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   lua,
 }:
 

--- a/pkgs/tools/package-management/lix/common-lix.nix
+++ b/pkgs/tools/package-management/lix/common-lix.nix
@@ -72,7 +72,7 @@ assert lib.assertMsg (
     cargoDeps = docCargoDeps;
   },
 
-  enableDocumentation ? stdenv.hostPlatform == stdenv.buildPlatform,
+  enableDocumentation ? stdenv.hostPlatform.equals stdenv.buildPlatform,
   enableStatic ? stdenv.hostPlatform.isStatic,
   enableStrictLLVMChecks ? true,
   withAWS ? !enableStatic && (stdenv.hostPlatform.isLinux || stdenv.hostPlatform.isDarwin),

--- a/pkgs/tools/package-management/nix/common-autoconf.nix
+++ b/pkgs/tools/package-management/nix/common-autoconf.nix
@@ -214,7 +214,7 @@ let
         # removes config.nix entirely and is not present in 2.3.x, we need to
         # patch around an issue where the Nix configure step pulls in the build
         # system's bash and other utilities when cross-compiling.
-        lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform && !atLeast224) ''
+        lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform && !atLeast224) ''
           mkdir tmp/
           substitute corepkgs/config.nix.in tmp/config.nix.in \
             --subst-var-by bash ${bash}/bin/bash \
@@ -246,7 +246,7 @@ let
       ++
         lib.optionals
           (
-            stdenv.hostPlatform != stdenv.buildPlatform
+            stdenv.hostPlatform.notEquals stdenv.buildPlatform
             && stdenv.hostPlatform ? nix
             && stdenv.hostPlatform.nix ? system
           )
@@ -269,7 +269,7 @@ let
         "--jobserver-style=pipe"
         "profiledir=$(out)/etc/profile.d"
       ]
-      ++ lib.optional (stdenv.hostPlatform != stdenv.buildPlatform) "PRECOMPILE_HEADERS=0"
+      ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "PRECOMPILE_HEADERS=0"
       ++ lib.optional (stdenv.hostPlatform.isDarwin) "PRECOMPILE_HEADERS=1";
 
     installFlags = [ "sysconfdir=$(out)/etc" ];

--- a/pkgs/tools/package-management/nix/modular/src/libstore/package.nix
+++ b/pkgs/tools/package-management/nix/modular/src/libstore/package.nix
@@ -41,7 +41,7 @@ mkMesonLibrary (finalAttrs: {
     # There have been issues building these dependencies
     ++ lib.optional stdenv.hostPlatform.isDarwin darwin.apple_sdk.libs.sandbox
     ++ lib.optional (
-      stdenv.hostPlatform == stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin)
+      stdenv.hostPlatform.equals stdenv.buildPlatform && (stdenv.isLinux || stdenv.isDarwin)
     ) aws-sdk-cpp;
 
   propagatedBuildInputs = [

--- a/pkgs/tools/security/hashcat/default.nix
+++ b/pkgs/tools/security/hashcat/default.nix
@@ -70,7 +70,7 @@ stdenv.mkDerivation rec {
       "USE_SYSTEM_XXHASH=1"
       "USE_SYSTEM_ZLIB=1"
     ]
-    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform) [
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.equals stdenv.buildPlatform) [
       "IS_APPLE_SILICON='${if stdenv.hostPlatform.isAarch64 then "1" else "0"}'"
     ];
 

--- a/pkgs/tools/security/tor/default.nix
+++ b/pkgs/tools/security/tor/default.nix
@@ -87,7 +87,7 @@ stdenv.mkDerivation rec {
     [ "--enable-gpl" ]
     ++
       # cross compiles correctly but needs the following
-      lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [ "--disable-tool-name-check" ]
+      lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [ "--disable-tool-name-check" ]
     ++
       # sandbox is broken on aarch64-linux https://gitlab.torproject.org/tpo/core/tor/-/issues/40599
       lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [

--- a/pkgs/tools/system/collectd/default.nix
+++ b/pkgs/tools/system/collectd/default.nix
@@ -56,7 +56,9 @@ stdenv.mkDerivation rec {
       "--disable-werror"
     ]
     ++ plugins.configureFlags
-    ++ lib.optionals (stdenv.buildPlatform != stdenv.hostPlatform) [ "--with-fp-layout=nothing" ];
+    ++ lib.optionals (stdenv.buildPlatform.notEquals stdenv.hostPlatform) [
+      "--with-fp-layout=nothing"
+    ];
 
   # do not create directories in /var during installPhase
   postConfigure = ''

--- a/pkgs/tools/system/netdata/default.nix
+++ b/pkgs/tools/system/netdata/default.nix
@@ -291,7 +291,7 @@ stdenv'.mkDerivation (finalAttrs: {
   };
 
   meta = with lib; {
-    broken = stdenv.buildPlatform != stdenv.hostPlatform || withEbpf;
+    broken = stdenv.buildPlatform.notEquals stdenv.hostPlatform || withEbpf;
     description = "Real-time performance monitoring tool";
     homepage = "https://www.netdata.cloud/";
     changelog = "https://github.com/netdata/netdata/releases/tag/v${version}";

--- a/pkgs/tools/system/nvtop/default.nix
+++ b/pkgs/tools/system/nvtop/default.nix
@@ -23,7 +23,7 @@ let
     builtins.map (gpu: {
       name = gpu;
       value =
-        (gpu == "apple" && stdenv.buildPlatform.isDarwin && stdenv.hostPlatform == stdenv.buildPlatform)
+        (gpu == "apple" && stdenv.buildPlatform.isDarwin && stdenv.hostPlatform.equals stdenv.buildPlatform)
         || (gpu != "apple" && stdenv.buildPlatform.isLinux);
     }) defaultGPUFamilies
   );

--- a/pkgs/tools/text/diffutils/default.nix
+++ b/pkgs/tools/text/diffutils/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
     # "pr" need not be on the PATH as a run-time dep, so we need to tell
     # configure where it is. Covers the cross and native case alike.
     lib.optional (coreutils != null) "PR_PROGRAM=${coreutils}/bin/pr"
-    ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) "gl_cv_func_getopt_gnu=yes";
+    ++ lib.optional (stdenv.buildPlatform.notEquals stdenv.hostPlatform) "gl_cv_func_getopt_gnu=yes";
 
   # Test failure on QEMU only (#300550)
   doCheck = !stdenv.buildPlatform.isRiscV64;

--- a/pkgs/tools/text/gnupatch/default.nix
+++ b/pkgs/tools/text/gnupatch/default.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ autoreconfHook ];
 
-  configureFlags = lib.optionals (stdenv.hostPlatform != stdenv.buildPlatform) [
+  configureFlags = lib.optionals (stdenv.hostPlatform.notEquals stdenv.buildPlatform) [
     "ac_cv_func_strnlen_working=yes"
   ];
 

--- a/pkgs/tools/text/gnused/default.nix
+++ b/pkgs/tools/text/gnused/default.nix
@@ -27,7 +27,7 @@ stdenv.mkDerivation rec {
   preConfigure = "patchShebangs ./build-aux/help2man";
 
   # Prevents attempts of running 'help2man' on cross-built binaries.
-  PERL = if stdenv.hostPlatform == stdenv.buildPlatform then null else "missing";
+  PERL = if stdenv.hostPlatform.equals stdenv.buildPlatform then null else "missing";
 
   meta = {
     homepage = "https://www.gnu.org/software/sed/";

--- a/pkgs/tools/typesetting/asciidoc/default.nix
+++ b/pkgs/tools/typesetting/asciidoc/default.nix
@@ -290,7 +290,7 @@ python3.pkgs.buildPythonApplication rec {
         substituteInPlace $f --replace "00:37:42" "00:00:00"
       done
     ''
-    + lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    + lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       # We want to use asciidoc from the build platform to build the documentation.
       substituteInPlace Makefile.in \
         --replace "python3 -m asciidoc.a2x" "${buildPackages.asciidoc}/bin/a2x"

--- a/pkgs/tools/typesetting/tex/texlive/bin.nix
+++ b/pkgs/tools/typesetting/tex/texlive/bin.nix
@@ -197,9 +197,7 @@ let
         "libpaper"
         "zlib"
       ]
-      ++ lib.optional (
-        stdenv.hostPlatform != stdenv.buildPlatform
-      ) "BUILDCC=${buildPackages.stdenv.cc.targetPrefix}cc";
+      ++ lib.optional (stdenv.hostPlatform.notEquals stdenv.buildPlatform) "BUILDCC=${buildPackages.stdenv.cc.targetPrefix}cc";
 
     # move binaries to corresponding split outputs, based on content of texlive.tlpdb
     binToOutput = lib.listToAttrs (

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -56,7 +56,7 @@ with pkgs;
     };
 
   stdenvNoLibs =
-    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform then
+    if stdenvNoCC.hostPlatform.notEquals stdenvNoCC.buildPlatform then
       # We cannot touch binutils or cc themselves, because that will cause
       # infinite recursion. So instead, we just choose a libc based on the
       # current platform. That means we won't respect whatever compiler was
@@ -78,7 +78,7 @@ with pkgs;
       mkStdenvNoLibs stdenv;
 
   stdenvNoLibc =
-    if stdenvNoCC.hostPlatform != stdenvNoCC.buildPlatform then
+    if stdenvNoCC.hostPlatform.notEquals stdenvNoCC.buildPlatform then
       (
         if stdenvNoCC.hostPlatform.isDarwin || stdenvNoCC.hostPlatform.useLLVM or false then
           overrideCC stdenvNoCC buildPackages.llvmPackages.clangNoLibc
@@ -504,7 +504,7 @@ with pkgs;
 
   fetchcvs =
     if
-      stdenv.buildPlatform != stdenv.hostPlatform
+      stdenv.buildPlatform.notEquals stdenv.hostPlatform
     # hack around splicing being crummy with things that (correctly) don't eval.
     then
       buildPackages.fetchcvs
@@ -603,7 +603,7 @@ with pkgs;
 
   fetchsvn =
     if
-      stdenv.buildPlatform != stdenv.hostPlatform
+      stdenv.buildPlatform.notEquals stdenv.hostPlatform
     # hack around splicing being crummy with things that (correctly) don't eval.
     then
       buildPackages.fetchsvn
@@ -624,7 +624,7 @@ with pkgs;
 
   # `fetchurl' downloads a file from the network.
   fetchurl =
-    if stdenv.buildPlatform != stdenv.hostPlatform then
+    if stdenv.buildPlatform.notEquals stdenv.hostPlatform then
       buildPackages.fetchurl # No need to do special overrides twice,
     else
       makeOverridable (import ../build-support/fetchurl) {
@@ -1759,7 +1759,7 @@ with pkgs;
     if stdenv.hostPlatform.isDarwin then
       callPackage ../stdenv/darwin/make-bootstrap-tools.nix {
         localSystem = stdenv.buildPlatform;
-        crossSystem = if stdenv.buildPlatform == stdenv.hostPlatform then null else stdenv.hostPlatform;
+        crossSystem = if stdenv.buildPlatform.equals stdenv.hostPlatform then null else stdenv.hostPlatform;
       }
     else if stdenv.hostPlatform.isLinux then
       callPackage ../stdenv/linux/make-bootstrap-tools.nix { }
@@ -5992,7 +5992,7 @@ with pkgs;
   # The GCC used to build libc for the target platform. Normal gccs will be
   # built with, and use, that cross-compiled libc.
   gccWithoutTargetLibc =
-    assert stdenv.targetPlatform != stdenv.hostPlatform;
+    assert stdenv.targetPlatform.notEquals stdenv.hostPlatform;
     let
       libcCross1 = binutilsNoLibc.libc;
     in
@@ -6058,14 +6058,16 @@ with pkgs;
       # should be done with a (native) compiler of the same version.
       # If we are cross-compiling GNAT, we may as well do the same.
       gnat-bootstrap =
-        if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
+        if
+          stdenv.hostPlatform.equals stdenv.targetPlatform && stdenv.buildPlatform.equals stdenv.hostPlatform
+        then
           buildPackages.gnat-bootstrap11
         else
           buildPackages.gnat11;
       stdenv =
         if
-          stdenv.hostPlatform == stdenv.targetPlatform
-          && stdenv.buildPlatform == stdenv.hostPlatform
+          stdenv.hostPlatform.equals stdenv.targetPlatform
+          && stdenv.buildPlatform.equals stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
           && stdenv.buildPlatform.isx86_64
         then
@@ -6086,14 +6088,16 @@ with pkgs;
       # should be done with a (native) compiler of the same version.
       # If we are cross-compiling GNAT, we may as well do the same.
       gnat-bootstrap =
-        if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
+        if
+          stdenv.hostPlatform.equals stdenv.targetPlatform && stdenv.buildPlatform.equals stdenv.hostPlatform
+        then
           buildPackages.gnat-bootstrap12
         else
           buildPackages.gnat12;
       stdenv =
         if
-          stdenv.hostPlatform == stdenv.targetPlatform
-          && stdenv.buildPlatform == stdenv.hostPlatform
+          stdenv.hostPlatform.equals stdenv.targetPlatform
+          && stdenv.buildPlatform.equals stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
           && stdenv.buildPlatform.isx86_64
         then
@@ -6114,14 +6118,16 @@ with pkgs;
       # should be done with a (native) compiler of the same version.
       # If we are cross-compiling GNAT, we may as well do the same.
       gnat-bootstrap =
-        if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
+        if
+          stdenv.hostPlatform.equals stdenv.targetPlatform && stdenv.buildPlatform.equals stdenv.hostPlatform
+        then
           buildPackages.gnat-bootstrap13
         else
           buildPackages.gnat13;
       stdenv =
         if
-          stdenv.hostPlatform == stdenv.targetPlatform
-          && stdenv.buildPlatform == stdenv.hostPlatform
+          stdenv.hostPlatform.equals stdenv.targetPlatform
+          && stdenv.buildPlatform.equals stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
           && stdenv.buildPlatform.isx86_64
         then
@@ -6142,14 +6148,16 @@ with pkgs;
       # should be done with a (native) compiler of the same version.
       # If we are cross-compiling GNAT, we may as well do the same.
       gnat-bootstrap =
-        if stdenv.hostPlatform == stdenv.targetPlatform && stdenv.buildPlatform == stdenv.hostPlatform then
+        if
+          stdenv.hostPlatform.equals stdenv.targetPlatform && stdenv.buildPlatform.equals stdenv.hostPlatform
+        then
           buildPackages.gnat-bootstrap14
         else
           buildPackages.gnat14;
       stdenv =
         if
-          stdenv.hostPlatform == stdenv.targetPlatform
-          && stdenv.buildPlatform == stdenv.hostPlatform
+          stdenv.hostPlatform.equals stdenv.targetPlatform
+          && stdenv.buildPlatform.equals stdenv.hostPlatform
           && stdenv.buildPlatform.isDarwin
           && stdenv.buildPlatform.isx86_64
         then
@@ -7040,8 +7048,8 @@ with pkgs;
     callPackage ../build-support/cc-wrapper (
       let
         self = {
-          nativeTools = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeTools or false;
-          nativeLibc = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeLibc or false;
+          nativeTools = stdenv.targetPlatform.equals stdenv.hostPlatform && stdenv.cc.nativeTools or false;
+          nativeLibc = stdenv.targetPlatform.equals stdenv.hostPlatform && stdenv.cc.nativeLibc or false;
           nativePrefix = stdenv.cc.nativePrefix or "";
           noLibc = !self.nativeLibc && (self.libc == null);
 
@@ -7073,14 +7081,14 @@ with pkgs;
   wrapBintoolsWith =
     {
       bintools,
-      libc ? if stdenv.targetPlatform != stdenv.hostPlatform then libcCross else stdenv.cc.libc,
+      libc ? if stdenv.targetPlatform.notEquals stdenv.hostPlatform then libcCross else stdenv.cc.libc,
       ...
     }@extraArgs:
     callPackage ../build-support/bintools-wrapper (
       let
         self = {
-          nativeTools = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeTools or false;
-          nativeLibc = stdenv.targetPlatform == stdenv.hostPlatform && stdenv.cc.nativeLibc or false;
+          nativeTools = stdenv.targetPlatform.equals stdenv.hostPlatform && stdenv.cc.nativeTools or false;
+          nativeLibc = stdenv.targetPlatform.equals stdenv.hostPlatform && stdenv.cc.nativeLibc or false;
           nativePrefix = stdenv.cc.nativePrefix or "";
 
           noLibc = (self.libc == null);
@@ -7900,12 +7908,12 @@ with pkgs;
   binutils-unwrapped = callPackage ../development/tools/misc/binutils {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     # FHS sys dirs presumably only have stuff for the build platform
-    noSysDirs = (stdenv.targetPlatform != stdenv.hostPlatform) || noSysDirs;
+    noSysDirs = (stdenv.targetPlatform.notEquals stdenv.hostPlatform) || noSysDirs;
   };
   binutils-unwrapped-all-targets = callPackage ../development/tools/misc/binutils {
     inherit (darwin.apple_sdk.frameworks) CoreServices;
     # FHS sys dirs presumably only have stuff for the build platform
-    noSysDirs = (stdenv.targetPlatform != stdenv.hostPlatform) || noSysDirs;
+    noSysDirs = (stdenv.targetPlatform.notEquals stdenv.hostPlatform) || noSysDirs;
     withAllTargets = true;
   };
   binutils = wrapBintoolsWith {
@@ -7929,7 +7937,7 @@ with pkgs;
   binutils-unwrapped_2_38 = callPackage ../development/tools/misc/binutils/2.38 {
     autoreconfHook = autoreconfHook269;
     # FHS sys dirs presumably only have stuff for the build platform
-    noSysDirs = (stdenv.targetPlatform != stdenv.hostPlatform) || noSysDirs;
+    noSysDirs = (stdenv.targetPlatform.notEquals stdenv.hostPlatform) || noSysDirs;
   };
 
   libbfd_2_38 = callPackage ../development/tools/misc/binutils/2.38/libbfd.nix {
@@ -8157,7 +8165,7 @@ with pkgs;
   # This is for e.g. LLVM libraries on linux.
   gccForLibs =
     if
-      stdenv.targetPlatform == stdenv.hostPlatform && targetPackages.stdenv.cc.isGNU
+      stdenv.targetPlatform.equals stdenv.hostPlatform && targetPackages.stdenv.cc.isGNU
     # Can only do this is in the native case, otherwise we might get infinite
     # recursion if `targetPackages.stdenv.cc.cc` itself uses `gccForLibs`.
     then
@@ -9359,7 +9367,7 @@ with pkgs;
       throw "Unknown libc ${name}";
 
   libcCross =
-    if stdenv.targetPlatform == stdenv.buildPlatform then
+    if stdenv.targetPlatform.equals stdenv.buildPlatform then
       null
     else
       libcCrossChooser stdenv.targetPlatform.libc;
@@ -10045,7 +10053,7 @@ with pkgs;
         "fblibc"
       ]
     then
-      libcIconv (if stdenv.hostPlatform != stdenv.buildPlatform then libcCross else stdenv.cc.libc)
+      libcIconv (if stdenv.hostPlatform.notEquals stdenv.buildPlatform then libcCross else stdenv.cc.libc)
     else if stdenv.hostPlatform.isDarwin then
       darwin.libiconv
     else

--- a/pkgs/top-level/darwin-packages.nix
+++ b/pkgs/top-level/darwin-packages.nix
@@ -15,7 +15,7 @@ let
   #
   # TODO(@Ericson2314) Make unconditional, or optional but always true by
   # default.
-  targetPrefix = lib.optionalString (stdenv.targetPlatform != stdenv.hostPlatform) (
+  targetPrefix = lib.optionalString (stdenv.targetPlatform.notEquals stdenv.hostPlatform) (
     stdenv.targetPlatform.config + "-"
   );
 
@@ -132,7 +132,8 @@ makeScopeWithSplicing' {
       };
 
       binutils = pkgs.wrapBintoolsWith {
-        libc = if stdenv.targetPlatform != stdenv.hostPlatform then pkgs.libcCross else pkgs.stdenv.cc.libc;
+        libc =
+          if stdenv.targetPlatform.notEquals stdenv.hostPlatform then pkgs.libcCross else pkgs.stdenv.cc.libc;
         bintools = self.binutils-unwrapped;
       };
 

--- a/pkgs/top-level/perl-packages.nix
+++ b/pkgs/top-level/perl-packages.nix
@@ -12801,7 +12801,7 @@ with self;
       hash = "sha256-TH1g4m2iwH8Fik40UCHpJQUnOzPJVCIVl34IRhHwns8=";
     };
     buildInputs = [ FCGIClient ];
-    postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    postPatch = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       sed -i '/use IO::File/d' Makefile.PL
     '';
     meta = {
@@ -18084,7 +18084,7 @@ with self;
       hash = "sha256-34tRQ9mn3pnEe1XxoXC9H2n3EZNcGGptwKtW3QV1jjU=";
     };
     # Do not abort cross-compilation on failure to load native JSON module into host perl
-    preConfigure = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    preConfigure = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       substituteInPlace Makefile.PL --replace "exit 0;" ""
     '';
     buildInputs = [ TestPod ];
@@ -19817,7 +19817,7 @@ with self;
       export NO_NETWORK_TESTING=1
     '';
     # support cross-compilation by avoiding using `has_module` which does not work in miniperl (it requires B native module)
-    postPatch = lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+    postPatch = lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
       substituteInPlace Makefile.PL --replace 'if has_module' 'if 0; #'
     '';
     doCheck = !stdenv.hostPlatform.isDarwin;
@@ -21661,11 +21661,11 @@ with self;
       url = "mirror://cpan/authors/id/L/LE/LEONT/Module-Build-0.4234.tar.gz";
       hash = "sha256-Zq6sYSdBi+XkcerTdEZIx2a9AUgoJcW2ZlJnXyvIao8=";
     };
-    postConfigure = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    postConfigure = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       # for unknown reason, the first run of Build fails
       ./Build || true
     '';
-    postPatch = lib.optionalString (stdenv.hostPlatform != stdenv.buildPlatform) ''
+    postPatch = lib.optionalString (stdenv.hostPlatform.notEquals stdenv.buildPlatform) ''
       # remove version check since miniperl uses a stub of File::Temp, which do not provide a version:
       # https://github.com/arsv/perl-cross/blob/master/cnf/stub/File/Temp.pm
       sed -i '/File::Temp/d' \
@@ -32848,7 +32848,7 @@ with self;
 
   TermReadKey =
     let
-      cross = stdenv.hostPlatform != stdenv.buildPlatform;
+      cross = stdenv.hostPlatform.notEquals stdenv.buildPlatform;
     in
     buildPerlPackage {
       pname = "TermReadKey";
@@ -38484,7 +38484,7 @@ with self;
     };
     patches = [ ../development/perl-modules/xml-parser-0001-HACK-Assumes-Expat-paths-are-good.patch ];
     postPatch =
-      lib.optionalString (stdenv.buildPlatform != stdenv.hostPlatform) ''
+      lib.optionalString (stdenv.buildPlatform.notEquals stdenv.hostPlatform) ''
         substituteInPlace Expat/Makefile.PL --replace 'use English;' '#'
       ''
       + lib.optionalString stdenv.hostPlatform.isCygwin ''

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -278,7 +278,7 @@ let
               pkgsMusl = super';
             })
           ] ++ overlays;
-          ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
+          ${if stdenv.hostPlatform.equals stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
             config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
           };
         }
@@ -295,7 +295,7 @@ let
               pkgsi686Linux = super';
             })
           ] ++ overlays;
-          ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
+          ${if stdenv.hostPlatform.equals stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
             config = lib.systems.parse.tripleFromSystem (
               stdenv.hostPlatform.parsed
               // {


### PR DESCRIPTION
As suggested by @wolfgangwalther https://github.com/NixOS/nixpkgs/pull/380005#discussion_r1947114008, I've scaled back this PR to focus on the treewide deprecation of `==` comparison between elaborated platform attrsets. The other changes are replaced by #380342.

This is in contrast to the previous effort to fully support `==` with elaborated platform attrsets: #238331. Also related: #278001.

A "backwards compatibility" item has been added to the release notes.

Added `equals` and `notEquals` functions to elaborated systems. This makes replacing `==` and `!=` usage simpler, and also provides a convenient alternative to using `lib.systems.equals` directly.

Added an extra attr (`warnAboutEquality`) to elaborated systems that exists only to produce a warning when evaluated. This is intended to detect `==` comparison being used with platform attrsets, suggested by @roberth https://github.com/NixOS/nixpkgs/pull/380005#discussion_r1946245110.

This approach isn't perfect, because it is only evaluated if the `==` comparison has not already short-circuited. E.g. if the attr-count is different or some other difference has already been found before getting to the `warnAboutEquality` attr. These limitations were raised by @wolfgangwalther https://github.com/NixOS/nixpkgs/pull/380005#discussion_r1947132275 and were also discussed in [this note](https://github.com/NixOS/nixpkgs/pull/238331#issuecomment-1600066095).

The treewide change has been done using some regex search/replace together with vim's quickfix list and some manual checking. It covers ~600 changes, so I haven't been able to check each individual replacement in detail. As mentioned by @roberth, many of the replacements could probably use `canExec` instead of `equals`, but that change is not in scope for this PR.


<details><summary>Old summary</summary>
<p>

Intended to enable composition of package sets by preserving the original un-elaborated arguments passed to `lib.systems.elaborate`.

This PR does not actually make package sets composable, but it is intended that the implementation proposed here will enable @wolfgangwalther to revisit their earlier work in #303849 and #376988 without needing to make changes to the public API or the `nixpkgs` nixos module.

Adds:
- `lib.systems.isElaborated`
- A `_type` tag for elaborated systems
- `input` attr on elaborated systems
- `lib.systems.equals` ignores the new `input` attr

Additionally:
- added `equals` and `notEquals` "method" attr-functions for convenience, and to allow comparison without needing access to `lib`
- treewide migration from `==` -> `<platform>.equals`
- elaborated platforms now warn when fully evaluated, in order to warn against using `==`


</p>
</details> 

cc @wolfgangwalther @roberth

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [x] `nix-build ./lib/tests/release.nix --abort-on-warn --show-trace`
  - [ ] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - [ ] and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - [ ] or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - [ ] made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
