### PR TITLE
yazi: quote paths, use `lib.getExe'`

### DIFF
--- a/pkgs/by-name/ya/yazi/package.nix
+++ b/pkgs/by-name/ya/yazi/package.nix
@@ -99,8 +99,8 @@ runCommand yazi-unwrapped.name
   ''
     mkdir -p "$out/bin"
     ln -s "${yazi-unwrapped}/share" "$out/share"
-    ln -s ${yazi-unwrapped}/bin/ya "$out/bin/ya"
-    makeWrapper ${yazi-unwrapped}/bin/yazi "$out/bin/yazi" \
+    ln -s ${lib.getExe' yazi-unwrapped "ya"} "$out/bin/ya"
+    makeWrapper ${lib.getExe' yazi-unwrapped "yazi"} "$out/bin/yazi" \
       --prefix PATH : ${lib.makeBinPath runtimePaths} \
       ${lib.optionalString (configHome != null) "--set YAZI_CONFIG_HOME ${configHome}"}
   ''

--- a/pkgs/by-name/ya/yazi/package.nix
+++ b/pkgs/by-name/ya/yazi/package.nix
@@ -58,36 +58,36 @@ let
       null
     else
       runCommand "YAZI_CONFIG_HOME" { } ''
-        mkdir -p $out
+        mkdir -p "$out"
         ${lib.concatMapStringsSep "\n" (
           name:
           lib.optionalString (settings ? ${name} && settings.${name} != { }) ''
-            ln -s ${settingsFormat.generate "${name}.toml" settings.${name}} $out/${name}.toml
+            ln -s ${settingsFormat.generate "${name}.toml" settings.${name}} "$out/${name}.toml"
           ''
         ) files}
 
-        mkdir $out/plugins
+        mkdir "$out/plugins"
         ${lib.optionalString (plugins != { }) ''
           ${lib.concatStringsSep "\n" (
             lib.mapAttrsToList (
               name: value:
-              "ln -s ${value} $out/plugins/${if lib.hasSuffix ".yazi" name then name else "${name}.yazi"}"
+              ''ln -s ${value} "$out/plugins/${if lib.hasSuffix ".yazi" name then name else "${name}.yazi"}"''
             ) plugins
           )}
         ''}
 
-        mkdir $out/flavors
+        mkdir "$out/flavors"
         ${lib.optionalString (flavors != { }) ''
           ${lib.concatStringsSep "\n" (
             lib.mapAttrsToList (
               name: value:
-              "ln -s ${value} $out/flavors/${if lib.hasSuffix ".yazi" name then name else "${name}.yazi"}"
+              ''ln -s ${value} "$out/flavors/${if lib.hasSuffix ".yazi" name then name else "${name}.yazi"}"''
             ) flavors
           )}
         ''}
 
 
-        ${lib.optionalString (initLua != null) "ln -s ${initLua} $out/init.lua"}
+        ${lib.optionalString (initLua != null) ''ln -s "${initLua}" "$out/init.lua"''}
       '';
 in
 runCommand yazi-unwrapped.name
@@ -97,10 +97,10 @@ runCommand yazi-unwrapped.name
     nativeBuildInputs = [ makeWrapper ];
   }
   ''
-    mkdir -p $out/bin
-    ln -s ${yazi-unwrapped}/share $out/share
-    ln -s ${yazi-unwrapped}/bin/ya $out/bin/ya
-    makeWrapper ${yazi-unwrapped}/bin/yazi $out/bin/yazi \
+    mkdir -p "$out/bin"
+    ln -s "${yazi-unwrapped}/share" "$out/share"
+    ln -s ${yazi-unwrapped}/bin/ya "$out/bin/ya"
+    makeWrapper ${yazi-unwrapped}/bin/yazi "$out/bin/yazi" \
       --prefix PATH : ${lib.makeBinPath runtimePaths} \
       ${lib.optionalString (configHome != null) "--set YAZI_CONFIG_HOME ${configHome}"}
   ''


### PR DESCRIPTION
Related PR: #380069

## Things done

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
