### PR TITLE
haskellPackages.tailwind: fix build

### DIFF
--- a/pkgs/development/haskell-modules/configuration-nix.nix
+++ b/pkgs/development/haskell-modules/configuration-nix.nix
@@ -1426,6 +1426,16 @@ self: super: builtins.intersectAttrs super {
           pkgs.nodePackages."@tailwindcss/line-clamp"
           pkgs.nodePackages."@tailwindcss/typography"
         ];
+        # Added a shim for the `tailwindcss` CLI entry point
+        nativeBuildInputs = (oa.nativeBuildInputs or []) ++ [ pkgs.buildPackages.makeBinaryWrapper ];
+        postInstall = (oa.postInstall or "") + ''
+          nodePath=""
+          for p in "$out" "${pkgs.nodePackages.postcss}" $plugins; do
+            nodePath="$nodePath''${nodePath:+:}$p/lib/node_modules"
+          done
+          makeWrapper "$out/bin/tailwindcss" "$out/bin/tailwind" --prefix NODE_PATH : "$nodePath"
+          unset nodePath
+        '';
       })) super.tailwind;
 
   emanote = addBuildDepend pkgs.stork super.emanote;

--- a/pkgs/development/tools/tailwindcss/default.nix
+++ b/pkgs/development/tools/tailwindcss/default.nix
@@ -29,12 +29,12 @@ let
     }
     .${system} or throwSystem;
 in
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "tailwindcss";
   version = "3.4.17";
 
   src = fetchurl {
-    url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v${version}/tailwindcss-${plat}";
+    url = "https://github.com/tailwindlabs/tailwindcss/releases/download/v${finalAttrs.version}/tailwindcss-${plat}";
     inherit hash;
   };
 
@@ -44,13 +44,15 @@ stdenv.mkDerivation rec {
   dontFixup = true;
 
   installPhase = ''
+    runHook preInstall
     mkdir -p $out/bin
-    cp ${src} $out/bin/tailwindcss
+    cp ${finalAttrs.src} $out/bin/tailwindcss
     chmod 755 $out/bin/tailwindcss
+    runHook postInstall
   '';
 
   passthru.tests.helptext = runCommand "tailwindcss-test-helptext" { } ''
-    ${tailwindcss}/bin/tailwindcss --help > $out
+    ${lib.getExe finalAttrs.finalPackage} --help > $out
   '';
   passthru.updateScript = ./update.sh;
 
@@ -63,4 +65,4 @@ stdenv.mkDerivation rec {
     mainProgram = "tailwindcss";
     platforms = platforms.darwin ++ platforms.linux;
   };
-}
+})


### PR DESCRIPTION
Previously:

- https://github.com/NixOS/nixpkgs/pull/364323#issuecomment-2628902991
- https://github.com/srid/tailwind-haskell/issues/21

This PR moves the override which previously was in nodePackages.tailwindcss into the Haskell override.

https://github.com/NixOS/nixpkgs/blob/25fe86dff71eb20ecb175b3112b8c86c9367a37a/pkgs/development/node-packages/overrides.nix#L261-L280

We also run the preInstall and postInstall hooks in installPhase for tailwindcss, since that's needed, and convert it over to fixed-point style.

## Things done

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [25.05 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) (or backporting [24.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) and [25.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).