### PR TITLE
brlaser: switch to more-maintained upstream, same as Fedora

### DIFF
--- a/pkgs/by-name/br/brlaser/package.nix
+++ b/pkgs/by-name/br/brlaser/package.nix
@@ -9,13 +9,13 @@
 
 stdenv.mkDerivation rec {
   pname = "brlaser";
-  version = "6-unstable-2023-02-30";
+  version = "6.2.7";
 
   src = fetchFromGitHub {
-    owner = "pdewacht";
+    owner = "Owl-Maintain";
     repo = "brlaser";
-    rev = "2a49e3287c70c254e7e3ac9dabe9d6a07218c3fa";
-    sha256 = "sha256-1fvO9F7ifbYQHAy54mOx052XutfKXSK6iT/zj4Mhbww=";
+    tag = "v${version}";
+    hash = "sha256-a+TjLmjqBz0b7v6kW1uxh4BGzrYOQ8aMdVo4orZeMT4=";
   };
 
   nativeBuildInputs = [
@@ -38,40 +38,11 @@ stdenv.mkDerivation rec {
     longDescription = ''
       Although most Brother printers support a standard printer language such as PCL or PostScript, not all do. If you have a monochrome Brother laser printer (or multi-function device) and the other open source drivers don't work, this one might help.
 
-      This driver is known to work with these printers:
-
-          Brother DCP-1510
-          Brother DCP-1602
-          Brother DCP-7030
-          Brother DCP-7040
-          Brother DCP-7055
-          Brother DCP-7055W
-          Brother DCP-7060D
-          Brother DCP-7065DN
-          Brother DCP-7080
-          Brother DCP-L2500D
-          Brother DCP-L2520D
-          Brother DCP-L2540DW
-          Brother HL-1110
-          Brother HL-1200
-          Brother HL-2030
-          Brother HL-2140
-          Brother HL-2220
-          Brother HL-2270DW
-          Brother HL-5030
-          Brother HL-L2300D
-          Brother HL-L2320D
-          Brother HL-L2340D
-          Brother HL-L2360D
-          Brother MFC-1910W
-          Brother MFC-7240
-          Brother MFC-7360N
-          Brother MFC-7365DN
-          Brother MFC-7840W
-          Brother MFC-L2710DW
-          Lenovo M7605D
+      This driver is known to work with many printers in the DCP, HL and MFC series, along with a few others.
+      See the homepage for a full list.
     '';
-    homepage = "https://github.com/pdewacht/brlaser";
+    homepage = "https://github.com/Owl-Maintain/brlaser";
+    changelog = "https://github.com/Owl-Maintain/brlaser/releases/tag/v${version}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
     maintainers = with lib.maintainers; [ StijnDW ];

--- a/pkgs/by-name/br/brlaser/package.nix
+++ b/pkgs/by-name/br/brlaser/package.nix
@@ -45,6 +45,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/Owl-Maintain/brlaser/releases/tag/v${version}";
     license = lib.licenses.gpl2Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ StijnDW ];
+    maintainers = with lib.maintainers; [ onny ];
   };
 }


### PR DESCRIPTION
Continuation of work by @ahydronous, supersedes https://github.com/NixOS/nixpkgs/pull/342800
Fixes https://github.com/NixOS/nixpkgs/issues/290431#issue-2146740113

Fedora switched to a more-maintained upstream fork because it supports more printers.

See: https://packages.fedoraproject.org/pkgs/printer-driver-brlaser/printer-driver-brlaser/index.html and
https://github.com/pdewacht/brlaser/pull/92

Changed upstream from https://github.com/pdewacht/brlaser to https://github.com/Owl-Maintain/brlaser".

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
