### PR TITLE
pimsync: 0.1.0 -> 0.2.0

### DIFF
--- a/pkgs/by-name/pi/pimsync/package.nix
+++ b/pkgs/by-name/pi/pimsync/package.nix
@@ -5,37 +5,47 @@
   pkg-config,
   sqlite,
   scdoc,
+  installShellFiles,
   makeWrapper,
+  nix-update-script,
 }:
 
 rustPlatform.buildRustPackage rec {
   pname = "pimsync";
-  version = "0.1.0";
+  version = "0.2.0";
 
   src = fetchFromSourcehut {
     owner = "~whynothugo";
     repo = "pimsync";
     rev = "v${version}";
-    hash = "sha256-upOCrpbveSSFrhdHDkTOmja4MLmsgtuoDHMsgXyulWI=";
+    hash = "sha256-mNOKAnBpCo4LFn7l16UG7V3cCJkUhRxhB/0jwoPLttM=";
   };
 
   useFetchCargoVendor = true;
-  cargoHash = "sha256-i9t/6z1UJFppv3y7anB+df+UldGP2TynYKKIUAZff5Y=";
+  cargoHash = "sha256-2Uj+dDtuykQx1tBSGN3AE3Bz904bHfkbhKN3VIeG40M=";
+
+  PIMSYNC_VERSION = version;
 
   nativeBuildInputs = [
     pkg-config
     scdoc
     makeWrapper
+    installShellFiles
   ];
 
   buildInputs = [
     sqlite
   ];
 
-  makeFlags = [
-    "build"
-    "PREFIX=${placeholder "out"}"
-  ];
+  postBuild = ''
+    make man
+  '';
+
+  postInstall = ''
+    installManPage target/pimsync.1 target/pimsync.conf.5 target/pimsync-migration.7
+  '';
+
+  passthru.updateScript = nix-update-script { };
 
   meta = {
     description = "Synchronise calendars and contacts";


### PR DESCRIPTION
pimsync now tries to create a version string using git-describe[1], but
only if there isn't an environment variable PIMSYNC_VERSION. That is
then used instead. Also, makeFlags in fact don't change the behavior of buildRustPackage as
far as I know. Lastly, I also compile and install man pages now.

[1]: https://git.sr.ht/~whynothugo/pimsync/commit/4df1e23799ab71cf9fb214f608a6612775baf910
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
