### PR TITLE
perlPackages.BioExtAlign: bug fix and add test

### DIFF
--- a/pkgs/by-name/ke/kent/package.nix
+++ b/pkgs/by-name/ke/kent/package.nix
@@ -53,7 +53,7 @@ stdenv.mkDerivation rec {
     export HOME=$TMPDIR
     export DESTBINDIR=$HOME/bin
 
-    mkdir -p $HOME/lib $HOME/bin/x86_64
+    mkdir -p $HOME/lib $HOME/bin/${stdenv.hostPlatform.parsed.cpu.name}
 
     cd ./src
     chmod +x ./checkUmask.sh
@@ -63,8 +63,8 @@ stdenv.mkDerivation rec {
     cd jkOwnLib
     make
 
-    cp ../lib/x86_64/jkOwnLib.a $HOME/lib
-    cp ../lib/x86_64/jkweb.a $HOME/lib
+    cp ../lib/${stdenv.hostPlatform.parsed.cpu.name}/jkOwnLib.a $HOME/lib
+    cp ../lib/${stdenv.hostPlatform.parsed.cpu.name}/jkweb.a $HOME/lib
     cp -r ../inc  $HOME/
 
     cd ../utils
@@ -79,7 +79,7 @@ stdenv.mkDerivation rec {
     mkdir -p $out/bin $out/lib $out/inc
     cp $HOME/lib/jkOwnLib.a $out/lib
     cp $HOME/lib/jkweb.a $out/lib
-    cp $HOME/bin/x86_64/* $out/bin
+    cp $HOME/bin/${stdenv.hostPlatform.parsed.cpu.name}/* $out/bin
     cp -r $HOME/inc/* $out/inc/
 
     runHook postInstall

--- a/pkgs/development/perl-modules/Bio-Ext-Align/default.nix
+++ b/pkgs/development/perl-modules/Bio-Ext-Align/default.nix
@@ -8,10 +8,7 @@ buildPerlPackage rec {
   pname = "BioExtAlign";
   version = "1.5.1";
 
-  outputs = [
-    "out"
-    "dev"
-  ];
+  outputs = [ "out" ];
 
   src = fetchFromGitHub {
     owner = "bioperl";
@@ -20,7 +17,15 @@ buildPerlPackage rec {
     sha256 = "sha256-+0tZ6q3PFem8DWa2vq+njOLmjDvMB0JhD0FGk00lVMA=";
   };
 
-  patches = [ ./fprintf.patch ];
+  patches = [
+    # Starting for Perl 5.6, implicit function declaration are treated as errors
+    # There may be an error but ensembl-vep (the main package for this dependency)
+    # runs
+    ./no-implicit-function.patch
+    # Tests need other parts of BioExt, disabling them
+    ./disable-other-tests.patch
+    ./fprintf.patch
+  ];
 
   # Do not install other Bio-ext packages
   preConfigure = ''
@@ -30,6 +35,15 @@ buildPerlPackage rec {
   # Disable tests as it requires Bio::Tools::Align which is in a different directory
   buildPhase = ''
     make
+
+  '';
+
+  checkPhase = ''
+    runHook preCheck
+
+    make test
+
+    runHook postCheck
   '';
 
   meta = {
@@ -39,5 +53,6 @@ buildPerlPackage rec {
       Part of BioPerl Extensions (BioPerl-Ext) distribution, a collection of Bioperl C-compiled extensions.
     '';
     license = with lib.licenses; [ artistic1 ];
+    maintainers = with lib.maintainers; [ apraga ];
   };
 }

--- a/pkgs/development/perl-modules/Bio-Ext-Align/default.nix
+++ b/pkgs/development/perl-modules/Bio-Ext-Align/default.nix
@@ -35,7 +35,6 @@ buildPerlPackage rec {
   # Disable tests as it requires Bio::Tools::Align which is in a different directory
   buildPhase = ''
     make
-
   '';
 
   checkPhase = ''

--- a/pkgs/development/perl-modules/Bio-Ext-Align/disable-other-tests.patch
+++ b/pkgs/development/perl-modules/Bio-Ext-Align/disable-other-tests.patch
@@ -1,0 +1,84 @@
+diff --git a/Bio/Ext/Align/test.pl b/Bio/Ext/Align/test.pl
+index 72411f3..1deb77b 100755
+--- a/Bio/Ext/Align/test.pl
++++ b/Bio/Ext/Align/test.pl
+@@ -8,13 +8,10 @@ my $DEBUG = $ENV{'BIOPERLDEBUG'} || 0;
+ BEGIN {
+     eval { require Test; };
+     use Test;
+-    plan tests => 9;
++    plan tests => 4;
+ }
+ 
+ use Bio::Ext::Align;
+-use Bio::Tools::dpAlign;
+-use Bio::Seq;
+-use Bio::AlignIO;
+ 
+ $loaded = 1;
+ ok(1); # modules loaded
+@@ -34,64 +31,3 @@ $alb = &Bio::Ext::Align::Align_Sequences_ProteinSmithWaterman($seq1,$seq2,
+ 					 $seq2->seq,15,50,STDERR) if $DEBUG;
+ 
+ 
+-warn( "Testing Local Alignment case...\n") if $DEBUg;
+-
+-$alnout = new Bio::AlignIO(-format => 'pfam', -fh => \*STDERR);
+-$aln = &Bio::Ext::Align::Align_DNA_Sequences("AATGCCATTGACGG",
+-					     "CAGCCTCGCTTAG",3,-1,3,1,
+-		      Bio::Tools::dpAlign::DPALIGN_LOCAL_MILLER_MYERS);
+-
+-$out = Bio::SimpleAlign->new();
+-
+-$out->add_seq(Bio::LocatableSeq->new(-seq   => $aln->aln1,
+-				     -start => $aln->start1,
+-				     -end   => $aln->end1,
+-				     -id    => "one"));
+-
+-$out->add_seq(Bio::LocatableSeq->new(-seq   => $aln->aln2,
+-				     -start => $aln->start2,
+-				     -end   => $aln->end2,
+-				     -id    => "two"));
+-$alnout->write_aln($out) if $DEBUG;
+-
+-$aln = &Bio::Ext::Align::Align_Protein_Sequences("WLGQRNLVSSTGGNLLNVWLKDW","WMGNRNVVNLLNVWFRDW",0,
+-						 Bio::Tools::dpAlign::DPALIGN_LOCAL_MILLER_MYERS);
+-$out = Bio::SimpleAlign->new();
+-ok($aln);
+-
+-$out->add_seq(Bio::LocatableSeq->new(-seq   => $aln->aln1,
+-				     -start => $aln->start1,
+-				     -end   => $aln->end1,
+-				     -id    => "one"));
+-
+-$out->add_seq(Bio::LocatableSeq->new(-seq   => $aln->aln2,
+-				     -start => $aln->start2,
+-				     -end   => $aln->end2,
+-				     -id    => "two"));
+-$alnout->write_aln($out) if $DEBUG;
+-ok(1);
+-
+-warn( "Testing Global Alignment case...\n") if $DEBUG;
+-
+-$factory = new Bio::Tools::dpAlign('-alg' => Bio::Tools::dpAlign::DPALIGN_GLOBAL_MILLER_MYERS);
+-$s1 = new Bio::Seq(-id => "one", -seq => "AATGCCATTGACGG", -alphabet => 'dna');
+-$s2 = new Bio::Seq(-id => "two", -seq => "CAGCCTCGCTTAG", -alphabet => 'dna');
+-$aln = $factory->pairwise_alignment($s1, $s2);
+-$alnout->write_aln($aln) if $DEBUG;
+-$factory->align_and_show($s1, $s2) if $DEBUG;
+-
+-ok(1);
+-
+-$s1 = new Bio::Seq(-id => "one", -seq => "WLGQRNLVSSTGGNLLNVWLKDW", 
+-		   -alphabet => 'protein');
+-$s2 = new Bio::Seq(-id => "two", -seq => "WMGNRNVVNLLNVWFRDW", 
+-		   -alphabet => 'protein');
+-$aln = $factory->pairwise_alignment($s1, $s2);
+-$alnout->write_aln($aln) if $DEBUG;
+-$factory->align_and_show($s1, $s2) if $DEBUG;
+-ok(1);
+-
+-$prof = $factory->sequence_profile($s1);
+-warn( "Optimal Alignment Score = %d\n", $factory->pairwise_alignment_score($prof, $s2)) if $DEBUG;
+-
+-ok($factory->pairwise_alignment_score($prof,$s2),77);

--- a/pkgs/development/perl-modules/Bio-Ext-Align/fprintf.patch
+++ b/pkgs/development/perl-modules/Bio-Ext-Align/fprintf.patch
@@ -7,7 +7,7 @@ index 0e07b67..0eab932 100644
  dpAlign_fatal(char * s)
  {
 -    fprintf(stderr, s);
-+    fputs(stderr, s);
++    fputs(s, stderr);
      exit(-1);
  }
  

--- a/pkgs/development/perl-modules/Bio-Ext-Align/no-implicit-function.patch
+++ b/pkgs/development/perl-modules/Bio-Ext-Align/no-implicit-function.patch
@@ -1,0 +1,13 @@
+diff --git a/Bio/Ext/Align/Makefile.PL b/Bio/Ext/Align/Makefile.PL
+index cc6c343..ea5cffa 100755
+--- a/Bio/Ext/Align/Makefile.PL
++++ b/Bio/Ext/Align/Makefile.PL
+@@ -5,7 +5,7 @@ WriteMakefile(
+     'NAME'	=> 'Bio::Ext::Align',
+     'VERSION'	=> '1.5.1',
+     'LIBS'	=> ['-lm'],   # e.g., '-lm' 
+-    'DEFINE'	=> '-DPOSIX -DNOERROR',     # e.g., '-DHAVE_SOMETHING' 
++    'DEFINE'	=> '-DPOSIX -DNOERROR -Wno-implicit-function-declaration',     # e.g., '-DHAVE_SOMETHING'
+     'INC'	=> '-I./libs',     # e.g., '-I/usr/include/other'
+     'MYEXTLIB'  => 'libs/libsw$(LIB_EXT)',
+     'clean'     => { 'FILES' => 'libs/*.o libs/*.a' }


### PR DESCRIPTION
Bug: with perl > 5.36, the compiler is more restrictive with errors. This package has implicit function definitions. The fix is to ignore the errors as vep, the main package for that, runs without issue. Also this package is no longer maintained

We also add test that were missing from the package. Not all test can be run as they depends on other Perl modules in Bioper.

Basic functionnality was tested by hand with `vep` 

```
vep -i ~/Downloads/homo_sapiens_GRCh38.vcf --assembly GRCh38 --species homo_sapiens --merged --cache  --cache_version 110 --dir_cache .
```


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [X] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
