### PR TITLE
python312Packages.blackjax: 1.2.4 -> 1.2.5

### DIFF
--- a/pkgs/development/python-modules/blackjax/default.nix
+++ b/pkgs/development/python-modules/blackjax/default.nix
@@ -23,14 +23,14 @@
 
 buildPythonPackage rec {
   pname = "blackjax";
-  version = "1.2.4";
+  version = "1.2.5";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "blackjax-devs";
     repo = "blackjax";
     tag = version;
-    hash = "sha256-qaQBbRAKExRHr4Uhm5/Q1Ydon6ePsjG2PWbwSdR9QZM=";
+    hash = "sha256-2GTjKjLIWFaluTjdWdUF9Iim973y81xv715xspghRZI=";
   };
 
   build-system = [ setuptools-scm ];

--- a/pkgs/development/python-modules/cvxpy/default.nix
+++ b/pkgs/development/python-modules/cvxpy/default.nix
@@ -75,6 +75,11 @@ buildPythonPackage rec {
     "test_diffcp_sdp_example"
     "test_huber"
     "test_partial_problem"
+
+    # cvxpy.error.SolverError: Solver 'CVXOPT' failed. Try another solver, or solve with verbose=True for more information.
+    "test_oprelcone_1_m1_k3_complex"
+    "test_oprelcone_1_m3_k1_complex"
+    "test_oprelcone_2"
   ];
 
   pythonImportsCheck = [ "cvxpy" ];

--- a/pkgs/development/python-modules/qutip/default.nix
+++ b/pkgs/development/python-modules/qutip/default.nix
@@ -17,6 +17,7 @@
   # tests
   pytestCheckHook,
   pytest-rerunfailures,
+  writableTmpDirAsHomeHook,
   python,
 
   # optional-dependencies
@@ -38,11 +39,12 @@ buildPythonPackage rec {
     hash = "sha256-5j47Wqt9i6vC3uwRzQ9+8pk+ENl5w6PvnP+830RLCls=";
   };
 
-  postPatch = ''
+  postPatch =
     # build-time constriant, used to ensure forward and backward compat
-    substituteInPlace pyproject.toml setup.cfg \
-      --replace-fail "numpy>=2.0.0" "numpy"
-  '';
+    ''
+      substituteInPlace pyproject.toml setup.cfg \
+        --replace-fail "numpy>=2.0.0" "numpy"
+    '';
 
   build-system = [
     cython_0
@@ -59,6 +61,7 @@ buildPythonPackage rec {
   nativeCheckInputs = [
     pytestCheckHook
     pytest-rerunfailures
+    writableTmpDirAsHomeHook
   ] ++ lib.flatten (builtins.attrValues optional-dependencies);
 
   # QuTiP tries to access the home directory to create an rc file for us.
@@ -66,7 +69,6 @@ buildPythonPackage rec {
   # This is due to the Cython-compiled modules not being in the correct location
   # of the source tree.
   preCheck = ''
-    export HOME=$(mktemp -d);
     export OMP_NUM_THREADS=$NIX_BUILD_CORES
     mkdir -p test && cd test
   '';
@@ -79,11 +81,6 @@ buildPythonPackage rec {
   '';
 
   pythonImportsCheck = [ "qutip" ];
-
-  pytestFlagsArray = lib.optionals (stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isAarch64) [
-    # Fatal Python error: Aborted
-    "--deselect=../tests/core/test_metrics.py::Test_hellinger_dist::test_monotonicity[25]"
-  ];
 
   optional-dependencies = {
     graphics = [ matplotlib ];
@@ -104,6 +101,10 @@ buildPythonPackage rec {
       # Tests fail at ~80%
       # ../tests/test_animation.py::test_result_state Fatal Python error: Aborted
       lib.systems.inspect.patterns.isDarwin
+
+      # Several tests fail with a segfault
+      # ../tests/test_random.py::test_rand_super_bcsz[int-CSR-choi-None-rep(1)] Fatal Python error: Aborted
+      "aarch64-linux"
     ];
   };
 }


### PR DESCRIPTION
## Things done

- **python312Packages.blackjax: 1.2.4 -> 1.2.5**
- **python312Packages.cvxpy: disable failing tests**

Changelog: https://github.com/blackjax-devs/blackjax/releases/tag/1.2.5

cc @drewrisinger @bcdarwin

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
