### PR TITLE
shader-slang: 2025.4 -> 2025.6.1

### DIFF
--- a/pkgs/by-name/sh/shader-slang/package.nix
+++ b/pkgs/by-name/sh/shader-slang/package.nix
@@ -9,7 +9,6 @@
   lz4,
   libxml2,
   libX11,
-  spirv-headers,
   glslang,
   llvmPackages_13,
   versionCheckHook,
@@ -28,13 +27,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "shader-slang";
-  version = "2025.4";
+  version = "2025.6.1";
 
   src = fetchFromGitHub {
     owner = "shader-slang";
     repo = "slang";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-odZEWiE8SQrfPlRjkI6HkB+sHUhj5ySyBQCKQua7CKA=";
+    hash = "sha256-yNPAJX7OxxQLXDm3s7Hx5QA9fxy1qbAMp4LKYVqxMVM=";
     fetchSubmodules = true;
   };
 
@@ -76,21 +75,20 @@ stdenv.mkDerivation (finalAttrs: {
       miniz
       lz4
       libxml2
-      spirv-headers
     ]
-    ++ (lib.optionals stdenv.hostPlatform.isLinux [
+    ++ lib.optionals stdenv.hostPlatform.isLinux [
       libX11
-    ])
-    ++ (lib.optionals withLLVM [
+    ]
+    ++ lib.optionals withLLVM [
       # Slang only supports LLVM 13:
       # https://github.com/shader-slang/slang/blob/master/docs/building.md#llvm-support
       llvmPackages_13.llvm
       llvmPackages_13.libclang
-    ])
-    ++ (lib.optionals withGlslang [
+    ]
+    ++ lib.optionals withGlslang [
       # SPIRV-tools is included in glslang.
       glslang
-    ]);
+    ];
 
   separateDebugInfo = true;
 
@@ -125,16 +123,12 @@ stdenv.mkDerivation (finalAttrs: {
       "-DSLANG_ENABLE_SLANG_RHI=OFF"
       "-DSLANG_USE_SYSTEM_MINIZ=ON"
       "-DSLANG_USE_SYSTEM_LZ4=ON"
-      "-DSLANG_SPIRV_HEADERS_INCLUDE_DIR=${spirv-headers}/include"
       "-DSLANG_SLANG_LLVM_FLAVOR=${if withLLVM then "USE_SYSTEM_LLVM" else "DISABLE"}"
     ]
-    # Currently depends on unreleased op type `SpvOpTypeNodePayloadArrayAMDX`,
-    # which will be included in next release >1.3.296
-    ++ lib.optional (lib.versionAtLeast spirv-headers.version "1.3.297.0") "-DSLANG_USE_SYSTEM_SPIRV_HEADERS=ON"
-    ++ (lib.optionals withGlslang [
+    ++ lib.optionals withGlslang [
       "-DSLANG_USE_SYSTEM_SPIRV_TOOLS=ON"
       "-DSLANG_USE_SYSTEM_GLSLANG=ON"
-    ])
+    ]
     ++ lib.optional (!withGlslang) "-DSLANG_ENABLE_SLANG_GLSLANG=OFF";
 
   nativeInstallCheckInputs = [ versionCheckHook ];


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Changelogs:

- https://github.com/shader-slang/slang/releases/tag/v2025.5
- https://github.com/shader-slang/slang/releases/tag/v2025.5.1
- https://github.com/shader-slang/slang/releases/tag/v2025.5.2
- https://github.com/shader-slang/slang/releases/tag/v2025.5.3
- https://github.com/shader-slang/slang/releases/tag/v2025.6
- https://github.com/shader-slang/slang/releases/tag/v2025.6.1

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
