### PR TITLE
batman-adv: 2024.4 -> 2025.0

### DIFF
--- a/pkgs/os-specific/linux/batman-adv/version.nix
+++ b/pkgs/os-specific/linux/batman-adv/version.nix
@@ -1,16 +1,14 @@
 {
-  version = "2024.4";
+  version = "2025.0";
 
   # To get these, run:
   #
   # ```
-  # for tool in alfred batctl batman-adv; do
-  #   nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2024.4/$tool-2024.4.tar.gz --type sha256 | xargs nix hash to-sri --type sha256
-  # done
+  # for tool in alfred batctl batman-adv; do nix-prefetch-url https://downloads.open-mesh.org/batman/releases/batman-adv-2025.0/$tool-2025.0.tar.gz --type sha256 | xargs nix hash convert --hash-algo sha256 --to sri; done
   # ```
   sha256 = {
-    alfred = "sha256-06WtkGtygDbkc1+dZKcrlzHxb4Hz2N9Ay0eFkaO9IpQ=";
-    batctl = "sha256-5CvfGk7LSxiLzTrKF+EgSWpCtlR1k7kX4//PlD4/KRM=";
-    batman-adv = "sha256-pVTfb8erzMayQ/Vup7GESGyV6phtsRM/h6r+I32pLyE=";
+    alfred = "sha256-x7U5aZp0RuoKGLh9uF/Y+SCiv0mnAqkD+ACitygRI4s=";
+    batctl = "sha256-3V9bcd0XUOuo1p3TrfcHiXQcbPY4zyvyzLwvuE9cFo8=";
+    batman-adv = "sha256-uQxFRNPPOfbXzZIGEmsWL1EQ+7SYDeltRfvPUDPQhRo=";
   };
 }


### PR DESCRIPTION
- batman-adv
  - support latest kernels (5.4 - 6.14)
  - handle VLAN 0 as untagged VLAN
  - TT changes in OGMs no longer contain redundant TT changes
  - coding style cleanups and refactoring
  - bugs squashed:
  - fix incorrect offset in OGM handler for translation table TVLV
  - force stop of throughput detection workers on interface removal
- batctl
  - subsecond precision support for ping intervals
  - coding style cleanups and refactoring
- alfred
  - coding style cleanups and refactoring

Changelog: https://www.open-mesh.org/news/120

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
