### PR TITLE
pkgs/top-level: make package sets composable (platform override approach)

### DIFF
--- a/lib/systems/default.nix
+++ b/lib/systems/default.nix
@@ -534,6 +534,9 @@ let
               "-uefi"
             ];
           };
+        }
+        // {
+          override = allArgs.override or (newArgs: elaborate (allArgs // newArgs));
         };
     in
     assert final.useAndroidPrebuilt -> final.isAndroid;

--- a/lib/tests/systems.nix
+++ b/lib/tests/systems.nix
@@ -281,6 +281,7 @@ lib.runTests (
                 emulatorAvailable = null;
                 staticEmulatorAvailable = null;
                 isCompatible = null;
+                override = null;
               } ? ${platformAttrName};
           };
 

--- a/pkgs/test/top-level/stage.nix
+++ b/pkgs/test/top-level/stage.nix
@@ -104,9 +104,8 @@ assert isComposable "pkgsStatic";
 assert isComposable "pkgsi686Linux";
 
 # Special cases regarding buildPlatform vs hostPlatform
-# TODO: fails
-# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
-# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
+assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
+assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
 assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
 assert discardEvaluationErrors (
   pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64

--- a/pkgs/test/top-level/stage.nix
+++ b/pkgs/test/top-level/stage.nix
@@ -87,36 +87,37 @@ assert isIdempotent "pkgsStatic";
 assert isIdempotent "pkgsi686Linux";
 assert isIdempotent "pkgsx86_64Darwin";
 
-# TODO: fails
-# assert isNoop [ "pkgsStatic" ] "pkgsMusl";
-# TODO: fails because of ppc64-musl
-# assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
+assert isNoop [ "pkgsStatic" ] "pkgsMusl";
+assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
 # This will fail on all systems which are not handled in pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix,
 # for example armv6l-linux, powerpc64le-linux, riscv64-linux
 assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsLLVM") allLLVMExamples;
 
-# TODO: fails
-# assert isComposable "pkgsExtraHardening";
-# assert isComposable "pkgsLLVM";
+assert isComposable "pkgsExtraHardening";
+assert isComposable "pkgsLLVM";
+# TODO: Results in infinite recursion
 # assert isComposable "pkgsLLVMLibc";
-# assert isComposable "pkgsArocc";
-# assert isComposable "pkgsZig";
-# TODO: attribute 'abi' missing
-# assert isComposable "pkgsMusl";
-# TODO: fails
-# assert isComposable "pkgsStatic";
-# assert isComposable "pkgsi686Linux";
+assert isComposable "pkgsArocc";
+assert isComposable "pkgsZig";
+assert isComposable "pkgsMusl";
+assert isComposable "pkgsStatic";
+assert isComposable "pkgsi686Linux";
 
 # Special cases regarding buildPlatform vs hostPlatform
 # TODO: fails
 # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
 # assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
-# assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
-# assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
+assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
+assert discardEvaluationErrors (
+  pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64
+);
 
 # pkgsCross should keep upper cross settings
-# TODO: fails
-# assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
-# assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+assert discardEvaluationErrors (
+  with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic
+);
+assert discardEvaluationErrors (
+  with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM
+);
 
 emptyFile

--- a/pkgs/test/top-level/stage.nix
+++ b/pkgs/test/top-level/stage.nix
@@ -1,0 +1,122 @@
+# run like this:
+#  nix-build pkgs/test/top-level/stage.nix
+{
+  localSystem ? {
+    system = builtins.currentSystem;
+  },
+}:
+
+with import ../../top-level { inherit localSystem; };
+
+let
+  # To silence platform specific evaluation errors
+  discardEvaluationErrors = e: (builtins.tryEval e).success -> e;
+
+  # Basic test for idempotency of the package set, i.e:
+  # Applying the same package set twice should work and
+  # not change anything.
+  isIdempotent = set: discardEvaluationErrors (pkgs.${set}.stdenv == pkgs.${set}.${set}.stdenv);
+
+  # Some package sets should be noops in certain circumstances.
+  # This is very similar to the idempotency test, but not going
+  # via the super' overlay.
+  isNoop =
+    parent: child:
+    discardEvaluationErrors (
+      (lib.getAttrFromPath parent pkgs).stdenv == (lib.getAttrFromPath parent pkgs).${child}.stdenv
+    );
+
+  allMuslExamples = builtins.attrNames (
+    lib.filterAttrs (_: system: lib.hasSuffix "-musl" system.config) lib.systems.examples
+  );
+
+  allLLVMExamples = builtins.attrNames (
+    lib.filterAttrs (_: system: system.useLLVM or false) lib.systems.examples
+  );
+
+  # A package set should only change specific configuration, but needs
+  # to keep all other configuration from previous layers in place.
+  # Each package set has one or more key characteristics for which we
+  # test here. Those should be kept, even when applying the "set" package
+  # set.
+  isComposable =
+    set:
+    lib.all discardEvaluationErrors (
+      [
+        (pkgsCross.ppc64-musl.${set}.stdenv.hostPlatform.gcc.abi == "elfv2")
+        (pkgs.pkgsLLVM.${set}.stdenv.hostPlatform.useLLVM)
+        (pkgs.pkgsArocc.${set}.stdenv.hostPlatform.useArocc)
+        (pkgs.pkgsZig.${set}.stdenv.hostPlatform.useZig)
+        (pkgs.pkgsLinux.${set}.stdenv.buildPlatform.isLinux)
+        (pkgs.pkgsStatic.${set}.stdenv.hostPlatform.isStatic)
+        (pkgs.pkgsi686Linux.${set}.stdenv.hostPlatform.isx86_32)
+        (pkgs.pkgsx86_64Darwin.${set}.stdenv.hostPlatform.isx86_64)
+        (builtins.elem "trivialautovarinit" pkgs.pkgsExtraHardening.${set}.stdenv.cc.defaultHardeningFlags)
+      ] # Can't compose two different libcs...
+      ++ lib.optionals (!builtins.elem set [ "pkgsLLVMLibc" ]) [
+        (pkgsCross.mingwW64.${set}.stdenv.hostPlatform.config == "x86_64-w64-mingw32")
+        (pkgsCross.mingwW64.${set}.stdenv.hostPlatform.libc == "msvcrt")
+        (pkgs.pkgsMusl.${set}.stdenv.hostPlatform.isMusl)
+      ]
+      ++
+        lib.optionals
+          (
+            !builtins.elem set [
+              "pkgsMusl"
+              "pkgsStatic"
+            ]
+          )
+          [
+            (pkgs.pkgsLLVMLibc.${set}.stdenv.hostPlatform.isLLVMLibc)
+          ]
+    );
+in
+
+# Appends same defaultHardeningFlags again on each .pkgsExtraHardening - thus not idempotent.
+# assert isIdempotent "pkgsExtraHardening";
+# TODO: Remove the isDarwin condition, which currently results in infinite recursion.
+# Also see https://github.com/NixOS/nixpkgs/pull/330567#discussion_r1894653309
+assert (stdenv.hostPlatform.isDarwin || isIdempotent "pkgsLLVM");
+# TODO: This currently results in infinite recursion, even on Linux
+# assert isIdempotent "pkgsLLVMLibc";
+assert isIdempotent "pkgsArocc";
+assert isIdempotent "pkgsZig";
+assert isIdempotent "pkgsLinux";
+assert isIdempotent "pkgsMusl";
+assert isIdempotent "pkgsStatic";
+assert isIdempotent "pkgsi686Linux";
+assert isIdempotent "pkgsx86_64Darwin";
+
+# TODO: fails
+# assert isNoop [ "pkgsStatic" ] "pkgsMusl";
+# TODO: fails because of ppc64-musl
+# assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsMusl") allMuslExamples;
+# This will fail on all systems which are not handled in pkgs/os-specific/bsd/openbsd/pkgs/mkDerivation.nix,
+# for example armv6l-linux, powerpc64le-linux, riscv64-linux
+assert lib.all (sys: isNoop [ "pkgsCross" sys ] "pkgsLLVM") allLLVMExamples;
+
+# TODO: fails
+# assert isComposable "pkgsExtraHardening";
+# assert isComposable "pkgsLLVM";
+# assert isComposable "pkgsLLVMLibc";
+# assert isComposable "pkgsArocc";
+# assert isComposable "pkgsZig";
+# TODO: attribute 'abi' missing
+# assert isComposable "pkgsMusl";
+# TODO: fails
+# assert isComposable "pkgsStatic";
+# assert isComposable "pkgsi686Linux";
+
+# Special cases regarding buildPlatform vs hostPlatform
+# TODO: fails
+# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsMusl.stdenv.hostPlatform.isMusl);
+# assert discardEvaluationErrors (pkgsCross.gnu64.pkgsi686Linux.stdenv.hostPlatform.isx86_32);
+# assert discardEvaluationErrors (pkgsCross.mingwW64.pkgsLinux.stdenv.hostPlatform.isLinux);
+# assert discardEvaluationErrors (pkgsCross.aarch64-darwin.pkgsx86_64Darwin.stdenv.hostPlatform.isx86_64);
+
+# pkgsCross should keep upper cross settings
+# TODO: fails
+# assert discardEvaluationErrors (with pkgsStatic.pkgsCross.gnu64.stdenv.hostPlatform; isGnu && isStatic);
+# assert discardEvaluationErrors (with pkgsLLVM.pkgsCross.musl64.stdenv.hostPlatform; isMusl && useLLVM);
+
+emptyFile

--- a/pkgs/top-level/default.nix
+++ b/pkgs/top-level/default.nix
@@ -134,22 +134,18 @@ let
   config = lib.showWarnings configEval.config.warnings configEval.config;
 
   # A few packages make a new package set to draw their dependencies from.
-  # (Currently to get a cross tool chain, or forced-i686 package.) Rather than
-  # give `all-packages.nix` all the arguments to this function, even ones that
-  # don't concern it, we give it this function to "re-call" nixpkgs, inheriting
-  # whatever arguments it doesn't explicitly provide. This way,
-  # `all-packages.nix` doesn't know more than it needs too.
+  # Rather than give `all-packages.nix` all the arguments to this function,
+  # even ones that don't concern it, we give it this function to "re-call"
+  # nixpkgs, inheriting whatever arguments it doesn't explicitly provide. This
+  # way, `all-packages.nix` doesn't know more than it needs to.
   #
   # It's OK that `args` doesn't include default arguments from this file:
   # they'll be deterministically inferred. In fact we must *not* include them,
   # because it's important that if some parameter which affects the default is
   # substituted with a different argument, the default is re-inferred.
   #
-  # To put this in concrete terms, this function is basically just used today to
-  # use package for a different platform for the current platform (namely cross
-  # compiling toolchains and 32-bit packages on x86_64). In both those cases we
-  # want the provided non-native `localSystem` argument to affect the stdenv
-  # chosen.
+  # To put this in concrete terms, we want the provided non-native `localSystem`
+  # and `crossSystem` arguments to affect the stdenv chosen.
   #
   # NB!!! This thing gets its `config` argument from `args`, i.e. it's actually
   # `config0`. It is important to keep it to `config0` format (as opposed to the

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -212,12 +212,7 @@ let
     lib.optionalAttrs allowCustomOverrides ((config.packageOverrides or (super: { })) super);
 
   # Convenience attributes for instantitating package sets. Each of
-  # these will instantiate a new version of allPackages. Currently the
-  # following package sets are provided:
-  #
-  # - pkgsCross.<system> where system is a member of lib.systems.examples
-  # - pkgsMusl
-  # - pkgsi686Linux
+  # these will instantiate a new version of allPackages.
   otherPackageSets = self: super: {
     # This maps each entry in lib.systems.examples to its own package
     # set. Each of these will contain all packages cross compiled for

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -232,11 +232,16 @@ let
           }
         );
       # This is only cross when we are already cross, otherwise local.
+      # For the case of "native cross", i.e. pkgsCross.gnu64 on a x86_64-linux system, we need to adjust **both**
+      # localSystem **and** crossSystem, otherwise they're out of sync.
       mkHybridPkgs =
         name: hybridAttrs:
-        mkPkgs name {
-          ${if isNative then "localSystem" else "crossSystem"} = stdenv.hostPlatform.override hybridAttrs;
-        };
+        mkPkgs name (
+          let
+            newSystem = stdenv.hostPlatform.override hybridAttrs;
+          in
+          { crossSystem = newSystem; } // lib.optionalAttrs isNative { localSystem = newSystem; }
+        );
     in
     self: super: {
       # This maps each entry in lib.systems.examples to its own package

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -213,213 +213,189 @@ let
 
   # Convenience attributes for instantitating package sets. Each of
   # these will instantiate a new version of allPackages.
-  otherPackageSets = self: super: {
-    # This maps each entry in lib.systems.examples to its own package
-    # set. Each of these will contain all packages cross compiled for
-    # that target system. For instance, pkgsCross.raspberryPi.hello,
-    # will refer to the "hello" package built for the ARM6-based
-    # Raspberry Pi.
-    pkgsCross = lib.mapAttrs (n: crossSystem: nixpkgsFun { inherit crossSystem; }) lib.systems.examples;
-
-    pkgsLLVM = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsLLVM = super';
-        })
-      ] ++ overlays;
-      # Bootstrap a cross stdenv using the LLVM toolchain.
-      # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
-        useLLVM = true;
-        linker = "lld";
-      };
-    };
-
-    pkgsLLVMLibc = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsLLVMLibc = super';
-        })
-      ] ++ overlays;
-      # Bootstrap a cross stdenv using LLVM libc.
-      # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
-        config = lib.systems.parse.tripleFromSystem (makeLLVMParsedPlatform stdenv.hostPlatform.parsed);
-        libc = "llvm";
-      };
-    };
-
-    pkgsArocc = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsArocc = super';
-        })
-      ] ++ overlays;
-      # Bootstrap a cross stdenv using the Aro C compiler.
-      # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
-        useArocc = true;
-        linker = "lld";
-      };
-    };
-
-    pkgsZig = nixpkgsFun {
-      overlays = [
-        (self': super': {
-          pkgsZig = super';
-        })
-      ] ++ overlays;
-      # Bootstrap a cross stdenv using the Zig toolchain.
-      # This is currently not possible when compiling natively,
-      # so we don't need to check hostPlatform != buildPlatform.
-      crossSystem = stdenv.hostPlatform // {
-        useZig = true;
-        linker = "lld";
-      };
-    };
-
-    # All packages built with the Musl libc. This will override the
-    # default GNU libc on Linux systems. Non-Linux systems are not
-    # supported. 32-bit is also not supported.
-    pkgsMusl =
-      if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then
-        nixpkgsFun {
-          overlays = [
-            (self': super': {
-              pkgsMusl = super';
-            })
-          ] ++ overlays;
-          ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
-            config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
-          };
-        }
-      else
-        throw "Musl libc only supports 64-bit Linux systems.";
-
-    # All packages built for i686 Linux.
-    # Used by wine, firefox with debugging version of Flash, ...
-    pkgsi686Linux =
-      if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86 then
-        nixpkgsFun {
-          overlays = [
-            (self': super': {
-              pkgsi686Linux = super';
-            })
-          ] ++ overlays;
-          ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
-            config = lib.systems.parse.tripleFromSystem (
-              stdenv.hostPlatform.parsed
-              // {
-                cpu = lib.systems.parse.cpuTypes.i686;
-              }
-            );
-          };
-        }
-      else
-        throw "i686 Linux package set can only be used with the x86 family.";
-
-    # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
-    pkgsx86_64Darwin =
-      if stdenv.hostPlatform.isDarwin then
-        nixpkgsFun {
-          overlays = [
-            (self': super': {
-              pkgsx86_64Darwin = super';
-            })
-          ] ++ overlays;
-          localSystem = {
-            config = lib.systems.parse.tripleFromSystem (
-              stdenv.hostPlatform.parsed
-              // {
-                cpu = lib.systems.parse.cpuTypes.x86_64;
-              }
-            );
-          };
-        }
-      else
-        throw "x86_64 Darwin package set can only be used on Darwin systems.";
-
-    # If already linux: the same package set unaltered
-    # Otherwise, return a natively built linux package set for the current cpu architecture string.
-    # (ABI and other details will be set to the default for the cpu/os pair)
-    pkgsLinux =
-      if stdenv.hostPlatform.isLinux then
-        self
-      else
-        nixpkgsFun {
-          localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
-        };
-
-    # Fully static packages.
-    # Currently uses Musl on Linux (couldn’t get static glibc to work).
-    pkgsStatic = nixpkgsFun ({
-      overlays = [
-        (self': super': {
-          pkgsStatic = super';
-        })
-      ] ++ overlays;
-      crossSystem = {
-        isStatic = true;
-        config = lib.systems.parse.tripleFromSystem (
-          if stdenv.hostPlatform.isLinux then
-            makeMuslParsedPlatform stdenv.hostPlatform.parsed
-          else
-            stdenv.hostPlatform.parsed
-        );
-        gcc =
-          lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") { abi = "elfv2"; }
-          // stdenv.hostPlatform.gcc or { };
-      };
-    });
-
-    pkgsExtraHardening = nixpkgsFun {
-      overlays = [
-        (
-          self': super':
-          {
-            pkgsExtraHardening = super';
-            stdenv = super'.withDefaultHardeningFlags (
-              super'.stdenv.cc.defaultHardeningFlags
-              ++ [
-                "shadowstack"
-                "pacret"
-                "trivialautovarinit"
+  otherPackageSets =
+    let
+      mkPkgs =
+        name: nixpkgsArgs:
+        nixpkgsFun (
+          nixpkgsArgs
+          // {
+            overlays =
+              [
+                (self': super': {
+                  "${name}" = super';
+                })
               ]
-            ) super'.stdenv;
-            glibc = super'.glibc.override rec {
-              enableCET = if self'.stdenv.hostPlatform.isx86_64 then "permissive" else false;
-              enableCETRuntimeDefault = enableCET != false;
+              ++ nixpkgsArgs.overlays or [ ]
+              ++ overlays;
+          }
+        );
+    in
+    self: super: {
+      # This maps each entry in lib.systems.examples to its own package
+      # set. Each of these will contain all packages cross compiled for
+      # that target system. For instance, pkgsCross.raspberryPi.hello,
+      # will refer to the "hello" package built for the ARM6-based
+      # Raspberry Pi.
+      pkgsCross = lib.mapAttrs (n: crossSystem: nixpkgsFun { inherit crossSystem; }) lib.systems.examples;
+
+      pkgsLLVM = mkPkgs "pkgsLLVM" {
+        # Bootstrap a cross stdenv using the LLVM toolchain.
+        # This is currently not possible when compiling natively,
+        # so we don't need to check hostPlatform != buildPlatform.
+        crossSystem = stdenv.hostPlatform // {
+          useLLVM = true;
+          linker = "lld";
+        };
+      };
+
+      pkgsLLVMLibc = mkPkgs "pkgsLLVMLibc" {
+        # Bootstrap a cross stdenv using LLVM libc.
+        # This is currently not possible when compiling natively,
+        # so we don't need to check hostPlatform != buildPlatform.
+        crossSystem = stdenv.hostPlatform // {
+          config = lib.systems.parse.tripleFromSystem (makeLLVMParsedPlatform stdenv.hostPlatform.parsed);
+          libc = "llvm";
+        };
+      };
+
+      pkgsArocc = mkPkgs "pkgsArocc" {
+        # Bootstrap a cross stdenv using the Aro C compiler.
+        # This is currently not possible when compiling natively,
+        # so we don't need to check hostPlatform != buildPlatform.
+        crossSystem = stdenv.hostPlatform // {
+          useArocc = true;
+          linker = "lld";
+        };
+      };
+
+      pkgsZig = mkPkgs "pkgsZig" {
+        # Bootstrap a cross stdenv using the Zig toolchain.
+        # This is currently not possible when compiling natively,
+        # so we don't need to check hostPlatform != buildPlatform.
+        crossSystem = stdenv.hostPlatform // {
+          useZig = true;
+          linker = "lld";
+        };
+      };
+
+      # All packages built with the Musl libc. This will override the
+      # default GNU libc on Linux systems. Non-Linux systems are not
+      # supported. 32-bit is also not supported.
+      pkgsMusl =
+        if stdenv.hostPlatform.isLinux && stdenv.buildPlatform.is64bit then
+          mkPkgs "pkgsMusl" {
+            ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
+              config = lib.systems.parse.tripleFromSystem (makeMuslParsedPlatform stdenv.hostPlatform.parsed);
             };
           }
-          // lib.optionalAttrs (with super'.stdenv.hostPlatform; isx86_64 && isLinux) {
-            # causes shadowstack disablement
-            pcre = super'.pcre.override { enableJit = false; };
-            pcre-cpp = super'.pcre-cpp.override { enableJit = false; };
-            pcre16 = super'.pcre16.override { enableJit = false; };
+        else
+          throw "Musl libc only supports 64-bit Linux systems.";
+
+      # All packages built for i686 Linux.
+      # Used by wine, firefox with debugging version of Flash, ...
+      pkgsi686Linux =
+        if stdenv.hostPlatform.isLinux && stdenv.hostPlatform.isx86 then
+          mkPkgs "pkgsi686Linux" {
+            ${if stdenv.hostPlatform == stdenv.buildPlatform then "localSystem" else "crossSystem"} = {
+              config = lib.systems.parse.tripleFromSystem (
+                stdenv.hostPlatform.parsed
+                // {
+                  cpu = lib.systems.parse.cpuTypes.i686;
+                }
+              );
+            };
           }
-        )
-      ] ++ overlays;
+        else
+          throw "i686 Linux package set can only be used with the x86 family.";
+
+      # x86_64-darwin packages for aarch64-darwin users to use with Rosetta for incompatible packages
+      pkgsx86_64Darwin =
+        if stdenv.hostPlatform.isDarwin then
+          mkPkgs "pkgsx86_64Darwin" {
+            localSystem = {
+              config = lib.systems.parse.tripleFromSystem (
+                stdenv.hostPlatform.parsed
+                // {
+                  cpu = lib.systems.parse.cpuTypes.x86_64;
+                }
+              );
+            };
+          }
+        else
+          throw "x86_64 Darwin package set can only be used on Darwin systems.";
+
+      # If already linux: the same package set unaltered
+      # Otherwise, return a natively built linux package set for the current cpu architecture string.
+      pkgsLinux =
+        if stdenv.hostPlatform.isLinux then
+          self
+        else
+          mkPkgs "pkgsLinux" {
+            localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
+          };
+
+      # Fully static packages.
+      # Currently uses Musl on Linux (couldn’t get static glibc to work).
+      pkgsStatic = mkPkgs "pkgsStatic" {
+        crossSystem = {
+          isStatic = true;
+          config = lib.systems.parse.tripleFromSystem (
+            if stdenv.hostPlatform.isLinux then
+              makeMuslParsedPlatform stdenv.hostPlatform.parsed
+            else
+              stdenv.hostPlatform.parsed
+          );
+          gcc =
+            lib.optionalAttrs (stdenv.hostPlatform.system == "powerpc64-linux") { abi = "elfv2"; }
+            // stdenv.hostPlatform.gcc or { };
+        };
+      };
+
+      pkgsExtraHardening = mkPkgs "pkgsExtraHardening" {
+        overlays = [
+          (
+            self': super':
+            {
+              stdenv = super'.withDefaultHardeningFlags (
+                super'.stdenv.cc.defaultHardeningFlags
+                ++ [
+                  "shadowstack"
+                  "pacret"
+                  "trivialautovarinit"
+                ]
+              ) super'.stdenv;
+              glibc = super'.glibc.override rec {
+                enableCET = if self'.stdenv.hostPlatform.isx86_64 then "permissive" else false;
+                enableCETRuntimeDefault = enableCET != false;
+              };
+            }
+            // lib.optionalAttrs (with super'.stdenv.hostPlatform; isx86_64 && isLinux) {
+              # causes shadowstack disablement
+              pcre = super'.pcre.override { enableJit = false; };
+              pcre-cpp = super'.pcre-cpp.override { enableJit = false; };
+              pcre16 = super'.pcre16.override { enableJit = false; };
+            }
+          )
+        ];
+      };
+
+      # Extend the package set with zero or more overlays. This preserves
+      # preexisting overlays. Prefer to initialize with the right overlays
+      # in one go when calling Nixpkgs, for performance and simplicity.
+      appendOverlays =
+        extraOverlays:
+        if extraOverlays == [ ] then self else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
+
+      # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
+      #       of allocations. DO NOT USE THIS IN NIXPKGS.
+      #
+      # Extend the package set with a single overlay. This preserves
+      # preexisting overlays. Prefer to initialize with the right overlays
+      # in one go when calling Nixpkgs, for performance and simplicity.
+      # Prefer appendOverlays if used repeatedly.
+      extend = f: self.appendOverlays [ f ];
     };
-
-    # Extend the package set with zero or more overlays. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    appendOverlays =
-      extraOverlays:
-      if extraOverlays == [ ] then self else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
-
-    # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
-    #       of allocations. DO NOT USE THIS IN NIXPKGS.
-    #
-    # Extend the package set with a single overlay. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    # Prefer appendOverlays if used repeatedly.
-    extend = f: self.appendOverlays [ f ];
-  };
 
   # The complete chain of package set builders, applied from top to bottom.
   # stdenvOverlays must be last as it brings package forward from the

--- a/pkgs/top-level/stage.nix
+++ b/pkgs/top-level/stage.nix
@@ -353,22 +353,6 @@ let
           localSystem = lib.systems.elaborate "${stdenv.hostPlatform.parsed.cpu.name}-linux";
         };
 
-    # Extend the package set with zero or more overlays. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    appendOverlays =
-      extraOverlays:
-      if extraOverlays == [ ] then self else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
-
-    # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
-    #       of allocations. DO NOT USE THIS IN NIXPKGS.
-    #
-    # Extend the package set with a single overlay. This preserves
-    # preexisting overlays. Prefer to initialize with the right overlays
-    # in one go when calling Nixpkgs, for performance and simplicity.
-    # Prefer appendOverlays if used repeatedly.
-    extend = f: self.appendOverlays [ f ];
-
     # Fully static packages.
     # Currently uses Musl on Linux (couldn’t get static glibc to work).
     pkgsStatic = nixpkgsFun ({
@@ -419,6 +403,22 @@ let
         )
       ] ++ overlays;
     };
+
+    # Extend the package set with zero or more overlays. This preserves
+    # preexisting overlays. Prefer to initialize with the right overlays
+    # in one go when calling Nixpkgs, for performance and simplicity.
+    appendOverlays =
+      extraOverlays:
+      if extraOverlays == [ ] then self else nixpkgsFun { overlays = args.overlays ++ extraOverlays; };
+
+    # NOTE: each call to extend causes a full nixpkgs rebuild, adding ~130MB
+    #       of allocations. DO NOT USE THIS IN NIXPKGS.
+    #
+    # Extend the package set with a single overlay. This preserves
+    # preexisting overlays. Prefer to initialize with the right overlays
+    # in one go when calling Nixpkgs, for performance and simplicity.
+    # Prefer appendOverlays if used repeatedly.
+    extend = f: self.appendOverlays [ f ];
   };
 
   # The complete chain of package set builders, applied from top to bottom.


### PR DESCRIPTION
Same goal as in #303849 and #376988, which were reverted because of breaking changes to NixOS. This time with a new approach, based on the idea in https://github.com/NixOS/nixpkgs/pull/376988#issuecomment-2637936400.

This makes the changes in the main commit 1f9012beb7caf8bfef77b8b3136a8dd58755e609 embarrassingly simple.

@MattSturgeon I took the `_type = platform` and the override things we discussed in #380005 in here. Technically, this makes the two PRs independent now: This PR here should already work without yours merged, relying on: https://github.com/NixOS/nixpkgs/blob/354b12de95fe2884c6ca82a48a253c127aa5d9ac/pkgs/top-level/default.nix#L96-L100

However, by doing this, we commit to "platforms can not be compared with equality", so we should still continue with #380005.

## Things done

The tests can be run with `nix-build pkgs/test/top-level/stage.nix`.

- Built on platform(s) from `lib/systems/flake-systems.nix`:
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [ ] armv6l-linux: `attribute 'armv6l' missing` (fails the same way before this PR)
  - [x] armv7l-linux
  - [x] i686-linux
  - [x] mipsel-linux
  - [x] aarch64-darwin
  - [x] armv5tel-linux
  - [ ] powerpc64le-linux: `attribute 'powerpc64le' missing` (fails the same way before this PR)
  - [ ] riscv64-linux: `attribute 'riscv64' missing` (fails the same way before this PR)
  - [ ] x86_64-freebsd: `infinite recursion encountered` (fails the same way before this PR)
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
