### PR TITLE
librsvg: Put vala behind gobject-introspection conditional, fix xfce static evals

### DIFF
--- a/pkgs/desktops/xfce/core/garcon/default.nix
+++ b/pkgs/desktops/xfce/core/garcon/default.nix
@@ -1,4 +1,10 @@
-{ lib, mkXfceDerivation, gobject-introspection, gtk3, libxfce4ui, libxfce4util }:
+{ stdenv, lib, mkXfceDerivation, gtk3, libxfce4ui, libxfce4util,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  buildPackages,
+  gobject-introspection,
+}:
 
 mkXfceDerivation {
   category = "xfce";
@@ -7,7 +13,9 @@ mkXfceDerivation {
 
   sha256 = "sha256-MeZkDb2QgGMaloO6Nwlj9JmZByepd6ERqpAWqrVv1xw=";
 
-  nativeBuildInputs = [ gobject-introspection ];
+  nativeBuildInputs = lib.optionals withIntrospection [
+    gobject-introspection
+  ];
 
   buildInputs = [ gtk3 libxfce4ui libxfce4util ];
 

--- a/pkgs/desktops/xfce/core/libxfce4ui/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4ui/default.nix
@@ -1,9 +1,8 @@
 {
+  stdenv,
   mkXfceDerivation,
   lib,
-  gobject-introspection,
   perl,
-  vala,
   libICE,
   libSM,
   libepoxy,
@@ -13,6 +12,12 @@
   xfconf,
   gtk3,
   libxfce4util,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  buildPackages,
+  gobject-introspection,
+  vala,
 }:
 
 mkXfceDerivation {
@@ -22,11 +27,14 @@ mkXfceDerivation {
 
   sha256 = "sha256-M+OapPHQ/WxlkUzHPx+ELstVyGoZanCxCL0N8hDWSN8=";
 
-  nativeBuildInputs = [
-    gobject-introspection
-    perl
-    vala
-  ];
+  nativeBuildInputs =
+    [
+      perl
+    ]
+    ++ lib.optionals withIntrospection [
+      gobject-introspection
+      vala # vala bindings require GObject introspection
+    ];
 
   buildInputs = [
     libICE

--- a/pkgs/desktops/xfce/core/libxfce4util/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4util/default.nix
@@ -1,9 +1,14 @@
 {
+  stdenv,
   mkXfceDerivation,
   lib,
-  gobject-introspection,
   vala,
   glib,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  buildPackages,
+  gobject-introspection,
 }:
 
 mkXfceDerivation {
@@ -13,9 +18,9 @@ mkXfceDerivation {
 
   sha256 = "sha256-0qbJSCXHsVz3XILHICFhciyz92LgMZiR7XFLAESHRGQ=";
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals withIntrospection [
     gobject-introspection
-    vala
+    vala # vala bindings require GObject introspection
   ];
 
   propagatedBuildInputs = [

--- a/pkgs/desktops/xfce/core/libxfce4windowing/default.nix
+++ b/pkgs/desktops/xfce/core/libxfce4windowing/default.nix
@@ -1,6 +1,6 @@
-{ lib
+{ stdenv
+, lib
 , mkXfceDerivation
-, gobject-introspection
 , wayland-scanner
 , glib
 , gtk3
@@ -11,6 +11,11 @@
 , wayland
 , wayland-protocols
 , wlr-protocols
+, withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages
+, buildPackages
+, gobject-introspection
 }:
 
 mkXfceDerivation {
@@ -21,8 +26,9 @@ mkXfceDerivation {
   sha256 = "sha256-Xw1hs854K5dZCAYoBMoqJzdSxPRFUYqEpWxg4DLSK5Q=";
 
   nativeBuildInputs = [
-    gobject-introspection
     wayland-scanner
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/desktops/xfce/core/thunar/default.nix
+++ b/pkgs/desktops/xfce/core/thunar/default.nix
@@ -1,4 +1,5 @@
-{ mkXfceDerivation
+{ stdenv
+, mkXfceDerivation
 , lib
 , docbook_xsl
 , exo
@@ -14,10 +15,12 @@
 , pcre2
 , xfce4-panel
 , xfconf
-, gobject-introspection
 , makeWrapper
 , symlinkJoin
 , thunarPlugins ? []
+, withIntrospection ? false
+, buildPackages
+, gobject-introspection
 }:
 
 let unwrapped = mkXfceDerivation {
@@ -29,8 +32,9 @@ let unwrapped = mkXfceDerivation {
 
   nativeBuildInputs = [
     docbook_xsl
-    gobject-introspection
     libxslt
+  ] ++ lib.optionals withIntrospection [
+    gobject-introspection
   ];
 
   buildInputs = [

--- a/pkgs/desktops/xfce/core/xfce4-panel/default.nix
+++ b/pkgs/desktops/xfce/core/xfce4-panel/default.nix
@@ -1,9 +1,9 @@
-{ lib
+{ stdenv
+, lib
 , mkXfceDerivation
 , cairo
 , exo
 , garcon
-, gobject-introspection
 , gtk-layer-shell
 , gtk3
 , libdbusmenu-gtk3
@@ -12,9 +12,14 @@
 , libxfce4util
 , libxfce4windowing
 , tzdata
-, vala
 , wayland
 , xfconf
+, withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages
+, buildPackages
+, gobject-introspection
+, vala
 }:
 
 mkXfceDerivation {
@@ -24,9 +29,9 @@ mkXfceDerivation {
 
   sha256 = "sha256-tLWjU0M7tuE+qqDwaE1CtnOjDiPWno8Mf7hhxYxbvjo=";
 
-  nativeBuildInputs = [
+  nativeBuildInputs = lib.optionals withIntrospection [
     gobject-introspection
-    vala
+    vala # vala bindings require GObject introspection
   ];
 
   buildInputs = [

--- a/pkgs/desktops/xfce/core/xfconf/default.nix
+++ b/pkgs/desktops/xfce/core/xfconf/default.nix
@@ -1,4 +1,5 @@
 {
+  stdenv,
   lib,
   mkXfceDerivation,
   gobject-introspection,
@@ -6,6 +7,10 @@
   vala,
   libxfce4util,
   glib,
+  withIntrospection ?
+    lib.meta.availableOn stdenv.hostPlatform gobject-introspection
+    && stdenv.hostPlatform.emulatorAvailable buildPackages,
+  buildPackages,
 }:
 
 mkXfceDerivation {
@@ -15,11 +20,14 @@ mkXfceDerivation {
 
   sha256 = "sha256-U+Sk7ubBr1ZD1GLQXlxrx0NQdhV/WpVBbnLcc94Tjcw=";
 
-  nativeBuildInputs = [
-    gobject-introspection
-    perl
-    vala
-  ];
+  nativeBuildInputs =
+    [
+      perl
+    ]
+    ++ lib.optionals withIntrospection [
+      gobject-introspection
+      vala # vala bindings require GObject introspection
+    ];
 
   buildInputs = [ libxfce4util ];
 

--- a/pkgs/development/libraries/librsvg/default.nix
+++ b/pkgs/development/libraries/librsvg/default.nix
@@ -89,12 +89,12 @@ stdenv.mkDerivation (finalAttrs: {
       cargo-c
       cargo-auditable-cargo-wrapper
       python3Packages.docutils
-      vala
       rustPlatform.cargoSetupHook
     ]
     ++ lib.optionals withIntrospection [
       gobject-introspection
       gi-docgen
+      vala # vala bindings require GObject introspection
     ];
 
   buildInputs =
@@ -104,7 +104,9 @@ stdenv.mkDerivation (finalAttrs: {
       dav1d
       pango
       freetype
-      vala
+    ]
+    ++ lib.optionals withIntrospection [
+      vala # for share/vala/Makefile.vapigen
     ]
     ++ lib.optionals stdenv.hostPlatform.isDarwin [
       Foundation


### PR DESCRIPTION
`vala` depends on `gobject-introspection`

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
`vala` depends on `gobject-introspection``vala` depends on `gobject-introspection`