### PR TITLE
home-assistant-custom-modules.battery_notes: init at 2.8.3

### DIFF
--- a/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
@@ -33,4 +33,3 @@ buildHomeAssistantComponent rec {
     license = lib.licenses.mit;
   };
 }
-

--- a/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
+++ b/pkgs/servers/home-assistant/custom-components/battery_notes/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  fetchFromGitHub,
+  buildHomeAssistantComponent,
+  colorlog,
+  ruff,
+}:
+
+buildHomeAssistantComponent rec {
+  owner = "andrew-codechimp";
+  domain = "battery_notes";
+  version = "2.8.3";
+
+  src = fetchFromGitHub {
+    owner = "andrew-codechimp";
+    repo = "HA-Battery-Notes";
+    tag = version;
+    hash = "sha256-6CgIZS/Qmz0EP3s5uOErlDhRBSnmEuPsGXpyJwXU3AM=";
+  };
+
+  dependencies = [
+    colorlog
+    ruff
+  ];
+
+  meta = {
+    changelog = "https://github.com/andrew-codechimp/HA-Battery-Notes/releases/tag/v${version}";
+    description = ''
+      A Home Assistant integration to provide battery notes of devices
+    '';
+    homepage = "https://github.com/andrew-codechimp/HA-Battery-Notes";
+    maintainers = with lib.maintainers; [ matthiasbeyer ];
+    license = lib.licenses.mit;
+  };
+}
+


### PR DESCRIPTION
I did not yet test this integration in my local setup.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
