### PR TITLE
lomiri.lomiri-thumbnailer: Raise default extraction timeout

### DIFF
--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/2001-Raise-default-extraction-timeout.patch
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/2001-Raise-default-extraction-timeout.patch
@@ -1,0 +1,70 @@
+From d2f977692f931faaad0972f8d121252ddea27501 Mon Sep 17 00:00:00 2001
+From: OPNA2608 <opna2608@protonmail.com>
+Date: Fri, 7 Feb 2025 19:13:13 +0100
+Subject: [PATCH] data/com.lomiri.Thumbnailer.gschema.xml: Raise
+ extraction-timeout
+
+---
+ data/com.lomiri.Thumbnailer.gschema.xml                       | 2 +-
+ .../liblomiri-thumbnailer-qt_test.cpp                         | 4 ++--
+ tests/settings/settings_test.cpp                              | 4 ++--
+ 3 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/data/com.lomiri.Thumbnailer.gschema.xml b/data/com.lomiri.Thumbnailer.gschema.xml
+index 094f850..9de4ab0 100644
+--- a/data/com.lomiri.Thumbnailer.gschema.xml
++++ b/data/com.lomiri.Thumbnailer.gschema.xml
+@@ -66,7 +66,7 @@
+     </key>
+ 
+     <key type="i" name="extraction-timeout">
+-      <default>10</default>
++      <default>20</default>
+       <summary>Maximum amount of time to wait for an image extraction or download (in seconds)</summary>
+       <description>
+         This parameter sets the amount of time (in seconds) to wait for a remote image download or a thumbnail extraction before giving up.
+diff --git a/tests/liblomiri-thumbnailer-qt/liblomiri-thumbnailer-qt_test.cpp b/tests/liblomiri-thumbnailer-qt/liblomiri-thumbnailer-qt_test.cpp
+index 8fc06cf..278ebbb 100644
+--- a/tests/liblomiri-thumbnailer-qt/liblomiri-thumbnailer-qt_test.cpp
++++ b/tests/liblomiri-thumbnailer-qt/liblomiri-thumbnailer-qt_test.cpp
+@@ -467,13 +467,13 @@ TEST_F(LibThumbnailerTest, request_timeout)
+     }
+ 
+     Thumbnailer thumbnailer(dbus_->connection());
+-    auto reply = thumbnailer.getArtistArt("sleep", "12", QSize(256, 256));
++    auto reply = thumbnailer.getArtistArt("sleep", "22", QSize(256, 256));
+ 
+     reply->waitForFinished();
+ 
+     EXPECT_TRUE(reply->isFinished());
+     EXPECT_EQ("Thumbnailer: RequestImpl::dbusCallFinished(): D-Bus error: Handler::createFinished(): "
+-              "could not get thumbnail for artist: sleep/12 (256,256): TIMEOUT",
++              "could not get thumbnail for artist: sleep/22 (256,256): TIMEOUT",
+               reply->errorMessage());
+     EXPECT_FALSE(reply->isValid());
+ }
+diff --git a/tests/settings/settings_test.cpp b/tests/settings/settings_test.cpp
+index cd5931e..8a9a839 100644
+--- a/tests/settings/settings_test.cpp
++++ b/tests/settings/settings_test.cpp
+@@ -46,7 +46,7 @@ TEST(Settings, defaults_from_schema)
+     EXPECT_EQ(7200, settings.retry_error_max_seconds());
+     EXPECT_EQ(8, settings.max_downloads());
+     EXPECT_EQ(0, settings.max_extractions());
+-    EXPECT_EQ(10, settings.extraction_timeout());
++    EXPECT_EQ(20, settings.extraction_timeout());
+     EXPECT_EQ(10, settings.max_backlog());
+     EXPECT_FALSE(settings.trace_client());
+     EXPECT_EQ(1, settings.log_level());
+@@ -69,7 +69,7 @@ TEST(Settings, missing_schema)
+     EXPECT_EQ(7200, settings.retry_error_max_seconds());
+     EXPECT_EQ(8, settings.max_downloads());
+     EXPECT_EQ(0, settings.max_extractions());
+-    EXPECT_EQ(10, settings.extraction_timeout());
++    EXPECT_EQ(20, settings.extraction_timeout());
+     EXPECT_EQ(10, settings.max_backlog());
+     EXPECT_FALSE(settings.trace_client());
+     EXPECT_EQ(1, settings.log_level());
+-- 
+2.47.1
+

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -3,6 +3,7 @@
   lib,
   fetchFromGitLab,
   gitUpdater,
+  nixosTests,
   testers,
   boost,
   cmake,
@@ -173,7 +174,11 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   passthru = {
-    tests.pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    tests = {
+      # gallery app delegates to thumbnailer, tests various formats
+      vm = nixosTests.lomiri-gallery-app;
+      pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+    };
     updateScript = gitUpdater { };
   };
 

--- a/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
+++ b/pkgs/desktops/lomiri/services/lomiri-thumbnailer/default.nix
@@ -53,6 +53,10 @@ stdenv.mkDerivation (finalAttrs: {
     ./1003-doc-liblomiri-thumbnailer-qt-examples-Drop-qt5_use_m.patch
     ./1004-Re-enable-coverge-reporting.patch
     ./1005-Make-GTest-available-to-example-test.patch
+
+    # In aarch64 lomiri-gallery-app VM tests, default 10s timeout for thumbnail extractor is often too tight
+    # Raise to 20s to work around this (too much more will run into D-Bus' call timeout)
+    ./2001-Raise-default-extraction-timeout.patch
   ];
 
   postPatch = ''


### PR DESCRIPTION
Attempt to fix https://hydra.nixos.org/build/287530711

To accommodate weaker test environments, raise the timeout for the thumbnail generator.

Passed once on my aarch64-hardware, will give it afew more attempts just to make sure it's working reliably-ish (at least on my end).

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
