### PR TITLE
onnxruntime: Add support for openvino execution provider

### DIFF
--- a/pkgs/by-name/op/openvino/cmake-install-paths.patch
+++ b/pkgs/by-name/op/openvino/cmake-install-paths.patch
@@ -1,0 +1,145 @@
+--- a/cmake/developer_package/packaging/archive.cmake
++++ b/cmake/developer_package/packaging/archive.cmake
+@@ -25,14 +25,15 @@ endif()
+ macro(ov_archive_cpack_set_dirs)
+     # common "archive" package locations
+     # TODO: move current variables to OpenVINO specific locations
+-    set(OV_CPACK_INCLUDEDIR runtime/include)
+-    set(OV_CPACK_OPENVINO_CMAKEDIR runtime/cmake)
+-    set(OV_CPACK_DOCDIR docs)
+-    set(OV_CPACK_LICENSESDIR licenses)
+-    set(OV_CPACK_SAMPLESDIR samples)
++    set(OV_CPACK_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
++    set(OV_CPACK_OPENVINO_CMAKEDIR "${CMAKE_INSTALL_FULL_LIBDIR}/cmake/openvino")
++    set(OV_CPACK_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/openvino")
++    set(OV_CPACK_LICENSESDIR "${CMAKE_INSTALL_DATAROOTDIR}/licenses/openvino")
++    set(OV_CPACK_SAMPLESDIR "${CMAKE_INSTALL_DATAROOTDIR}/openvino/samples")
+     set(OV_CPACK_WHEELSDIR wheels)
+     set(OV_CPACK_DEVREQDIR tools)
+-    set(OV_CPACK_PYTHONDIR python)
++    find_package(Python QUIET REQUIRED COMPONENTS Interpreter Development)
++    set(OV_CPACK_PYTHONDIR "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+ 
+     if(USE_BUILD_TYPE_SUBFOLDER)
+         set(build_type ${CMAKE_BUILD_TYPE})
+@@ -49,11 +50,11 @@ macro(ov_archive_cpack_set_dirs)
+         set(OV_CPACK_RUNTIMEDIR runtime/lib/${ARCH_FOLDER}/${build_type})
+         set(OV_CPACK_ARCHIVEDIR runtime/lib/${ARCH_FOLDER}/${build_type})
+     else()
+-        set(OV_CPACK_LIBRARYDIR runtime/lib/${ARCH_FOLDER})
+-        set(OV_CPACK_RUNTIMEDIR runtime/lib/${ARCH_FOLDER})
+-        set(OV_CPACK_ARCHIVEDIR runtime/lib/${ARCH_FOLDER})
++        set(OV_CPACK_LIBRARYDIR "${CMAKE_INSTALL_LIBDIR}")
++        set(OV_CPACK_RUNTIMEDIR "${CMAKE_INSTALL_LIBDIR}")
++        set(OV_CPACK_ARCHIVEDIR "${CMAKE_INSTALL_LIBDIR}")
+     endif()
+-    set(OV_CPACK_PLUGINSDIR ${OV_CPACK_RUNTIMEDIR})
++    set(OV_CPACK_PLUGINSDIR "${OV_CPACK_RUNTIMEDIR}/openvino")
+ endmacro()
+ 
+ ov_archive_cpack_set_dirs()
+@@ -78,9 +79,9 @@ macro(ov_define_component_include_rules)
+     # licensing
+     unset(OV_CPACK_COMP_LICENSING_EXCLUDE_ALL)
+     # samples
+-    unset(OV_CPACK_COMP_CPP_SAMPLES_EXCLUDE_ALL)
+-    unset(OV_CPACK_COMP_C_SAMPLES_EXCLUDE_ALL)
+-    unset(OV_CPACK_COMP_PYTHON_SAMPLES_EXCLUDE_ALL)
++    set(OV_CPACK_COMP_CPP_SAMPLES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
++    set(OV_CPACK_COMP_C_SAMPLES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
++    set(OV_CPACK_COMP_PYTHON_SAMPLES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
+     # python
+     unset(OV_CPACK_COMP_PYTHON_OPENVINO_EXCLUDE_ALL)
+     unset(OV_CPACK_COMP_BENCHMARK_APP_EXCLUDE_ALL)
+@@ -92,8 +93,8 @@ macro(ov_define_component_include_rules)
+     # nodejs
+     set(OV_CPACK_COMP_NPM_EXCLUDE_ALL EXCLUDE_FROM_ALL)
+     # scripts
+-    unset(OV_CPACK_COMP_INSTALL_DEPENDENCIES_EXCLUDE_ALL)
+-    unset(OV_CPACK_COMP_SETUPVARS_EXCLUDE_ALL)
++    set(OV_CPACK_COMP_INSTALL_DEPENDENCIES_EXCLUDE_ALL EXCLUDE_FROM_ALL)
++    set(OV_CPACK_COMP_SETUPVARS_EXCLUDE_ALL EXCLUDE_FROM_ALL)
+     # pkgconfig
+     set(OV_CPACK_COMP_PKG_CONFIG_EXCLUDE_ALL ${OV_CPACK_COMP_CORE_DEV_EXCLUDE_ALL})
+     # symbolic links
+--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
++++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+@@ -28,7 +28,7 @@ ov_add_target(ADD_CPPLINT
+                       npu_tools_utils)
+ 
+ set_target_properties(${TARGET_NAME} PROPERTIES
+-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
++                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
+                           CXX_STANDARD 17)
+ 
+ # TODO: fix warnings and remove this exception
+@@ -41,13 +41,13 @@ endif()
+ #
+ 
+ install(TARGETS ${TARGET_NAME}
+-        RUNTIME DESTINATION "tools/${TARGET_NAME}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${NPU_INTERNAL_COMPONENT}
+         ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ 
+ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+-            DESTINATION "tools/${TARGET_NAME}"
++            DESTINATION "${OV_CPACK_DOCDIR}" RENAME README-${TARGET_NAME}.md
+             COMPONENT ${NPU_INTERNAL_COMPONENT}
+             ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ endif()
+--- a/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
++++ b/src/plugins/intel_npu/tools/protopipe/CMakeLists.txt
+@@ -52,7 +52,7 @@ ov_add_target(ADD_CPPLINT
+               LINK_LIBRARIES PRIVATE ${DEPENDENCIES})
+ 
+ set_target_properties(${TARGET_NAME} PROPERTIES
+-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
++                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
+                           CXX_STANDARD 17)
+ 
+ #
+@@ -60,13 +60,13 @@ set_target_properties(${TARGET_NAME} PROPERTIES
+ #
+ 
+ install(TARGETS ${TARGET_NAME}
+-        RUNTIME DESTINATION "tools/${TARGET_NAME}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${NPU_INTERNAL_COMPONENT}
+         ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ 
+ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+-            DESTINATION "tools/${TARGET_NAME}"
++            DESTINATION "${OV_CPACK_DOCDIR}" RENAME README-${TARGET_NAME}.md
+             COMPONENT ${NPU_INTERNAL_COMPONENT}
+             ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ endif()
+--- a/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
++++ b/src/plugins/intel_npu/tools/single-image-test/CMakeLists.txt
+@@ -50,7 +50,7 @@ ov_add_target(ADD_CPPLINT
+ ov_set_threading_interface_for(${TARGET_NAME})
+ 
+ set_target_properties(${TARGET_NAME} PROPERTIES
+-                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR}
++                          FOLDER ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_NAME ov-${TARGET_NAME}
+                           CXX_STANDARD 17)
+ 
+ # TODO: fix warnings and remove this exception
+@@ -63,13 +63,13 @@ endif()
+ #
+ 
+ install(TARGETS ${TARGET_NAME}
+-        RUNTIME DESTINATION "tools/${TARGET_NAME}"
++        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+         COMPONENT ${NPU_INTERNAL_COMPONENT}
+         ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ 
+ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+-            DESTINATION "tools/${TARGET_NAME}"
++            DESTINATION "${OV_CPACK_DOCDIR}" RENAME README-${TARGET_NAME}.md
+             COMPONENT ${NPU_INTERNAL_COMPONENT}
+             ${OV_CPACK_COMP_NPU_INTERNAL_EXCLUDE_ALL})
+ endif()

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -201,6 +201,7 @@ effectiveStdenv.mkDerivation rec {
     (lib.cmakeBool "onnxruntime_USE_NCCL" (cudaSupport && ncclSupport))
   ] ++ lib.optionals openvinoSupport [
     (lib.cmakeBool "onnxruntime_USE_OPENVINO" true)
+    (lib.cmakeFeature "onnxruntime_USE_OPENVINO_AUTO" (if effectiveStdenv.hostPlatform.system == "x86_64-linux" then "NPU,GPU,CPU" else "GPU"))
     (lib.cmakeBool "onnxruntime_USE_OPENVINO_GPU" true)
     (lib.cmakeBool "onnxruntime_USE_OPENVINO_CPU" (effectiveStdenv.hostPlatform.system == "x86_64-linux"))
     (lib.cmakeBool "onnxruntime_USE_OPENVINO_NPU" (effectiveStdenv.hostPlatform.system == "x86_64-linux"))

--- a/pkgs/development/libraries/onnxruntime/default.nix
+++ b/pkgs/development/libraries/onnxruntime/default.nix
@@ -25,6 +25,9 @@
 , pythonSupport ? true
 , cudaSupport ? config.cudaSupport
 , ncclSupport ? config.cudaSupport
+, openvino
+, openvinoSupport ? stdenv.isLinux
+, onnxruntime
 , cudaPackages ? {}
 }@inputs:
 
@@ -146,6 +149,8 @@ effectiveStdenv.mkDerivation rec {
   ]) ++ lib.optionals effectiveStdenv.hostPlatform.isDarwin [
     Foundation
     libiconv
+  ] ++ lib.optionals openvinoSupport [
+    openvino
   ] ++ lib.optionals cudaSupport (with cudaPackages; [
     cuda_cccl # cub/cub.cuh
     libcublas # cublas_v2.h
@@ -194,6 +199,12 @@ effectiveStdenv.mkDerivation rec {
     "-Donnxruntime_USE_FULL_PROTOBUF=OFF"
     (lib.cmakeBool "onnxruntime_USE_CUDA" cudaSupport)
     (lib.cmakeBool "onnxruntime_USE_NCCL" (cudaSupport && ncclSupport))
+  ] ++ lib.optionals openvinoSupport [
+    (lib.cmakeBool "onnxruntime_USE_OPENVINO" true)
+    (lib.cmakeBool "onnxruntime_USE_OPENVINO_GPU" true)
+    (lib.cmakeBool "onnxruntime_USE_OPENVINO_CPU" (effectiveStdenv.hostPlatform.system == "x86_64-linux"))
+    (lib.cmakeBool "onnxruntime_USE_OPENVINO_NPU" (effectiveStdenv.hostPlatform.system == "x86_64-linux"))
+    (lib.cmakeFeature "OpenVINO_DIR" "${lib.getDev openvino}/runtime/cmake")
   ] ++ lib.optionals pythonSupport [
     "-Donnxruntime_ENABLE_PYTHON=ON"
   ] ++ lib.optionals cudaSupport [
@@ -203,12 +214,11 @@ effectiveStdenv.mkDerivation rec {
     (lib.cmakeFeature "onnxruntime_NVCC_THREADS" "1")
   ];
 
-  env = lib.optionalAttrs effectiveStdenv.cc.isClang {
-    NIX_CFLAGS_COMPILE = "-Wno-error";
-  };
+  env.NIX_CFLAGS_COMPILE = "-Wno-error";
 
-  # aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox
-  doCheck = !(cudaSupport || effectiveStdenv.buildPlatform.system == "aarch64-linux");
+  # - aarch64-linux fails cpuinfo test, because /sys/devices/system/cpu/ does not exist in the sandbox
+  # - enoent $out/lib/libonnxruntime_provider_shared.so when built with openvino support
+  doCheck = !(cudaSupport || openvinoSupport || effectiveStdenv.buildPlatform.system == "aarch64-linux");
 
   requiredSystemFeatures = lib.optionals cudaSupport [ "big-parallel" ];
 
@@ -243,6 +253,7 @@ effectiveStdenv.mkDerivation rec {
     protobuf = protobuf_21;
     tests = lib.optionalAttrs pythonSupport {
       python = python3Packages.onnxruntime;
+      withTests = onnxruntime.override { openvinoSupport = false; };
     };
   };
 

--- a/pkgs/development/python-modules/onnxruntime/default.nix
+++ b/pkgs/development/python-modules/onnxruntime/default.nix
@@ -4,6 +4,7 @@
   buildPythonPackage,
   autoPatchelfHook,
   onnxruntime,
+  openvino,
   coloredlogs,
   numpy,
   packaging,
@@ -58,6 +59,7 @@ buildPythonPackage {
       # dependency between the two. Option 2, because onnxruntime takes forever to build with cuda support.
       onnxruntime
     ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ openvino ]
     ++ lib.optionals onnxruntime.passthru.cudaSupport (
       with onnxruntime.passthru.cudaPackages;
       [

--- a/pkgs/development/python-modules/openvino/default.nix
+++ b/pkgs/development/python-modules/openvino/default.nix
@@ -3,7 +3,6 @@
   buildPythonPackage,
   openvino-native,
   numpy,
-  python,
 }:
 
 buildPythonPackage {
@@ -18,8 +17,8 @@ buildPythonPackage {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/${python.sitePackages}
-    cp -Rv * $out/${python.sitePackages}/
+    mkdir -p $out
+    cp -Rv * $out/
 
     runHook postInstall
   '';

--- a/pkgs/development/python-modules/openvino/default.nix
+++ b/pkgs/development/python-modules/openvino/default.nix
@@ -3,6 +3,7 @@
   buildPythonPackage,
   openvino-native,
   numpy,
+  packaging,
 }:
 
 buildPythonPackage {
@@ -12,7 +13,10 @@ buildPythonPackage {
 
   src = openvino-native.python;
 
-  propagatedBuildInputs = [ numpy ];
+  dependencies = [
+    numpy
+    packaging
+  ];
 
   installPhase = ''
     runHook preInstall
@@ -23,10 +27,7 @@ buildPythonPackage {
     runHook postInstall
   '';
 
-  pythonImportsCheck = [
-    "openvino"
-    "openvino.runtime"
-  ];
+  pythonImportsCheck = [ "openvino" ];
 
   meta = with lib; {
     description = "OpenVINO(TM) Runtime";

--- a/pkgs/top-level/python-packages.nix
+++ b/pkgs/top-level/python-packages.nix
@@ -9797,6 +9797,7 @@ self: super: with self; {
       python3Packages = self;
       pythonSupport = true;
     };
+    inherit (pkgs) openvino;
   };
 
   onnxruntime-tools = callPackage ../development/python-modules/onnxruntime-tools { };


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

Enable the openvino provider for onnxruntime.

<del>Builds on 1.18.1, but breaks on https://github.com/NixOS/nixpkgs/pull/364362, which is imminent.</del>

```
>>> import onnxruntime as rt
>>> rt.get_available_providers()
['OpenVINOExecutionProvider', 'CPUExecutionProvider']
```

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [x] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
