### PR TITLE
gnupg: fix static

### DIFF
--- a/pkgs/tools/security/gnupg/24.nix
+++ b/pkgs/tools/security/gnupg/24.nix
@@ -4,6 +4,7 @@
   fetchurl,
   fetchFromGitLab,
   buildPackages,
+  autoreconfHook,
   pkg-config,
   texinfo,
   gettext,
@@ -44,6 +45,7 @@ stdenv.mkDerivation rec {
 
   depsBuildBuild = [ buildPackages.stdenv.cc ];
   nativeBuildInputs = [
+    autoreconfHook
     pkg-config
     texinfo
     libgpg-error
@@ -82,6 +84,7 @@ stdenv.mkDerivation rec {
     [
       ./fix-libusb-include-path.patch
       ./CVE-2022-3219.patch
+      ./static.patch
     ]
     ++ lib.map (v: "${freepgPatches}/STABLE-BRANCH-2-4-freepg/" + v) [
       "0002-gpg-accept-subkeys-with-a-good-revocation-but-no-sel.patch"

--- a/pkgs/tools/security/gnupg/static.patch
+++ b/pkgs/tools/security/gnupg/static.patch
@@ -1,0 +1,38 @@
+From 440ccccb02ec438b4077b5885e5a1483e12c38b1 Mon Sep 17 00:00:00 2001
+From: Alyssa Ross <hi@alyssa.is>
+Date: Sun, 9 Feb 2025 08:51:32 +0100
+Subject: [PATCH] build: use pkg-config to find tss2-esys
+
+Otherwise, tss2-esys's dependencies (other tss2 libraries, OpenSSL)
+won't be linked when tss2-esys is a static library.
+---
+Link: https://dev.gnupg.org/D606
+
+ configure.ac | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index dc444657f..a60c1820c 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1574,8 +1574,8 @@ if test "$build_tpm2d" = "yes"; then
+     AC_SEARCH_LIBS([TSS_Create],[tss ibmtss],have_libtss=IBM,
+                    [AC_MSG_ERROR([IBM TPM Software Stack requested but not found])])
+   elif test "$with_tss" = intel; then
+-    AC_SEARCH_LIBS([Esys_Initialize],[tss2-esys],have_libtss=Intel,
+-                   [AC_MSG_ERROR([Intel TPM Software Stack requested but not found])])
++    PKG_CHECK_MODULES([LIBTSS], [tss2-esys tss2-mu tss2-rc tss2-tctildr],have_libtss=Intel,
++                      [AC_MSG_ERROR([Intel TPM Software Stack requested but not found])])
+   else
+     AC_MSG_ERROR([Invalid TPM Software Stack requested: $with_tss])
+   fi
+@@ -1605,7 +1605,6 @@ if test "$build_tpm2d" = "yes"; then
+ 	AC_MSG_WARN([Need Esys_TR_GetTpmHandle API (usually requires Intel TSS 2.4.0 or later, disabling TPM support)])
+ 	have_libtss=no
+     ])
+-    LIBTSS_LIBS="$LIBS -ltss2-mu -ltss2-rc -ltss2-tctildr"
+     AC_DEFINE(HAVE_INTEL_TSS, 1, [Defined if we have the Intel TSS])
+   fi
+   LIBS="$_save_libs"
+-- 
+2.47.0


### PR DESCRIPTION
Patch has been submitted upstream, but past experience trying to send patches to GnuPG does not make me optimistic that this will be dealt with any time soon.  If it doesn't work out upstream I'll submit it to freepg, whose patchset we're already using.


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
