### PR TITLE
megatools: 1.11.1 -> 1.11.4

### DIFF
--- a/pkgs/by-name/me/megatools/package.nix
+++ b/pkgs/by-name/me/megatools/package.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
   src = fetchgit {
     url = "https://xff.cz/git/megatools";
     rev = version;
-    sha256 = "sha256-z2BUSNXl0u+28TzhLmNjcgNVLBmr3m+FuRWr8o/EINw=";
+    hash = "sha256-z2BUSNXl0u+28TzhLmNjcgNVLBmr3m+FuRWr8o/EINw=";
   };
 
   nativeBuildInputs = [
@@ -44,7 +44,8 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Command line client for Mega.co.nz";
-    homepage = "https://megatools.megous.com/";
+    homepage = "https://xff.cz/megatools/";
+    changelog = "https://xff.cz/megatools/builds/NEWS";
     license = licenses.gpl2Plus;
     maintainers = with maintainers; [ viric ];
     platforms = platforms.unix;

--- a/pkgs/by-name/me/megatools/package.nix
+++ b/pkgs/by-name/me/megatools/package.nix
@@ -47,7 +47,10 @@ stdenv.mkDerivation rec {
     homepage = "https://xff.cz/megatools/";
     changelog = "https://xff.cz/megatools/builds/NEWS";
     license = licenses.gpl2Plus;
-    maintainers = with maintainers; [ viric ];
+    maintainers = with maintainers; [
+      viric
+      vji
+    ];
     platforms = platforms.unix;
   };
 }

--- a/pkgs/by-name/me/megatools/package.nix
+++ b/pkgs/by-name/me/megatools/package.nix
@@ -16,12 +16,12 @@
 
 stdenv.mkDerivation rec {
   pname = "megatools";
-  version = "1.11.1";
+  version = "1.11.3";
 
   src = fetchgit {
-    url = "https://megous.com/git/megatools";
+    url = "https://xff.cz/git/megatools";
     rev = version;
-    sha256 = "sha256-AdvQqaRTsKTqdfNfFiWtA9mIPVGuui+Ru9TUARVG0+Q=";
+    sha256 = "sha256-z2BUSNXl0u+28TzhLmNjcgNVLBmr3m+FuRWr8o/EINw=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/by-name/me/megatools/package.nix
+++ b/pkgs/by-name/me/megatools/package.nix
@@ -42,15 +42,15 @@ stdenv.mkDerivation rec {
   enableParallelBuilding = true;
   strictDeps = true;
 
-  meta = with lib; {
+  meta = {
     description = "Command line client for Mega.co.nz";
     homepage = "https://xff.cz/megatools/";
     changelog = "https://xff.cz/megatools/builds/NEWS";
-    license = licenses.gpl2Plus;
-    maintainers = with maintainers; [
+    license = lib.licenses.gpl2Plus;
+    maintainers = with lib.maintainers; [
       viric
       vji
     ];
-    platforms = platforms.unix;
+    platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/by-name/me/megatools/package.nix
+++ b/pkgs/by-name/me/megatools/package.nix
@@ -16,12 +16,12 @@
 
 stdenv.mkDerivation rec {
   pname = "megatools";
-  version = "1.11.3";
+  version = "1.11.4";
 
   src = fetchgit {
     url = "https://xff.cz/git/megatools";
     rev = version;
-    hash = "sha256-z2BUSNXl0u+28TzhLmNjcgNVLBmr3m+FuRWr8o/EINw=";
+    hash = "sha256-pF87bphrlI0VYFXD8RMztGr+NqBSL6np/cldCbHiK7A=";
   };
 
   nativeBuildInputs = [


### PR DESCRIPTION
From the [changelog](https://xff.cz/megatools/builds/NEWS):

```
megatools 1.11.3 - 2025-02-03
=============================

This release changes the location of the project website, and email address
of the maintainer across documentation.
```

This should allow the nixpkgs-update bot to find new versions again, which previously failed due to this change ([see logs](https://nixpkgs-update-logs.nix-community.org/megatools/2025-01-28.log)). 
Also adds changelog URL as given on the project homepage.

I’d also be happy to co-maintain this package.

<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [x] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [x] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
