### PR TITLE
ocamlPackages.easy-format: 1.3.3 -> 1.3.4

### DIFF
--- a/pkgs/development/ocaml-modules/easy-format/default.nix
+++ b/pkgs/development/ocaml-modules/easy-format/default.nix
@@ -10,12 +10,12 @@ let
     if lib.versionAtLeast ocaml.version "4.08" then
       {
         version = "1.3.4";
-        sha256 = "sha256-Hb8FHp9oV03ebi4lSma5xSTKQl6As26Zr5btlkq2EMM=";
+        hash = "sha256-Hb8FHp9oV03ebi4lSma5xSTKQl6As26Zr5btlkq2EMM=";
       }
     else
       {
         version = "1.3.2";
-        sha256 = "sha256:09hrikx310pac2sb6jzaa7k6fmiznnmhdsqij1gawdymhawc4h1l";
+        hash = "sha256-NEDCuILVN65ekBHrBqu1P1Zn5lHqS7O0YOqCMPqMGSY=";
       };
 in
 
@@ -25,15 +25,34 @@ buildDunePackage rec {
 
   src = fetchurl {
     url = "https://github.com/ocaml-community/easy-format/releases/download/${version}/easy-format-${version}.tbz";
-    inherit (params) sha256;
+    inherit (params) hash;
   };
 
   doCheck = true;
 
-  meta = with lib; {
+  meta = {
     description = "High-level and functional interface to the Format module of the OCaml standard library";
+    longDescription = ''
+      This module offers a high-level and functional interface to the Format module of
+      the OCaml standard library. It is a pretty-printing facility, i.e. it takes as
+      input some code represented as a tree and formats this code into the most
+      visually satisfying result, breaking and indenting lines of code where
+      appropriate.
+
+      Input data must be first modelled and converted into a tree using 3 kinds of
+      nodes:
+
+      * atoms
+      * lists
+      * labelled nodes
+
+      Atoms represent any text that is guaranteed to be printed as-is. Lists can model
+      any sequence of items such as arrays of data or lists of definitions that are
+      labelled with something like "int main", "let x =" or "x:".
+    '';
     homepage = "https://github.com/ocaml-community/easy-format";
-    license = licenses.bsd3;
-    maintainers = [ maintainers.vbgl ];
+    changelog = "https://github.com/ocaml-community/easy-format/releases/tag/${params.version}";
+    license = lib.licenses.bsd3;
+    maintainers = with lib.maintainers; [ vbgl ];
   };
 }

--- a/pkgs/development/ocaml-modules/easy-format/default.nix
+++ b/pkgs/development/ocaml-modules/easy-format/default.nix
@@ -9,8 +9,8 @@ let
   params =
     if lib.versionAtLeast ocaml.version "4.08" then
       {
-        version = "1.3.3";
-        sha256 = "sha256:05n4mm1yz33h9gw811ivjw7x4m26lpmf7kns9lza4v6227lwmz7a";
+        version = "1.3.4";
+        sha256 = "sha256-Hb8FHp9oV03ebi4lSma5xSTKQl6As26Zr5btlkq2EMM=";
       }
     else
       {


### PR DESCRIPTION
WIP

note: I'm still trying to figure out why `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"` is failing. mainly mirage-crypto-rng

Changelog: https://github.com/ocaml-community/easy-format/releases/tag/1.3.4
Diff: https://github.com/ocaml-community/easy-format@1.3.3...1.3.4

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
