### PR TITLE
textlsp: init at 0.3.2

### DIFF
--- a/pkgs/by-name/te/textlsp/package.nix
+++ b/pkgs/by-name/te/textlsp/package.nix
@@ -1,0 +1,40 @@
+{
+  python3,
+  fetchFromGitHub,
+  lib,
+}:
+python3.pkgs.buildPythonApplication rec {
+  pname = "textlsp";
+  version = "0.3.2";
+
+  src = fetchFromGitHub {
+    owner = "hangyav";
+    repo = "textLSP";
+    tag = "v${version}";
+    hash = "sha256-Z1ozkS6zo/h0j0AU5K+Ri/ml8KqCjdEcQKpFtNER4Hk=";
+  };
+
+  build-system = [ python3.pkgs.setuptools ];
+  dependencies = with python3.pkgs; [
+    pygls
+    lsprotocol
+    language-tool-python
+    tree-sitter_0_21
+    gitpython
+    appdirs
+    openai
+    sortedcontainers
+    langdetect
+    ollama
+  ];
+
+  meta = {
+    description = "Language server for text spell and grammar check with various tools";
+    homepage = "https://github.com/hangyav/textLSP/tree/main";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ justdeeevin ];
+    mainProgram = "textlsp";
+    changelog = "https://github.com/hangyav/textLSP/releases/tag/v${version}";
+    platforms = lib.platforms.all;
+  };
+}

--- a/pkgs/development/python-modules/language-tool-python/default.nix
+++ b/pkgs/development/python-modules/language-tool-python/default.nix
@@ -1,0 +1,37 @@
+{
+  python3,
+  fetchFromGitHub,
+  buildPythonPackage,
+  lib,
+}:
+buildPythonPackage rec {
+  pname = "language-tool-python";
+  version = "2.8.0";
+
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "jxmorris12";
+    repo = "language_tool_python";
+    tag = "${version}";
+    hash = "sha256-v82RCg2lE0/ETJTiMogrI09fZ28tq1jhzFhbC89kbTU=";
+  };
+
+  build-system = [ python3.pkgs.setuptools ];
+  dependencies = with python3.pkgs; [
+    requests
+    tqdm
+    psutil
+    toml
+    pip
+  ];
+
+  meta = {
+    description = "Free python grammar checker";
+    homepage = "https://github.com/jxmorris12/language_tool_python";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [ justdeeevin ];
+    platforms = lib.platforms.all;
+    changelog = "https://github.com/jxmorris12/language_tool_python/releases/tag/${version}";
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -7185,6 +7185,8 @@ self: super: with self; {
 
   language-tags = callPackage ../development/python-modules/language-tags { };
 
+  language-tool-python = callPackage ../development/python-modules/language-tool-python { };
+
   lanms-neo = callPackage ../development/python-modules/lanms-neo { };
 
   lark = callPackage ../development/python-modules/lark { };


### PR DESCRIPTION
Adds TextLSP, a language server for grammar and spelling. Also adds the Python library `language-tool-python`, upon which TextLSP depends.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
