### PR TITLE
python313Packages.{typepy,tabledata,pytablewriter,dataproperty}: refactor, use setuptools-scm

### DIFF
--- a/pkgs/development/python-modules/dataproperty/default.nix
+++ b/pkgs/development/python-modules/dataproperty/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools-scm,
   loguru,
   mbstrdecoder,
   pytestCheckHook,
@@ -14,18 +15,20 @@
 buildPythonPackage rec {
   pname = "dataproperty";
   version = "1.1.0";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "thombashi";
-    repo = pname;
+    repo = "dataproperty";
     tag = "v${version}";
     hash = "sha256-IEEwdOcC9nKwVumWnjpZlqYKCFGwZebMh7nGdGVjibE=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
     mbstrdecoder
     typepy
     tcolorpy
@@ -42,11 +45,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "dataproperty" ];
 
-  meta = with lib; {
+  meta = {
     description = "Library for extracting properties from data";
-    homepage = "https://github.com/thombashi/dataproperty";
+    homepage = "https://github.com/thombashi/DataProperty";
     changelog = "https://github.com/thombashi/DataProperty/releases/tag/${src.tag}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ genericnerdyusername ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ genericnerdyusername ];
   };
 }

--- a/pkgs/development/python-modules/pytablewriter/default.nix
+++ b/pkgs/development/python-modules/pytablewriter/default.nix
@@ -12,7 +12,7 @@
   pytestCheckHook,
   pythonOlder,
   pyyaml,
-  setuptools,
+  setuptools-scm,
   simplejson,
   tabledata,
   tcolorpy,
@@ -25,20 +25,20 @@
 buildPythonPackage rec {
   pname = "pytablewriter";
   version = "1.2.1";
-  format = "pyproject";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "thombashi";
-    repo = pname;
+    repo = "pytablewriter";
     tag = "v${version}";
     hash = "sha256-YuuSMKTSG3oybvA6TDWNnGg4EiDAw2tRlM0S9mBQlkc=";
   };
 
-  nativeBuildInputs = [ setuptools ];
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     dataproperty
     mbstrdecoder
     pathvalidate
@@ -103,11 +103,11 @@ buildPythonPackage rec {
     "test/writer/test_elasticsearch_writer.py"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "Library to write a table in various formats";
     homepage = "https://github.com/thombashi/pytablewriter";
     changelog = "https://github.com/thombashi/pytablewriter/releases/tag/${src.tag}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ genericnerdyusername ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ genericnerdyusername ];
   };
 }

--- a/pkgs/development/python-modules/tabledata/default.nix
+++ b/pkgs/development/python-modules/tabledata/default.nix
@@ -2,6 +2,7 @@
   buildPythonPackage,
   fetchFromGitHub,
   lib,
+  setuptools-scm,
   dataproperty,
   typepy,
   pytestCheckHook,
@@ -10,27 +11,29 @@
 buildPythonPackage rec {
   pname = "tabledata";
   version = "1.3.4";
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "thombashi";
-    repo = pname;
+    repo = "tabledata";
     tag = "v${version}";
     hash = "sha256-kZAEKUOcxb3fK3Oh6+4byJJlB/xzDAEGNpUDEKyVkhs=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools-scm ];
+
+  dependencies = [
     dataproperty
     typepy
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
 
-  meta = with lib; {
+  meta = {
     homepage = "https://github.com/thombashi/tabledata";
     description = "Library to represent tabular data";
     changelog = "https://github.com/thombashi/tabledata/releases/tag/${src.tag}";
-    maintainers = with maintainers; [ genericnerdyusername ];
-    license = licenses.mit;
+    maintainers = with lib.maintainers; [ genericnerdyusername ];
+    license = lib.licenses.mit;
   };
 }

--- a/pkgs/development/python-modules/typepy/default.nix
+++ b/pkgs/development/python-modules/typepy/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildPythonPackage,
   fetchFromGitHub,
+  setuptools-scm,
   mbstrdecoder,
   python-dateutil,
   pytz,
@@ -14,18 +15,20 @@
 buildPythonPackage rec {
   pname = "typepy";
   version = "1.3.4";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
   src = fetchFromGitHub {
     owner = "thombashi";
-    repo = pname;
+    repo = "typepy";
     tag = "v${version}";
     hash = "sha256-lgwXoEtv2nBRKiWQH5bDrAIfikKN3cOqcHLEdnSAMpc=";
   };
 
-  propagatedBuildInputs = [ mbstrdecoder ];
+  build-system = [ setuptools-scm ];
+
+  dependencies = [ mbstrdecoder ];
 
   optional-dependencies = {
     datetime = [
@@ -42,11 +45,11 @@ buildPythonPackage rec {
 
   pythonImportsCheck = [ "typepy" ];
 
-  meta = with lib; {
+  meta = {
     description = "Library for variable type checker/validator/converter at a run time";
     homepage = "https://github.com/thombashi/typepy";
     changelog = "https://github.com/thombashi/typepy/releases/tag/${src.tag}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ genericnerdyusername ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ genericnerdyusername ];
   };
 }


### PR DESCRIPTION
## Description of changes

setuptools-scm is required to report the correct package versions

## `nixpkgs-review` result

failures in `lm-eval` and `sbomnix` are due to unrelated failures in dependencies

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:x: 4 packages failed to build:</summary>
  <ul>
    <li>python312Packages.lm-eval</li>
    <li>python312Packages.lm-eval.dist</li>
    <li>sbomnix</li>
    <li>sbomnix.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 40 packages built:</summary>
  <ul>
    <li>python312Packages.dataproperty</li>
    <li>python312Packages.dataproperty.dist</li>
    <li>python312Packages.dfdiskcache</li>
    <li>python312Packages.dfdiskcache.dist</li>
    <li>python312Packages.pytablewriter</li>
    <li>python312Packages.pytablewriter.dist</li>
    <li>python312Packages.pytest-md-report</li>
    <li>python312Packages.pytest-md-report.dist</li>
    <li>python312Packages.riscof</li>
    <li>python312Packages.riscof.dist</li>
    <li>python312Packages.riscv-isac</li>
    <li>python312Packages.riscv-isac.dist</li>
    <li>python312Packages.simplesqlite</li>
    <li>python312Packages.simplesqlite.dist</li>
    <li>python312Packages.sqliteschema</li>
    <li>python312Packages.sqliteschema.dist</li>
    <li>python312Packages.tabledata</li>
    <li>python312Packages.tabledata.dist</li>
    <li>python312Packages.typepy</li>
    <li>python312Packages.typepy.dist</li>
    <li>python313Packages.dataproperty</li>
    <li>python313Packages.dataproperty.dist</li>
    <li>python313Packages.dfdiskcache</li>
    <li>python313Packages.dfdiskcache.dist</li>
    <li>python313Packages.pytablewriter</li>
    <li>python313Packages.pytablewriter.dist</li>
    <li>python313Packages.pytest-md-report</li>
    <li>python313Packages.pytest-md-report.dist</li>
    <li>python313Packages.riscof</li>
    <li>python313Packages.riscof.dist</li>
    <li>python313Packages.riscv-isac</li>
    <li>python313Packages.riscv-isac.dist</li>
    <li>python313Packages.simplesqlite</li>
    <li>python313Packages.simplesqlite.dist</li>
    <li>python313Packages.sqliteschema</li>
    <li>python313Packages.sqliteschema.dist</li>
    <li>python313Packages.tabledata</li>
    <li>python313Packages.tabledata.dist</li>
    <li>python313Packages.typepy</li>
    <li>python313Packages.typepy.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc