### PR TITLE
lib: init lib.fallback

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -75,7 +75,7 @@ let
       importJSON importTOML warn warnIf warnIfNot throwIf throwIfNot checkListOfEnum
       info showWarnings nixpkgsVersion version isInOldestRelease oldestSupportedReleaseIsAtLeast
       mod compare splitByAndCompare seq deepSeq lessThan add sub
-      functionArgs setFunctionArgs isFunction toFunction mirrorFunctionArgs
+      functionArgs fallback setFunctionArgs isFunction toFunction mirrorFunctionArgs
       fromHexString toHexString toBaseDigits inPureEvalMode isBool isInt pathExists
       genericClosure readFile;
     inherit (self.fixedPoints) fix fix' converge extends composeExtensions

--- a/lib/tests/misc.nix
+++ b/lib/tests/misc.nix
@@ -22,6 +22,7 @@ let
   lib = import ../default.nix;
 
   inherit (lib)
+    fallback
     allUnique
     and
     attrNames
@@ -2611,5 +2612,45 @@ runTests {
       directory = ./packages-from-directory/c;
     };
     expected = "c";
+  };
+
+  # Tests for lib.fallback
+  # Truthy
+  testFallbackTruthyString = {
+    expr = fallback "default" null;
+    expected = "default";
+  };
+  testFallbackTruthyList = {
+    expr = fallback [ 1 2 3 ] null;
+    expected = [ 1 2 3 ];
+  };
+  testFallbackTruthyAttrs = {
+    expr = fallback { foo = "bar"; } null;
+    expected = { foo = "bar"; };
+  };
+  testFallbackTruthyBool= {
+    expr = fallback true null;
+    expected = true;
+  };
+  # Falsey
+  testFallbackFalseyNull = {
+    expr = fallback null "fallback";
+    expected = "fallback";
+  };
+  testFallbackFalseyList = {
+    expr = fallback [] [ 1 2 3 ];
+    expected = [ 1 2 3 ];
+  };
+  testFallbackFalseyAttrs = {
+    expr = fallback {} { foo = "bar"; };
+    expected = { foo = "bar"; };
+  };
+  testFallbackFalseyBool = {
+    expr = fallback false true;
+    expected = true;
+  };
+  testFallbackFalseyString = {
+    expr = fallback "" "fallback";
+    expected = "fallback";
   };
 }

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1210,14 +1210,24 @@ in {
       lib.reverseList (go i);
 
   /**
-    Returns the first argument if it is truthy, otherwise the second argument.
+    Returns the first argument unless it is empty or null, in which case it returns the second argument.
 
-    Truthiness is determined by the following rules:
-    - Booleans: `true` is truthy, `false` is falsy.
-    - Lists: Any non-empty list is truthy, the empty list is falsy.
-    - Sets: Any non-empty set is truthy, the empty set is falsy.
-    - Strings: Any non-empty string is truthy, the empty string is falsy.
-    - null: is falsy.
+    The following values are determined to be empty:
+    `false`, `[]`, `{}`, `""`, `null`
+
+    # Inputs
+
+    `a`
+    : 1\. Function argument
+
+    `b`
+    : The argument to return if the first argument is empty or null.
+
+    # Type
+
+    ```
+    fallback :: a -> b -> a | b
+    ```
   */
   fallback = a: b:
     if a == [] || a == null || a == {} || a == "" || a == false

--- a/lib/trivial.nix
+++ b/lib/trivial.nix
@@ -1208,4 +1208,19 @@ in {
       assert (base >= 2);
       assert (i >= 0);
       lib.reverseList (go i);
+
+  /**
+    Returns the first argument if it is truthy, otherwise the second argument.
+
+    Truthiness is determined by the following rules:
+    - Booleans: `true` is truthy, `false` is falsy.
+    - Lists: Any non-empty list is truthy, the empty list is falsy.
+    - Sets: Any non-empty set is truthy, the empty set is falsy.
+    - Strings: Any non-empty string is truthy, the empty string is falsy.
+    - null: is falsy.
+  */
+  fallback = a: b:
+    if a == [] || a == null || a == {} || a == "" || a == false
+    then b
+    else a;
 }


### PR DESCRIPTION
Reasoning behind this:

- `if foo == [ ] then foo else something` is verbose to type. I especially dont like to type `foo` twice since it can be very long in some cases (`some.options.path.nested.attrs`)

Some quick grep on gitub yielded this where it could be used:

- https://github.com/NixOS/nixpkgs/blob/7a4c8e8d0d6db84561750f21039153d6ca06400e/nixos/modules/services/web-servers/nginx/default.nix#L317
- [SameFile]#L324
- https://github.com/NixOS/nixpkgs/blob/27f79a9daa9ca35b20f25a8effb5e5a75eebc164/lib/options.nix#L327C14-L327C123
- https://github.com/vinceliuice/grub2-themes/blob/f6ab2438e124f60a340a526543e498e5e33b3c53/flake.nix#L20
- https://github.com/eamsden/nixos-urbit/blob/b58ce4f19c3be7d5461ef36d022e5f7753e380b9/overlay.nix#L3

I also found that 

`lib.fallback a b (a: a)` might make sense instead.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
