### PR TITLE
python313Packages.sacrebleu: 2.5.0 -> 2.5.1, refactor

### DIFF
--- a/pkgs/development/python-modules/sacrebleu/default.nix
+++ b/pkgs/development/python-modules/sacrebleu/default.nix
@@ -3,6 +3,9 @@
   buildPythonPackage,
   fetchFromGitHub,
 
+  # build-system
+  setuptools-scm,
+
   # Propagated build inputs
   portalocker,
   regex,
@@ -20,21 +23,18 @@ let
 in
 buildPythonPackage {
   inherit pname version;
-  format = "setuptools";
+  pyproject = true;
 
   src = fetchFromGitHub {
     owner = "mjpost";
-    repo = pname;
+    repo = "sacrebleu";
     tag = "v${version}";
     hash = "sha256-ErssNc8X376E26maGJo/P19CA7FDxZ4/h6mgRB+YNZc=";
   };
 
-  # postPatch = ''
-  #   substituteInPlace setup.py \
-  #     --replace "portalocker==" "portalocker>="
-  # '';
+  build-system = [ setuptools-scm ];
 
-  propagatedBuildInputs = [
+  dependencies = [
     portalocker
     regex
     tabulate
@@ -43,7 +43,7 @@ buildPythonPackage {
     lxml
   ];
 
-  checkInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   disabledTestPaths = [
     # require network access
@@ -57,12 +57,12 @@ buildPythonPackage {
 
   pythonImportsCheck = [ "sacrebleu" ];
 
-  meta = with lib; {
+  meta = {
     description = "Hassle-free computation of shareable, comparable, and reproducible BLEU, chrF, and TER scores";
     mainProgram = "sacrebleu";
     homepage = "https://github.com/mjpost/sacrebleu";
-    changelog = "https://github.com/mjpost/sacrebleu/blob/v{version}/CHANGELOG.md";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ happysalada ];
+    changelog = "https://github.com/mjpost/sacrebleu/blob/v${version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ happysalada ];
   };
 }

--- a/pkgs/development/python-modules/sacrebleu/default.nix
+++ b/pkgs/development/python-modules/sacrebleu/default.nix
@@ -19,7 +19,7 @@
 }:
 let
   pname = "sacrebleu";
-  version = "2.5.0";
+  version = "2.5.1";
 in
 buildPythonPackage {
   inherit pname version;
@@ -29,7 +29,7 @@ buildPythonPackage {
     owner = "mjpost";
     repo = "sacrebleu";
     tag = "v${version}";
-    hash = "sha256-ErssNc8X376E26maGJo/P19CA7FDxZ4/h6mgRB+YNZc=";
+    hash = "sha256-nLZotWQLrN9hB1fBuDJkvGr4SMvQz8Ucl8ybpNhf9Ic=";
   };
 
   build-system = [ setuptools-scm ];


### PR DESCRIPTION
## Description of changes

https://github.com/mjpost/sacrebleu/blob/v2.5.1/CHANGELOG.md
https://github.com/mjpost/sacrebleu/compare/refs/tags/v2.5.0...refs/tags/v2.5.1

## `nixpkgs-review` result

`lm-eval` also requires #380138, failure in `fairseq` is unrelated

Generated using [`nixpkgs-review`](https://github.com/Mic92/nixpkgs-review).

Command: `nixpkgs-review`

---
### `x86_64-linux`
<details>
  <summary>:x: 6 packages failed to build:</summary>
  <ul>
    <li>python312Packages.fairseq</li>
    <li>python312Packages.fairseq.dist</li>
    <li>python312Packages.lm-eval</li>
    <li>python312Packages.lm-eval.dist</li>
    <li>python313Packages.fairseq</li>
    <li>python313Packages.fairseq.dist</li>
  </ul>
</details>
<details>
  <summary>:white_check_mark: 4 packages built:</summary>
  <ul>
    <li>python312Packages.sacrebleu</li>
    <li>python312Packages.sacrebleu.dist</li>
    <li>python313Packages.sacrebleu</li>
    <li>python313Packages.sacrebleu.dist</li>
  </ul>
</details>

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc