### PR TITLE
python3Packages.twisted: disable test_cpuCount test

### DIFF
--- a/pkgs/development/python-modules/twisted/default.nix
+++ b/pkgs/development/python-modules/twisted/default.nix
@@ -109,6 +109,10 @@ buildPythonPackage rec {
             "MulticastTests.test_multicast"
             "MulticastTests.test_multiListen"
           ];
+          "src/twisted/trial/test/test_script.py" = [
+            # Fails in LXC containers with less than all cores availaible (limits.cpu)
+            "AutoJobsTests.test_cpuCount"
+          ];
           "src/twisted/internet/test/test_unix.py" = [
             # flaky?
             "UNIXTestsBuilder.test_sendFileDescriptorTriggersPauseProducing"


### PR DESCRIPTION
This test checks for the number of availaible CPU cores using two different methods, and asserts that they are equal. In situations such as LXC containers that do not have all cores availaible, one method can still return the real total CPU core count, and the other will return the number enabled. This causes a needless build fail in LXC based containers.

Link to test upstream test: https://github.com/twisted/twisted/blob/68a6209788719ceb0d694e02691e51a652cc7e95/src/twisted/trial/test/test_script.py#L537

Without these patches, build fail like so on my 12 core cpu with 5 enabled on the container:

```
Traceback (most recent call last):
  File "/nix/store/p3bqghyrd4jz8l4mzc66zrrfq5p0ildd-python3.12-twisted-24.11.0/lib/python3.12/site-packages/twisted/trial/test/test_script.py", line 542, in test_cpuCount
    self.assertEqual(trial._autoJobs(), os.cpu_count())
  File "/nix/store/p3bqghyrd4jz8l4mzc66zrrfq5p0ildd-python3.12-twisted-24.11.0/lib/python3.12/site-packages/twisted/trial/_synctest.py", line 444, in assertEqual
    super().assertEqual(first, second, msg)
  File "/nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/lib/python3.12/unittest/case.py", line 885, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/nix/store/0l539chjmcq5kdd43j6dgdjky4sjl7hl-python3-3.12.8/lib/python3.12/unittest/case.py", line 878, in _baseAssertEqual
    raise self.failureException(msg)
twisted.trial.unittest.FailTest: 5 != 12

twisted.trial.test.test_script.AutoJobsTests.test_cpuCount
-------------------------------------------------------------------------------
Ran 11431 tests in 142.492s

FAILED (skips=714, failures=1, successes=10716)
```

I tested this commit picked onto master to confirm its functionality without building a billion packages from staging.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
