### PR TITLE
ocamlPackages.vg: 0.9.4 → 0.9.5

### DIFF
--- a/pkgs/development/ocaml-modules/vg/default.nix
+++ b/pkgs/development/ocaml-modules/vg/default.nix
@@ -9,23 +9,21 @@
   uchar,
   result,
   gg,
-  uutf,
   otfm,
-  js_of_ocaml,
-  js_of_ocaml-ppx,
-  pdfBackend ? true, # depends on uutf and otfm
-  htmlcBackend ? true, # depends on js_of_ocaml
+  brr,
+  pdfBackend ? true, # depends on otfm
+  htmlcBackend ? true, # depends on brr
 }:
 
 let
   inherit (lib) optionals versionOlder;
 
   pname = "vg";
-  version = "0.9.4";
+  version = "0.9.5";
   webpage = "https://erratique.ch/software/${pname}";
 in
 
-if versionOlder ocaml.version "4.03" then
+if versionOlder ocaml.version "4.14" then
   throw "vg is not available for OCaml ${ocaml.version}"
 else
 
@@ -35,7 +33,7 @@ else
 
     src = fetchurl {
       url = "${webpage}/releases/${pname}-${version}.tbz";
-      sha256 = "181sz6l5xrj5jvwg4m2yqsjzwp2s5h8v0mwhjcwbam90kdfx2nak";
+      hash = "sha256-qcTtvIfSUwzpUZDspL+54UTNvWY6u3BTvfGWF6c0Jvw=";
     };
 
     nativeBuildInputs = [
@@ -52,21 +50,18 @@ else
         gg
       ]
       ++ optionals pdfBackend [
-        uutf
         otfm
       ]
       ++ optionals htmlcBackend [
-        js_of_ocaml
-        js_of_ocaml-ppx
+        brr
       ];
 
     strictDeps = true;
 
     buildPhase =
       topkg.buildPhase
-      + " --with-uutf ${lib.boolToString pdfBackend}"
       + " --with-otfm ${lib.boolToString pdfBackend}"
-      + " --with-js_of_ocaml ${lib.boolToString htmlcBackend}"
+      + " --with-brr ${lib.boolToString htmlcBackend}"
       + " --with-cairo2 false";
 
     inherit (topkg) installPhase;


### PR DESCRIPTION
## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
