### PR TITLE
rog-control-center: fix libxkbcommon.so not found crash, and more issues to be solved

### DIFF
--- a/pkgs/by-name/as/asusctl/package.nix
+++ b/pkgs/by-name/as/asusctl/package.nix
@@ -88,6 +88,9 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     make prefix=$out install-data
+
+    patchelf $out/bin/rog-control-center \
+      --add-needed ${lib.getLib libxkbcommon}/lib/libxkbcommon.so.0
   '';
 
   meta = with lib; {


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

With #379418, `rog-control-center` will crash with

```
❯ rog-control-center
thread 'main' panicked at /build/asusctl-6.1.0-vendor/winit-0.30.8/src/platform_impl/linux/wayland/seat/keyboard/mod.rs:300:41:
called `Result::unwrap()` on an `Err` value: XKBNotFound
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
zsh: IOT instruction (core dumped)  rog-control-center
```

After some investigation into the code ([winit](https://github.com/rust-windowing/winit/blob/c09160d1a8cb6bb560cce32b72d6c0b0b673c9dc/src/platform_impl/linux/common/xkb/mod.rs#L49), [xkbcommon-dl](https://github.com/rust-windowing/xkbcommon-dl/blob/631fcaac6bb5607585527d8e89ddfc26fa8ec285/src/lib.rs#L313)), it turns out to be a so dependency probelm.

So I added `patchelf` and now it launches.

I apologize for not checking thoroughly in my PR.

I didn't realize another big issue until I see the GUI: the upstream breaks the old kernel module **YET AGAIN**.

According to changelog:

> asus-armoury driver support.

this, unexpectedly, means

```
[ERROR rog_control_center::ui::setup_system] The kernel module asus-armoury is required, if you do not have this you will need to either build or install a kernel which includes the patchwork. This driver is in process of being upstreamed
```

It seems they (in part) breaks the functionality of the old kernel module even on old devices and force everyone two use their cutting-edge patchsets.

We now need their patchset as listed [here](https://github.com/flukejones/linux/tree/wip/ally-6.13) or [there](https://gitlab.com/asus-linux/fedora-kernel/-/raw/rog-6.13/asus-patch-series.patch).

My laptop model was released in 2021, not new at all. Everything worked previously with mainline vanilla kernel. So I guess most of the users using this software get affected now.

We now have two option:

- Revert to somewhre between the latest release and the last. As last release has some major bug making the software not function **at all** ([Ref](https://gitlab.com/asus-linux/asusctl/-/issues/550)). And the latest is also dysfunctional in another way. This is challenging because they have so many seemingly-refactoring commits.

- Somehow maintain these wip and continuously breaking patchsets in modules or nixos-hardware, and somehow warn/force the users to use them and compile kernel ...

How can they make a stable release which breaks all mainlined and stable stuff intentionally? It feels so unreal and I need sleep.

Anyway, I am looking for suggestions from more experienced community maintainers.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
