### PR TITLE
python312Packages.pyannote-audio: 3.1.1 -> 3.1.2; python312Packages.gpytorch: 1.13 -> 1.14; python312Packages.botorch: 0.12.0 -> 0.13.0: python312Packages.optuna: 4.1.0 -> 4.2.0

### DIFF
--- a/pkgs/development/python-modules/ax-platform/default.nix
+++ b/pkgs/development/python-modules/ax-platform/default.nix
@@ -13,17 +13,19 @@
   pyfakefs,
   pyre-extensions,
   pytestCheckHook,
+  pythonAtLeast,
   pythonOlder,
   setuptools-scm,
   setuptools,
   sqlalchemy,
+  tabulate,
   typeguard,
   yappi,
 }:
 
 buildPythonPackage rec {
   pname = "ax-platform";
-  version = "0.4.3";
+  version = "0.5.0";
   pyproject = true;
 
   disabled = pythonOlder "3.10";
@@ -32,7 +34,7 @@ buildPythonPackage rec {
     owner = "facebook";
     repo = "ax";
     tag = version;
-    hash = "sha256-jmBjrtxqg4Iu3Qr0HRqjVfwURXzbJaGm+DBFNHYk/vA=";
+    hash = "sha256-CMKdnPvzQ9tvU9/01mRaWi/Beuyo19CtaXNJCoiwLOw=";
   };
 
   env.ALLOW_BOTORCH_LATEST = "1";
@@ -62,16 +64,13 @@ buildPythonPackage rec {
     mercurial
     pyfakefs
     pytestCheckHook
+    tabulate
     yappi
-  ] ++ lib.flatten (builtins.attrValues optional-dependencies);
+  ] ++ lib.flatten (lib.attrValues optional-dependencies);
 
   disabledTestPaths = [
     "ax/benchmark"
     "ax/runners/tests/test_torchx.py"
-    # requires pyre_extensions
-    "ax/telemetry/tests"
-    "ax/core/tests/test_utils.py"
-    "ax/early_stopping/tests/test_strategies.py"
     # broken with sqlalchemy 2
     "ax/core/tests/test_experiment.py"
     "ax/service/tests/test_ax_client.py"
@@ -80,16 +79,30 @@ buildPythonPackage rec {
     "ax/storage"
   ];
 
-  disabledTests = [
-    # exact comparison of floating points
-    "test_optimize_l0_homotopy"
-    # AssertionError: 5 != 2
-    "test_get_standard_plots_moo"
-    # AssertionError: Expected 'warning' to be called once. Called 3 times
-    "test_validate_kwarg_typing"
-    # uses torch.equal
-    "test_convert_observations"
-  ];
+  disabledTests =
+    [
+      # exact comparison of floating points
+      "test_optimize_l0_homotopy"
+      # AssertionError: 5 != 2
+      "test_get_standard_plots_moo"
+      # AssertionError: Expected 'warning' to be called once. Called 3 times
+      "test_validate_kwarg_typing"
+      # uses torch.equal
+      "test_convert_observations"
+      # broken with sqlalchemy 2
+      "test_sql_storage"
+    ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      #  Both `metric_aggregation` and `criterion` must be `ReductionCriterion`
+      "test_SingleDiagnosticBestModelSelector_max_mean"
+      "test_SingleDiagnosticBestModelSelector_min_mean"
+      "test_SingleDiagnosticBestModelSelector_min_min"
+      "test_SingleDiagnosticBestModelSelector_model_cv_kwargs"
+      "test_init"
+      "test_gen"
+      # "use MIN or MAX" does not match "Both `metric_aggregation` and `criterion` must be `ReductionCriterion`
+      "test_user_input_error"
+    ];
 
   pythonImportsCheck = [ "ax" ];
 

--- a/pkgs/development/python-modules/botorch/default.nix
+++ b/pkgs/development/python-modules/botorch/default.nix
@@ -6,24 +6,26 @@
   gpytorch,
   linear-operator,
   multipledispatch,
+  pyre-extensions,
   pyro-ppl,
   setuptools,
   setuptools-scm,
   torch,
   scipy,
   pytestCheckHook,
+  pythonAtLeast,
 }:
 
 buildPythonPackage rec {
   pname = "botorch";
-  version = "0.12.0";
+  version = "0.13.0";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "pytorch";
     repo = "botorch";
     tag = "v${version}";
-    hash = "sha256-CKlerCUadObpPq4jQAiFDBOZMHZ4QccAKQz30OFe64E=";
+    hash = "sha256-Hik0HPHFoN1+uIeVxG7UPKc1ADBoTTBkL2+LhHDrr+s=";
   };
 
   build-system = [
@@ -35,14 +37,10 @@ buildPythonPackage rec {
     gpytorch
     linear-operator
     multipledispatch
+    pyre-extensions
     pyro-ppl
     scipy
     torch
-  ];
-
-  pythonRelaxDeps = [
-    "gpytorch"
-    "linear-operator"
   ];
 
   nativeCheckInputs = [ pytestCheckHook ];
@@ -55,9 +53,17 @@ buildPythonPackage rec {
 
   disabledTests =
     [ "test_all_cases_covered" ]
+    ++ lib.optionals (pythonAtLeast "3.13") [
+      # RuntimeError: Boolean value of Tensor with more than one value is ambiguous
+      "test_optimize_acqf_mixed_binary_only"
+    ]
     ++ lib.optionals (stdenv.buildPlatform.system == "x86_64-linux") [
       # stuck tests on hydra
       "test_moo_predictive_entropy_search"
+    ]
+    ++ lib.optionals (stdenv.hostPlatform.isDarwin) [
+      # RuntimeError: required keyword attribute 'value' has the wrong type
+      "test_posterior_in_trace_mode"
     ]
     ++ lib.optionals (stdenv.hostPlatform.isDarwin && stdenv.hostPlatform.isAarch64) [
       # Numerical error slightly above threshold

--- a/pkgs/development/python-modules/gpytorch/default.nix
+++ b/pkgs/development/python-modules/gpytorch/default.nix
@@ -15,14 +15,14 @@
 
 buildPythonPackage rec {
   pname = "gpytorch";
-  version = "1.13";
+  version = "1.14";
   pyproject = true;
 
   src = fetchFromGitHub {
     owner = "cornellius-gp";
     repo = pname;
     tag = "v${version}";
-    hash = "sha256-jdEJdUFIyM7TTKUHY8epjyZCGolH8nrr7FCyfw+x56s=";
+    hash = "sha256-whZjqAs3nyjKMzAGi+OnyBtboq0UuV8m11A4IzkWtec=";
   };
 
   build-system = [

--- a/pkgs/development/python-modules/pyannote-audio/default.nix
+++ b/pkgs/development/python-modules/pyannote-audio/default.nix
@@ -31,7 +31,7 @@
 
 buildPythonPackage rec {
   pname = "pyannote-audio";
-  version = "3.3.1";
+  version = "3.3.2";
   pyproject = true;
 
   disabled = pythonOlder "3.9";
@@ -40,7 +40,7 @@ buildPythonPackage rec {
     owner = "pyannote";
     repo = "pyannote-audio";
     tag = version;
-    hash = "sha256-85whRoc3JoDSE4DqivY/3hfvLHcvgsubR/DLCPtLEP0=";
+    hash = "sha256-Qx7NDXkT3eQr9PZXlYuoJD01dzsVCvfq6HNPnyLzyAQ=";
     fetchSubmodules = true;
   };
 

--- a/pkgs/development/python-modules/resampy/default.nix
+++ b/pkgs/development/python-modules/resampy/default.nix
@@ -1,19 +1,22 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
-  cython,
   fetchFromGitHub,
   numba,
   numpy,
+  optuna,
+  pytest-cov-stub,
   pytestCheckHook,
   pythonOlder,
+  setuptools,
   scipy,
 }:
 
 buildPythonPackage rec {
   pname = "resampy";
   version = "0.4.3";
-  format = "setuptools";
+  pyproject = true;
 
   disabled = pythonOlder "3.7";
 
@@ -24,21 +27,26 @@ buildPythonPackage rec {
     hash = "sha256-LOWpOPAEK+ga7c3bR15QvnHmON6ARS1Qee/7U/VMlTY=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
-    cython
     numba
   ];
 
+  optional-dependencies.design = [ optuna ];
+
   nativeCheckInputs = [
+    pytest-cov-stub
     pytestCheckHook
     scipy
-  ];
+  ] ++ optional-dependencies.design;
 
-  postPatch = ''
-    substituteInPlace setup.cfg \
-      --replace " --cov-report term-missing --cov resampy --cov-report=xml" ""
-  '';
+  disabledTests = lib.optionals (stdenv.hostPlatform.system == "aarch64-linux") [
+    # crashing the interpreter
+    "test_quality_sine_parallel"
+    "test_resample_nu_quality_sine_parallel"
+  ];
 
   pythonImportsCheck = [ "resampy" ];
 

--- a/pkgs/development/python-modules/synergy/default.nix
+++ b/pkgs/development/python-modules/synergy/default.nix
@@ -1,31 +1,36 @@
 {
   lib,
+  stdenv,
   buildPythonPackage,
   fetchFromGitHub,
-  pytestCheckHook,
   pythonOlder,
+  setuptools,
   numpy,
   scipy,
   matplotlib,
   plotly,
   pandas,
+  hypothesis,
+  pytestCheckHook,
 }:
 
 buildPythonPackage rec {
   pname = "synergy";
   version = "1.0.0";
-  format = "setuptools";
+  pyproject = true;
+
   disabled = pythonOlder "3.5";
 
-  # Pypi does not contain unit tests
   src = fetchFromGitHub {
     owner = "djwooten";
     repo = "synergy";
     tag = "v${version}";
-    sha256 = "sha256-df5CBEcRx55/rSMc6ygMVrHbbEcnU1ISJheO+WoBSCI=";
+    hash = "sha256-df5CBEcRx55/rSMc6ygMVrHbbEcnU1ISJheO+WoBSCI=";
   };
 
-  propagatedBuildInputs = [
+  build-system = [ setuptools ];
+
+  dependencies = [
     numpy
     scipy
     matplotlib
@@ -33,7 +38,25 @@ buildPythonPackage rec {
     pandas
   ];
 
-  nativeCheckInputs = [ pytestCheckHook ];
+  nativeCheckInputs = [
+    hypothesis
+    pytestCheckHook
+  ];
+
+  disabledTests =
+    [
+      # flaky: hypothesis.errors.FailedHealthCheck
+      "test_asymptotic_limits"
+      "test_inverse"
+      # AssertionError: synthetic_BRAID_reference_1.csv
+      #  E3=0 not in (0.10639582639915163, 1.6900177333904622)
+      "test_BRAID_fit_bootstrap"
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [
+      # AssertionError: np.False_ is not true
+      "test_fit_loewe_antagonism"
+    ];
+
   pythonImportsCheck = [ "synergy" ];
 
   meta = with lib; {


### PR DESCRIPTION
https://github.com/cornellius-gp/gpytorch/compare/refs/tags/v1.13...v1.14
https://github.com/pytorch/botorch/blob/refs/tags/v0.13.0/CHANGELOG.md
https://github.com/optuna/optuna/releases/tag/4.2.0
https://github.com/pyannote/pyannote-audio/blob/refs/tags/3.3.2/CHANGELOG.md
https://github.com/facebook/Ax/releases/tag/0.5.0

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
