### PR TITLE
haskell.packages.ghc{90,810}.cabal2nix: fix build of dependency tar

### DIFF
--- a/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-8.10.x.nix
@@ -141,8 +141,16 @@ self: super: {
   # bundled with GHC < 9.0.
   wai-extra = dontHaddock super.wai-extra;
 
-  # Overly-strict bounds introducted by a revision in version 0.3.2.
-  text-metrics = doJailbreak super.text-metrics;
+  # tar > 0.6 requires os-string which can't be built with bytestring < 0.11
+  tar = overrideCabal (drv: {
+    jailbreak = true;
+    buildDepends = drv.buildDepends or [ ] ++ [
+      self.bytestring-handle
+    ];
+  }) self.tar_0_6_0_0;
+  # text-metrics >= 0.3.3 requires GHC2021
+  text-metrics = doDistribute (doJailbreak self.text-metrics_0_3_2);
+  bytestring-handle = unmarkBroken (doDistribute super.bytestring-handle);
 
   # Doesn't build with 9.0, see https://github.com/yi-editor/yi/issues/1125
   yi-core = doDistribute (markUnbroken super.yi-core);

--- a/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
+++ b/pkgs/development/haskell-modules/configuration-ghc-9.0.x.nix
@@ -70,6 +70,11 @@ self: super: {
 
   # Jailbreaks & Version Updates
 
+  # tar > 0.6 requires os-string which can't be built with bytestring < 0.11
+  tar = doDistribute (doJailbreak self.tar_0_6_0_0);
+  # text-metrics >= 0.3.3 requires GHC2021
+  text-metrics = doDistribute self.text-metrics_0_3_2;
+
   # For GHC < 9.4, some packages need data-array-byte as an extra dependency
   primitive = addBuildDepends [ self.data-array-byte ] super.primitive;
   # For GHC < 9.2, os-string is not required.

--- a/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
+++ b/pkgs/development/haskell-modules/configuration-hackage2nix/main.yaml
@@ -117,6 +117,8 @@ extra-packages:
   - extensions == 0.1.0.2               # 2024-10-20: for GHC 9.10/Cabal 3.12
   - network-run == 0.4.0                # 2024-10-20: for GHC 9.10/network == 3.1.*
   - ghc-source-gen < 0.4.6.0            # 2024-12-31: support GHC < 9.0
+  - tar == 0.6.0.0                      # 2025-02-08: last version to not require os-string (which can't be buil with GHC < 9.2)
+  - text-metrics < 0.3.3                # 2025-02-08: >= 0.3.3 uses GHC2021
 
 package-maintainers:
   abbradar:


### PR DESCRIPTION
- tar > 0.6.0.0 depends on os-string >= 2.0.0. All os-string versions require bytestring >= 0.11 (or even newer).
- text-metrics >= 0.3.3 requires the GHC2021 language extension group.
- For GHC 8.10.7, we need to additionally provide bytestring-handle.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
