### PR TITLE
rakarrack: fix ALSA plugins load path using alsa-lib drop-in wrapper

### DIFF
--- a/pkgs/applications/audio/rakarrack/default.nix
+++ b/pkgs/applications/audio/rakarrack/default.nix
@@ -1,7 +1,21 @@
-{ lib, stdenv, fetchurl, alsa-lib, alsa-utils, fltk, libjack2, libXft,
-libXpm, libjpeg, libpng, libsamplerate, libsndfile, zlib }:
+{
+  lib,
+  stdenv,
+  fetchurl,
+  alsa-lib-with-plugins,
+  alsa-utils,
+  fltk,
+  libjack2,
+  libXft,
+  libXpm,
+  libjpeg,
+  libpng,
+  libsamplerate,
+  libsndfile,
+  zlib,
+}:
 
-stdenv.mkDerivation  rec {
+stdenv.mkDerivation rec {
   pname = "rakarrack";
   version = "0.6.1";
 
@@ -14,8 +28,19 @@ stdenv.mkDerivation  rec {
 
   patches = [ ./fltk-path.patch ];
 
-  buildInputs = [ alsa-lib alsa-utils fltk libjack2 libXft libXpm libjpeg
-    libpng libsamplerate libsndfile zlib ];
+  buildInputs = [
+    alsa-lib-with-plugins
+    alsa-utils
+    fltk
+    libjack2
+    libXft
+    libXpm
+    libjpeg
+    libpng
+    libsamplerate
+    libsndfile
+    zlib
+  ];
 
   meta = with lib; {
     description = "Multi-effects processor emulating a guitar effects pedalboard";


### PR DESCRIPTION
## Description of changes

`rakarrack` tries to load ALSA plugins from the output path of `alsa-lib`, while they would actually built in `alsa-plugins`. This leads to plugin load failures, and can result in failure initializing MIDI and a subsequent crash depending on the setup:
```
ALSA lib conf.c:4005:(snd_config_hooks_call) Cannot open shared library libasound_module_conf_pulse.so (/nix/store/lxvizzp9h9fxrgr4pxclf7ydaz53rrcp-alsa-lib-1.2.9/lib/alsa-lib/libasound_module_conf_pulse.so: cannot open shared object file: No such file or directory)
ALSA lib seq.c:935:(snd_seq_open_noupdate) Unknown SEQ default
Cannot activate ALSA seq client
Segmentation fault (core dumped)
```

This fixes it by using an `alsa-lib` wrapper fixing the plugin load path issue. I consider it as a more transparent and thus superior solution than https://github.com/NixOS/nixpkgs/pull/273181, and would therefore suggest it should supersede the older PR. To allow CI, this includes the commit from https://github.com/NixOS/nixpkgs/pull/277180 it depends on.

Also supersedes https://github.com/NixOS/nixpkgs/pull/278293 due to being open.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) (or backporting [23.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2305.section.md) and [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
