### PR TITLE
Revert "perl: 5.40.0 -> 5.40.1; perl538: 5.38.2 -> 5.38.3"

### DIFF
--- a/pkgs/development/interpreters/perl/default.nix
+++ b/pkgs/development/interpreters/perl/default.nix
@@ -57,16 +57,16 @@ in rec {
   # Maint version
   perl538 = callPackage ./interpreter.nix {
     self = perl538;
-    version = "5.38.3";
-    sha256 = "sha256-ioAzhZ3R116wyRWO7dc4TfGva0aipOhQc7B+bMfFuHM=";
+    version = "5.38.2";
+    sha256 = "sha256-oKMVNEUet7g8fWWUpJdUOlTUiLyQygD140diV39AZV4=";
     inherit passthruFun;
   };
 
   # Maint version
   perl540 = callPackage ./interpreter.nix {
     self = perl540;
-    version = "5.40.1";
-    sha256 = "sha256-AvjEW7N57Qw951FPrUjHFP1Gvo8LU2v9UyAFAWWh7iY=";
+    version = "5.40.0";
+    sha256 = "sha256-x0A0jzVzljJ6l5XT6DI7r9D+ilx4NfwcuroMyN/nFh8=";
     inherit passthruFun;
   };
 }


### PR DESCRIPTION
Reverts NixOS/nixpkgs#375815

Needs more changes to make cross work, discussed in #staging.