### PR TITLE
authelia: move web to arguments

### DIFF
--- a/pkgs/servers/authelia/default.nix
+++ b/pkgs/servers/authelia/default.nix
@@ -7,6 +7,7 @@
   installShellFiles,
   callPackage,
   nixosTests,
+  authelia-web ? callPackage ./web.nix { inherit nodejs pnpm fetchFromGitHub; },
 }:
 
 let
@@ -16,7 +17,8 @@ let
     src
     vendorHash
     ;
-  web = callPackage ./web.nix { inherit nodejs pnpm fetchFromGitHub; };
+
+  web = authelia-web;
 in
 buildGoModule rec {
   inherit


### PR DESCRIPTION
I've moved web to be a argument for authelia, instead of being in the `let` statement. Doing this allows to override the web however you want, e.g. like so.

```nix
pkgs.authelia.override (p: {
  web = let
    orig_web = pkgs.callPackage "${pkgs.path}/pkgs/servers/authelia/web.nix" { inherit (p) nodejs pnpm fetchFromGitHub; };
  in orig_web.overrideAttrs (old: {
    postPatch = old.postPatch + ''
      substituteInPlace src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx \
        --replace-fail "const [rememberMe, setRememberMe] = useState(false)" "const [rememberMe, setRememberMe] = useState(true)"
    '';
  });
})
```

However, I'm unsure if this is the best way. In the ideal  world, I would be able to do something like.

```nix
pkgs.authelia.override (p: {
  web = p.web.overrideAttrs (old: {
    postPatch = old.postPatch + ''
      substituteInPlace src/views/LoginPortal/FirstFactor/FirstFactorForm.tsx \
        --replace-fail "const [rememberMe, setRememberMe] = useState(false)" "const [rememberMe, setRememberMe] = useState(true)"
    '';
  });
})
```

But I don't think that works with default arguments. I would be happy if we could do that, instead of having the extra steps that I listed above.

I would like comments on this PR by the maintainers :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [x] `sandbox = relaxed`
  - [x] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
