### PR TITLE
glibc_multi: add output "static"

### DIFF
--- a/pkgs/development/libraries/glibc/multi.nix
+++ b/pkgs/development/libraries/glibc/multi.nix
@@ -16,7 +16,8 @@ runCommand "${nameVersion.name}-multi-${nameVersion.version}"
       "out"
       "bin"
       "dev"
-    ]; # TODO: no static version here (yet)
+      "static"
+    ];
     passthru = {
       libgcc = lib.lists.filter (x: x != null) [
         (glibc64.libgcc or null)
@@ -42,4 +43,13 @@ runCommand "${nameVersion.name}-multi-${nameVersion.version}"
     cp -rs '${glibc32.dev}'/include "$dev/"
     chmod +w -R "$dev"
     cp -rsf '${glibc64.dev}'/include "$dev/"
+
+    mkdir -p "$static/lib" "$static/lib64"
+    # create symlinks for files used for dynamic linking
+    # -> removing this will cause dynamically linked programs to segfault
+    cp -rs '${glibc32.out}'/lib/* "$static/lib"
+    cp -rs '${glibc64.out}'/lib/* "$static/lib64"
+    # create symlinks for files used for static linking
+    cp -rs '${glibc32.static}'/lib/* "$static/lib"
+    cp -rs '${glibc64.static}'/lib/* "$static/lib64"
   ''


### PR DESCRIPTION
This change enables static compilation with glibc in a multilib setup. For building a nix shell the output can now be referenced as follows:

```
devShells.default = pkgs.mkShell {
    packages = [
        pkgs.glibc_multi.static
    ];
};
```

In the implementation I was forced to make two design decisions:
1. The directory `$static/lib64` has to be a "real" directory and not a symlink. Otherwise, the path to this directory is not added to $NIX_LDFLAGS, which in turn causes the files to not be visible to gcc and ld during the build process (for details see `pkgs/build-support/bintools-wrapper/setup-hook.sh` line 16).
2. The directories `$static/lib` and `$static/lib64` have to contain symlinks to both the files used for static and for dynamic linking (i.e. the outputs of `static` and `out` of the 32 and 64 bit variants). Without this, dynamic linking still works, however the resulting binaries will segfault.


(the following is not part of the commit message)

I'm unsure why I've had to add the files for dynamic linking into the output for static linking to prevent the resulting binaries to segfault. However, since this solution works and does not modify/impact any other modules and packages, I'm satisfied with it.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).


## Snippets for Manual Testing

I've used the following setup for manual testing:

hello-world.c
```.c
#include <stdio.h>

void main() {
    printf("Hello World!");
}
```

flake.nix
```.nix
{
  description = "Flake for testing";
  inputs = {
    nixpkgs.url = "path:/home/tim/repos/nixpkgs";
    flake-utils.url = "github:numtide/flake-utils";
  };
  outputs = {
    nixpkgs,
    flake-utils,
    ...
  }:
    flake-utils.lib.eachDefaultSystem
    (
      system: let
        pkgs = nixpkgs.legacyPackages.${system};
      in {
        devShells.default = pkgs.mkShell {
          packages = [
            pkgs.gcc_multi
            pkgs.glibc_multi
            pkgs.glibc_multi.static
          ];
        };
      }
    );
}
```

Then I've used the following commands for testing.

```.bash
# enter the development shell
$ nix develop .
# compile all variants of hello world
$ gcc hello-world.c -o hello-world-64bit-dynamic
$ gcc -static hello-world.c -o hello-world-64bit-static
$ gcc -m32 hello-world.c -o hello-world-32bit-dynamic
$ gcc -static -m32 hello-world.c -o hello-world-32bit-static
# run all binaries
$ ./hello-world-64bit-dynamic ; ./hello-world-64bit-static ; ./hello-world-32bit-dynamic ; ./hello-world-32bit-static
```


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
