### PR TITLE
nwg-displays: update to python3Packages

### DIFF
--- a/pkgs/by-name/nw/nwg-displays/package.nix
+++ b/pkgs/by-name/nw/nwg-displays/package.nix
@@ -7,13 +7,13 @@
   gtk-layer-shell,
   gtk3,
   pango,
-  python310Packages,
+  python3Packages,
   wrapGAppsHook3,
   hyprlandSupport ? true,
   wlr-randr,
 }:
 
-python310Packages.buildPythonApplication rec {
+python3Packages.buildPythonApplication rec {
   pname = "nwg-displays";
   version = "0.3.22";
 
@@ -39,9 +39,9 @@ python310Packages.buildPythonApplication rec {
       gdk-pixbuf
       gtk-layer-shell
       pango
-      python310Packages.gst-python
-      python310Packages.i3ipc
-      python310Packages.pygobject3
+      python3Packages.gst-python
+      python3Packages.i3ipc
+      python3Packages.pygobject3
     ]
     ++ lib.optionals hyprlandSupport [
       wlr-randr


### PR DESCRIPTION
Build failure from python310Packages.mistune while building nwg-displays (see Log)

Just updating and generalizing to python3Packages fixes it, I don't think there's a reason to specify a direct version?

Also, nwg-displays is only one of 3 packages using "python310Packages" if github search isn't omitting anything so I don't think it's needed to fix the runtime dependency of mistune, since it's only an optional dependency for python < 3.11, but not sure how this is generally handled in nixpkgs with python:

https://github.com/lepture/mistune/blob/9058e0ddb4d34dab43e18d71db3af8038f74b65f/pyproject.toml#L5-L7

<details>
<summary>Log</summary>

```
no configure script, doing nothing
Running phase: buildPhase
Executing pypaBuildPhase
Creating a wheel...
pypa build flags: --no-isolation --outdir dist/ --wheel
* Getting build dependencies for wheel...
copying path '/nix/store/pb8vdlp6nd8j32pbbg8wxbldwgiip7ii-ffmpeg-headless-7.1-lib' from 'https://cache.nixos.org'...
copying path '/nix/store/08ii4m8q0a2p2qf4m206fd7wrk6yalls-i3-4.24' from 'https://cache.nixos.org'...
copying path '/nix/store/8f3g0crdy6a89jm7w6lyrfi7ic93rgw9-libtiff-4.7.0-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/h3bvdaldbfl9lh94yc37pj7rx3z2vvvi-pango-1.56.1-dev' from 'https://cache.nixos.org'...
copying path '/nix/store/mpm51zng2br23b25w71xhjbrfl65bqpv-xorg-server-21.1.15' from 'https://cache.nixos.org'...
copying path '/nix/store/icrw4qdgspnxj79vm90066idmnnz2n5j-python3.10-zopfli-0.2.3' from 'https://cache.nixos.org'...
copying src/mistune/renderers/markdown.py -> build/lib/mistune/renderers
copying path '/nix/store/pdh4v9sd11asbbk8sqkqcax9i1xdgzbc-xorg-server-21.1.15' from 'https://cache.nixos.org'...
copying src/mistune/renderers/html.py -> build/lib/mistune/renderers
copying src/mistune/renderers/__init__.py -> build/lib/mistune/renderers
copying src/mistune/renderers/rst.py -> build/lib/mistune/renderers
copying src/mistune/renderers/_list.py -> build/lib/mistune/renderers
running egg_info
writing src/mistune.egg-info/PKG-INFO
writing dependency_links to src/mistune.egg-info/dependency_links.txt
writing requirements to src/mistune.egg-info/requires.txt
writing top-level names to src/mistune.egg-info/top_level.txt
reading manifest file 'src/mistune.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'docs/_build'
adding license file 'LICENSE'
writing manifest file 'src/mistune.egg-info/SOURCES.txt'
copying src/mistune/py.typed -> build/lib/mistune
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
creating build/bdist.linux-x86_64/wheel
creating build/bdist.linux-x86_64/wheel/mistune
copying build/lib/mistune/toc.py -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/__main__.py -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/inline_parser.py -> build/bdist.linux-x86_64/wheel/./mistune
creating build/bdist.linux-x86_64/wheel/mistune/directives
copying build/lib/mistune/directives/toc.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/directives/image.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/directives/admonition.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/directives/_rst.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/directives/_fenced.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/directives/include.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/directives/_base.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/directives/__init__.py -> build/bdist.linux-x86_64/wheel/./mistune/directives
copying build/lib/mistune/markdown.py -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/core.py -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/block_parser.py -> build/bdist.linux-x86_64/wheel/./mistune
creating build/bdist.linux-x86_64/wheel/mistune/plugins
copying build/lib/mistune/plugins/url.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/ruby.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/spoiler.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/abbr.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/def_list.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/table.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/speedup.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/math.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/task_lists.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/footnotes.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/__init__.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
copying build/lib/mistune/plugins/formatting.py -> build/bdist.linux-x86_64/wheel/./mistune/plugins
creating build/bdist.linux-x86_64/wheel/mistune/renderers
copying build/lib/mistune/renderers/markdown.py -> build/bdist.linux-x86_64/wheel/./mistune/renderers
copying build/lib/mistune/renderers/html.py -> build/bdist.linux-x86_64/wheel/./mistune/renderers
copying build/lib/mistune/renderers/__init__.py -> build/bdist.linux-x86_64/wheel/./mistune/renderers
copying build/lib/mistune/renderers/rst.py -> build/bdist.linux-x86_64/wheel/./mistune/renderers
copying path '/nix/store/2fda7m7vb070350w3dkqpfn237gc3hqf-tk-8.6.15-dev' from 'https://cache.nixos.org'...
copying build/lib/mistune/renderers/_list.py -> build/bdist.linux-x86_64/wheel/./mistune/renderers
copying build/lib/mistune/py.typed -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/util.py -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/list_parser.py -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/helpers.py -> build/bdist.linux-x86_64/wheel/./mistune
copying build/lib/mistune/__init__.py -> build/bdist.linux-x86_64/wheel/./mistune
running install_egg_info
Copying src/mistune.egg-info to build/bdist.linux-x86_64/wheel/./mistune-3.1.0-py3.10.egg-info
running install_scripts
creating build/bdist.linux-x86_64/wheel/mistune-3.1.0.dist-info/WHEEL
creating '/build/source/dist/.tmp-6bkkvc6a/mistune-3.1.0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
adding 'mistune/__init__.py'
adding 'mistune/__main__.py'
adding 'mistune/block_parser.py'
adding 'mistune/core.py'
adding 'mistune/helpers.py'
adding 'mistune/inline_parser.py'
adding 'mistune/list_parser.py'
adding 'mistune/markdown.py'
adding 'mistune/py.typed'
adding 'mistune/toc.py'
adding 'mistune/util.py'
adding 'mistune/directives/__init__.py'
adding 'mistune/directives/_base.py'
adding 'mistune/directives/_fenced.py'
adding 'mistune/directives/_rst.py'
adding 'mistune/directives/admonition.py'
adding 'mistune/directives/image.py'
adding 'mistune/directives/include.py'
adding 'mistune/directives/toc.py'
adding 'mistune/plugins/__init__.py'
adding 'mistune/plugins/abbr.py'
adding 'mistune/plugins/def_list.py'
adding 'mistune/plugins/footnotes.py'
adding 'mistune/plugins/formatting.py'
adding 'mistune/plugins/math.py'
adding 'mistune/plugins/ruby.py'
adding 'mistune/plugins/speedup.py'
adding 'mistune/plugins/spoiler.py'
adding 'mistune/plugins/table.py'
adding 'mistune/plugins/task_lists.py'
adding 'mistune/plugins/url.py'
adding 'mistune/renderers/__init__.py'
adding 'mistune/renderers/_list.py'
adding 'mistune/renderers/html.py'
adding 'mistune/renderers/markdown.py'
adding 'mistune/renderers/rst.py'
adding 'mistune-3.1.0.dist-info/LICENSE'
adding 'mistune-3.1.0.dist-info/METADATA'
adding 'mistune-3.1.0.dist-info/WHEEL'
adding 'mistune-3.1.0.dist-info/top_level.txt'
adding 'mistune-3.1.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Sourcing python-remove-tests-dir-hook
Successfully built mistune-3.1.0-py3-none-any.whl
Sourcing python-catch-conflicts-hook.sh
Sourcing python-remove-bin-bytecode-hook.sh
Sourcing pypa-build-hook
Using pypaBuildPhase
Sourcing python-runtime-deps-check-hook
Using pythonRuntimeDepsCheckHook
Sourcing pypa-install-hook
Using pypaInstallPhase
Sourcing python-imports-check-hook.sh
Using pythonImportsCheckPhase
Sourcing python-namespaces-hook
Sourcing python-catch-conflicts-hook.sh
copying path '/nix/store/w9hjl2hk09xdrvjr98b1gvk790d8820d-gdk-pixbuf-2.42.12-dev' from 'https://cache.nixos.org'...
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for mistune-3.1.0-py3-none-any.whl
Running phase: unpackPhase
unpacking source archive /nix/store/wn0ha1asvc4ppyci2bwhyx4nxcql2d8g-pyftpdlib-2.0.1.tar.gz
source root is pyftpdlib-2.0.1
setting SOURCE_DATE_EPOCH to timestamp 1729604611 of file "pyftpdlib-2.0.1/setup.cfg"
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
copying path '/nix/store/5cvdv2aax4maw87y5v53kcll9fv3hqp8-librsvg-2.58.3-dev' from 'https://cache.nixos.org'...
Running phase: buildPhase
copying path '/nix/store/mcs2dnknkcsjbf0kxhfzxr3g46nxqxj2-gtk+3-3.24.43-dev' from 'https://cache.nixos.org'...
Executing pypaBuildPhase
adding 'mistune/inline_parser.py'
adding 'mistune/list_parser.py'
adding 'mistune/markdown.py'
adding 'mistune/py.typed'
adding 'mistune/toc.py'
adding 'mistune/util.py'
adding 'mistune/directives/__init__.py'
adding 'mistune/directives/_base.py'
adding 'mistune/directives/_fenced.py'
adding 'mistune/directives/_rst.py'
adding 'mistune/directives/admonition.py'
adding 'mistune/directives/image.py'
adding 'mistune/directives/include.py'
adding 'mistune/directives/toc.py'
adding 'mistune/plugins/__init__.py'
adding 'mistune/plugins/abbr.py'
adding 'mistune/plugins/def_list.py'
adding 'mistune/plugins/footnotes.py'
adding 'mistune/plugins/formatting.py'
adding 'mistune/plugins/math.py'
adding 'mistune/plugins/ruby.py'
adding 'mistune/plugins/speedup.py'
adding 'mistune/plugins/spoiler.py'
adding 'mistune/plugins/table.py'
adding 'mistune/plugins/task_lists.py'
adding 'mistune/plugins/url.py'
adding 'mistune/renderers/__init__.py'
adding 'mistune/renderers/_list.py'
adding 'mistune/renderers/html.py'
adding 'mistune/renderers/markdown.py'
adding 'mistune/renderers/rst.py'
adding 'mistune-3.1.0.dist-info/LICENSE'
adding 'mistune-3.1.0.dist-info/METADATA'
adding 'mistune-3.1.0.dist-info/WHEEL'
adding 'mistune-3.1.0.dist-info/top_level.txt'
adding 'mistune-3.1.0.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built mistune-3.1.0-py3-none-any.whl
Finished creating a wheel...
Finished executing pypaBuildPhase
Running phase: pythonRuntimeDepsCheckHook
@nix { "action": "setPhase", "phase": "pythonRuntimeDepsCheckHook" }
Executing pythonRuntimeDepsCheck
Checking runtime dependencies for mistune-3.1.0-py3-none-any.whl
  - typing-extensions not installed
```

</details>
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
