### PR TITLE
nixos/goaccess: init

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -344,6 +344,12 @@
     githubId = 241628;
     name = "Adam Russell";
   };
+  aabccd021 = {
+    email = "aabccd021@gmail.com";
+    github = "aabccd021";
+    githubId = 33031950;
+    name = "Muhamad Abdurahman";
+  };
   aacebedo = {
     email = "alexandre@acebedo.fr";
     github = "aacebedo";

--- a/nixos/doc/manual/release-notes/rl-2505.section.md
+++ b/nixos/doc/manual/release-notes/rl-2505.section.md
@@ -153,6 +153,8 @@
 
 - [Recyclarr](https://github.com/recyclarr/recyclarr) a TRaSH Guides synchronizer for Sonarr and Radarr. Available as [services.recyclarr](#opt-services.recyclarr.enable).
 
+- [GoAccess](https://goaccess.io/), a real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems. Available as [services.goaccess](#opt-services.goaccess.enable).
+
 <!-- To avoid merge conflicts, consider adding your item at an arbitrary place in the list instead. -->
 
 ## Backward Incompatibilities {#sec-release-25.05-incompatibilities}

--- a/nixos/modules/module-list.nix
+++ b/nixos/modules/module-list.nix
@@ -1494,6 +1494,7 @@
   ./services/web-apps/gotosocial.nix
   ./services/web-apps/grocy.nix
   ./services/web-apps/pixelfed.nix
+  ./services/web-apps/goaccess.nix
   ./services/web-apps/goatcounter.nix
   ./services/web-apps/guacamole-client.nix
   ./services/web-apps/guacamole-server.nix

--- a/nixos/modules/services/web-apps/goaccess.nix
+++ b/nixos/modules/services/web-apps/goaccess.nix
@@ -1,0 +1,167 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+let
+  cfg = config.services.goaccess;
+
+  mapSiteCfg =
+    fn: lib.mkMerge (builtins.attrValues (builtins.mapAttrs (name: value: fn name value) cfg.sites));
+
+  siteOptions = {
+    options = {
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 7890;
+        description = "Port number for the GoAccess";
+      };
+
+      logFile = lib.mkOption {
+        type = lib.types.str;
+        description = "Path to the log file";
+        example = "/var/log/nginx/myapp-access.log";
+      };
+
+      wsHost = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = ''
+          Hostname for the WebSocket connection.
+          You can use this hostname to access GoAccess via ssh tunneling.
+          For example, if you are ssh tunneling with `ssh -L 8080:127.0.0.1:80 -N user@remote`.
+          you need to set this option to `ws://127.0.0.1:8080`.
+        '';
+        example = "ws://127.0.0.1:8080";
+      };
+
+      configFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Path to the GoAccess configuration file
+          See default configuration: https://github.com/allinurl/goaccess/blob/master/config/goaccess.conf
+        '';
+        example = "/etc/goaccess/goaccess.conf";
+      };
+    };
+  };
+
+in
+{
+
+  options.services.goaccess = {
+
+    enable = lib.mkEnableOption ''
+      GoAccess: Real-time web log analyzer and
+            interactive viewer that runs in a terminal in *nix systems'';
+
+    sites = lib.mkOption {
+      type = lib.types.attrsOf (lib.types.submodule siteOptions);
+      description = "GoAccess sites configurations";
+      default = { };
+      example = lib.literalExpression ''
+        {
+          myapp = {
+            port = 7890;
+            logFile = "/var/log/nginx/myapp-access.log";
+            wsHost = "ws://127.0.0.1:8080";
+            configFile = pkgs.writeText "goaccess.conf" \'\'
+              log-format COMBINED
+              real-time-html true
+              html-refresh 30
+              no-query-string true
+            \'\';
+          };
+        }
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+
+    users.users = mapSiteCfg (
+      siteName: siteCfg: {
+        "goaccess-${siteName}" = {
+          isSystemUser = true;
+          group = config.services.nginx.group;
+        };
+      }
+    );
+
+    systemd.services = mapSiteCfg (
+      siteName: siteCfg: {
+
+        "goaccess-${siteName}" = {
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStart =
+              ''
+                ${lib.getExe pkgs.goaccess} \
+                  --port=${builtins.toString siteCfg.port} \
+                  --output=/var/lib/goaccess-${siteName}/index.html \
+                  --log-file=${siteCfg.logFile} \
+              ''
+              + (lib.optionalString (
+                siteCfg.wsHost != null
+              ) " --ws-url=${siteCfg.wsHost}/goaccess/${siteName}/ws")
+              + (lib.optionalString (siteCfg.configFile != null) " --config-file=${siteCfg.configFile}");
+            Restart = "on-failure";
+            User = "goaccess-${siteName}";
+            StateDirectory = "goaccess-${siteName}";
+            WorkingDirectory = "/var/lib/goaccess-${siteName}";
+            NoNewPrivileges = true;
+            PrivateDevices = "yes";
+            PrivateTmp = true;
+            ProtectHome = "read-only";
+            ProtectKernelModules = "yes";
+            ProtectKernelTunables = "yes";
+            ProtectSystem = "strict";
+            ReadOnlyPaths = [ siteCfg.logFile ];
+            ReadWritePaths = [
+              "/proc/self"
+              "/var/lib/goaccess-${siteName}"
+            ];
+            SystemCallFilter = "~@clock @cpu-emulation @debug @keyring @memlock @module @mount @obsolete @privileged @reboot @resources @setuid @swap @raw-io";
+          };
+        };
+
+      }
+    );
+
+    services.nginx.virtualHosts."localhost" = mapSiteCfg (
+      siteName: siteCfg: {
+
+        locations."/goaccess/${siteName}/" = {
+          alias = "/var/lib/goaccess-${siteName}/";
+          extraConfig = ''
+            # Limit access to clients connecting from localhost
+            allow 127.0.0.1;
+            deny all;
+          '';
+        };
+
+        locations."/goaccess/${siteName}/ws" = {
+          proxyPass = "http://127.0.0.1:${builtins.toString siteCfg.port}";
+          extraConfig = ''
+            # Upgrade connection to WebSocket
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_buffering off;
+            proxy_read_timeout 7d;
+
+            # Limit access to clients connecting from localhost
+            allow 127.0.0.1;
+            deny all;
+          '';
+        };
+
+      }
+    );
+  };
+
+  meta.maintainers = with lib.maintainers; [ bhankas ];
+}

--- a/nixos/tests/all-tests.nix
+++ b/nixos/tests/all-tests.nix
@@ -396,6 +396,7 @@ in {
   gnome-xorg = handleTest ./gnome-xorg.nix {};
   gns3-server = handleTest ./gns3-server.nix {};
   gnupg = handleTest ./gnupg.nix {};
+  goaccess = handleTest ./goaccess.nix {};
   goatcounter = handleTest ./goatcounter.nix {};
   go-neb = handleTest ./go-neb.nix {};
   gobgpd = handleTest ./gobgpd.nix {};

--- a/nixos/tests/goaccess.nix
+++ b/nixos/tests/goaccess.nix
@@ -1,0 +1,48 @@
+import ./make-test-python.nix (
+  { lib, pkgs, ... }:
+
+  {
+    name = "goaccess";
+
+    meta.maintainers = with lib.maintainers; [ bhankas ];
+
+    nodes.machine =
+      { config, ... }:
+      {
+
+        services.nginx = {
+          enable = true;
+          virtualHosts."localhost".locations."/" = {
+            extraConfig = ''
+              access_log /var/log/nginx/myapp-access.log combined;
+            '';
+          };
+        };
+
+        services.goaccess = {
+          enable = true;
+          sites = {
+            myapp = {
+              port = 7890;
+              logFile = "/var/log/nginx/myapp-access.log";
+              configFile = pkgs.writeText "goaccess.conf" ''
+                log-format COMBINED
+              '';
+            };
+          };
+        };
+      };
+
+    testScript = ''
+      start_all()
+      machine.wait_for_unit("goaccess-myapp.service")
+      # wait for goaccess to fully come up
+
+      with subtest("goaccess service starts"):
+          machine.wait_until_succeeds(
+              "curl -sSfL http://127.0.0.1/goaccess/myapp/ > /dev/null",
+              timeout=30
+          )
+    '';
+  }
+)

--- a/pkgs/by-name/go/goaccess/package.nix
+++ b/pkgs/by-name/go/goaccess/package.nix
@@ -7,6 +7,7 @@
   libmaxminddb,
   ncurses,
   openssl,
+  nixosTests,
   withGeolocation ? true,
 }:
 
@@ -35,6 +36,8 @@ stdenv.mkDerivation rec {
     "--enable-utf8"
     "--with-openssl"
   ] ++ lib.optionals withGeolocation [ "--enable-geoip=mmdb" ];
+
+  passthru.tests.moduleTest = nixosTests.goaccess;
 
   meta = with lib; {
     description = "Real-time web log analyzer and interactive viewer that runs in a terminal in *nix systems";


### PR DESCRIPTION
Initial implementation of [goaccess](https://goaccess.io/) service.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [x] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
