### PR TITLE
khal: fix build

### DIFF
--- a/pkgs/by-name/kh/khal/package.nix
+++ b/pkgs/by-name/kh/khal/package.nix
@@ -41,6 +41,10 @@ python.pkgs.buildPythonApplication rec {
     hash = "sha256-YP2kQ/qXPDwvFvlHf+A2Ymvk49dmt5tAnTaOhrOV92M=";
   };
 
+  postPatch = ''
+    sed -i /intersphinx/d doc/source/conf.py
+  '';
+
   build-system = with python.pkgs; [
     setuptools
     setuptools-scm

--- a/pkgs/by-name/kh/khal/package.nix
+++ b/pkgs/by-name/kh/khal/package.nix
@@ -16,7 +16,7 @@ let
         src = fetchFromGitHub {
           owner = "collective";
           repo = "icalendar";
-          rev = "refs/tags/v${version}";
+          tag = "v${version}";
           hash = "sha256-2gpWfLXR4HThw23AWxY2rY9oiK6CF3Qiad8DWHCs4Qk=";
         };
         patches = [ ];
@@ -37,7 +37,7 @@ python.pkgs.buildPythonApplication rec {
   src = fetchFromGitHub {
     owner = "pimutils";
     repo = "khal";
-    rev = "refs/tags/v${version}";
+    tag = "v${version}";
     hash = "sha256-YP2kQ/qXPDwvFvlHf+A2Ymvk49dmt5tAnTaOhrOV92M=";
   };
 
@@ -115,11 +115,11 @@ python.pkgs.buildPythonApplication rec {
     "test_event_no_dst"
   ];
 
-  meta = with lib; {
+  meta = {
     description = "CLI calendar application";
-    homepage = "http://lostpackets.de/khal/";
+    homepage = "https://lostpackets.de/khal/";
     changelog = "https://github.com/pimutils/khal/releases/tag/v${version}";
-    license = licenses.mit;
-    maintainers = with maintainers; [ gebner ];
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ gebner ];
   };
 }


### PR DESCRIPTION
sphinx 8.x, introduced to nixpkgs in 0708c34, removed a very old and long-deprecated way of defining intersphinx_mappings[1]. khal imports and defines intersphinx_mappings in that old way[2], but doesn't use intersphinx anywhere, as far as I managed to notice. So I just delete the lines containing intersphinx. There is also an upstream issue[3].

[1]: https://www.sphinx-doc.org/en/master/changes/8.0.html#incompatible-changes
[2]: https://github.com/pimutils/khal/blob/a0e3fd1cd193e5d3b2eb3b81e99e0818f1f26d2a/doc/source/conf.py#L312
[3]: pimutils/khal#1356

While touching the khal file, I also refactored the code a little, replacing `rev` with `tag` in `fetchFromGitHub` as well as removing `with lib;` from `meta`.
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
