### PR TITLE
nexusmods-app: add release-note for resetting before upgrading

### DIFF
--- a/doc/redirects.json
+++ b/doc/redirects.json
@@ -86,6 +86,9 @@
     "index.html#building-a-titanium-app",
     "index.html#emulating-or-simulating-the-app"
   ],
+  "sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded": [
+    "release-notes.html#sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded"
+  ],
   "sec-nixpkgs-release-25.05-lib": [
     "release-notes.html#sec-nixpkgs-release-25.05-lib"
   ],

--- a/doc/release-notes/rl-2505.section.md
+++ b/doc/release-notes/rl-2505.section.md
@@ -18,6 +18,16 @@
 
 - `titaniumenv`, `titanium`, and `titanium-alloy` have been removed due to lack of maintenance in Nixpkgs.
 
+### NexusMods.App upgraded {#sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded}
+
+- `nexusmods-app` has been upgraded from version 0.6.3 to 0.7.3.
+
+  - Before upgrading, you **must reset all app state** (mods, games, settings, etc). NexusMods.App will crash if any state from a version older than 0.7.0 is still present.
+
+  - Typically, you can can reset to a clean state by running `NexusMods.App uninstall-app`. See Nexus Mod's [how to uninstall the app](https://nexus-mods.github.io/NexusMods.App/users/Uninstall) documentation for more detail and alternative methods.
+
+  - This should not be necessary going forward, because loading app state from 0.7.0 or newer is now supported. This is documented in the [0.7.1 changelog](https://github.com/Nexus-Mods/NexusMods.App/releases/tag/v0.7.1).
+
 ## Nixpkgs Library {#sec-nixpkgs-release-25.05-lib}
 
 ### Breaking changes {#sec-nixpkgs-release-25.05-lib-breaking}

--- a/nixos/doc/manual/redirects.json
+++ b/nixos/doc/manual/redirects.json
@@ -1922,6 +1922,9 @@
     "index.html#building-a-titanium-app",
     "index.html#emulating-or-simulating-the-app"
   ],
+  "sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded": [
+    "release-notes.html#sec-nixpkgs-release-25.05-incompatibilities-nexusmods-app-upgraded"
+  ],
   "sec-nixpkgs-release-25.05-lib": [
     "release-notes.html#sec-nixpkgs-release-25.05-lib"
   ],


### PR DESCRIPTION
24.11 includes nexusmods-app version 0.6.3, while 25.05 currently has version 0.7.3.

Unfortunately, nexusmods-app is only able to load state from version 0.7.0 and newer. This is because NexusMods.App is still alpha software; until 0.7.1 no method of importing _old_ app state had been implemented.

To clarify, app state includes not only its settings, but also things like "managed" game directories, downloaded mods, etc.

Because 24.11 has a version older than 0.7.0, end-users must be instructed to reset to a clean state themselves, ideally _before_ upgrading. If they do not, the app will crash while attempting to load its state.

Since this is a _breaking change_ for anyone upgrading from 24.11 to 25.05, I've added a "backwards incompatiblity" item to the release notes.

Since the release note explicitly mentions 25.05's nexusmods-app package version, we'll have to remember to update the release notes in future package package updates.

---

I wasn't sure how to use the `redirects add-content` tool correctly, so I ended up adding the redirects manually.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->


<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
