### PR TITLE
steel: init at 0.6.0-unstable-2025-02-27

### DIFF
--- a/pkgs/by-name/st/steel/package.nix
+++ b/pkgs/by-name/st/steel/package.nix
@@ -1,0 +1,126 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  curl,
+  pkg-config,
+  makeBinaryWrapper,
+  libgit2,
+  oniguruma,
+  openssl,
+  sqlite,
+  zlib,
+
+  unstableGitUpdater,
+  writeShellScript,
+  yq,
+
+  includeLSP ? true,
+  includeForge ? true,
+}:
+rustPlatform.buildRustPackage {
+  pname = "steel";
+  version = "0.6.0-unstable-2025-02-27";
+
+  src = fetchFromGitHub {
+    owner = "mattwparas";
+    repo = "steel";
+    rev = "f1a605a0f3fe321f4605a80c4497eda2eac5ffce";
+    hash = "sha256-3Iqoy2J9wY3T5jOSjtEk1aT+Q3ncNmmpQ/LY/iyvKuY=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-PWE64CwHCQWvOGeOqdsqX6rAruWlnCwsQpcxS221M3g=";
+
+  nativeBuildInputs = [
+    curl
+    makeBinaryWrapper
+    pkg-config
+    rustPlatform.bindgenHook
+  ];
+
+  buildInputs = [
+    curl
+    libgit2
+    oniguruma
+    openssl
+    sqlite
+    zlib
+  ];
+
+  postPatch = ''
+    rm .cargo/config.toml
+  '';
+
+  cargoBuildFlags =
+    [
+      "--package"
+      "steel-interpreter"
+      "--package"
+      "cargo-steel-lib"
+    ]
+    ++ lib.optionals includeLSP [
+      "--package"
+      "steel-language-server"
+    ]
+    ++ lib.optionals includeForge [
+      "--package"
+      "forge"
+    ];
+
+  # Tests are disabled since they always fail when building with Nix
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/lib/steel
+
+    substituteInPlace cogs/installer/download.scm \
+      --replace-fail '"cargo-steel-lib"' '"$out/bin/cargo-steel-lib"'
+
+    pushd cogs
+    $out/bin/steel install.scm
+    popd
+
+    mv $out/lib/steel/bin/repl-connect $out/bin
+    rm -rf $out/lib/steel/bin
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/steel --set-default STEEL_HOME "$out/lib/steel"
+  '';
+
+  env = {
+    OPENSSL_NO_VENDOR = true;
+    RUSTONIG_SYSTEM_LIBONIG = true;
+    STEEL_HOME = "${placeholder "out"}/lib/steel";
+  };
+
+  passthru.updateScript = unstableGitUpdater {
+    tagConverter = writeShellScript "steel-tagConverter.sh" ''
+      export PATH="${
+        lib.makeBinPath [
+          curl
+          yq
+        ]
+      }:$PATH"
+
+      version=$(curl -s https://raw.githubusercontent.com/mattwparas/steel/refs/heads/master/Cargo.toml | tomlq -r .workspace.package.version)
+
+      read -r tag
+      test "$tag" = "0" && tag="$version"; echo "$tag"
+    '';
+  };
+
+  meta = {
+    description = "Embedded scheme interpreter in Rust";
+    homepage = "https://github.com/mattwparas/steel";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    maintainers = with lib.maintainers; [ HeitorAugustoLN ];
+    mainProgram = "steel";
+    platforms = lib.platforms.unix;
+    sourceProvenance = [ lib.sourceTypes.fromSource ];
+  };
+}


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

- Adds [steel](https://github.com/mattwparas/steel), an embedded scheme interpreter in Rust.

![merge sort in steel](https://github.com/user-attachments/assets/194c08c6-4aa5-4fb9-86fa-10c20b56d43f)


## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
