### PR TITLE
nixos/it-tools: init module

### DIFF
--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1616,6 +1616,7 @@
   ./services/web-apps/invidious.nix
   ./services/web-apps/invoiceplane.nix
   ./services/web-apps/isso.nix
+  ./services/web-apps/it-tools.nix
   ./services/web-apps/jirafeau.nix
   ./services/web-apps/jitsi-meet.nix
   ./services/web-apps/kanboard.nix

--- a/nixos/modules/services/web-apps/it-tools.nix
+++ b/nixos/modules/services/web-apps/it-tools.nix
@@ -1,0 +1,122 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.it-tools;
+in
+{
+  options.services.it-tools = {
+    enable = lib.mkEnableOption "it-tools";
+
+    package = lib.mkPackageOption pkgs "it-tools" { };
+
+    nginx = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to configure nginx.
+        '';
+      };
+
+      domain = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          The domain used by the nginx virtualHost.
+        '';
+      };
+
+      forceSSL = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether or not to force the use of SSL.";
+      };
+
+      useACMEHost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          A host of an existing Let's Encrypt certificate to use.
+
+          *Note that this still requires services.it-tools.nginx.domain to be set.
+        '';
+      };
+    };
+
+    caddy = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to configure caddy.
+        '';
+      };
+
+      domain = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          The domain used by the caddy virtualHost.
+        '';
+      };
+
+      useACMEHost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          A host of an existing Let's Encrypt certificate to use.
+
+          *Note that this still requires services.it-tools.caddy.domain to be set.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.nginx = lib.mkIf cfg.nginx.enable {
+      enable = true;
+      recommendedProxySettings = true;
+
+      virtualHosts.${cfg.nginx.domain} = {
+        forceSSL = cfg.nginx.forceSSL;
+
+        enableACME = lib.mkDefault (cfg.nginx.forceSSL && cfg.nginx.useACMEHost == null);
+        useACMEHost = cfg.nginx.useACMEHost;
+
+        root = "${cfg.package}/lib";
+      };
+    };
+
+    services.caddy = lib.mkIf cfg.caddy.enable {
+      enable = true;
+
+      virtualHosts.${cfg.caddy.domain} = {
+        useACMEHost = cfg.caddy.useACMEHost;
+
+        extraConfig = ''
+          root * ${cfg.package}/lib
+          file_server
+        '';
+      };
+    };
+
+    assertions = [
+      {
+        assertion = !cfg.nginx.enable || (cfg.nginx.domain != null);
+        message = "To use services.it-tools.nginx, you need to set services.it-tools.nginx.domain";
+      }
+      {
+        assertion = !cfg.caddy.enable || (cfg.caddy.domain != null);
+        message = "To use services.it-tools.caddy, you need to set services.it-tools.caddy.domain";
+      }
+    ];
+  };
+
+  meta.maintainers = [
+    lib.maintainers.akotro
+  ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -754,6 +754,7 @@ in
   iscsi-root = runTest ./iscsi-root.nix;
   isolate = runTest ./isolate.nix;
   isso = runTest ./isso.nix;
+  it-tools = import ./it-tools { inherit recurseIntoAttrs runTest; };
   jackett = runTest ./jackett.nix;
   jellyfin = runTest ./jellyfin.nix;
   jellyseerr = runTest ./jellyseerr.nix;

--- a/nixos/tests/it-tools/caddy.nix
+++ b/nixos/tests/it-tools/caddy.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+{
+  name = "it-tools-caddy";
+  meta.maintainers = [ lib.maintainers.akotro ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.it-tools = {
+        enable = true;
+        caddy = {
+          enable = true;
+          domain = "localhost:80";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("caddy.service")
+    machine.wait_for_open_port(80)
+    machine.succeed("curl --fail --show-error --silent http://localhost:80/ | grep '<title>IT Tools - Handy online tools for developers</title>'")
+  '';
+}

--- a/nixos/tests/it-tools/default.nix
+++ b/nixos/tests/it-tools/default.nix
@@ -1,0 +1,5 @@
+{ recurseIntoAttrs, runTest, ... }:
+recurseIntoAttrs {
+  nginx = runTest ./nginx.nix;
+  caddy = runTest ./caddy.nix;
+}

--- a/nixos/tests/it-tools/nginx.nix
+++ b/nixos/tests/it-tools/nginx.nix
@@ -1,0 +1,23 @@
+{ lib, ... }:
+{
+  name = "it-tools-nginx";
+  meta.maintainers = [ lib.maintainers.akotro ];
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      services.it-tools = {
+        enable = true;
+        nginx = {
+          enable = true;
+          domain = "localhost";
+        };
+      };
+    };
+
+  testScript = ''
+    machine.wait_for_unit("nginx.service")
+    machine.wait_for_open_port(80)
+    machine.succeed("curl --fail --show-error --silent http://localhost:80/ | grep '<title>IT Tools - Handy online tools for developers</title>'")
+  '';
+}

--- a/pkgs/by-name/it/it-tools/package.nix
+++ b/pkgs/by-name/it/it-tools/package.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   nodejs,
   pnpm_8,
+  nixosTests,
 }:
 stdenv.mkDerivation rec {
   pname = "it-tools";
@@ -43,6 +44,11 @@ stdenv.mkDerivation rec {
 
     runHook postInstall
   '';
+
+  passthru.tests = {
+    it-tools-nginx = nixosTests.it-tools.nginx;
+    it-tools-caddy = nixosTests.it-tools.caddy;
+  };
 
   meta = {
     description = "Self-hostable website containing handy tools for developers, with great UX";


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds a service definition for running an instance of it-tools.

This is how I use it in my own config, let me know if I have missed any other use cases.

```nix
services.it-tools = {
  enable = true;
  nginx = {
    enable = true;
    domain = "it.${useACMEHost}";
    useACMEHost = useACMEHost;
  };
};
```

Fixes #348389.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
