### PR TITLE
protoc-gen-grpc-java: init at 1.70.0

### DIFF
--- a/pkgs/by-name/pr/protoc-gen-grpc-java/default.nix
+++ b/pkgs/by-name/pr/protoc-gen-grpc-java/default.nix
@@ -1,0 +1,52 @@
+{
+  stdenv,
+  lib,
+  fetchurl,
+  protobuf,
+  autoPatchelfHook,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "protoc-gen-grpc-java";
+  version = "1.70.0";
+
+  src =
+    let
+      system =
+        {
+          "x86_64-linux" = "linux-x86_64";
+          "aarch64-linux" = "linux-aarch_64";
+          "x86_64-darwin" = "osx-x86_64";
+          "aarch64-darwin" = "osx-aarch_64";
+        }
+        .${stdenv.hostPlatform.system};
+    in
+    with finalAttrs;
+    fetchurl {
+      url = "https://repo1.maven.org/maven2/io/grpc/${pname}/${version}/${pname}-${version}-${system}.exe";
+      hash = "sha256-NjP0iznsJAtpIFxjCpt9o+Jt/knxI3MGIAhAStGCPLw=";
+    };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+  ];
+
+  buildInputs = [
+    protobuf
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    install -m755 -D $src $out/bin/protoc-gen-grpc-java
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Protobuf plugin for generating Java code";
+    homepage = "https://github.com/grpc/grpc-java";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ patwid ];
+  };
+})


### PR DESCRIPTION
The Protobuf plugin for generating java code.

Currently, fetching the dynamically linked elf binary from maven and using autoPatchelfHook to patch it. In future, it should be possible to build it from source instead.

Homepage: https://github.com/grpc/grpc-java/tree/master/compiler

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
