### PR TITLE
nixos/services.boinc: add virtualbox.enable option

### DIFF
--- a/nixos/modules/services/computing/boinc/client.nix
+++ b/nixos/modules/services/computing/boinc/client.nix
@@ -54,6 +54,18 @@ in
       '';
     };
 
+    virtualbox = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        example = lib.literalExpression "true";
+        description = ''
+          This would add the boinc user to the virtualbox's group, as well as
+          enable the virtualbox service.
+        '';
+      };
+    };
+
     extraEnvPackages = lib.mkOption {
       type = lib.types.listOf lib.types.package;
       default = [ ];
@@ -62,9 +74,9 @@ in
         Additional packages to make available in the environment in which
         BOINC will run. Common choices are:
 
-        - {var}`pkgs.virtualbox`:
-          The VirtualBox virtual machine framework. Required by some BOINC
-          projects, such as ATLAS@home.
+        Please note that putting `pkgs.virtualbox` here would result the
+        non-wrapped version being used, and it will not work.
+
         - {var}`pkgs.ocl-icd`:
           OpenCL infrastructure library. Required by BOINC projects that
           use OpenCL, in addition to a device-specific OpenCL driver.
@@ -88,8 +100,13 @@ in
       description = "BOINC Client";
       home = cfg.dataDir;
       isSystemUser = true;
+      extraGroups = lib.mkIf cfg.virtualbox.enable [ "vboxusers" ];
     };
     users.groups.boinc = { };
+
+    virtualisation.virtualbox.host = lib.mkIf cfg.virtualbox.enable {
+      enable = true;
+    };
 
     systemd.tmpfiles.rules = [
       "d '${cfg.dataDir}' - boinc boinc - -"


### PR DESCRIPTION
<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The current document / implementation guides the user to do something like
```nix
services.boinc.extraEnvPackages = [pkgs.virtualbox];
```
However, this would not use the virtualbox that's wrapped by security wrappers.
This has been mentioned in #76108 before.

I think adding a `virtualbox.enable` as this PR aims to do, can clarify where to configure boinc with virtualbox. However, I'm open to other ways to improve this.

Thank you for your time :)

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
