### PR TITLE
openmp: Portability improvements

### DIFF
--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -64,6 +64,7 @@ stdenv.mkDerivation (rec {
   ];
 
   cmakeFlags = [
+    (lib.cmakeBool "LIBOMP_ENABLE_SHARED" (!stdenv.hostPlatform.isStatic && stdenv.hostPlatform.hasSharedLibraries))
     (lib.cmakeBool "LIBOMP_OMPD_SUPPORT" ompdSupport)
     (lib.cmakeBool "LIBOMP_OMPD_GDB_SUPPORT" ompdGdbSupport)
   ] ++ lib.optionals (lib.versions.major release_version == "13") [

--- a/pkgs/development/compilers/llvm/common/openmp/default.nix
+++ b/pkgs/development/compilers/llvm/common/openmp/default.nix
@@ -14,9 +14,15 @@
 , clang-unwrapped
 , perl
 , pkg-config
+, python3
 , version
 , devExtraCmakeFlags ? []
+, ompdSupport ? true
+, ompdGdbSupport ? ompdSupport
 }:
+
+assert lib.assertMsg (ompdGdbSupport -> ompdSupport) "OMPD GDB support requires OMPD support!";
+
 let
   pname = "openmp";
   src' =
@@ -53,9 +59,14 @@ stdenv.mkDerivation (rec {
 
   buildInputs = [
     (if stdenv.buildPlatform == stdenv.hostPlatform then llvm else targetLlvm)
+  ] ++ lib.optionals (ompdSupport && ompdGdbSupport) [
+    python3
   ];
 
-  cmakeFlags = lib.optionals (lib.versions.major release_version == "13") [
+  cmakeFlags = [
+    (lib.cmakeBool "LIBOMP_OMPD_SUPPORT" ompdSupport)
+    (lib.cmakeBool "LIBOMP_OMPD_GDB_SUPPORT" ompdGdbSupport)
+  ] ++ lib.optionals (lib.versions.major release_version == "13") [
     "-DLIBOMPTARGET_BUILD_AMDGCN_BCLIB=OFF" # Building the AMDGCN device RTL fails
   ] ++ lib.optionals (lib.versionAtLeast release_version "14") [
     "-DCLANG_TOOL=${clang-unwrapped}/bin/clang"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

This PR adds some portability fixes to the `openmp` derivation:

- Build static libraries if the host platform requires it
- Allow disabling OMPD support and its GDB integration
- Add `python3` to the `buildInputs` if the OMPD GDB plugin is enabled. This was working already due to a transitive dependency on `python3`, but it was for the _build_ platform, which means cross compilation failed.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux (musl, cross from x86_64-linux)
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
