### PR TITLE
Phoenix & Dove: init at 2025.02.21.1

### DIFF
--- a/pkgs/by-name/do/dove/package.nix
+++ b/pkgs/by-name/do/dove/package.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  stdenvNoCC,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "dove";
+  version = "2025.02.21.1";
+
+  src =
+    if stdenv.isDarwin then
+      fetchzip {
+        url = "https://codeberg.org/celenity/Dove/raw/tag/${finalAttrs.version}/archives/dove-osx.zip";
+        hash = "sha256-kgboCDCQjVqJaGWNffTjuuMWjZH1xucWic2R9CLrjx0=";
+        stripRoot = false;
+      }
+    else
+      fetchzip {
+        url = "https://codeberg.org/celenity/Dove/raw/tag/${finalAttrs.version}/archives/dove.zip";
+        hash = "sha256-wlFC9TMlMqMYCTFSiJ0JUUKi3hd6vRcNRovkAh3BSps=";
+        stripRoot = false;
+        # general.config.filename is hard-coded to mozilla.cfg in wrapFirefox, so removing this setting:
+        postFetch = ''
+          sed -i '/general.config.filename/d' $out/prefs/dove.js
+        '';
+      };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    ${
+      if stdenv.isDarwin then
+        ''
+          cp $src/macos/* $out/
+        ''
+      else
+        ''
+          cp -r $src/policies.json $src/dove.cfg $src/prefs $out/
+        ''
+    }
+    install -Dm644 $src/README.md $out/share/doc/dove/README.md
+    install -Dm644 $src/COPYING $out/share/doc/dove/COPYING
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A suite of configurations & advanced modifications for Mozilla Thunderbird with a focus on privacy, security, freedom, & usability";
+    homepage = "https://dove.celenity.dev/";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      jbgi
+    ];
+    platforms = lib.platforms.all;
+  };
+})

--- a/pkgs/by-name/ph/phoenix/package.nix
+++ b/pkgs/by-name/ph/phoenix/package.nix
@@ -1,0 +1,67 @@
+{
+  lib,
+  stdenv,
+  fetchzip,
+  stdenvNoCC,
+  nix-update-script,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "phoenix";
+  version = "2025.02.21.1";
+
+  src =
+    if stdenv.isDarwin then
+      fetchzip {
+        url = "https://codeberg.org/celenity/Phoenix/raw/tag/${finalAttrs.version}/archives/phoenix-osx.zip";
+        hash = "sha256-OwQu5f19QDNVEM4y630vsPL43D3TU9Utlt592ADmJ7M=";
+        stripRoot = false;
+      }
+    else
+      fetchzip {
+        url = "https://codeberg.org/celenity/Phoenix/raw/tag/${finalAttrs.version}/archives/phoenix.zip";
+        hash = "sha256-YFziMQiw0xAcMfjHQacz42zYDg9OihordfD7kRqYgPo=";
+        stripRoot = false;
+        # general.config.filename is hard-coded to mozilla.cfg in wrapFirefox, so removing this setting:
+        postFetch = ''
+          sed -i '/general.config.filename/d' $out/prefs/phoenix-desktop.js
+        '';
+      };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir $out
+    ${
+      if stdenv.isDarwin then
+        ''
+          cp $src/macos/* $out/
+          cp -r $src/configs/macos $out/configs
+          cp -r $src/userjs/macos $out/userjs
+        ''
+      else
+        ''
+          cp -r $src/policies.json $src/phoenix.cfg $src/prefs $src/configs $out/
+          cp -r $src/userjs/linux $out/userjs
+        ''
+    }
+    install -Dm644 $src/COPYING $out/share/doc/phoenix/COPYING
+    install -Dm644 $src/README.md $out/share/doc/phoenix/README.md
+    install -Dm644 $src/userjs/README.md $out/share/doc/phoenix/userjs/README.md
+
+    runHook postInstall
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "A suite of configurations & advanced modifications for Mozilla Firefox with a focus on privacy, security, freedom, & usability";
+    homepage = "https://phoenix.celenity.dev";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [
+      jbgi
+    ];
+    platforms = lib.platforms.all;
+  };
+})


### PR DESCRIPTION
[Phoenix](https://codeberg.org/celenity/Phoenix) and [Dove](https://codeberg.org/celenity/Dove) are suites of configurations & advanced modifications for Mozilla Firefox & Thunderbird (respectively) with a focus on privacy, security, freedom, & usability.

Fix #379289.

Usage:

```nix
  environment.etc."firefox/defaults/pref/phoenix-desktop.js".source =
    "${pkgs.phoenix}/prefs/phoenix-desktop.js";
  environment.etc."firefox/phoenix/userjs".source = "${pkgs.phoenix}/userjs";
  environment.etc."firefox/phoenix/configs".source = "${pkgs.phoenix}/configs";

  environment.etc."thunderbird/defaults/pref/dove.js".source =
    "${pkgs.dove}/prefs/dove.js";

  nixpkgs.overlays = [
    (self: super: {
      # Alternatively, use programs.firefox options, but this way also works for home-manager:
      firefox = super.firefox.override {
        extraPoliciesFiles = [ "${pkgs.phoenix}/policies.json" ];
        extraPrefsFiles = [ "${pkgs.phoenix}/phoenix.cfg" ];
      };

      thunderbird = super.thunderbird.override {
        extraPoliciesFiles = [ "${pkgs.dove}/policies.json" ];
        extraPrefsFiles = [ "${pkgs.dove}/dove.cfg" ];
      };
    })
  ];
```

WARNING: by default phoenix config will delete browsing history when closing firefox (got to setting to re-enabled if needed)

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
