### PR TITLE
pythonPackages.django-ckeditor: Add known vulnerability description following its formal deprecation in Feburary 2024

### DIFF
--- a/pkgs/development/python-modules/django-ckeditor/default.nix
+++ b/pkgs/development/python-modules/django-ckeditor/default.nix
@@ -50,10 +50,41 @@ buildPythonPackage rec {
   pythonImportsCheck = [ "ckeditor" ];
 
   meta = with lib; {
-    description = " Django admin CKEditor integration";
+    description = "Django admin CKEditor integration";
     homepage = "https://github.com/django-ckeditor/django-ckeditor";
     changelog = "https://github.com/django-ckeditor/django-ckeditor/blob/${version}/CHANGELOG.rst";
     license = licenses.bsd3;
     maintainers = with maintainers; [ onny ];
+    knownVulnerabilities = [
+      ''
+        django-ckeditor bundles CKEditor 4.22.1 which isn’t supported anmyore and
+        which does have unfixed security issues
+
+        Existing users of django-ckeditor should consider switching to a
+        different editor such as CKEditor 5 (django-ckeditor-5), after verifying
+        that its GPL licensing terms are acceptable, or ProseMirror
+        (django-prose-mirror by the author of django-ckeditor). Support of the
+        CKEditor 4 package is provided by its upstream developers as a
+        non-free/commercial LTS package until December 2028.
+
+        Note that while there are publically known vulnerabilities for the
+        CKEditor 4 series, the exploitability of these issues depends on how
+        CKEditor is used by the given Django application.
+
+        Further information:
+
+        * List of vulnerabilites fixed in CKEditor 4.24.0-lts:
+
+          * GHSA-fq6h-4g8v-qqvm
+          * GHSA-fq6h-4g8v-qqvm
+          * GHSA-mw2c-vx6j-mg76
+
+        * The django-ckeditor deprecation notice:
+          <https://406.ch/writing/django-ckeditor/>
+
+        * The non-free/commerical CKEditor 4 LTS package:
+          <https://ckeditor.com/ckeditor-4-support/>
+      ''
+    ];
   };
 }


### PR DESCRIPTION
django-ckeditor has been formally deprecated and issues a Django system check warning on every use:

> System check identified some issues:
>
> WARNINGS:
> ?: (ckeditor.W001) django-ckeditor bundles CKEditor 4.22.1 which isn't supported anmyore and which does have unfixed security issues, see for example https://ckeditor.com/cke4/release/CKEditor-4.24.0-LTS . You should consider strongly switching to a different editor (maybe CKEditor 5 respectively django-ckeditor-5 after checking whether the CKEditor 5 license terms work for you) or switch to the non-free CKEditor 4 LTS package. See https://ckeditor.com/ckeditor-4-support/ for more on this. (Note! This notice has been added by the django-ckeditor developers and we are not affiliated with CKSource and were not involved in the licensing change, so please refrain from complaining to us. Thanks.)

This change reproduces a rephrased version of the above warning targeted more at NixOS users of affected dependants and including the list of vulnerability fixed in the non-free CKEditor 4.20 version.

@onny

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
