### PR TITLE
net-cpp: Fix FTBFS

### DIFF
--- a/pkgs/by-name/ne/net-cpp/package.nix
+++ b/pkgs/by-name/ne/net-cpp/package.nix
@@ -5,7 +5,8 @@
   fetchpatch,
   gitUpdater,
   testers,
-  boost,
+  # https://gitlab.com/ubports/development/core/lib-cpp/net-cpp/-/issues/5
+  boost186,
   cmake,
   curl,
   doxygen,
@@ -50,10 +51,17 @@ stdenv.mkDerivation (finalAttrs: {
       url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/941d9eceaa66a06eabb1eb79554548b47d4a60ab/debian/patches/1007_wait-for-flask.patch";
       hash = "sha256-nsGkZBuqahsg70PLUxn5EluDjmfZ0/wSnOYimfAI4ag=";
     })
+
     # Bump std version to 14 for gtest 1.13+
     (fetchpatch {
       url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/f3a031eb7e4ce7df00781100f16de58a4709afcb/debian/patches/0001-Bump-std-version-to-14-needed-for-googletest-1.13.0.patch";
       hash = "sha256-3ykqCfZjtTx7zWQ5rkMhVp7D5fkpoCjl0CVFwwEd4U4=";
+    })
+
+    # Fix newer flask rejecting large chunks by default
+    (fetchpatch {
+      url = "https://salsa.debian.org/ubports-team/net-cpp/-/raw/f2050b5318cba3860fa1042e9b81e1b792b972c4/debian/patches/1008_set-MAX-CONTENT-LENGTH-for-flask-server-to-let-it-accept-big-chunks-of-data.patch";
+      hash = "sha256-lfMRjpmysrhzdG6OOSpBGvYJCi1hrERI/SRf+rAakbA=";
     })
   ];
 
@@ -73,7 +81,7 @@ stdenv.mkDerivation (finalAttrs: {
   ];
 
   buildInputs = [
-    boost
+    boost186
     curl
   ];
 

--- a/pkgs/desktops/lomiri/services/biometryd/default.nix
+++ b/pkgs/desktops/lomiri/services/biometryd/default.nix
@@ -4,7 +4,7 @@
   fetchFromGitLab,
   gitUpdater,
   testers,
-  # Pin Boost 1.86 due to use of boost::asio::io_service.
+  # https://gitlab.com/ubports/development/core/biometryd/-/issues/8
   boost186,
   cmake,
   cmake-extras,


### PR DESCRIPTION
Noticed while reviewing #380514.

- Boost 1.87's removal of deprecated interfaces breaks the build - upstream issue opened, pinning to `boost186`
- Flask update broke a test, fetch patch from Debian to fix it

Also update the boost pinning comment in `lomiri.biometryd` to point to the upstream issue about the situation.

~Undrafting when I've checked that this was the last remaining Boost-related issue.~

Seems to be the only Boost-related issue in the failures.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
