### PR TITLE
sdl2-compat: init at 2.30.52

### DIFF
--- a/pkgs/by-name/sd/sdl2-compat/package.nix
+++ b/pkgs/by-name/sd/sdl2-compat/package.nix
@@ -1,0 +1,98 @@
+{
+  cmake,
+  lib,
+  fetchFromGitHub,
+  monado,
+  ninja,
+  nix-update-script,
+  SDL2_ttf,
+  SDL2_net,
+  SDL2_gfx,
+  SDL2_sound,
+  SDL2_mixer,
+  SDL2_image,
+  sdl3,
+  stdenv,
+  testers,
+  testSupport ? true,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "sdl2-compat";
+  version = "2.30.52";
+
+  src = fetchFromGitHub {
+    owner = "libsdl-org";
+    repo = "sdl2-compat";
+    tag = "release-${finalAttrs.version}";
+    hash = "sha256-pdY+yrLWIjMTjmKdYvX4DjzXy2cKaw6P90BPu8K163k";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+  ];
+
+  buildInputs = [
+    sdl3
+  ];
+
+  outputs = [
+    "out"
+    "dev"
+  ];
+
+  outputBin = "dev";
+
+  cmakeFlags = [
+    (lib.cmakeBool "SDL2COMPAT_TESTS" finalAttrs.finalPackage.doCheck)
+  ];
+
+  doCheck = testSupport && stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+
+  postFixup =
+    if stdenv.hostPlatform.isDarwin then
+      ''
+        install_name_tool -add_rpath ${lib.makeLibraryPath [ sdl3 ]} $out/lib/libSDL2.dylib
+      ''
+    else
+      ''
+        patchelf --add-rpath ${lib.makeLibraryPath [ sdl3 ]} $out/lib/libSDL2.so
+      '';
+
+  passthru = {
+    tests =
+      let
+        replaceSDL2 = drv: drv.override { SDL2 = finalAttrs.finalPackage; };
+      in
+      {
+        pkg-config = testers.hasPkgConfigModules { package = finalAttrs.finalPackage; };
+        SDL2_ttf = replaceSDL2 SDL2_ttf;
+        SDL2_net = replaceSDL2 SDL2_net;
+        SDL2_gfx = replaceSDL2 SDL2_gfx;
+        SDL2_sound = replaceSDL2 SDL2_sound;
+        SDL2_mixer = replaceSDL2 SDL2_mixer;
+        SDL2_image = replaceSDL2 SDL2_image;
+      }
+      // lib.optionalAttrs stdenv.hostPlatform.isLinux {
+        monado = replaceSDL2 monado;
+      };
+
+    updateScript = nix-update-script {
+      extraArgs = [
+        "--version-regex"
+        "release-(.*)"
+      ];
+    };
+  };
+
+  meta = {
+    description = "SDL2 compatibility layer that uses SDL3 behind the scenes";
+    homepage = "https://libsdl.org";
+    changelog = "https://github.com/libsdl-org/sdl2-compat/releases/tag/${finalAttrs.src.tag}";
+    license = lib.licenses.zlib;
+    maintainers = with lib.maintainers; [ nadiaholmquist ];
+    platforms = lib.platforms.unix;
+    pkgConfigModules = [ "sdl2_compat" ];
+  };
+})


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Adds sdl2-compat, the SDL3-based compatibility layer for SDL2 applications. See the repo at https://github.com/libsdl-org/sdl2-compat for more info.

I tried to match the same outputs as the SDL2 package so that this can be used as a drop-in replacement for it.

I have done some basic testing of this using the VVVVVV game as packaged in nixpkgs on both x86_64-linux and aarch64-darwin and it seems to work. However, testing of more stuff before merging would probably be good, if there's anything people can think of that would be good to try.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
