### PR TITLE
python-modules.appengine-python-standard: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -17241,6 +17241,12 @@
     githubId = 1237862;
     name = "Ollie Bunting";
   };
+  ollyfg = {
+    name = "Oliver Fawcett";
+    email = "oliver@fawcetts.nz";
+    github = "ollyfg";
+    githubId = 8495389;
+  };
   oluceps = {
     email = "nixos@oluceps.uk";
     github = "oluceps";

--- a/pkgs/development/python-modules/appengine-python-standard/default.nix
+++ b/pkgs/development/python-modules/appengine-python-standard/default.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  fetchPypi,
+  pytestCheckHook,
+  pythonOlder,
+  callPackage,
+
+  setuptools,
+
+  attrs,
+  frozendict,
+  google-auth,
+  mock,
+  pillow,
+  protobuf,
+  pytz,
+  requests,
+  ruamel-yaml,
+  six,
+  urllib3,
+}:
+
+buildPythonPackage rec {
+  pname = "appengine-python-standard";
+  version = "1.1.9";
+  pyproject = true;
+
+  disabled = pythonOlder "3.7";
+
+  src = fetchFromGitHub {
+    owner = "GoogleCloudPlatform";
+    repo = "appengine-python-standard";
+    tag = "v${version}";
+    hash = "sha256-XsqBhuSKm0OvvhT/BNWo4ca5FKrVVIsSVsHaXHNn16s=";
+  };
+
+  build-system = [
+    setuptools
+  ];
+
+  dependencies =
+    let
+      urllib3_v1 = urllib3.overridePythonAttrs (old: rec {
+        version = "1.26.20";
+        src = fetchPypi {
+          pname = "urllib3";
+          inherit version;
+          hash = "sha256-QMLcDGgeR+uPkOfie/b/ffLmd0If1GdW2hFhw5ynDTI=";
+        };
+      });
+    in
+    [
+      attrs
+      frozendict
+      google-auth
+      mock
+      pillow
+      protobuf
+      pytz
+      requests
+      ruamel-yaml
+      six
+      urllib3_v1
+    ];
+
+  nativeCheckInputs = [ pytestCheckHook ];
+
+  pythonImportsCheck = [ "appengine-python-standard" ];
+
+  meta = {
+    homepage = "https://github.com/GoogleCloudPlatform/appengine-python-standard";
+    description = "Google App Engine services SDK for Python 3";
+    license = lib.licenses.asl20;
+    maintainers = with lib.maintainers; [ ollyfg ];
+  };
+}

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -718,6 +718,8 @@ self: super: with self; {
 
   apollo-fpga = callPackage ../development/python-modules/apollo-fpga { };
 
+  appengine-python-standard = callPackage ../development/python-modules/appengine-python-standard { };
+
   app-model = callPackage ../development/python-modules/app-model { };
 
   appdirs = callPackage ../development/python-modules/appdirs { };


### PR DESCRIPTION
This PR adds a new python package: appengine-python-standard.

This is used when writing services that use Google's managed App Engine environment.
More details on the Github repository for this package: https://github.com/GoogleCloudPlatform/appengine-python-standard

I am adding this because it is used in one of my personal projects, so I'm happy to maintain it.

This PR is a draft while I figure out a few things (and review some other PRs).

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
