### PR TITLE
doc: Improve gradle section

### DIFF
--- a/doc/languages-frameworks/gradle.section.md
+++ b/doc/languages-frameworks/gradle.section.md
@@ -17,11 +17,11 @@ stdenv.mkDerivation (finalAttrs: {
   src = fetchFromGitLab {
     owner = "pdftk-java";
     repo = "pdftk";
-    rev = "v${finalAttrs.version}";
+    tag = "v${finalAttrs.version}";
     hash = "sha256-ciKotTHSEcITfQYKFZ6sY2LZnXGChBJy0+eno8B3YHY=";
   };
 
-  nativeBuildInputs = [ gradle ];
+  nativeBuildInputs = [ gradle makeWrapper ];
 
   # if the package has dependencies, mitmCache must be set
   mitmCache = gradle.fetchDeps {
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
     mkdir -p $out/{bin,share/pdftk}
     cp build/libs/pdftk-all.jar $out/share/pdftk
 
-    makeWrapper ${jre}/bin/java $out/bin/pdftk \
+    makeWrapper ${lib.getExe jre} $out/bin/pdftk \
       --add-flags "-jar $out/share/pdftk/pdftk-all.jar"
 
     cp ${finalAttrs.src}/pdftk.1 $out/share/man/man1
@@ -74,6 +74,7 @@ package. Using the pdftk example above:
 ```nix
 { lib
 , stdenv
+, gradle
 # ...
 , pdftk
 }:
@@ -87,30 +88,22 @@ stdenv.mkDerivation (finalAttrs: {
 })
 ```
 
-This allows you to `override` any arguments of the `pkg` used for
-the update script (for example, `pkg = pdftk.override { enableSomeFlag =
-true };`), so this is the preferred way.
+This allows you to `override` any arguments of the `pkg` used for the update script (for example, `pkg = pdftk.override { enableSomeFlag = true };)`.
 
-The second is to create a `let` binding for the package, like this:
+The second is to use `finalAttrs.finalPackage` like this:
 
 ```nix
-let self = stdenv.mkDerivation {
+stdenv.mkDerivation (finalAttrs: {
   # ...
   mitmCache = gradle.fetchDeps {
-    pkg = self;
+    pkg = finalAttrs.finalPackage;
     data = ./deps.json;
   };
-}; in self
+})
 ```
+The limitation of this method is that you cannot override the `pkg` derivations's arguments.
 
-This is useful if you can't easily pass the derivation as its own
-argument, or if your `mkDerivation` call is responsible for building
-multiple packages.
-
-In the former case, the update script will stay the same even if the
-derivation is called with different arguments. In the latter case, the
-update script will change depending on the derivation arguments. It's up
-to you to decide which one would work best for your derivation.
+In the former case, the update script will stay the same even if the derivation is called with different arguments. In the latter case, the update script will change depending on the derivation arguments. It's up to you to decide which one would work best for your derivation.
 
 ## Update Script {#gradle-update-script}
 


### PR DESCRIPTION
- add `makeWrapper` to `nativeBuildInputs` so the example actually works
- switch the `fetchFromGitHub` call to using `tag`
- use `finalAttrs.finalPackage` for the `mitmCache` instead of the existing hack
- use `lib.getExe` to get the java binary


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
